### PR TITLE
Remove placeholder logic

### DIFF
--- a/app/presenters/publishing_api/generic_edition_presenter.rb
+++ b/app/presenters/publishing_api/generic_edition_presenter.rb
@@ -19,7 +19,7 @@ module PublishingApi
         document_type:,
         public_updated_at: item.public_timestamp || item.updated_at,
         rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
-        schema_name: "placeholder_#{item.class.name.underscore}",
+        schema_name: "placeholder",
         auth_bypass_ids: [item.auth_bypass_id],
       )
       content.merge!(PayloadBuilder::PublicDocumentPath.for(item))

--- a/test/unit/app/presenters/publishing_api/generic_edition_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/generic_edition_presenter_test.rb
@@ -24,7 +24,7 @@ module PublishingApi
         base_path: public_path,
         title: "The title",
         description: "The summary",
-        schema_name: "placeholder_news_article",
+        schema_name: "placeholder",
         document_type: "press_release",
         locale: "en",
         public_updated_at: edition.updated_at,


### PR DESCRIPTION
We were previously sending some content items to Publishing API with a schema type prefixed `placeholder_` to indicate that content item was still rendered by Whitehall.

This is no longer the case, so we can remove that logic.

The `GenericEditionPresenter` is used solely in tests, reverting this to use a generic `placeholder` schema as the logic will be removed from Publishing API in https://github.com/alphagov/publishing-api/pull/2504.

This will need to be updated again when the `placeholder` schema is completely removed.

[Trello card](https://trello.com/c/xAZ7nU8h)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
