### PR TITLE
Spike out using a form object to update an editions change note

### DIFF
--- a/app/controllers/admin/draft_edition_change_notes_controller.rb
+++ b/app/controllers/admin/draft_edition_change_notes_controller.rb
@@ -1,0 +1,36 @@
+class Admin::DraftEditionChangeNotesController < Admin::BaseController
+  before_action :find_edition, :enforce_permissions!, :redirect_to_show_page_unless_editable
+  layout "design_system"
+
+  def edit
+    @change_note_form = ChangeNoteForm.build_from_edition(@edition)
+  end
+
+  def update
+    @change_note_form = ChangeNoteForm.new(change_note_params)
+
+    if @change_note_form.save!(@edition)
+      redirect_to admin_edition_path(@edition), notice: "Change note updated successfully"
+    else
+      render :edit
+    end
+  end
+
+private
+
+  def find_edition
+    @edition = Edition.find(params[:edition_id])
+  end
+
+  def enforce_permissions!
+    enforce_permission!(:update, @edition)
+  end
+
+  def redirect_to_show_page_unless_editable
+    redirect_to admin_edition_path(@edition) unless @edition.editable?
+  end
+
+  def change_note_params
+    params.require(:change_note_form).permit(:minor_change, :change_note)
+  end
+end

--- a/app/forms/change_note_form.rb
+++ b/app/forms/change_note_form.rb
@@ -1,7 +1,9 @@
 class ChangeNoteForm
   include ActiveModel::Model
+  include ActiveModel::Attributes
 
-  attr_accessor :minor_change, :change_note
+  attribute :minor_change, :boolean, default: false
+  attribute :change_note
 
   validates :minor_change, inclusion: { in: [true, false] }
   validates :change_note, presence: true, if: :major_version?
@@ -14,8 +16,6 @@ class ChangeNoteForm
   end
 
   def save!(edition)
-    self.minor_change = ActiveModel::Type::Boolean.new.cast(minor_change)
-
     return false unless valid?
 
     if major_version?

--- a/app/forms/change_note_form.rb
+++ b/app/forms/change_note_form.rb
@@ -1,0 +1,39 @@
+class ChangeNoteForm
+  include ActiveModel::Model
+
+  attr_accessor :minor_change, :change_note
+
+  validates :minor_change, inclusion: { in: [true, false] }
+  validates :change_note, presence: true, if: :major_version?
+
+  def self.build_from_edition(edition)
+    new(
+      minor_change: edition.minor_change,
+      change_note: edition.change_note,
+    )
+  end
+
+  def save!(edition)
+    self.minor_change = ActiveModel::Type::Boolean.new.cast(minor_change)
+
+    return false unless valid?
+
+    if major_version?
+      edition.update!(
+        change_note:,
+        minor_change:,
+      )
+    else
+      edition.update!(
+        change_note: nil,
+        minor_change:,
+      )
+    end
+  end
+
+private
+
+  def major_version?
+    minor_change == false
+  end
+end

--- a/app/views/admin/draft_edition_change_notes/edit.html.erb
+++ b/app/views/admin/draft_edition_change_notes/edit.html.erb
@@ -1,0 +1,50 @@
+<% content_for :page_title, "#{@edition.title}: Change note" %>
+<% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @change_note_form)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @change_note_form, url: admin_edition_update_change_note_path(@edition), method: :patch do |form| %>
+      <%= render "govuk_publishing_components/components/radio", {
+        heading: "Change note",
+        name: "change_note_form[minor_change]",
+        id: "change_note_form_minor_change",
+        heading: "Change note",
+        heading_caption: @edition.title,
+        heading_level: 1,
+        error_items: errors_for(@change_note_form.errors, :minor_change),
+        items: [
+          {
+            value: false,
+            text: "Yes - information has been added, updated or removed",
+            hint_text: "A change note will be published on the page and emailed to users subscribed to email alerts. The ‘last updated’ date will change.",
+            bold: true,
+            checked: @change_note_form.minor_change == false,
+            conditional: (render "govuk_publishing_components/components/textarea", {
+              label: {
+                text: "Describe the change for users",
+                bold: true,
+              },
+              name: "change_note_form[change_note]",
+              id: "change_note_form_change_note",
+              error_message: errors_for_input(@change_note_form.errors, :change_note),
+              value: @change_note_form.change_note,
+              hint: (tag.p('Tell users what has changed, where and why. Write in full sentences, leading with the most important words. For example, "College A has been removed from the registered sponsors list because its licence has been suspended."', class: "govuk-!-margin-bottom-0 govuk-!-margin-top-0") +
+                    link_to("Guidance about change notes (opens in a new tab)", "https://www.gov.uk/guidance/content-design/writing-for-gov-uk#change-notes", target: "_blank", class: "govuk-link")).html_safe
+            })
+          },
+          {
+            value: true,
+            text: "No – it’s a minor edit that does not change the meaning",
+            bold: true,
+            hint_text: "This includes fixing a typo or broken link, a style change or similar. Users signed up to email alerts will not get notified and the ‘last updated’ date will not change.",
+            checked: @change_note_form.minor_change,
+          }
+        ]
+      } %>
+
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Save"
+      } %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/editions/show/_main.html.erb
+++ b/app/views/admin/editions/show/_main.html.erb
@@ -40,6 +40,12 @@
         margin_bottom: 3,
       } %>
 
