### PR TITLE
Transition Individual User and Edit world locations page to GOV UK design system.

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -12,7 +12,11 @@ class Admin::UsersController < Admin::BaseController
   end
 
   def edit
-    head :forbidden unless @user.editable_by?(current_user)
+    unless @user.editable_by?(current_user)
+      head :forbidden
+      return
+    end
+    render_design_system(:edit, :legacy_edit)
   end
 
   def update
@@ -24,14 +28,14 @@ class Admin::UsersController < Admin::BaseController
     if @user.update(user_params)
       redirect_to admin_user_path(@user), notice: "World locations have been updated"
     else
-      render action: "edit"
+      render_design_system(:edit, :legacy_edit)
     end
   end
 
 private
 
   def get_layout
-    design_system_actions = %w[index show] if preview_design_system?(next_release: false)
+    design_system_actions = %w[index show edit] if preview_design_system?(next_release: false)
 
     if design_system_actions&.include?(action_name)
       "design_system"

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -7,7 +7,9 @@ class Admin::UsersController < Admin::BaseController
     render_design_system(:index, :legacy_index)
   end
 
-  def show; end
+  def show
+    render_design_system(:show, :legacy_show)
+  end
 
   def edit
     head :forbidden unless @user.editable_by?(current_user)
@@ -20,7 +22,7 @@ class Admin::UsersController < Admin::BaseController
     end
 
     if @user.update(user_params)
-      redirect_to admin_user_path(@user), notice: "Your settings have been saved"
+      redirect_to admin_user_path(@user), notice: "World locations have been updated"
     else
       render action: "edit"
     end
@@ -29,7 +31,7 @@ class Admin::UsersController < Admin::BaseController
 private
 
   def get_layout
-    design_system_actions = %w[index] if preview_design_system?(next_release: false)
+    design_system_actions = %w[index show] if preview_design_system?(next_release: false)
 
     if design_system_actions&.include?(action_name)
       "design_system"

--- a/app/helpers/admin/user_helper.rb
+++ b/app/helpers/admin/user_helper.rb
@@ -1,0 +1,17 @@
+module Admin::UserHelper
+  def show_world_locations(user)
+    if user.world_locations.present?
+      user.world_locations.join(", ", &:name)
+    else
+      ""
+    end
+  end
+
+  def show_edit_link(user)
+    if user.editable_by?(current_user)
+      edit_admin_user_path(user)
+    else
+      ""
+    end
+  end
+end

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -1,20 +1,36 @@
-<% page_title "Edit " + @user.name, "Users" %>
-<section class="user">
-  <h1>Edit settings</h1>
-  <%= form_for @user, as: :user, url: admin_user_path(@user), html: { method: :put } do |form| %>
-    <%= form.errors %>
+<% content_for :page_title, "Edit world Locations" %>
+<% content_for :title, "Edit world Locations" %>
+<% content_for :context, @user.name %>
 
-    <% if @user.editable_by?(current_user) %>
-      <%= form.label :world_location_ids, "Select the world locations" %>
-      <%= form.select :world_location_ids,
-                      options_from_collection_for_select(WorldLocation.ordered_by_name, "id", "name", form.object.world_location_ids),
-                      { include_blank: true },
-                      multiple: true,
-                      class: "chzn-select form-control",
-                      data: { placeholder: "World locations…"} %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for @user, as: :user, url: admin_user_path(@user), method: :put do |form| %>
+      <%= render "components/autocomplete", {
+        id: "user_world_location_ids",
+        name: "user[world_location_ids][]",
+        label: {
+          text: "Locations",
+          heading_size: "l",
+        },
+        select: {
+          multiple: true,
+          selected: form.object.world_location_ids,
+          options: [""] + WorldLocation.all.map { |l| [l.name, l.id] },
+        },
+      } %>
+      <div class="govuk-button-group">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Save",
+          data_attributes: {
+            module: "gem-track-click",
+            "track-category": "form-button",
+            "track-action": "world-location-save-button",
+            "track-label": "Save",
+          },
+        } %>
 
+        <%= link_to "Cancel", admin_user_path(@user), class: "govuk-link govuk-link--no-visited-state" %>
+      </div>
     <% end %>
-
-    <%= form.save_or_cancel cancel: admin_user_path(@user) %>
-  <% end %>
-</section>
+  </div>
+</div>

--- a/app/views/admin/users/legacy_edit.html.erb
+++ b/app/views/admin/users/legacy_edit.html.erb
@@ -1,0 +1,20 @@
+<% page_title "Edit " + @user.name, "Users" %>
+<section class="user">
+  <h1>Edit settings</h1>
+  <%= form_for @user, as: :user, url: admin_user_path(@user), html: { method: :put } do |form| %>
+    <%= form.errors %>
+
+    <% if @user.editable_by?(current_user) %>
+      <%= form.label :world_location_ids, "Select the world locations" %>
+      <%= form.select :world_location_ids,
+                      options_from_collection_for_select(WorldLocation.ordered_by_name, "id", "name", form.object.world_location_ids),
+                      { include_blank: true },
+                      multiple: true,
+                      class: "chzn-select form-control",
+                      data: { placeholder: "World locations…"} %>
+
+    <% end %>
+
+    <%= form.save_or_cancel cancel: admin_user_path(@user) %>
+  <% end %>
+</section>

