### PR TITLE
Use correct locale for non-English edition links

### DIFF
--- a/app/components/admin/editions/show/sidebar_actions_component.rb
+++ b/app/components/admin/editions/show/sidebar_actions_component.rb
@@ -269,7 +269,7 @@ private
   def add_view_action
     if @edition.publicly_visible?
       actions << link_to("View on website (opens in new tab)",
-                         @edition.public_url(locale: @edition.primary_locale),
+                         @edition.public_url,
                          class: "govuk-link",
                          target: "_blank",
                          rel: "noopener",

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -692,6 +692,7 @@ EXISTS (
   def public_path(options = {})
     return if base_path.nil?
 
+    options[:locale] ||= primary_locale
     append_url_options(base_path, options)
   end
 

--- a/test/unit/app/models/edition/urls_test.rb
+++ b/test/unit/app/models/edition/urls_test.rb
@@ -1,0 +1,44 @@
+require "test_helper"
+
+class Edition::UrlsTest < ActiveSupport::TestCase
+  def edition
+    @edition ||= create(:published_publication, title: "Price of steel")
+  end
+
+  test "base_path is the path on GOV.UK without a locale or query parameters" do
+    assert_equal "/government/publications/price-of-steel",
+                 edition.base_path
+  end
+
+  test "public_path is the path to the document on GOV.UK" do
+    assert_equal "/government/publications/price-of-steel",
+                 edition.public_path
+  end
+
+  test "public_path accepts locale parameter" do
+    assert_equal "/government/publications/price-of-steel.fr",
+                 edition.public_path(locale: "fr")
+  end
+
+  test "public_path defaults to using the primary locale" do
+    edition.primary_locale = "fr"
+    assert_equal "/government/publications/price-of-steel.fr",
+                 edition.public_path
+  end
+
+  test "public_url is a full URL to the document on GOV.UK" do
+    assert_equal "https://www.test.gov.uk/government/publications/price-of-steel",
+                 edition.public_url
+  end
+
+  test "public_url with `draft: true` links to the draft stack" do
+    assert_equal "https://draft-origin.test.gov.uk/government/publications/price-of-steel",
+                 edition.public_url(draft: true)
+  end
+
+  test "public_url defaults to using the primary_locale" do
+    edition.primary_locale = "fr"
+    assert_equal "https://www.test.gov.uk/government/publications/price-of-steel.fr",
+                 edition.public_url
+  end
+end


### PR DESCRIPTION
The method `Edition#public_url` returns the publicly visible URL for a document on the GOV.UK website.

However it was not returning the correct URL for editions with a non-English primary locale – for example, for foreign-language only news articles or consultations.

This bug was partially fixed in #7803 but only for the "View on website" link shown in the sidebar for published editions.

We've since received a [Zendesk ticket][1] telling us that the "Preview on website" link, as well as the links in publisher notification emails, were still missing the locale from the end of the URL. This meant users got "Page not found" errors when following those links.

This commit fixes the root cause of the problem, meaning I can safely remove the fix applied in #7803 as it's no longer required.

---

For reference, the "Preview on website" link does not explicitly set a locale when getting the public URL:

https://github.com/alphagov/whitehall/blob/6e86aaea8b86cedc6e6689deebcec87a12269bf7/app/components/admin/editions/show/preview_component.html.erb#L11

Nor do the email notifications:

https://github.com/alphagov/whitehall/blob/cf42f9e3202fbb19b90c3bfe9e893ab5e28904cd/app/services/author_notifier_service.rb#L40-L42

Therefore the changes made to `Edition#public_url` should fix these broken links (and any others throughout the app).

[1]: https://govuk.zendesk.com/agent/tickets/5491481

---

Trello: https://trello.com/c/xzQvVgtw/1767-fix-broken-links-for-non-english-editions

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
