### PR TITLE
Fix schema to match migrations

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1094,6 +1094,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_25_154359) do
     t.date "end_date"
     t.string "content_id"
     t.text "summary"
+    t.bigint "featured_image_data_id"
+    t.index ["featured_image_data_id"], name: "index_topical_events_on_featured_image_data_id"
     t.index ["slug"], name: "index_topical_events_on_slug"
   end
 


### PR DESCRIPTION
This changes were missed during rebasing from the changes in `https://github.com/alphagov/whitehall/pull/8413`
from [this](db/migrate/20231023164158_add_featured_image_data_ref_to_topical_events.rb) migration script [here](https://github.com/alphagov/whitehall/pull/8413/commits/34db8da5c83eaacf82a1546a75118407cebc6aa1#diff-52f30e9d168bf9df46873ab332383eb14e313fa56f5e555468b2df06d9f567f5)