### PR TITLE
Refactor worker to accept any type of assetable

### DIFF
--- a/app/workers/create_asset_relationship_worker.rb
+++ b/app/workers/create_asset_relationship_worker.rb
@@ -1,38 +1,31 @@
 class CreateAssetRelationshipWorker < WorkerBase
-  def perform(start_id, end_id)
+  attr_reader :asset_counter, :count
+
+  def perform(assetable_type, start_id, end_id)
     logger.info("CreateAssetRelationshipWorker start!")
-    assetable_type = AttachmentData
+
+    assetable_type = assetable_type.constantize
     assetables = assetable_type.where(id: start_id..end_id, use_non_legacy_endpoints: false)
     logger.info "Number of #{assetable_type} found: #{assetables.count}"
     logger.info "Creating Asset for records from #{start_id} to #{end_id}"
 
-    count = 0
-    asset_counter = 0
+    @count = 0
+    @asset_counter = 0
+
     assetables.each do |assetable|
       assetable.use_non_legacy_endpoints = true
       assetable.save!
 
-      begin
-        save_asset_original(assetable, assetable_type.to_s)
-        asset_counter += 1
-      rescue GdsApi::HTTPNotFound
-        logger.warn "#{assetable_type} with id:#{assetable.id} for original asset is not found in AM for legacy url path: #{assetable.file.path}"
+      all_variants = assetable.bitmap? ? assetable.file.versions.keys.push(:original) : [Asset.variants[:original].to_sym]
+      all_variants.each do |variant|
+        @asset_counter += 1 if save_asset(assetable, assetable_type, variant)
       end
 
-      if assetable.pdf?
-        begin
-          save_asset_thumbnail(assetable, assetable_type.to_s)
-          asset_counter += 1
-        rescue GdsApi::HTTPNotFound
-          logger.warn "#{assetable_type} with id:#{assetable.id} for thumbnail asset is not found in AM for legacy url path: #{assetable.file.thumbnail.asset_manager_path}"
-        end
-      end
-
-      count += 1
+      @count += 1
     end
 
-    logger.info("Created assets for #{count} assetable")
-    logger.info("Created asset counter #{asset_counter}")
+    logger.info("Created assets for #{@count} assetable")
+    logger.info("Created asset counter #{@asset_counter}")
     logger.info("CreateAssetRelationshipWorker finish!")
   end
 
@@ -42,34 +35,37 @@ private
     Services.asset_manager
   end
 
-  def save_asset_id_to_assets(assetable_id, assetable_type, variant, asset_manager_id, filename)
-    asset = Asset.new(asset_manager_id:, assetable_type:, assetable_id:, variant:, filename:)
-    asset.save!
+  def save_asset(assetable, assetable_type, variant)
+    path = variant == :original ? assetable.file.path : assetable.file.versions[variant].path
+    asset_info = get_asset_data(path)
+    save_asset_id_to_assets(assetable.id, assetable_type, Asset.variants[variant], asset_info[:asset_manager_id], asset_info[:filename])
+  rescue GdsApi::HTTPNotFound
+    logger.warn "#{assetable_type} of id##{assetable.id} - could not find asset variant :#{variant} at path #{path}"
+
+    false
   end
 
   def get_asset_data(legacy_url_path)
