### PR TITLE
Adding document to Document Collection via URL

### DIFF
--- a/app/controllers/admin/document_collection_group_document_search_controller.rb
+++ b/app/controllers/admin/document_collection_group_document_search_controller.rb
@@ -7,17 +7,23 @@ class Admin::DocumentCollectionGroupDocumentSearchController < Admin::BaseContro
   def search_options; end
 
   def search
-    if params[:search_option].blank?
+    case params[:search_option]
+    when "title-or-slug"
+      redirect_to(action: :search_title_slug, document_collection_id: @collection, group_id: @group)
+    when "url"
+      redirect_to(action: :add_by_url, document_collection_id: @collection, group_id: @group)
+    else
       flash.now[:alert] = "Please select a search option"
       render :search_options
     end
-    redirect_to(action: :search_title_slug, document_collection_id: @collection, group_id: @group) if params[:search_option] == "title-or-slug"
   end
 
   def search_title_slug
     flash.now[:alert] = "Please enter a search query" if params[:query] && params[:query].empty?
     @results = Edition.published.with_title_containing(params[:query].strip) if params[:query].present?
   end
+
+  def add_by_url; end
 
 private
 

--- a/app/helpers/admin/document_collection_group_memberships_helper.rb
+++ b/app/helpers/admin/document_collection_group_memberships_helper.rb
@@ -1,0 +1,17 @@
+module Admin::DocumentCollectionGroupMembershipsHelper
+  def document_collection_group_member_title(membership)
+    if membership.non_whitehall_link
+      membership.non_whitehall_link.title
+    else
+      membership.document.latest_edition.title
+    end
+  end
+
+  def document_collection_group_member_url(membership)
+    if membership.non_whitehall_link
+      Plek.website_root + membership.non_whitehall_link.base_path
+    else
+      membership.document.latest_edition.public_url
+    end
+  end
+end

