### PR TITLE
561 new document sub navigation page

### DIFF
--- a/app/controllers/admin/new_document_controller.rb
+++ b/app/controllers/admin/new_document_controller.rb
@@ -1,0 +1,45 @@
+class Admin::NewDocumentController < Admin::BaseController
+  before_action :check_new_design_system_permissions, only: %i[index]
+
+  layout :get_layout
+
+  def index; end
+
+  def new_document_options_redirect
+    redirect_options = {
+      "call-for-evidence": new_admin_call_for_evidence_path,
+      "case-study": new_admin_case_study_path,
+      "consultation": new_admin_consultation_path,
+      "detailed-guide": new_admin_detailed_guide_path,
+      "document-collection": new_admin_document_collection_path,
+      "fatality-notice": new_admin_fatality_notice_path,
+      "news-article": new_admin_news_article_path,
+      "publication": new_admin_publication_path,
+      "speech": new_admin_speech_path,
+      "statistical-data-set": new_admin_statistical_data_set_path,
+    }
+
+    if params[:new_document_options].present?
+      selected_option = params.require(:new_document_options).to_sym
+      redirect_to redirect_options[selected_option]
+    else
+      redirect_to admin_new_document_path, alert: "Please select a new document option"
+    end
+  end
+
+private
+
+  def check_new_design_system_permissions
+    forbidden! unless new_design_system?
+  end
+
+  def get_layout
+    design_system_actions = %w[index new_document_options_redirect] if preview_design_system?(next_release: false)
+
+    if design_system_actions&.include?(action_name)
+      "design_system"
+    else
+      "admin"
+    end
+  end
+end

--- a/app/views/admin/new_document/index.html.erb
+++ b/app/views/admin/new_document/index.html.erb
@@ -1,0 +1,99 @@
+<% content_for :page_title, "New document" %>
+<% content_for :title, "New document" %>
+<% content_for :title_margin_bottom, 6 %>
+
+<%
+  new_document_radio_items = [
+    {
+      value: "call-for-evidence",
+      text: "Call for evidence",
+      bold: true,
+      hint_text: "Use this to request people's views when it is not a consultation.",
+    },
+    {
+      value: "case-study",
+      text: "Case study",
+      bold: true,
+      hint_text: "Use this to share real examples that help users understand a process or an important" +
+        " aspect of government policy covered on GOV.UK.",
+    },
+    {
+      value: "consultation",
+      text: "Consultation",
+      bold: true,
+      hint_text: "Use this for documents requiring a collective agreement across government, and requests for people's view on a question with an outcome.",
+    },
+    {
+      value: "detailed-guide",
+      text: "Detailed guide",
+      bold: true,
+      hint_text: "Use this to tell users the steps they need to take to complete a clearly defined task. They are usually aimed at specialist or professional audiences.",
+    },
+    {
+      value: "document-collection",
+      text: "Document collection",
+      bold: true,
+      hint_text: "Use this to group related documents on a single page for a specific audience or around a specific theme.",
+    },
+    {
+      value: "fatality-notice",
+      text: "Fatality notice",
+      bold: true,
+      hint_text: "Use this to provide official confirmation of the death of a member of the armed forces while on deployment. Ministry of Defence only.",
+    },
+    {
+      value: "news-article",
+      text: "News article",
+      bold: true,
+      hint_text: "Use this for news story, press release, government response, and world news story.",
+    },
+    {
+      value: "publication",
+      text: "Publication",
+      bold: true,
+      hint_text: "Use this for standalone government documents, white papers, strategy documents, and reports.",
+    },
+    {
+      value: "speech",
+      text: "Speech",
+      bold: true,
+      hint_text: "Use this for speeches by ministers or other named spokespeople, and ministerial statements to Parliament.",
+    },
+    {
+      value: "statistical-data-set",
+      text: "Statistical data set",
+      bold: true,
+      hint_text: "Use this for data that you publish monthly or more often without analysis.",
+    },
+  ]
+%>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with url: admin_new_document_options_path do %>
+      <%= render "govuk_publishing_components/components/radio", {
+        name: "new_document_options",
+        id: "new_document_options",
+        items: new_document_radio_items,
+      } %>
+      <%= render "govuk_publishing_components/components/inset_text", {
+        text: sanitize("Check the #{link_to("content types guidance", admin_whats_new_path, {class: "govuk-link"})}" +
+                         " if you need more help in choosing a content type."),
+      } %>
+
+      <div class="govuk-button-group">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Next",
+          data_attributes: {
+            module: "gem-track-click",
+            "track-category": "form-button",
+            "track-action": "new-document-radio-options-next-button",
+            "track-label": "Next",
+          },
+        } %>
+
+        <%= link_to("Cancel", root_path, class: "govuk-link govuk-link--no-visited-state") %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/new_document/index.html.erb
+++ b/app/views/admin/new_document/index.html.erb
@@ -1,6 +1,4 @@
 <% content_for :page_title, "New document" %>
