### PR TITLE
Use "test_helper" rather than "fast_test_helper"

### DIFF
--- a/test/unit/lib/data_hygiene/govspeak_link_validator_test.rb
+++ b/test/unit/lib/data_hygiene/govspeak_link_validator_test.rb
@@ -1,4 +1,4 @@
-require "fast_test_helper"
+require "test_helper"
 
 class Edition::GovspeakLinkValidatorTest < ActiveSupport::TestCase
   test "should be valid if the input is nil" do


### PR DESCRIPTION
The GovspeakLinkValidator test was failing when run independently of the rest of the MiniTest test suite:

```
rails test test/unit/lib/data_hygiene/govspeak_link_validator_test.rb
/Users/ollie.treend/govuk/whitehall/test/unit/lib/data_hygiene/govspeak_link_validator_test.rb:3:in `<main>': uninitialized constant Edition (NameError)

class Edition::GovspeakLinkValidatorTest < ActiveSupport::TestCase
      ^^^^^^^
```

This was happening because the test was including the "fast test helper", which only sets up a minimal set of dependencies, compared to the regular "test helper" which includes the entire application.

It was causing the newly introduced parallel tests to fail, for example here:
https://github.com/alphagov/whitehall/actions/runs/6495804055/job/17642125464

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
