### PR TITLE
Allow csv attachments to use modern urls

### DIFF
--- a/app/controllers/admin/attachments_controller.rb
+++ b/app/controllers/admin/attachments_controller.rb
@@ -34,7 +34,7 @@ class Admin::AttachmentsController < Admin::BaseController
     attachment.attributes = attachment_params
     message = "Attachment '#{attachment.title}' updated"
     if attachment.is_a?(FileAttachment)
-      attachment.attachment_data.use_non_legacy_endpoints = use_non_legacy_endpoints unless attachment.attachment_data.csv?
+      attachment.attachment_data.use_non_legacy_endpoints = use_non_legacy_endpoints
 
       attachment.attachment_data.attachable = attachable
       if attachment.filename_changed? && attachable.allows_inline_attachments?
@@ -104,7 +104,7 @@ private
     FileAttachment.new(attachment_params).tap do |file_attachment|
       file_attachment.build_attachment_data unless file_attachment.attachment_data
       file_attachment.attachment_data.attachable = attachable
-      file_attachment.attachment_data.use_non_legacy_endpoints = use_non_legacy_endpoints? unless file_attachment.attachment_data.csv?
+      file_attachment.attachment_data.use_non_legacy_endpoints = use_non_legacy_endpoints?
     end
   end
 

--- a/app/controllers/admin/bulk_uploads_controller.rb
+++ b/app/controllers/admin/bulk_uploads_controller.rb
@@ -26,7 +26,7 @@ class Admin::BulkUploadsController < Admin::BaseController
     @bulk_upload.attachments_attributes = create_params[:attachments_attributes]
     @bulk_upload.attachments.each do |attachment|
       attachment.attachment_data.attachable = @edition
-      attachment.attachment_data.use_non_legacy_endpoints = use_non_legacy_endpoints? unless attachment.attachment_data.csv?
+      attachment.attachment_data.use_non_legacy_endpoints = use_non_legacy_endpoints?
     end
     if @bulk_upload.save_attachments
       redirect_to admin_edition_attachments_path(@edition)

--- a/app/workers/create_asset_relationship_worker.rb
+++ b/app/workers/create_asset_relationship_worker.rb
@@ -2,7 +2,7 @@ class CreateAssetRelationshipWorker < WorkerBase
   def perform(start_id, end_id)
     logger.info("CreateAssetRelationshipWorker start!")
     assetable_type = AttachmentData
-    assetables = assetable_type.where(id: start_id..end_id).where.not(content_type: "text/csv")
+    assetables = assetable_type.where(id: start_id..end_id)
     logger.info "Number of #{assetable_type} found: #{assetables.count}"
     logger.info "Creating Asset for records from #{start_id} to #{end_id}"
 


### PR DESCRIPTION
This change is to allow csv attachments to use modern non-legacy urls like any other file attachment.
This had to be done separately as it relied on frontend code change 'https://github.com/alphagov/frontend/pull/3761' to be merged.


[Trello](https://trello.com/c/LV4TnjlP/176-story-csv-previews-should-work-with-modern-urls)