--- a/app/views/admin/users/legacy_show.html.erb
+++ b/app/views/admin/users/legacy_show.html.erb
@@ -1,0 +1,31 @@
+<% page_title @user.name, "Users" %>
+<section class="user">
+  <nav class="actions">
+    <%= link_to "&laquo; User list".html_safe, admin_users_path, title: "See user list", class: "btn btn-default" %>
+    <% if @user.editable_by?(current_user) %>
+      <%= link_to "Edit", edit_admin_user_path(@user), title: "Edit Settings", class: "btn btn-default" %>
+    <% end %>
+  </nav>
+  <div class="settings">
+    <h1>Settings</h1>
+
+    <h2>Name</h2>
+    <p class="name"><%= @user.name %></p>
+
+    <h2>Role</h2>
+    <p class="role"><%= @user.role %></p>
+
+    <h2>Organisation</h2>
+    <p class="organisation"><%= @user.organisation_name %></p>
+
+    <h2>World locations</h2>
+    <ul class="world-locations">
+      <% @user.world_locations.each do |location| %>
+        <li><%= location.name %></li>
+      <% end %>
+    </ul>
+
+    <h2>Email Address</h2>
+    <p class="email"><%= mail_to @user.email %></p>
+  </div>
+</section>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -1,31 +1,42 @@
+<% content_for :back_link do %>
+  <%= render "govuk_publishing_components/components/back_link", {
+    href: admin_users_path,
+  } %>
+<% end %>
 <% page_title @user.name, "Users" %>
-<section class="user">
-  <nav class="actions">
-    <%= link_to "&laquo; User list".html_safe, admin_users_path, title: "See user list", class: "btn btn-default" %>
-    <% if @user.editable_by?(current_user) %>
-      <%= link_to "Edit", edit_admin_user_path(@user), title: "Edit Settings", class: "btn btn-default" %>
-    <% end %>
-  </nav>
-  <div class="settings">
-    <h1>Settings</h1>
+<% content_for :title, @user.name %>
+<% content_for :title_margin_bottom, 4 %>
 
-    <h2>Name</h2>
-    <p class="name"><%= @user.name %></p>
-
-    <h2>Role</h2>
-    <p class="role"><%= @user.role %></p>
-
-    <h2>Organisation</h2>
-    <p class="organisation"><%= @user.organisation_name %></p>
-
-    <h2>World locations</h2>
-    <ul class="world-locations">
-      <% @user.world_locations.each do |location| %>
-        <li><%= location.name %></li>
-      <% end %>
-    </ul>
-
-    <h2>Email Address</h2>
-    <p class="email"><%= mail_to @user.email %></p>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/summary_list", {
+      title: "",
+      items: [
+        {
+          field: "Name",
+          value: @user.name,
+        },
+        {
+          field: "Email",
+          value: @user.email,
+        },
+        {
+          field: "Role",
+          value: @user.role,
+        },
+        {
+          field: "Organisation",
+          value: @user.organisation,
+        },
+        {
+          field: "World locations",
+          value: show_world_locations(@user),
+          edit: {
+            href: show_edit_link(@user),
+            link_text: "Edit",
+          },
+        },
+      ],
+    } %>
   </div>
-</section>
+</div>

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -11,8 +11,15 @@ When(/^I view my own user record$/) do
 end
 
 Then(/^I can see my user details/) do
