### PR TITLE
Migrate more calls for evidence

### DIFF
--- a/db/data_migration/20230915000000_migrate_calls_for_evidence.csv
+++ b/db/data_migration/20230915000000_migrate_calls_for_evidence.csv
@@ -1,0 +1,17 @@
+Document ID,Path
+169069,/government/consultations/atol-call-for-evidence
+168303,/government/consultations/call-for-evidence-on-the-impact-of-rid-and-adr-2013-amendments
+5416,/government/consultations/call-for-evidence-on-the-production-of-an-appraisal-tool-for-local-speed-limits
+202512,/government/consultations/measures-to-support-uptake-of-ultra-low-emission-vehicles-from-2015-to-2020
+444687,/government/consultations/roads-policing-review-future-methods-to-improve-safety-and-reduce-causalities
+308936,/government/consultations/carriage-of-dangerous-goods-regulations-2015-adr-and-rid-updates
+527903,/government/consultations/proposed-instrument-to-regulate-traffic-on-m20-motorway-call-for-views
+472406,/government/consultations/changes-to-the-uk-operator-licensing-regime-and-arrangements-for-the-temporary-posting-of-workers-in-the-uk-and-eu-request-for-evidence
+5381,/government/consultations/call-for-evidence-nats-government-share-ownership
+379249,/government/consultations/cycling-and-walking-investment-strategy-cwis-safety-review
+518824,/government/consultations/2040-zero-emissions-airport-target
+501197,/government/consultations/exemptions-to-2035-phase-out-date-for-the-sale-of-new-non-zero-emission-hgvs-26-tonnes-and-under
+371306,/government/consultations/reforming-the-heavy-goods-vehicle-road-user-levy
+403897,/government/consultations/williams-rail-review
+526655,/government/consultations/review-of-the-public-service-vehicles-accessibility-regulations-2000
+524843,/government/consultations/heavy-vehicle-testing-review-call-for-evidence

--- a/lib/tasks/migrate_calls_for_evidence.rake
+++ b/lib/tasks/migrate_calls_for_evidence.rake
@@ -29,6 +29,12 @@ namespace :migrate_calls_for_evidence do
 
     document_ids.each do |document_id|
       document = Document.find(document_id)
+
+      if document.latest_edition.is_a?(CallForEvidence)
+        print "S" # skip; already migrated
+        next
+      end
+
       DataHygiene::MigrateConsultationToCallForEvidence.new(document:, whodunnit:).call
       successes << document_id
       print "."


### PR DESCRIPTION
Department for Transport have asked us to migrate 16 more consultations to the new call for evidence type. These were missed from the initial list of documents to migrate.

The request was made to us in Zendesk ticket [#5478771][1].

This CSV contains all 16 documents to be migrated. However 4 of them are in a draft state so will not migrate successfully. I've asked DfT to delete or publish the drafts so the documnets can be migrated.

In the meantime, the 12 published documents will migrate correctly. And we can re-run this migration to catch the final 4 once they're in the correct state.

Migrate these documents by running:

```
rake migrate_calls_for_evidence:migrate MIGRATION_CSV_PATH="20230915000000_migrate_calls_for_evidence.csv"
```

[1]: https://govuk.zendesk.com/agent/tickets/5478771

Trello: https://trello.com/c/c31bnJbp/1727-migrate-calls-for-evidence-that-were-missed

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
