### PR TITLE
Add a confirm publish page to edition workflow

### DIFF
--- a/app/components/admin/editions/show/sidebar_actions_component.rb
+++ b/app/components/admin/editions/show/sidebar_actions_component.rb
@@ -142,20 +142,17 @@ private
 
   def add_publish_action
     if @publisher.can_perform? && @enforcer.can?(:publish)
-      actions << form_with(url: publish_admin_edition_path(@edition, lock_version: @edition.lock_version), method: :post, data: {
-        module: "prevent-multiple-form-submissions",
-      }) do
-        render("govuk_publishing_components/components/button", {
-          text: "Publish",
-          title: "Publish #{@edition.title}",
-          data_attributes: {
-            module: "gem-track-click",
-            "track-category": "button-pressed",
-            "track-action": "#{dasherized_class_name}-button",
-            "track-label": "Publish",
-          },
-        })
-      end
+      actions << render("govuk_publishing_components/components/button", {
+        text: "Publish",
+        title: "Publish #{@edition.title}",
+        href: confirm_publish_admin_edition_path(@edition, lock_version: @edition.lock_version),
+        data_attributes: {
+          module: "gem-track-click",
+          "track-category": "button-pressed",
+          "track-action": "#{dasherized_class_name}-button",
+          "track-label": "Publish",
+        },
+      })
     elsif @force_publisher.can_perform? && @enforcer.can?(:force_publish)
       actions << render("govuk_publishing_components/components/button", {
         text: "Force publish",

--- a/app/controllers/admin/edition_workflow_controller.rb
+++ b/app/controllers/admin/edition_workflow_controller.rb
@@ -33,7 +33,7 @@ class Admin::EditionWorkflowController < Admin::BaseController
       enforce_permission!(:update, @edition)
     when "reject"
       enforce_permission!(:reject, @edition)
-    when "publish", "schedule"
+    when "publish", "schedule", "confirm_publish"
       enforce_permission!(:publish, @edition)
     when "force_publish", "confirm_force_publish", "force_schedule", "confirm_force_schedule"
       enforce_permission!(:force_publish, @edition)
@@ -63,6 +63,12 @@ class Admin::EditionWorkflowController < Admin::BaseController
     end
     redirect_to new_admin_edition_editorial_remark_path(@edition),
                 notice: "Document rejected; please explain why in an internal note"
+  end
+
+  def confirm_publish
+    unless @edition.valid?(:publish)
+      redirect_to admin_edition_path(@edition), alert: @edition.errors[:base].join(". ")
+    end
   end
 
   def publish
@@ -167,7 +173,7 @@ class Admin::EditionWorkflowController < Admin::BaseController
 private
 
   def get_layout
-    design_system_actions = %w[confirm_approve_retrospectively confirm_force_schedule confirm_unpublish confirm_unschedule confirm_unwithdraw unpublish confirm_force_publish]
+    design_system_actions = %w[confirm_approve_retrospectively confirm_force_schedule confirm_publish confirm_unpublish confirm_unschedule confirm_unwithdraw unpublish confirm_force_publish]
     if design_system_actions.include?(action_name)
       "design_system"
     else
@@ -293,6 +299,8 @@ private
       "unpublish this edition"
     when "confirm_force_publish"
       "force publish this edition"
+    when "confirm_publish"
+      "publish this edition"
     when "confirm_unwithdraw"
       "unwithdraw this edition"
     else

--- a/app/helpers/admin/edition_actions_helper.rb
+++ b/app/helpers/admin/edition_actions_helper.rb
@@ -61,7 +61,7 @@ module Admin::EditionActionsHelper
     else
       button_to(
         "Publish",
-        publish_admin_edition_path(edition, lock_version: edition.lock_version),
+        confirm_publish_admin_edition_path(edition, lock_version: edition.lock_version),
         title: button_title,
         class: "btn btn-success publish",
       )

--- a/app/views/admin/edition_workflow/confirm_publish.html.erb
+++ b/app/views/admin/edition_workflow/confirm_publish.html.erb
@@ -1,0 +1,20 @@
+<% content_for :context, @edition.title %>
+<% content_for :page_title, "Publish: #{@edition.title}" %>
+<% content_for :title, "Publish" %>
+<% content_for :title_margin_bottom, 6 %>
+<% render "admin/tracking/subtype_tracking", document_type: @edition.type, document: @edition %>
+
+<div class="govuk-grid-row">
+  <section class="govuk-grid-column-two-thirds">
+    <%= form_tag publish_admin_edition_path(@edition, lock_version: @edition.lock_version), class: "well publish-form" do %>
+      <p class="govuk-body govuk-!-margin-bottom-7">Once you publish, this document will be visible to the public</p>
+      <div class="govuk-button-group govuk-!-margin-bottom-6">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Publish",
+        } %>
+
+        <%= link_to("Cancel", [:admin, @edition], class: "govuk-link govuk-link--no-visited-state") %>
+      </div>
+    <% end %>
+  </section>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -186,6 +186,7 @@ Whitehall::Application.routes.draw do
           post :approve_retrospectively, to: "edition_workflow#approve_retrospectively"
           post :reject, to: "edition_workflow#reject"
           post :publish, to: "edition_workflow#publish"
+          get  :confirm_publish, to: "edition_workflow#confirm_publish"
           get  :confirm_force_publish, to: "edition_workflow#confirm_force_publish"
           post :force_publish, to: "edition_workflow#force_publish"
           get  :confirm_unpublish, to: "edition_workflow#confirm_unpublish"

--- a/features/step_definitions/document_steps.rb
+++ b/features/step_definitions/document_steps.rb
@@ -83,6 +83,7 @@ When("I submit {edition}") do |edition|
 end
 
 When("I publish {edition}") do |edition|
+  stub_publishing_api_links_with_taxons(edition.content_id, %w[a-taxon-content-id])
   visit_edition_admin edition.title
   publish
 end

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -162,6 +162,7 @@ module DocumentHelper
         click_button "Force publish"
       end
     else
+      click_link "Publish"
       click_button "Publish"
     end
 

--- a/test/components/admin/editions/show/sidebar_actions_component_test.rb
+++ b/test/components/admin/editions/show/sidebar_actions_component_test.rb
@@ -140,7 +140,7 @@ class Admin::Editions::Show::SidebarActionsComponentTest < ViewComponent::TestCa
     render_inline(Admin::Editions::Show::SidebarActionsComponent.new(edition:, current_user:))
 
     assert_selector "li", count: 4
-    assert_selector "button", text: "Publish"
+    assert_selector "a", text: "Publish"
     assert_selector "button", text: "Reject"
     assert_selector "a", text: "Edit draft"
     assert_selector "a", text: "Delete draft"

--- a/test/functional/admin/generic_editions_controller_tests/publishing_documents_test.rb
+++ b/test/functional/admin/generic_editions_controller_tests/publishing_documents_test.rb
@@ -13,7 +13,7 @@ class Admin::GenericEditionsController::PublishingDocumentsTest < ActionControll
     stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
 
     get :show, params: { id: edition }
-    assert_select publish_form_selector(edition), count: 1
+    assert_select publish_link_selector(edition), count: 1
   end
 
   view_test "should not display the publish form if edition is not publishable" do
@@ -21,6 +21,6 @@ class Admin::GenericEditionsController::PublishingDocumentsTest < ActionControll
     stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
 
     get :show, params: { id: edition }
-    refute_select publish_form_selector(edition)
+    refute_select publish_link_selector(edition)
   end
 end

--- a/test/support/css_selectors.rb
+++ b/test/support/css_selectors.rb
@@ -73,8 +73,8 @@ module CssSelectors
     "#world-locations"
   end
 
-  def publish_form_selector(document)
-    "form[action='#{publish_admin_edition_path(document, lock_version: document.lock_version)}']"
+  def publish_link_selector(document)
+    "a[href='#{confirm_publish_admin_edition_path(document, lock_version: document.lock_version)}']"
   end
 
   def force_publish_button_selector(document)

--- a/test/unit/app/helpers/admin/edition_actions_helper_test.rb
+++ b/test/unit/app/helpers/admin/edition_actions_helper_test.rb
@@ -5,7 +5,7 @@ class Admin::EditionActionsHelperTest < ActionView::TestCase
     edition = create(:submitted_edition, title: "edition-title")
     html = publish_edition_form(edition)
     fragment = Nokogiri::HTML.fragment(html)
-    assert_equal publish_admin_edition_path(edition, lock_version: edition.lock_version), (fragment / "form").first["action"]
+    assert_equal confirm_publish_admin_edition_path(edition, lock_version: edition.lock_version), (fragment / "form").first["action"]
     assert_equal "Publish", (fragment / "input[type=submit]").first["value"]
     assert_equal "Publish edition-title", (fragment / "input[type=submit]").first["title"]
     assert((fragment / "input[type=submit]").first["data-confirm"].blank?)


### PR DESCRIPTION
In order to prevent cases of accidental publishing we have added an interstitial page to the publish journey.

Trello card: https://trello.com/c/US0cgYnR

