### PR TITLE
Add lead_image_id foreign key to editions table

### DIFF
--- a/app/components/admin/edition_images/uploaded_images_component.html.erb
+++ b/app/components/admin/edition_images/uploaded_images_component.html.erb
@@ -3,7 +3,7 @@
   font_size: "l",
 } %>
 
-<% if can_have_lead_image? %>
+<% if has_lead_image %>
   <%= render "govuk_publishing_components/components/heading", {
     text: "Lead image",
     font_size: "m",
@@ -18,18 +18,18 @@
 <% end %>
 
 <div class="govuk-grid-row">
-  <% if lead_image %>
+  <% if lead_image_hash %>
     <div class="govuk-grid-column-one-third">
-      <img src="<%= lead_image[:url] %>" alt="<%= lead_image[:preview_alt_text] %>" class="app-view-edition-resource__preview">
-      <% unless lead_image[:all_image_asset_variants_uploaded] %><span class="govuk-tag govuk-tag--green">Processing</span><% end %>
+      <img src="<%= lead_image_hash[:url] %>" alt="<%= lead_image_hash[:preview_alt_text] %>" class="app-view-edition-resource__preview">
+      <% unless lead_image_hash[:all_image_asset_variants_uploaded] %><span class="govuk-tag govuk-tag--green">Processing</span><% end %>
     </div>
     <div class="govuk-grid-column-two-thirds">
-      <p class="govuk-body"><strong>Caption: </strong><%= lead_image[:caption] %></p>
-      <p class="govuk-body"><strong>Alt text: </strong><%= lead_image[:alt_text] %></p>
+      <p class="govuk-body"><strong>Caption: </strong><%= lead_image_hash[:caption] %></p>
+      <p class="govuk-body"><strong>Alt text: </strong><%= lead_image_hash[:alt_text] %></p>
     </div>
   <% end %>
 
-  <% if lead_image || @edition.type == "CaseStudy" %>
+  <% if lead_image_hash || @edition.type == "CaseStudy" %>
     <%= form_with(url: update_image_display_option_admin_edition_path(@edition), method: :patch) do |form| %>
       <div class="app-view-edition-resource__actions govuk-grid-column-full govuk-button-group">
         <% if @edition.type == "CaseStudy" %>
@@ -41,8 +41,8 @@
           } %>
         <% end %>
 
-        <% if lead_image %>
-          <% lead_image[:links].each do |link| %><%= link %><% end %>
+        <% if lead_image_hash %>
+          <% lead_image_hash[:links].each do |link| %><%= link %><% end %>
         <% end %>
       </div>
     <% end %>

--- a/app/models/case_study.rb
+++ b/app/models/case_study.rb
@@ -9,6 +9,8 @@ class CaseStudy < Edition
   include Edition::WorldwideOrganisations
   include Edition::LeadImage
 
+  after_update :update_lead_image, if: :saved_change_to_image_display_option?
+
   def rendering_app
     Whitehall::RenderingApp::GOVERNMENT_FRONTEND
   end
@@ -31,5 +33,13 @@ class CaseStudy < Edition
 
   def publishing_api_presenter
     PublishingApi::CaseStudyPresenter
+  end
+
+  def update_lead_image
+    if image_display_option == "no_image"
+      update_column(:lead_image_id, nil)
+    elsif lead_image.blank? && images.present?
+      update_column(:lead_image_id, oldest_image.id)
+    end
   end
 end

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -45,6 +45,8 @@ class Edition < ApplicationRecord
   has_many :depended_upon_contacts, through: :edition_dependencies, source: :dependable, source_type: "Contact"
   has_many :depended_upon_editions, through: :edition_dependencies, source: :dependable, source_type: "Edition"
 
+  belongs_to :lead_image, class_name: "Image"
+
   validates_with SafeHtmlValidator
   validates_with NoFootnotesInGovspeakValidator, attribute: :body
   validates_with TaxonValidator, on: :publish
@@ -766,5 +768,11 @@ private
                                           .first
 
     first_version_with_state.try(:user)
+  end
+
+  def oldest_image
+    return if images.blank?
+
+    images.order(:created_at, :id).first
   end
 end

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -492,7 +492,8 @@ EXISTS (
                                     change_note
                                     minor_change
                                     force_published
-                                    scheduled_publication]
+                                    scheduled_publication
+                                    lead_image_id]
       draft_attributes = attributes.except(*ignorable_attribute_keys)
         .merge("state" => "draft", "creator" => user, "previously_published" => previously_published)
 

