### PR TITLE
Add edition_lead_image table and lead image association

### DIFF
--- a/app/components/admin/edition_images/uploaded_images_component.html.erb
+++ b/app/components/admin/edition_images/uploaded_images_component.html.erb
@@ -18,18 +18,18 @@
 <% end %>
 
 <div class="govuk-grid-row">
-  <% if lead_image %>
+  <% if lead_image_hash %>
     <div class="govuk-grid-column-one-third">
-      <img src="<%= lead_image[:url] %>" alt="<%= lead_image[:preview_alt_text] %>" class="app-view-edition-resource__preview">
-      <% unless lead_image[:all_image_asset_variants_uploaded] %><span class="govuk-tag govuk-tag--green">Processing</span><% end %>
+      <img src="<%= lead_image_hash[:url] %>" alt="<%= lead_image_hash[:preview_alt_text] %>" class="app-view-edition-resource__preview">
+      <% unless lead_image_hash[:all_image_asset_variants_uploaded] %><span class="govuk-tag govuk-tag--green">Processing</span><% end %>
     </div>
     <div class="govuk-grid-column-two-thirds">
-      <p class="govuk-body"><strong>Caption: </strong><%= lead_image[:caption] %></p>
-      <p class="govuk-body"><strong>Alt text: </strong><%= lead_image[:alt_text] %></p>
+      <p class="govuk-body"><strong>Caption: </strong><%= lead_image_hash[:caption] %></p>
+      <p class="govuk-body"><strong>Alt text: </strong><%= lead_image_hash[:alt_text] %></p>
     </div>
   <% end %>
 
-  <% if lead_image || @edition.type == "CaseStudy" %>
+  <% if lead_image_hash || @edition.type == "CaseStudy" %>
     <%= form_with(url: update_image_display_option_admin_edition_path(@edition), method: :patch) do |form| %>
       <div class="app-view-edition-resource__actions govuk-grid-column-full govuk-button-group">
         <% if @edition.type == "CaseStudy" %>
@@ -41,8 +41,8 @@
           } %>
         <% end %>
 
-        <% if lead_image %>
-          <% lead_image[:links].each do |link| %><%= link %><% end %>
+        <% if lead_image_hash %>
+          <% lead_image_hash[:links].each do |link| %><%= link %><% end %>
         <% end %>
       </div>
     <% end %>

--- a/app/components/admin/edition_images/uploaded_images_component.rb
+++ b/app/components/admin/edition_images/uploaded_images_component.rb
@@ -3,12 +3,10 @@
 class Admin::EditionImages::UploadedImagesComponent < ViewComponent::Base
   def initialize(edition:)
     @edition = edition
-    @lead_image = has_lead_image? ? @edition.images.first : nil
-    @document_images = @edition.images.drop(has_lead_image? ? 1 : 0)
   end
 
   def has_lead_image?
-    can_have_lead_image? && @edition.images.any?
+    can_have_lead_image? && @edition.lead_image.present?
   end
 
   def can_have_lead_image?
@@ -16,11 +14,16 @@ class Admin::EditionImages::UploadedImagesComponent < ViewComponent::Base
   end
 
   def lead_image
-    image_to_hash @lead_image, 0 if has_lead_image?
+    @lead_image ||= can_have_lead_image? ? @edition.lead_image : nil
+  end
+
+  def lead_image_hash
+    image_to_hash(lead_image, 0) if lead_image
   end
 
   def document_images
-    @document_images.map.with_index(1) { |image, index| image_to_hash image, index }
+    @document_images ||= (@edition.images - [lead_image].compact)
+                          .map.with_index(1) { |image, index| image_to_hash(image, index) }
   end
 
   def new_image_display_option
@@ -32,7 +35,7 @@ class Admin::EditionImages::UploadedImagesComponent < ViewComponent::Base
   end
 
   def update_image_display_option_button_text
