### PR TITLE
Allow external redirects to caa.co.uk

### DIFF
--- a/app/validators/gov_uk_url_format_validator.rb
+++ b/app/validators/gov_uk_url_format_validator.rb
@@ -1,6 +1,7 @@
 # Accepts options[:message] and options[:allowed_protocols]
 class GovUkUrlFormatValidator < ActiveModel::EachValidator
   EXTERNAL_HOST_ALLOW_LIST = %w[
+    .caa.co.uk
     .gov.uk
     .judiciary.uk
     .nationalhighways.co.uk


### PR DESCRIPTION
This allows users to unpublish documents and redirect it to URLs on the Civil Aviation Authority (CAA) website.

Requested in Zendesk ticket:
https://govuk.zendesk.com/agent/tickets/4994883

And agreed in Slack thread:
https://gds.slack.com/archives/CACV3TACU/p1694690016148749

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
