### PR TITLE
Ensure parameter state is maintained for consultation time inputs

### DIFF
--- a/app/views/admin/consultations/_date_fields.html.erb
+++ b/app/views/admin/consultations/_date_fields.html.erb
@@ -32,11 +32,11 @@
           width: 2,
         },
         hour: {
-          value: params.dig("edition", "scheduled_publication(4i)")&.to_i || edition.opening_at&.hour,
+          value: params.dig("edition", "opening_at(4i)")&.to_i || edition.opening_at&.hour,
           id: "edition_opening_at_4i",
         },
         minute: {
-          value: params.dig("edition", "scheduled_publication(5i)")&.to_i || edition.opening_at&.min,
+          value: params.dig("edition", "opening_at(5i)")&.to_i || edition.opening_at&.min,
           id: "edition_opening_at_5i",
         },
       }
@@ -78,11 +78,11 @@
           width: 2,
         },
         hour: {
-          value: params.dig("edition", "scheduled_publication(4i)")&.to_i || edition.closing_at&.hour,
+          value: params.dig("edition", "closing_at(4i)")&.to_i || edition.closing_at&.hour,
           id: "edition_closing_at_4i",
         },
         minute: {
-          value: params.dig("edition", "scheduled_publication(5i)")&.to_i || edition.closing_at&.min,
+          value: params.dig("edition", "closing_at(5i)")&.to_i || edition.closing_at&.min,
           id: "edition_closing_at_5i",
         },
       }


### PR DESCRIPTION
Fixes a bug where the time input on the opening and closing date fields were losing the user's input in the event of a validation error.
