### PR TITLE
Maintain number of important board members on edit

### DIFF
--- a/app/views/admin/organisations/_form.html.erb
+++ b/app/views/admin/organisations/_form.html.erb
@@ -328,7 +328,7 @@
           {
             text: n,
             value: n,
-            selected: @organisation.management_roles.count == n,
+            selected: @organisation.important_board_members == n,
           }
         end,
       } %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

# What
- Display `@organisation.important_board_members` instead of `@organisation.management_roles.count` as selected on the organisation form.

# Why
- The organisation form was defaulting to displaying the the maximum number of board member photos instead of respecting the saved value.
- https://govuk.zendesk.com/agent/tickets/5519838
