### PR TITLE
Republish Editions that have attachments

### DIFF
--- a/lib/tasks/republish_attachments.rake
+++ b/lib/tasks/republish_attachments.rake
@@ -1,11 +1,18 @@
 desc "Republish all documents with non-pdf attachments"
-task republish_non_pdf_attachments: :environment do
-  document_ids = Attachment.joins(:attachment_data)
-                           .joins("JOIN editions ON editions.id = attachments.attachable_id AND attachments.attachable_type = 'Edition'")
-                           .where.not(deleted: true)
-                           .where.not(attachment_data: { content_type: "application/pdf" })
-                           .where.not(attachable: nil)
-                           .where(editions: { state: "published" }).distinct.pluck(:document_id)
+task :republish_attachments, %i[content_type weeks_ago] => :environment do |_, args|
+  content_type = args[:content_type]
+  weeks_ago = args[:weeks_ago]
+
+  query = Attachment.joins(:attachment_data)
+                    .joins("JOIN editions ON editions.id = attachments.attachable_id AND attachments.attachable_type = 'Edition'")
+                    .where.not(deleted: true)
+                    .where.not(attachable: nil)
+                    .where(editions: { state: "published" })
+
+  query = query.where(attachment_data: { content_type: }) if content_type
+  query = query.where("editions.public_timestamp >= :start_date", { start_date: Time.zone.now - weeks_ago.to_i.weeks }) if weeks_ago
+
+  document_ids = query.distinct.pluck(:document_id)
 
   puts "#{document_ids.length} items to republish"
 

--- a/test/unit/lib/tasks/republish_attachments_test.rb
+++ b/test/unit/lib/tasks/republish_attachments_test.rb
@@ -1,0 +1,69 @@
+require "test_helper"
+require "rake"
+
+class RepublishAttachmentsRake < ActiveSupport::TestCase
+  setup do
+    @edition_with_pdf_attachment = create(:published_edition, traits: [:with_document])
+    create(:file_attachment, attachable: @edition_with_pdf_attachment)
+
+    @edition_with_csv_attachment = create(:published_edition, traits: [:with_document])
+    create(:csv_attachment, attachable: @edition_with_csv_attachment)
+
+    @old_edition = build(:published_edition, traits: [:with_document])
+    @old_edition.first_published_at = Time.zone.now - 4.weeks
+    @old_edition.save!
+    create(:csv_attachment, attachable: @old_edition)
+  end
+
+  teardown do
+    Rake::Task["republish_attachments"].reenable # without this, calling `invoke` does nothing after first test
+  end
+
+  test "it selects documents with any attachment type to be republished by default" do
+    expect_pdf_attachment.once
+    expect_csv_attachment.once
+    expect_old_csv_edition.once
+
+    Rake.application.invoke_task "republish_attachments"
+  end
+
+  test "it selects documents with only the given attachment content type to be republished" do
+    expect_pdf_attachment.never
+    expect_csv_attachment.once
+    expect_old_csv_edition.once
+
+    Rake.application.invoke_task "republish_attachments[text/csv]"
+  end
+
+  test "it selects documents that are newer than the provided weeks_ago value" do
+    expect_pdf_attachment.never
+    expect_csv_attachment.once
+    expect_old_csv_edition.never
+
+    Rake.application.invoke_task "republish_attachments[text/csv,3]"
+  end
+
+  def expect_pdf_attachment
+    PublishingApiDocumentRepublishingWorker.expects(:perform_async_in_queue).with(
+      "bulk_republishing",
+      @edition_with_pdf_attachment.document_id,
+      true,
+    )
+  end
+
+  def expect_csv_attachment
+    PublishingApiDocumentRepublishingWorker.expects(:perform_async_in_queue).with(
+      "bulk_republishing",
+      @edition_with_csv_attachment.document_id,
+      true,
+    )
+  end
+
+  def expect_old_csv_edition
+    PublishingApiDocumentRepublishingWorker.expects(:perform_async_in_queue).with(
+      "bulk_republishing",
+      @old_edition.document_id,
+      true,
+    )
+  end
+end


### PR DESCRIPTION
This commit adds changes to the exisisting task to allow 
i> documents with only the given attachment content type to be republished 
ii> documents that are newer than the provided weeks_ago value to be republished
iii> or both

[https://trello.com/c/7tjZgnOl/217-bug-in-prod-domains-in-attachment-urls-are-published-by-whitehall-with-wrong-domain-name](trello)