+      <% if @edition.editable? %>
+        <p class="govuk-body">
+          <%= link_to "Modify change note", admin_edition_edit_change_note_path(@edition), class: "govuk-link" %>
+        </p>
+      <% end %>
+
       <p class="govuk-body-lead">
         <% if @edition.minor_change? %>
           Minor change

--- a/config/locales/en/admin/change_note_form.yml
+++ b/config/locales/en/admin/change_note_form.yml
@@ -1,0 +1,11 @@
+en:
+  activemodel:
+      errors:
+        models:
+          change_note_form:
+            attributes:
+              minor_change:
+                inclusion: Select whether this is a major or minor update
+              change_note:
+                blank: "Enter a change note"
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -172,6 +172,9 @@ Whitehall::Application.routes.draw do
         get :edit_slug, on: :member, controller: :edition_slug
         patch :update_slug, on: :member, controller: :edition_slug
 
+        get :edit_change_note, to: "draft_edition_change_notes#edit"
+        patch :update_change_note, to: "draft_edition_change_notes#update"
+
         collection do
           post :export
           get :confirm_export

--- a/test/forms/change_note_form_test.rb
+++ b/test/forms/change_note_form_test.rb
@@ -1,0 +1,53 @@
+require "test_helper"
+
+class ChangeNoteFormTest < ActiveSupport::TestCase
+  include ActionDispatch::TestProcess
+
+  test "is invalid when minor_change is not present" do
+    change_note_form = ChangeNoteForm.new(change_note: "This is present", minor_change: nil)
+    assert_not change_note_form.valid?
+  end
+
+  test "is invalid when it is a major change and change_note is not present" do
+    change_note_form = ChangeNoteForm.new(change_note: nil, minor_change: false)
+    assert_not change_note_form.valid?
+  end
+
+  test "is valid when it is a minor change and a change_note is not present" do
+    change_note_form = ChangeNoteForm.new(change_note: nil, minor_change: true)
+    assert change_note_form.valid?
+  end
+
+  test "is valid when it is a major change and change_note is present" do
+    change_note_form = ChangeNoteForm.new(change_note: "This is present", minor_change: false)
+    assert change_note_form.valid?
+  end
+
+  test "#save returns false and adds errors to the form object when invalid" do
+    change_note_form = ChangeNoteForm.new
+    edition = build(:edition)
+
+    assert_equal false, change_note_form.save!(edition)
+    assert_equal ["Minor change Select whether this is a major or minor update"], change_note_form.errors.full_messages
+  end
+
+  test "#save updates the edition successfully when it is a major change and a change note is present" do
+    edition = create(:edition)
+    change_note_form = ChangeNoteForm.new(change_note: "This is present", minor_change: "false")
+
+    change_note_form.save!(edition)
+
+    assert_equal "This is present", edition.reload.change_note
+    assert_equal false, edition.minor_change
+  end
+
+  test "#save updates the edition successfully and sets the change note to nil when it is a minor change" do
+    edition = create(:edition, change_note: "Lots of changes.")
+    change_note_form = ChangeNoteForm.new(change_note: "I'm still present", minor_change: "true")
+
+    change_note_form.save!(edition)
+
+    assert_equal nil, edition.reload.change_note
+    assert_equal true, edition.minor_change
+  end
+end

--- a/test/forms/change_note_form_test.rb
+++ b/test/forms/change_note_form_test.rb
@@ -28,7 +28,7 @@ class ChangeNoteFormTest < ActiveSupport::TestCase
     edition = build(:edition)
 
     assert_equal false, change_note_form.save!(edition)
-    assert_equal ["Minor change #{I18n.t('activemodel.errors.models.change_note_form.attributes.minor_change.inclusion')}"], change_note_form.errors.full_messages
+    assert_equal ["Change note #{I18n.t('activemodel.errors.models.change_note_form.attributes.change_note.blank')}"], change_note_form.errors.full_messages
   end
 
   test "#save updates the edition successfully when it is a major change and a change note is present" do

--- a/test/forms/change_note_form_test.rb
+++ b/test/forms/change_note_form_test.rb
@@ -32,22 +32,20 @@ class ChangeNoteFormTest < ActiveSupport::TestCase
   end
 
   test "#save updates the edition successfully when it is a major change and a change note is present" do
