### PR TITLE
Consultation date component migration

### DIFF
--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -9,9 +9,9 @@ class Consultation < Publicationesque
 
   validates :opening_at, presence: true, unless: ->(consultation) { consultation.can_have_some_invalid_data? }
   validates :closing_at, presence: true, unless: ->(consultation) { consultation.can_have_some_invalid_data? }
+  validates :closing_at, comparison: { greater_than: :opening_at, message: "must be after the opening on date" }, if: proc { |record| record.opening_at && record.closing_at }
   validates :external_url, presence: true, if: :external?
   validates :external_url, uri: true, allow_blank: true
-  validate :validate_closes_after_opens
   validate :validate_consultation_principles, unless: ->(consultation) { Edition::PRE_PUBLICATION_STATES.include? consultation.state }
 
   has_one :outcome, class_name: "ConsultationOutcome", foreign_key: :edition_id, dependent: :destroy
@@ -185,12 +185,6 @@ class Consultation < Publicationesque
   end
 
 private
-
-  def validate_closes_after_opens
-    if closing_at && opening_at && closing_at.to_date <= opening_at.to_date
-      errors.add :closing_at, "must be after the opening on date"
-    end
-  end
 
   def validate_consultation_principles
     unless read_consultation_principles

--- a/app/models/consultation_response.rb
+++ b/app/models/consultation_response.rb
@@ -1,9 +1,12 @@
 class ConsultationResponse < ApplicationRecord
   include Attachable
+  include DateValidation
 
   belongs_to :consultation, foreign_key: :edition_id
 
-  validates :published_on, recent_date: true
+  date_attributes(:published_on)
+
+  validates :published_on, comparison: { greater_than: Date.parse("1900-01-01"), message: "should be greater than 1900" }
   validates :summary, presence: { unless: :has_attachments }
   validates_with SafeHtmlValidator
   validates_with NoFootnotesInGovspeakValidator, attribute: :summary

--- a/app/models/date_validation.rb
+++ b/app/models/date_validation.rb
@@ -26,6 +26,10 @@ module DateValidation
     @invalid_date_attributes = Set.new if @invalid_date_attributes.nil?
     if date.is_a?(Hash)
       begin
+        # Rails will cast the year part of the date to 0 if the year input parameter is a non-numeric string
+        # This only seems to happen to the year part, other parts remain as strings
+        raise TypeError if (date[1]).zero?
+
         Date.new(date[1], date[2], date[3])
         @invalid_date_attributes.delete(attribute)
       rescue ArgumentError, TypeError

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -33,7 +33,7 @@ class Edition < ApplicationRecord
 
   include DateValidation
 
-  date_attributes :scheduled_publication, :first_published_at, :delivered_on
+  date_attributes :scheduled_publication, :first_published_at, :delivered_on, :opening_at, :closing_at
 
   has_many :editorial_remarks, dependent: :destroy
   has_many :edition_authors, dependent: :destroy

--- a/app/views/admin/consultation_responses/_form.html.erb
+++ b/app/views/admin/consultation_responses/_form.html.erb
@@ -1,24 +1,36 @@
+<% prefix = "consultation_#{consultation_response.singular_routing_symbol}" %>
+
 <%= form_for [:admin, consultation, consultation_response], url: [:admin, consultation, consultation_response.singular_routing_symbol] do |form| %>
   <%= render "govuk_publishing_components/components/fieldset", {
     legend_text: "Published on (required)",
     heading_size: "l"
   } do %>
-    <%= render "components/datetime_fields", {
-      prefix: "consultation_#{consultation_response.singular_routing_symbol}",
+    <%= render "components/datetime_fields_with_govuk_date_component", {
+      prefix: prefix,
       field_name: "published_on",
       date_only: true,
       error_items: errors_for(consultation_response.errors, :published_on),
       year: {
-        value: consultation_response.published_on&.year,
-        start_year: 1997,
-        end_year: Date.today.year + 5
+        value: params.dig("#{prefix}", "published_on(1i)") || consultation_response.published_on&.year,
+        id: "#{prefix}_published_on_1i",
+        name: "#{prefix}[published_on(1i)]]]",
+        label: "Year",
+        width: 4,
       },
       month: {
-        value: consultation_response.published_on&.month
+        value: params.dig("#{prefix}", "published_on(2i)") || consultation_response.published_on&.month,
+        id: "#{prefix}_published_on_2i",
+        name: "#{prefix}[published_on(2i)]]]",
+        label: "Month",
+        width: 2,
       },
       day: {
-        id: "consultation_#{consultation_response.singular_routing_symbol}_published_on",
-        value: consultation_response.published_on&.day
+        # id: "consultation_#{consultation_response.singular_routing_symbol}_published_on",
+        value: params.dig("#{prefix}", "published_on(3i)") || consultation_response.published_on&.day,
+        id: "#{prefix}_published_on_3i",
+        name: "#{prefix}[published_on(3i)]]]",
+        label: "Day",
+        width: 2,
       }
     } %>
   <% end %>

--- a/app/views/admin/consultations/_date_fields.html.erb
+++ b/app/views/admin/consultations/_date_fields.html.erb
@@ -4,32 +4,39 @@
     heading_size: "l",
     id: "edition_opening_at",
   } do %>
