### PR TITLE
Improve CI run time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,10 @@ jobs:
   test-ruby:
     name: Test Ruby
     uses: ./.github/workflows/minitest.yml
+  
+  test-ruby-parallel:
+    name: Test Ruby
+    uses: ./.github/workflows/minitest-parallel.yml
 
   integration-tests-parallel:
     name: Integration tests

--- a/.github/workflows/integration-tests-parallel.yml
+++ b/.github/workflows/integration-tests-parallel.yml
@@ -1,57 +1,15 @@
-name: CI
+name: Run integration tests
 
-on:
-  workflow_dispatch: {}
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - "Jenkinsfile"
-      - ".git**"
-  pull_request:
+on: workflow_call
 
 jobs:
-  security-analysis:
-    name: Security Analysis
-    uses: alphagov/govuk-infrastructure/.github/workflows/brakeman.yml@main
-
-  lint-scss:
-    name: Lint SCSS
-    uses: ./.github/workflows/lintscss.yml
-
-  lint-javascript:
-    name: Lint JavaScript
-    uses: ./.github/workflows/lintjs.yml
-
-  lint-prettier:
-    name: Prettier
-    uses: ./.github/workflows/lintprettier.yml
-
-  lint-ruby:
-    name: Lint Ruby
-    uses: alphagov/govuk-infrastructure/.github/workflows/rubocop.yml@main
-
-  lint-erb:
-    name: Lint ERB
-    uses: ./.github/workflows/linterb.yml
-
-  test-javascript:
-    name: Test JavaScript
-    uses: alphagov/govuk-infrastructure/.github/workflows/jasmine.yml@main
-    with:
-      useWithRails: true
-
-  test-ruby:
-    name: Test Ruby
-    uses: ./.github/workflows/minitest.yml
-
-  integration-tests-parallel:
-    name: Integration tests
-    uses: ./.github/workflows/integration-tests-parallel.yml
-
-  integration-tests:
-    name: Integration tests
+  run-parallel-integration-tests:
+    name: Run integration tests
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node_rake_task: ["cucumber:ok", "cucumber:preview_design_system"]
     steps:
       - name: Setup MySQL
         id: setup-mysql
@@ -64,7 +22,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends ghostscript
-
       - name: Checkout repository
         uses: actions/checkout@v4
 
@@ -89,7 +46,7 @@ jobs:
         env:
           RAILS_ENV: test
           TEST_DATABASE_URL: ${{ steps.setup-mysql.outputs.db-url }}
-        run: bundle exec rails cucumber
+        run: bundle exec rails ${{ matrix.node_rake_task }}
 
       - name: Upload screenshots
         uses: actions/upload-artifact@v3

--- a/.github/workflows/minitest-parallel.yml
+++ b/.github/workflows/minitest-parallel.yml
@@ -1,0 +1,79 @@
+name: Run Minitest
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: 'The branch, tag or SHA to checkout'
+        required: false
+        type: string
+      publishingApiRef:
+        description: 'The branch, tag or SHA to checkout Publishing API'
+        required: false
+        default: 'main'
+        type: string
+
+jobs:
+  run-minitest:
+    name: Run Minitest
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ci_node_total: [4]
+        ci_node_index: [0, 1, 2, 3]
+    steps:
+      - name: Setup MySQL
+        id: setup-mysql
+        uses: alphagov/govuk-infrastructure/.github/actions/setup-mysql@main
+
+      - name: Setup Redis
+        uses: alphagov/govuk-infrastructure/.github/actions/setup-redis@main
+
+      - name: Install additional system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends ghostscript
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          repository: alphagov/whitehall
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Checkout Publishing API (for Content Schemas)
+        uses: actions/checkout@v4
+        with:
+          repository: alphagov/publishing-api
+          ref: ${{ inputs.publishingApiRef }}
+          path: vendor/publishing-api
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Setup Node
+        uses: alphagov/govuk-infrastructure/.github/actions/setup-node@main
+
+      - name: Precompile assets
+        uses: alphagov/govuk-infrastructure/.github/actions/precompile-rails-assets@main
+
+      - name: Initialize database
+        env:
+          RAILS_ENV: test
+          TEST_DATABASE_URL: ${{ steps.setup-mysql.outputs.db-url }}
+        run: bundle exec rails db:setup
+
+      - name: Make bin/minitest-ci executable
+        run: chmod +x ./bin/minitest-ci
+
+      - name: Run Minitest
+        env:
+          RAILS_ENV: test
+          GOVUK_CONTENT_SCHEMAS_PATH: vendor/publishing-api/content_schemas
+          TEST_DATABASE_URL: ${{ steps.setup-mysql.outputs.db-url }}
+          CI_NODE_TOTAL: ${{ matrix.ci_node_total }}
+          CI_NODE_INDEX: ${{ matrix.ci_node_index }}
+        run: |
+          ./bin/minitest-ci

--- a/bin/minitest-ci
+++ b/bin/minitest-ci
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+
+tests = Dir["test/**/*_test.rb"].
+  sort.
+  shuffle(random: Random.new(ENV['GITHUB_SHA'].to_i(16))).
+  select.
+  with_index do |el, i|
+    i % ENV["CI_NODE_TOTAL"].to_i == ENV["CI_NODE_INDEX"].to_i
+  end
+
+exec "bundle exec rails test #{tests.join(" ")}"


### PR DESCRIPTION
# What
[Trello ticket link](https://trello.com/c/IS5QUoaK/1757-split-and-parallelise-minitest-job-in-ci)
This PR improves the time it takes our CI tests to run by:
- Parallelising the integration tests so that one process runs the `cucumber:ok` task and one process runs the `cucumber:preview_design_system` task
- Parallelising the MiniTest workflow using a matrix strategy, randomly distributing tests across 4 nodes. 

**Benchmark:** Approximately 17m39s (average of the 10 most recent merge to main CI runs)

With the changes proposed, this PR reduces CI run time to approximately 7 minutes.

# Why
This is to help reduce developer toil and time to deploy changes. The current run time is excessive and slows down development.

# Additional information
## Order of implementation
To avoid having a period where there are no Minitest or integration checks in our CI/CD pipeline, these changes must be implemented in the following order:
1. Merge the new parallelised tests to main
2. Create new branch rules so that parallelised tests must pass before merging
3. Remove non-parallelised branch rules
4. Remove non-parallelised workflows



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