-<% content_for :title, "New document" %>
-<% content_for :title_margin_bottom, 6 %>
 
 <%
   new_document_radio_items = [
@@ -72,6 +70,8 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_with url: admin_new_document_options_path do %>
       <%= render "govuk_publishing_components/components/radio", {
+        heading: "New document",
+        heading_level: 1,
         name: "new_document_options",
         id: "new_document_options",
         items: new_document_radio_items,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -240,6 +240,10 @@ Whitehall::Application.routes.draw do
 
       get "/whats-new" => "whats_new#index", as: :whats_new
 
+      get "/new-document" => "new_document#index", as: :new_document
+      get :new_document_options, to: "new_document#new_document_options_redirect"
+      post :new_document_options, to: "new_document#new_document_options_redirect"
+
       resources :statistics_announcements, except: [:destroy] do
         member do
           get :cancel

--- a/test/functional/admin/new_document_controller_test.rb
+++ b/test/functional/admin/new_document_controller_test.rb
@@ -5,15 +5,7 @@ class Admin::NewDocumentControllerTest < ActionController::TestCase
     login_as_preview_design_system_user :writer
   end
 
-  def radio_button_values
-    %w[call-for-evidence case-study consultation detailed-guide document-collection fatality-notice news-article publication speech statistical-data-set]
-  end
-
-  def assert_select_radio_button(value)
-    assert_select ".govuk-radios__item input[type=radio][name=new_document_options][value=#{value}]", count: 1
-  end
-
-  test "GET #index renders the 'New Document' page with all relevant radio selection options and inset text" do
+  view_test "GET #index renders the 'New Document' page with the header, all relevant radio selection options and inset text" do
     get :index
 
     assert_response :success
@@ -37,7 +29,6 @@ class Admin::NewDocumentControllerTest < ActionController::TestCase
       "new_document_options": "call-for-evidence",
     }
     post :new_document_options_redirect, params: request_params
-    assert_response :success
     assert_redirected_to new_admin_call_for_evidence_path
   end
 
@@ -47,10 +38,17 @@ class Admin::NewDocumentControllerTest < ActionController::TestCase
     }
 
     post :new_document_options_redirect, params: request_params
-    # puts response.body
     assert_redirected_to admin_new_document_path
     assert_equal flash[:alert], "Please select a new document option"
-    # follow_redirect!
-    # assert_select ".gem-c-error-alert__message", text: /Please select a new document option/
+  end
+
+private
+
+  def radio_button_values
+    %w[call-for-evidence case-study consultation detailed-guide document-collection fatality-notice news-article publication speech statistical-data-set]
+  end
+
+  def assert_select_radio_button(value)
+    assert_select ".govuk-radios__item input[type=radio][name=new_document_options][value=#{value}]", count: 1
   end
 end

--- a/test/functional/admin/new_document_controller_test.rb
+++ b/test/functional/admin/new_document_controller_test.rb
@@ -1,0 +1,56 @@
+require "test_helper"
+
+class Admin::NewDocumentControllerTest < ActionController::TestCase
+  setup do
+    login_as_preview_design_system_user :writer
+  end
+
+  def radio_button_values
+    %w[call-for-evidence case-study consultation detailed-guide document-collection fatality-notice news-article publication speech statistical-data-set]
+  end
+
+  def assert_select_radio_button(value)
+    assert_select ".govuk-radios__item input[type=radio][name=new_document_options][value=#{value}]", count: 1
+  end
+
+  test "GET #index renders the 'New Document' page with all relevant radio selection options and inset text" do
+    get :index
+
+    assert_response :success
+    assert_select "h1.govuk-heading-xl", text: "New document"
+
+    radio_button_values.each do |value|
+      assert_select_radio_button(value)
+    end
+
+    assert_select ".govuk-inset-text", text: "Check the content types guidance if you need more help in choosing a content type."
+  end
+
+  test "access to the New document index page is forbidden for users without design system permissions" do
+    login_as :writer
+    get :index
+    assert_response :forbidden
+  end
+
+  test "POST #new_document_options_redirect redirects to #call-for-evidence if search option passed is call-for-evidence" do
+    request_params = {
+      "new_document_options": "call-for-evidence",
+    }
+    post :new_document_options_redirect, params: request_params
+    assert_response :success
+    assert_redirected_to new_admin_call_for_evidence_path
+  end
+
+  test "when no radio buttons are selected a flash notice is shown and the user remains on the index page" do
+    request_params = {
+      new_document_options: "",
+    }
+
+    post :new_document_options_redirect, params: request_params
+    # puts response.body
+    assert_redirected_to admin_new_document_path
+    assert_equal flash[:alert], "Please select a new document option"
+    # follow_redirect!
+    # assert_select ".gem-c-error-alert__message", text: /Please select a new document option/
+  end
+end