-    <%= render "components/datetime_fields", {
+    <%= render "components/datetime_fields_with_govuk_date_component", {
         field_name: "opening_at",
         prefix: "edition",
         error_items: errors_for(edition.errors, :opening_at),
-        date_hint: "For example, 01 August 2022",
+        date_hint: "For example, 01 08 2022",
         time_hint: "For example, 09:30 or 19:30",
         year: {
-          value: edition.opening_at&.year,
-          start_year: 1997,
-          end_year: Date.today.year + 5,
+          value: params.dig("edition", "opening_at(1i)") || edition.opening_at&.year,
           id: "edition_opening_at_1i",
+          name: "edition[opening_at(1i)]]]",
+          label: "Year",
+          width: 4,
         },
         month: {
-          value: edition.opening_at&.month,
+          value: params.dig("edition", "opening_at(2i)") || edition.opening_at&.month,
           id: "edition_opening_at_2i",
+          name: "edition[opening_at(2i)]]]",
+          label: "Month",
+          width: 2,
         },
         day: {
-          value: edition.opening_at&.day,
+          value: params.dig("edition", "opening_at(3i)") || edition.opening_at&.day,
           id: "edition_opening_at_3i",
+          name: "edition[opening_at(3i)]]]",
+          label: "Day",
+          width: 2,
         },
         hour: {
-          value: edition.opening_at&.hour,
+          value: params.dig("edition", "scheduled_publication(4i)")&.to_i || edition.opening_at&.hour,
           id: "edition_opening_at_4i",
         },
         minute: {
-          value: edition.opening_at&.min,
+          value: params.dig("edition", "scheduled_publication(5i)")&.to_i || edition.opening_at&.min,
           id: "edition_opening_at_5i",
         },
       }
@@ -43,32 +50,39 @@
     heading_size: "l",
     id: "edition_closing_at",
   } do %>
