### PR TITLE
Migrate remaining date inputs to govuk publishing component

### DIFF
--- a/app/models/government.rb
+++ b/app/models/government.rb
@@ -1,5 +1,8 @@
 class Government < ApplicationRecord
+  include DateValidation
   include PublishesToPublishingApi
+
+  date_attributes(:start_date, :end_date)
 
   validates :name, presence: true, uniqueness: { case_sensitive: false }
   validates :slug, presence: true, uniqueness: { case_sensitive: false }

--- a/app/models/offsite_link.rb
+++ b/app/models/offsite_link.rb
@@ -1,4 +1,6 @@
 class OffsiteLink < ApplicationRecord
+  include DateValidation
+
   module LinkTypes
     def self.all
       @all ||= %w[
@@ -42,6 +44,8 @@ class OffsiteLink < ApplicationRecord
       end
     end
   end
+
+  date_attributes(:date)
 
   belongs_to :parent, polymorphic: true
   has_many :features, inverse_of: :offsite_link, dependent: :destroy

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -1,8 +1,11 @@
 class Organisation < ApplicationRecord
+  include DateValidation
   include PublishesToPublishingApi
   include Searchable
   include Organisation::OrganisationSearchIndexConcern
   include Organisation::OrganisationTypeConcern
+
+  date_attributes(:closed_at)
 
   DEFAULT_JOBS_URL = "https://www.civilservicejobs.service.gov.uk/csr".freeze
   FEATURED_DOCUMENTS_DISPLAY_LIMIT = 6

--- a/app/views/admin/governments/_form.html.erb
+++ b/app/views/admin/governments/_form.html.erb
@@ -19,44 +19,67 @@
         legend_text: "Dates",
         heading_size: "l"
       } do %>
-        <%= render "components/datetime_fields", {
+        <%= render "components/datetime_fields_with_govuk_date_component", {
           date_only: true,
           prefix: "government",
           field_name: "start_date",
           id: "government_start_date",
           heading_size: "m",
-          date_hint: "For example, 01 August 2015",
+          date_hint: "For example, 01 08 2015",
           date_heading: "Start date (required)",
           year: {
-            value: government.start_date&.year,
-            start_year: 1800,
+            id: "government_start_date_1i",
+            value: params.dig("government", "start_date(1i)") || government.start_date&.year,
+            name: "government[start_date(1i)]",
+            label: "Year",
+            width: 4,
           },
           month: {
-            value: government.start_date&.month
+            id: "government_start_date_2i",
+            value: params.dig("government", "start_date(2i)") || government.start_date&.month,
+            name: "government[start_date(2i)]",
+            label: "Month",
+            width: 2,
           },
           day: {
-            value: government.start_date&.day,
+            id: "government_start_date_3i",
+            value: params.dig("government", "start_date(3i)") || government.start_date&.month,
+            name: "government[start_date(3i)]",
+            label: "Day",
+            width: 2,
           },
           error_items: errors_for(government.errors, :start_date)
         } %>
 
-        <%= render "components/datetime_fields", {
+        <%= render "components/datetime_fields_with_govuk_date_component", {
           date_only: true,
           prefix: "government",
           field_name: "end_date",
           id: "government_end_date",
           heading_size: "m",
-          date_hint: "For example, 01 August 2022",
+          date_hint: "For example, 01 08 2022",
           date_heading: "End date",
+          error_items: errors_for(government.errors, :end_date),
           year: {
-            value: government.end_date&.year,
-            start_year: 1800
+            id: "government_end_date_1i",
+            value: params.dig("government", "end_date(1i)") || government.end_date&.year,
+            name: "government[end_date(1i)]",
+            label: "Year",
+            width: 4,
           },
           month: {
-            value: government.end_date&.month
+            id: "government_end_date_2i",
+            value: params.dig("government", "end_date(2i)") || government.end_date&.month,
+            name: "government[end_date(2i)]",
+            label: "Month",
+            width: 2,
           },
           day: {
-            value: government.end_date&.day
+            id: "government_end_date_3i",
+            value: params.dig("government", "end_date(3i)") || government.end_date&.month,
+            name: "government[end_date(3i)]",
+            label: "Day",
+            width: 2,
           },
         } %>
       <% end %>

--- a/app/views/admin/offsite_links/_form.html.erb
+++ b/app/views/admin/offsite_links/_form.html.erb
@@ -39,7 +39,7 @@
     end
   } %>
 
-  <%= render "components/datetime_fields", {
+  <%= render "components/datetime_fields_with_govuk_date_component", {
     prefix: "offsite_link",
     field_name: "date",
     date_heading: "Date",
@@ -48,17 +48,24 @@
     error_items: errors_for(offsite_link.errors, :date),
     year: {
       id: "offsite_link_date_1i",
-      value: offsite_link.date&.year,
-      start_year: Date.today.year - 2,
-      end_year: Date.today.year + 2,
+      value: params.dig("offsite_link", "date(1i)") || offsite_link.date&.year,
+      name: "offsite_link[date(1i)]",
+      label: "Year",
+      width: 4
     },
     month: {
       id: "offsite_link_date_2i",
-      value: offsite_link.date&.month,
+      value: params.dig("offsite_link", "date(2i)") || offsite_link.date&.month,
+      name: "offsite_link[date(2i)]",
+      label: "Month",
+      width: 2
     },
     day: {
       id: "offsite_link_date_3i",
-      value: offsite_link.date&.day,
+      value: params.dig("offsite_link", "date(3i)") || offsite_link.date&.day,
+      name: "offsite_link[date(3i)]",
+      label: "Day",
+      width: 2
     },
   } %>
 

--- a/app/views/admin/organisations/_closed_fields.html.erb
+++ b/app/views/admin/organisations/_closed_fields.html.erb
@@ -64,24 +64,34 @@
   },
 } %>
 
