### PR TITLE
Fix ConsultationResponseForm & CallForEvidenceResponseForm bug

### DIFF
--- a/app/controllers/admin/calls_for_evidence_controller.rb
+++ b/app/controllers/admin/calls_for_evidence_controller.rb
@@ -39,4 +39,11 @@ private
   def document_can_be_previously_published
     false
   end
+
+  def build_edition_dependencies
+    super
+    participation = @edition.call_for_evidence_participation || @edition.build_call_for_evidence_participation
+    response_form = participation.call_for_evidence_response_form || participation.build_call_for_evidence_response_form
+    response_form.call_for_evidence_response_form_data || response_form.build_call_for_evidence_response_form_data
+  end
 end

--- a/app/controllers/admin/consultations_controller.rb
+++ b/app/controllers/admin/consultations_controller.rb
@@ -39,4 +39,11 @@ private
   def document_can_be_previously_published
     false
   end
+
+  def build_edition_dependencies
+    super
+    participation = @edition.consultation_participation || @edition.build_consultation_participation
+    response_form = participation.consultation_response_form || participation.build_consultation_response_form
+    response_form.consultation_response_form_data || response_form.build_consultation_response_form_data
+  end
 end

--- a/app/models/call_for_evidence_response_form.rb
+++ b/app/models/call_for_evidence_response_form.rb
@@ -4,7 +4,7 @@ class CallForEvidenceResponseForm < ApplicationRecord
 
   delegate :url, :file, to: :call_for_evidence_response_form_data
 
-  validates :title, presence: true
+  validates :title, :call_for_evidence_response_form_data, presence: true
 
   accepts_nested_attributes_for :call_for_evidence_response_form_data
 

--- a/app/models/consultation_response_form.rb
+++ b/app/models/consultation_response_form.rb
@@ -4,7 +4,7 @@ class ConsultationResponseForm < ApplicationRecord
 
   delegate :url, :file, to: :consultation_response_form_data
 
-  validates :title, presence: true
+  validates :title, :consultation_response_form_data, presence: true
 
   accepts_nested_attributes_for :consultation_response_form_data
 

--- a/app/views/admin/calls_for_evidence/_form.html.erb
+++ b/app/views/admin/calls_for_evidence/_form.html.erb
@@ -131,7 +131,7 @@
                   },
                   name: "edition[call_for_evidence_participation_attributes][call_for_evidence_response_form_attributes][call_for_evidence_response_form_data_attributes][file]",
                   id: "edition_call_for_evidence_participation_attributes_call_for_evidence_response_form_call_for_evidence_response_form_data_file",
-                  error_items: errors_for(call_for_evidence_response_form_data.errors, :file),
+                  error_items: errors_for(call_for_evidence_response_form_data.errors, :file) || errors_for(call_for_evidence_response_form.errors, :call_for_evidence_response_form_data),
                 }
                 )
               }
@@ -146,7 +146,7 @@
           },
           name: "edition[call_for_evidence_participation_attributes][call_for_evidence_response_form_attributes][call_for_evidence_response_form_data_attributes][file]",
           id: "edition_call_for_evidence_participation_call_for_evidence_response_form_call_for_evidence_response_form_data_file",
-          error_items: errors_for(call_for_evidence_response_form_data.errors, :file),
+          error_items: errors_for(call_for_evidence_response_form_data.errors, :file) || errors_for(call_for_evidence_response_form.errors, :call_for_evidence_response_form_data),
         } %>
         <% if call_for_evidence_response_form_data.file_cache.present? %>
           <%= hidden_field_tag "edition[call_for_evidence_participation_attributes][call_for_evidence_response_form_attributes][call_for_evidence_response_form_data_attributes][file_cache]", call_for_evidence_response_form_data.file_cache %>

--- a/app/views/admin/calls_for_evidence/_form.html.erb
+++ b/app/views/admin/calls_for_evidence/_form.html.erb
@@ -45,113 +45,116 @@
       heading_level: 3,
       heading_size: "l"
     } do %>
+
       <% call_for_evidence_participation = edition.call_for_evidence_participation || edition.build_call_for_evidence_participation %>
-      <%= hidden_field_tag "edition[call_for_evidence_participation_attributes][id]", call_for_evidence_participation.id %>
 
