### PR TITLE
Add a missing "govuk-link" class

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -320,8 +320,8 @@ private
       notice = "Your document has been saved"
       html_safe = false
     else
-      link_path = edit_admin_edition_tags_path(@edition)
-      notice = "Your document has been saved. You need to #{view_context.link_to 'add topic tags', link_path} before you can publish this document."
+      add_topic_tags = view_context.link_to("add topic tags", edit_admin_edition_tags_path(@edition), class: "govuk-link")
+      notice = "Your document has been saved. You need to #{add_topic_tags} before you can publish this document."
       html_safe = true
     end
     { flash: { notice:, html_safe: } }

--- a/test/functional/admin/corporate_information_pages_controller_test.rb
+++ b/test/functional/admin/corporate_information_pages_controller_test.rb
@@ -39,7 +39,7 @@ class Admin::CorporateInformationPagesControllerTest < ActionController::TestCas
 
     assert page = @organisation.corporate_information_pages.last
     assert_redirected_to @controller.admin_edition_path(edition)
-    expected_message = "Your document has been saved. You need to <a href=\"/government/admin/editions/#{edition.id}/tags/edit\">add topic tags</a> before you can publish this document."
+    expected_message = "Your document has been saved. You need to <a class=\"govuk-link\" href=\"/government/admin/editions/#{edition.id}/tags/edit\">add topic tags</a> before you can publish this document."
     assert_equal expected_message, flash[:notice]
     assert_equal corporate_information_page_attributes[:body], page.body
     assert_equal corporate_information_page_attributes[:corporate_information_page_type_id], page.corporate_information_page_type_id
@@ -54,7 +54,7 @@ class Admin::CorporateInformationPagesControllerTest < ActionController::TestCas
 
     assert page = organisation.corporate_information_pages.last
     assert_redirected_to @controller.admin_edition_path(edition)
-    assert_equal "Your document has been saved. You need to <a href=\"/government/admin/editions/#{edition.id}/tags/edit\">add topic tags</a> before you can publish this document.", flash[:notice]
+    assert_equal "Your document has been saved. You need to <a class=\"govuk-link\" href=\"/government/admin/editions/#{edition.id}/tags/edit\">add topic tags</a> before you can publish this document.", flash[:notice]
     assert_equal corporate_information_page_attributes[:body], page.body
     assert_equal corporate_information_page_attributes[:corporate_information_page_type_id], page.corporate_information_page_type_id
     assert_equal corporate_information_page_attributes[:summary], page.summary
@@ -89,7 +89,7 @@ class Admin::CorporateInformationPagesControllerTest < ActionController::TestCas
 
     assert_equal new_attributes[:body], corporate_information_page.body
     assert_equal new_attributes[:summary], corporate_information_page.summary
-    assert_equal "Your document has been saved. You need to <a href=\"/government/admin/editions/#{edition.id}/tags/edit\">add topic tags</a> before you can publish this document.", flash[:notice]
+    assert_equal "Your document has been saved. You need to <a class=\"govuk-link\" href=\"/government/admin/editions/#{edition.id}/tags/edit\">add topic tags</a> before you can publish this document.", flash[:notice]
     assert_redirected_to @controller.admin_edition_path(edition)
   end
 

--- a/test/functional/admin/generic_editions_controller_test.rb
+++ b/test/functional/admin/generic_editions_controller_test.rb
@@ -13,7 +13,7 @@ class Admin::GenericEditionsControllerTest < ActionController::TestCase
       post :create, params: { edition: params, save_and_continue: "Save and continue editing" }
     end
 
-    expected_message = "Your document has been saved. You need to <a href=\"/government/admin/editions/#{Edition.last.id}/tags/edit\">add topic tags</a> before you can publish this document."
+    expected_message = "Your document has been saved. You need to <a class=\"govuk-link\" href=\"/government/admin/editions/#{Edition.last.id}/tags/edit\">add topic tags</a> before you can publish this document."
     assert_equal expected_message, flash[:notice]
     assert_redirected_to @controller.admin_edition_path(GenericEdition.last)
   end
@@ -39,7 +39,7 @@ class Admin::GenericEditionsControllerTest < ActionController::TestCase
 
     assert_not edition.has_been_tagged?
 
-    expected_message = "Your document has been saved. You need to <a href=\"/government/admin/editions/#{edition.id}/tags/edit\">add topic tags</a> before you can publish this document."
+    expected_message = "Your document has been saved. You need to <a class=\"govuk-link\" href=\"/government/admin/editions/#{edition.id}/tags/edit\">add topic tags</a> before you can publish this document."
     assert_equal expected_message, flash[:notice]
   end
 

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -93,7 +93,7 @@ module AdminEditionControllerTestHelpers
 
         edition = edition_class.last
         assert_redirected_to @controller.admin_edition_path(edition)
-        expected_message = "Your document has been saved. You need to <a href=\"/government/admin/editions/#{edition.id}/tags/edit\">add topic tags</a> before you can publish this document."
+        expected_message = "Your document has been saved. You need to <a class=\"govuk-link\" href=\"/government/admin/editions/#{edition.id}/tags/edit\">add topic tags</a> before you can publish this document."
         assert_equal expected_message, flash[:notice]
       end
 
@@ -219,7 +219,7 @@ module AdminEditionControllerTestHelpers
             }
 
         assert_redirected_to @controller.admin_edition_path(edition)
-        expected_message = "Your document has been saved. You need to <a href=\"/government/admin/editions/#{edition.id}/tags/edit\">add topic tags</a> before you can publish this document."
+        expected_message = "Your document has been saved. You need to <a class=\"govuk-link\" href=\"/government/admin/editions/#{edition.id}/tags/edit\">add topic tags</a> before you can publish this document."
         assert_equal expected_message, flash[:notice]
       end
 


### PR DESCRIPTION
## Before

<img width="741" alt="link before" src="https://github.com/alphagov/whitehall/assets/7735945/e09b18bd-a2f8-426e-a88b-0bb2695fad22">

## After

<img width="741" alt="link after" src="https://github.com/alphagov/whitehall/assets/7735945/98214677-46f5-4e1e-b4b2-20618fc0f7fa">

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
