### PR TITLE
Enable DefaultNewsOrganisationImageData to have assets and use non-le…

### DIFF
--- a/app/models/default_news_organisation_image_data.rb
+++ b/app/models/default_news_organisation_image_data.rb
@@ -1,4 +1,8 @@
 class DefaultNewsOrganisationImageData < ApplicationRecord
+  has_many :assets,
+           as: :assetable,
+           inverse_of: :assetable
+
   mount_uploader :file, FeaturedImageUploader, mount_on: :carrierwave_image
   validates :file, presence: true
 end

--- a/lib/whitehall/asset_manager_storage.rb
+++ b/lib/whitehall/asset_manager_storage.rb
@@ -102,7 +102,7 @@ class Whitehall::AssetManagerStorage < CarrierWave::Storage::Abstract
   def self.use_non_legacy_behaviour?(model)
     return unless model
 
-    return true if model.instance_of?(AttachmentData) || model.instance_of?(ImageData) || model.instance_of?(Organisation)
+    return true if model.instance_of?(AttachmentData) || model.instance_of?(ImageData) || model.instance_of?(Organisation) || model.instance_of?(DefaultNewsOrganisationImageData)
 
     model.respond_to?("use_non_legacy_endpoints") && model.use_non_legacy_endpoints
   end

--- a/test/unit/lib/whitehall/asset_manager_storage_test.rb
+++ b/test/unit/lib/whitehall/asset_manager_storage_test.rb
@@ -164,6 +164,14 @@ class Whitehall::AssetManagerStorageTest < ActiveSupport::TestCase
       @uploader.store!(@file)
     end
   end
+
+  test "should call AssetManagerCreateAssetWorker if uploader model is DefaultNewsOrganisationImageData" do
+    model = build(:default_news_organisation_image_data)
+    @uploader.stubs(:model).returns(model)
+
+    AssetManagerCreateAssetWorker.expects(:perform_async).with(anything, anything, anything, anything, anything, anything)
+    @uploader.store!(@file)
+  end
 end
 
 class Whitehall::AssetManagerStorage::FileTest < ActiveSupport::TestCase


### PR DESCRIPTION
…gacy-url

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
