### PR TITLE
Created rake task for AttachmentData migration to Assets

### DIFF
--- a/app/workers/create_asset_relationship_worker.rb
+++ b/app/workers/create_asset_relationship_worker.rb
@@ -1,0 +1,76 @@
+class CreateAssetRelationshipWorker < WorkerBase
+  def perform(start_id, end_id)
+    logger.info("CreateAssetRelationshipWorker start!")
+    assetable_type = AttachmentData
+    assetables = assetable_type.where(id: start_id..end_id)
+    logger.info "Number of #{assetable_type} found: #{assetables.count}"
+    logger.info "Creating Asset for records from #{start_id} to #{end_id}"
+
+    count = 0
+    asset_counter = 0
+    assetables.each do |assetable|
+      assetable.use_non_legacy_endpoints = true
+      assetable.save!
+      begin
+        path = save_asset_original(assetable, assetable_type.to_s)
+        asset_counter += 1
+      rescue GdsApi::HTTPNotFound
+        logger.warn "#{assetable_type} with id:#{assetable.id} for original asset is not found in AM for legacy url path: #{path}"
+      end
+
+      if assetable.pdf?
+        begin
+          path = save_asset_thumbnail(assetable, assetable_type.to_s)
+          asset_counter += 1
+        rescue GdsApi::HTTPNotFound
+          logger.warn "#{assetable_type} with id:#{assetable.id} for thumbnail asset is not found in AM for legacy url path: #{path}"
+        end
+      end
+
+      count += 1
+    end
+    logger.info("Created assets for #{count} assetable")
+    logger.info("Created asset counter #{asset_counter}")
+    logger.info("CreateAssetRelationshipWorker finish!")
+  end
+
+private
+
+  def asset_manager
+    Services.asset_manager
+  end
+
+  def save_asset_id_to_assets(assetable_id, assetable_type, variant, asset_manager_id, filename)
+    asset = Asset.new(asset_manager_id:, assetable_type:, assetable_id:, variant:, filename:)
+    asset.save!
+  end
+
+  def get_asset_data(legacy_url_path)
+    asset_info = []
+    path = legacy_url_path.sub(/^\//, "")
+    response_hash = asset_manager.whitehall_asset(path)
+    asset_manager_id = response_hash["id"]
+    asset_info << asset_manager_id[/\/assets\/(.*)/, 1]
+    asset_info << get_filename(response_hash)
+  end
+
+  def save_asset_thumbnail(attachment, assetable_type)
+    path = attachment.file.thumbnail.asset_manager_path
+    asset_info = get_asset_data(path)
+
+    save_asset_id_to_assets(attachment.id, assetable_type, Asset.variants["thumbnail"], asset_info[0], asset_info[1])
+    path
+  end
+
+  def save_asset_original(attachment, assetable_type)
+    path = attachment.file.path
+    asset_info = get_asset_data(path)
+    save_asset_id_to_assets(attachment.id, assetable_type, Asset.variants["original"], asset_info[0], asset_info[1])
+    path
+  end
+
+  def get_filename(response)
+    attributes = response.to_hash
+    attributes["name"]
+  end
+end

--- a/lib/tasks/migrate_to_assets_table.rake
+++ b/lib/tasks/migrate_to_assets_table.rake
@@ -1,0 +1,5 @@
+desc "Create Asset relationship for AttachmentData"
+
+task :create_asset_relationship, %i[start_id end_id] => :environment do |_, args|
+  CreateAssetRelationshipWorker.perform_async(args[:start_id].to_i, args[:end_id].to_i)
+end

--- a/lib/tasks/test_asset_migration.rake
+++ b/lib/tasks/test_asset_migration.rake
@@ -1,0 +1,68 @@
+def asset_manager
+  Services.asset_manager
+end
+
+def is_original(asset)
+  asset.variant.eql?("original")
+end
+
+def is_legacy_url_path_same(legacy_url_path_in_attachment_data, legacy_url_path_in_asset_manager)
+  puts "Whitehall path is    #{legacy_url_path_in_attachment_data}"
+  puts "AssetManager path is #{legacy_url_path_in_asset_manager}"
+  legacy_url_path_in_attachment_data == legacy_url_path_in_asset_manager
+end
+
+def validation_log(expect, assetable_type)
+  if expect
+    puts "legacy url matches for both #{assetable_type} and AssetManager"
+  end
+end
+
+def legacy_url_asset_manager(asset)
+  response_hash = asset_manager.asset(asset.asset_manager_id)
+  path = response_hash["file_url"][/\/static.dev.gov.uk\/(.*)/, 1]
+  "/#{path}"
+end
+
+# The idea of the test is to randomly check for 100 newly created assets that they are as expected.
+# If the asset is as expected then it should have same legacy path in Asset Manager and Attachment Data
+# legacy path from asset manager is returned as a part of file_url in response.
+# This test is only intended to run once in integration
+desc "Validate Asset relationship for AttachmentData"
+task test_asset_migration: :environment do
+  length = Asset.last.id
+
+  mismatch_array = []
+  assetable_type = AttachmentData
+
+  100.times do
+    random_number_as_id = Random.new.rand(1..length)
+
+    begin
+      asset = Asset.find(random_number_as_id)
+      if asset
+        attachment_data = assetable_type.find(asset.assetable_id)
+
+        if is_original(asset)
+          expect = is_legacy_url_path_same(attachment_data.file.path, legacy_url_asset_manager(asset))
+          validation_log(expect, assetable_type.to_s)
+        else
+          expect = is_legacy_url_path_same(attachment_data.file.thumbnail.path, legacy_url_asset_manager(asset))
+          puts "legacy url matches for both #{assetable_type} and AssetManager"
+        end
+
+        unless expect
+          mismatch_array << random_number_as_id
+        end
+      end
+    rescue ActiveRecord::RecordNotFound
+      puts "Asset not found for asset id: #{random_number_as_id}"
+    end
+  end
+
+  if mismatch_array.size.positive?
+    puts "All assets in Assets are not as expected, there is a mismatch for ids: #{mismatch_array}"
+  else
+    puts "All assets in Assets are as expected"
+  end
+end


### PR DESCRIPTION
In order to be able to populate Asset with Attachment details we want to request asset_manager_id from asset-manager and save them along with other detail like attachment_data_id. This rake task intends to do this.

[trello](https://trello.com/c/jB2kP508/104-task-migrate-database-for-attachmentdata-to-use-new-asset-id-instead)
