### PR TITLE
Refactor migration worker to support organisation

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -12,6 +12,9 @@ class Organisation < ApplicationRecord
 
   belongs_to :default_news_image, class_name: "DefaultNewsOrganisationImageData", foreign_key: :default_news_organisation_image_data_id
 
+  has_many :assets,
+           as: :assetable,
+           inverse_of: :assetable
   has_many :child_organisational_relationships,
            foreign_key: :parent_organisation_id,
            class_name: "OrganisationalRelationship"
@@ -555,6 +558,13 @@ class Organisation < ApplicationRecord
 
   def publishing_api_presenter
     PublishingApi::OrganisationPresenter
+  end
+
+  def all_asset_variants_uploaded?
+    asset_variants = assets.map(&:variant).map(&:to_sym)
+    required_variants = LogoUploader.versions.keys.push(:original)
+
+    (required_variants - asset_variants).empty?
   end
 
 private

--- a/app/workers/create_asset_relationship_worker.rb
+++ b/app/workers/create_asset_relationship_worker.rb
@@ -1,9 +1,9 @@
 class CreateAssetRelationshipWorker < WorkerBase
-  def perform(assetable_type, start_id, end_id)
+  def perform(start_id, end_id)
     logger.info("CreateAssetRelationshipWorker start!")
 
-    assetable_type = assetable_type.constantize
-    assetables = assetable_type.where(id: start_id..end_id, use_non_legacy_endpoints: false)
+    assetable_type = Organisation
+    assetables = assetable_type.where(id: start_id..end_id, organisation_logo_type_id: 14)
     logger.info "Number of #{assetable_type} found: #{assetables.count}"
     logger.info "Creating Asset for records from #{start_id} to #{end_id}"
 
@@ -11,13 +11,7 @@ class CreateAssetRelationshipWorker < WorkerBase
     asset_counter = 0
 
     assetables.each do |assetable|
-      assetable.use_non_legacy_endpoints = true
-      assetable.save!
-
-      all_variants = assetable.bitmap? ? assetable.file.versions.keys.push(:original) : [Asset.variants[:original].to_sym]
-      all_variants.each do |variant|
-        asset_counter += 1 if save_asset(assetable, assetable_type, variant)
-      end
+      asset_counter += 1 if save_asset(assetable, assetable_type, Asset.variants[:original].to_sym)
 
       count += 1
     end
@@ -36,7 +30,7 @@ private
   end
 
   def save_asset(assetable, assetable_type, variant)
-    path = variant == :original ? assetable.file.path : assetable.file.versions[variant].path
+    path = assetable.logo.path
     asset_info = get_asset_data(path)
     save_asset_id_to_assets(assetable.id, assetable_type, Asset.variants[variant], asset_info[:asset_manager_id], asset_info[:filename])
   rescue GdsApi::HTTPNotFound

--- a/lib/tasks/create_asset_relationship.rake
+++ b/lib/tasks/create_asset_relationship.rake
@@ -1,5 +1,5 @@
 desc "Create Asset relationship for AttachmentData"
 
-task :create_asset_relationship, %i[assetable_type start_id end_id] => :environment do |_, args|
-  CreateAssetRelationshipWorker.perform_async(args[:assetable_type], args[:start_id].to_i, args[:end_id].to_i)
+task :create_asset_relationship, %i[start_id end_id] => :environment do |_, args|
+  CreateAssetRelationshipWorker.perform_async(args[:start_id].to_i, args[:end_id].to_i)
 end

--- a/test/factories/organisations.rb
+++ b/test/factories/organisations.rb
@@ -6,6 +6,11 @@ FactoryBot.define do
     sequence(:analytics_identifier) { |index| "T#{index}" }
     organisation_logo_type_id { OrganisationLogoType::SingleIdentity.id }
 
+    trait(:with_logo) do
+      organisation_logo_type_id { 14 }
+      logo { image_fixture_file }
+    end
+
     trait(:closed) do
       govuk_status { "closed" }
       govuk_closed_status { "no_longer_exists" }
@@ -40,6 +45,7 @@ FactoryBot.define do
     end
   end
 
+  factory :organisation_with_logo, parent: :organisation, traits: [:with_logo]
   factory :closed_organisation, parent: :organisation, traits: [:closed]
 
   factory :ministerial_department, parent: :organisation do

--- a/test/unit/app/models/organisation_test.rb
+++ b/test/unit/app/models/organisation_test.rb
@@ -1183,4 +1183,18 @@ class OrganisationTest < ActiveSupport::TestCase
 
     organisation.destroy!
   end
+
+  test "#all_asset_variants_uploaded? returns true if all asset variants present" do
+    organisation = build(:organisation)
+    organisation.assets.build(asset_manager_id: "asset_manager_id", variant: Asset.variants[:original], filename: "filename.png")
+    organisation.save!
+
+    assert organisation.all_asset_variants_uploaded?
+  end
+
+  test "#all_asset_variants_uploaded? returns false if there are no assets" do
+    organisation = build(:organisation)
+
+    assert_not organisation.all_asset_variants_uploaded?
+  end
 end