--- a/app/views/admin/document_collection_group_document_search/add_by_url.html.erb
+++ b/app/views/admin/document_collection_group_document_search/add_by_url.html.erb
@@ -1,0 +1,40 @@
+<% content_for :back_link do %>
+  <%= render "govuk_publishing_components/components/back_link", {
+    href: admin_document_collection_group_search_options_path(@collection, @group),
+  } %>
+<% end %>
+<% content_for :page_title, "Add document" %>
+<% content_for :title, "Add document" %>
+<% content_for :context, @group.heading %>
+<% content_for :title_margin_bottom, 6 %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds app-view-document-collection-document-search-bar">
+    <%= form_with :get do |_form| %>
+      <%= render "govuk_publishing_components/components/input", {
+        label: {
+          text: "Add by URL",
+        },
+        name: "document_url",
+        id: "document_url",
+        heading_size: "l",
+      } %>
+
+      <div class="govuk-button-group govuk-!-margin-top-8">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Add",
+          data_attributes: {
+            module: "gem-track-click",
+            "track-category": "form-button",
+            "track-action": "document-collection-add-by-url-button",
+            "track-label": "Add",
+          },
+        } %>
+
+        <%= link_to "Cancel",
+                    admin_document_collection_group_document_collection_group_memberships_path(@collection, @group),
+                    class: "govuk-link govuk-link--no-visited-state" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/document_collection_group_document_search/add_by_url.html.erb
+++ b/app/views/admin/document_collection_group_document_search/add_by_url.html.erb
@@ -10,7 +10,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds app-view-document-collection-document-search-bar">
-    <%= form_with :get do |_form| %>
+    <%= form_with url: admin_document_collection_group_govuk_url_member_path(@collection, @group), method: :post do |_form| %>
       <%= render "govuk_publishing_components/components/input", {
         label: {
           text: "Add by URL",

--- a/app/views/admin/document_collection_group_document_search/search_options.html.erb
+++ b/app/views/admin/document_collection_group_document_search/search_options.html.erb
@@ -6,7 +6,7 @@
 <% content_for :page_title, "Add document" %>
 <% content_for :title, "Add document" %>
 <% content_for :context, @group.heading %>
-<% content_for :title_margin_bottom, 4 %>
+<% content_for :title_margin_bottom, 6 %>
 
 <%
   search_options = [

--- a/app/views/admin/document_collection_group_document_search/search_options.html.erb
+++ b/app/views/admin/document_collection_group_document_search/search_options.html.erb
@@ -12,11 +12,11 @@
   search_options = [
     {
       value: "url",
-      text: "Search via URL",
+      text: "By URL",
     },
     {
       value: "title-or-slug",
-      text: "Search via title",
+      text: "By title",
     },
   ]
 %>
@@ -25,10 +25,8 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_with url: admin_document_collection_group_search_options_path(@collection, @group) do %>
       <%= render "govuk_publishing_components/components/radio", {
-        heading: "Search options",
         name: "search_option",
         id: "search_option",
-        heading_size: "l",
         items: search_options,
       } %>
 

--- a/app/views/admin/document_collection_group_document_search/search_title_slug.html.erb
+++ b/app/views/admin/document_collection_group_document_search/search_title_slug.html.erb
@@ -6,7 +6,7 @@
 <% content_for :page_title, "Add document" %>
 <% content_for :title, "Add document" %>
 <% content_for :context, @group.heading %>
-<% content_for :title_margin_bottom, 4 %>
+<% content_for :title_margin_bottom, 6 %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds app-view-document-collection-document-search-bar">

--- a/app/views/admin/document_collection_group_document_search/search_title_slug.html.erb
+++ b/app/views/admin/document_collection_group_document_search/search_title_slug.html.erb
@@ -27,7 +27,7 @@
       <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
       <% if @results.empty? %>
-        <p class="govuk-body app-view-document-collection-document-search-results__no_documents">No results found. Search again using the <%= link_to "full URL", "#", class: "govuk-link govuk-link--no-visited-state" %>.</p>
+        <p class="govuk-body app-view-document-collection-document-search-results__no_documents">No results found. Search again using the <%= link_to "full URL", admin_document_collection_group_add_by_url_path(@collection, @group), class: "govuk-link govuk-link--no-visited-state" %>.</p>
       <% else %>
         <div class="govuk-table--with-actions app-view-document-collection-document-search-results__table">
           <%= render "govuk_publishing_components/components/table",

--- a/app/views/admin/document_collection_group_memberships/index.html.erb
+++ b/app/views/admin/document_collection_group_memberships/index.html.erb
@@ -58,13 +58,14 @@
       <div class="govuk-table--with-actions app-view-document-collection-group-memberships-index__table">
         <%= render "govuk_publishing_components/components/table", {
           rows: @group.memberships.map do |membership|
-            title =  membership.document.latest_edition.title
+            title = document_collection_group_member_title(membership)
+            url = document_collection_group_member_url(membership)
             [
               {
                 text: title,
               },
               {
-                text: link_to(sanitize("View #{tag.span(title, class: "govuk-visually-hidden")}"), membership.document.latest_edition.public_url, class: "govuk-link") +
+                text: link_to(sanitize("View #{tag.span(title, class: "govuk-visually-hidden")}"), url, class: "govuk-link") +
                   link_to(sanitize("Remove #{tag.span(title, class: "govuk-visually-hidden")}"), confirm_destroy_admin_document_collection_group_document_collection_group_membership_path(@collection, @group, membership), class: "govuk-link gem-link--destructive govuk-!-margin-left-3"),
               },
             ]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,7 @@ Whitehall::Application.routes.draw do
           post :search_options, to: "document_collection_group_document_search#search"
           get :search_title_slug, to: "document_collection_group_document_search#search_title_slug"
           get :add_by_url, to: "document_collection_group_document_search#add_by_url"
+          post "govuk-url-member" => "document_collection_group_memberships#create_member_by_govuk_url", as: :govuk_url_member
           member { get :confirm_destroy }
           resource :document_collection_group_membership,
                    as: :members,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,6 +35,7 @@ Whitehall::Application.routes.draw do
           get :search_options, to: "document_collection_group_document_search#search_options"
           post :search_options, to: "document_collection_group_document_search#search"
           get :search_title_slug, to: "document_collection_group_document_search#search_title_slug"
+          get :add_by_url, to: "document_collection_group_document_search#add_by_url"
           member { get :confirm_destroy }
           resource :document_collection_group_membership,
                    as: :members,

--- a/features/document-collections.feature
+++ b/features/document-collections.feature
@@ -78,6 +78,15 @@ Feature: Grouping documents into a collection
     Then I should see "Document 1" in the list for the collection group "Group"
 
   @design-system-only
+  Scenario: Adding a document to a group via URL
+    Given a document collection "Collection" exists
+    And the document collection "Collection" has a group with the heading "Group"
+    And a GovUK Url exists "https://www.gov.uk/document-1" with title "Document 1"
+    When I select to add a new document to the collection group "By URL"
+    And I add URL "https://www.gov.uk/document-1" to the document collection
+    Then I should see "Document 1" in the list for the collection group "Group"
+
+  @design-system-only
   Scenario: Removing a document from a group
     Given a published publication called "Document to be removed" in a published document collection
     When I remove the publication "Document to be removed" from the group

--- a/features/document-collections.feature
+++ b/features/document-collections.feature
@@ -72,7 +72,7 @@ Feature: Grouping documents into a collection
     Given a document collection "Collection" exists
     And the document collection "Collection" has a group with the heading "Group"
     And a published document "Document 1" exists
-    When I select to add a new document to the collection group through "Search via title"
+    When I select to add a new document to the collection group "By title"
     And I search by "title" for "Document 1"
     And I add "Document 1" to the document collection
     Then I should see "Document 1" in the list for the collection group "Group"
@@ -107,11 +107,11 @@ Feature: Grouping documents into a collection
     And the document collection "Collection" has a group with the heading "Group"
     And a published document "Document 1" exists
     And a published document "Document 2" exists
-    When I select to add a new document to the collection group through "Search via title"
+    When I select to add a new document to the collection group "By title"
     And I search by "title" for "Document 1"
     And I add "Document 1" to the document collection
     Then I should see "Document 1" in the list for the collection group "Group"
-    When I select to add a new document to the collection group through "Search via title"
+    When I select to add a new document to the collection group "By title"
     And I search by "title" for "Document 2"
     And I add "Document 2" to the document collection
     Then I should see "Document 2" in the list for the collection group "Group"

--- a/features/step_definitions/document_collection_steps.rb
+++ b/features/step_definitions/document_collection_steps.rb
@@ -295,3 +295,21 @@ Then(/^I should see "([^"]*)" in the list for the collection group "([^"]*)"$/) 
   documents = all(".govuk-table__cell").map(&:text)
   expect(documents).to include document_title
 end
+
+And(/^a GovUK Url exists "([^"]*)" with title "([^"]*)"$/) do |url, title|
+  base_path = URI.parse(url).path
+  content_id = SecureRandom.uuid
+
+  stub_publishing_api_has_lookups(base_path => content_id)
+  stub_publishing_api_has_item(
+    content_id:,
+    base_path:,
+    publishing_app: "content-publisher",
+    title:,
+  )
+end
+
+And(/^I add URL "([^"]*)" to the document collection$/) do |url|
+  fill_in "Add by URL", with: url
+  click_button "Add"
+end

--- a/features/step_definitions/document_collection_steps.rb
+++ b/features/step_definitions/document_collection_steps.rb
@@ -273,7 +273,7 @@ And(/^the document collection group's documents should be in the following order
   expect(actual_order).to eq(expected_order)
 end
 
-When(/^I select to add a new document to the collection group through "([^"]*)"$/) do |search_option|
+When(/^I select to add a new document to the collection group "([^"]*)"$/) do |search_option|
   visit admin_document_collection_group_document_collection_group_memberships_path(@document_collection, @group)
   click_link "Add document"
   choose search_option

--- a/test/functional/admin/document_collection_group_document_search_controller_test.rb
+++ b/test/functional/admin/document_collection_group_document_search_controller_test.rb
@@ -76,6 +76,7 @@ class Admin::DocumentCollectionGroupDocumentSearchControllerTest < ActionControl
     get :search_title_slug, params: @request_params
     assert_template "document_collection_group_document_search/search_title_slug"
     assert_select ".govuk-body", text: /No results found. Search again using the full URL./
+    assert_select ".govuk-body .govuk-link[href='/government/admin/collections/#{@collection.id}/groups/#{@group.id}/add_by_url']", text: "full URL"
   end
 
   view_test "GET #search_title_slug with an empty query string shows an alert flash" do

--- a/test/functional/admin/document_collection_group_document_search_controller_test.rb
+++ b/test/functional/admin/document_collection_group_document_search_controller_test.rb
@@ -31,13 +31,19 @@ class Admin::DocumentCollectionGroupDocumentSearchControllerTest < ActionControl
   test "POST #search is a noop when passed param is unrecognised" do
     @request_params[:search_option] = "non-existant"
     post :search, params: @request_params
-    assert_template nil
+    assert_template "document_collection_group_document_search/search_options"
   end
 
   test "POST #search redirects to #search_title_slug if search option passed is title-or-slug" do
     @request_params[:search_option] = "title-or-slug"
     post :search, params: @request_params
     assert_redirected_to admin_document_collection_group_search_title_slug_path(@collection, @group)
+  end
+
+  test "POST #search redirects to #add_by_url if search option passed is url" do
+    @request_params[:search_option] = "url"
+    post :search, params: @request_params
+    assert_redirected_to admin_document_collection_group_add_by_url_path(@collection, @group)
   end
 
   test "GET #search_title_slug without query renders search for title & slug page with no results section" do
@@ -77,5 +83,10 @@ class Admin::DocumentCollectionGroupDocumentSearchControllerTest < ActionControl
     get :search_title_slug, params: @request_params
     assert_template "document_collection_group_document_search/search_title_slug"
     assert_select ".gem-c-error-alert__message", text: /Please enter a search query/
+  end
+
+  view_test "GET #add_by_url should render add_by_url page" do
+    get :add_by_url, params: @request_params
+    assert_template "document_collection_group_document_search/add_by_url"
   end
 end

--- a/test/functional/admin/legacy_document_collection_group_document_search_controller_test.rb
+++ b/test/functional/admin/legacy_document_collection_group_document_search_controller_test.rb
@@ -24,4 +24,9 @@ class Admin::LegacyDocumentCollectionGroupDocumentSearchControllerTest < ActionC
     get :search_title_slug, params: @request_params
     assert_template :forbidden
   end
+
+  test "GET #add_by_url blocks out users with no permissions" do
+    get :add_by_url, params: @request_params
+    assert_template :forbidden
+  end
 end

--- a/test/functional/admin/legacy_document_collection_group_memberships_controller_test.rb
+++ b/test/functional/admin/legacy_document_collection_group_memberships_controller_test.rb
@@ -112,4 +112,10 @@ class Admin::LegacyDocumentCollectionGroupMembershipsControllerTest < ActionCont
     assert_response :forbidden
     assert_includes "Sorry, you don’t have access to this document", @response.body
   end
+
+  test "GET #create_member_by_govuk_url forbids the user to see anything" do
+    post :create_member_by_govuk_url, params: { document_collection_id: @collection, group_id: @group }
+    assert_response :forbidden
+    assert_includes "Sorry, you don’t have access to this document", @response.body
+  end
 end

--- a/test/unit/app/helpers/admin/document_collection_group_memberships_helper_test.rb
+++ b/test/unit/app/helpers/admin/document_collection_group_memberships_helper_test.rb
@@ -1,0 +1,39 @@
+require "test_helper"
+
+class Admin::DocumentCollectionGroupMembershipsHelperTest < ActionView::TestCase
+  setup do
+    @document_collection_group = build(:document_collection, :with_group).groups.first
+  end
+
+  test "document_collection_group_member_title should return title if membership is a non_whitehall_link" do
+    non_whitehall_link = DocumentCollectionNonWhitehallLink.new(
+      base_path: "GOVUK PATH",
+      title: "GOVUK TITLE",
+    )
+    membership = @document_collection_group.memberships.build(non_whitehall_link:)
+    assert_equal "GOVUK TITLE", document_collection_group_member_title(membership)
+  end
+
+  test "document_collection_group_member_title should return title if membership is a document" do
+    edition = build(:edition, title: "DOC TITLE")
+    document = build(:document, slug: "DOC PATH", latest_edition: edition)
+    membership = @document_collection_group.memberships.build(document:)
+    assert_equal "DOC TITLE", document_collection_group_member_title(membership)
+  end
+
+  test "document_collection_group_member_url should return full url if membership is a non_whitehall_link" do
+    non_whitehall_link = DocumentCollectionNonWhitehallLink.new(
+      base_path: "/GOVUK-PATH",
+      title: "GOVUK TITLE",
+    )
+    membership = @document_collection_group.memberships.build(non_whitehall_link:)
+    assert_equal "https://www.test.gov.uk/GOVUK-PATH", document_collection_group_member_url(membership)
+  end
+
+  test "document_collection_group_member_url should return public url if membership is a document" do
+    edition = build(:edition, title: "DOC TITLE")
+    document = build(:document, slug: "DOC-PATH", latest_edition: edition)
+    membership = @document_collection_group.memberships.build(document:)
+    assert_equal "https://www.test.gov.uk/government/generic-editions/DOC-PATH", document_collection_group_member_url(membership)
+  end
+end


### PR DESCRIPTION
## What

Implement the flow, using the GOV.UK Design System, for adding an external/non-Whitehall document to a document collection group.

## Why

Part of transitioning all of Whitehall publisher to the GOV.UK Design System.

## Visuals

### Search options page

<img width="634" alt="image" src="https://github.com/alphagov/whitehall/assets/138604938/c06d4333-ebe4-4ae8-bb30-1499d708015b">

### Add by URL page

<img width="773" alt="image" src="https://github.com/alphagov/whitehall/assets/138604938/2f80fe4a-00d2-4645-a550-465755d15976">

### Add by URL page (with errors)

<img width="1153" alt="image" src="https://github.com/alphagov/whitehall/assets/138604938/59025237-c4bd-40c8-b275-c62c82208e74">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

https://trello.com/c/GHwLSfqa/529-add-a-document-to-a-group-from-a-url