### PR TITLE
Block publishing when image assets are still uploading

### DIFF
--- a/app/models/attachable.rb
+++ b/app/models/attachable.rb
@@ -95,7 +95,7 @@ module Attachable
       deleted_attachments.map { |a| ChangedAttachment.new(a, :deleted) }
   end
 
-  def uploaded_to_asset_manager?
+  def attachments_uploaded_to_asset_manager?
     attachments
       .map(&:attachment_data)
       .compact

--- a/app/models/edition/images.rb
+++ b/app/models/edition/images.rb
@@ -19,6 +19,13 @@ module Edition::Images
     accepts_nested_attributes_for :images, reject_if: :no_substantive_attributes?, allow_destroy: true
 
     add_trait Trait
+
+    def images_uploaded_to_asset_manager?
+      images
+        .map(&:image_data)
+        .compact
+        .all?(&:all_asset_variants_uploaded?)
+    end
   end
 
   def allows_image_attachments?

--- a/app/models/edition/publishing.rb
+++ b/app/models/edition/publishing.rb
@@ -6,7 +6,8 @@ module Edition::Publishing
 
     validates :major_change_published_at, presence: true, if: :published?
     validate :change_note_present!, if: :change_note_required?
-    validate :attachment_uploaded_to_asset_manager!, if: :asset_manager_check_required?
+    validate :attachments_uploaded_to_asset_manager!, if: :attachments_in_asset_manager_check_required?
+    validate :images_uploaded_to_asset_manager!, if: :images_in_asset_manager_check_required?
 
     scope :significant_change, -> { where(minor_change: false) }
   end
@@ -52,12 +53,20 @@ module Edition::Publishing
     end
   end
 
-  def asset_manager_check_required?
+  def attachments_in_asset_manager_check_required?
     allows_attachments? && published?
   end
 
-  def attachment_uploaded_to_asset_manager!
-    errors.add(:attachments, "must have finished uploading") unless uploaded_to_asset_manager?
+  def attachments_uploaded_to_asset_manager!
+    errors.add(:attachments, "must have finished uploading") unless attachments_uploaded_to_asset_manager?
+  end
+
+  def images_in_asset_manager_check_required?
+    allows_image_attachments? && published?
+  end
+
+  def images_uploaded_to_asset_manager!
+    errors.add(:images, "must have finished uploading") unless images_uploaded_to_asset_manager?
   end
 
   def build_unpublishing(attributes = {})

--- a/test/unit/app/models/attachable_test.rb
+++ b/test/unit/app/models/attachable_test.rb
@@ -406,13 +406,13 @@ class AttachableTest < ActiveSupport::TestCase
     assert_equal [attachable_edition], attachable_edition.attachables
   end
 
-  test "#uploaded_to_asset_manager? returns false if any of the assets are not ready" do
+  test "#attachments_uploaded_to_asset_manager? returns false if any of the assets are not ready" do
     file_attachment_with_all_assets = build(:file_attachment)
     file_attachment_with_missing_assets = build(:file_attachment_with_no_assets)
     attachable_edition = build(:edition)
     attachable_edition.attachments = [file_attachment_with_all_assets, file_attachment_with_missing_assets]
 
-    assert_not attachable_edition.uploaded_to_asset_manager?
+    assert_not attachable_edition.attachments_uploaded_to_asset_manager?
   end
 
   test "attachments_ready_for_publishing filters out file attachments with missing assets" do

--- a/test/unit/app/models/edition/publishing_test.rb
+++ b/test/unit/app/models/edition/publishing_test.rb
@@ -157,7 +157,7 @@ class Edition::PublishingTest < ActiveSupport::TestCase
     assert_equal edition, edition.unpublished_edition
   end
 
-  test "is valid if all assets have been uploaded" do
+  test "is valid if all file attachment assets have been uploaded" do
     published_edition = build(:published_edition)
     attachment = build(:file_attachment)
     published_edition.attachments << attachment
@@ -165,11 +165,30 @@ class Edition::PublishingTest < ActiveSupport::TestCase
     assert published_edition.valid?
   end
 
-  test "is invalid if some assets are missing" do
+  test "is invalid if some file attachment assets are missing" do
     published_edition = build(:published_edition)
     attachment = build(:file_attachment_with_no_assets)
     published_edition.attachments << attachment
 
     assert_not published_edition.valid?
+    assert_includes published_edition.errors[:attachments], "must have finished uploading"
+  end
+
+  test "is valid if all image assets have been uploaded" do
+    published_edition = build(:published_news_article)
+    image = build(:image_with_assets)
+    published_edition.images << image
+
+    assert published_edition.valid?
+  end
+
+  test "is invalid if some image assets are missing" do
+    published_edition = build(:published_news_article)
+    image_data = build(:image_data, use_non_legacy_endpoints: true)
+    image = build(:image, image_data:)
+    published_edition.images << image
+
+    assert_not published_edition.valid?
+    assert_includes published_edition.errors[:images], "must have finished uploading"
   end
 end


### PR DESCRIPTION
Extending the functionality already in place for file attachments.

If any of the 7 variants of an image (1 original + 6 carrierwave versions) are still uploading, then the user will see an error message informing them that they cannot publish/force-publish/submit.

This check is based on a method implemented in the ImageData class, which verifies all existing assets associated with it.

[Trello card](https://trello.com/c/lcMrLZs6/197-validate-image-uploads-before-publish)
