### PR TITLE
Keep list of user permissions in one place

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,6 +28,7 @@ class User < ApplicationRecord
     PREVIEW_NEXT_RELEASE = "Preview next release".freeze
     USE_NON_LEGACY_ENDPOINTS = "Use non legacy endpoints".freeze
     EMAIL_OVERRIDE_EDITOR = "Email override editor".freeze
+    SIDEKIQ_ADMIN = "Sidekiq Admin".freeze
   end
 
   def role

--- a/lib/sidekiq_gds_sso_middleware.rb
+++ b/lib/sidekiq_gds_sso_middleware.rb
@@ -1,7 +1,7 @@
 require "sidekiq/web"
 
 class SidekiqGdsSsoMiddleware
-  SIDEKIQ_SIGNON_PERMISSION = "Sidekiq Admin".freeze
+  SIDEKIQ_SIGNON_PERMISSION = User::Permissions::SIDEKIQ_ADMIN
 
   def self.call(...) = new(...).call
 


### PR DESCRIPTION
Whitehall keeps a list of user permissions that it accepts from Signon users in the module User::Permissions as constants.

The only exception to that was the "Sidekiq Admin" permission, which was defined in SidekiqGdsSsoMiddleware.

To simplify things I've decided to centralise the list of 'known' user permissions. This will make it easier to keep track of the permissions, and gives us an easy way to answer the question: "Which permissions does Whitehall use?".

Now that the list is kept in one place, the answer is simple. If it's not listed in User::Permissions, then Whitehall doesn't know or care about it.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
