### PR TITLE
Filter out already migrated AttachmentData

### DIFF
--- a/app/workers/create_asset_relationship_worker.rb
+++ b/app/workers/create_asset_relationship_worker.rb
@@ -2,7 +2,7 @@ class CreateAssetRelationshipWorker < WorkerBase
   def perform(start_id, end_id)
     logger.info("CreateAssetRelationshipWorker start!")
     assetable_type = AttachmentData
-    assetables = assetable_type.where(id: start_id..end_id)
+    assetables = assetable_type.where(id: start_id..end_id, use_non_legacy_endpoints: false)
     logger.info "Number of #{assetable_type} found: #{assetables.count}"
     logger.info "Creating Asset for records from #{start_id} to #{end_id}"
 


### PR DESCRIPTION
Only run migration for AttachmentData that do not have the use_non_legacy_endpoints flag already set.
