### PR TITLE
Add deletion checks in worker

### DIFF
--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -62,8 +62,10 @@ class AttachmentData < ApplicationRecord
   end
 
   def all_asset_variants_uploaded?
-    unique_asset_variants = assets.map(&:variant).to_set
-    unique_asset_variants.size == (pdf? ? 2 : 1)
+    asset_variants = assets.map(&:variant).map(&:to_sym)
+    required_variants = pdf? ? AttachmentUploader.versions.keys.push(:original) : [Asset.variants[:original].to_sym]
+
+    (required_variants - asset_variants).empty?
   end
 
   def update_file_attributes

--- a/app/models/image_data.rb
+++ b/app/models/image_data.rb
@@ -37,14 +37,12 @@ class ImageData < ApplicationRecord
   end
 
   def all_asset_variants_uploaded?
-    if use_non_legacy_endpoints
-      asset_variants = assets.map(&:variant).map(&:to_sym).to_set
-      all_variants = ImageUploader.versions.keys.push(:original).to_set
+    return true unless use_non_legacy_endpoints
 
-      return asset_variants == all_variants
-    end
+    asset_variants = assets.map(&:variant).map(&:to_sym)
+    required_variants = bitmap? ? ImageUploader.versions.keys.push(:original) : [Asset.variants[:original].to_sym]
 
-    true
+    (required_variants - asset_variants).empty?
   end
 
 private

--- a/app/workers/asset_manager_create_asset_worker.rb
+++ b/app/workers/asset_manager_create_asset_worker.rb
@@ -9,6 +9,9 @@ class AssetManagerCreateAssetWorker < WorkerBase
     file = File.open(temporary_location)
 
     assetable_id, assetable_type, asset_variant = asset_params.values_at("assetable_id", "assetable_type", "asset_variant")
+
+    return logger.info("Assetable #{assetable_type} of id #{assetable_id} does not exist") unless assetable_type.constantize.where(id: assetable_id).exists?
+
     asset_options = { file:, auth_bypass_ids:, draft: }
     authorised_organisation_uids = get_authorised_organisation_ids(attachable_model_class, attachable_model_id)
     asset_options[:access_limited_organisation_ids] = authorised_organisation_uids if authorised_organisation_uids

--- a/test/factories/image_data.rb
+++ b/test/factories/image_data.rb
@@ -16,4 +16,13 @@ FactoryBot.define do
       image_data.assets << build(:asset, asset_manager_id: "asset_manager_id_s216", variant: Asset.variants[:s216], filename: "s216_minister-of-funk.960x640.jpg")
     end
   end
+
+  factory :image_data_svg, parent: :image_data do
+    file { File.open(Rails.root.join("test/fixtures/images/test-svg.svg")) }
+    use_non_legacy_endpoints { true }
+
+    after(:build) do |attachment_data|
+      attachment_data.assets << build(:asset, asset_manager_id: "asset_manager_id", variant: Asset.variants[:original], filename: "test-svg.svg")
+    end
+  end
 end

--- a/test/unit/app/models/image_data_test.rb
+++ b/test/unit/app/models/image_data_test.rb
@@ -90,6 +90,12 @@ class ImageDataTest < ActiveSupport::TestCase
     assert image_data.all_asset_variants_uploaded?
   end
 
+  test "use_non_legacy_endpoints: true - all_asset_variants_uploaded? returns true if original asset present for svg" do
+    image_data = build(:image_data_svg)
+
+    assert image_data.all_asset_variants_uploaded?
+  end
+
   test "use_non_legacy_endpoints: true - all_asset_variants_uploaded? returns false if some assets are missing" do
     image_data = build(:image_data, use_non_legacy_endpoints: true)
     image_data.assets = [build(:asset), build(:asset, variant: Asset.variants[:s960])]


### PR DESCRIPTION
When there are any issues with the assets (i.e. the user sees a "PROCESSING" label on the UI), the user would delete the corresponding attachment (file or image).

If the assetable type is `ImageData` the worker will retry but then subsequently fail because the asset model has validation of presence for the assetable field. ImageDatas do get deleted so the assetable cannot be found.

We have added a check to ensure there is no further execution if assetable has been deleted. Added additional tests to cover for some worker retry behaviour.

[Treelo card](https://trello.com/c/zsXWiOne/196-add-uniqueness-constraint-on-assets)
