### PR TITLE
Fix bug - excluded nations on calls for evidence

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -344,7 +344,7 @@ private
   end
 
   def build_national_exclusion_params
-    design_system_controllers = %w[consultations detailed_guides publications]
+    design_system_controllers = %w[calls_for_evidence consultations detailed_guides publications]
     return unless design_system_controllers.include?(controller_name)
     return if edition_params["nation_inapplicabilities_attributes"].blank?
 


### PR DESCRIPTION
This fixes an issue reported by a user in Zendesk ticket [5494745][1], where they're unable to set or change national exclusions on call for evidence documents.

This is because the editions controller needs to know the names of document types that can have national exclusions. Hardcoding the controller names here is a bit of a smell, as pointed out in the description of PR #6872 which introduced it.

I'd like to think there's a cleaner way to do this – I think it's ripe for refactoring. But for now this is the quick fix.

[1]: https://govuk.zendesk.com/agent/tickets/5494745

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
