### PR TITLE
Use asset_manager_id for deleting an individual image

### DIFF
--- a/test/factories/image_data.rb
+++ b/test/factories/image_data.rb
@@ -2,4 +2,18 @@ FactoryBot.define do
   factory :image_data do
     file { image_fixture_file }
   end
+
+  factory :image_data_with_assets, parent: :image_data do
+    use_non_legacy_endpoints { true }
+
+    after(:build) do |image_data|
+      image_data.assets << build(:asset, asset_manager_id: "asset_manager_id_original", variant: Asset.variants[:original], filename: "minister-of-funk.960x640.jpg")
+      image_data.assets << build(:asset, asset_manager_id: "asset_manager_id_s960", variant: Asset.variants[:s960], filename: "s960_minister-of-funk.960x640.jpg")
+      image_data.assets << build(:asset, asset_manager_id: "asset_manager_id_s712", variant: Asset.variants[:s712], filename: "s712_minister-of-funk.960x640.jpg")
+      image_data.assets << build(:asset, asset_manager_id: "asset_manager_id_s630", variant: Asset.variants[:s630], filename: "s630_minister-of-funk.960x640.jpg")
+      image_data.assets << build(:asset, asset_manager_id: "asset_manager_id_s465", variant: Asset.variants[:s465], filename: "s465_minister-of-funk.960x640.jpg")
+      image_data.assets << build(:asset, asset_manager_id: "asset_manager_id_s300", variant: Asset.variants[:s300], filename: "s300_minister-of-funk.960x640.jpg")
+      image_data.assets << build(:asset, asset_manager_id: "asset_manager_id_s216", variant: Asset.variants[:s216], filename: "s216_minister-of-funk.960x640.jpg")
+    end
+  end
 end

--- a/test/factories/images.rb
+++ b/test/factories/images.rb
@@ -3,4 +3,10 @@ FactoryBot.define do
     alt_text { "An accessible description of the image" }
     image_data
   end
+
+  factory :image_with_asset, parent: :image do
+    after(:build) do |image|
+      image.image_data = build(:image_data_with_assets)
+    end
+  end
 end

--- a/test/integration/image_deletion_integration_test.rb
+++ b/test/integration/image_deletion_integration_test.rb
@@ -1,0 +1,108 @@
+require "test_helper"
+require "capybara/rails"
+
+class ImageDeletionIntegrationTest < ActionDispatch::IntegrationTest
+  extend Minitest::Spec::DSL
+  include Capybara::DSL
+  include Rails.application.routes.url_helpers
+  include TaxonomyHelper
+
+  describe "image deletion" do
+    context "given a draft document with images" do
+      context "images don't have assets" do
+        let(:managing_editor) { create(:managing_editor) }
+        let(:image) { build(:image) }
+        let(:edition) { create(:news_article) }
+        let(:versions) { %i[s960 s712 s630 s465 s300 s216] }
+
+        before do
+          login_as(managing_editor)
+          stub_publishing_api_has_linkables([], document_type: "topic")
+          edition.images << image
+          setup_publishing_api_for(edition)
+          stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+
+          stub_whitehall_asset(image.image_data.file.file.filename, id: image.image_data.file.file.asset_manager_path)
+          versions.each { |version| stub_whitehall_asset(image.image_data.file.versions[version].file.filename, id: image.image_data.file.versions[version].file.asset_manager_path) }
+          edition.save!
+        end
+
+        context "when image is deleted" do
+          before do
+            visit admin_news_article_path(edition)
+            click_link "Modify images"
+            click_link "Delete image"
+            click_button "Delete image"
+            assert_text "minister-of-funk.960x640.jpg has been deleted"
+          end
+
+          it "deletes the corresponding asset in Asset Manager" do
+            Services.asset_manager.expects(:delete_asset).times(7).with(regexp_matches(/.*minister-of-funk.960x640.jpg.*/))
+            assert_equal 7, AssetManagerDeleteAssetWorker.jobs.count
+
+            AssetManagerDeleteAssetWorker.drain
+          end
+        end
+      end
+
+      context "images have assets" do
+        let(:managing_editor) { create(:managing_editor) }
+        let(:image) { build(:image_with_asset) }
+        let(:first_asset_id) { image.image_data.assets.first.asset_manager_id }
+        let(:edition) { create(:news_article) }
+
+        before do
+          login_as(managing_editor)
+          stub_publishing_api_has_linkables([], document_type: "topic")
+          edition.images << image
+          setup_publishing_api_for(edition)
+          stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+
+          image.image_data.assets.each { |asset| stub_asset(asset.asset_manager_id) }
+
+          edition.save!
+        end
+
+        context "when one image is deleted" do
+          before do
+            visit admin_news_article_path(edition)
+            click_link "Modify images"
+            click_link "Delete image"
+            click_button "Delete image"
+            assert_text "minister-of-funk.960x640.jpg has been deleted"
+          end
+
+          it "deletes the corresponding asset in Assets and Assets Asset Manager" do
+            Services.asset_manager.expects(:delete_asset).times(7).with(regexp_matches(/asset_manager_id.*/))
+
+            AssetManagerDeleteAssetWorker.drain
+          end
+        end
+      end
+    end
+
+  private
+
+    def ends_with(expected)
+      ->(actual) { actual.end_with?(expected) }
+    end
+
+    def setup_publishing_api_for(edition)
+      stub_publishing_api_has_links({ content_id: edition.document.content_id, links: {} })
+    end
+
+    def stub_whitehall_asset(filename, attributes = {})
+      url_id = "http://asset-manager/assets/#{attributes[:id]}"
+      Services.asset_manager.stubs(:whitehall_asset)
+              .with(&ends_with(filename))
+              .returns(attributes.merge(id: url_id).stringify_keys)
+    end
+
+    def stub_asset(asset_manger_id, attributes = {})
+      url_id = "http://asset-manager/assets/#{asset_manger_id}"
+      Services.asset_manager.stubs(:asset)
+              .with(asset_manger_id)
+              .returns(attributes.merge(id: url_id).stringify_keys)
+    end
+  end
+end