--- a/test/unit/app/workers/create_asset_relationship_worker_test.rb
+++ b/test/unit/app/workers/create_asset_relationship_worker_test.rb
@@ -1,0 +1,120 @@
+require "test_helper"
+
+class CreateAssetRelationshipWorkerTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
+  describe CreateAssetRelationshipWorker do
+    let(:worker) { CreateAssetRelationshipWorker.new }
+    let(:expected_number_of_variants) { 1 }
+
+    context "all assets can be retrieved from asset-manager" do
+      before do
+        stub_all_assets(assetables)
+        stub_create_asset("asset_manager_id")
+
+        Sidekiq.logger.expects(:info).times(6)
+
+        @output = worker.perform(start_id, end_id)
+        AssetManagerCreateAssetWorker.drain
+        assetables.map(&:reload)
+      end
+
+      context "worker is run for a single assetable" do
+        let(:assetable) { create(:organisation_with_logo) }
+        let(:assetables) { [assetable] }
+        let(:start_id) { assetable.id }
+        let(:end_id) { assetable.id }
+
+        it "generates assets for all logo variants" do
+          assert_equal expected_number_of_variants, assetable.assets.count
+          assert_equal true, assetable.all_asset_variants_uploaded?
+        end
+
+        it "increments counters" do
+          assert_equal expected_number_of_variants, @output[:asset_counter]
+          assert_equal 1, @output[:count]
+        end
+      end
+
+      context "worker is run for an interval of assetables" do
+        let(:first_assetable) { create(:organisation_with_logo) }
+        let(:second_assetable) { create(:organisation_with_logo) }
+        let(:assetables) { [first_assetable, second_assetable] }
+        let(:start_id) { first_assetable.id }
+        let(:end_id) { second_assetable.id }
+
+        it "generates assets for all logo variants" do
+          assert_equal expected_number_of_variants, first_assetable.assets.count
+          assert_equal expected_number_of_variants, second_assetable.assets.count
+        end
+
+        it "increments counters" do
+          assert_equal (expected_number_of_variants * 2), @output[:asset_counter]
+          assert_equal 2, @output[:count]
+        end
+      end
+    end
+
+    context "assets cannot be found in asset manager" do
+      let(:assetable) { create(:organisation_with_logo) }
+      let(:start_id) { assetable.id }
+      let(:end_id) { assetable.id }
+
+      before do
+        Services.asset_manager.stubs(:whitehall_asset).raises(GdsApi::HTTPNotFound, "Error message")
+      end
+
+      it "rescues HTTPNotFound error and logs if asset cannot be found at path" do
+        Sidekiq.logger.expects(:info).times(6)
+        Sidekiq.logger.expects(:warn).times(1).with(regexp_matches(/minister-of-funk.960x640.jpg/))
+
+        worker.perform(start_id, end_id)
+        assetable.reload
+
+        assert_equal 0, assetable.assets.count
+      end
+    end
+
+    context "skips organisations without a custom logo" do
+      let(:assetable) { create(:organisation) }
+      let(:start_id) { assetable.id }
+      let(:end_id) { assetable.id }
+
+      it "does not save any assets" do
+        Sidekiq.logger.expects(:info).times(4)
+        Sidekiq.logger.expects(:info).with("Created assets for 0 assetable").once
+        Sidekiq.logger.expects(:info).with("Created asset counter 0").once
+
+        worker.perform(start_id, end_id)
+        assetable.reload
+
+        assert_equal 0, assetable.assets.count
+      end
+    end
+  end
+
+private
+
+  def ends_with(expected)
+    ->(actual) { actual.end_with?(expected) }
+  end
+
+  def stub_whitehall_asset(filename, attributes = {})
+    url_id = "http://asset-manager/assets/#{attributes[:id]}"
+    Services.asset_manager.stubs(:whitehall_asset)
+            .with(&ends_with(filename))
+            .returns(attributes.merge(id: url_id, name: filename).stringify_keys)
+  end
+
+  def stub_all_assets(assetables)
+    assetables.each do |assetable|
+      stub_whitehall_asset(assetable.logo.file.filename, id: "asset_id_14652342")
+    end
+  end
+
+  def stub_create_asset(asset_manger_id)
+    url_id = "http://asset-manager/assets/#{asset_manger_id}"
+    Services.asset_manager.stubs(:create_asset)
+            .returns("id" => url_id, "name" => "filename.pdf")
+  end
+end


### PR DESCRIPTION
Migrate organisations to use asset manager IDs instead of `legacy_url_path` if they have a file logo.

[Trello card](https://trello.com/c/cZD9ZZ2h/212-task-migrate-database-for-organisation-logo)
