### PR TITLE
Only render attachments in previews when we allow inline attachments

### DIFF
--- a/app/views/admin/editions/_standard_fields.html.erb
+++ b/app/views/admin/editions/_standard_fields.html.erb
@@ -63,7 +63,7 @@
       right_to_left: form.object.translation_rtl?,
       data_attributes: {
         image_ids: edition.images.map { |img| img[:id] }.to_json,
-        attachment_ids: edition.allows_attachments? ? edition.attachments.map(&:id) : [],
+        attachment_ids: edition.allows_inline_attachments? ? edition.attachments.map(&:id) : [],
         alternative_format_provider_id: (edition.alternative_format_provider_id || current_user.organisation.try(:id)),
       },
     } %>


### PR DESCRIPTION
Some of our documents that do not allow inline attachments have been wrongly showing inline attachments in the body preview on the edit edition page. This has led to publishers being confused at where their embedded attachment goes when they publish the document.

This was caused because we were passing the attachment ids to the component that renders the preview based on whether they `allow_attachments?` However publications are a document_type that `allow_attachments?` but doesn't `allows_inline_attachments?`. And so incorrectly shows inline attachments in the preview.

This fixes this issue by only passing the attachment ids through to the component that renders the preview if the edition `allows_inline_attachments?`

trello card: https://trello.com/c/24R4gThb

Before: 
<img width="785" alt="Screenshot 2023-09-29 at 17 59 31" src="https://github.com/alphagov/whitehall/assets/17481621/34198dca-7fe1-4b86-96ee-857d8a0ea983">

After:
<img width="788" alt="Screenshot 2023-09-29 at 18 00 27" src="https://github.com/alphagov/whitehall/assets/17481621/e5a055fb-9230-4984-b7dc-eee62f57b3d1">