-      <%= render "govuk_publishing_components/components/input", {
-        label: {
-          text: "Link URL",
-        },
-        name: "edition[call_for_evidence_participation_attributes][link_url]",
-        id: "edition_call_for_evidence_participation_link_url",
-        heading_size: "m",
-        value: call_for_evidence_participation.link_url,
-        error_items: errors_for(call_for_evidence_participation.errors, :link_url),
-      } %>
-
-      <%= render "govuk_publishing_components/components/input", {
-        label: {
-          text: "Email",
-        },
-        name: "edition[call_for_evidence_participation_attributes][email]",
-        id: "edition_call_for_evidence_participation_email",
-        heading_size: "m",
-        value: call_for_evidence_participation.email,
-        error_items: errors_for(call_for_evidence_participation.errors, :email),
-      } %>
-
-      <%= render "govuk_publishing_components/components/textarea", {
-        label: {
-          text: "Postal address",
-          heading_size: "m",
-        },
-        name: "edition[call_for_evidence_participation_attributes][postal_address]",
-        id: "edition_call_for_evidence_participation_postal_address",
-        value: call_for_evidence_participation.postal_address,
-        error_items: errors_for(call_for_evidence_participation.errors, :postal_address),
-        rows: 4,
-      } %>
-
-      <% call_for_evidence_response_form = call_for_evidence_participation.call_for_evidence_response_form || call_for_evidence_participation.build_call_for_evidence_response_form %>
-      <% call_for_evidence_response_form_data = call_for_evidence_response_form.call_for_evidence_response_form_data || call_for_evidence_response_form.build_call_for_evidence_response_form_data %>
-
-      <%= render "govuk_publishing_components/components/input", {
-        label: {
-          text: "Downloadable response form title",
-        },
-        name: "edition[call_for_evidence_participation_attributes][call_for_evidence_response_form_attributes][title]",
-        id: "edition_call_for_evidence_participation_call_for_evidence_response_form_title",
-        heading_size: "m",
-        value: call_for_evidence_response_form.title,
-        error_items: errors_for(call_for_evidence_response_form.errors, :title),
-      } %>
-
-      <% if call_for_evidence_response_form.call_for_evidence_response_form_data.try(:persisted?) %>
-        <div class="attachment">
-          <p class="govuk-body">Current data: <%= link_to File.basename(call_for_evidence_response_form.call_for_evidence_response_form_data.file.path), call_for_evidence_response_form.call_for_evidence_response_form_data.file.url, class: "govuk-link" %></p>
-
-          <%= hidden_field_tag "edition[call_for_evidence_participation_attributes][call_for_evidence_response_form_attributes][call_for_evidence_response_form_data_attributes][file_cache]", call_for_evidence_response_form_data.file_cache %>
-          <%= hidden_field_tag "edition[call_for_evidence_participation_attributes][call_for_evidence_response_form_attributes][call_for_evidence_response_form_data_attributes][id]", call_for_evidence_response_form_data.id %>
-          <%= hidden_field_tag "edition[call_for_evidence_participation_attributes][call_for_evidence_response_form_attributes][id]", call_for_evidence_response_form.id %>
-
-          <%= render "govuk_publishing_components/components/radio", {
-            heading: "Actions:",
-            name: "edition[call_for_evidence_participation_attributes][call_for_evidence_response_form_attributes][attachment_action]",
-            id: "edition_call_for_evidence_participation_call_for_evidence_response_form_attachment_action",
-            heading_size: "m",
-            error_items: errors_for(call_for_evidence_response_form.errors, :attachment_action),
-            items: [
-              {
-                value: "keep",
-                text: "Keep",
-                checked: ["keep", nil].include?(params.dig("edition", "call_for_evidence_participation_attributes", "call_for_evidence_response_form_attributes", "attachment_action")),
-              },
-              {
-                value: "remove",
-                text: "Remove",
-                checked: params.dig("edition", "call_for_evidence_participation_attributes", "call_for_evidence_response_form_attributes", "attachment_action") == "remove",
-              },
-              {
-                value: "replace",
-                text: "Replace",
-                checked: params.dig("edition", "call_for_evidence_participation_attributes", "call_for_evidence_response_form_attributes", "attachment_action") == "replace",
-                conditional: render("govuk_publishing_components/components/file_upload", {
-                  label: {
-                    text: "Replacement"
-                  },
-                  name: "edition[call_for_evidence_participation_attributes][call_for_evidence_response_form_attributes][call_for_evidence_response_form_data_attributes][file]",
-                  id: "edition_call_for_evidence_participation_attributes_call_for_evidence_response_form_call_for_evidence_response_form_data_file",
-                  error_items: errors_for(call_for_evidence_response_form_data.errors, :file) || errors_for(call_for_evidence_response_form.errors, :call_for_evidence_response_form_data),
-                }
-                )
-              }
-            ]
-          } %>
-        </div>
-      <% else %>
-        <%= render "govuk_publishing_components/components/file_upload", {
+      <%= form.fields_for :call_for_evidence_participation, call_for_evidence_participation do |call_for_evidence_participation_form| %>
+        <%= render "govuk_publishing_components/components/input", {
           label: {
-            text: "File",
+            text: "Link URL",
+          },
+          name: "edition[call_for_evidence_participation_attributes][link_url]",
+          id: "edition_call_for_evidence_participation_link_url",
+          heading_size: "m",
+          value: call_for_evidence_participation.link_url,
+          error_items: errors_for(call_for_evidence_participation.errors, :link_url),
+        } %>
+
+        <%= render "govuk_publishing_components/components/input", {
+          label: {
+            text: "Email",
+          },
+          name: "edition[call_for_evidence_participation_attributes][email]",
+          id: "edition_call_for_evidence_participation_email",
+          heading_size: "m",
+          value: call_for_evidence_participation.email,
+          error_items: errors_for(call_for_evidence_participation.errors, :email),
+        } %>
+
+        <%= render "govuk_publishing_components/components/textarea", {
+          label: {
+            text: "Postal address",
             heading_size: "m",
           },
-          name: "edition[call_for_evidence_participation_attributes][call_for_evidence_response_form_attributes][call_for_evidence_response_form_data_attributes][file]",
-          id: "edition_call_for_evidence_participation_call_for_evidence_response_form_call_for_evidence_response_form_data_file",
-          error_items: errors_for(call_for_evidence_response_form_data.errors, :file) || errors_for(call_for_evidence_response_form.errors, :call_for_evidence_response_form_data),
+          name: "edition[call_for_evidence_participation_attributes][postal_address]",
+          id: "edition_call_for_evidence_participation_postal_address",
+          value: call_for_evidence_participation.postal_address,
+          error_items: errors_for(call_for_evidence_participation.errors, :postal_address),
+          rows: 4,
         } %>
-        <% if call_for_evidence_response_form_data.file_cache.present? %>
-          <%= hidden_field_tag "edition[call_for_evidence_participation_attributes][call_for_evidence_response_form_attributes][call_for_evidence_response_form_data_attributes][file_cache]", call_for_evidence_response_form_data.file_cache %>
 
-          <p class="govuk-body already-uploaded"><%= "#{File.basename(call_for_evidence_response_form_data.file_cache)} already uploaded" %></p>
+        <% call_for_evidence_response_form = call_for_evidence_participation.call_for_evidence_response_form || call_for_evidence_participation.build_call_for_evidence_response_form %>
+
+        <%= call_for_evidence_participation_form.fields_for :call_for_evidence_response_form, call_for_evidence_response_form do |response_form| %>
+          <%= render "govuk_publishing_components/components/input", {
+            label: {
+              text: "Downloadable response form title",
+            },
+            name: "edition[call_for_evidence_participation_attributes][call_for_evidence_response_form_attributes][title]",
+            id: "edition_call_for_evidence_participation_call_for_evidence_response_form_title",
+            heading_size: "m",
+            value: call_for_evidence_response_form.title,
+            error_items: errors_for(call_for_evidence_response_form.errors, :title),
+          } %>
+
+          <% call_for_evidence_response_form_data = call_for_evidence_response_form.call_for_evidence_response_form_data || call_for_evidence_response_form.build_call_for_evidence_response_form_data %>
+
+          <%= response_form.fields_for :call_for_evidence_response_form_data, call_for_evidence_response_form_data do |call_for_evidence_response_form_data_form| %>
+            <%= call_for_evidence_response_form_data_form.hidden_field :file_cache, value: call_for_evidence_response_form_data.file_cache %>
+
+            <% if call_for_evidence_response_form.call_for_evidence_response_form_data.try(:persisted?) %>
+              <div class="attachment">
+                <p class="govuk-body">Current data: <%= link_to File.basename(call_for_evidence_response_form_data.file.path), call_for_evidence_response_form_data.file.url, class: "govuk-link" %></p>
+
+                <%= render "govuk_publishing_components/components/radio", {
+                  heading: "Actions:",
+                  name: "edition[call_for_evidence_participation_attributes][call_for_evidence_response_form_attributes][attachment_action]",
+                  id: "edition_call_for_evidence_participation_call_for_evidence_response_form_attachment_action",
+                  heading_size: "m",
+                  error_items: errors_for(call_for_evidence_response_form.errors, :attachment_action),
+                  items: [
+                    {
+                      value: "keep",
+                      text: "Keep",
+                      checked: ["keep", nil].include?(params.dig("edition", "call_for_evidence_participation_attributes", "call_for_evidence_response_form_attributes", "attachment_action")),
+                    },
+                    {
+                      value: "remove",
+                      text: "Remove",
+                      checked: params.dig("edition", "call_for_evidence_participation_attributes", "call_for_evidence_response_form_attributes", "attachment_action") == "remove",
+                    },
+                    {
+                      value: "replace",
+                      text: "Replace",
+                      checked: params.dig("edition", "call_for_evidence_participation_attributes", "call_for_evidence_response_form_attributes", "attachment_action") == "replace",
+                      conditional: render("govuk_publishing_components/components/file_upload", {
+                        label: {
+                          text: "Replacement"
+                        },
+                        name: "edition[call_for_evidence_participation_attributes][call_for_evidence_response_form_attributes][call_for_evidence_response_form_data_attributes][file]",
+                        id: "edition_call_for_evidence_participation_attributes_call_for_evidence_response_form_call_for_evidence_response_form_data_file",
+                        error_items: errors_for(call_for_evidence_response_form_data.errors, :file) || errors_for(call_for_evidence_response_form.errors, :call_for_evidence_response_form_data),
+                      }
+                      )
+                    }
+                  ]
+                } %>
+              </div>
+            <% else %>
+              <%= render "govuk_publishing_components/components/file_upload", {
+                label: {
+                  text: "File",
+                  heading_size: "m",
+                },
+                name: "edition[call_for_evidence_participation_attributes][call_for_evidence_response_form_attributes][call_for_evidence_response_form_data_attributes][file]",
+                id: "edition_call_for_evidence_participation_call_for_evidence_response_form_call_for_evidence_response_form_data_file",
+                error_items: errors_for(call_for_evidence_response_form_data.errors, :file) || errors_for(call_for_evidence_response_form.errors, :call_for_evidence_response_form_data),
+              } %>
+              <% if call_for_evidence_response_form_data.file_cache.present? %>
+                <p class="govuk-body already-uploaded"><%= "#{File.basename(call_for_evidence_response_form_data.file_cache)} already uploaded" %></p>
+              <% end %>
+            <% end %>
+          <% end %>
         <% end %>
       <% end %>
     <% end %>

--- a/app/views/admin/calls_for_evidence/_form.html.erb
+++ b/app/views/admin/calls_for_evidence/_form.html.erb
@@ -46,7 +46,7 @@
       heading_size: "l"
     } do %>
 
