### PR TITLE
Add indexes to support finding by Content ID

### DIFF
--- a/db/migrate/20230915163657_add_index_for_document_content_ids.rb
+++ b/db/migrate/20230915163657_add_index_for_document_content_ids.rb
@@ -1,0 +1,6 @@
+class AddIndexForDocumentContentIds < ActiveRecord::Migration[7.0]
+  def change
+    add_index(:documents, :content_id)
+    add_index(:attachments, :content_id)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_06_151938) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_15_163657) do
   create_table "assets", charset: "utf8mb3", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.string "variant", null: false
@@ -68,6 +68,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_06_151938) do
     t.index ["attachable_id", "attachable_type"], name: "index_attachments_on_attachable_id_and_attachable_type"
     t.index ["attachable_type", "attachable_id", "ordering"], name: "no_duplicate_attachment_orderings", unique: true
     t.index ["attachment_data_id"], name: "index_attachments_on_attachment_data_id"
+    t.index ["content_id"], name: "index_attachments_on_content_id"
     t.index ["ordering"], name: "index_attachments_on_ordering"
   end
 
@@ -243,6 +244,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_06_151938) do
     t.string "content_id", null: false
     t.integer "latest_edition_id"
     t.integer "live_edition_id"
+    t.index ["content_id"], name: "index_documents_on_content_id"
     t.index ["document_type"], name: "index_documents_on_document_type"
     t.index ["latest_edition_id"], name: "index_documents_on_latest_edition_id"
     t.index ["live_edition_id"], name: "index_documents_on_live_edition_id"


### PR DESCRIPTION
## Changes

The action `admin/documents#by_content_id` is used frequently by publishers looking to edit documents. It's called by the 'edit in admin' bookmarklet in addition to the [GOV.UK browser extension][1], both of which are widely used by publishers.

Despite its heavy use, calls to this endpoint can sometimes wait up to eight seconds for a response. It turns out the database hasn't been optimised for this particular read pattern.

I've added an index to the "documents" and "attachments" tables. These are the two tables that get queried by this endpoint. It should speed up response times dramatically.

In theory I should be able to implement these as unique indexes. Content IDs on GOV.UK are designed as UUIDs, and therefore should be universally unique.

However when testing this locally against a recent copy of integration data, it looks like there's _at least one_ document with a duplicate Content ID. 😬 I've therefore opted to use regular non-unique indexes for these columns rather than open a potential can o' worms. There should still be a considerable performance increase compared to having no index at all.

## Performance issues

The poor performance of this controller action can be observed in [this Grafana dashboard][2]. This shows that, within the past 7 days (11/09/2023–18/09/2023) the `admin/documents#by_content_id` action took **up to 23 seconds to run**.

<img width="707" alt="Screenshot of Grafana dashboard" src="https://github.com/alphagov/whitehall/assets/7735945/0a116764-591b-4735-a445-f025307e6cc6">


[1]: https://docs.publishing.service.gov.uk/repos/govuk-browser-extension.html
[2]: https://grafana.eks.production.govuk.digital/d/e3ae671f-17bc-4dc6-a7af-faac40c322e4/richard-towersat-average-request-time-by-controller-action?orgId=1&var-namespace=apps&var-app=whitehall-admin&from=now-7d&to=now

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
