### PR TITLE
Allow organisation to use FeaturedImageData

### DIFF
--- a/app/controllers/admin/organisations_controller.rb
+++ b/app/controllers/admin/organisations_controller.rb
@@ -191,6 +191,9 @@ private
     if organisation_params[:logo].present? && organisation_params[:logo_cache].present?
       organisation_params.delete(:logo_cache)
     end
+    if organisation_params.dig(:default_news_image_attributes, :file_cache).present? && organisation_params.dig(:default_news_image_attributes, :file).present?
+      organisation_params[:default_news_image_attributes].delete(:file_cache)
+    end
 
     organisation_params
   end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -10,8 +10,8 @@ class Organisation < ApplicationRecord
   DEFAULT_JOBS_URL = "https://www.civilservicejobs.service.gov.uk/csr".freeze
   FEATURED_DOCUMENTS_DISPLAY_LIMIT = 6
 
-  belongs_to :default_news_image, class_name: "DefaultNewsOrganisationImageData", foreign_key: :default_news_organisation_image_data_id
-  has_one :default_news_image_new, class_name: "FeaturedImageData", as: :featured_imageable, inverse_of: :featured_imageable
+  belongs_to :default_news_image_old, class_name: "DefaultNewsOrganisationImageData", foreign_key: :default_news_organisation_image_data_id
+  has_one :default_news_image, class_name: "FeaturedImageData", as: :featured_imageable, inverse_of: :featured_imageable
 
   has_many :assets,
            as: :assetable,

--- a/app/presenters/publishing_api/organisation_presenter.rb
+++ b/app/presenters/publishing_api/organisation_presenter.rb
@@ -412,8 +412,7 @@ module PublishingApi
     end
 
     def default_news_image
