### PR TITLE
Remove `placeholder` content schema test

### DIFF
--- a/test/unit/app/presenters/publishing_api/generic_edition_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/generic_edition_presenter_test.rb
@@ -46,7 +46,6 @@ module PublishingApi
 
       presented_item = present(edition)
       assert_equal expected_hash, presented_item.content
-      assert_valid_against_publisher_schema(presented_item.content, "placeholder")
     end
 
     test "links hash includes topics and parent if set" do


### PR DESCRIPTION
https://trello.com/c/mz4v8tb5

Placeholder schemas were a transitionary state between Whitehall and other publishing apps.

As they are now redundant, we are removing them from Publishing API.

Whitehall's GenericEditionPresenter is to be removed/refactored as it is no longer used, however, this spec prevents us removing the schema.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
