### PR TITLE
Use Update Column instead of save when migrating topical event logos

### DIFF
--- a/lib/tasks/migrate_topical_events.rake
+++ b/lib/tasks/migrate_topical_events.rake
@@ -15,8 +15,7 @@ task :migrate_topical_events, %i[start_id end_id] => :environment do |_, args|
   topical_events.each do |topical_event|
     all_variants = topical_event.logo.versions.keys.push(:original)
     assetable = FeaturedImageData.create!(carrierwave_image: topical_event.carrierwave_image)
-    topical_event.logo_new = assetable
-    topical_event.save!
+    topical_event.update_column("featured_image_data_id", assetable.id)
 
     all_variants.each do |variant|
       path = variant == :original ? topical_event.logo.path : topical_event.logo.versions[variant].path


### PR DESCRIPTION
This is so that Topical Event would not get unnecessarily published.

https://trello.com/c/l7AHikFh/233-story-implement-non-legacy-urls-for-topical-event-logo

