### PR TITLE
Remove hint text

### DIFF
--- a/app/views/admin/editions/_standard_fields.html.erb
+++ b/app/views/admin/editions/_standard_fields.html.erb
@@ -59,7 +59,6 @@
     <%= render "components/govspeak-editor", {
       label: {
         text: "Body" + "#{' (required)' if form.object.body_required?}",
-        hint_text: "If your attachment is still being processed, it will not be visible in preview.",
         heading_size: "m",
       },
       name: "edition[body]",


### PR DESCRIPTION
The hint should be conditionally rendered on editions that have attachments and images and ideally only in the case where those attachments and images are actually still uploading.