-    <%= render "components/datetime_fields", {
+    <%= render "components/datetime_fields_with_govuk_date_component", {
         field_name: "closing_at",
         prefix: "edition",
         error_items: errors_for(edition.errors, :closing_at),
-        date_hint: "For example, 01 August 2022",
+        date_hint: "For example, 01 08 2022",
         time_hint: "For example, 09:30 or 19:30",
         year: {
-          value: edition.closing_at&.year,
-          start_year: 1997,
-          end_year: Date.today.year + 5,
+          value: params.dig("edition", "closing_at(1i)") || edition.closing_at&.year,
           id: "edition_closing_at_1i",
+          name: "edition[closing_at(1i)]]]",
+          label: "Year",
+          width: 4,
         },
         month: {
-          value: edition.closing_at&.month,
+          value: params.dig("edition", "closing_at(2i)") || edition.closing_at&.month,
           id: "edition_closing_at_2i",
+          name: "edition[closing_at(2i)]]]",
+          label: "Month",
+          width: 2,
         },
         day: {
-          value: edition.closing_at&.day,
+          value: params.dig("edition", "closing_at(3i)") || edition.closing_at&.day,
           id: "edition_closing_at_3i",
+          name: "edition[closing_at(3i)]]]",
+          label: "Day",
+          width: 2,
         },
         hour: {
-          value: edition.closing_at&.hour,
+          value: params.dig("edition", "scheduled_publication(4i)")&.to_i || edition.closing_at&.hour,
           id: "edition_closing_at_4i",
         },
         minute: {
-          value: edition.closing_at&.min,
+          value: params.dig("edition", "scheduled_publication(5i)")&.to_i || edition.closing_at&.min,
           id: "edition_closing_at_5i",
         },
       }

--- a/app/views/admin/consultations/_required_fields_for_imported_editions.html.erb
+++ b/app/views/admin/consultations/_required_fields_for_imported_editions.html.erb
@@ -1,1 +1,0 @@
-<%= render partial: 'legacy_date_fields', locals: { form: form } %>

--- a/features/step_definitions/consultation_steps.rb
+++ b/features/step_definitions/consultation_steps.rb
@@ -10,11 +10,11 @@ When(/^I draft a new "(.*?)" language consultation "(.*?)"$/) do |locale, title|
   fill_in "Email", with: "participate@gov.uk"
 
   within "#edition_opening_at" do
-    fill_in_date_and_time_field(1.day.ago.to_s)
+    fill_in_govuk_publishing_date_and_time_field(1.day.ago.to_s)
   end
 
   within "#edition_closing_at" do
-    fill_in_date_and_time_field(6.days.from_now.to_s)
+    fill_in_govuk_publishing_date_and_time_field(6.days.from_now.to_s)
   end
 
   check "Does not apply to Wales"

--- a/features/support/datetime_field_helper.rb
+++ b/features/support/datetime_field_helper.rb
@@ -9,6 +9,17 @@ module DatetimeFieldHelper
     select date.strftime("%M"), from: "Minute"
   end
 
+  def fill_in_govuk_publishing_date_and_time_field(date)
+    if date.is_a? String
+      date = Time.zone.parse(date)
+    end
+
+    fill_in_govuk_publishing_date_fields(date)
+
+    select date.strftime("%H"), from: "Hour"
+    select date.strftime("%M"), from: "Minute"
+  end
+
   def fill_in_date_fields(date)
     date = Time.zone.parse(date)
 

--- a/test/functional/admin/consultations_controller_test.rb
+++ b/test/functional/admin/consultations_controller_test.rb
@@ -25,8 +25,10 @@ class Admin::ConsultationsControllerTest < ActionController::TestCase
 
     assert_select "form#new_edition" do
       assert_select "textarea[name='edition[summary]']"
-      assert_select "select[name*='edition[opening_at']", count: 5
-      assert_select "select[name*='edition[closing_at']", count: 5
+      assert_select "input[name*='edition[opening_at']", count: 3
+      assert_select "select[name*='edition[opening_at']", count: 2
+      assert_select "input[name*='edition[closing_at']", count: 3
+      assert_select "select[name*='edition[closing_at']", count: 2
       assert_select "input[type='text'][name='edition[consultation_participation_attributes][link_url]']"
       assert_select "input[type='text'][name='edition[consultation_participation_attributes][email]']"
       assert_select "input[type='text'][name='edition[consultation_participation_attributes][consultation_response_form_attributes][title]']"
@@ -156,8 +158,10 @@ class Admin::ConsultationsControllerTest < ActionController::TestCase
 
     assert_select "form#edit_edition" do
       assert_select "textarea[name='edition[summary]']"
-      assert_select "select[name*='edition[opening_at']", count: 5
-      assert_select "select[name*='edition[closing_at']", count: 5
+      assert_select "input[name*='edition[opening_at']", count: 3
+      assert_select "select[name*='edition[opening_at']", count: 2
+      assert_select "input[name*='edition[closing_at']", count: 3
+      assert_select "select[name*='edition[closing_at']", count: 2
       assert_select "input[type='text'][name='edition[consultation_participation_attributes][link_url]']"
       assert_select "input[type='text'][name='edition[consultation_participation_attributes][email]']"
       assert_select "textarea[name='edition[consultation_participation_attributes][postal_address]']"


### PR DESCRIPTION
### What

Migrate to GOVUK publishing date input component for consultation and consultation response forms. 

Also includes moving away from custom validation of open/close relative dates and a workaround for some peculiar Rails behaviour around handling non-numeric string inputs for the year fields.

### Why

User research indicates that the GOVUK publishing component date input provides a superior user experience to the Rails date helper component

### Screenshots

Before:

Consultation Opening Date
![Screenshot 2023-09-18 at 16 46 18](https://github.com/alphagov/whitehall/assets/137083285/a1eaa738-33fc-4b6b-bf8e-b32c6d621115)

Consultation Closing Date
![Screenshot 2023-09-18 at 16 46 27](https://github.com/alphagov/whitehall/assets/137083285/3705125d-e455-49cf-ba88-46a91c0df9d8)

Consultation Response Published On
![Screenshot 2023-09-18 at 16 46 43](https://github.com/alphagov/whitehall/assets/137083285/900cdaf1-e386-4d47-9bfa-198731ae9917)

After (with validation errors present):

Consultation Opening Date
![Screenshot 2023-09-18 at 16 38 50](https://github.com/alphagov/whitehall/assets/137083285/103fed41-ed06-45f9-a519-eece4fa131ef)

Consultation Closing Date
![Screenshot 2023-09-18 at 16 38 55](https://github.com/alphagov/whitehall/assets/137083285/50bac2b1-0379-4df9-8e3c-37a9ba475962)

Consultation Response Published On
![Screenshot 2023-09-18 at 16 49 11](https://github.com/alphagov/whitehall/assets/137083285/d2511d9c-c32f-44d6-a08d-f3e6589b2319)