-<%= render "components/datetime_fields", {
+<%= render "components/datetime_fields_with_govuk_date_component", {
   date_only: true,
   prefix: "organisation",
   field_name: "closed_at",
   id: "organisation_closed_at",
   heading_size: "m",
-  date_hint: "For example, 01 August 2022",
+  date_hint: "For example, 01 08 2022",
   date_heading: "Closed date",
   year: {
-    value: organisation.closed_at&.year,
-    start_year: Date.today.year - 5,
-    end_year: Date.today.year,
+    id: "organisation_closed_at_1i",
+    value: params.dig('organisation', 'closed_at(1i)') || organisation.closed_at&.year,
+    name: "organisation[closed_at(1i)]",
+    label: "Year",
+    width: 4,
   },
   month: {
-    value: organisation.closed_at&.month
+    id: "organisation_closed_at_2i",
+    value: params.dig('organisation', 'closed_at(2i)') || organisation.closed_at&.month,
+    name: "organisation[closed_at(2i)]",
+    label: "Month",
+    width: 2,
   },
   day: {
-    value: organisation.closed_at&.day,
+    id: "organisation_closed_at_3i",
+    value: params.dig('organisation', 'closed_at(3i)') || organisation.closed_at&.day,
+    name: "organisation[closed_at(3i)]",
+    label: "Day",
+    width: 2,
   },
   error_items: errors_for(organisation.errors, :closed_at)
 } %>

--- a/features/support/governments_helper.rb
+++ b/features/support/governments_helper.rb
@@ -1,5 +1,5 @@
 module GovernmentsHelper
-  def create_government(name:, start_date: nil, end_date: nil)
+  def create_government(name:, start_date: Time.zone.today, end_date: nil)
     visit admin_governments_path
 
     click_on "Create new government"
@@ -7,11 +7,11 @@ module GovernmentsHelper
     fill_in "Name", with: name
 
     within "#government_start_date" do
-      fill_in_date_fields(start_date) if start_date
+      fill_in_govuk_publishing_date_fields(start_date)
     end
 
     within "#government_end_date" do
-      fill_in_date_fields(end_date) if end_date
+      fill_in_govuk_publishing_date_fields(end_date) if end_date
     end
 
     click_on "Save"
@@ -23,11 +23,11 @@ module GovernmentsHelper
     click_on name
 
     within "#government_start_date" do
-      fill_in_date_fields(attributes[:start_date]) if attributes[:start_date]
+      fill_in_govuk_publishing_date_fields(attributes[:start_date]) if attributes[:start_date]
     end
 
     within "#government_end_date" do
-      fill_in_date_fields(attributes[:end_date]) if attributes[:end_date]
+      fill_in_govuk_publishing_date_fields(attributes[:end_date]) if attributes[:end_date]
     end
 
     click_on "Save"

--- a/test/functional/admin/governments_controller_test.rb
+++ b/test/functional/admin/governments_controller_test.rb
@@ -26,12 +26,18 @@ class Admin::GovernmentsControllerTest < ActionController::TestCase
     login_as :gds_admin
     get :new
     assert_select "input[name='government[name]']"
-    assert_select "select[name='government[start_date(1i)]'] option[value='#{Time.zone.today.year}'][selected='selected']"
-    assert_select "select[name='government[start_date(2i)]'] option[value='#{Time.zone.today.month}'][selected='selected']"
-    assert_select "select[name='government[start_date(3i)]'] option[value='#{Time.zone.today.day}'][selected='selected']"
-    assert_select "select[name='government[end_date(1i)]']"
-    assert_select "select[name='government[end_date(2i)]']"
-    assert_select "select[name='government[end_date(3i)]']"
+    assert_select "input[name='government[start_date(1i)]']" do |element|
+      element.attr("value").value == @government.start_date.year.to_s
+    end
+    assert_select "input[name='government[start_date(2i)]']" do |element|
+      element.attr("value").value == @government.start_date.month.to_s
+    end
+    assert_select "input[name='government[start_date(3i)]']" do |element|
+      element.attr("value").value == @government.start_date.day.to_s
+    end
+    assert_select "input[name='government[end_date(1i)]']"
+    assert_select "input[name='government[end_date(2i)]']"
+    assert_select "input[name='government[end_date(3i)]']"
   end
 
   test "#close sets the end date to today" do
@@ -67,12 +73,18 @@ class Admin::GovernmentsControllerTest < ActionController::TestCase
     get :edit, params: { id: @government.id }
 
     assert_select "input[name='government[name]'][value='#{@government.name}']"
-    assert_select "select[name='government[start_date(1i)]'] option[value='#{@government.start_date.year}'][selected='selected']"
-    assert_select "select[name='government[start_date(2i)]'] option[value='#{@government.start_date.month}'][selected='selected']"
-    assert_select "select[name='government[start_date(3i)]'] option[value='#{@government.start_date.day}'][selected='selected']"
-    assert_select "select[name='government[end_date(1i)]']"
-    assert_select "select[name='government[end_date(2i)]']"
-    assert_select "select[name='government[end_date(3i)]']"
+    assert_select "input[name='government[start_date(1i)]']" do |element|
+      element.attr("value").value == @government.start_date.year.to_s
+    end
+    assert_select "input[name='government[start_date(2i)]']" do |element|
+      element.attr("value").value == @government.start_date.month.to_s
+    end
+    assert_select "input[name='government[start_date(3i)]']" do |element|
+      element.attr("value").value == @government.start_date.day.to_s
+    end
+    assert_select "input[name='government[end_date(1i)]']"
+    assert_select "input[name='government[end_date(2i)]']"
+    assert_select "input[name='government[end_date(3i)]']"
     assert_select "a[href='#{prepare_to_close_admin_government_path(@government)}']", text: "Prepare to close this government"
   end
 

--- a/test/functional/admin/offsite_links_controller_test.rb
+++ b/test/functional/admin/offsite_links_controller_test.rb
@@ -65,7 +65,7 @@ class Admin::OffsiteLinksControllerTest < ActionController::TestCase
       assert_select "div input[id=offsite_link_title]"
       assert_select "div textarea[id=offsite_link_summary]"
       assert_select "div select[id=offsite_link_link_type]"
-      (1..3).each { |n| assert_select "div select[id=offsite_link_date_#{n}i]" }
+      (1..3).each { |n| assert_select "div input[id=offsite_link_date_#{n}i]" }
       assert_select "div input[id=offsite_link_url]"
 
       assert_select "button[type=submit]"


### PR DESCRIPTION
### What

Replace the last remaining select-based date inputs on Whitehall with the GOV.UK Publishing date input.

### Why

The GOV.UK Publishing date input provides a better user experience, according to user research

### Screenshots (with errors)

Organisation Close Date
![Screenshot 2023-09-20 at 15 05 27](https://github.com/alphagov/whitehall/assets/137083285/df4cd243-58cf-4a9b-a346-13847e14d275)

Government Start Date
![Screenshot 2023-09-20 at 15 51 04](https://github.com/alphagov/whitehall/assets/137083285/34790cdb-ae41-4662-8ad1-2407450b2174)

Government End Date
![Screenshot 2023-09-20 at 15 53 38](https://github.com/alphagov/whitehall/assets/137083285/8cd2297a-a62b-4b88-afaa-96aa6c6a80f3)

Offsite Links Date
![Screenshot 2023-09-20 at 15 53 38](https://github.com/alphagov/whitehall/assets/137083285/9ab8c6d4-2506-4c21-a4fa-ed727941842c)

### Links

https://trello.com/c/IFGDegsk
