### PR TITLE
Spike out adding custom error messages via locales

### DIFF
--- a/config/locales/en/attachments.yml
+++ b/config/locales/en/attachments.yml
@@ -1,0 +1,8 @@
+en:
+  activerecord:
+    errors:
+      models:
+        attachment:
+          attributes:
+            title:
+              blank: Enter a title

--- a/config/locales/en/editions.yml
+++ b/config/locales/en/editions.yml
@@ -1,0 +1,9 @@
+en:
+  activerecord:
+    errors:
+      models:
+        edition:
+          attributes:
+            first_published_at:
+              blank: Enter the date when the document was first published
+              invalid_date: The date is not in the correct format

--- a/config/locales/en/govspeak_content.yml
+++ b/config/locales/en/govspeak_content.yml
@@ -1,0 +1,8 @@
+en:
+  activerecord:
+    errors:
+      models:
+        govspeak_content:
+          attributes:
+            body:
+              blank: Enter a body

--- a/features/step_definitions/previously_published_steps.rb
+++ b/features/step_definitions/previously_published_steps.rb
@@ -37,7 +37,7 @@ Then(/^I see a validation error for the future date$/) do
 end
 
 Then(/^I see a validation error for the missing publication date$/) do
-  expect(page).to have_content("First published at can't be blank")
+  expect(page).to have_content("Enter the date when the document was first published")
 end
 
 Then(/^I should not see a validation error on the previously published date$/) do

--- a/test/components/admin/error_summary_component_test.rb
+++ b/test/components/admin/error_summary_component_test.rb
@@ -109,6 +109,15 @@ class Admin::ErrorSummaryComponentTest < ViewComponent::TestCase
     assert_equal third_link.text, "Date is invalid"
     assert_equal third_link[:href], "#error_summary_test_object_date"
   end
+
+  test "Uses custom error messages when present in the locales" do
+    attachment = build(:attachment, title: nil)
+    attachment.validate
+
+    render_inline(Admin::ErrorSummaryComponent.new(object: attachment, parent_class: "attachment"))
+
+    assert_equal "Enter a title", page.all(".gem-c-error-summary__list-item")[0].find("a").text
+  end
 end
 
 class ErrorSummaryTestObject

--- a/test/functional/admin/publications_controller_test.rb
+++ b/test/functional/admin/publications_controller_test.rb
@@ -88,7 +88,7 @@ class Admin::PublicationsControllerTest < ActionController::TestCase
 
   test "should validate first_published_at field on create if previously_published is true" do
     post :create, params: { edition: controller_attributes_for(:publication).merge(previously_published: "true") }
-    assert_equal "First published at can't be blank", assigns(:edition).errors.full_messages.last
+    assert_equal "First published at Enter the date when the document was first published", assigns(:edition).errors.full_messages.last
   end
 
   view_test "edit displays publication fields and guidance" do

--- a/test/unit/app/models/edition_test.rb
+++ b/test/unit/app/models/edition_test.rb
@@ -783,7 +783,7 @@ class EditionTest < ActiveSupport::TestCase
   test "first_published_at required when previously_published" do
     edition = build(:edition, previously_published: true)
     assert_not edition.valid?
-    assert_equal "First published at can't be blank", edition.errors.full_messages.first
+    assert_equal "First published at Enter the date when the document was first published", edition.errors.full_messages.first
 
     edition.first_published_at = Time.zone.now
     assert edition.valid?


### PR DESCRIPTION
## Description

### The problem

A common ask from design is that we give more descriptive error messages. At the moment the implementation uses default rails messages. We use `#full_message` https://api.rubyonrails.org/v6.1.4/classes/ActiveModel/Error.html#method-i-full_message in the[ error summary component](https://github.com/alphagov/whitehall/blob/8b7b867216ec45a3c15b6d00db5507187882a41c/app/components/admin/error_summary_component.rb#L30)

Essentially this combines the attribute and standard error message to construct the error message

For example a blank title would produce

```
Title can't be blank
```
as `error.attribute == :title` and `error.message == "can't be blank"

Eventually we want to end up with a full set of error messages which live in locales rather than the model itself. Getting to that point is actually slightly tricky as we have many models, all of which need custom error messages. Replacing all of these in one go in one PR would be a pretty insurmountable task.

It feels like we need a way to slowly add these in. Most likely 1 section or even model at a time.

Due to this we need to ensure the original implementation continues to work when custom error messages aren't present in the locales for that specific error.

### Proposed solution

This attempts to solve this issue by extending the error summary component. For each error we check whether an error message is present in the locales. If one is, then we use that error message in place of the error found on the object. If not, then we continue to use `#full_message`.

There's actually some more hidden complexity here as often there are nested errors which require some additional work to figure out where the locale should exist.

Originally, if one was found in the locales, i just used `error.message` but i noticed that errors added in the model itself take precedent. This can be fixed by removing the message from the model itself, but for shared errors (for example the `invalid_date` one added recently by Ryan it's used in many places.

I do think that probably the right thing to do is update all those messages in 1 go and remove the error message from the `DateValidation` concern. 

### Error text above inputs

I've not worried about extending this implementation to the [ErrorsHelper](https://github.com/alphagov/whitehall/blob/8b7b867216ec45a3c15b6d00db5507187882a41c/app/helpers/errors_helper.rb#L1) which handles rendering the error message above the relevant field. If people are happy with this approach it could quite easily be extended to this helper though

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