-    if has_lead_image?
+    if @edition.images.present?
       return "#{new_image_display_option == 'no_image' ? 'Hide' : 'Show'} lead image"
     end
 
@@ -56,7 +59,7 @@ private
   def image_to_hash(image, index)
     {
       url: image.url,
-      preview_alt_text: index.zero? ? "Lead image" : "Image #{index}",
+      preview_alt_text: lead_image == image ? "Lead image" : "Image #{index}",
       caption: image.caption.presence || "None",
       alt_text: image.alt_text.presence || "None",
       markdown: unique_names? ? "[Image: #{image.filename}]" : "!!#{index}",

--- a/app/components/admin/edition_images/uploaded_images_component.rb
+++ b/app/components/admin/edition_images/uploaded_images_component.rb
@@ -12,7 +12,7 @@ class Admin::EditionImages::UploadedImagesComponent < ViewComponent::Base
   end
 
   def can_have_lead_image?
-    @edition.is_a? Edition::FirstImagePulledOut
+    @edition.can_have_custom_lead_image?
   end
 
   def lead_image

--- a/app/controllers/admin/case_studies_controller.rb
+++ b/app/controllers/admin/case_studies_controller.rb
@@ -2,4 +2,25 @@ class Admin::CaseStudiesController < Admin::EditionsController
   def edition_class
     CaseStudy
   end
+
+  def update_image_display_option
+    @edition.assign_attributes(image_display_option_params)
+
+    if updater.can_perform? && @edition.save_as(current_user)
+      @edition.update_lead_image
+      updater.perform!
+
+      redirect_to admin_edition_images_path(@edition), notice: "The lead image has been updated"
+    else
+      redirect_to admin_edition_images_path(@edition), alert: updater.failure_reason
+    end
+  end
+
+private
+
+  def image_display_option_params
+    params
+    .require(:edition)
+    .permit(:image_display_option)
+  end
 end

--- a/app/controllers/admin/edition_images_controller.rb
+++ b/app/controllers/admin/edition_images_controller.rb
@@ -29,6 +29,7 @@ class Admin::EditionImagesController < Admin::BaseController
     @new_image.image_data.validate_on_image = @new_image
 
     if @new_image.save
+      @edition.update_lead_image if @edition.can_have_custom_lead_image?
       redirect_to edit_admin_edition_image_path(@edition, @new_image.id), notice: "#{@new_image.filename} successfully uploaded"
     elsif new_image_needs_cropping?
       @data_url = image_data_url

--- a/app/controllers/admin/edition_images_controller.rb
+++ b/app/controllers/admin/edition_images_controller.rb
@@ -10,6 +10,7 @@ class Admin::EditionImagesController < Admin::BaseController
   def destroy
     filename = image.image_data.carrierwave_image
     image.destroy!
+
     redirect_to admin_edition_images_path(@edition), notice: "#{filename} has been deleted"
   end
 

--- a/app/controllers/admin/edition_images_controller.rb
+++ b/app/controllers/admin/edition_images_controller.rb
@@ -10,6 +10,7 @@ class Admin::EditionImagesController < Admin::BaseController
   def destroy
     filename = image.image_data.carrierwave_image
     image.destroy!
+    @edition.update_lead_image if @edition.can_have_custom_lead_image?
 
     redirect_to admin_edition_images_path(@edition), notice: "#{filename} has been deleted"
   end

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -171,17 +171,6 @@ class Admin::EditionsController < Admin::BaseController
     end
   end
 
-  def update_image_display_option
-    @edition.assign_attributes(params.require(:edition).permit(:image_display_option))
-
-    if updater.can_perform? && @edition.save_as(current_user)
-      updater.perform!
-      redirect_to admin_edition_images_path(@edition), notice: "The lead image has been updated"
-    else
-      redirect_to admin_edition_images_path(@edition), alert: updater.failure_reason
-    end
-  end
-
   def update_bypass_id
     EditionAuthBypassUpdater.new(edition: @edition, current_user:, updater:).call
 

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -716,6 +716,10 @@ EXISTS (
     PublishingApi::GenericEditionPresenter
   end
 
+  def can_have_custom_lead_image?
+    is_a?(Edition::FirstImagePulledOut)
+  end
+
 private
 
   def date_for_government

--- a/app/models/edition/first_image_pulled_out.rb
+++ b/app/models/edition/first_image_pulled_out.rb
@@ -15,6 +15,8 @@ module Edition::FirstImagePulledOut
   end
 
   def update_lead_image
+    remove_lead_image and return if %w[no_image organisation_image].include?(image_display_option)
+
     return if lead_image.present? || images.blank?
 
     edition_lead_image = build_edition_lead_image(image: oldest_image)
@@ -25,5 +27,11 @@ private
 
   def oldest_image
     images.order(:created_at, :id).first
+  end
+
+  def remove_lead_image
+    return if edition_lead_image.blank?
+
+    edition_lead_image.destroy!
   end
 end

--- a/app/models/edition/first_image_pulled_out.rb
+++ b/app/models/edition/first_image_pulled_out.rb
@@ -13,4 +13,17 @@ module Edition::FirstImagePulledOut
   def image_disallowed_in_body_text?(index)
     index == 1
   end
+
+  def update_lead_image
+    return if lead_image.present? || images.blank?
+
+    edition_lead_image = build_edition_lead_image(image: oldest_image)
+    edition_lead_image.save!
+  end
+
+private
+
+  def oldest_image
+    images.order(:created_at, :id).first
+  end
 end

--- a/app/models/edition/images.rb
+++ b/app/models/edition/images.rb
@@ -9,6 +9,13 @@ module Edition::Images
           Rails.logger.warn "Ignoring errors on saving image for edition with id #{edition.id}: #{image.errors.full_messages.join(', ')}"
         end
         image.save!(validate: false)
+
+        next unless @edition.can_have_custom_lead_image?
+
+        if @edition.lead_image == a
+          edition_lead_image = edition.build_edition_lead_image(image:)
+          edition_lead_image.save!
+        end
       end
     end
   end

--- a/app/models/edition/lead_image.rb
+++ b/app/models/edition/lead_image.rb
@@ -1,6 +1,11 @@
 module Edition::LeadImage
   extend ActiveSupport::Concern
 
+  included do
+    has_one :edition_lead_image, foreign_key: :edition_id, dependent: :destroy
+    has_one :lead_image, through: :edition_lead_image, source: :image
+  end
+
   def has_lead_image?
     !image_data.nil?
   end

--- a/app/models/edition/lead_image.rb
+++ b/app/models/edition/lead_image.rb
@@ -19,16 +19,16 @@ module Edition::LeadImage
   end
 
   def lead_image_alt_text
-    if images.first.try(:alt_text)
-      images.first.alt_text.squish
+    if lead_image.try(:alt_text)
+      lead_image.alt_text.squish
     else
       ""
     end
   end
 
   def lead_image_caption
-    if images.first
-      caption = images.first.caption && images.first.caption.strip
+    if lead_image
+      caption = lead_image.caption && lead_image.caption.strip
       caption.presence
     end
   end
@@ -58,8 +58,8 @@ private
   end
 
   def image_data
-    if images.first
-      images.first.image_data
+    if lead_image
+      lead_image.image_data
     elsif lead_organisations.any? && lead_organisations.first.default_news_image
       lead_organisations.first.default_news_image
     elsif organisations.any? && organisations.first.default_news_image

--- a/app/models/edition_lead_image.rb
+++ b/app/models/edition_lead_image.rb
@@ -1,0 +1,4 @@
+class EditionLeadImage < ApplicationRecord
+  belongs_to :edition
+  belongs_to :image
+end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,6 +1,7 @@
 class Image < ApplicationRecord
   belongs_to :image_data
   belongs_to :edition
+  has_one :edition_lead_image, dependent: :destroy
 
   validates :alt_text, presence: true, allow_blank: true, length: { maximum: 255 }, unless: :skip_main_validation?
   validates :image_data, presence: { message: "must be present" }

--- a/app/presenters/publishing_api/case_study_presenter.rb
+++ b/app/presenters/publishing_api/case_study_presenter.rb
@@ -81,7 +81,7 @@ module PublishingApi
     end
 
     def image_available?
-      item.images.any? || emphasised_organisation_default_image_available?
+      item.lead_image.present? || emphasised_organisation_default_image_available?
     end
 
     def image_required?

--- a/app/views/admin/editions/show/_main.html.erb
+++ b/app/views/admin/editions/show/_main.html.erb
@@ -190,7 +190,7 @@
           ],
           rows: @edition.images.map do | image |
             [
-              { text: sanitize("#{image.filename} #{tag.span("Lead image", class: 'govuk-tag app-view-summary__tag') if @edition.is_a? Edition::FirstImagePulledOut and image == @edition.images.first}") },
+              { text: sanitize("#{image.filename} #{tag.span("Lead image", class: 'govuk-tag app-view-summary__tag') if @edition.can_have_custom_lead_image? && image == @edition.lead_image}") },
             ]
           end,
         } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -210,7 +210,7 @@ Whitehall::Application.routes.draw do
           get :audit_trail, to: "edition_audit_trail#index"
           get :document_history, to: "edition_document_history#index"
           patch :update_bypass_id
