### PR TITLE
Link all pre-publication attachments to their parent document

### DIFF
--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -135,7 +135,7 @@ class AttachmentData < ApplicationRecord
   end
 
   def draft_attachment
-    attachments.find { |attachment| attachment.attachable_type == "Edition" && attachment.attachable&.draft? }
+    attachments.find { |attachment| attachment.attachable_type == "Edition" && Edition::PRE_PUBLICATION_STATES.include?(attachment.attachable&.state) }
   end
 
   def draft_edition

--- a/test/unit/app/services/asset_manager/attachment_updater_test.rb
+++ b/test/unit/app/services/asset_manager/attachment_updater_test.rb
@@ -150,6 +150,51 @@ class AssetManager::AttachmentUpdaterTest < ActiveSupport::TestCase
         end
       end
 
+      context "when attachment belongs to a scheduled edition" do
+        let(:scheduled_edition) { FactoryBot.create(:scheduled_edition) }
+        let(:attachment) { FactoryBot.create(:file_attachment, file: simple_pdf, attachable: scheduled_edition) }
+        let(:parent_document_url) { scheduled_edition.public_url(draft: true) }
+
+        it "sets parent_document_url for attachment using draft hostname" do
+          update_service.expects(:call)
+                          .with(original_asset.asset_manager_id, attachment_data, nil, { "parent_document_url" => parent_document_url })
+          update_service.expects(:call)
+                        .with(thumbnail_asset.asset_manager_id, attachment_data, nil, { "parent_document_url" => parent_document_url })
+
+          updater.call(attachment_data, link_header: true)
+        end
+      end
+
+      context "when attachment belongs to a submitted edition" do
+        let(:submitted_edition) { FactoryBot.create(:submitted_edition) }
+        let(:attachment) { FactoryBot.create(:file_attachment, file: simple_pdf, attachable: submitted_edition) }
+        let(:parent_document_url) { submitted_edition.public_url(draft: true) }
+
+        it "sets parent_document_url for attachment using draft hostname" do
+          update_service.expects(:call)
+                          .with(original_asset.asset_manager_id, attachment_data, nil, { "parent_document_url" => parent_document_url })
+          update_service.expects(:call)
+                        .with(thumbnail_asset.asset_manager_id, attachment_data, nil, { "parent_document_url" => parent_document_url })
+
+          updater.call(attachment_data, link_header: true)
+        end
+      end
+
+      context "when attachment belongs to a rejected edition" do
+        let(:rejected_edition) { FactoryBot.create(:rejected_edition) }
+        let(:attachment) { FactoryBot.create(:file_attachment, file: simple_pdf, attachable: rejected_edition) }
+        let(:parent_document_url) { rejected_edition.public_url(draft: true) }
+
+        it "sets parent_document_url for attachment using draft hostname" do
+          update_service.expects(:call)
+                          .with(original_asset.asset_manager_id, attachment_data, nil, { "parent_document_url" => parent_document_url })
+          update_service.expects(:call)
+                        .with(thumbnail_asset.asset_manager_id, attachment_data, nil, { "parent_document_url" => parent_document_url })
+
+          updater.call(attachment_data, link_header: true)
+        end
+      end
+
       context "when edition is published" do
         it "sets parent_document_url for all assets" do
           update_service.expects(:call)


### PR DESCRIPTION
In https://github.com/alphagov/whitehall/pull/7834, we linked draft attachments to their parent documents, to allow a CSV preview to provide a link back to the parent document. However this missed a number of pre-publication states: scheduled, submitted and rejected. This stopped CSV attachments of those documents from being previewed as the frontend code always expects a linked document to be present.

Therefore updating the logic to link all pre-publication states, not just draft.

[Zendesk ticket](https://govuk.zendesk.com/agent/tickets/5534478)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