--- a/app/models/edition/images.rb
+++ b/app/models/edition/images.rb
@@ -9,6 +9,11 @@ module Edition::Images
           Rails.logger.warn "Ignoring errors on saving image for edition with id #{edition.id}: #{image.errors.full_messages.join(', ')}"
         end
         image.save!(validate: false)
+
+        if @edition.lead_image == a
+          edition.lead_image_id = image.id
+          edition.save!(validate: false)
+        end
       end
     end
   end

--- a/app/models/edition/lead_image.rb
+++ b/app/models/edition/lead_image.rb
@@ -14,16 +14,16 @@ module Edition::LeadImage
   end
 
   def lead_image_alt_text
-    if images.first.try(:alt_text)
-      images.first.alt_text.squish
+    if lead_image.try(:alt_text)
+      lead_image.alt_text.squish
     else
       ""
     end
   end
 
   def lead_image_caption
-    if images.first
-      caption = images.first.caption && images.first.caption.strip
+    if lead_image
+      caption = lead_image.caption && lead_image.caption.strip
       caption.presence
     end
   end
@@ -53,8 +53,8 @@ private
   end
 
   def image_data
-    if images.first
-      images.first.image_data
+    if lead_image
+      lead_image.image_data
     elsif lead_organisations.any? && lead_organisations.first.default_news_image
       lead_organisations.first.default_news_image
     elsif organisations.any? && organisations.first.default_news_image

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -5,7 +5,8 @@ class Image < ApplicationRecord
   validates :alt_text, presence: true, allow_blank: true, length: { maximum: 255 }, unless: :skip_main_validation?
   validates :image_data, presence: { message: "must be present" }
 
-  after_destroy :destroy_image_data_if_required
+  after_destroy :destroy_image_data_if_required, :update_lead_image_association
+  after_create :update_lead_image_association
 
   accepts_nested_attributes_for :image_data
 
@@ -23,6 +24,10 @@ private
     if image_data && Image.where(image_data_id: image_data.id).empty?
       image_data.destroy!
     end
+  end
+
+  def update_lead_image_association
+    edition.try(:update_lead_image)
   end
 
   def skip_main_validation?

--- a/app/models/news_article.rb
+++ b/app/models/news_article.rb
@@ -92,6 +92,12 @@ class NewsArticle < Announcement
     PublishingApi::NewsArticlePresenter
   end
 
+  def update_lead_image
+    return if lead_image.present? || images.blank?
+
+    update_column(:lead_image_id, oldest_image.id)
+  end
+
 private
 
   def organisations_are_not_associated

--- a/app/presenters/publishing_api/case_study_presenter.rb
+++ b/app/presenters/publishing_api/case_study_presenter.rb
@@ -81,7 +81,7 @@ module PublishingApi
     end
 
     def image_available?
-      item.images.any? || emphasised_organisation_default_image_available?
+      item.lead_image.present? || emphasised_organisation_default_image_available?
     end
 
     def image_required?

--- a/db/data_migration/20231023091943_backfill_lead_image_id.rb
+++ b/db/data_migration/20231023091943_backfill_lead_image_id.rb
@@ -1,0 +1,7 @@
+puts "Backfilling lead_image_id for case studies"
+
+CaseStudy.joins(:images).distinct.find_each(batch_size: 100, &:update_lead_image)
+
+puts "Backfilling lead_image_id for news articles"
+
+NewsArticle.joins(:images).distinct.find_each(batch_size: 100, &:update_lead_image)

--- a/db/migrate/20231023125930_add_lead_image_foreign_key_to_edition.rb
+++ b/db/migrate/20231023125930_add_lead_image_foreign_key_to_edition.rb
@@ -1,0 +1,13 @@
+class AddLeadImageForeignKeyToEdition < ActiveRecord::Migration[7.0]
+  def change
+    change_table :editions, bulk: true do |t|
+      fk_options = {
+        to_table: :images,
+        on_delete: :nullify,
+        on_update: :cascade,
+      }
+
+      t.references :lead_image, foreign_key: fk_options, type: :integer
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_23_110956) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_23_125930) do
   create_table "assets", charset: "utf8mb3", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.string "variant", null: false
@@ -386,10 +386,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_23_110956) do
     t.string "auth_bypass_id", null: false
     t.string "mapped_specialist_topic_content_id"
     t.string "taxonomy_topic_email_override"
+    t.integer "lead_image_id"
     t.index ["alternative_format_provider_id"], name: "index_editions_on_alternative_format_provider_id"
     t.index ["closing_at"], name: "index_editions_on_closing_at"
     t.index ["document_id"], name: "index_editions_on_document_id"
     t.index ["first_published_at"], name: "index_editions_on_first_published_at"
