### PR TITLE
Fix an unclosed HTML tag

### DIFF
--- a/app/views/admin/editions/_govspeak_help.html.erb
+++ b/app/views/admin/editions/_govspeak_help.html.erb
@@ -204,7 +204,7 @@
     <pre class='govspeak-help__pre'>[Contact:<em>n</em>]</pre>
     <p class='govuk-body'>(n is the ID of the contact you want to embed.)</p>
     <p class='govuk-body'>You can find the ID on the list of contacts for an <%= link_to "organisation", admin_organisations_path, class: "govuk-link" %> or <%= link_to "worldwide organisation", admin_worldwide_organisations_path, class: "govuk-link" %>.</p>
-    <p class='govuk-body'>If it doesn’t exist you will have to add it (see <a class="govuk-link" href='https://www.gov.uk/guidance/how-to-publish-on-gov-uk/organisation-pages'>‘Organisation pages’ guidance). </p>
+    <p class='govuk-body'>If it doesn’t exist you will have to add it (see <a class="govuk-link" href='https://www.gov.uk/guidance/how-to-publish-on-gov-uk/organisation-pages'>‘Organisation pages’ guidance</a>). </p>
   <% end %>
 
   <%= render "govuk_publishing_components/components/details", {


### PR DESCRIPTION
The link tag was not closed, causing it to render strangely in the browser.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
