### PR TITLE
Stop marking attachments as present at unpublished

### DIFF
--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -24,8 +24,6 @@ class AttachmentData < ApplicationRecord
 
   OPENDOCUMENT_EXTENSIONS = %w[ODT ODP ODS].freeze
 
-  attribute :present_at_unpublish, :boolean, default: false
-
   def filename
     file.present? && file.file.filename
   end
@@ -107,10 +105,6 @@ class AttachmentData < ApplicationRecord
   delegate :unpublished?, to: :last_attachable
 
   delegate :unpublished_edition, to: :last_attachable
-
-  def present_at_unpublish?
-    self[:present_at_unpublish]
-  end
 
   def replaced?
     replaced_by.present?

--- a/app/services/asset_manager/attachment_updater.rb
+++ b/app/services/asset_manager/attachment_updater.rb
@@ -37,15 +37,9 @@ class AssetManager::AttachmentUpdater
   end
 
   def self.get_draft(attachment_data)
-    (
-      attachment_data.draft? &&
-        !attachment_data.unpublished? &&
-        !attachment_data.replaced?
-    ) || (
-      attachment_data.unpublished? &&
-        !attachment_data.present_at_unpublish? &&
-        !attachment_data.replaced?
-    )
+    attachment_data.draft? &&
+      !attachment_data.unpublished? &&
+      !attachment_data.replaced?
   end
 
   def self.get_link_header(attachment_data)
@@ -59,7 +53,7 @@ class AssetManager::AttachmentUpdater
   end
 
   def self.get_redirect_url(attachment_data)
-    return nil unless attachment_data.unpublished? && attachment_data.present_at_unpublish?
+    return nil unless attachment_data.unpublished?
 
     attachment_data.unpublished_edition.unpublishing.document_url
   end

--- a/app/services/edition_unpublisher.rb
+++ b/app/services/edition_unpublisher.rb
@@ -24,19 +24,10 @@ private
     edition.public_send(verb)
     edition.save!(validate: false)
     edition.document.features.each(&:end!)
-    mark_attachments_as_present_at_unpublish
   end
 
   def prepare_edition
     edition.force_published = false
     edition.reset_version_numbers
-  end
-
-  def mark_attachments_as_present_at_unpublish
-    Attachment.where(attachable: edition.attachables).find_each do |attachment|
-      next unless attachment.attachment_data
-
-      attachment.attachment_data.update!(present_at_unpublish: true)
-    end
   end
 end

--- a/db/migrate/20231020151031_drop_present_at_unpublishing_column_from_attachments.rb
+++ b/db/migrate/20231020151031_drop_present_at_unpublishing_column_from_attachments.rb
@@ -1,0 +1,5 @@
+class DropPresentAtUnpublishingColumnFromAttachments < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :attachment_data, :present_at_unpublish, :boolean, if_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -30,7 +30,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_23_110956) do
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.integer "replaced_by_id"
-    t.boolean "present_at_unpublish"
     t.index ["replaced_by_id"], name: "index_attachment_data_on_replaced_by_id"
   end
 

--- a/test/unit/app/services/asset_manager/attachment_updater_test.rb
+++ b/test/unit/app/services/asset_manager/attachment_updater_test.rb
@@ -106,20 +106,6 @@ class AssetManager::AttachmentUpdaterTest < ActiveSupport::TestCase
         end
       end
 
-      context "and attachment is unpublished" do
-        let(:unpublished) { true }
-
-        it "marks corresponding assets as not draft even though attachment is draft" do
-          attachment_data.update!(present_at_unpublish: true)
-          update_service.expects(:call)
-                        .with(original_asset.asset_manager_id, attachment_data, nil, { "draft" => false })
-          update_service.expects(:call)
-                        .with(thumbnail_asset.asset_manager_id, attachment_data, nil, { "draft" => false })
-
-          updater.call(attachment_data, draft_status: true)
-        end
-      end
-
       context "and attachment is replaced" do
         let(:replaced) { true }
 
@@ -183,7 +169,6 @@ class AssetManager::AttachmentUpdaterTest < ActiveSupport::TestCase
 
       before do
         attachment_data.stubs(:unpublished?).returns(unpublished)
-        attachment_data.stubs(:present_at_unpublish?).returns(true)
         attachment_data.stubs(:unpublished_edition).returns(unpublished_edition)
       end
 


### PR DESCRIPTION
Now that we have an unpublished state for editions, we no longer need to keep track of whether attachments were present at the edition's unpublishing, because unpublished editions now have to be superseded. Previously, unpublished editions were put into the draft state and it was therefore necessary to track which attachments were present when it was unpublished so that we could distinguish them from attachments which had been added to the draft since unpublishing.

I have added a migration to remove the database column from the attachment data table as well. I was undecided about whether to include this in the PR. On the one hand it's an irreversible change, so it would probably make sense to merge this PR and run for a few days without marking attachments as present to check that there are no ill effects. On the other, not including the migration presents the risk that we might forget to come back to tidy up and we'll have a dead database column hanging around. Let me know if the preferred option would be option 1 and I'll remove the migration commit from the PR.

Trello: https://trello.com/c/X4KpEBA7
