### PR TITLE
562 add more page

### DIFF
--- a/app/controllers/admin/more_controller.rb
+++ b/app/controllers/admin/more_controller.rb
@@ -1,0 +1,5 @@
+class Admin::MoreController < Admin::BaseController
+  layout "design_system"
+
+  def index; end
+end

--- a/app/controllers/admin/more_controller.rb
+++ b/app/controllers/admin/more_controller.rb
@@ -1,5 +1,22 @@
 class Admin::MoreController < Admin::BaseController
-  layout "design_system"
+  before_action :check_new_design_system_permissions, only: %i[index]
+  layout :get_layout
 
   def index; end
+
+private
+
+  def check_new_design_system_permissions
+    forbidden! unless new_design_system?
+  end
+
+  def get_layout
+    design_system_actions = %w[index] if preview_design_system?(next_release: false)
+
+    if design_system_actions&.include?(action_name)
+      "design_system"
+    else
+      "admin"
+    end
+  end
 end

--- a/app/helpers/admin/url_helper.rb
+++ b/app/helpers/admin/url_helper.rb
@@ -28,7 +28,7 @@ module Admin::UrlHelper
   end
 
   def admin_organisations_link
-    admin_link "Departments & agencies", admin_organisations_path
+    admin_link "Organisations", admin_organisations_path
   end
 
   def admin_roles_header_menu_link

--- a/app/helpers/admin/url_helper.rb
+++ b/app/helpers/admin/url_helper.rb
@@ -74,7 +74,11 @@ module Admin::UrlHelper
   end
 
   def admin_header_menu_link(name, path)
-    tag.li(link_to(name, path, role: "menuitem"), class: "masthead-menu-item")
+    if preview_design_system?
+      link_to(name, path, class: "govuk-link")
+    else
+      tag.li(link_to(name, path, role: "menuitem"), class: "masthead-menu-item")
+    end
   end
 
   def admin_header_link(name, path, path_matcher = nil, options = {})

--- a/app/helpers/admin/url_helper.rb
+++ b/app/helpers/admin/url_helper.rb
@@ -19,28 +19,56 @@ module Admin::UrlHelper
     admin_header_menu_link "Topical events", admin_topical_events_path
   end
 
+  def admin_topical_events_link
+    admin_link "Topical events", admin_topical_events_path
+  end
+
   def admin_organisations_header_menu_link
     admin_header_menu_link "Departments & agencies", admin_organisations_path
+  end
+
+  def admin_organisations_link
+    admin_link "Departments & agencies", admin_organisations_path
   end
 
   def admin_roles_header_menu_link
     admin_header_menu_link "Roles", admin_roles_path
   end
 
+  def admin_roles_link
+    admin_link "Roles", admin_roles_path
+  end
+
   def admin_people_header_menu_link
     admin_header_menu_link "People", admin_people_path
+  end
+
+  def admin_people_link
+    admin_link "People", admin_people_path
   end
 
   def admin_worldwide_organisations_header_menu_link
     admin_header_menu_link "Worldwide organisations", admin_worldwide_organisations_path
   end
 
+  def admin_worldwide_organisations_link
+    admin_link "Worldwide organisations", admin_worldwide_organisations_path
+  end
+
   def admin_world_location_news_header_menu_link
     admin_header_menu_link "World location news", admin_world_location_news_index_path
   end
 
+  def admin_world_location_news_link
+    admin_link "World location news", admin_world_location_news_index_path
+  end
+
   def admin_policy_groups_header_menu_link
     admin_header_menu_link "Groups", admin_policy_groups_path
+  end
+
+  def admin_policy_groups_link
+    admin_link "Groups", admin_policy_groups_path
   end
 
   def admin_users_header_link
@@ -53,13 +81,29 @@ module Admin::UrlHelper
     end
   end
 
+  def admin_fields_of_operation_link
+    if current_user && current_user.can_handle_fatalities?
+      admin_link "Fields of operation", admin_operational_fields_path
+    end
+  end
+
   def admin_cabinet_ministers_header_menu_link
     admin_header_menu_link "Cabinet ministers order", admin_cabinet_ministers_path
+  end
+
+  def admin_cabinet_ministers_link
+    admin_link "Cabinet ministers order", admin_cabinet_ministers_path
   end
 
   def admin_get_involved_header_menu_link
     if can?(:administer, :get_involved_section)
       admin_header_menu_link "Get involved", admin_get_involved_path
+    end
+  end
+
+  def admin_get_involved_link
+    if can?(:administer, :get_involved_section)
+      admin_link "Get involved", admin_get_involved_path
     end
   end
 
@@ -69,16 +113,26 @@ module Admin::UrlHelper
     end
   end
 
+  def admin_sitewide_settings_link
+    if can?(:administer, :sitewide_settings_section)
+      admin_link "Sitewide settings", admin_sitewide_settings_path
+    end
+  end
+
   def admin_governments_header_menu_link
     admin_header_menu_link "Governments", admin_governments_path
   end
 
+  def admin_governments_link
+    admin_link "Governments", admin_governments_path
+  end
+
   def admin_header_menu_link(name, path)
-    if preview_design_system?
-      link_to(name, path, class: "govuk-link")
-    else
-      tag.li(link_to(name, path, role: "menuitem"), class: "masthead-menu-item")
-    end
+    tag.li(link_to(name, path, role: "menuitem"), class: "masthead-menu-item")
+  end
+
+  def admin_link(name, path)
+    link_to(name, path, class: "govuk-link")
   end
 
   def admin_header_link(name, path, path_matcher = nil, options = {})