-          patch :update_image_display_option
+          patch :update_image_display_option, controller: "case_studies"
           get :confirm_destroy
         end
         resources :link_check_reports

--- a/db/data_migration/20231025091943_backfill_edition_lead_images.rb
+++ b/db/data_migration/20231025091943_backfill_edition_lead_images.rb
@@ -1,0 +1,7 @@
+puts "Backfilling lead_image_id for case studies"
+
+CaseStudy.joins(:images).distinct.find_each(batch_size: 100, &:update_lead_image)
+
+puts "Backfilling lead_image_id for news articles"
+
+NewsArticle.joins(:images).distinct.find_each(batch_size: 100, &:update_lead_image)

--- a/db/migrate/20231026125543_create_edition_lead_images.rb
+++ b/db/migrate/20231026125543_create_edition_lead_images.rb
@@ -1,0 +1,12 @@
+class CreateEditionLeadImages < ActiveRecord::Migration[7.0]
+  def change
+    create_table :edition_lead_images do |t|
+      t.integer "edition_id", foreign_key: true
+      t.integer "image_id", foreign_key: true
+      t.index %w[edition_id], name: "index_lead_image_on_edition_id", unique: true
+      t.index %w[image_id], name: "index_lead_image_on_image_id"
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_25_154359) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_26_125543) do
   create_table "assets", charset: "utf8mb3", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.string "variant", null: false
