### PR TITLE
Create rake task for Image Data Relationship

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -11,6 +11,7 @@ class Organisation < ApplicationRecord
   FEATURED_DOCUMENTS_DISPLAY_LIMIT = 6
 
   belongs_to :default_news_image, class_name: "DefaultNewsOrganisationImageData", foreign_key: :default_news_organisation_image_data_id
+  belongs_to :default_news_image_new, class_name: "FeaturedImageData", foreign_key: :featured_image_data_id
 
   has_many :assets,
            as: :assetable,

--- a/app/workers/create_asset_relationship_for_featured_image_data_worker.rb
+++ b/app/workers/create_asset_relationship_for_featured_image_data_worker.rb
@@ -1,0 +1,22 @@
+class CreateAssetRelationshipForFeaturedImageDataWorker < WorkerBase
+  def perform(start_id, end_id)
+    return if start_id > end_id
+
+    logger.info("CreateAssetRelationshipForFeaturedImageDataWorker start!")
+    Array(start_id..end_id).each do |id|
+      org = Organisation.find(id)
+      unless org.default_news_organisation_image_data_id.nil? && org.featured_image_data_id
+        carrierwave_image_from_default_news_organisation_image_data = DefaultNewsOrganisationImageData.find(org.default_news_organisation_image_data_id).carrierwave_image
+        logger.info("Create feature image data for \n org: #{id} \n default_news_organisation_image_data: #{org.default_news_organisation_image_data_id} \n carrierwave_image: #{carrierwave_image_from_default_news_organisation_image_data}")
+
+        featured_image_data = FeaturedImageData.new(carrierwave_image: carrierwave_image_from_default_news_organisation_image_data)
+        featured_image_data.save!
+
+        logger.info("featured_image_data #{featured_image_data.id} has been saved")
+        org.update_column(:featured_image_data_id, featured_image_data.id)
+      end
+    rescue StandardError => e
+      logger.info(e)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -736,8 +736,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_23_110956) do
     t.string "homepage_type", default: "news"
     t.boolean "political", default: false
     t.integer "ministerial_ordering"
+    t.bigint "featured_image_data_id"
     t.index ["content_id"], name: "index_organisations_on_content_id", unique: true
     t.index ["default_news_organisation_image_data_id"], name: "index_organisations_on_default_news_organisation_image_data_id"
+    t.index ["featured_image_data_id"], name: "index_organisations_on_featured_image_data_id"
     t.index ["organisation_logo_type_id"], name: "index_organisations_on_organisation_logo_type_id"
     t.index ["organisation_type_key"], name: "index_organisations_on_organisation_type_key"
     t.index ["slug"], name: "index_organisations_on_slug", unique: true

--- a/lib/tasks/create_asset_relationship_for_featured_image_data.rake
+++ b/lib/tasks/create_asset_relationship_for_featured_image_data.rake
@@ -1,0 +1,5 @@
+desc "Create Asset relationship for Featured Image Data"
+
+task :create_asset_relationship_for_featured_image_data, %i[start_id end_id] => :environment do |_, args|
+  CreateAssetRelationshipForFeaturedImageDataWorker.perform_async(args[:start_id].to_i, args[:end_id].to_i)
+end

--- a/test/unit/app/workers/create_asset_relationship_for_featured_image_data_worker_test.rb
+++ b/test/unit/app/workers/create_asset_relationship_for_featured_image_data_worker_test.rb
@@ -1,0 +1,44 @@
+require "test_helper"
+
+class CreateAssetRelationshipForFeaturedImageDataWorkerTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
+  describe CreateAssetRelationshipForFeaturedImageDataWorker do
+    before do
+      @worker = CreateAssetRelationshipForFeaturedImageDataWorker.new
+    end
+
+    it("should not run migration if start_id is greater than end_id") do
+      Organisation.expects(:find).with(anything).never
+      @worker.perform(2, 1)
+    end
+
+    it("creates featured_image_data_id if default_news_organisation_image_data is present") do
+      Sidekiq.logger.expects(:info).times(3)
+      default_news_image_data = build(:default_news_organisation_image_data)
+      organisation = create(:organisation, default_news_image: default_news_image_data)
+      assert organisation.featured_image_data_id.nil?
+      @worker.perform(organisation.id, organisation.id)
+      organisation.reload
+      assert organisation.featured_image_data_id
+    end
+
+    it("does not creates featured_image_data_id if default_news_organisation_image_data is not present") do
+      Sidekiq.logger.expects(:info).times(2)
+      organisation = create(:organisation)
+      assert organisation.featured_image_data_id.nil?
+      @worker.perform(organisation.id, organisation.id)
+      organisation.reload
+      assert organisation.featured_image_data_id.nil?
+    end
+
+    it("maps correct carrierwave_image to featured_image_data_id") do
+      Sidekiq.logger.expects(:info).times(3)
+      default_news_image_data = build(:default_news_organisation_image_data)
+      organisation = create(:organisation, default_news_image: default_news_image_data)
+      @worker.perform(organisation.id, organisation.id)
+      organisation.reload
+      assert_equal organisation.default_news_image_new.carrierwave_image, organisation.default_news_image.carrierwave_image
+    end
+  end
+end