--- a/test/unit/app/models/image_data_test.rb
+++ b/test/unit/app/models/image_data_test.rb
@@ -71,6 +71,14 @@ class ImageDataTest < ActiveSupport::TestCase
     assert build_example("960x640_jpeg.jpg").bitmap?
   end
 
+  test "should not delete assets when ImageData gets deleted" do
+    image_data = create(:image_data_with_assets)
+    assert_equal 7, image_data.assets.count
+
+    image_data.destroy!
+    assert_equal 7, image_data.assets.count
+  end
+
   def build_example(file_name)
     file = File.open(Rails.root.join("test/fixtures/images", file_name))
     build(:image_data, file:)

--- a/test/unit/lib/whitehall/asset_manager_storage_test.rb
+++ b/test/unit/lib/whitehall/asset_manager_storage_test.rb
@@ -161,8 +161,7 @@ class Whitehall::AssetManagerStorageTest < ActiveSupport::TestCase
 
   context "when use_non_legacy_endpoints permission is true and uploader model is ImageData" do
     setup do
-      model = build(:image_data)
-      model.stubs(:use_non_legacy_endpoints).returns(true)
+      model = build(:image_data_with_assets)
       model.id = 1
       @uploader.stubs(:model).returns(model)
       @assetable_type = ImageData.name
@@ -185,6 +184,14 @@ class Whitehall::AssetManagerStorageTest < ActiveSupport::TestCase
       AssetManagerCreateAssetWorker.expects(:perform_async).with(anything, asset_args, anything, anything, anything, anything)
 
       @uploader.store!(@file)
+    end
+
+    test "should call deleteAssetWorker with asset manager id" do
+      model = create(:image_with_asset)
+
+      AssetManagerDeleteAssetWorker.expects(:perform_async).times(7).with(nil, regexp_matches(/asset_manager_id./))
+
+      model.destroy!
     end
   end
 end


### PR DESCRIPTION
In order to be able to migrate image data to assets, we need to able to create and delete images with `asset_manager_id`. The PR takes care of deleting images using `asset_manager_id`.

[Trello](https://trello.com/c/glNOqpSL/135-story-use-assetmanagerid-for-deleting-an-individual-image)
