### PR TITLE
changed the add documents and reorder links from p tags to list tags …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@
 /node_modules
 /yarn-error.log
 .cache/
+.DS_Store

--- a/app/assets/stylesheets/admin/views/_document-collection-group-memberships-index.scss
+++ b/app/assets/stylesheets/admin/views/_document-collection-group-memberships-index.scss
@@ -1,6 +1,25 @@
 .app-view-document-collection-group-memberships-index__heading {
-  display: flex;
-  justify-content: space-between;
+  .gem-c-heading {
+    display: inline-block;
+    @include govuk-responsive-margin(2, "right");
+  }
+
+  .govuk-list {
+    float: right;
+
+    li {
+      display: inline-block;
+      @include govuk-responsive-padding(2, "left");
+      @include govuk-responsive-margin(2, "left");
+      border-left: 1px solid $govuk-border-colour;
+
+      &:first-child {
+        margin-left: 0;
+        padding-left: 0;
+        border-left: none;
+      }
+    }
+  }
 }
 
 .app-view-document-collection-group-memberships-index__table .govuk-table__cell {
@@ -8,16 +27,5 @@
 
   &:last-child {
     white-space: nowrap;
-  }
-}
-
-.app-view-document-collection-group-memberships-index__heading-links {
-  display: flex;
-  align-items: center;
-
-  & > p:first-child {
-    @include govuk-responsive-padding(2, "right");
-    @include govuk-responsive-margin(2, "right");
-    border-right: 1px solid $govuk-border-colour;
   }
 }

--- a/app/views/admin/document_collection_group_memberships/index.html.erb
+++ b/app/views/admin/document_collection_group_memberships/index.html.erb
@@ -26,17 +26,15 @@
             text: "Documents",
             margin_bottom: 6,
           } %>
-
-          <div class="app-view-document-collection-group-memberships-index__heading-links">
-            <p class="govuk-body govuk-!-text-align-right">
+          <ul class="govuk-list">
+            <li>
               <%= link_to "Add document", admin_document_collection_group_search_options_path(@collection, @group), class: "govuk-link" %>
-            </p>
+            </li>
 
-            <p class="govuk-body govuk-!-text-align-right">
+            <li>
               <%= link_to "Reorder document", reorder_admin_document_collection_group_document_collection_group_memberships_path(@collection, @group), class: "govuk-link" %>
-            </p>
-          </div>
-
+            </li>
+          </ul>
         </div>
       </div>
     <% else %>
@@ -47,9 +45,11 @@
             margin_bottom: 6,
           } %>
 
-          <p class="govuk-body govuk-!-text-align-right">
-            <%= link_to "Add document", admin_document_collection_group_search_options_path(@collection, @group), class: "govuk-link" %>
-          </p>
+          <ul class="govuk-list">
+            <li>
+              <%= link_to "Add document", admin_document_collection_group_search_options_path(@collection, @group), class: "govuk-link" %>
+            </li>
+          </ul>
         </div>
       </div>
     <% end %>


### PR DESCRIPTION
…as these are more semantically and stylistally correct

This commit is a continuation from a previously closed and merged branch, can be founder here:
https://github.com/alphagov/whitehall/pull/8318#discussion_r1352028169

This commit user story can be found in this Trello link: https://trello.com/c/kEcGRQ1X/531-allow-for-the-reordering-of-documents-within-a-group

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
