### PR TITLE
Refactor the document republishing worker tests

### DIFF
--- a/test/factories/editions.rb
+++ b/test/factories/editions.rb
@@ -157,34 +157,24 @@ FactoryBot.define do
     end
 
     trait(:unpublished) do
-      after(:create) do |edition|
-        edition.unpublishing = build(:unpublishing, edition:)
-      end
+      unpublishing { build(:unpublishing) }
     end
 
     trait(:published_in_error_redirect) do
-      after(:create) do |edition|
-        edition.unpublishing = build(:published_in_error_redirect_unpublishing, edition:)
-      end
+      unpublishing { build(:published_in_error_redirect_unpublishing) }
     end
 
     trait(:published_in_error_no_redirect) do
-      after(:create) do |edition|
-        edition.unpublishing = build(:published_in_error_no_redirect_unpublishing, edition:)
-      end
+      unpublishing { build(:published_in_error_no_redirect_unpublishing) }
     end
 
     trait(:consolidated_redirect) do
-      after(:create) do |edition|
-        edition.unpublishing = build(:consolidated_unpublishing, edition:)
-      end
+      unpublishing { build(:consolidated_unpublishing) }
     end
 
     trait(:withdrawn) do
       state { "withdrawn" }
-      after(:create) do |edition|
-        edition.unpublishing = build(:withdrawn_unpublishing, edition:)
-      end
+      unpublishing { build(:withdrawn_unpublishing) }
     end
   end
 

--- a/test/unit/app/services/asset_manager/attachment_updater_test.rb
+++ b/test/unit/app/services/asset_manager/attachment_updater_test.rb
@@ -178,7 +178,7 @@ class AssetManager::AttachmentUpdaterTest < ActiveSupport::TestCase
 
     describe "redirect url updates" do
       let(:unpublished_edition) { FactoryBot.create(:unpublished_edition) }
-      let(:redirect_url) { unpublished_edition.public_url }
+      let(:redirect_url) { unpublished_edition.unpublishing.document_url }
       let(:unpublished) { true }
 
       before do

--- a/test/unit/app/workers/publishing_api_document_republishing_worker_test.rb
+++ b/test/unit/app/workers/publishing_api_document_republishing_worker_test.rb
@@ -2,69 +2,92 @@ require "test_helper"
 require "gds_api/test_helpers/publishing_api"
 
 class PublishingApiDocumentRepublishingWorkerTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
   include GdsApi::TestHelpers::PublishingApi
 
-  test "it pushes the published and the draft editions of a document if there is a later draft" do
-    document = stub(
-      live_edition: live_edition = build(:edition, id: 1),
-      id: 1,
-      pre_publication_edition: draft_edition = build(:edition, id: 2),
-      lock!: true,
-    )
+  let(:document) { create(:document, editions: [live_edition, draft_edition].compact) }
 
-    Document.stubs(:find).returns(document)
+  context "when the document has a published edition and a draft edition" do
+    let(:live_edition) { build(:published_edition) }
+    let(:draft_edition) { build(:draft_edition) }
 
-    Whitehall::PublishingApi.expects(:publish).with(
-      live_edition,
-      "republish",
-      bulk_publishing: false,
-    )
+    it "publishes the live edition, then pushes the draft" do
+      # This sequence asserts that the Publishing API is called in the correct order.
+      # It's important to republish the 'published' edition first, then push the draft afterwards.
+      publish_then_draft = sequence("publish_then_draft")
 
-    Whitehall::PublishingApi
-      .expects(:patch_links)
-      .with(live_edition, bulk_publishing: false)
+      Whitehall::PublishingApi
+        .expects(:patch_links)
+        .with(live_edition, bulk_publishing: false)
 
-    Whitehall::PublishingApi
-      .expects(:save_draft)
-      .with(draft_edition, "republish", bulk_publishing: false)
+      Whitehall::PublishingApi
+        .expects(:publish)
+        .with(live_edition, "republish", bulk_publishing: false)
+        .in_sequence(publish_then_draft)
 
-    invocation_order = sequence("invocation_order")
-    ServiceListeners::PublishingApiHtmlAttachments
-      .expects(:process)
-      .with(live_edition, "republish")
-      .in_sequence(invocation_order)
-    ServiceListeners::PublishingApiHtmlAttachments
-      .expects(:process)
-      .with(draft_edition, "republish")
-      .in_sequence(invocation_order)
+      ServiceListeners::PublishingApiHtmlAttachments
+        .expects(:process)
+        .with(live_edition, "republish")
+        .in_sequence(publish_then_draft)
 
-    PublishingApiDocumentRepublishingWorker.new.perform(document.id)
-  end
+      Whitehall::PublishingApi
+        .expects(:save_draft)
+        .with(draft_edition, "republish", bulk_publishing: false)
+        .in_sequence(publish_then_draft)
 
-  class PublishException < StandardError; end
+      ServiceListeners::PublishingApiHtmlAttachments
+        .expects(:process)
+        .with(draft_edition, "republish")
+        .in_sequence(publish_then_draft)
 
-  class DraftException < StandardError; end
-  test "it pushes the published version first if there is a more recent draft" do
-    document = stub(
-      live_edition: build(:edition),
-      id: 1,
-      pre_publication_edition: build(:edition),
-      lock!: true,
-    )
-
-    Document.stubs(:find).returns(document)
-
-    Whitehall::PublishingApi.stubs(:publish).raises(PublishException)
-    Whitehall::PublishingApi.stubs(:patch_links)
-    Whitehall::PublishingApi.stubs(:save_draft).raises(DraftException)
-
-    assert_raises PublishException do
       PublishingApiDocumentRepublishingWorker.new.perform(document.id)
     end
   end
 