--- a/test/unit/app/workers/create_asset_relationship_worker_test.rb
+++ b/test/unit/app/workers/create_asset_relationship_worker_test.rb
@@ -3,118 +3,73 @@ require "test_helper"
 class CreateAssetRelationshipWorkerTest < ActiveSupport::TestCase
   extend Minitest::Spec::DSL
 
-  describe CreateAssetRelationshipWorker do
-    let(:worker) { CreateAssetRelationshipWorker.new }
-    let(:expected_number_of_variants) { 1 }
-
-    context "all assets can be retrieved from asset-manager" do
-      before do
-        stub_all_assets(assetables)
-        stub_create_asset("asset_manager_id")
-
-        Sidekiq.logger.expects(:info).times(6)
-
-        @output = worker.perform(start_id, end_id)
-        AssetManagerCreateAssetWorker.drain
-        assetables.map(&:reload)
-      end
-
-      context "worker is run for a single assetable" do
-        let(:assetable) { create(:organisation_with_logo) }
-        let(:assetables) { [assetable] }
-        let(:start_id) { assetable.id }
-        let(:end_id) { assetable.id }
-
-        it "generates assets for all logo variants" do
-          assert_equal expected_number_of_variants, assetable.assets.count
-          assert_equal true, assetable.all_asset_variants_uploaded?
-        end
-
-        it "increments counters" do
-          assert_equal expected_number_of_variants, @output[:asset_counter]
-          assert_equal 1, @output[:count]
-        end
-      end
-
-      context "worker is run for an interval of assetables" do
-        let(:first_assetable) { create(:organisation_with_logo) }
-        let(:second_assetable) { create(:organisation_with_logo) }
-        let(:assetables) { [first_assetable, second_assetable] }
-        let(:start_id) { first_assetable.id }
-        let(:end_id) { second_assetable.id }
-
-        it "generates assets for all logo variants" do
-          assert_equal expected_number_of_variants, first_assetable.assets.count
-          assert_equal expected_number_of_variants, second_assetable.assets.count
-        end
-
-        it "increments counters" do
-          assert_equal (expected_number_of_variants * 2), @output[:asset_counter]
-          assert_equal 2, @output[:count]
-        end
-      end
-    end
-
-    context "assets cannot be found in asset manager" do
-      let(:assetable) { create(:organisation_with_logo) }
-      let(:start_id) { assetable.id }
-      let(:end_id) { assetable.id }
-
-      before do
-        Services.asset_manager.stubs(:whitehall_asset).raises(GdsApi::HTTPNotFound, "Error message")
-      end
-
-      it "rescues HTTPNotFound error and logs if asset cannot be found at path" do
-        Sidekiq.logger.expects(:info).times(6)
-        Sidekiq.logger.expects(:warn).times(1).with(regexp_matches(/minister-of-funk.960x640.jpg/))
-
-        worker.perform(start_id, end_id)
-        assetable.reload
-
-        assert_equal 0, assetable.assets.count
-      end
-    end
-
-    context "skips organisations without a custom logo" do
-      let(:assetable) { create(:organisation) }
-      let(:start_id) { assetable.id }
-      let(:end_id) { assetable.id }
-
-      it "does not save any assets" do
-        Sidekiq.logger.expects(:info).times(4)
-        Sidekiq.logger.expects(:info).with("Created assets for 0 assetable").once
-        Sidekiq.logger.expects(:info).with("Created asset counter 0").once
-
-        worker.perform(start_id, end_id)
-        assetable.reload
-
-        assert_equal 0, assetable.assets.count
-      end
+  before do
+    @worker  = CreateAssetRelationshipWorker.new
+    variants = %i[original s960 s712 s630 s465 s300 s216]
+    @default_news_image_data = create(:default_news_organisation_image_data)
+    @featured_image_data = create(:featured_image_data)
+    variants.each do |variant|
+      stub_assets(variant, @default_news_image_data)
     end
   end
 
