### PR TITLE
Allow organisation to use FeaturedImageData

### DIFF
--- a/app/models/featured_image_data.rb
+++ b/app/models/featured_image_data.rb
@@ -4,6 +4,10 @@ class FeaturedImageData < ApplicationRecord
   validates :file, presence: true, if: :image_changed?
   validates_with ImageValidator, size: [960, 640], if: :image_changed?
 
+  has_many :assets,
+           as: :assetable,
+           inverse_of: :assetable
+
 private
 
   def image_changed?

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -10,8 +10,8 @@ class Organisation < ApplicationRecord
   DEFAULT_JOBS_URL = "https://www.civilservicejobs.service.gov.uk/csr".freeze
   FEATURED_DOCUMENTS_DISPLAY_LIMIT = 6
 
-  belongs_to :default_news_image_legacy, class_name: "DefaultNewsOrganisationImageData", foreign_key: :default_news_organisation_image_data_id
-  belongs_to :default_news_image, class_name: "FeaturedImageData", foreign_key: :featured_image_data_id
+  belongs_to :default_news_image, class_name: "DefaultNewsOrganisationImageData", foreign_key: :default_news_organisation_image_data_id
+  belongs_to :default_news_image_new, class_name: "FeaturedImageData", foreign_key: :featured_image_data_id
 
   has_many :assets,
            as: :assetable,

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -10,7 +10,8 @@ class Organisation < ApplicationRecord
   DEFAULT_JOBS_URL = "https://www.civilservicejobs.service.gov.uk/csr".freeze
   FEATURED_DOCUMENTS_DISPLAY_LIMIT = 6
 
-  belongs_to :default_news_image, class_name: "DefaultNewsOrganisationImageData", foreign_key: :default_news_organisation_image_data_id
+  belongs_to :default_news_image_legacy, class_name: "DefaultNewsOrganisationImageData", foreign_key: :default_news_organisation_image_data_id
+  belongs_to :default_news_image, class_name: "FeaturedImageData", foreign_key: :featured_image_data_id
 
   has_many :assets,
            as: :assetable,

--- a/db/migrate/20231023142600_add_featured_image_data_ref_to_organisations.rb
+++ b/db/migrate/20231023142600_add_featured_image_data_ref_to_organisations.rb
@@ -1,0 +1,5 @@
+class AddFeaturedImageDataRefToOrganisations < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :organisations, :featured_image_data, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_23_110956) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_23_142600) do
   create_table "assets", charset: "utf8mb3", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.string "variant", null: false
@@ -737,8 +737,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_23_110956) do
     t.string "homepage_type", default: "news"
     t.boolean "political", default: false
     t.integer "ministerial_ordering"
+    t.bigint "featured_image_data_id"
     t.index ["content_id"], name: "index_organisations_on_content_id", unique: true
     t.index ["default_news_organisation_image_data_id"], name: "index_organisations_on_default_news_organisation_image_data_id"
+    t.index ["featured_image_data_id"], name: "index_organisations_on_featured_image_data_id"
     t.index ["organisation_logo_type_id"], name: "index_organisations_on_organisation_logo_type_id"
     t.index ["organisation_type_key"], name: "index_organisations_on_organisation_type_key"
     t.index ["slug"], name: "index_organisations_on_slug", unique: true

--- a/test/components/admin/organisations/show/summary_list_component_test.rb
+++ b/test/components/admin/organisations/show/summary_list_component_test.rb
@@ -65,7 +65,7 @@ class Admin::Organisations::Show::SummaryListComponentTest < ViewComponent::Test
   end
 
   test "renders default news image row if the organisation has a default news image" do
-    news_image = build_stubbed(:default_news_organisation_image_data)
+    news_image = build_stubbed(:featured_image_data)
     organisation = build_stubbed(:ministerial_department, default_news_image: news_image)
 
     render_inline(Admin::Organisations::Show::SummaryListComponent.new(organisation:))

--- a/test/unit/app/models/edition/lead_image_test.rb
+++ b/test/unit/app/models/edition/lead_image_test.rb
@@ -60,7 +60,7 @@ class Edition::LeadImageTest < ActiveSupport::TestCase
 
   test "#lead_image_has_all_assets? returns true if the lead image data doesn't implement all_asset_variants_uploaded?" do
     # e.g. DefaultNewsOrganisationImageData doesn't yet implement all_asset_variants_uploaded?
-    image = build(:default_news_organisation_image_data)
+    image = build(:featured_image_data)
     organisation = build(:organisation, default_news_image: image)
     model = stub("Target", { images: [], lead_organisations: [], organisations: [organisation] }).extend(Edition::LeadImage)
 

--- a/test/unit/app/presenters/publishing_api/case_study_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/case_study_presenter_test.rb
@@ -104,7 +104,7 @@ class PublishingApi::CaseStudyPresenterTest < ActiveSupport::TestCase
   end
 
   test "falls back to the organisation's default news image when there is no image" do
-    organisation_image = DefaultNewsOrganisationImageData.new(file: image_fixture_file)
+    organisation_image = build(:featured_image_data)
     organisation = create(:organisation, default_news_image: organisation_image)
 
     case_study = create(:published_case_study, lead_organisations: [organisation])

--- a/test/unit/app/presenters/publishing_api/organisation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/organisation_presenter_test.rb
@@ -18,7 +18,7 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
 
   test "presents an Organisation ready for adding to the publishing API" do
     parent_organisation = create(:organisation, name: "Department for Stuff")
-    news_image = create(:default_news_organisation_image_data)
+    news_image = create(:featured_image_data)
     organisation = create(
       :organisation,
       name: "Organisation of Things",


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