-      <% call_for_evidence_participation = edition.call_for_evidence_participation || edition.build_call_for_evidence_participation %>
+      <% call_for_evidence_participation = edition.call_for_evidence_participation %>
 
       <%= form.fields_for :call_for_evidence_participation, call_for_evidence_participation do |call_for_evidence_participation_form| %>
         <%= render "govuk_publishing_components/components/input", {
@@ -83,7 +83,7 @@
           rows: 4,
         } %>
 
-        <% call_for_evidence_response_form = call_for_evidence_participation.call_for_evidence_response_form || call_for_evidence_participation.build_call_for_evidence_response_form %>
+        <% call_for_evidence_response_form = call_for_evidence_participation.call_for_evidence_response_form %>
 
         <%= call_for_evidence_participation_form.fields_for :call_for_evidence_response_form, call_for_evidence_response_form do |response_form| %>
           <%= render "govuk_publishing_components/components/input", {
@@ -97,7 +97,7 @@
             error_items: errors_for(call_for_evidence_response_form.errors, :title),
           } %>
 
-          <% call_for_evidence_response_form_data = call_for_evidence_response_form.call_for_evidence_response_form_data || call_for_evidence_response_form.build_call_for_evidence_response_form_data %>
+          <% call_for_evidence_response_form_data = call_for_evidence_response_form.call_for_evidence_response_form_data %>
 
           <%= response_form.fields_for :call_for_evidence_response_form_data, call_for_evidence_response_form_data do |call_for_evidence_response_form_data_form| %>
             <%= call_for_evidence_response_form_data_form.hidden_field :file_cache, value: call_for_evidence_response_form_data.file_cache %>