@@ -262,6 +262,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_25_154359) do
     t.integer "dependable_id"
     t.string "dependable_type"
     t.index ["dependable_id", "dependable_type", "edition_id"], name: "index_edition_dependencies_on_dependable_and_edition", unique: true
+  end
+
+  create_table "edition_lead_images", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "edition_id"
+    t.integer "image_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["edition_id"], name: "index_lead_image_on_edition_id", unique: true
+    t.index ["image_id"], name: "index_lead_image_on_image_id"
   end
 
   create_table "edition_organisations", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|

--- a/test/components/admin/edition_images/uploaded_images_component_test.rb
+++ b/test/components/admin/edition_images/uploaded_images_component_test.rb
@@ -5,7 +5,7 @@ require "test_helper"
 class Admin::EditionImages::UploadedImagesComponentTest < ViewComponent::TestCase
   test "lead image rendered for case study" do
     images = [build_stubbed(:image), build_stubbed(:image)]
-    edition = build_stubbed(:draft_case_study, images:)
+    edition = build_stubbed(:draft_case_study, images:, lead_image: images.first)
     render_inline(Admin::EditionImages::UploadedImagesComponent.new(edition:))
 
     assert_selector "img", count: 2

--- a/test/factories/edition_lead_image.rb
+++ b/test/factories/edition_lead_image.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :edition_lead_image, aliases: %i[lead_image] do
+    edition
+    image
+  end
+end

