### PR TITLE
Fix db migration and version sue to missing migration script

### DIFF
--- a/db/migrate/20231025154359_add_featured_image_data_ref_to_organisations.rb
+++ b/db/migrate/20231025154359_add_featured_image_data_ref_to_organisations.rb
@@ -1,0 +1,5 @@
+class AddFeaturedImageDataRefToOrganisations < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :organisations, :featured_image_data, index: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_23_110956) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_25_154359) do
   create_table "assets", charset: "utf8mb3", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.string "variant", null: false


### PR DESCRIPTION
Fix db migration and version sue to missing migration script

We accidentally pushed the schema without the actual migration script so we added it back and updated the version in schema.

[Trello Card](https://trello.com/c/hxnlRSx1/205-story-defaultnewsorganisationimagedatafeaturedimagedata-to-use-assetid)