+    t.index ["lead_image_id"], name: "index_editions_on_lead_image_id"
     t.index ["opening_at"], name: "index_editions_on_opening_at"
     t.index ["operational_field_id"], name: "index_editions_on_operational_field_id"
     t.index ["public_timestamp", "document_id"], name: "index_editions_on_public_timestamp_and_document_id"
@@ -1253,6 +1255,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_23_110956) do
 
   add_foreign_key "documents", "editions", column: "latest_edition_id", on_update: :cascade, on_delete: :nullify
   add_foreign_key "documents", "editions", column: "live_edition_id", on_update: :cascade, on_delete: :nullify
+  add_foreign_key "editions", "images", column: "lead_image_id", on_update: :cascade, on_delete: :nullify
   add_foreign_key "link_checker_api_report_links", "link_checker_api_reports"
   add_foreign_key "related_mainstreams", "editions"
   add_foreign_key "statistics_announcements", "statistics_announcement_dates", column: "current_release_date_id", on_update: :cascade, on_delete: :nullify

--- a/test/components/admin/edition_images/uploaded_images_component_test.rb
+++ b/test/components/admin/edition_images/uploaded_images_component_test.rb
@@ -5,7 +5,7 @@ require "test_helper"
 class Admin::EditionImages::UploadedImagesComponentTest < ViewComponent::TestCase
   test "lead image rendered for case study" do
     images = [build_stubbed(:image), build_stubbed(:image)]
-    edition = build_stubbed(:draft_case_study, images:)
+    edition = build_stubbed(:draft_case_study, images:, lead_image: images.first)
     render_inline(Admin::EditionImages::UploadedImagesComponent.new(edition:))
 
     assert_selector "img", count: 2

--- a/test/unit/app/models/case_study_test.rb
+++ b/test/unit/app/models/case_study_test.rb
@@ -19,4 +19,44 @@ class CaseStudyTest < ActiveSupport::TestCase
   test "is not translatable when non-English" do
     assert_not build(:case_study, primary_locale: :es).translatable?
   end
+
+  test "#update_lead_image updates the lead_image association to the oldest image" do
+    image1 = build_stubbed(:image)
+    image2 = build_stubbed(:image)
+    case_study = build_stubbed(:case_study, images: [image1, image2])
+
+    case_study.stubs(:lead_image).returns(nil)
+    case_study.images.stubs(:order).with(:created_at, :id).returns([image1, image2])
+
+    case_study.expects(:update_column)
+    .with(:lead_image_id, image1.id)
+    .returns(true)
+    .once
+
+    case_study.update_lead_image
+  end
+
+  test "#update_lead_image returns nil if lead_image is present" do
+    case_study = build(:case_study)
+    build(:image)
+    case_study.stubs(:lead_image).returns(case_study)
+
+    assert_nil case_study.update_lead_image
+  end
+
+  test "#update_lead_image returns nil if no images are present" do
+    case_study = build(:case_study)
+    assert_nil case_study.update_lead_image
+  end
+
+  test "#update_lead_image updates lead_image to nil if image_display_option is 'no_image'" do
+    case_study = create(:case_study, image_display_option: "custom_image")
+
+    case_study.expects(:update_column)
+    .with(:lead_image_id, nil)
+    .returns(true)
+    .once
+
+    case_study.update!(image_display_option: "no_image")
+  end
 end

--- a/test/unit/app/models/edition/images_test.rb
+++ b/test/unit/app/models/edition/images_test.rb
@@ -104,6 +104,25 @@ class Edition::ImagesTest < ActiveSupport::TestCase
     assert_equal new_draft.images.first.image_data, published_edition.images.first.image_data
   end
 
