### PR TITLE
Refactor attachment updater to separate methods

### DIFF
--- a/app/services/asset_manager/attachment_updater.rb
+++ b/app/services/asset_manager/attachment_updater.rb
@@ -1,75 +1,35 @@
 class AssetManager::AttachmentUpdater
-  def self.call(
-    attachment_data,
-    access_limited: false,
-    draft_status: false,
-    link_header: false,
-    redirect_url: false,
-    replacement_id: false
-  )
+  def self.call(attachment_data)
+    return if attachment_data.deleted? || attachment_data.attachments.first.attachable.nil?
+
+    asset_attributes = {
+      "access_limited_organisation_ids" => attachment_data.access_limitation,
+      "draft" => attachment_data.draft? && !(attachment_data.replaced? || attachment_data.unpublished?),
+      "parent_document_url" => attachment_data.attachable_url,
+    }
+
+    attachment_data.assets.each do |asset|
+      AssetManager::AssetUpdater.call(asset.asset_manager_id, attachment_data, nil, asset_attributes)
+    end
+  end
+
+  def self.replace(attachment_data)
+    return if attachment_data.deleted? || !attachment_data.replaced?
+
+    attachment_data.assets.each do |asset|
+      replacement_id = attachment_data.replacement_asset_for(asset)&.asset_manager_id
+
+      next if replacement_id.nil?
+
+      AssetManager::AssetUpdater.call(asset.asset_manager_id, attachment_data, nil, { "replacement_id" => replacement_id })
+    end
+  end
+
+  def self.redirect(attachment_data)
     return if attachment_data.deleted?
 
     attachment_data.assets.each do |asset|
-      asset_attributes = get_asset_attributes(attachment_data, asset, access_limited, draft_status, link_header, redirect_url, replacement_id)
-
-      next unless asset_attributes.any?
-
-      AssetManager::AssetUpdater.call(asset.asset_manager_id, attachment_data, nil, asset_attributes.deep_stringify_keys)
-    end
-  end
-
-  def self.get_asset_attributes(attachment_data, asset, access_limited, draft_status, link_header, redirect_url, replacement_id)
-    new_attributes = {
-      access_limited_organisation_ids: access_limited ? get_access_limited(attachment_data) : nil,
-      draft: draft_status ? get_draft(attachment_data) : nil,
-      parent_document_url: link_header ? get_link_header(attachment_data) : nil,
-      replacement_id: replacement_id ? get_replacement_id(attachment_data, asset.variant) : nil,
-    }.compact
-    new_attributes.merge!(redirect_url: get_redirect_url(attachment_data)) if redirect_url
-
-    new_attributes
-  end
-
-  def self.get_access_limited(attachment_data)
-    return [] unless attachment_data.access_limited?
-
-    AssetManagerAccessLimitation.for(attachment_data.access_limited_object)
-  end
-
-  def self.get_draft(attachment_data)
-    attachment_data.draft? &&
-      !attachment_data.unpublished? &&
-      !attachment_data.replaced?
-  end
-
-  def self.get_link_header(attachment_data)
-    visible_edition = attachment_data.visible_edition_for(nil)
-    draft_edition = attachment_data.draft_edition
-    if visible_edition.blank? && draft_edition
-      draft_edition.public_url(draft: true)
-    elsif visible_edition.present?
-      visible_edition.public_url
-    end
-  end
-
-  def self.get_redirect_url(attachment_data)
-    return nil unless attachment_data.unpublished?
-
-    attachment_data.unpublished_attachable.unpublishing.document_url
-  end
-
-  def self.get_replacement_id(replaced_attachment_data, variant)
-    return nil unless replaced_attachment_data.replaced?
-
-    replacement = replaced_attachment_data.replaced_by
-    replacement_asset = replacement.assets.where(variant:).first
-
-    if replacement_asset
-      replacement_asset.asset_manager_id
-    else
-      original_variant = replacement.assets.where(variant: Asset.variants[:original]).first
-
-      original_variant ? original_variant.asset_manager_id : nil
+      AssetManager::AssetUpdater.call(asset.asset_manager_id, attachment_data, nil, { "redirect_url" => attachment_data.redirect_url })
     end
   end
 end