--- a/app/views/admin/more/index.html.erb
+++ b/app/views/admin/more/index.html.erb
@@ -1,0 +1,24 @@
+<% content_for :page_title, "More" %>
+<% content_for :title, "More" %>
+<% content_for :title_margin_bottom, 6 %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/list", {
+      items: [
+        admin_organisations_header_menu_link,
+        admin_policy_groups_header_menu_link,
+        admin_roles_header_menu_link,
+        admin_people_header_menu_link,
+        admin_topical_events_header_menu_link,
+        admin_worldwide_organisations_header_menu_link,
+        admin_world_location_news_header_menu_link,
+        admin_fields_of_operation_header_menu_link,
+        admin_cabinet_ministers_header_menu_link,
+        admin_get_involved_header_menu_link,
+        admin_sitewide_settings_header_menu_link,
+        admin_governments_header_menu_link,
+      ],
+    } %>
+  </div>
+</div>

--- a/app/views/admin/more/index.html.erb
+++ b/app/views/admin/more/index.html.erb
@@ -6,18 +6,18 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/list", {
       items: [
-        admin_organisations_header_menu_link,
-        admin_policy_groups_header_menu_link,
-        admin_roles_header_menu_link,
-        admin_people_header_menu_link,
-        admin_topical_events_header_menu_link,
-        admin_worldwide_organisations_header_menu_link,
-        admin_world_location_news_header_menu_link,
-        admin_fields_of_operation_header_menu_link,
-        admin_cabinet_ministers_header_menu_link,
-        admin_get_involved_header_menu_link,
-        admin_sitewide_settings_header_menu_link,
-        admin_governments_header_menu_link,
+        admin_organisations_link,
+        admin_policy_groups_link,
+        admin_roles_link,
+        admin_people_link,
+        admin_topical_events_link,
+        admin_worldwide_organisations_link,
+        admin_world_location_news_link,
+        admin_fields_of_operation_link,
+        admin_cabinet_ministers_link,
+        admin_get_involved_link,
+        admin_sitewide_settings_link,
+        admin_governments_link,
       ],
     } %>
   </div>

--- a/app/views/admin/more/index.html.erb
+++ b/app/views/admin/more/index.html.erb
@@ -6,18 +6,18 @@
   <div class="govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/list", {
       items: [
-        admin_organisations_link,
-        admin_policy_groups_link,
-        admin_roles_link,
-        admin_people_link,
-        admin_topical_events_link,
-        admin_worldwide_organisations_link,
-        admin_world_location_news_link,
-        admin_fields_of_operation_link,
         admin_cabinet_ministers_link,
+        admin_fields_of_operation_link,
         admin_get_involved_link,
-        admin_sitewide_settings_link,
         admin_governments_link,
+        admin_policy_groups_link,
+        admin_organisations_link,
+        admin_people_link,
+        admin_roles_link,
+        admin_sitewide_settings_link,
+        admin_topical_events_link,
+        admin_world_location_news_link,
+        admin_worldwide_organisations_link,
       ],
     } %>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -244,6 +244,8 @@ Whitehall::Application.routes.draw do
       get :new_document_options, to: "new_document#new_document_options_redirect"
       post :new_document_options, to: "new_document#new_document_options_redirect"
 
+      get "/more" => "more#index", as: :more
+
       resources :statistics_announcements, except: [:destroy] do
         member do
           get :cancel

--- a/test/functional/admin/more_controller_test.rb
+++ b/test/functional/admin/more_controller_test.rb
@@ -1,0 +1,16 @@
+require "test_helper"
+
+class Admin::MoreControllerTest < ActionController::TestCase
+  setup do
+    login_as_preview_design_system_user :writer
+  end
+
+  view_test "GET #index renders the 'More' page with a correctly formatted list of links" do
+    get :index
+
+    assert_response :success
+    assert_select "h1.govuk-heading-xl", text: "More"
+    assert_select ".govuk-list"
+    assert_select "a.govuk-link", text: "Departments & agencies"
+  end
+end

--- a/test/functional/admin/more_controller_test.rb
+++ b/test/functional/admin/more_controller_test.rb
@@ -11,6 +11,6 @@ class Admin::MoreControllerTest < ActionController::TestCase
     assert_response :success
     assert_select "h1.govuk-heading-xl", text: "More"
     assert_select ".govuk-list"
-    assert_select "a.govuk-link", text: "Departments & agencies"
+    assert_select "a.govuk-link", text: "Cabinet ministers order"
   end
 end


### PR DESCRIPTION
Trello: [562 | Link More drop down in the sub navigation to new page with "more" links](https://trello.com/c/UCCxgSnI/562-link-more-drop-down-in-the-sub-navigation-to-new-page-with-more-links)

This PR creates a new view which users will be directed to when they click on the "More" link in the navigation. Screenshot below. 

Changes: 
- Updates routes file for the new page
- Adds a new controller for the new page
- Adds a new view for the new page
- Adds a test for the new page
- Adds temporary "forbidden" toggle for users without Design System permissions
- Reorders links and changes "Departments & Agencies" to "Organisations"

![Screenshot 2023-10-25 at 16 27 26](https://github.com/alphagov/whitehall/assets/6080548/a2c89caf-72b9-47de-a3ca-57050515dcf9)