### PR TITLE
Use build stubbed where possible in view components

### DIFF
--- a/test/components/admin/audit_trail_component_test.rb
+++ b/test/components/admin/audit_trail_component_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class Admin::AuditTrailComponentTest < ViewComponent::TestCase
   setup do
-    @non_editionable_item = create(:worldwide_organisation)
+    @non_editionable_item = build_stubbed(:worldwide_organisation)
   end
 
   test "renders audit trail entries" do

--- a/test/components/admin/audit_trail_entry_component_test.rb
+++ b/test/components/admin/audit_trail_entry_component_test.rb
@@ -2,54 +2,54 @@ require "test_helper"
 
 class Admin::AuditTrailEntryComponentTest < ViewComponent::TestCase
   setup do
-    @non_editionable_item = create(:worldwide_organisation)
+    @non_editionable_item = build(:worldwide_organisation)
   end
 
   test "shows `Organisation created` when the version has an `create` event" do
-    version = create(:version, event: "create", item: @non_editionable_item)
+    version = build(:version, event: "create", item: @non_editionable_item)
 
     render_inline(Admin::AuditTrailEntryComponent.new(version:))
     assert_selector "h3", text: "Organisation created"
   end
 
   test "shows `Organisation updated` when the version has an `update` event" do
-    version = create(:version, item: @non_editionable_item)
+    version = build(:version, item: @non_editionable_item)
 
     render_inline(Admin::AuditTrailEntryComponent.new(version:))
     assert_selector "h3", text: "Organisation updated"
   end
 
   test "shows `No history before this time` when the version has an `initial` event" do
-    version = create(:version, event: "initial", item: @non_editionable_item)
+    version = build(:version, event: "initial", item: @non_editionable_item)
 
     render_inline(Admin::AuditTrailEntryComponent.new(version:))
     assert_selector "h3", text: "No history before this time"
   end
 
   test "shows `Unknown action` when the version has an event that is not `create` or `update`" do
-    version = create(:version, event: "something-else", item: @non_editionable_item)
+    version = build(:version, event: "something-else", item: @non_editionable_item)
 
     render_inline(Admin::AuditTrailEntryComponent.new(version:))
     assert_selector "h3", text: "Unknown action"
   end
 
   test "shows the author of the event and the time when the version was created" do
-    actor = create(:user)
-    version = create(:version, user: actor, item: @non_editionable_item)
+    actor = build_stubbed(:user)
+    version = build_stubbed(:version, user: actor, item: @non_editionable_item)
 
     render_inline(Admin::AuditTrailEntryComponent.new(version:))
     assert_selector "p", text: "11 November 2011 11:11am by #{actor.name}"
   end
 
   test "shows `User (removed)` and the time the version was created when the user record has been removed" do
-    version = create(:version, whodunnit: "1", item: @non_editionable_item)
+    version = build_stubbed(:version, whodunnit: "1", item: @non_editionable_item)
 
     render_inline(Admin::AuditTrailEntryComponent.new(version:))
     assert_selector "p", text: "11 November 2011 11:11am by User (removed)"
   end
 
   test "shows `User (unknown)` and the time the version was created when there is no associated user record" do
-    version = create(:version, item: @non_editionable_item)
+    version = build_stubbed(:version, item: @non_editionable_item)
 
     render_inline(Admin::AuditTrailEntryComponent.new(version:))
     assert_selector "p", text: "11 November 2011 11:11am by User (unknown)"

--- a/test/components/admin/edition_images/uploaded_images_component_test.rb
+++ b/test/components/admin/edition_images/uploaded_images_component_test.rb
@@ -4,8 +4,8 @@ require "test_helper"
 
 class Admin::EditionImages::UploadedImagesComponentTest < ViewComponent::TestCase
   test "lead image rendered for case study" do
-    images = [build(:image), build(:image)]
-    edition = create(:draft_case_study, images:)
+    images = [build_stubbed(:image), build_stubbed(:image)]
+    edition = build_stubbed(:draft_case_study, images:)
     render_inline(Admin::EditionImages::UploadedImagesComponent.new(edition:))
 
     assert_selector "img", count: 2
@@ -14,8 +14,8 @@ class Admin::EditionImages::UploadedImagesComponentTest < ViewComponent::TestCas
   end
 
   test "lead image not rendered for publication" do
-    images = [build(:image), build(:image)]
-    edition = create(:draft_publication, images:)
+    images = [build_stubbed(:image), build_stubbed(:image)]
+    edition = build_stubbed(:draft_publication, images:)
     render_inline(Admin::EditionImages::UploadedImagesComponent.new(edition:))
 
     assert_selector "img", count: 2
@@ -26,10 +26,10 @@ class Admin::EditionImages::UploadedImagesComponentTest < ViewComponent::TestCas
   test "image filename markdown displayed" do
     jpeg = upload_fixture("images/960x640_jpeg.jpg")
     gif = upload_fixture("images/960x640_gif.gif")
