### PR TITLE
Remove references to slug on document filter

### DIFF
--- a/app/views/admin/document_collection_groups/legacy_index.html.erb
+++ b/app/views/admin/document_collection_groups/legacy_index.html.erb
@@ -13,7 +13,7 @@
     <div id="document-finder" class="document-finder form-inline well remove-top-margin">
       <label for="title">Add</label>
       <div class="document-finder-fields">
-        <%= search_field_tag :title, "", placeholder: "Title or slug&hellip;".html_safe, results: 5, autosave: "unique", autofocus: true, class: "form-control input-sm", autocomplete: "off" %>
+        <%= search_field_tag :title, "", placeholder: "Title&hellip;".html_safe, results: 5, autosave: "unique", autofocus: true, class: "form-control input-sm", autocomplete: "off" %>
         <%= button_tag "Find", type: "button", id: "find-documents", class: "btn btn-default btn-sm add-right-margin" %>
         <%= image_tag "loading-666666.gif", class: "js-loader" %>
         <p class="tip">

--- a/app/views/admin/editions/_filter_options.html.erb
+++ b/app/views/admin/editions/_filter_options.html.erb
@@ -14,7 +14,7 @@
     <% if filter_by.include?(:title) %>
       <%= render "govuk_publishing_components/components/input", {
         label: {
-          text: "Title or slug",
+          text: "Title",
           bold: true,
         },
         name: "title",

--- a/app/views/admin/editions/_legacy_filter_options.html.erb
+++ b/app/views/admin/editions/_legacy_filter_options.html.erb
@@ -8,7 +8,7 @@
 
   <% if filter_by.include?(:title) %>
     <div class="filter-grouping" id="title_filter">
-      <%= label_tag :search_title, "Title or slug" %>
+      <%= label_tag :search_title, "Title" %>
       <div class="btn-enter-wrapper">
         <%= search_field_tag :title, @filter.options[:title], id: "search_title", class: "form-control", placeholder: "Search title", autocomplete: "off" %>
         <%= submit_tag "enter", class: "btn-enter js-btn-enter js-hidden" %>

--- a/app/views/admin/statistics_announcements/_filter_options.html.erb
+++ b/app/views/admin/statistics_announcements/_filter_options.html.erb
@@ -7,7 +7,7 @@
 
     <%= render "govuk_publishing_components/components/input", {
       label: {
-        text: "Title or slug",
+        text: "Title",
         bold: true,
       },
       name: "title",

--- a/features/step_definitions/admin_statistics_announcements_steps.rb
+++ b/features/step_definitions/admin_statistics_announcements_steps.rb
@@ -150,7 +150,7 @@ end
 
 When(/^I search for announcements containing "(.*?)"$/) do |keyword|
   visit admin_statistics_announcements_path
-  fill_in "Title or slug", with: keyword
+  fill_in "Title", with: keyword
   select "All organisations", from: "Organisation"
   click_on "Search"
 end

--- a/spec/javascripts/admin_legacy/views/editions/filter_options.spec.js
+++ b/spec/javascripts/admin_legacy/views/editions/filter_options.spec.js
@@ -6,7 +6,7 @@ describe('GOVUK.FilterOptions', function () {
       '<div>' +
         '<form class="filter-options js-editions-filter-form" action="/government/admin/editions" method="get">' +
           '<div id="title_filter" class="filter-grouping">' +
-            '<label for="search_title">Title or slug</label>' +
+            '<label for="search_title">Title</label>' +
             '<div class="btn-enter-wrapper">' +
               '<input type="search" value="hello world" placeholder="Search title" name="title" id="search_title">' +
               '<input type="submit" value="enter" name="commit" class="btn-enter js-btn-enter js-hidden">' +


### PR DESCRIPTION
The word slug is not well used by publishers and it is usually the same as the page title. It will be less confusing to users if we just use one.

trello card: https://trello.com/c/Uttw5Q63
Before:
![image](https://github.com/alphagov/whitehall/assets/17481621/7cf6df8b-d86c-40e2-976b-634ecdf09ddc)


After: 
![image](https://github.com/alphagov/whitehall/assets/17481621/7b9b1fca-e48b-4505-99b6-d9c3ee6ec8eb)