-  expect(page).to have_selector(".user .name", text: @user.name)
-  expect(page).to have_selector(".user .email", text: %r{#{@user.email}})
+  if using_design_system?
+    expect(page).to have_selector(".govuk-summary-list__row:nth-child(1) .govuk-summary-list__key", text: "Name")
+    expect(page).to have_selector(".govuk-summary-list__row:nth-child(1) .govuk-summary-list__value", text: @user.name)
+    expect(page).to have_selector(".govuk-summary-list__row:nth-child(2) .govuk-summary-list__key", text: "Email")
+    expect(page).to have_selector(".govuk-summary-list__row:nth-child(2) .govuk-summary-list__value", text: @user.email)
+  else
+    expect(page).to have_selector(".user .name", text: @user.name)
+    expect(page).to have_selector(".user .email", text: %r{#{@user.email}})
+  end
 end
 
 Then(/^I cannot change my user details/) do
@@ -29,7 +36,13 @@ end
 Then(/^I should see that I am logged in as a "([^"]*)"$/) do |role|
   visit admin_user_path(@user)
   click_link "#user_settings"
-  expect(page).to have_selector(".user .settings .role", text: role)
+  if using_design_system?
+    expect(page).to have_selector(".govuk-summary-list__row:nth-child(3) .govuk-summary-list__key", text: "Role")
+    expect(page).to have_selector(".govuk-summary-list__row:nth-child(3) .govuk-summary-list__value", text: @user.role)
+  else
+    expect(page).to have_selector(".user .settings .role", text: role)
+
+  end
 end
 
 Then(/^I should see an email address "([^"]*)"$/) do |email_address|

--- a/test/functional/admin/legacy_users_controller_test.rb
+++ b/test/functional/admin/legacy_users_controller_test.rb
@@ -8,6 +8,7 @@ class Admin::LegacyUsersControllerTest < ActionController::TestCase
   end
 
   should_be_an_admin_controller
+  should_render_bootstrap_implementation_with_preview_next_release
 
   view_test "index shows list of enabled users" do
     disabled_user = create(:disabled_user)

--- a/test/functional/admin/users_controller_test.rb
+++ b/test/functional/admin/users_controller_test.rb
@@ -41,16 +41,15 @@ class Admin::UsersControllerTest < ActionController::TestCase
   end
 
   view_test "edit displays form" do
-    login_as create(:gds_editor)
+    login_as_preview_design_system_user :gds_editor
     get :edit, params: { id: @user.id }
-
     assert_select "form[action='#{admin_user_path(@user)}']" do
       assert_select "button", text: "Save"
     end
   end
 
   view_test "edit displays cancel link" do
-    login_as create(:gds_editor)
+    login_as_preview_design_system_user :gds_editor
     get :edit, params: { id: @user.id }
 
     assert_select "a.govuk-link", text: "Cancel"

--- a/test/functional/admin/users_controller_test.rb
+++ b/test/functional/admin/users_controller_test.rb
@@ -12,17 +12,17 @@ class Admin::UsersControllerTest < ActionController::TestCase
     disabled_user = create(:disabled_user)
     get :index
 
-    assert_select ".govuk-table__row:last-child td:first-child", @user.name
-    refute_select(".govuk-table__row:last-child td:first-child", text: %r{#{disabled_user.name}})
+    assert_select ".govuk-table__cell", @user.name
+    refute_select(".govuk-table__cell", text: %r{#{disabled_user.name}})
   end
 
   view_test "show displays user name and email address" do
     get :show, params: { id: @user.id }
 
-    assert_select ".user .settings" do
-      assert_select ".name", "user-name"
-      assert_select ".email", "user@example.com"
-    end
+    assert_select ".govuk-summary-list__row:nth-child(1) .govuk-summary-list__key", text: "Name"
+    assert_select ".govuk-summary-list__row:nth-child(1) .govuk-summary-list__value", text: @user.name
+    assert_select ".govuk-summary-list__row:nth-child(2) .govuk-summary-list__key", text: "Email"
+    assert_select ".govuk-summary-list__row:nth-child(2) .govuk-summary-list__value", text: @user.email
   end
 
   view_test "show displays edit if you are able to edit the record" do
@@ -45,7 +45,7 @@ class Admin::UsersControllerTest < ActionController::TestCase
     get :edit, params: { id: @user.id }
 
     assert_select "form[action='#{admin_user_path(@user)}']" do
-      assert_select "input[type='submit'][value='Save']"
+      assert_select "button", text: "Save"
     end
   end
 
@@ -53,7 +53,7 @@ class Admin::UsersControllerTest < ActionController::TestCase
     login_as create(:gds_editor)
     get :edit, params: { id: @user.id }
 
-    assert_select ".or_cancel a[href='#{admin_user_path(@user)}']"
+    assert_select "a.govuk-link", text: "Cancel"
   end
 
   test "update saves world location changes by gds editors and redirects to :show" do


### PR DESCRIPTION
This PR transits individual user and world locations edit page to gov uk design system.
It does the following:
Duplicates existing show and edit page to legacy.
Added new show and edit page with design system.
Updated user controller and test file.

**Screen shot:**
**User show page:**
Before:
![image](https://github.com/alphagov/whitehall/assets/131259138/38245714-4354-4f33-b5c7-0040fb0541fe)

**After:**
![image](https://github.com/alphagov/whitehall/assets/131259138/cd22976f-c325-4fcb-ad80-2081d7ebdb71)

**Edit World location page:**
**Before:**
![image](https://github.com/alphagov/whitehall/assets/131259138/5922d82e-4d5f-43f9-ad35-76f30e32306c)

**After:**
![image](https://github.com/alphagov/whitehall/assets/131259138/f5208cd6-3e26-4286-8717-34f80384a598)

**Trello:**
https://trello.com/c/L8C5pFU1/548-transition-individual-user-page-to-govuk-design-system
