### PR TITLE
Fix lead image url for svg

### DIFF
--- a/app/models/edition/lead_image.rb
+++ b/app/models/edition/lead_image.rb
@@ -6,11 +6,11 @@ module Edition::LeadImage
   end
 
   def lead_image_url
-    image_data ? image_url : placeholder_image_url
+    image_data ? image_url(:s300) : placeholder_image_url
   end
 
   def high_resolution_lead_image_url
-    image_data ? image_data.file.url(:s960) : placeholder_image_url
+    image_data ? image_url(:s960) : placeholder_image_url
   end
 
   def lead_image_alt_text
@@ -43,12 +43,12 @@ private
     )
   end
 
-  def image_url
+  def image_url(version)
     content_type = file.content_type
     if content_type && content_type =~ /svg/
       image_data.file.url
     else
-      image_data.file.url(:s300)
+      image_data.file.url(version)
     end
   end
 

--- a/test/unit/app/models/edition/lead_image_test.rb
+++ b/test/unit/app/models/edition/lead_image_test.rb
@@ -35,9 +35,10 @@ class Edition::LeadImageTest < ActiveSupport::TestCase
     uploader = stub("Uploader", file:)
     image_data = stub("ImageData", file: uploader)
     image = stub("Image", alt_text: "alt_text", image_data:)
-    uploader.expects(:url).with.returns("url")
+    uploader.expects(:url).with.returns("url").twice
     model.stubs(images: [image])
     assert_equal "url", model.lead_image_url
+    assert_equal "url", model.high_resolution_lead_image_url
     assert_equal "alt_text", model.lead_image_alt_text
   end
 


### PR DESCRIPTION
The high_resolution_lead_image_url field would return nil when calling the url method with :s960 argument, as the svg attachments do not have carrierwave versions.

Making it return the original by default, similar to what we return for the lead_image_url field.