--- a/test/functional/admin/new_document_controller_test.rb
+++ b/test/functional/admin/new_document_controller_test.rb
@@ -9,12 +9,10 @@ class Admin::NewDocumentControllerTest < ActionController::TestCase
     get :index
 
     assert_response :success
-    assert_select "h1.govuk-heading-xl", text: "New document"
-
+    assert_select "h1.gem-c-radio__heading-text", text: "New document"
     radio_button_values.each do |value|
       assert_select_radio_button(value)
     end
-
     assert_select ".govuk-inset-text", text: "Check the content types guidance if you need more help in choosing a content type."
   end
 
@@ -24,12 +22,16 @@ class Admin::NewDocumentControllerTest < ActionController::TestCase
     assert_response :forbidden
   end
 
-  test "POST #new_document_options_redirect redirects to #call-for-evidence if search option passed is call-for-evidence" do
-    request_params = {
-      "new_document_options": "call-for-evidence",
-    }
-    post :new_document_options_redirect, params: request_params
-    assert_redirected_to new_admin_call_for_evidence_path
+  test "POST #new_document_options_redirect redirects each radio buttons to their expected paths" do
+    redirect_options.each do |selected_option, expected_path|
+      request_params = {
+        "new_document_options": selected_option,
+      }
+
+      post :new_document_options_redirect, params: request_params
+
+      assert_redirected_to expected_path
+    end
   end
 
   test "when no radio buttons are selected a flash notice is shown and the user remains on the index page" do
@@ -38,6 +40,7 @@ class Admin::NewDocumentControllerTest < ActionController::TestCase
     }
 
     post :new_document_options_redirect, params: request_params
+
     assert_redirected_to admin_new_document_path
     assert_equal flash[:alert], "Please select a new document option"
   end
@@ -50,5 +53,20 @@ private
 
   def assert_select_radio_button(value)
     assert_select ".govuk-radios__item input[type=radio][name=new_document_options][value=#{value}]", count: 1
+  end
+
+  def redirect_options
+    {
+      "call-for-evidence": new_admin_call_for_evidence_path,
+      "case-study": new_admin_case_study_path,
+      "consultation": new_admin_consultation_path,
+      "detailed-guide": new_admin_detailed_guide_path,
+      "document-collection": new_admin_document_collection_path,
+      "fatality-notice": new_admin_fatality_notice_path,
+      "news-article": new_admin_news_article_path,
+      "publication": new_admin_publication_path,
+      "speech": new_admin_speech_path,
+      "statistical-data-set": new_admin_statistical_data_set_path,
+    }
   end
 end


### PR DESCRIPTION
Trello: [561 | Link New Document drop down in the sub navigation to new page with radio selection](https://trello.com/c/BTRbQkCR/561-link-new-document-drop-down-in-the-sub-navigation-to-new-page-with-radio-selection)

This PR creates a new view which users will be directed to when they click on the "New document" link in the navigation bar.

Changes:

- When a user makes a selection on the type of new document they would like to create they are redirected to the correct new document type.
- When there are no radio buttons selected - they are shown an error and they remain on the New document page - this is to ensure we are not influencing their selection.
- Tests coverage includes testing the users permission granting only certain users the ability to view this page, functionality re when a user selects a radio button / does not select a button the test ensures they are shown the correct new document page or an error respectively.
- This PR also includes changes to the routes file and the necessary controller implementations

Screenshot below:

This screenshot is what the user sees when they first land on the landing page:

![whitehall-admin dev gov uk_government_admin_new-document (3)](https://github.com/alphagov/whitehall/assets/138006225/153f3845-daa8-4e7c-a29d-c8139fda02bf)

---

This screenshot is what the user sees when they select Next without selecting a radio button:

![whitehall-admin dev gov uk_government_admin_new-document (4)](https://github.com/alphagov/whitehall/assets/138006225/67078cce-1266-449b-b569-ee8cf808c3e1)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