--- a/test/functional/admin/case_studies_controller_test.rb
+++ b/test/functional/admin/case_studies_controller_test.rb
@@ -17,4 +17,14 @@ class Admin::CaseStudiesControllerTest < ActionController::TestCase
   should_allow_association_between_world_locations_and :case_study
   should_send_drafts_to_content_preview_environment_for :case_study
   should_render_govspeak_history_and_fact_checking_tabs_for :case_study
+
+  test "PATCH :update_image_display_option updates the image_display option and handles updating an editions lead image" do
+    edition = create(:draft_case_study, image_display_option: "custom_image")
+    create(:edition_lead_image, edition:)
+
+    patch :update_image_display_option, params: { id: edition.id, edition: { image_display_option: "no_image" } }
+
+    assert_equal "no_image", edition.reload.image_display_option
+    assert_nil edition.lead_image
+  end
 end

--- a/test/functional/admin/edition_images_controller_test.rb
+++ b/test/functional/admin/edition_images_controller_test.rb
@@ -101,6 +101,20 @@ class Admin::EditionImagesControllerTest < ActionDispatch::IntegrationTest
     post admin_edition_images_path(edition), params: { image: { image_data: { file: } } }
   end
 
+  test "DELETE :destroy when a lead image is present it deletes the edition_lead_image and sets a new lead image" do
+    login_authorised_user
+    image1 = build(:image)
+    image2 = build(:image)
+    edition = create(:draft_case_study, images: [image1, image2])
+    create(:edition_lead_image, edition:, image: image1)
+
+    delete admin_edition_image_path(edition, image1), params: { edition_id: edition.id, id: image1.id }
+
+    assert_equal 1, edition.reload.images.count
+    assert_equal image2, edition.lead_image
+    assert_redirected_to admin_edition_images_path(edition)
+  end
+
   def login_authorised_user
     user = create(:gds_editor)
     login_as user

--- a/test/functional/admin/edition_images_controller_test.rb
+++ b/test/functional/admin/edition_images_controller_test.rb
@@ -38,6 +38,16 @@ class Admin::EditionImagesControllerTest < ActionDispatch::IntegrationTest
     assert_equal edit_admin_edition_image_path(edition, edition.images.last), path
   end
 
+  test "#create updates the lead_image association if edition can have a custom lead image" do
+    login_authorised_user
+    edition = create(:news_article)
+
+    file = upload_fixture("images/960x640_jpeg.jpg")
+    post admin_edition_images_path(edition), params: { image: { image_data: { file: } } }
+
+    assert_equal "960x640_jpeg.jpg", edition.lead_image.filename
+  end
+
   test "#create shows the cropping page if image is too large" do
     login_authorised_user
     edition = create(:news_article)

--- a/test/unit/app/models/edition/first_image_pulled_out_test.rb
+++ b/test/unit/app/models/edition/first_image_pulled_out_test.rb
@@ -51,6 +51,28 @@ class Edition::FirstImagePulledOutTest < ActiveSupport::TestCase
     edition.update_lead_image
   end
 
+  test "#update_lead_image deletes the associated edition_lead_image if image_display_option is 'no_image'" do
+    edition_lead_image = build(:edition_lead_image)
+    edition = build(:news_article, image_display_option: "no_image", edition_lead_image:)
+
+    edition_lead_image
+    .expects(:destroy!)
+    .once
+
+    edition.update_lead_image
+  end
+
+  test "#update_lead_image deletes the associated edition_lead_image if image_display_option is 'organisation_image'" do
+    edition_lead_image = build(:edition_lead_image)
+    edition = build(:news_article, image_display_option: "organisation_image", edition_lead_image:)
+
+    edition_lead_image
+    .expects(:destroy!)
+    .once
+
+    edition.update_lead_image
+  end
+
   test "#update_lead_image returns nil if lead_image is present" do
     edition = build(:news_article)
     build(:image)

