### PR TITLE
Enable use non legacy endpoints for file attachments

### DIFF
--- a/app/controllers/admin/attachments_controller.rb
+++ b/app/controllers/admin/attachments_controller.rb
@@ -34,7 +34,7 @@ class Admin::AttachmentsController < Admin::BaseController
     attachment.attributes = attachment_params
     message = "Attachment '#{attachment.title}' updated"
     if attachment.is_a?(FileAttachment)
-      attachment.attachment_data.use_non_legacy_endpoints = use_non_legacy_endpoints
+      attachment.attachment_data.use_non_legacy_endpoints = use_non_legacy_endpoints unless attachment.attachment_data.csv?
 
       attachment.attachment_data.attachable = attachable
       if attachment.filename_changed? && attachable.allows_inline_attachments?
@@ -104,7 +104,7 @@ private
     FileAttachment.new(attachment_params).tap do |file_attachment|
       file_attachment.build_attachment_data unless file_attachment.attachment_data
       file_attachment.attachment_data.attachable = attachable
-      file_attachment.attachment_data.use_non_legacy_endpoints = use_non_legacy_endpoints?
+      file_attachment.attachment_data.use_non_legacy_endpoints = use_non_legacy_endpoints? unless file_attachment.attachment_data.csv?
     end
   end
 
@@ -203,7 +203,7 @@ private
   end
 
   def use_non_legacy_endpoints?
-    current_user.can_use_non_legacy_endpoints?
+    true
   end
 
   def clear_file_cache(attachment_params)

--- a/app/controllers/admin/bulk_uploads_controller.rb
+++ b/app/controllers/admin/bulk_uploads_controller.rb
@@ -26,7 +26,7 @@ class Admin::BulkUploadsController < Admin::BaseController
     @bulk_upload.attachments_attributes = create_params[:attachments_attributes]
     @bulk_upload.attachments.each do |attachment|
       attachment.attachment_data.attachable = @edition
-      attachment.attachment_data.use_non_legacy_endpoints = use_non_legacy_endpoints?
+      attachment.attachment_data.use_non_legacy_endpoints = use_non_legacy_endpoints? unless attachment.attachment_data.csv?
     end
     if @bulk_upload.save_attachments
       redirect_to admin_edition_attachments_path(@edition)
@@ -46,7 +46,7 @@ private
   end
 
   def use_non_legacy_endpoints?
-    current_user.can_use_non_legacy_endpoints?
+    true
   end
 
   def create_params

--- a/features/support/asset_manager_helper.rb
+++ b/features/support/asset_manager_helper.rb
@@ -4,5 +4,9 @@ Before do
   asset_manager = stub_everything("asset-manager")
   asset_details = { "id" => "http://asset-manager/assets/asset-id" }
   asset_manager.stubs(:whitehall_asset).returns(asset_details)
+  non_legacy_asset_details = { "id" => "http://asset-manager/assets/asset-id", "name" => "filename.pdf" }
+  asset_manager.stubs(:create_asset).returns(non_legacy_asset_details)
+  asset_manager.stubs(:asset).returns(non_legacy_asset_details)
+
   Services.stubs(:asset_manager).returns(asset_manager)
 end

--- a/test/functional/admin/attachments_controller_test.rb
+++ b/test/functional/admin/attachments_controller_test.rb
@@ -169,16 +169,7 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
     assert_equal 0, attachable.reload.attachments.size
   end
 
-  test "use_non_legacy_endpoints is false - POST :create triggers a job to be queued to store the attachment in Asset Manager" do
-    attachment = valid_file_attachment_params
-
-    AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(anything, anything, anything, @edition.class.to_s, @edition.id, [@edition.auth_bypass_id])
-
-    post :create, params: { edition_id: @edition.id, type: "file", attachment: }
-  end
-
-  test "use_non_legacy_endpoints is true - POST :create triggers a job to be queued to store the attachment in Asset Manager" do
-    login_as_use_non_legacy_endpoints_user :gds_editor
+  test "POST :create triggers a job to be queued to store the attachment in Asset Manager" do
     attachment = valid_file_attachment_params
     variant = Asset.variants[:original]
     model_type = AttachmentData.to_s
