### PR TITLE
Restore default access_and_opening_time for worldwide offices

### DIFF
--- a/db/data_migration/20230918174022_restore_default_access_and_opening_times_to_worldwide_offices.rb
+++ b/db/data_migration/20230918174022_restore_default_access_and_opening_times_to_worldwide_offices.rb
@@ -1,0 +1,16 @@
+## When we removed default_access_and_opening_times from worlwide orgs, some
+## offices which didn't have a custom access_and_opening_time weren't backfilled
+## with the default.
+## Fortunately, no office where access and opening times are nil have subsequently been
+## updated so we can restore it, by retrieving the Office from Publishing API
+## The PR was merged at 8am on 23/8/2023 so that's the date i've chosen to use here.
+## It will also mean if for some reason this is run in the future all, offices that
+## have been updated since then won't be affected.
+
+offices = WorldwideOffice.where(updated_at: ..Time.zone.local(2023, 8, 23, 8, 0, 0), access_and_opening_times: nil)
+
+offices.find_each(batch_size: 10) do |office|
+  content_item = Services.publishing_api.get_content(office.content_id).to_h
+  access_and_opening_times = content_item.dig("details", "access_and_opening_times")
+  office.update_column("access_and_opening_times", access_and_opening_times) if access_and_opening_times != office.access_and_opening_times
+end


### PR DESCRIPTION
## Description

When we removed default_access_and_opening_times from worldwide orgs, some offices which didn't have a custom access_and_opening_time weren't backfilled with the default value that lived on the worldwide organisation.

This means thats a small subset (42) worldwide offices have an access_and_opening_time of nil, when the worldwide organisation had a default.

Fortunately, none of these offices have been updated since that PR being merged.

We can backfill these with the correct value by retrieving the WorldwideOffice from Publishing API and if the access_and_opening_time is present/different on the object to the one we have in our database then we know that it is one that we missed in the backfill.

We can be confident of this for 2 reasons:

1. On save the object is republished
2. No updates have occurred since the PR was merged for any of these offices.

The PR was merged at 8am on 23/8/2023 so that's the date i've chosen to use here. It will also mean if for some reason this is run in the future all, offices that have been updated since then won't be affected.

## Code i ran to investigate


```
WorldwideOffice.where(access_and_opening_times: nil).count
=> 222

WorldwideOffice.where(updated_at: ..DateTime.new(2023,8,23,8), access_and_opening_times: nil)
=> 222


offices = WorldwideOffice.where(updated_at: ..DateTime.new(2023,8,23,8), access_and_opening_times: nil)

offices.find_each(batch_size:10).reject do |office|
  content_item = Services.publishing_api.get_content(office.content_id).to_h
  content_item.dig("details", "access_and_opening_times") == office.access_and_opening_times
end.count
=> 42
```

## PR that removed default access and opening times from worldwide orgs

https://github.com/alphagov/whitehall/pull/8149

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