--- a/test/unit/app/models/edition/first_image_pulled_out_test.rb
+++ b/test/unit/app/models/edition/first_image_pulled_out_test.rb
@@ -27,4 +27,40 @@ class Edition::FirstImagePulledOutTest < ActiveSupport::TestCase
     assert body_text_valid("foo\n!!10\nbar")
     assert body_text_valid("foo\nfoo bar !!1\nbar")
   end
+
+  test "#update_lead_image updates the lead_image association to the oldest image" do
+    image1 = build_stubbed(:image)
+    image2 = build_stubbed(:image)
+    edition = build_stubbed(:news_article, images: [image1, image2])
+
+    edition.stubs(:lead_image).returns(nil)
+    edition.images.stubs(:order).with(:created_at, :id).returns([image1, image2])
+    edition_lead_image = mock
+
+    edition
+    .expects(:build_edition_lead_image)
+    .with(image: image1)
+    .once
+    .returns(edition_lead_image)
+
+    edition_lead_image
+    .expects(:save!)
+    .once
+    .returns(true)
+
+    edition.update_lead_image
+  end
+
+  test "#update_lead_image returns nil if lead_image is present" do
+    edition = build(:news_article)
+    build(:image)
+    edition.stubs(:lead_image).returns(edition)
+
+    assert_nil edition.update_lead_image
+  end
+
+  test "#update_lead_image returns nil if no images are present" do
+    edition = build(:news_article)
+    assert_nil edition.update_lead_image
+  end
 end

--- a/test/unit/app/models/edition/images_test.rb
+++ b/test/unit/app/models/edition/images_test.rb
@@ -7,6 +7,14 @@ class Edition::ImagesTest < ActiveSupport::TestCase
     def previously_published
       false
     end
+
+    def lead_image; end
+
+    def build_edition_lead_image(args)
+      EditionLeadImage.new(edition: self, **args)
+    end
+
+    def can_have_custom_lead_image?; end
   end
 
   include ActionDispatch::TestProcess
@@ -102,6 +110,26 @@ class Edition::ImagesTest < ActiveSupport::TestCase
 
     assert_equal 1, new_draft.images.count
     assert_equal new_draft.images.first.image_data, published_edition.images.first.image_data
+  end
+
+  test "#create_draft should create a new edition_lead_image correctly when a lead image is present on the published_edition" do
+    image1 = create(:image)
+    image2 = create(:image)
+
+    published_edition = EditionWithImages.create!(
+      valid_edition_attributes.merge(
+        state: "published",
+        major_change_published_at: Time.zone.now,
+        first_published_at: Time.zone.now,
+        images: [image1, image2],
+      ),
+    )
+    published_edition.stubs(:lead_image).returns(image2)
+    published_edition.stubs(:can_have_custom_lead_image?).returns(true)
+
+    draft_edition = published_edition.create_draft(build(:user))
+
+    assert_equal image2.image_data.images.last.id, EditionLeadImage.find_by!(edition_id: draft_edition.id).image.id
   end
 
   test "captions for images can be changed between versions" do

--- a/test/unit/app/models/edition/lead_image_test.rb
+++ b/test/unit/app/models/edition/lead_image_test.rb
@@ -2,41 +2,41 @@ require "test_helper"
 
 class Edition::LeadImageTest < ActiveSupport::TestCase
   test "should use placeholder image if none had been uploaded" do
-    model = stub("Target", images: [], lead_organisations: [], organisations: []).extend(Edition::LeadImage)
+    model = stub("Target", lead_image: nil, lead_organisations: [], organisations: []).extend(Edition::LeadImage)
     assert_match %r{placeholder}, model.lead_image_url
     assert_equal "", model.lead_image_alt_text
   end
 
   test "should use empty string if no alt_text is provided" do