+  test "#create_draft should update the lead_image correctly when one is present on the published_edition" do
+    image1 = create(:image)
+    image2 = create(:image)
+
+    published_edition = EditionWithImages.create!(
+      valid_edition_attributes.merge(
+        state: "published",
+        major_change_published_at: Time.zone.now,
+        first_published_at: Time.zone.now,
+        images: [image1, image2],
+        lead_image_id: image2.id,
+      ),
+    )
+
+    draft_edition = published_edition.create_draft(build(:user))
+
+    assert_equal image2.image_data.images.last, draft_edition.lead_image
+  end
+
   test "captions for images can be changed between versions" do
     published_edition = EditionWithImages.new(
       valid_edition_attributes.merge(

--- a/test/unit/app/models/edition/lead_image_test.rb
+++ b/test/unit/app/models/edition/lead_image_test.rb
@@ -2,41 +2,41 @@ require "test_helper"
 
 class Edition::LeadImageTest < ActiveSupport::TestCase
   test "should use placeholder image if none had been uploaded" do
-    model = stub("Target", images: [], lead_organisations: [], organisations: []).extend(Edition::LeadImage)
+    model = stub("Target", lead_image: nil, lead_organisations: [], organisations: []).extend(Edition::LeadImage)
     assert_match %r{placeholder}, model.lead_image_url
     assert_equal "", model.lead_image_alt_text
   end
 
   test "should use empty string if no alt_text is provided" do
-    model = stub("Target", images: [], lead_organisations: [], organisations: []).extend(Edition::LeadImage)
+    model = stub("Target", lead_image: nil, lead_organisations: [], organisations: []).extend(Edition::LeadImage)
     file = stub("File", content_type: "image/jpg")
     uploader = stub("Uploader", file:)
     image_data = stub("ImageData", file: uploader)
     image = stub("Image", alt_text: nil, image_data:)
-    model.stubs(images: [image])
+    model.stubs(lead_image: image)
     assert_equal "", model.lead_image_alt_text
   end
 
   test "should use first image with version :s300 if an image is present" do
-    model = stub("Target", images: [], lead_organisations: [], organisations: []).extend(Edition::LeadImage)
+    model = stub("Target", lead_image: nil, lead_organisations: [], organisations: []).extend(Edition::LeadImage)
     file = stub("File", content_type: "image/jpg")
     uploader = stub("Uploader", file:)
     image_data = stub("ImageData", file: uploader)
     image = stub("Image", alt_text: "alt_text", image_data:)
     uploader.expects(:url).with(:s300).returns("url")
-    model.stubs(images: [image])
+    model.stubs(lead_image: image)
     assert_equal "url", model.lead_image_url
     assert_equal "alt_text", model.lead_image_alt_text
   end
 
   test "uses unversioned url if the image is an SVG" do
-    model = stub("Target", images: [], lead_organisations: [], organisations: []).extend(Edition::LeadImage)
+    model = stub("Target", lead_image: nil, lead_organisations: [], organisations: []).extend(Edition::LeadImage)
     file = stub("File", content_type: "image/svg+xml")
     uploader = stub("Uploader", file:)
     image_data = stub("ImageData", file: uploader)
     image = stub("Image", alt_text: "alt_text", image_data:)
     uploader.expects(:url).with.returns("url")
-    model.stubs(images: [image])
+    model.stubs(lead_image: image)
     assert_equal "url", model.lead_image_url
     assert_equal "alt_text", model.lead_image_alt_text
   end
@@ -45,7 +45,7 @@ class Edition::LeadImageTest < ActiveSupport::TestCase
     image_with_missing_assets = build(:image_with_no_assets)
     image_with_missing_assets.image_data.assets << [build(:asset)]
 
-    model = stub("Target", { images: [image_with_missing_assets] }).extend(Edition::LeadImage)
+    model = stub("Target", { lead_image: image_with_missing_assets }).extend(Edition::LeadImage)
 
     assert_not model.lead_image_has_all_assets?
   end
@@ -53,7 +53,7 @@ class Edition::LeadImageTest < ActiveSupport::TestCase
   test "#lead_image_has_all_assets? returns true if the lead image (ImageData) has all assets" do
     image_with_missing_assets = build(:image)
 
-    model = stub("Target", { images: [image_with_missing_assets] }).extend(Edition::LeadImage)
+    model = stub("Target", { lead_image: image_with_missing_assets }).extend(Edition::LeadImage)
 
     assert model.lead_image_has_all_assets?
   end
@@ -62,7 +62,7 @@ class Edition::LeadImageTest < ActiveSupport::TestCase
     # e.g. DefaultNewsOrganisationImageData doesn't yet implement all_asset_variants_uploaded?
     image = build(:default_news_organisation_image_data)
     organisation = build(:organisation, default_news_image: image)
-    model = stub("Target", { images: [], lead_organisations: [], organisations: [organisation] }).extend(Edition::LeadImage)
+    model = stub("Target", { lead_image: nil, lead_organisations: [], organisations: [organisation] }).extend(Edition::LeadImage)
 
     assert model.lead_image_has_all_assets?
   end

--- a/test/unit/app/models/image_test.rb
+++ b/test/unit/app/models/image_test.rb
@@ -53,4 +53,19 @@ class ImageTest < ActiveSupport::TestCase
     assert_equal 640, image.height
     assert image.bitmap?
   end
+
+  test "calls edition#update_lead_image after destroy when method is defined in the model" do
+    case_study = build(:case_study)
+    image = create(:image)
+    image.stubs(:edition).returns(case_study)
+    case_study.expects(:update_lead_image).once
+
+    image.destroy!
+  end
+
+  test "calls edition#update_lead_image after create when method is defined in the model" do
+    case_study = build_stubbed(:case_study)
+    case_study.expects(:update_lead_image).once
+    create(:image, edition: case_study)
+  end
 end

--- a/test/unit/app/models/news_article_test.rb
+++ b/test/unit/app/models/news_article_test.rb
@@ -157,4 +157,33 @@ class WorldNewsStoryTypeNewsArticleTest < ActiveSupport::TestCase
 
     assert news_article.valid?
   end
+
+  test "#update_lead_image updates the lead_image association to the oldest image" do
+    image1 = build_stubbed(:image)
+    image2 = build_stubbed(:image)
+    news_article = build_stubbed(:news_article, images: [image1, image2])
+
+    news_article.stubs(:lead_image).returns(nil)
+    news_article.images.stubs(:order).with(:created_at, :id).returns([image1, image2])
+
+    news_article.expects(:update_column)
+    .with(:lead_image_id, image1.id)
+    .returns(true)
+    .once
+
+    news_article.update_lead_image
+  end
+
+  test "#update_lead_image returns nil if lead_image is present" do
+    news_article = build(:news_article)
+    build(:image)
+    news_article.stubs(:lead_image).returns(news_article)
+
+    assert_nil news_article.update_lead_image
+  end
+
+  test "#update_lead_image returns nil if no images are present" do
+    news_article = build(:news_article)
+    assert_nil news_article.update_lead_image
+  end
 end

--- a/test/unit/app/models/speech_test.rb
+++ b/test/unit/app/models/speech_test.rb
@@ -145,8 +145,9 @@ class SpeechTest < ActiveSupport::TestCase
   end
 
   test "search_index includes default image_url if it has one" do
-    image = create(:image)
-    speech = create(:published_speech, images: [image])
+    image = build(:image)
+    speech = build(:published_speech, document: build(:document))
+    speech.stubs(:lead_image).returns(image)
     assert_equal image.url(:s300), speech.search_index["image_url"]
   end
 

--- a/test/unit/app/presenters/publishing_api/case_study_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/case_study_presenter_test.rb
@@ -75,7 +75,8 @@ class PublishingApi::CaseStudyPresenterTest < ActiveSupport::TestCase
 
   test "includes details of the case study image if present" do
     image = build(:image, alt_text: "Image alt text", caption: "A caption")
-    case_study = create(:published_case_study, images: [image])
+    case_study = build_stubbed(:published_case_study, document: build_stubbed(:document))
+    case_study.stubs(:lead_image).returns(image)
 
     expected_hash = {
       url: image.url(:s300),
@@ -90,7 +91,8 @@ class PublishingApi::CaseStudyPresenterTest < ActiveSupport::TestCase
 
   test "returns case study image caption as nil (not false) when it is blank" do
     image = build(:image, alt_text: "Image alt text", caption: "")
-    case_study = create(:published_case_study, images: [image])
+    case_study = build_stubbed(:published_case_study, document: build_stubbed(:document))
+    case_study.stubs(:lead_image).returns(image)
 
     expected_hash = {
       url: image.url(:s300),


### PR DESCRIPTION
## Description

Currently, a lead image is assigned for News Articles and Case Studies by adding an image to the edition. There's no way to change select a lead image. This means that if the publisher wants to assign a new lead image, they're forced to remove and 
reupload all the images.

We want to build in functionality that allows a user to select a lead image.

This draft PR does the following:

1. Adds a lead_image_id fk to the editions table
2. handles setting `lead_image_id` when the first image is created
3. handles setting `lead_image_id` when to the next image when the lead image is deleted
4. handles setting `lead_image_id` to nil when the user toggles lead image off for case studies
5. handles setting `lead_image_id` correctly for new draft editions
6. adds a migration to backfill lead_image_id
7. updated places that used `images.first` to use the lead image association

Once i get some initial feedback, i'll break the above out into 3 PRs

1. will add the association to the db
2. will handle adding the callbacks which populate `lead_image_id` & add the backfill data migration

At this point i'll run the backfill on int, staging and prod

3. will update the code to use the new association in place of `edition.images.first`

## Out of scope

- Adding the ability for users to choose a lead image via the UI (we're still waiting or some finalised designs on this)
- Updating the validation which checks the lead_image is not being used in the markdown of the document. (i'll handle this in another PR)

## Trello card

https://trello.com/c/5vCiIxeQ/1064-lead-image-handling-backend-work

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
