### PR TITLE
Switch order of parameters in 'if' statement

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -316,7 +316,7 @@ private
   end
 
   def saved_confirmation_notice
-    if @edition.has_been_tagged? || params[:save].present?
+    if params[:save].present? || @edition.has_been_tagged?
       notice = "Your document has been saved"
       html_safe = false
     else


### PR DESCRIPTION
I've switched the order of these parameters in the 'if' statement.

Whilst only a subtle change, this should allow clicks of the "Save" button (i.e. `params[:save].present?`) to avoid calling out to the Publishing API (i.e. `@edition.has_been_tagged?`).

Despite being a relatively small optimisation, it should slightly speed up these requests by removing an external API call.

Clicks of the "Save and continue" button will still trigger that Publishing API call, which is required to work out which flash message to show.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
