### PR TITLE
Migrate topical event and role appointment date input components

### DIFF
--- a/app/models/role_appointment.rb
+++ b/app/models/role_appointment.rb
@@ -1,6 +1,9 @@
 class RoleAppointment < ApplicationRecord
+  include DateValidation
   include HasContentId
   include PublishesToPublishingApi
+
+  date_attributes(:started_at, :ended_at)
 
   CURRENT_CONDITION = { ended_at: nil }.freeze
 

--- a/app/models/topical_event.rb
+++ b/app/models/topical_event.rb
@@ -1,7 +1,10 @@
 class TopicalEvent < ApplicationRecord
+  include DateValidation
   include PublishesToPublishingApi
   include Searchable
   include SimpleWorkflow
+
+  date_attributes(:start_date, :end_date)
 
   searchable title: :name,
              link: :search_link,

--- a/app/views/admin/role_appointments/_form.html.erb
+++ b/app/views/admin/role_appointments/_form.html.erb
@@ -29,27 +29,34 @@
   } do %>
     <%= render "start_date_field", heading_size: "m", form: form %>
 
-    <%= render "components/datetime_fields", {
+    <%= render "components/datetime_fields_with_govuk_date_component", {
       date_heading: "End date",
       heading_size: "m",
       field_name: "ended_at",
       prefix: "role_appointment",
       id: "role_appointment_ended_at",
       date_only: true,
-      date_hint: "For example, 01 August 2022",
+      date_hint: "For example, 01 08 2022",
       year: {
-        value: form.object.ended_at&.year,
-        start_year: Date.today.year,
-        end_year: 1700,
+        value: params.dig("role_appointment", "ended_at(1i)") || form.object.ended_at&.year,
         id: "role_appointment_ended_at_1i",
+        name: "role_appointment[ended_at(1i)]",
+        label: "Year",
+        width: 4
       },
       month: {
-        value: form.object.ended_at&.month,
+        value: params.dig("role_appointment", "ended_at(2i)") || form.object.ended_at&.month,
         id: "role_appointment_ended_at_2i",
+        name: "role_appointment[ended_at(2i)]",
+        label: "Month",
+        width: 2
       },
       day: {
-        value: form.object.ended_at&.day,
+        value: params.dig("role_appointment", "ended_at(3i)") || form.object.ended_at&.day,
         id: "role_appointment_ended_at_3i",
+        name: "role_appointment[ended_at(3i)]",
+        label: "Day",
+        width: 2
       },
       error_items: errors_for(form.object.errors, :ended_at),
     }

--- a/app/views/admin/role_appointments/_start_date_field.html.erb
+++ b/app/views/admin/role_appointments/_start_date_field.html.erb
@@ -1,24 +1,31 @@
-<%= render "components/datetime_fields", {
+<%= render "components/datetime_fields_with_govuk_date_component", {
   date_heading: "Start date (required)",
   heading_size: heading_size,
   field_name: "started_at",
   prefix: "role_appointment",
   id: "role_appointment_started_at",
   date_only: true,
-  date_hint: "For example, 01 August 2015",
+  date_hint: "For example, 01 08 2015",
   year: {
-    value: form.object.started_at&.year,
-    start_year: Date.today.year,
-    end_year: 1700,
+    value: params.dig("role_appointment", "started_at(1i)") || form.object.started_at&.year,
     id: "role_appointment_started_at_1i",
+    name: "role_appointment[started_at(1i)]",
+    label: "Year",
+    width: 4
   },
   month: {
-    value: form.object.started_at&.month,
+    value: params.dig("role_appointment", "started_at(2i)") || form.object.started_at&.month,
     id: "role_appointment_started_at_2i",
+    name: "role_appointment[started_at(2i)]",
+    label: "Month",
+    width: 2
   },
   day: {
-    value: form.object.started_at&.day,
+    value: params.dig("role_appointment", "started_at(3i)") || form.object.started_at&.day,
     id: "role_appointment_started_at_3i",
+    name: "role_appointment[started_at(3i)]",
+    label: "Day",
+    width: 2
   },
   error_items: errors_for(form.object.errors, :started_at),
 } %>

--- a/app/views/admin/topical_events/_form.html.erb
+++ b/app/views/admin/topical_events/_form.html.erb
@@ -63,44 +63,69 @@
       heading_size: "l",
       margin_bottom: 2
     } do %>
-      <%= render "components/datetime_fields", {
+      <%= render "components/datetime_fields_with_govuk_date_component", {
         date_only: true,
         prefix: "topical_event",
         field_name: "start_date",
         id: "topical_event_start_date",
         heading_size: "m",
-        date_hint: "For example, 01 August 2015",
+        date_hint: "For example, 01 08 2015",
         date_heading: "Start date",
         margin_bottom: 2,
         year: {
-          value: topical_event.start_date&.year
+          id: "topical_event_start_date(1i)",
+          name: "topical_event[start_date(1i)]",
+          value: params.dig("topical_event", "start_date(1i)") || topical_event.start_date&.year,
+          label: "Year",
+          width: 4
         },
         month: {
-          value: topical_event.start_date&.month
+          id: "topical_event_start_date(2i)",
+          name: "topical_event[start_date(2i)]",
+          value: params.dig("topical_event", "start_date(2i)") || topical_event.start_date&.month,
+          label: "Month",
+          width: 2
         },
         day: {
-          value: topical_event.start_date&.day,
+          id: "topical_event_start_date(3i)",
+          name: "topical_event[start_date(3i)]",
+          value: params.dig("topical_event", "start_date(3i)") || topical_event.start_date&.day,
+          label: "Day",
+          width: 2
         },
         error_items: errors_for(topical_event.errors, :start_date)
       } %>
 
-      <%= render "components/datetime_fields", {
+      <%= render "components/datetime_fields_with_govuk_date_component", {
         date_only: true,
         prefix: "topical_event",
         field_name: "end_date",
         id: "topical_event_end_date",
         heading_size: "m",
-        date_hint: "For example, 01 August 2022",
+        date_hint: "For example, 01 08 2022",
         date_heading: "End date",
         year: {
-          value: topical_event.end_date&.year
+          id: "topical_event_end_date(1i)",
+          name: "topical_event[end_date(1i)]",
+          value: params.dig("topical_event", "end_date(1i)") || topical_event.end_date&.year,
+          label: "Year",
+          width: 4
         },
         month: {
-          value: topical_event.end_date&.month
+          id: "topical_event_end_date(2i)",
+          name: "topical_event[end_date(2i)]",
+          value: params.dig("topical_event", "end_date(2i)") || topical_event.end_date&.month,
+          label: "Month",
+          width: 2
         },
         day: {
-          value: topical_event.end_date&.day
+          id: "topical_event_end_date(3i)",
+          name: "topical_event[end_date(3i)]",
+          value: params.dig("topical_event", "end_date(3i)") || topical_event.end_date&.day,
+          label: "Day",
+          width: 2
         },
+        error_items: errors_for(topical_event.errors, :end_date)
       } %>
     <% end %>
   </div>

--- a/features/step_definitions/role_steps.rb
+++ b/features/step_definitions/role_steps.rb
@@ -78,7 +78,7 @@ Then(/^I should be able to appoint "([^"]*)" to the new role$/) do |person_name|
   click_on "Create new appointment"
   select person_name, from: "Person"
   within "#role_appointment_started_at" do
-    fill_in_date_fields(1.day.ago.to_s)
+    fill_in_govuk_publishing_date_fields(1.day.ago.to_s)
   end
   click_on "Save"
 end

--- a/features/support/topical_events_helper.rb
+++ b/features/support/topical_events_helper.rb
@@ -12,10 +12,10 @@ module TopicalEventsHelper
     fill_in "Description", with: options[:description] || "topic-description"
     fill_in "Summary", with: options[:description] || "topic-summary"
     within "#topical_event_start_date" do
-      fill_in_date_fields(options[:start_date] || 1.day.ago.to_s)
+      fill_in_govuk_publishing_date_fields(options[:start_date] || 1.day.ago.to_s)
     end
     within "#topical_event_end_date" do
-      fill_in_date_fields(options[:end_date] || 1.month.from_now.to_s)
+      fill_in_govuk_publishing_date_fields(options[:end_date] || 1.month.from_now.to_s)
     end
 
     click_button "Save"

--- a/test/functional/admin/role_appointments_controller_test.rb
+++ b/test/functional/admin/role_appointments_controller_test.rb
@@ -26,9 +26,15 @@ class Admin::RoleAppointmentsControllerTest < ActionController::TestCase
     get :new, params: { role_id: role.id, make_current: true }
     assert_select "form[action=?]", admin_role_role_appointments_path(role) do
       assert_select "input[name='role_appointment[make_current]']"
-      assert_select "select[name='role_appointment[started_at(1i)]'] option[value='#{Time.zone.today.year}'][selected='selected']"
-      assert_select "select[name='role_appointment[started_at(2i)]'] option[value='#{Time.zone.today.month}'][selected='selected']"
-      assert_select "select[name='role_appointment[started_at(3i)]'] option[value='#{Time.zone.today.day}'][selected='selected']"
+      assert_select "input[name='role_appointment[started_at(1i)]']" do |element|
+        element.attr("value").value == Time.zone.today.year.to_s
+      end
+      assert_select "input[name='role_appointment[started_at(2i)]']" do |element|
+        element.attr("value").value == Time.zone.today.month.to_s
+      end
+      assert_select "input[name='role_appointment[started_at(3i)]']" do |element|
+        element.attr("value").value == Time.zone.today.day.to_s
+      end
     end
   end
 


### PR DESCRIPTION
### What

Speeding things up a bit now as it seems we've worked out most of the tricky parts. This updates the topical events and role appointment date inputs to use the GOV.UK Publishing date input.

### Why

There's a lot of user research behind https://components.publishing.service.gov.uk/component-guide/date_input. That wasn't the case with the existing Whitehall date selection components.

### Screenshots (with errors)

Topical Events:
![Screenshot 2023-09-20 at 14 26 05](https://github.com/alphagov/whitehall/assets/137083285/97305f77-de4e-4ade-b505-158b8f48b132)

Role Appointments:
![Screenshot 2023-09-20 at 14 25 41](https://github.com/alphagov/whitehall/assets/137083285/a83f73fe-6871-4f55-884e-51cca4ee49c4)

### Links

Trello: https://trello.com/c/IFGDegsk