### PR TITLE
Remove use of SetUploadedToWorker

### DIFF
--- a/config/initializers/govuk_errors.rb
+++ b/config/initializers/govuk_errors.rb
@@ -1,6 +1,5 @@
 GovukError.configure do |config|
   config.excluded_exceptions += [
-    "AssetManagerAttachmentSetUploadedToWorker::AttachmentDataNotFoundTransient",
     "Redis::CannotConnectError",
   ]
 


### PR DESCRIPTION
This worker has been deleted since it has been replaced with the use of the Asset model to track assets.

Removing this error usage missed before.

[Trello card](https://trello.com/c/qyrBIWrY/226-remove-usage-of-setuploadedtoworker)
