### PR TITLE
Ensure change note input field is visible for all pre-publication documents

### DIFF
--- a/app/models/edition/publishing.rb
+++ b/app/models/edition/publishing.rb
@@ -40,7 +40,7 @@ module Edition::Publishing
   def change_note_required?
     return false if new_record?
 
-    draft? && previous_edition.present?
+    pre_publication? && previous_edition.present?
   end
 
   def change_note_present!

--- a/test/unit/app/models/edition/publishing_test.rb
+++ b/test/unit/app/models/edition/publishing_test.rb
@@ -13,6 +13,18 @@ class Edition::PublishingChangeNoteTest < ActiveSupport::TestCase
     assert_not edition.valid?
   end
 
+  test "a submitted edition is invalid without change note once saved if a published edition already exists" do
+    published_edition = create(:published_edition)
+    edition = create(:submitted_edition, change_note: nil, minor_change: false, document: published_edition.document)
+    assert_not edition.valid?
+  end
+
+  test "a rejected edition is invalid without change note once saved if a published edition already exists" do
+    published_edition = create(:published_edition)
+    edition = create(:rejected_edition, change_note: nil, minor_change: false, document: published_edition.document)
+    assert_not edition.valid?
+  end
+
   test "a draft is invalid without change note once saved if an unpublished edition already exists" do
     unpublished_edition = create(:unpublished_edition)
     edition = create(:draft_edition, change_note: nil, minor_change: false, document: unpublished_edition.document)


### PR DESCRIPTION
Users were reporting that the change note field was not visible on submitted documents. This change ensures that the change note input is visible on all pre publication documents, fixing a bug introduced in 4eb10f4.


