### PR TITLE
Moving preview path to asset domain

### DIFF
--- a/app/helpers/attachments_helper.rb
+++ b/app/helpers/attachments_helper.rb
@@ -15,7 +15,8 @@ module AttachmentsHelper
 
   def preview_path_for_attachment(attachment)
     if attachment.attachment_data.all_asset_variants_uploaded?
-      "/media/#{attachment.attachment_data.assets.first.asset_manager_id}/#{attachment.attachment_data.assets.first.filename}/preview"
+      # "/media/#{attachment.attachment_data.assets.first.asset_manager_id}/#{attachment.attachment_data.assets.first.filename}/preview"
+      URI.join(Plek.asset_root, Addressable::URI.encode("media/#{attachment.attachment_data.assets.first.asset_manager_id}/#{attachment.attachment_data.assets.first.filename}/preview")).to_s
     end
   end
 

--- a/test/unit/app/helpers/attachments_helper_test.rb
+++ b/test/unit/app/helpers/attachments_helper_test.rb
@@ -162,7 +162,7 @@ class AttachmentsHelperTest < ActionView::TestCase
       content_type: "text/csv",
       filename: attachment.filename,
       file_size: attachment.file_size,
-      preview_url: "/media/asset_manager_id/sample.csv/preview",
+      preview_url: "#{Plek.asset_root}/media/asset_manager_id/sample.csv/preview",
     }
     assert_equal expect_params, attachment_component_params(attachment)
   end


### PR DESCRIPTION
This PR is to allow csv url paths to be published with asset domain path, to try and fix the csv preview issue.

Mission is to be able to move it to relative path so nightly data copy dont copy the wrong hard coded production urls to lower environment. But moving to relative path is fairly complicated and requires adding logic to allow routing from "gov.uk" domain to asset domain with "/media" path.
To allow fixing of some of csv's not working in prod. We are moving things to hard-coded asset path.(This is also already the case for other attachment types).
[Trello](https://trello.com/b/zKiroi2H/govuk-asset-management-in-whitehall)
