### PR TITLE
Enable use_non_legacy_endpoints for ImageData

### DIFF
--- a/app/controllers/admin/edition_images_controller.rb
+++ b/app/controllers/admin/edition_images_controller.rb
@@ -85,6 +85,6 @@ private
   end
 
   def use_non_legacy_endpoints?
-    current_user.can_use_non_legacy_endpoints?
+    true
   end
 end


### PR DESCRIPTION
This rolls out image data changes to all users.

[Trello card](https://trello.com/c/0T3j5iQq/171-task-roll-out-imagedata-to-all-users)