-    model = stub("Target", images: [], lead_organisations: [], organisations: []).extend(Edition::LeadImage)
+    model = stub("Target", lead_image: nil, lead_organisations: [], organisations: []).extend(Edition::LeadImage)
     file = stub("File", content_type: "image/jpg")
     uploader = stub("Uploader", file:)
     image_data = stub("ImageData", file: uploader)
     image = stub("Image", alt_text: nil, image_data:)
-    model.stubs(images: [image])
+    model.stubs(lead_image: image)
     assert_equal "", model.lead_image_alt_text
   end
 
   test "should use first image with version :s300 if an image is present" do
-    model = stub("Target", images: [], lead_organisations: [], organisations: []).extend(Edition::LeadImage)
+    model = stub("Target", lead_image: nil, lead_organisations: [], organisations: []).extend(Edition::LeadImage)
     file = stub("File", content_type: "image/jpg")
     uploader = stub("Uploader", file:)
     image_data = stub("ImageData", file: uploader)
     image = stub("Image", alt_text: "alt_text", image_data:)
     uploader.expects(:url).with(:s300).returns("url")
-    model.stubs(images: [image])
+    model.stubs(lead_image: image)
     assert_equal "url", model.lead_image_url
     assert_equal "alt_text", model.lead_image_alt_text
   end
 
   test "uses unversioned url if the image is an SVG" do
-    model = stub("Target", images: [], lead_organisations: [], organisations: []).extend(Edition::LeadImage)
+    model = stub("Target", lead_image: nil, lead_organisations: [], organisations: []).extend(Edition::LeadImage)
     file = stub("File", content_type: "image/svg+xml")
     uploader = stub("Uploader", file:)
     image_data = stub("ImageData", file: uploader)
     image = stub("Image", alt_text: "alt_text", image_data:)
     uploader.expects(:url).with.returns("url")
-    model.stubs(images: [image])
+    model.stubs(lead_image: image)
     assert_equal "url", model.lead_image_url
     assert_equal "alt_text", model.lead_image_alt_text
   end
@@ -45,7 +45,7 @@ class Edition::LeadImageTest < ActiveSupport::TestCase
     image_with_missing_assets = build(:image_with_no_assets)
     image_with_missing_assets.image_data.assets << [build(:asset)]
 
-    model = stub("Target", { images: [image_with_missing_assets] }).extend(Edition::LeadImage)
+    model = stub("Target", { lead_image: image_with_missing_assets }).extend(Edition::LeadImage)
 
     assert_not model.lead_image_has_all_assets?
   end
@@ -53,7 +53,7 @@ class Edition::LeadImageTest < ActiveSupport::TestCase
   test "#lead_image_has_all_assets? returns true if the lead image (ImageData) has all assets" do
     image_with_missing_assets = build(:image)
 
-    model = stub("Target", { images: [image_with_missing_assets] }).extend(Edition::LeadImage)
+    model = stub("Target", { lead_image: image_with_missing_assets }).extend(Edition::LeadImage)
 
     assert model.lead_image_has_all_assets?
   end
@@ -62,7 +62,7 @@ class Edition::LeadImageTest < ActiveSupport::TestCase
     # e.g. DefaultNewsOrganisationImageData doesn't yet implement all_asset_variants_uploaded?
     image = build(:default_news_organisation_image_data)
     organisation = build(:organisation, default_news_image: image)
-    model = stub("Target", { images: [], lead_organisations: [], organisations: [organisation] }).extend(Edition::LeadImage)
+    model = stub("Target", { lead_image: nil, lead_organisations: [], organisations: [organisation] }).extend(Edition::LeadImage)
 
     assert model.lead_image_has_all_assets?
   end