-  test "it pushes all locales for the published document" do
-    document = create(:document, content_id: SecureRandom.uuid)
+  context "when the document is published with no draft" do
+    let(:live_edition) { build(:published_edition) }
+    let(:draft_edition) { nil }
+
+    it "publishes the live edition" do
+      Whitehall::PublishingApi
+        .expects(:patch_links)
+        .with(live_edition, bulk_publishing: false)
+
+      Whitehall::PublishingApi
+        .expects(:publish)
+        .with(live_edition, "republish", bulk_publishing: false)
+
+      ServiceListeners::PublishingApiHtmlAttachments
+        .expects(:process)
+        .with(live_edition, "republish")
+
+      PublishingApiDocumentRepublishingWorker.new.perform(document.id)
+    end
+  end
+
+  context "when the document is draft and there is no published edition" do
+    let(:live_edition) { nil }
+    let(:draft_edition) { build(:draft_edition) }
+
+    it "pushes the draft edition" do
+      Whitehall::PublishingApi
+        .expects(:patch_links)
+        .with(draft_edition, bulk_publishing: false)
+
+      Whitehall::PublishingApi
+        .expects(:save_draft)
+        .with(draft_edition, "republish", bulk_publishing: false)
+
+      ServiceListeners::PublishingApiHtmlAttachments
+        .expects(:process)
+        .with(draft_edition, "republish")
+
+      PublishingApiDocumentRepublishingWorker.new.perform(document.id)
+    end
+  end
+
+  it "pushes all locales for the published document" do
+    document = create(:document)
     edition = build(:published_edition, title: "Published edition", document:)
     with_locale(:es) { edition.title = "spanish-title" }
     edition.save!
@@ -75,19 +98,15 @@ class PublishingApiDocumentRepublishingWorkerTest < ActiveSupport::TestCase
       stub_publishing_api_publish(document.content_id, locale: "en", update_type: nil),
       stub_publishing_api_put_content(document.content_id, with_locale(:es) { presenter.content }),
       stub_publishing_api_publish(document.content_id, locale: "es", update_type: nil),
+      stub_publishing_api_patch_links(document.content_id, links: presenter.links),
     ]
-    # Have to separate this as we need to manually assert it was done twice. If
-    # we split the pushing of links into a separate job, then we would only push
-    # links once and could put this back into the array.
-    patch_links_request = stub_publishing_api_patch_links(document.content_id, links: presenter.links)
 
     PublishingApiDocumentRepublishingWorker.new.perform(document.id)
 
     assert_all_requested(requests)
-    assert_requested(patch_links_request, times: 1)
   end
 
-  test "it runs the PublishingApiUnpublishingWorker if the latest edition has an unpublishing" do
+  it "runs the PublishingApiUnpublishingWorker if the latest edition has an unpublishing" do
     document = create(:document, content_id: SecureRandom.uuid)
     edition = create(:unpublished_edition, title: "Unpublished edition", document:)
     unpublishing = edition.unpublishing
@@ -98,7 +117,7 @@ class PublishingApiDocumentRepublishingWorkerTest < ActiveSupport::TestCase
     PublishingApiDocumentRepublishingWorker.new.perform(document.id)
   end
 
-  test "it publishes and then unpublishes if the published edition is withdrawn" do
+  it "publishes and then unpublishes if the published edition is withdrawn" do
     unpublishing = build(:withdrawn_unpublishing, id: 10)
     document = stub(
       live_edition: live_edition = create(:withdrawn_edition, unpublishing:),
@@ -131,7 +150,7 @@ class PublishingApiDocumentRepublishingWorkerTest < ActiveSupport::TestCase
     PublishingApiDocumentRepublishingWorker.new.perform(document.id)
   end
 
-  test "it raises if an unknown combination is encountered" do
+  it "raises if an unknown combination is encountered" do
     document = build(:document,
                      live_edition: build(:edition, id: 2, unpublishing: build(:unpublishing, id: 4, unpublishing_reason_id: 100)),
                      id: 1,
@@ -143,7 +162,7 @@ class PublishingApiDocumentRepublishingWorkerTest < ActiveSupport::TestCase
     end
   end
 
-  test "it completes silently if there are no live or pre_publication editions" do
+  it "completes silently if there are no live or pre_publication editions" do
     # whitehall has a lot of old documents that only have superseded editions
     # we want to ignore these and not have to try and avoid passing them in
     # when doing bulk republishing


### PR DESCRIPTION
## Context

We're introducing a new 'unpublished' state for editions in #8304. As part of that work, we need to make some changes to the PublishingApiDocumentRepublishingWorker since unpublished documents will no longer be in a 'draft' state.

I've spent some time trying to understand the PublishingApiDocumentRepublishingWorker worker – what it does, and how it does it. I started reading the unit test but found it quite hard to
follow. I also spotted that there was some missing test coverage for a
specific code path.

## Changes made in this PR

I've refactored this test file with the intention of:

- improving the readability of the tests, so it's easier for future
  developers to work on it,
- testing & confirming my own understanding of the worker's expected
  behaviour, and
- adding test coverage to the `there_is_only_a_draft?` path which was
  previously untested.

## Note for reviewers

I recommend reviewing this commit-by-commit. I've tried to include as much detail as possible within each commit message.

Trello: https://trello.com/c/4ttikeTH/1529-add-an-unpublished-state-for-whitehall-documents

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