--- a/app/views/admin/consultations/_form.html.erb
+++ b/app/views/admin/consultations/_form.html.erb
@@ -45,7 +45,7 @@
       heading_level: 3,
       heading_size: "l"
     } do %>
-      <% consultation_participation = edition.consultation_participation || edition.build_consultation_participation %>
+      <% consultation_participation = edition.consultation_participation %>
 
       <%= form.fields_for :consultation_participation, consultation_participation do |consultation_participation_form| %>
         <%= render "govuk_publishing_components/components/input", {
@@ -82,7 +82,7 @@
           rows: 4,
         } %>
 
-        <% consultation_response_form = consultation_participation.consultation_response_form || consultation_participation.build_consultation_response_form %>
+        <% consultation_response_form = consultation_participation.consultation_response_form %>
 
         <%= consultation_participation_form.fields_for :consultation_response_form, consultation_response_form do |response_form| %>
           <%= render "govuk_publishing_components/components/input", {
@@ -96,7 +96,7 @@
             error_items: errors_for(consultation_response_form.errors, :title),
           } %>
 
-          <% consultation_response_form_data = consultation_response_form.consultation_response_form_data || consultation_response_form.build_consultation_response_form_data %>
+          <% consultation_response_form_data = consultation_response_form.consultation_response_form_data %>
 
           <%= response_form.fields_for :consultation_response_form_data, consultation_response_form_data do |consultation_response_form_data_form| %>
             <%= consultation_response_form_data_form.hidden_field  :file_cache, value: consultation_response_form_data.file_cache %>