-      return unless item.default_news_image
-      return { url: default_news_image_url } if default_news_image_is_svg?
+      return unless item.default_news_image && item.default_news_image.all_asset_variants_uploaded?
 
       {
         url: default_news_image_url(:s300),
@@ -423,11 +422,6 @@ module PublishingApi
 
     def default_news_image_url(size = nil)
       size ? item.default_news_image.file.url(size) : item.default_news_image.file.url
-    end
-
-    def default_news_image_is_svg?
-      content_type = item.default_news_image.file.content_type
-      content_type && content_type =~ /svg/
     end
   end
 end

--- a/app/workers/create_asset_relationship_worker.rb
+++ b/app/workers/create_asset_relationship_worker.rb
@@ -15,9 +15,9 @@ class CreateAssetRelationshipWorker < WorkerBase
 
     organisations.each do |organisation|
       variants.each do |variant|
-        legacy_path = get_legacy_path(organisation.default_news_image.file, variant)
+        legacy_path = get_legacy_path(organisation.default_news_image_old.file, variant)
         asset_info = get_whitehall_asset_data(legacy_path)
-        save_asset_id_to_assets(organisation.default_news_image_new.id, assetable_type, Asset.variants[variant], asset_info[:asset_manager_id], asset_info[:filename])
+        save_asset_id_to_assets(organisation.default_news_image.id, assetable_type, Asset.variants[variant], asset_info[:asset_manager_id], asset_info[:filename])
         asset_counter += 1
       rescue GdsApi::HTTPNotFound
         logger.warn "#{assetable_type} of id##{organisation.id} - could not find asset variant :#{variant} at path #{legacy_path}"

--- a/test/components/admin/organisations/show/summary_list_component_test.rb
+++ b/test/components/admin/organisations/show/summary_list_component_test.rb
@@ -65,7 +65,7 @@ class Admin::Organisations::Show::SummaryListComponentTest < ViewComponent::Test
   end
 
   test "renders default news image row if the organisation has a default news image" do
-    news_image = build_stubbed(:default_news_organisation_image_data)
+    news_image = build_stubbed(:featured_image_data)
     organisation = build_stubbed(:ministerial_department, default_news_image: news_image)
 
     render_inline(Admin::Organisations::Show::SummaryListComponent.new(organisation:))

--- a/test/factories/organisations.rb
+++ b/test/factories/organisations.rb
@@ -22,7 +22,7 @@ FactoryBot.define do
 
     trait(:with_default_news_image) do
       after :build do |organisation|
-        organisation.default_news_image_new = build(:featured_image_data)
+        organisation.default_news_image = build(:featured_image_data)
       end
     end
 
@@ -62,6 +62,7 @@ FactoryBot.define do
 
   factory :organisation_with_logo, parent: :organisation, traits: [:with_logo]
   factory :organisation_with_logo_and_assets, parent: :organisation, traits: [:with_logo_and_assets]
+  factory :organisation_with_default_news_image, parent: :organisation, traits: [:with_default_news_image]
   factory :closed_organisation, parent: :organisation, traits: [:closed]
 
   factory :ministerial_department, parent: :organisation do

--- a/test/unit/app/models/edition/lead_image_test.rb
+++ b/test/unit/app/models/edition/lead_image_test.rb
@@ -60,7 +60,7 @@ class Edition::LeadImageTest < ActiveSupport::TestCase
 
   test "#lead_image_has_all_assets? returns true if the lead image data doesn't implement all_asset_variants_uploaded?" do
     # e.g. DefaultNewsOrganisationImageData doesn't yet implement all_asset_variants_uploaded?
-    image = build(:default_news_organisation_image_data)
+    image = build(:featured_image_data)
     organisation = build(:organisation, default_news_image: image)
     model = stub("Target", { images: [], lead_organisations: [], organisations: [organisation] }).extend(Edition::LeadImage)
 

--- a/test/unit/app/models/organisation_test.rb
+++ b/test/unit/app/models/organisation_test.rb
@@ -167,8 +167,14 @@ class OrganisationTest < ActiveSupport::TestCase
     assert organisation.errors[:logo].present?
   end
 
-  test "can have a default news article image" do
+  test "can have a default news article image legacy" do
     image = build(:default_news_organisation_image_data)
+    organisation = build(:organisation, default_news_image_old: image)
+    assert_equal image, organisation.default_news_image_old
+  end
+
+  test "can have a default news article image" do
+    image = build(:featured_image_data)
     organisation = build(:organisation, default_news_image: image)
     assert_equal image, organisation.default_news_image
   end
@@ -1069,7 +1075,7 @@ class OrganisationTest < ActiveSupport::TestCase
     end
 
     organisation.update!(
-      default_news_image: create(:default_news_organisation_image_data),
+      default_news_image_old: create(:default_news_organisation_image_data),
     )
   end
 

--- a/test/unit/app/presenters/publishing_api/case_study_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/case_study_presenter_test.rb
@@ -104,7 +104,7 @@ class PublishingApi::CaseStudyPresenterTest < ActiveSupport::TestCase
   end
 
   test "falls back to the organisation's default news image when there is no image" do
-    organisation_image = DefaultNewsOrganisationImageData.new(file: image_fixture_file)
+    organisation_image = build(:featured_image_data)
     organisation = create(:organisation, default_news_image: organisation_image)
 
     case_study = create(:published_case_study, lead_organisations: [organisation])

--- a/test/unit/app/presenters/publishing_api/organisation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/organisation_presenter_test.rb
@@ -18,7 +18,7 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
 
   test "presents an Organisation ready for adding to the publishing API" do
     parent_organisation = create(:organisation, name: "Department for Stuff")
-    news_image = create(:default_news_organisation_image_data)
+    news_image = create(:featured_image_data)
     organisation = create(
       :organisation,
       name: "Organisation of Things",
@@ -355,5 +355,14 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
         { path: "#{organisation.base_path}.cy.atom", type: "exact" },
       ], presented_item.content[:routes]
     end
+  end
+
+  test "should ignore the default news image if all variants are not uploaded" do
+    featured_image = build(:featured_image_data)
+    featured_image.assets.destroy_all
+    organisation = build(:organisation, default_news_image: featured_image)
+    presenter = PublishingApi::OrganisationPresenter.new(organisation)
+
+    assert_nil presenter.content.dig(:details, :default_news_image)
   end
 end

--- a/test/unit/app/workers/asset_manager_create_asset_worker_test.rb
+++ b/test/unit/app/workers/asset_manager_create_asset_worker_test.rb
@@ -182,9 +182,9 @@ class AssetManagerCreateAssetWorkerTest < ActiveSupport::TestCase
 
   test "should publish model when the last file is created if the model inherits PublishesToPublishingApi module" do
     organisation = create(:organisation, :with_default_news_image)
-    last_asset = organisation.default_news_image_new.assets.last.destroy
+    last_asset = organisation.default_news_image.assets.last.destroy
     asset_params = {
-      assetable_id: organisation.default_news_image_new.id,
+      assetable_id: organisation.default_news_image.id,
       asset_variant: last_asset.variant,
       assetable_type: FeaturedImageData.to_s,
     }.deep_stringify_keys
@@ -199,9 +199,9 @@ class AssetManagerCreateAssetWorkerTest < ActiveSupport::TestCase
 
   test "should not publish model if all assets variant are not uploaded and the model inherits PublishesToPublishingApi module" do
     organisation = create(:organisation, :with_default_news_image)
-    last_asset = organisation.default_news_image_new.assets.destroy_all.last
+    last_asset = organisation.default_news_image.assets.destroy_all.last
     asset_params = {
-      assetable_id: organisation.default_news_image_new.id,
+      assetable_id: organisation.default_news_image.id,
       asset_variant: last_asset.variant,
       assetable_type: FeaturedImageData.to_s,
     }.deep_stringify_keys

--- a/test/unit/app/workers/create_asset_relationship_for_featured_image_data_worker_test.rb
+++ b/test/unit/app/workers/create_asset_relationship_for_featured_image_data_worker_test.rb
@@ -16,29 +16,29 @@ class CreateAssetRelationshipForFeaturedImageDataWorkerTest < ActiveSupport::Tes
     it("creates featured_image_data_id if default_news_organisation_image_data is present") do
       Sidekiq.logger.expects(:info).times(3)
       default_news_image_data = build(:default_news_organisation_image_data)
-      organisation = create(:organisation, default_news_image: default_news_image_data)
-      assert_nil organisation.default_news_image_new
+      organisation = create(:organisation, default_news_image_old: default_news_image_data)
+      assert_nil organisation.default_news_image
       @worker.perform(organisation.id, organisation.id)
       organisation.reload
-      assert_not_nil organisation.default_news_image_new
+      assert_not_nil organisation.default_news_image
     end
 
     it("does not creates featured_image_data_id if default_news_organisation_image_data is not present") do
       Sidekiq.logger.expects(:info).times(2)
       organisation = create(:organisation)
-      assert_nil organisation.default_news_image_new
+      assert_nil organisation.default_news_image
       @worker.perform(organisation.id, organisation.id)
       organisation.reload
-      assert_nil organisation.default_news_image_new
+      assert_nil organisation.default_news_image
     end
 
     it("maps correct carrierwave_image to featured_image_data_id") do
       Sidekiq.logger.expects(:info).times(3)
       default_news_image_data = build(:default_news_organisation_image_data)
-      organisation = create(:organisation, default_news_image: default_news_image_data)
+      organisation = create(:organisation, default_news_image_old: default_news_image_data)
       @worker.perform(organisation.id, organisation.id)
       organisation.reload
-      assert_equal organisation.default_news_image_new.carrierwave_image, organisation.default_news_image.carrierwave_image
+      assert_equal organisation.default_news_image_old.carrierwave_image, organisation.default_news_image.carrierwave_image
     end
   end
 end

--- a/test/unit/app/workers/create_asset_relationship_worker_test.rb
+++ b/test/unit/app/workers/create_asset_relationship_worker_test.rb
@@ -19,7 +19,7 @@ class CreateAssetRelationshipWorkerTest < ActiveSupport::TestCase
     organisation = build_organisation_with_default_and_featured_image
 
     @worker.perform(0, organisation.id)
-    assert_equal 7, Asset.where(assetable_type: "FeaturedImageData", assetable_id: organisation.default_news_image_new.id).count
+    assert_equal 7, Asset.where(assetable_type: "FeaturedImageData", assetable_id: organisation.default_news_image.id).count
   end
 
   it("should skip Organisation if default_news_organisation_image_data is nil") do
@@ -39,7 +39,7 @@ class CreateAssetRelationshipWorkerTest < ActiveSupport::TestCase
     Sidekiq.logger.expects(:warn).times(7).with(regexp_matches(/big-cheese.960x640.jpg/))
 
     default_news_image_data = create(:default_news_organisation_image_data, file: File.open(Rails.root.join("test/fixtures/big-cheese.960x640.jpg")))
-    create(:organisation, default_news_image: default_news_image_data, default_news_image_new: @featured_image_data)
+    create(:organisation, default_news_image_old: default_news_image_data, default_news_image: @featured_image_data)
     organisation_with_image = build_organisation_with_default_and_featured_image
 
     Services.asset_manager.stubs(:whitehall_asset).with(&ends_with("big-cheese.960x640.jpg")).raises(GdsApi::HTTPNotFound, "Error message")
@@ -72,5 +72,5 @@ def stub_assets(variant, default_news_image_data)
 end
 
 def build_organisation_with_default_and_featured_image
-  create(:organisation, default_news_image: @default_news_image_data, default_news_image_new: @featured_image_data)
+  create(:organisation, default_news_image_old: @default_news_image_data, default_news_image: @featured_image_data)
 end

--- a/test/unit/lib/whitehall/asset_manager_storage_test.rb
+++ b/test/unit/lib/whitehall/asset_manager_storage_test.rb
@@ -46,6 +46,14 @@ class Whitehall::AssetManagerStorageTest < ActiveSupport::TestCase
     assert_equal file, storage.retrieve!("identifier")
   end
 
+  test "calls AssetManagerCreateAssetWorker when uploader is invoked for FeaturedImageData " do
+    featured_image_data = build(:featured_image_data)
+    @uploader.stubs(:model).returns(featured_image_data)
+    asset_params = { assetable_id: featured_image_data.id, asset_variant: "original", assetable_type: "FeaturedImageData" }.deep_stringify_keys
+    AssetManagerCreateAssetWorker.expects(:perform_async).once.with(anything, asset_params, nil, nil, nil, [])
+    @uploader.store!(@file)
+  end
+
   context "uploader model is AttachmentData" do
     setup do
       model = build(:attachment_data)


### PR DESCRIPTION
This Change makes Organisations use Asset manager ids instead of legacy url path for Organisations default news images. It also shifts the responsiblity for Image configuration into an intermediate class FeaturedImageData which is used for all similar use cases in whitehall. This should make things more consistent across these classes.

 [Trello Card](https://trello.com/c/hxnlRSx1/205-story-defaultnewsorganisationimagedatafeaturedimagedata-to-use-assetid)