@@ -373,7 +364,6 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
   end
 
   test "use_non_legacy_endpoints is true -  PUT :update with a file triggers a job to be queued to store the attachment in Asset Manager" do
-    login_as_use_non_legacy_endpoints_user :gds_editor
     attachment = create(:file_attachment_with_assets, attachable: @edition)
     variant = Asset.variants[:original]
     model_type = attachment.attachment_data.class.to_s
@@ -444,27 +434,7 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
     assert_equal "whitepaper.pdf", attachment.filename
   end
 
-  test "use_non_legacy_endpoints is false - POST :discards file_cache when a file is provided" do
-    greenpaper_pdf = upload_fixture("greenpaper.pdf", "application/pdf")
-    whitepaper_pdf = upload_fixture("whitepaper.pdf", "application/pdf")
-    whitepaper_attachment_data = build(:attachment_data, file: whitepaper_pdf)
-
-    AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(regexp_matches(/whitepaper/), regexp_matches(/whitepaper/), anything, anything, anything, anything).never
-    AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(regexp_matches(/greenpaper/), regexp_matches(/greenpaper/), anything, anything, anything, anything).times(2)
-
-    post :create,
-         params: {
-           edition_id: @edition,
-           type: "file",
-           attachment: {
-             title: "New title",
-             attachment_data_attributes: { file: greenpaper_pdf, file_cache: whitepaper_attachment_data.file_cache },
-           },
-         }
-  end
-
-  test "use_non_legacy_endpoints is true - POST :discards file_cache when a file is provided" do
-    login_as_use_non_legacy_endpoints_user :gds_editor
+  test "POST :discards file_cache when a file is provided" do
     greenpaper_pdf = upload_fixture("greenpaper.pdf", "application/pdf")
     whitepaper_pdf = upload_fixture("whitepaper.pdf", "application/pdf")
     whitepaper_attachment_data = build(:attachment_data, file: whitepaper_pdf)
@@ -506,7 +476,6 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
   end
 
   test "use_non_legacy_endpoints is true - PUT :discards file_cache when a file is provided" do
-    login_as_use_non_legacy_endpoints_user :gds_editor
     attachment = create(:file_attachment_with_assets, attachable: @edition)
     attachment_data = attachment.attachment_data
     greenpaper_pdf = upload_fixture("greenpaper.pdf", "application/pdf")

--- a/test/unit/app/workers/asset_manager_attachment_metadata_worker_test.rb
+++ b/test/unit/app/workers/asset_manager_attachment_metadata_worker_test.rb
@@ -25,13 +25,19 @@ class AssetManagerAttachmentMetadataWorkerTest < ActiveSupport::TestCase
     end
 
     context "attachment data has missing assets" do
-      it "does not call updater nor deleter" do
+      before do
         attachment_data.use_non_legacy_endpoints = true
         attachment_data.save!
+      end
 
+      it "does not call updater" do
         AssetManager::AttachmentUpdater.expects(:call).never
 
-        AssetManager::AttachmentDeleter.expects(:call).never
+        worker.perform(attachment_data.id)
+      end
+
+      it "calls deleter" do
+        AssetManager::AttachmentDeleter.expects(:call)
 
         worker.perform(attachment_data.id)
       end


### PR DESCRIPTION
This is the first release of the epic related to migrating `whitehall` to use non-legacy endpoints in `asset-manager`.

We are enabling the `use_non_legacy_endpoints` for all attachments that belong to an `AttachmentData`. The scope of this change includes all document types that include the `Attachable` concern. 

Whilst `csv` files pertain to this scope, they are a special case due to the `/preview` functionality so they will be released separately.

[Trello card](https://trello.com/c/lnpH3zBG/100-task-roll-out-attachmentdata-to-all-users-except-for-csvs)