--- a/app/views/admin/consultations/_form.html.erb
+++ b/app/views/admin/consultations/_form.html.erb
@@ -46,112 +46,114 @@
       heading_size: "l"
     } do %>
       <% consultation_participation = edition.consultation_participation || edition.build_consultation_participation %>
-      <%= hidden_field_tag "edition[consultation_participation_attributes][id]", consultation_participation.id %>
 
-      <%= render "govuk_publishing_components/components/input", {
-        label: {
-          text: "Link URL",
-        },
-        name: "edition[consultation_participation_attributes][link_url]",
-        id: "edition_consultation_participation_link_url",
-        heading_size: "m",
-        value: consultation_participation.link_url,
-        error_items: errors_for(consultation_participation.errors, :link_url),
-      } %>
-
-      <%= render "govuk_publishing_components/components/input", {
-        label: {
-          text: "Email",
-        },
-        name: "edition[consultation_participation_attributes][email]",
-        id: "edition_consultation_participation_email",
-        heading_size: "m",
-        value: consultation_participation.email,
-        error_items: errors_for(consultation_participation.errors, :email),
-      } %>
-
-      <%= render "govuk_publishing_components/components/textarea", {
-        label: {
-          text: "Postal address",
-          heading_size: "m",
-        },
-        name: "edition[consultation_participation_attributes][postal_address]",
-        id: "edition_consultation_participation_postal_address",
-        value: consultation_participation.postal_address,
-        error_items: errors_for(consultation_participation.errors, :postal_address),
-        rows: 4,
-      } %>
-
-      <% consultation_response_form = consultation_participation.consultation_response_form || consultation_participation.build_consultation_response_form %>
-      <% consultation_response_form_data = consultation_response_form.consultation_response_form_data || consultation_response_form.build_consultation_response_form_data %>
-
-      <%= render "govuk_publishing_components/components/input", {
-        label: {
-          text: "Downloadable response form title",
-        },
-        name: "edition[consultation_participation_attributes][consultation_response_form_attributes][title]",
-        id: "edition_consultation_participation_consultation_response_form_title",
-        heading_size: "m",
-        value: consultation_response_form.title,
-        error_items: errors_for(consultation_response_form.errors, :title),
-      } %>
-
-      <% if consultation_response_form.consultation_response_form_data.try(:persisted?) %>
-        <div class="attachment">
-          <p class="govuk-body">Current data: <%= link_to File.basename(consultation_response_form.consultation_response_form_data.file.path), consultation_response_form.consultation_response_form_data.file.url, class: "govuk-link" %></p>
-
-          <%= hidden_field_tag "edition[consultation_participation_attributes][consultation_response_form_attributes][consultation_response_form_data_attributes][file_cache]", consultation_response_form_data.file_cache %>
-          <%= hidden_field_tag "edition[consultation_participation_attributes][consultation_response_form_attributes][consultation_response_form_data_attributes][id]", consultation_response_form_data.id %>
-          <%= hidden_field_tag "edition[consultation_participation_attributes][consultation_response_form_attributes][id]", consultation_response_form.id %>
-
-          <%= render "govuk_publishing_components/components/radio", {
-            heading: "Actions:",
-            name: "edition[consultation_participation_attributes][consultation_response_form_attributes][attachment_action]",
-            id: "edition_consultation_participation_consultation_response_form_attachment_action",
-            heading_size: "m",
-            error_items: errors_for(consultation_response_form.errors, :attachment_action),
-            items: [
-              {
-                value: "keep",
-                text: "Keep",
-                checked: ["keep", nil].include?(params.dig("edition", "consultation_participation_attributes", "consultation_response_form_attributes", "attachment_action")),
-              },
-              {
-                value: "remove",
-                text: "Remove",
-                checked: params.dig("edition", "consultation_participation_attributes", "consultation_response_form_attributes", "attachment_action") == "remove",
-              },
-              {
-                value: "replace",
-                text: "Replace",
-                checked: params.dig("edition", "consultation_participation_attributes", "consultation_response_form_attributes", "attachment_action") == "replace",
-                conditional: render("govuk_publishing_components/components/file_upload", {
-                    label: {
-                      text: "Replacement"
-                    },
-                    name: "edition[consultation_participation_attributes][consultation_response_form_attributes][consultation_response_form_data_attributes][file]",
-                    id: "edition_consultation_participation_consultation_response_form_consultation_response_form_data_file",
-                    error_items: errors_for(consultation_response_form_data.errors, :file) || errors_for(consultation_response_form.errors, :consultation_response_form_data),
-                  }
-                )
-              }
-            ]
-          } %>
-        </div>
-      <% else %>
-        <%= render "govuk_publishing_components/components/file_upload", {
+      <%= form.fields_for :consultation_participation, consultation_participation do |consultation_participation_form| %>
+        <%= render "govuk_publishing_components/components/input", {
           label: {
-            text: "File",
+            text: "Link URL",
+          },
+          name: "edition[consultation_participation_attributes][link_url]",
+          id: "edition_consultation_participation_link_url",
+          heading_size: "m",
+          value: consultation_participation.link_url,
+          error_items: errors_for(consultation_participation.errors, :link_url),
+        } %>
+
+        <%= render "govuk_publishing_components/components/input", {
+          label: {
+            text: "Email",
+          },
+          name: "edition[consultation_participation_attributes][email]",
+          id: "edition_consultation_participation_email",
+          heading_size: "m",
+          value: consultation_participation.email,
+          error_items: errors_for(consultation_participation.errors, :email),
+        } %>
+
+        <%= render "govuk_publishing_components/components/textarea", {
+          label: {
+            text: "Postal address",
             heading_size: "m",
           },
-          name: "edition[consultation_participation_attributes][consultation_response_form_attributes][consultation_response_form_data_attributes][file]",
-          id: "edition_consultation_participation_consultation_response_form_consultation_response_form_data_file",
-          error_items: errors_for(consultation_response_form_data.errors, :file) || errors_for(consultation_response_form.errors, :consultation_response_form_data),
+          name: "edition[consultation_participation_attributes][postal_address]",
+          id: "edition_consultation_participation_postal_address",
+          value: consultation_participation.postal_address,
+          error_items: errors_for(consultation_participation.errors, :postal_address),
+          rows: 4,
         } %>
-        <% if consultation_response_form_data.file_cache.present? %>
-          <%= hidden_field_tag "edition[consultation_participation_attributes][consultation_response_form_attributes][consultation_response_form_data_attributes][file_cache]", consultation_response_form_data.file_cache %>
 
-          <p class="govuk-body already-uploaded"><%= "#{File.basename(consultation_response_form_data.file_cache)} already uploaded" %></p>
+        <% consultation_response_form = consultation_participation.consultation_response_form || consultation_participation.build_consultation_response_form %>
+
+        <%= consultation_participation_form.fields_for :consultation_response_form, consultation_response_form do |response_form| %>
+          <%= render "govuk_publishing_components/components/input", {
+            label: {
+              text: "Downloadable response form title",
+            },
+            name: "edition[consultation_participation_attributes][consultation_response_form_attributes][title]",
+            id: "edition_consultation_participation_consultation_response_form_title",
+            heading_size: "m",
+            value: consultation_response_form.title,
+            error_items: errors_for(consultation_response_form.errors, :title),
+          } %>
+
+          <% consultation_response_form_data = consultation_response_form.consultation_response_form_data || consultation_response_form.build_consultation_response_form_data %>
+
+          <%= response_form.fields_for :consultation_response_form_data, consultation_response_form_data do |consultation_response_form_data_form| %>
+            <%= consultation_response_form_data_form.hidden_field  :file_cache, value: consultation_response_form_data.file_cache %>
+
+            <% if consultation_response_form.consultation_response_form_data.try(:persisted?) %>
+              <div class="attachment">
+                <p class="govuk-body">Current data: <%= link_to File.basename(consultation_response_form_data.file.path), consultation_response_form_data.file.url, class: "govuk-link" %></p>
+
+                <%= render "govuk_publishing_components/components/radio", {
+                  heading: "Actions:",
+                  name: "edition[consultation_participation_attributes][consultation_response_form_attributes][attachment_action]",
+                  id: "edition_consultation_participation_consultation_response_form_attachment_action",
+                  heading_size: "m",
+                  error_items: errors_for(consultation_response_form.errors, :attachment_action),
+                  items: [
+                    {
+                      value: "keep",
+                      text: "Keep",
+                      checked: ["keep", nil].include?(params.dig("edition", "consultation_participation_attributes", "consultation_response_form_attributes", "attachment_action")),
+                    },
+                    {
+                      value: "remove",
+                      text: "Remove",
+                      checked: params.dig("edition", "consultation_participation_attributes", "consultation_response_form_attributes", "attachment_action") == "remove",
+                    },
+                    {
+                      value: "replace",
+                      text: "Replace",
+                      checked: params.dig("edition", "consultation_participation_attributes", "consultation_response_form_attributes", "attachment_action") == "replace",
+                      conditional: render("govuk_publishing_components/components/file_upload", {
+                          label: {
+                            text: "Replacement"
+                          },
+                          name: "edition[consultation_participation_attributes][consultation_response_form_attributes][consultation_response_form_data_attributes][file]",
+                          id: "edition_consultation_participation_consultation_response_form_consultation_response_form_data_file",
+                          error_items: errors_for(consultation_response_form_data.errors, :file) || errors_for(consultation_response_form.errors, :consultation_response_form_data),
+                        }
+                      )
+                    }
+                  ]
+                } %>
+              </div>
+            <% else %>
+              <%= render "govuk_publishing_components/components/file_upload", {
+                label: {
+                  text: "File",
+                  heading_size: "m",
+                },
+                name: "edition[consultation_participation_attributes][consultation_response_form_attributes][consultation_response_form_data_attributes][file]",
+                id: "edition_consultation_participation_consultation_response_form_consultation_response_form_data_file",
+                error_items: errors_for(consultation_response_form_data.errors, :file) || errors_for(consultation_response_form.errors, :consultation_response_form_data),
+              } %>
+              <% if consultation_response_form_data.file_cache.present? %>
+                <p class="govuk-body already-uploaded"><%= "#{File.basename(consultation_response_form_data.file_cache)} already uploaded" %></p>
+              <% end %>
+            <% end %>
+          <% end %>
         <% end %>
       <% end %>
     <% end %>

--- a/app/views/admin/consultations/_form.html.erb
+++ b/app/views/admin/consultations/_form.html.erb
@@ -130,8 +130,8 @@
                       text: "Replacement"
                     },
                     name: "edition[consultation_participation_attributes][consultation_response_form_attributes][consultation_response_form_data_attributes][file]",