-    jpeg_image_data = create(:image_data, file: jpeg)
-    gif_image_data = create(:image_data, file: gif)
-    images = [build(:image, image_data: jpeg_image_data), build(:image, image_data: gif_image_data)]
-    edition = create(:draft_publication, images:)
+    jpeg_image_data = build_stubbed(:image_data, file: jpeg)
+    gif_image_data = build_stubbed(:image_data, file: gif)
+    images = [build_stubbed(:image, image_data: jpeg_image_data), build_stubbed(:image, image_data: gif_image_data)]
+    edition = build_stubbed(:draft_publication, images:)
     render_inline(Admin::EditionImages::UploadedImagesComponent.new(edition:))
 
     assert_selector "input[value='[Image: 960x640_jpeg.jpg]']"
@@ -37,8 +37,8 @@ class Admin::EditionImages::UploadedImagesComponentTest < ViewComponent::TestCas
   end
 
   test "image index markdown used for duplicate filenames" do
-    images = [build(:image), build(:image)]
-    edition = create(:draft_publication, images:)
+    images = [build_stubbed(:image), build_stubbed(:image)]
+    edition = build_stubbed(:draft_publication, images:)
     render_inline(Admin::EditionImages::UploadedImagesComponent.new(edition:))
 
     assert_selector "input[value='!!1']"

--- a/test/components/admin/editions/audit_trail_entry_component_test.rb
+++ b/test/components/admin/editions/audit_trail_entry_component_test.rb
@@ -6,9 +6,10 @@ class Admin::Editions::AuditTrailEntryComponentTest < ViewComponent::TestCase
   include Rails.application.routes.url_helpers
 
   test "it constructs output based on the entry when an actor is present" do
-    actor = create(:user)
-    edition = create(:edition)
-    version = edition.versions.create!(event: "create", created_at: Time.zone.local(2020, 1, 1, 11, 11), whodunnit: actor.id)
+    actor = build_stubbed(:user)
+    edition = build_stubbed(:edition)
+    version = edition.versions.new(event: "create", created_at: Time.zone.local(2020, 1, 1, 11, 11))
+    version.stubs(:user).returns(actor)
     audit = Document::PaginatedTimeline::VersionPresenter.new(version, is_first_edition: true)
 
     render_inline(Admin::Editions::AuditTrailEntryComponent.new(entry: audit, edition:))
@@ -31,12 +32,13 @@ class Admin::Editions::AuditTrailEntryComponentTest < ViewComponent::TestCase
   end
 
   test "it links to the diff page is the action is published and the edition passed in is different to the versions" do
-    actor = create(:user)
-    edition = create(:edition, :published)
-    edition.versions.create!(event: "create", created_at: Time.zone.local(2020, 1, 1, 11, 11), whodunnit: actor.id)
-    version = edition.versions.create!(event: "published", created_at: Time.zone.local(2020, 1, 1, 11, 11), whodunnit: actor.id, state: "published")
+    actor = build_stubbed(:user)
+    edition = build_stubbed(:edition, :published)
+    edition.versions.new(event: "create", created_at: Time.zone.local(2020, 1, 1, 11, 11), whodunnit: actor.id)
+    version = edition.versions.new(event: "published", created_at: Time.zone.local(2020, 1, 1, 11, 11), state: "published")
+    version.stubs(:user).returns(actor)
     audit = Document::PaginatedTimeline::VersionPresenter.new(version, is_first_edition: true)
-    newer_edition = create(:edition, :draft)
+    newer_edition = build_stubbed(:edition, :draft)
 
     render_inline(Admin::Editions::AuditTrailEntryComponent.new(entry: audit, edition: newer_edition))
 

--- a/test/components/admin/editions/document_history_tab_component_test.rb
+++ b/test/components/admin/editions/document_history_tab_component_test.rb
@@ -6,8 +6,8 @@ class Admin::Editions::DocumentHistoryTabComponentTest < ViewComponent::TestCase
   include Rails.application.routes.url_helpers
 
   setup do
-    @user = create(:departmental_editor)
-    @user2 = create(:departmental_editor)
+    @user = build_stubbed(:departmental_editor)
+    @user2 = build_stubbed(:departmental_editor)
     seed_document_event_history
     @timeline = Document::PaginatedTimeline.new(document: @document, page: 1)
 

--- a/test/components/admin/editions/tags_component_test.rb
+++ b/test/components/admin/editions/tags_component_test.rb
@@ -51,7 +51,12 @@ class Admin::Editions::TagsComponentTest < ViewComponent::TestCase
     },
   ].each do |hash|
     test "returns the correct tag for the #{hash[:state]} state" do
-      edition = create(:edition, hash[:state])
+      edition = if hash[:state] == :unpublished
+                  unpublishing = build(:unpublishing)
+                  build(:edition, unpublishing:)
+                else
+                  build(:edition, hash[:state])
+                end
 
       expected_output = "<span class=\"#{hash[:expected_tag_classes]}\">#{hash[:label_text]}</span>"
       output = render_inline(Admin::Editions::TagsComponent.new(edition)).to_html.strip


### PR DESCRIPTION
## Description

There's quite a few places in the view component tests where we can use build or build_stubbed instead of create. This speeds the tests up by about 15%.


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
