### PR TITLE
Fix test regarding to GOVUK_ASSET_ROOT

### DIFF
--- a/test/unit/app/presenters/publishing_api/organisation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/organisation_presenter_test.rb
@@ -136,8 +136,7 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
     )
     presented_item = present(organisation)
 
-    expected_image_url = "https://static.test.gov.uk" \
-      "/government/uploads/system/uploads/organisation/logo/#{organisation.logo.model.id}/960x640_jpeg.jpg"
+    expected_image_url = "#{Plek.asset_root}/government/uploads/system/uploads/organisation/logo/#{organisation.logo.model.id}/960x640_jpeg.jpg"
 
     assert_equal(
       {

--- a/test/unit/app/presenters/publishing_api/worldwide_organisation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/worldwide_organisation_presenter_test.rb
@@ -124,7 +124,7 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
            worldwide_organisation: worldwide_org,
            attachments: [create(:file_attachment)])
     expected_body_text = "<div class=\"govspeak\"><p>Some stuff and some attachments"
-    expected_body_attachment_link = Regexp.new(/<a class="govuk-link" href="https:\/\/static.test.gov.uk\/government\/uploads\/system\/uploads\/attachment_data\/file\/\d+\/greenpaper.pdf">file-attachment-title-\d+<\/a>/)
+    expected_body_attachment_link = Regexp.new(/<a class="govuk-link" href="#{Plek.asset_root}\/government\/uploads\/system\/uploads\/attachment_data\/file\/\d+\/greenpaper.pdf">file-attachment-title-\d+<\/a>/)
     expected_body_attachment_metadata = "(<span class=\"gem-c-attachment-link__attribute\"><abbr title=\"Portable Document Format\" class=\"gem-c-attachment-link__abbr\">PDF</abbr></span>, <span class=\"gem-c-attachment-link__attribute\">3.39 KB</span>, <span class=\"gem-c-attachment-link__attribute\">1 page</span>)"
 
     presented_item = present(worldwide_org)

--- a/test/unit/lib/data_hygiene/migrate_consultation_to_call_for_evidence_test.rb
+++ b/test/unit/lib/data_hygiene/migrate_consultation_to_call_for_evidence_test.rb
@@ -60,7 +60,7 @@ class MigrateConsultationToCallForEvidenceTest < ActiveSupport::TestCase
 
     # Stub requests for asset files
     # and respond with the requested fixture file
-    urls_starting = "https://static.test.gov.uk/government/uploads/system/uploads/"
+    urls_starting = "#{Plek.asset_root}/government/uploads/system/uploads/"
     stub_request(:get, %r{^#{Regexp.escape(urls_starting)}})
       .to_return do |request|
         fixture_name = request.uri.to_s.split("/").last


### PR DESCRIPTION
GOVUK_ASSET_ROOT has been specified in govuk-docker since [this commit that fixes static asset url in dev env](https://github.com/alphagov/govuk-docker/commit/854556a399001fe53f72983099d1d26894b27062). Thus local environment no longer resolve to default of "https://static.test.gov.uk" and changes the behavior of these tests.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