-    edition = create(:edition)
+    edition = build_stubbed(:edition)
     change_note_form = ChangeNoteForm.new(change_note: "This is present", minor_change: "false")
 
-    change_note_form.save!(edition)
+    edition.expects(:update!).with(change_note: "This is present", minor_change: false)
 
-    assert_equal "This is present", edition.reload.change_note
-    assert_equal false, edition.minor_change
+    change_note_form.save!(edition)
   end
 
   test "#save updates the edition successfully and sets the change note to nil when it is a minor change" do
-    edition = create(:edition, change_note: "Lots of changes.")
+    edition = build_stubbed(:edition, change_note: "Lots of changes.")
     change_note_form = ChangeNoteForm.new(change_note: "I'm still present", minor_change: "true")
 
-    change_note_form.save!(edition)
+    edition.expects(:update!).with(change_note: nil, minor_change: true)
 
-    assert_equal nil, edition.reload.change_note
-    assert_equal true, edition.minor_change
+    change_note_form.save!(edition)
   end
 end

--- a/test/forms/change_note_form_test.rb
+++ b/test/forms/change_note_form_test.rb
@@ -28,7 +28,7 @@ class ChangeNoteFormTest < ActiveSupport::TestCase
     edition = build(:edition)
 
     assert_equal false, change_note_form.save!(edition)
-    assert_equal ["Minor change Select whether this is a major or minor update"], change_note_form.errors.full_messages
+    assert_equal ["Minor change #{I18n.t('activemodel.errors.models.change_note_form.attributes.minor_change.inclusion')}"], change_note_form.errors.full_messages
   end
 
   test "#save updates the edition successfully when it is a major change and a change note is present" do

--- a/test/functional/admin/draft_edition_change_notes_controller_test.rb
+++ b/test/functional/admin/draft_edition_change_notes_controller_test.rb
@@ -1,0 +1,56 @@
+require "test_helper"
+
+class Admin::DraftEditionChangeNotesControllerTest < ActionController::TestCase
+  include Admin::EditionRoutesHelper
+
+  setup do
+    login_as :gds_admin
+    @edition = create(:edition, change_note: "Change note", minor_change: false)
+  end
+
+  should_be_an_admin_controller
+
+  test "GET :edit assigns the correct " do
+    get :edit, params: { edition_id: @edition.id }
+
+    assert_response :success
+    assert_equal @edition, assigns(:edition)
+    assert_equal "Change note", assigns(:change_note_form).change_note
+    assert_equal false, assigns(:change_note_form).minor_change
+  end
+
+  test "PATCH :update updates an editions change note and version" do
+    patch :update,
+          params: {
+            edition_id: @edition.id,
+            change_note_form: {
+              change_note: "New change note!",
+              minor_change: "false",
+            },
+          }
+
+    assert_equal "New change note!", @edition.reload.change_note
+  end
+
+  test "PATCH :update re-renders the :edit template when invalid data is passed" do
+    patch :update,
+          params: {
+            edition_id: @edition.id,
+            change_note_form: {
+              change_note: nil,
+              minor_change: "false",
+            },
+          }
+
+    assert_template :edit
+  end
+
+  %i[edit update].each do |action_method|
+    test "#{action_method} redirects back to the document summary page if edition is not editable" do
+      edition = create(:published_edition)
+
+      get action_method, params: { edition_id: edition.id }
+      assert_redirected_to @controller.admin_edition_path(edition)
+    end
+  end
+end


### PR DESCRIPTION
## Description

This is a first attempt at implementing [form objects](https://dev.to/drbragg/rails-design-patterns-form-object-4d47). These will help us simplify building out editing over multiple pages.

I chose to use change notes for the spike as it's fairly small and self contained. It's also easily linked to from the document summary page.

One thing that i ran into that was slightly inconvenient in that there's already an `edition_change_notes_controller` which handles updating change notes for published editions. This was built in as it was a common 2ndline task.

I've got around this by naming this controller the `DraftEditionChangeNotesController` but tbh i think it probably makes more sense to rename the existing controller to something like `gds_admin_change_note_controller` or something similar and using `EditionChangeNotesController` for this. Or even better, start using subfolders so it could live in

`admin/editions/change_note_controller.rb` 

If we use subfolders i think it would probably be part of a larger refactor though.

For now though since this is mainly proof of concept, i've gone with the path of least resistance.

Likewise edit view is essentially copy paste of the code used in the edit page. I've not refactored it into a partial though, but it should be if we decide to go ahead and use this as some point.

## Screenshots

<img width="576" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/58123cd3-c1b6-4266-9f9e-8a5c21219561">

<img width="769" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/93cd75e5-c912-4f9d-a5ff-5a70f374ac3f">

<img width="812" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/25cec972-35f8-45c3-b61c-1d9f9a1724d8">

## Trello card

https://trello.com/c/DKQeargF/1716-spike-out-using-form-objects-to-perform-partial-validation-of-edition-input



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