-                    id: "edition_consultation_participation_attributes_consultation_response_form_consultation_response_form_data_file",
-                    error_items: errors_for(consultation_response_form_data.errors, :file),
+                    id: "edition_consultation_participation_consultation_response_form_consultation_response_form_data_file",
+                    error_items: errors_for(consultation_response_form_data.errors, :file) || errors_for(consultation_response_form.errors, :consultation_response_form_data),
                   }
                 )
               }
@@ -146,7 +146,7 @@
           },
           name: "edition[consultation_participation_attributes][consultation_response_form_attributes][consultation_response_form_data_attributes][file]",
           id: "edition_consultation_participation_consultation_response_form_consultation_response_form_data_file",
-          error_items: errors_for(consultation_response_form_data.errors, :file),
+          error_items: errors_for(consultation_response_form_data.errors, :file) || errors_for(consultation_response_form.errors, :consultation_response_form_data),
         } %>
         <% if consultation_response_form_data.file_cache.present? %>
           <%= hidden_field_tag "edition[consultation_participation_attributes][consultation_response_form_attributes][consultation_response_form_data_attributes][file_cache]", consultation_response_form_data.file_cache %>

--- a/test/unit/app/models/call_for_evidence_response_form_test.rb
+++ b/test/unit/app/models/call_for_evidence_response_form_test.rb
@@ -10,6 +10,11 @@ class CallForEvidenceResponseFormTest < ActiveSupport::TestCase
     assert_not form.valid?
   end
 
