### PR TITLE
CSV previews to work with modern urls

### DIFF
--- a/app/helpers/attachments_helper.rb
+++ b/app/helpers/attachments_helper.rb
@@ -14,7 +14,14 @@ module AttachmentsHelper
   end
 
   def preview_path_for_attachment(attachment)
-    "/government/uploads/system/uploads/attachment_data/file/#{attachment.attachment_data.id}/#{attachment.filename}/preview"
+    if attachment.attachment_data.use_non_legacy_endpoints
+      if attachment.attachment_data.all_asset_variants_uploaded?
+        return Plek.external_url_for("assets-origin") + "/media/#{attachment.attachment_data.assets.first.asset_manager_id}/#{attachment.attachment_data.assets.first.filename}/preview"
+      end
+
+      return nil
+    end
+    Plek.external_url_for("assets-origin") + "/government/uploads/system/uploads/attachment_data/file/#{attachment.attachment_data.id}/#{attachment.filename}/preview"
   end
 
   def attachment_component_params(attachment, alternative_format_contact_email: nil)

--- a/app/models/file_attachment.rb
+++ b/app/models/file_attachment.rb
@@ -68,8 +68,20 @@ private
 
   def preview_url
     if csv? && attachable.is_a?(Edition)
+      if attachment_data.use_non_legacy_endpoints
+        return non_legacy_csv_preview
+      end
+
       Plek.asset_root + "/government/uploads/system/uploads/attachment_data/file/#{attachment_data.id}/#{filename}/preview"
     end
+  end
+
+  def non_legacy_csv_preview
+    if attachment_data.all_asset_variants_uploaded?
+      return Plek.asset_root + "/media/#{attachment_data.id}/#{filename}/preview"
+    end
+
+    nil
   end
 
   def filename_is_unique

--- a/test/factories/attachment_data.rb
+++ b/test/factories/attachment_data.rb
@@ -23,6 +23,14 @@ FactoryBot.define do
     end
   end
 
+  factory :attachment_data_with_csv_asset, parent: :attachment_data do
+    use_non_legacy_endpoints { true }
+    file { File.open(Rails.root.join("test/fixtures/dft_statistical_data_set_sample.csv")) }
+    after(:build) do |attachment_data|
+      attachment_data.assets << build(:asset, asset_manager_id: "asset_manager_id_original", variant: Asset.variants[:original], filename: "dft_statistical_data_set_sample.csv")
+    end
+  end
+
   factory :image_attachment_data, parent: :attachment_data do
     file { File.open(Rails.root.join("test/fixtures/minister-of-funk.960x640.jpg")) }
   end

--- a/test/unit/app/helpers/attachments_helper_test.rb
+++ b/test/unit/app/helpers/attachments_helper_test.rb
@@ -94,7 +94,7 @@ class AttachmentsHelperTest < ActionView::TestCase
     assert_equal expect_params, attachment_component_params(attachment)
   end
 
-  test "component params for previewable CSV attachment" do
+  test "component params for previewable CSV attachment with legacy preview path" do
     attachment = file_attachment("sample.csv", attachable: create(:edition))
     expect_params = {
       type: "file",
@@ -104,7 +104,7 @@ class AttachmentsHelperTest < ActionView::TestCase
       content_type: "text/csv",
       filename: attachment.filename,
       file_size: attachment.file_size,
-      preview_url: preview_path_for_attachment(attachment),
+      preview_url: "#{Plek.external_url_for('assets-origin')}/government/uploads/system/uploads/attachment_data/file/#{attachment.attachment_data.id}/sample.csv/preview",
     }
     assert_equal expect_params, attachment_component_params(attachment)
   end
@@ -168,6 +168,36 @@ class AttachmentsHelperTest < ActionView::TestCase
 
     assert inaccessible[:alternative_format_contact_email].eql? alternative_format_contact_email
     assert_not accessible.key? :alternative_format_contact_email
+  end
+
+  test "use_non_legacy_endpoints: component params for previewable CSV attachment when has no asset" do
+    attachment = file_attachment("sample.csv", attachable: create(:edition))
+    attachment.attachment_data.use_non_legacy_endpoints = true
+    expect_params = {
+      type: "file",
+      id: attachment.filename,
+      title: attachment.title,
+      url: attachment.url,
+      content_type: "text/csv",
+      filename: attachment.filename,
+      file_size: attachment.file_size,
+    }
+    assert_equal expect_params, attachment_component_params(attachment)
+  end
+
+  test "use_non_legacy_endpoints: component params for previewable CSV attachment when has asset" do
+    attachment = create(:file_attachment, attachable: create(:edition), attachment_data: build(:attachment_data_with_csv_asset))
+    expect_params = {
+      type: "file",
+      id: attachment.filename,
+      title: attachment.title,
+      url: attachment.url,
+      content_type: "text/csv",
+      filename: attachment.filename,
+      file_size: attachment.file_size,
+      preview_url: "#{Plek.external_url_for('assets-origin')}/media/asset_manager_id_original/dft_statistical_data_set_sample.csv/preview",
+    }
+    assert_equal expect_params, attachment_component_params(attachment)
   end
 
   def file_attachment(file_name, params = {})

--- a/test/unit/app/models/file_attachment_test.rb
+++ b/test/unit/app/models/file_attachment_test.rb
@@ -63,4 +63,14 @@ class FileAttachmentTest < ActiveSupport::TestCase
     attachment.attachment_data.file = {}
     assert attachment.filename_changed?
   end
+
+  test "return legacy preview_url by default" do
+    attachment = create(:csv_attachment, attachable: create(:edition))
+    assert_equal Plek.asset_root + "/government/uploads/system/uploads/attachment_data/file/#{attachment.attachment_data.id}/sample.csv/preview", attachment.publishing_api_details_for_format[:preview_url]
+  end
+
+  test "return non legacy preview_url if use_non_legacy_endpoints is true" do
+    attachment = create(:file_attachment, attachable: create(:edition), attachment_data: build(:attachment_data_with_csv_asset))
+    assert_equal Plek.asset_root + "/media/#{attachment.attachment_data.id}/dft_statistical_data_set_sample.csv/preview", attachment.publishing_api_details_for_format[:preview_url]
+  end
 end


### PR DESCRIPTION
**Fix Asset Preview to work with modern url**

This PR is trying to fix 2 problems related to csv preview

1. To move away from legacy url path, we needed csv previews to work with `/media/:id/:filename` endpoint in asset manager. So we are publishing csv preview url to be `/media/:id/:filename` instead of legacy_url.

2. Currently gov-speak body preview for csv does not work correctly when we try to view online, the reason being it is not configured correctly to use frontend domain. So we have made the changes to allow it to use frontend domain

We added check for non legacy endpoints so that we can return the non legacy preview url correctly.

[trello](https://trello.com/c/LV4TnjlP/176-story-csv-previews-should-work-with-modern-urls)