-    asset_info = []
+    asset_info = {}
     path = legacy_url_path.sub(/^\//, "")
-    response_hash = asset_manager.whitehall_asset(path)
-    asset_manager_id = response_hash["id"]
-    asset_info << asset_manager_id[/\/assets\/(.*)/, 1]
-    asset_info << get_filename(response_hash)
-  end
+    response_hash = asset_manager.whitehall_asset(path).to_hash
+    asset_info[:asset_manager_id] = get_asset_id(response_hash)
+    asset_info[:filename] = get_filename(response_hash)
 
-  def save_asset_thumbnail(assetable, assetable_type)
-    path = assetable.file.thumbnail.asset_manager_path
-    asset_info = get_asset_data(path)
-    save_asset_id_to_assets(assetable.id, assetable_type, Asset.variants["thumbnail"], asset_info[0], asset_info[1])
-  end
-
-  def save_asset_original(assetable, assetable_type)
-    path = assetable.file.path
-    asset_info = get_asset_data(path)
-    save_asset_id_to_assets(assetable.id, assetable_type, Asset.variants["original"], asset_info[0], asset_info[1])
+    asset_info
   end
 
   def get_filename(response)
-    attributes = response.to_hash
-    attributes["name"]
+    response["name"]
+  end
+
+  def get_asset_id(response)
+    url = response["id"]
+    url[/\/assets\/(.*)/, 1]
+  end
+
+  def save_asset_id_to_assets(assetable_id, assetable_type, variant, asset_manager_id, filename)
+    asset = Asset.new(asset_manager_id:, assetable_type:, assetable_id:, variant:, filename:)
+    asset.save!
   end
 end

--- a/lib/tasks/create_asset_relationship.rake
+++ b/lib/tasks/create_asset_relationship.rake
@@ -1,0 +1,5 @@
+desc "Create Asset relationship for AttachmentData"
+
+task :create_asset_relationship, %i[assetable_type start_id end_id] => :environment do |_, args|
+  CreateAssetRelationshipWorker.perform_async(args[:assetable_type], args[:start_id].to_i, args[:end_id].to_i)
+end

--- a/lib/tasks/migrate_to_assets_table.rake
+++ b/lib/tasks/migrate_to_assets_table.rake
@@ -1,5 +1,0 @@
-desc "Create Asset relationship for AttachmentData"
-
-task :create_asset_relationship, %i[start_id end_id] => :environment do |_, args|
-  CreateAssetRelationshipWorker.perform_async(args[:start_id].to_i, args[:end_id].to_i)
-end

--- a/test/unit/app/workers/create_asset_relationship_worker_test.rb
+++ b/test/unit/app/workers/create_asset_relationship_worker_test.rb
@@ -1,0 +1,115 @@
+require "test_helper"
+
+class CreateAssetRelationshipWorkerTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
+  describe CreateAssetRelationshipWorker do
+    let(:worker) { CreateAssetRelationshipWorker.new }
+    let(:assetable_type) { "ImageData" }
+
+    context "all assets can be retrieved from asset-manager" do
+      before do
+        stub_all_assets(assetables)
+
+        worker.perform(assetable_type, start_id, end_id)
+        AssetManagerCreateAssetWorker.drain
+        assetables.map(&:reload)
+      end
+
+      context "worker is run for a single assetable" do
+        let(:assetable) { create(:image_data) }
+        let(:assetables) { [assetable] }
+        let(:start_id) { assetable.id }
+        let(:end_id) { assetable.id }
+
+        it "generates assets for all image variants" do
+          assert_equal 7, assetable.assets.count
+          assert_equal true, assetable.use_non_legacy_endpoints
+          assert_equal true, assetable.all_asset_variants_uploaded?
+        end
+
+        it "increments counters" do
+          assert_equal 7, worker.asset_counter
+          assert_equal 1, worker.count
+        end
+      end
+
+      context "worker is run for an svg assetable" do
+        let(:assetable) { create(:image_data, file: File.open(Rails.root.join("test/fixtures/images/test-svg.svg"))) }
+        let(:assetables) { [assetable] }
+        let(:start_id) { assetable.id }
+        let(:end_id) { assetable.id }
+
+        it "generates assets for only original variant" do
+          assert_equal 1, assetable.assets.count
+          assert_equal true, assetable.use_non_legacy_endpoints
+          assert_equal true, assetable.all_asset_variants_uploaded?
+        end
+
+        it "increments counters" do
+          assert_equal 1, worker.asset_counter
+          assert_equal 1, worker.count
+        end
+      end
+
+      context "worker is run for an interval of assetables" do
+        let(:first_assetable) { create(:image_data) }
+        let(:second_assetable) { create(:image_data) }
+        let(:assetables) { [first_assetable, second_assetable] }
+        let(:start_id) { first_assetable.id }
+        let(:end_id) { second_assetable.id }
+
+        it "generates assets for all image variants" do
+          assert_equal 7, first_assetable.assets.count
+          assert_equal 7, second_assetable.assets.count
+          assert_equal true, first_assetable.use_non_legacy_endpoints
+          assert_equal true, second_assetable.use_non_legacy_endpoints
+        end
+
+        it "increments counters" do
+          assert_equal 14, worker.asset_counter
+          assert_equal 2, worker.count
+        end
+      end
+    end
+
+    context "assets cannot be found in asset manager" do
+      let(:assetable) { create(:image_data) }
+      let(:start_id) { assetable.id }
+      let(:end_id) { assetable.id }
+
+      before do
+        Services.asset_manager.stubs(:whitehall_asset).raises(GdsApi::HTTPNotFound, "Error message")
+      end
+
+      it "rescues HTTPNotFound error and logs if asset cannot be found at path" do
+        Sidekiq.logger.expects(:warn).times(7).with(regexp_matches(/minister-of-funk.960x640.jpg/))
+
+        worker.perform(assetable_type, start_id, end_id)
+        assetable.reload
+
+        assert_equal 0, assetable.assets.count
+        assert_equal true, assetable.use_non_legacy_endpoints
+      end
+    end
+  end
+
+private
+
+  def ends_with(expected)
+    ->(actual) { actual.end_with?(expected) }
+  end
+
+  def stub_whitehall_asset(filename, attributes = {})
+    url_id = "http://asset-manager/assets/#{attributes[:id]}"
+    Services.asset_manager.stubs(:whitehall_asset)
+            .with(&ends_with(filename))
+            .returns(attributes.merge(id: url_id, name: filename).stringify_keys)
+  end
+
+  def stub_all_assets(assetables)
+    assetables.each do |assetable|
+      stub_whitehall_asset(assetable.file.file.filename, id: "asset_id_14652342")
+    end
+  end
+end


### PR DESCRIPTION
Refactored the worker so that we can reuse for all the assetable types we need to migrate to use non-legacy flows. 

[Trello card](https://trello.com/c/5rSu7T0G/193-task-migrate-database-for-imagedata-to-use-new-asset-id-instead)