### PR TITLE
Remove domain names from csv preview urls

### DIFF
--- a/app/helpers/attachments_helper.rb
+++ b/app/helpers/attachments_helper.rb
@@ -15,7 +15,7 @@ module AttachmentsHelper
 
   def preview_path_for_attachment(attachment)
     if attachment.attachment_data.all_asset_variants_uploaded?
-      Plek.external_url_for("assets-origin") + "/media/#{attachment.attachment_data.assets.first.asset_manager_id}/#{attachment.attachment_data.assets.first.filename}/preview"
+      "/media/#{attachment.attachment_data.assets.first.asset_manager_id}/#{attachment.attachment_data.assets.first.filename}/preview"
     end
   end
 

--- a/test/unit/app/helpers/attachments_helper_test.rb
+++ b/test/unit/app/helpers/attachments_helper_test.rb
@@ -162,7 +162,7 @@ class AttachmentsHelperTest < ActionView::TestCase
       content_type: "text/csv",
       filename: attachment.filename,
       file_size: attachment.file_size,
-      preview_url: "#{Plek.external_url_for('assets-origin')}/media/asset_manager_id/sample.csv/preview",
+      preview_url: "/media/asset_manager_id/sample.csv/preview",
     }
     assert_equal expect_params, attachment_component_params(attachment)
   end


### PR DESCRIPTION
CSV preview urls should not be absolute because production environment has a complicated routing setup that depends on these urls being relative.

Additionally the "assets-origin" was a wrong domain name anyway because that points to AssetManager service directly. Any public url should hit CDN first, "assets" would have been a better choice.
