### PR TITLE
Fix unpublished edition attachment redirects when draft edition exists

### DIFF
--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -102,7 +102,7 @@ class AttachmentData < ApplicationRecord
 
   delegate :access_limited_object, to: :last_attachable
 
-  delegate :unpublished?, to: :last_attachable
+  delegate :unpublished?, to: :unpublished_attachable
 
   def replaced?
     replaced_by.present?
@@ -151,12 +151,20 @@ class AttachmentData < ApplicationRecord
     last_attachment.attachable || Attachable::Null.new
   end
 
+  def unpublished_attachable
+    unpublished_attachment&.attachable || Attachable::Null.new
+  end
+
   def significant_attachment(**args)
     last_publicly_visible_attachment || last_attachment(**args)
   end
 
   def last_attachment(**args)
     filtered_attachments(**args).last || Attachment::Null.new
+  end
+
+  def unpublished_attachment
+    attachments.reverse.detect { |a| a.attachable&.unpublished? }
   end
 
   def last_publicly_visible_attachment

--- a/app/services/asset_manager/attachment_updater.rb
+++ b/app/services/asset_manager/attachment_updater.rb
@@ -55,7 +55,7 @@ class AssetManager::AttachmentUpdater
   def self.get_redirect_url(attachment_data)
     return nil unless attachment_data.unpublished?
 
-    attachment_data.last_attachable.unpublishing.document_url
+    attachment_data.unpublished_attachable.unpublishing.document_url
   end
 
   def self.get_replacement_id(replaced_attachment_data, variant)

--- a/test/integration/attachment_redirect_due_to_unpublishing_integration_test.rb
+++ b/test/integration/attachment_redirect_due_to_unpublishing_integration_test.rb
@@ -61,6 +61,17 @@ class AttachmentRedirectDueToUnpublishingIntegrationTest < ActionDispatch::Integ
       end
     end
 
+    context "given a published document with file attachment and a draft" do
+      let(:edition) { create(:published_news_article) }
+      let!(:draft) { edition.create_draft(edition.creator) }
+
+      it "sets redirect URL for attachment in Asset Manager when document is unpublished" do
+        visit admin_news_article_path(edition)
+        unpublish_document_published_in_error
+        assert_sets_redirect_url_in_asset_manager_to redirect_url
+      end
+    end
+
     context "given a published document with HTML attachment" do
       let(:edition) { create(:published_publication, :with_html_attachment) }
 

--- a/test/unit/app/services/asset_manager/attachment_updater_test.rb
+++ b/test/unit/app/services/asset_manager/attachment_updater_test.rb
@@ -169,7 +169,7 @@ class AssetManager::AttachmentUpdaterTest < ActiveSupport::TestCase
 
       before do
         attachment_data.stubs(:unpublished?).returns(unpublished)
-        attachment_data.stubs(:last_attachable).returns(unpublished_edition)
+        attachment_data.stubs(:unpublished_attachable).returns(unpublished_edition)
       end
 
       it "updates redirect URL for all assets" do


### PR DESCRIPTION
This fixes a bug introduced in 4eb10f4. In that commit we stopped preventing users from unpublishing a document if a draft edition exists. However, the attachment redirect URL update behaviour assumed that the latest attachable would always be the unpublished one and failed to update the redirect if it found a draft.

The new behaviour checks for the existence of an unpublished attachable and updates the redirect if it finds one. There can only ever be a single unpublished attachment at the moment, so this is a safe approach.

Incidentally the way the attachment update process works is very confusing. For some reason the `AttachmentUpdater` accepts an `AttachmentData` model rather than an edition, so we then have to work out which edition we should be using to decide whether the attachment should be unpublished or not (even though we started the process with the edition we needed higher up the stack). I think it would probably make sense to re-model the `AttachmentUpdater` to depend upon an `Attachable` instead of an `AttachmentData`, but there are a few different classes that depend on the updater so there's a chance that may not be feasible. It rather looks like the parent classes have all been bent out of shape to enable usage of the `AttachmentUpdater` class rather than taking a step back and considering whether that class is offering the best available abstraction. 