-private
+  it("should save correctly assets with FeaturedImageData when asset_manager.whitehall_asset is fetched for DefaultNewsOrganisationImageData ") do
+    Sidekiq.logger.expects(:info).times(6)
+    organisation = build_organisation_with_default_and_featured_image
 
-  def ends_with(expected)
-    ->(actual) { actual.end_with?(expected) }
+    @worker.perform(0, organisation.id)
+    assert_equal 7, Asset.where(assetable_type: "FeaturedImageData", assetable_id: organisation.featured_image_data_id).count
   end
 
-  def stub_whitehall_asset(filename, attributes = {})
-    url_id = "http://asset-manager/assets/#{attributes[:id]}"
-    Services.asset_manager.stubs(:whitehall_asset)
-            .with(&ends_with(filename))
-            .returns(attributes.merge(id: url_id, name: filename).stringify_keys)
+  it("should skip Organisation if default_news_organisation_image_data is nil") do
+    Sidekiq.logger.expects(:info).times(6)
+
+    build_organisation_with_default_and_featured_image
+    organisation_without_image = create(:organisation)
+
+    output = @worker.perform(0, organisation_without_image.id)
+
+    assert_equal 7, output[:asset_counter]
+    assert_equal 1, output[:assetables_count]
   end
 
-  def stub_all_assets(assetables)
-    assetables.each do |assetable|
-      stub_whitehall_asset(assetable.logo.file.filename, id: "asset_id_14652342")
-    end
-  end
+  it("should log warning if asset is not found in asset manager") do
+    Sidekiq.logger.expects(:info).times(6)
+    Sidekiq.logger.expects(:warn).times(7).with(regexp_matches(/big-cheese.960x640.jpg/))
 
-  def stub_create_asset(asset_manger_id)
-    url_id = "http://asset-manager/assets/#{asset_manger_id}"
-    Services.asset_manager.stubs(:create_asset)
-            .returns("id" => url_id, "name" => "filename.pdf")
+    default_news_image_data = create(:default_news_organisation_image_data, file: File.open(Rails.root.join("test/fixtures/big-cheese.960x640.jpg")))
+    create(:organisation, default_news_image: default_news_image_data, default_news_image_new: @featured_image_data)
+    organisation_with_image = build_organisation_with_default_and_featured_image
+
+    Services.asset_manager.stubs(:whitehall_asset).with(&ends_with("big-cheese.960x640.jpg")).raises(GdsApi::HTTPNotFound, "Error message")
+
+    output = @worker.perform(0, organisation_with_image.id)
+    assert_equal 7, output[:asset_counter]
+    assert_equal 2, output[:assetables_count]
   end
+end
+
+  private
+
+def ends_with(expected)
+  ->(actual) { actual.end_with?(expected) }
+end
+
+def stub_whitehall_asset(filename, attributes = {})
+  url_id = "http://asset-manager/assets/#{attributes[:id]}"
+  Services.asset_manager.stubs(:whitehall_asset)
+          .with(&ends_with(filename))
+          .returns(attributes.merge(id: url_id, name: filename).stringify_keys)
+end
+
+def stub_assets(variant, default_news_image_data)
+  if variant == :original
+    stub_whitehall_asset(default_news_image_data.file.identifier.to_s, id: "asset_id")
+  else
+    stub_whitehall_asset("#{variant}_#{default_news_image_data.file.versions[variant].identifier}", id: "#{variant}_asset_id")
+  end
+end
+
+def build_organisation_with_default_and_featured_image
+  create(:organisation, default_news_image: @default_news_image_data, default_news_image_new: @featured_image_data)
 end


### PR DESCRIPTION
We want to migrate the DefaultNewsOrganisationImageData to FeaturedImageData so that we do the migration of assets before switching over to use FeaturedImageData for non legacy flow.

[Trello Card](https://trello.com/c/hxnlRSx1/205-story-defaultnewsorganisationimagedatafeaturedimagedata-to-use-assetid)
