### PR TITLE
Add custom error messaging for "invalid_date" for datetime fields

### DIFF
--- a/app/models/date_validation.rb
+++ b/app/models/date_validation.rb
@@ -56,7 +56,7 @@ module DateValidation
   class DateValidator < ActiveModel::Validator
     def validate(record)
       record.invalid_date_attributes&.each do |date_attribute|
-        record.errors.add date_attribute, :invalid_date, message: "must be a valid date in the correct format"
+        record.errors.add date_attribute, :invalid_date
       end
     end
   end

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -55,7 +55,7 @@ class Edition < ApplicationRecord
   validates :summary, presence: true, if: :summary_required?, length: { maximum: 65_535 }
   validates :previously_published, inclusion: { in: [true, false], message: "You must specify whether the document has been published before" }
   validates :first_published_at, presence: true, if: -> { previously_published || published_major_version }
-  validates :first_published_at, inclusion: { in: proc { Date.parse("1900-01-01")..Time.zone.now }, message: "must be between 1/1/1900 and the present" }, if: :draft?, allow_blank: true
+  validates :first_published_at, inclusion: { in: proc { Date.parse("1900-01-01")..Time.zone.now } }, if: :draft?, allow_blank: true
   validates :scheduled_publication, inclusion: { in: proc { Time.zone.now.. }, message: "must be in the future" }, if: :draft?, allow_blank: true
 
   UNMODIFIABLE_STATES = %w[scheduled published superseded deleted unpublished].freeze

--- a/config/application.rb
+++ b/config/application.rb
@@ -74,6 +74,11 @@ module Whitehall
     # the I18n.default_locale when a translation can not be found)
     config.i18n.fallbacks = true
 
+    # Allows us to add custom full messages to locale files which will override
+    # overrides the default behaviour of full_message and returns the translation
+    # when a translation is present
+    config.active_model.i18n_customize_full_message = true
+
     config.generators do |generate|
       generate.helper false
       generate.assets false

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -1,0 +1,13 @@
+en:
+  activerecord:
+    errors:
+      messages:
+        invalid_date: "is not in the correct format"
+      models:
+        edition:
+          attributes:
+            first_published_at:
+              format: "%{message}"
+              invalid_date: First published date is not in the correct format
+              blank: Enter a first published date
+              inclusion: First published date must be between 1/1/1900 and the present

--- a/features/step_definitions/previously_published_steps.rb
+++ b/features/step_definitions/previously_published_steps.rb
@@ -33,13 +33,13 @@ Then(/^I do not see a validation error for the 'previously published' option$/) 
 end
 
 Then(/^I see a validation error for the future date$/) do
-  expect(page).to have_content("First published at must be between 1/1/1900 and the present")
+  expect(page).to have_content("First published date must be between 1/1/1900 and the present")
 end
 
 Then(/^I see a validation error for the missing publication date$/) do
-  expect(page).to have_content("First published at can't be blank")
+  expect(page).to have_content("Enter a first published date")
 end
 
 Then(/^I should not see a validation error on the previously published date$/) do
-  expect(page).to_not have_content("First published at must be between 1/1/1900 and the present")
+  expect(page).to_not have_content("First published date must be between 1/1/1900 and the present")
 end

--- a/test/functional/admin/publications_controller_test.rb
+++ b/test/functional/admin/publications_controller_test.rb
@@ -88,7 +88,7 @@ class Admin::PublicationsControllerTest < ActionController::TestCase
 
   test "should validate first_published_at field on create if previously_published is true" do
     post :create, params: { edition: controller_attributes_for(:publication).merge(previously_published: "true") }
-    assert_equal "First published at can't be blank", assigns(:edition).errors.full_messages.last
+    assert_equal "Enter a first published date", assigns(:edition).errors.full_messages.last
   end
 
   view_test "edit displays publication fields and guidance" do

--- a/test/unit/app/models/edition_test.rb
+++ b/test/unit/app/models/edition_test.rb
@@ -783,7 +783,7 @@ class EditionTest < ActiveSupport::TestCase
   test "first_published_at required when previously_published" do
     edition = build(:edition, previously_published: true)
     assert_not edition.valid?
-    assert_equal "First published at can't be blank", edition.errors.full_messages.first
+    assert_equal "Enter a first published date", edition.errors.full_messages.first
 
     edition.first_published_at = Time.zone.now
     assert edition.valid?
@@ -793,7 +793,7 @@ class EditionTest < ActiveSupport::TestCase
     edition = build(:edition, first_published_at: 10.years.from_now)
 
     assert_not edition.valid?
-    assert_equal "First published at must be between 1/1/1900 and the present", edition.errors.full_messages.first
+    assert_equal "First published date must be between 1/1/1900 and the present", edition.errors.full_messages.first
   end
 
   test "#government returns the current government for a newly published edition" do


### PR DESCRIPTION
## Description

A common ask from design is that we give more descriptive error messages. At the moment the implementation uses default rails messages. We use `#full_message` https://api.rubyonrails.org/v6.1.4/classes/ActiveModel/Error.html#method-i-full_message in the[ error summary component](https://github.com/alphagov/whitehall/blob/8b7b867216ec45a3c15b6d00db5507187882a41c/app/components/admin/error_summary_component.rb#L30)

Essentially this combines the attribute and standard error message to construct the error message

For example a blank title would produce

```
Title can't be blank
```
as `error.attribute == :title` and `error.message == "can't be blank"

Eventually we want to end up with a full set of error messages which live in locales rather than the model itself. Getting to that point is actually slightly tricky as we have many models, all of which need custom error messages. Replacing all of these in one go in one PR would be a pretty insurmountable task.

Fortunately, Rails provides us with the functionality override the format of the `full_message` for individual models/attrs.

https://edgeguides.rubyonrails.org/configuring.html#configuring-active-model

This adds this setting to the config and adds a custom error message for datetime fields when the user inputs a date in an invalid format.

This PR does the minimal work possible to move this validation https://github.com/alphagov/whitehall/blob/ce464394bb23298757e621bd8def5f8bb2094bc2/app/models/date_validation.rb#L59
into a locale.

However, since we need to update the text for from `First published at` to `First published date` we've had to manually update all the error messages for that attr.

## Screenshots

### Call for evidence & consultation response edit pages

<img width="665" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/a3c50fb4-4a26-4479-809d-a8ad40e83ef1">

<img width="565" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/9a352b6a-8fd5-4b3b-b478-f77838b05597">

### Editions



## Guidance for review

One thing we need to be careful of is making the error messages too generic. For example, this page can have multiple date fields. 

If we use the same error message `Date is not in the correct format` we could have two links with the exact same text which would be an accessibility concern.

## Trello card

https://trello.com/c/ZuDpF2Cq/1646-design-investigate-formatting-help

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