--- a/test/unit/app/models/edition_test.rb
+++ b/test/unit/app/models/edition_test.rb
@@ -968,6 +968,16 @@ class EditionTest < ActiveSupport::TestCase
     assert_not edition.force_scheduled?
   end
 
+  test "#can_have_custom_lead_image? returns true if FirstImagePulledOut module is included" do
+    edition = build(:case_study)
+    assert edition.can_have_custom_lead_image?
+  end
+
+  test "#can_have_custom_lead_image? returns true if FirstImagePulledOut module is not included" do
+    edition = build(:edition)
+    assert_not edition.can_have_custom_lead_image?
+  end
+
   def decoded_token_payload(token)
     payload, _header = JWT.decode(
       token,

--- a/test/unit/app/models/speech_test.rb
+++ b/test/unit/app/models/speech_test.rb
@@ -145,8 +145,9 @@ class SpeechTest < ActiveSupport::TestCase
   end
 
   test "search_index includes default image_url if it has one" do
-    image = create(:image)
-    speech = create(:published_speech, images: [image])
+    image = build(:image)
+    speech = build(:published_speech, document: build(:document))
+    speech.stubs(:lead_image).returns(image)
     assert_equal image.url(:s300), speech.search_index["image_url"]
   end
 

--- a/test/unit/app/presenters/publishing_api/case_study_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/case_study_presenter_test.rb
@@ -75,7 +75,8 @@ class PublishingApi::CaseStudyPresenterTest < ActiveSupport::TestCase
 
   test "includes details of the case study image if present" do
     image = build(:image, alt_text: "Image alt text", caption: "A caption")
-    case_study = create(:published_case_study, images: [image])
+    case_study = build_stubbed(:published_case_study, document: build_stubbed(:document))
+    case_study.stubs(:lead_image).returns(image)
 
     expected_hash = {
       url: image.url(:s300),
@@ -90,7 +91,8 @@ class PublishingApi::CaseStudyPresenterTest < ActiveSupport::TestCase
 
   test "returns case study image caption as nil (not false) when it is blank" do
     image = build(:image, alt_text: "Image alt text", caption: "")
-    case_study = create(:published_case_study, images: [image])
+    case_study = build_stubbed(:published_case_study, document: build_stubbed(:document))
+    case_study.stubs(:lead_image).returns(image)
 
     expected_hash = {
       url: image.url(:s300),


### PR DESCRIPTION
## Background 


This is an alternate implementation to the one laid out in this PR - https://github.com/alphagov/whitehall/pull/8392 which added a foreign key to the editions table for a lead_image

## Description

Currently, a lead image is assigned for News Articles and Case Studies by adding an image to the edition. There's no way to change select a lead image. This means that if the publisher wants to assign a new lead image, they're forced to remove and 
reupload all the images.

We want to build in functionality that allows a user to select a lead image.

This draft PR does the following:

1. Adds a join table for images and editions for lead images (EditionLeadImage) using a has _one association.This has a unique constraint on edition_id to make sure there's only ever 1 lead_image
2. handles creating the edition_lead_image association when the `#create_draft` method is called (creates a new draft from a published edition)
3. handles creating the lead image association when the first image is created
3. handles creating the lead image association when a lead_ mage is deleted
4. handles deleting the `edition_lead_image` when the user toggles lead image visibility off/default image (default org image) for case studies
7. adds a migration to backfill lead_image_id
8. updated places that used `images.first` to use the new lead image association

Once i get some initial feedback, i'll break the above out into 3 PRs

1. will add the association to the db
2. will handle adding the callbacks which populate `lead_image_id` & add the backfill data migration

At this point i'll run the backfill on int, staging and prod

3. will update the code to use the new association in place of `edition.images.first`

## Out of scope

- Adding the ability for users to choose a lead image via the UI (we're still waiting or some finalised designs on this)
- Updating the validation which checks the lead_image is not being used in the markdown of the document. (i'll handle this in another PR)

## Trello card

https://trello.com/c/5vCiIxeQ/1064-lead-image-handling-backend-work

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
