### PR TITLE
Fix create asset worker to send updates for PolicyGroup

### DIFF
--- a/app/workers/asset_manager_create_asset_worker.rb
+++ b/app/workers/asset_manager_create_asset_worker.rb
@@ -23,6 +23,11 @@ class AssetManagerCreateAssetWorker < WorkerBase
       save_asset(assetable_id, assetable_type, asset_variant, asset_manager_id, filename)
     end
 
+    if attachable_model_class && !attachable_model_class.constantize.ancestors.include?(Edition)
+      attachment_data = AttachmentData.find(assetable_id)
+      ServiceListeners::AttachmentUpdater.call(attachment_data:)
+    end
+
     perform_draft_update(attachable_model_class, attachable_model_id)
 
     file.close

--- a/test/unit/app/workers/asset_manager_create_asset_worker_test.rb
+++ b/test/unit/app/workers/asset_manager_create_asset_worker_test.rb
@@ -115,6 +115,16 @@ class AssetManagerCreateAssetWorkerTest < ActiveSupport::TestCase
     @worker.perform(@file.path, @asset_args, true, consultation.class.to_s, consultation.id)
   end
 
+  test "triggers an update to asset-manager for policy group" do
+    policy_group = create(:policy_group, :with_file_attachment, description: "Description")
+
+    Services.asset_manager.stubs(:create_asset).returns(@asset_manager_response)
+
+    ServiceListeners::AttachmentUpdater.expects(:call).with(attachment_data: @model).once
+
+    @worker.perform(@file.path, @asset_args, true, policy_group.class.to_s, policy_group.id)
+  end
+
   test "triggers an update to publishing api after asset has been saved" do
     consultation = FactoryBot.create(:consultation)
     Services.asset_manager.stubs(:create_asset).returns(@asset_manager_response)


### PR DESCRIPTION
Whilst the draft update call to publishing api also triggers an asset manager call for the entire attachable (see listener in edition_services.rb), the publishing api call does not get triggered for policy group. Asset manager updates end up not being made.

We are now specifically making this call for all AttachmentDatas that belong to a PolicyGroup.

[Trello card](https://trello.com/c/nsYzdcqQ/228-fix-policy-group-issues)

