### PR TITLE
Fix several errors relating to date validation

### DIFF
--- a/app/models/date_validation.rb
+++ b/app/models/date_validation.rb
@@ -28,11 +28,14 @@ module DateValidation
       begin
         # Rails will cast the year part of the date to 0 if the year input parameter is a non-numeric string
         # This only seems to happen to the year part, other parts remain as strings
-        raise TypeError if (date[1]).zero?
+        raise TypeError if date[1].zero?
+
+        # Rails does not accept negative month values, but the Date constructor does
+        raise TypeError if (date[2]).negative?
 
         Date.new(date[1], date[2], date[3])
         @invalid_date_attributes.delete(attribute)
-      rescue ArgumentError, TypeError
+      rescue ArgumentError, TypeError, NoMethodError
         @invalid_date_attributes.add(attribute)
         date = nil
       end

--- a/test/unit/app/models/date_validation_test.rb
+++ b/test/unit/app/models/date_validation_test.rb
@@ -15,28 +15,48 @@ class DateValidationTest < ActiveSupport::TestCase
   end
 
   test "should be valid when date attribute is a valid date" do
+    model = StubModel.new(some_date: { 1 => 2023, 2 => 9, 3 => 10 })
+    assert model.valid?
+  end
+
+  test "should be valid when date attribute is a valid date with a time" do
     model = StubModel.new(some_date: { 1 => 2023, 2 => 9, 3 => 10, 4 => 0, 5 => 0 })
     assert model.valid?
   end
 
   test "should be invalid when date attribute is an invalid date" do
-    model = StubModel.new(some_date: { 1 => 2023, 2 => 9, 3 => 40 })
-    assert_not model.valid?
+    date_hashes = [
+      { 1 => 2023, 2 => 9, 3 => 40 },
+      { 1 => 2023, 2 => -1, 3 => 1 },
+    ]
+    date_hashes.each do |date_hash|
+      model = StubModel.new(some_date: date_hash)
+      assert_not model.valid?, "Failed with date hash #{date_hash}"
+    end
   end
 
   test "should be invalid when date attribute is partially completed" do
-    model = StubModel.new(some_date: { 1 => 2023, 2 => nil, 3 => 9 })
-    assert_not model.valid?
-  end
-
-  test "should be invalid when day is missing" do
-    model = StubModel.new(some_date: { 1 => 2023, 2 => 1, 3 => nil })
-    assert_not model.valid?
+    date_hashes = [
+      { 1 => nil, 2 => 1, 3 => 1 },
+      { 1 => 2023, 2 => nil, 3 => 1 },
+      { 1 => 2023, 2 => 1, 3 => nil },
+    ]
+    date_hashes.each do |date_hash|
+      model = StubModel.new(some_date: date_hash)
+      assert_not model.valid?, "Failed with date hash #{date_hash}"
+    end
   end
 
   test "should be invalid when not all date attribute parts are numeric" do
-    model = StubModel.new(some_date: { 1 => 2023, 2 => "January", 3 => 20 })
-    assert_not model.valid?
+    date_hashes = [
+      { 1 => "Twenty Twenty Three", 2 => 1, 3 => 1 },
+      { 1 => 2023, 2 => "January", 3 => 1 },
+      { 1 => 2023, 2 => 1, 3 => "One" },
+    ]
+    date_hashes.each do |date_hash|
+      model = StubModel.new(some_date: date_hash)
+      assert_not model.valid?, "Failed with date hash #{date_hash}"
+    end
   end
 
   # Rails casts the year part of the date to 0, before passing to the attribute setter, if the original year parameter is a non-numeric string.


### PR DESCRIPTION
Includes fixes for the following issues:
- When the year was nil, a NoMethodError was being thrown because we were attempting to call "zero?" on nil. We're now rescuing from the NoMethodError and marking the date invalid
- Entering a negative month value would trigger a MultiparameterAssigmentError, because Ruby Date constructor allows months to be set using a negative offset but Rails date assignment does not
