### PR TITLE
Update slug field on the edit edition page to page address

### DIFF
--- a/app/views/admin/editions/_standard_fields.html.erb
+++ b/app/views/admin/editions/_standard_fields.html.erb
@@ -9,13 +9,6 @@
     margin_bottom: 6,
   } %>
 
-  <% if edition.document&.slug.present? %>
-    <div class="govuk-!-margin-bottom-6">
-      <label for="edition_slug" class="gem-c-label govuk-label govuk-label--m govuk-!-font-weight-bold">Slug (read only)</label>
-      <input disabled="disabled" autocomplete="off" class="gem-c-input govuk-input govuk-body" id="edition_slug" name="edition[slug]" readonly="readonly" spellcheck="false" type="text" value="<%= edition.slug %>">
-    </div>
-  <% end %>
-
   <div class="govuk-!-margin-bottom-6 js-locale-switcher-field">
     <%= render "govuk_publishing_components/components/character_count", {
       textarea: {
@@ -34,6 +27,21 @@
       maxlength: 65,
     } %>
   </div>
+
+  <% if edition.document&.slug.present? %>
+    <div class="app-view-edit-edition__page-address govuk-!-margin-bottom-6">
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "Page address",
+        heading_level: 3,
+        font_size: "m",
+        margin_bottom: 2,
+      } %>
+
+      <%= render "govuk_publishing_components/components/hint", {
+        text: edition.public_url,
+      } %>
+    </div>
+  <% end %>
 
   <div class="js-locale-switcher-field">
     <%= render "govuk_publishing_components/components/character_count", {

--- a/features/edition-update-slug.feature
+++ b/features/edition-update-slug.feature
@@ -6,7 +6,7 @@ Feature: Edition update slug
     And a published news article "You will never guess" exists
     And I visit the edit slug page for "You will never guess"
     And I update the slug to "new-slug"
-    Then I can see the slug has been updated to "new-slug"
+    Then I can see the edition's public URL contains "new-slug"
 
   Scenario: Admin attempts to update a slug
     Given I am an admin

--- a/features/step_definitions/edition_update_slug_steps.rb
+++ b/features/step_definitions/edition_update_slug_steps.rb
@@ -8,10 +8,10 @@ And(/^I update the slug to "([^"]*)"$/) do |new_slug|
   click_button "Update"
 end
 
-Then(/^I can see the slug has been updated to "([^"]*)"$/) do |new_slug|
+Then(/^I can see the edition's public URL contains "([^"]*)"$/) do |new_slug|
   visit admin_edition_path(@edition)
   click_button "Create new edition"
-  expect(find("#edition_slug").value).to eq new_slug
+  expect(page.find(".app-view-edit-edition__page-address .govuk-hint")).to have_content new_slug
 end
 
 Then(/^I am told I do not have access to the document$/) do

--- a/test/functional/admin/document_collections_controller_test.rb
+++ b/test/functional/admin/document_collections_controller_test.rb
@@ -71,7 +71,7 @@ class Admin::DocumentCollectionsControllerTest < ActionController::TestCase
     get :edit, params: { id: document_collection }
 
     assert_select "form[action=?]", admin_document_collection_path(document_collection) do
-      assert_select "input[name='edition[slug]'][value=?]", document_collection.slug
+      assert_select ".app-view-edit-edition__page-address .govuk-hint", document_collection.public_url
       assert_select "textarea[name='edition[title]']", document_collection.title
       assert_select "textarea[name='edition[summary]']", text: document_collection.summary
       assert_select "textarea[name='edition[body]']", text: document_collection.body


### PR DESCRIPTION
## Description

On the edit edition page there is a read only input which shows a documents slug. This is confusing for users for 2 reasons:

1. they think they can edit it
2. they don't really know what a slug is

This updates the design to simply show the url of the document on GOV.UK.

## Screenshots

### Before

<img width="446" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/5beb2ea6-0224-4ffe-8dbb-df30a7397bb0">

### After

<img width="686" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/e141c4a4-3627-44ee-9af0-aff1af100aca">

The screenshot here shows dev.gov.uk because it's on my local env. It would show

```
http://www.integration.gov.uk/government/publications/futures-toolkit-for-policy-makers-and-analysts
```

on int and 

```
http://www.gov.uk/government/publications/futures-toolkit-for-policy-makers-and-analysts
```

on prod

## Trello card 

https://trello.com/b/0n3p84mY/publishing-experience-team

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
