### PR TITLE
Remove borderless from summary list component

### DIFF
--- a/app/views/admin/editions/show/_main.html.erb
+++ b/app/views/admin/editions/show/_main.html.erb
@@ -6,7 +6,6 @@
 
     <div>
       <%= render "govuk_publishing_components/components/summary_list", {
-        borderless: true,
         items: [
           { field: "Type of document", value: edition_type(@edition) },
           { field: "Status", value: status_text(@edition) },

--- a/app/views/admin/statistics_announcements/show/_main.html.erb
+++ b/app/views/admin/statistics_announcements/show/_main.html.erb
@@ -5,7 +5,6 @@
     </p>
 
     <%= render "govuk_publishing_components/components/summary_list", {
-      borderless: true,
       items: [
         { field: "Type", value: @statistics_announcement.display_type },
         { field: "Organisations", value: @statistics_announcement.organisations.map(&:name).to_sentence },


### PR DESCRIPTION
## Description

As per the Trello card:

The document summary page uses a summary list component towards the top of the page, containing fields such as: type of document, status, review date, etc.

By default, summary lists have lines between each row. However in Whitehall, we’ve used a modifier class to remove those lines.

The GOV.UK Design System advises against removing the lines because they are designed to aid accessibility. We don’t have a good reason to have removed them, so we should put them back.

### Guidance for review

I've also reinstated the borders for statistics announcements show page as it pulls heavily form the design of the edition summary page. 

This is the only other usage in the codebase.

## Screenshots

### Before

<img width="707" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/ac0e58b8-fa62-4240-abc8-520fe5816e36">

<img width="724" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/4e530f6d-a0ec-4eb5-8083-520d496ad7a9">


### After

<img width="751" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/6ca200b4-caf5-42b0-ac8b-568fa3c61bbe">

<img width="894" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/c8b5bdb0-533f-4e28-9220-e00059fb3b71">


## Trello card

https://trello.com/c/3XGs5mto/1797-add-lines-to-the-summary-list-on-the-document-summary-page

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
