### PR TITLE
Remove hardcoded controller names

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -344,8 +344,6 @@ private
   end
 
   def build_national_exclusion_params
-    design_system_controllers = %w[calls_for_evidence consultations detailed_guides publications]
-    return unless design_system_controllers.include?(controller_name)
     return if edition_params["nation_inapplicabilities_attributes"].blank?
 
     exclusion_params = edition_params["all_nation_applicability"] || []


### PR DESCRIPTION
Following the 'quick fix' that was applied in #8295, I wanted to see if there was anything I could do to avoid the need for hardcoding controller names altogether.

This seems like a safe change to make here. It hasn't caused any tests to fail. I suspect it was a hangover from the Design System Transition work which has now all-but-concluded.

It seems reasonable just to rely on the presence of `nation_inapplicabilities_attributes` - Edition types that don't apply differently to different nations will not be submitting these form fields in the first place.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
