### PR TITLE
Publish draft WW org when the state of the about CIP is submitted

### DIFF
--- a/app/models/corporate_information_page.rb
+++ b/app/models/corporate_information_page.rb
@@ -33,17 +33,20 @@ class CorporateInformationPage < Edition
   scope :accessible_documents_policy, -> { where(corporate_information_page_type_id: CorporateInformationPageType::AccessibleDocumentsPolicy.id) }
 
   def republish_owning_organisation_to_publishing_api
-    if state == "draft" && owning_organisation.is_a?(WorldwideOrganisation)
-      presenter = PublishingApi::WorldwideOrganisationPresenter.new(owning_organisation, state: "draft")
-      Services.publishing_api.put_content(presenter.content_id, presenter.content)
-    elsif owning_organisation.present?
-      Whitehall::PublishingApi.republish_async(owning_organisation)
+    return if owning_organisation.blank?
+
+    edition_states = %w[draft submitted]
+    if edition_states.include?(state) && worldwide_organisation.present?
+      presenter = PublishingApi::WorldwideOrganisationPresenter.new(owning_organisation, state:)
+      return Services.publishing_api.put_content(presenter.content_id, presenter.content)
     end
+
+    Whitehall::PublishingApi.republish_async(owning_organisation)
   end
 
   def republish_about_page_to_publishing_api
     about_us = if state == "draft"
-                 owning_organisation&.draft_about_us
+                 owning_organisation&.about_us_for(state: "draft")
                else
                  owning_organisation&.about_us
                end

--- a/app/models/has_corporate_information_pages.rb
+++ b/app/models/has_corporate_information_pages.rb
@@ -12,10 +12,6 @@ module HasCorporateInformationPages
     about_us.summary if about_us.present?
   end
 
-  def draft_summary
-    draft_about_us.summary if draft_about_us.present?
-  end
-
   def body
     about_us.body if about_us.present?
   end
@@ -38,7 +34,7 @@ module HasCorporateInformationPages
     corporate_information_pages.published.for_slug("about")
   end
 
-  def draft_about_us
-    corporate_information_pages.draft.for_slug("about")
+  def about_us_for(state:)
+    corporate_information_pages.where(state:).for_slug("about")
   end
 end

--- a/app/presenters/publishing_api/worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/worldwide_organisation_presenter.rb
@@ -57,20 +57,21 @@ module PublishingApi
     end
 
     def description
-      if state == "draft"
-        item.draft_summary
-      else
-        item.summary
-      end
+      return if about_us.blank?
+
+      about_us.summary
     end
 
     def body
-      about_us = if state == "draft"
-                   item.draft_about_us
-                 else
-                   item.about_us
-                 end
       Whitehall::GovspeakRenderer.new.govspeak_edition_to_html(about_us) || ""
+    end
+
+    def about_us
+      if %w[draft submitted].include?(state)
+        item.about_us_for(state:)
+      else
+        item.about_us
+      end
     end
 
     def main_office


### PR DESCRIPTION
> [!NOTE]  
> This works as expected in integration:
> 1. Create a draft of a worldwide organisation about us corporate information page
> 2. Published page is unchanged, draft page is updated
> 3. Submit the draft for 2nd eyes
> 4. Published page is unchanged, draft page remains updated
> 5. Publish the page, published page is updated

https://trello.com/c/dlZFPXcK

Worldwide organisation "about us" corporate information pages are unusual in that they are surfaced in the body of their owning worldwide organisation.

We previously fixed an issue where the draft page for worldwide organisations wasn't updating when a draft about us page was created (#8058).

We've now found that any subsequent changes that republish the worldwide organisation, do so without it's draft content.

This includes: changes to the worldwide organisation (such as a name change), changes that republish the worldwide organisation in callbacks, and changes to the about CIP which change it's "draft" state.

The immediate problem we want to fix is when the about CIP is submitted for 2nd eyes. We plan to find a better solution to the wider problem later.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