--- a/app/workers/asset_manager_attachment_metadata_worker.rb
+++ b/app/workers/asset_manager_attachment_metadata_worker.rb
@@ -10,15 +10,10 @@ class AssetManagerAttachmentMetadataWorker < WorkerBase
 
     return unless attachment_data.all_asset_variants_uploaded?
 
-    AssetManager::AttachmentUpdater.call(
-      attachment_data,
-      access_limited: true,
-      draft_status: true,
-      link_header: true,
-    )
+    AssetManager::AttachmentUpdater.call(attachment_data)
 
     AttachmentData.where(replaced_by: attachment_data).find_each do |replaced_attachment_data|
-      AssetManager::AttachmentUpdater.call(replaced_attachment_data, replacement_id: true)
+      AssetManager::AttachmentUpdater.replace(replaced_attachment_data)
     rescue AssetManager::ServiceHelper::AssetNotFound => e
       logger.warn("AssetManagerAttachmentMetadataWorker: #{e}")
     end

--- a/app/workers/asset_manager_attachment_redirect_url_update_worker.rb
+++ b/app/workers/asset_manager_attachment_redirect_url_update_worker.rb
@@ -5,6 +5,6 @@ class AssetManagerAttachmentRedirectUrlUpdateWorker < WorkerBase
     attachment_data = AttachmentData.find_by(id: attachment_data_id)
     return if attachment_data.blank?
 
-    AssetManager::AttachmentUpdater.call(attachment_data, redirect_url: true)
+    AssetManager::AttachmentUpdater.redirect(attachment_data)
   end
 end

--- a/test/unit/app/workers/asset_manager_attachment_metadata_worker_test.rb
+++ b/test/unit/app/workers/asset_manager_attachment_metadata_worker_test.rb
@@ -8,12 +8,7 @@ class AssetManagerAttachmentMetadataWorkerTest < ActiveSupport::TestCase
     let(:worker) { AssetManagerAttachmentMetadataWorker.new }
 
     it "calls both updater and deleter" do
-      AssetManager::AttachmentUpdater.expects(:call).with(
-        attachment_data,
-        access_limited: true,
-        draft_status: true,
-        link_header: true,
-      )
+      AssetManager::AttachmentUpdater.expects(:call).with(attachment_data)
 
       AssetManager::AttachmentDeleter.expects(:call).with(
         attachment_data,

--- a/test/unit/app/workers/asset_manager_attachment_redirect_url_update_worker_test.rb
+++ b/test/unit/app/workers/asset_manager_attachment_redirect_url_update_worker_test.rb
@@ -10,7 +10,7 @@ class AssetManagerAttachmentRedirectUrlUpdateWorkerTest < ActiveSupport::TestCas
     let(:worker) { AssetManagerAttachmentRedirectUrlUpdateWorker.new }
 
     it "calls AssetManager::AttachmentRedirectUrlUpdater" do
-      AssetManager::AttachmentUpdater.expects(:call).with(attachment_data, redirect_url: true)
+      AssetManager::AttachmentUpdater.expects(:redirect).with(attachment_data)
       worker.perform(attachment_data.id)
     end
   end


### PR DESCRIPTION
Whilst [fixing this bug](https://github.com/alphagov/whitehall/pull/8403) I had to extend the Whitehall AttachmentUpdater class to handle unpublished editions, but it was difficult to do so owing to the fact that the class provides a single method to handle updating the attachment metadata, creating a redirect, and replacing the attachment data with a new version.

Separating out that method into three separate method calls will decouple the three operations so that each can be changed independently if needed in future, and will generally aid developers in understanding this area of the code. I've also moved a lot of the logic into the `AttachmentData` model which seems like a better home for it, as the attachment data should be responsible for managing its own state and exposing that to consumers. This approach avoids an [anaemic domain model](https://martinfowler.com/bliki/AnemicDomainModel.html)

I would still like to move some of the responsibility from the `AttachmentData` model on to the `Attachment` itself, as the `AttachmentData` model does far too much reaching across to the `Attachable` via the `Attachment` for my liking, resulting in excessive coupling.

The `AssetUpdater` API is also inefficient because it accepts a hash of attributes that it could derive itself from the `AttachmentData` parameter it accepts, so I might open a quick PR for that too. However, the `AssetUpdater` has quite a few usages across the codebase so I'd need to be careful about backward compatibility

Trello: https://trello.com/c/HKzC61Ub
