### PR TITLE
Fix:Hide Edit link when user has no GDS Editor permission.

### DIFF
--- a/app/helpers/admin/user_helper.rb
+++ b/app/helpers/admin/user_helper.rb
@@ -9,9 +9,12 @@ module Admin::UserHelper
 
   def show_edit_link(user)
     if user.editable_by?(current_user)
-      edit_admin_user_path(user)
+      {
+        href: edit_admin_user_path(user),
+        link_text: "Edit",
+      }
     else
-      ""
+      {}
     end
   end
 end

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -31,10 +31,7 @@
         {
           field: "World locations",
           value: show_world_locations(@user),
-          edit: {
-            href: show_edit_link(@user),
-            link_text: "Edit",
-          },
+          edit: show_edit_link(@user),
         },
       ],
     } %>

--- a/test/functional/admin/users_controller_test.rb
+++ b/test/functional/admin/users_controller_test.rb
@@ -70,4 +70,18 @@ class Admin::UsersControllerTest < ActionController::TestCase
     put :update, params: { id: @user.id, user: { world_location_ids: [world_location.id] } }
     assert_response :forbidden
   end
+
+  view_test "show: displays Edit link if user has gds editor permission to edit the record." do
+    login_as_preview_design_system_user(:gds_editor)
+
+    get :show, params: { id: @user.id }
+
+    assert_select ".govuk-summary-list__actions", text: /Edit/
+  end
+
+  view_test "show: hides Edit link if user has no gds editor permission to edit the record." do
+    get :show, params: { id: @user.id }
+
+    assert_select ".govuk-summary-list__actions", false
+  end
 end


### PR DESCRIPTION
This PR adds logic to hide the "Edit" link at 'Individual User' page, when logged in user has no 'GDS Editor' permission.

It does the following:
Added helper method to 'show' view to hide "Edit" link based on the user permission.

**Screen shots:**
**User with GDS Editor permission:**
![image](https://github.com/alphagov/whitehall/assets/131259138/60375bf8-1b56-435a-8f6b-84f07e19a930)

**User without GDS Editor permission:**
![image](https://github.com/alphagov/whitehall/assets/131259138/0378bfe8-cc85-4869-ab95-ef9d76212431)

**Trello:**
https://trello.com/c/5CLy1wbs/582-fix-individual-user-page-to-hide-edit-link-when-user-has-no-gds-editor-permission