+  test "should be invalid without call_for_evidence_response_form_data" do
+    call_for_evidence = build(:call_for_evidence_response_form, call_for_evidence_response_form_data: nil)
+    assert_not call_for_evidence.valid?
+  end
+
   test "does not destroy response form data when other response forms are associated with it" do
     call_for_evidence_response_form = create(:call_for_evidence_response_form)
     call_for_evidence_response_form_data = call_for_evidence_response_form.call_for_evidence_response_form_data

--- a/test/unit/app/models/consultation_response_form_test.rb
+++ b/test/unit/app/models/consultation_response_form_test.rb
@@ -10,6 +10,11 @@ class ConsultationResponseFormTest < ActiveSupport::TestCase
     assert_not form.valid?
   end
 
+  test "should be invalid without a consultation_response_form_data" do
+    form = build(:consultation_response_form, consultation_response_form_data: nil)
+    assert_not form.valid?
+  end
+
   test "does not destroy response form data when other response forms are associated with it" do
     consultation_response_form = create(:consultation_response_form)
     consultation_response_form_data = consultation_response_form.consultation_response_form_data


### PR DESCRIPTION
## Description

There's a bug at the moment, where you can persist a consultation/call for evidence response form without uploading a file. You can do this by adding a title to the `Downloadable response form title` field, but not adding a file.

This PR addresses this bug and does some minor refactors. It:

- adds a presence validation to the consultation & call of evidence response form to check that response form data is present
- ensures that the new validation error is displayed above the file input when triggered
- refactors the forms to use `fields_for` instead using a bunch of `hidden_field_tag`'s 
- handles building dependencies in the controller, rather than constructing them within the view

## Screenshots

### Call for evidence

<img width="490" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/17292e6f-ce26-4b65-a05d-bade03ff06f9">

<img width="506" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/9598c6b7-21ac-40c2-bb97-35475d4487f0">

### Consultations

<img width="580" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/849bdef5-9b63-467f-b19c-98d788d84097">

<img width="567" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/e4fb538d-29c6-4790-be5f-5ee334800f9b">

 ## Trello card 

https://trello.com/c/VY1YoFIa/1544-whitehall-crashes-when-consultation-response-form-file-is-missing

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
