### PR TITLE
Add uniqueness constrain for assets

### DIFF
--- a/app/models/asset.rb
+++ b/app/models/asset.rb
@@ -6,6 +6,16 @@ class Asset < ApplicationRecord
   validates :variant, presence: true
   validates :filename, presence: true
 
+  validates :unique_variant_for_each_assetable, acceptance: true
+
+  def unique_variant_for_each_assetable
+    return unless assetable
+
+    if Asset.where(assetable_id:, variant:).where.not(id:).exists?
+      errors.add(:variant, "already exist for the assetable")
+    end
+  end
+
   enum variant: {
     original: "original".freeze,
     thumbnail: "thumbnail".freeze,

--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -62,7 +62,8 @@ class AttachmentData < ApplicationRecord
   end
 
   def all_asset_variants_uploaded?
-    assets.size == (pdf? ? 2 : 1)
+    unique_asset_variants = assets.map(&:variant).to_set
+    unique_asset_variants.size == (pdf? ? 2 : 1)
   end
 
   def update_file_attributes

--- a/test/integration/asset_manager_test.rb
+++ b/test/integration/asset_manager_test.rb
@@ -6,7 +6,7 @@ class AssetManagerIntegrationTest
 
     setup do
       @filename = "sample.docx"
-      @attachment = FactoryBot.build(:file_attachment_with_asset)
+      @attachment = FactoryBot.build(:file_attachment_with_no_assets, file: file_fixture(@filename))
       @asset_manager_response = { "id" => "http://asset-manager/assets/asset_manager_id", "name" => @filename }
     end
 

--- a/test/unit/app/models/asset_test.rb
+++ b/test/unit/app/models/asset_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class AssetTest < ActiveSupport::TestCase
   setup do
-    @attachment_data = build(:attachment_data)
+    @attachment_data = create(:attachment_data_with_no_assets)
     @variant = Asset.variants[:original]
   end
 
@@ -29,6 +29,20 @@ class AssetTest < ActiveSupport::TestCase
 
   test "should be valid if all fields present" do
     asset = Asset.new(assetable: @attachment_data, asset_manager_id: "asset_manager_id", variant: @variant, filename: "greenpaper.pdf")
+
+    assert asset.valid?
+  end
+
+  test "should not save if variant is duplicated regarding to assetable" do
+    Asset.create!(assetable: @attachment_data, asset_manager_id: "asset_manager_id", variant: @variant, filename: "greenpaper.pdf")
+    asset = Asset.new(assetable: @attachment_data, asset_manager_id: "asset_manager_id_2", variant: @variant, filename: "greenpaper.pdf")
+
+    assert_not asset.valid?
+  end
+
+  test "should allow updating an asset" do
+    asset = Asset.create!(assetable: @attachment_data, asset_manager_id: "asset_manager_id", variant: @variant, filename: "greenpaper.pdf")
+    asset.filename = "not-greepaper.pdf"
 
     assert asset.valid?
   end

--- a/test/unit/app/models/attachment_data_test.rb
+++ b/test/unit/app/models/attachment_data_test.rb
@@ -154,11 +154,12 @@ class AttachmentDataTest < ActiveSupport::TestCase
     greenpaper_pdf = upload_fixture("greenpaper.pdf", "application/pdf")
     attachment = build(:attachment_data, file: greenpaper_pdf)
 
+    second_attempt_attachment = build(:attachment_data_with_no_assets, file: nil, file_cache: attachment.file_cache)
+
     Services.asset_manager.expects(:create_asset).twice.with { |value|
       (value[:file].path.ends_with? "greenpaper.pdf") || (value[:file].path.ends_with? "greenpaper.pdf.png")
     }.returns("id" => "http://asset-manager/assets/#{@asset_manager_id}", "name" => "greenpaper.pdf")
 
-    second_attempt_attachment = build(:attachment_data, file: nil, file_cache: attachment.file_cache)
     assert second_attempt_attachment.save
 
     AssetManagerCreateAssetWorker.drain

--- a/test/unit/app/services/asset_manager/attachment_updater_test.rb
+++ b/test/unit/app/services/asset_manager/attachment_updater_test.rb
@@ -214,9 +214,10 @@ class AssetManager::AttachmentUpdaterTest < ActiveSupport::TestCase
     describe "replacement ID updates" do
       context "when attachment does not have a replacement" do
         let(:sample_rtf) { File.open(fixture_path.join("sample.rtf")) }
-        let(:attachment_data) { AttachmentData.create!(file: sample_rtf) }
+        let(:attachment_data) { create(:attachment_data, file: sample_rtf) }
 
         it "does not update asset manager" do
+          attachment_data.assets = [thumbnail_asset]
           attachment_data.assets.create!(asset_manager_id: "asset_manager_id", variant: original, filename: "sample.rtf")
           update_service.expects(:call).never
 
@@ -282,6 +283,7 @@ class AssetManager::AttachmentUpdaterTest < ActiveSupport::TestCase
         let(:replacement) { AttachmentData.create!(file: sample_docx) }
 
         it "raises a AssetNotFound error" do
+          attachment_data.assets = [thumbnail_asset]
           attachment_data.assets.create!(asset_manager_id: "asset_manager_id", variant: original, filename: "sample.rtf")
           replacement.assets.create!(asset_manager_id: "replacement_asset_manager_id", variant: original, filename: "sample.docx")
 


### PR DESCRIPTION
To avoid creating duplicate assets, we introduced uniqueness constraint on assets.
This change is backward compatible. e.g. If updating api fails in AssetManagerCreateAssetWorker, then the worker will only retry to update api and will not try to create duplicate asset.

[Trello card](https://trello.com/c/zsXWiOne/196-add-uniqueness-constraint-on-assets-assetmanagerid)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
