### PR TITLE
[DO NOT MERGE] Update brand colour name for BIS

### DIFF
--- a/app/models/organisation_brand_colour.rb
+++ b/app/models/organisation_brand_colour.rb
@@ -19,8 +19,8 @@ class OrganisationBrandColour
   )
   DepartmentForBusinessInnovationSkills = create!(
     id: 3,
-    title: "Department for Business, Innovation & Skills",
-    class_name: "department-for-business-innovation-skills",
+    title: "Department for Energy Security and Net Zero",
+    class_name: "department-for-energy-security-and-net-zero",
   )
   DepartmentForCommunitiesAndLocalGovernment = create!(
     id: 4,


### PR DESCRIPTION
**Do not merge until new release of GOV..UK Frontend goes out with these changes https://github.com/alphagov/govuk-frontend/pull/4331**

## Description

This department has now been broken up into other departments. This should now be updated 'Department for Energy Security and Net Zero'.

We shouldn't merge these changes until a new version of GOV.UK Frontend has been released which adds brand colour for Department for Energy Security and Net Zero

## Trello card

https://trello.com/c/XYjCuXRz/1325-update-old-bis-colour-name-in-whitehall

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
