### PR TITLE
Topical event to use asset ids

### DIFF
--- a/app/controllers/admin/topical_events_controller.rb
+++ b/app/controllers/admin/topical_events_controller.rb
@@ -43,8 +43,8 @@ class Admin::TopicalEventsController < Admin::BaseController
   def confirm_destroy; end
 
   def destroy
-    @topical_event.delete!
-    if @topical_event.deleted?
+    @topical_event.destroy!
+    if @topical_event.destroyed?
       redirect_to [:admin, TopicalEvent], notice: "Topical event destroyed"
     else
       redirect_to [:admin, TopicalEvent], alert: "Cannot destroy Topical event with associated content"

--- a/app/controllers/admin/topical_events_controller.rb
+++ b/app/controllers/admin/topical_events_controller.rb
@@ -61,6 +61,7 @@ class Admin::TopicalEventsController < Admin::BaseController
 
   def build_associated_objects
     @topical_event.social_media_accounts.build if @topical_event.social_media_accounts.blank?
+    @topical_event.build_logo if @topical_event.logo.blank?
   end
 
   def destroy_blank_social_media_accounts
@@ -74,14 +75,11 @@ class Admin::TopicalEventsController < Admin::BaseController
   end
 
   def object_params
-    params.require(:topical_event).permit(
+    topical_event_params = params.require(:topical_event).permit(
       :name,
       :summary,
       :description,
-      :logo,
       :logo_alt_text,
-      :logo_cache,
-      :remove_logo,
       :start_date,
       :end_date,
       related_topical_event_ids: [],
@@ -89,6 +87,17 @@ class Admin::TopicalEventsController < Admin::BaseController
       social_media_accounts_attributes: %i[social_media_service_id url _destroy id],
       featured_links_attributes: %i[title url _destroy id],
       topical_event_organisations_attributes: %i[id lead lead_ordering],
+      logo_attributes: %i[file file_cache id],
     )
+
+    clear_file_cache(topical_event_params)
+  end
+
+  def clear_file_cache(topical_event_params)
+    if topical_event_params.dig(:logo_attributes, :file).present? && topical_event_params.dig(:logo_attributes, :file_cache).present?
+      topical_event_params[:logo_attributes].delete(:file_cache)
+    end
+
+    topical_event_params
   end
 end

--- a/app/models/featured_image_data.rb
+++ b/app/models/featured_image_data.rb
@@ -15,4 +15,8 @@ class FeaturedImageData < ApplicationRecord
 
     (required_variants - asset_variants).empty?
   end
+
+  def filename
+    file&.file&.filename
+  end
 end

--- a/app/models/featured_image_data.rb
+++ b/app/models/featured_image_data.rb
@@ -9,14 +9,14 @@ class FeaturedImageData < ApplicationRecord
   validates :file, presence: true
   validates_with ImageValidator, size: [960, 640]
 
+  def filename
+    file&.file&.filename
+  end
+
   def all_asset_variants_uploaded?
     asset_variants = assets.map(&:variant).map(&:to_sym)
     required_variants = FeaturedImageUploader.versions.keys.push(:original)
 
     (required_variants - asset_variants).empty?
-  end
-
-  def filename
-    file&.file&.filename
   end
 end

--- a/app/models/social_media_account.rb
+++ b/app/models/social_media_account.rb
@@ -5,7 +5,7 @@ class SocialMediaAccount < ApplicationRecord
   after_save :republish_organisation_to_publishing_api
   after_destroy :republish_organisation_to_publishing_api
 
-  validates :social_media_service_id, presence: true
+  validates :social_media_service, presence: true
   validates :url, presence: true, uri: true
 
   include TranslatableModel

--- a/app/models/topical_event.rb
+++ b/app/models/topical_event.rb
@@ -73,7 +73,8 @@ class TopicalEvent < ApplicationRecord
            -> { where("editions.state" => "published") },
            through: :topical_event_memberships
 
-  belongs_to :logo_new, class_name: "FeaturedImageData", foreign_key: :featured_image_data_id
+  belongs_to :logo, class_name: "FeaturedImageData", foreign_key: :featured_image_data_id
+  accepts_nested_attributes_for :logo, reject_if: :all_blank
 
   scope :active, -> { where("end_date > ?", Time.zone.today) }
   scope :alphabetical, -> { order("name ASC") }
@@ -93,8 +94,6 @@ class TopicalEvent < ApplicationRecord
   accepts_nested_attributes_for :topical_event_organisations
   accepts_nested_attributes_for :topical_event_featurings
   accepts_nested_attributes_for :social_media_accounts, allow_destroy: true
-
-  mount_uploader :logo, FeaturedImageUploader, mount_on: :carrierwave_image
 
   extend FriendlyId
   friendly_id
@@ -246,9 +245,5 @@ private
 
   def more_than_a_year(from_time, to_time = 0)
     to_time > from_time + 1.year + 1.day # allow 1 day's leeway
-  end
-
-  def logo_changed?
-    changes["carrierwave_image"].present?
   end
 end

--- a/app/models/topical_event.rb
+++ b/app/models/topical_event.rb
@@ -73,7 +73,8 @@ class TopicalEvent < ApplicationRecord
            -> { where("editions.state" => "published") },
            through: :topical_event_memberships
 
-  belongs_to :logo, class_name: "FeaturedImageData", foreign_key: :featured_image_data_id, dependent: :destroy
+  has_one :logo, class_name: "FeaturedImageData", as: :featured_imageable, inverse_of: :featured_imageable, dependent: :destroy
+
   accepts_nested_attributes_for :logo, reject_if: :all_blank
 
   scope :active, -> { where("end_date > ?", Time.zone.today) }

--- a/app/models/topical_event.rb
+++ b/app/models/topical_event.rb
@@ -73,7 +73,7 @@ class TopicalEvent < ApplicationRecord
            -> { where("editions.state" => "published") },
            through: :topical_event_memberships
 
-  belongs_to :logo, class_name: "FeaturedImageData", foreign_key: :featured_image_data_id
+  belongs_to :logo, class_name: "FeaturedImageData", foreign_key: :featured_image_data_id, dependent: :destroy
   accepts_nested_attributes_for :logo, reject_if: :all_blank
 
   scope :active, -> { where("end_date > ?", Time.zone.today) }

--- a/app/presenters/publishing_api/topical_event_presenter.rb
+++ b/app/presenters/publishing_api/topical_event_presenter.rb
@@ -38,7 +38,7 @@ module PublishingApi
         details[:about_page_link_text] = item.topical_event_about_page.read_more_link_text if item.topical_event_about_page && item.topical_event_about_page.read_more_link_text
         details[:body] = body
         details[:emphasised_organisations] = item.lead_organisations.map(&:content_id)
-        details[:image] = image if item.logo_url
+        details[:image] = image if item.logo
         details[:start_date] = item.start_date.rfc3339 if item.start_date
         details[:end_date] = item.end_date.rfc3339 if item.end_date
         details[:ordered_featured_documents] = ordered_featured_documents
@@ -52,7 +52,7 @@ module PublishingApi
 
     def image
       {
-        url: item.logo_url(:s300),
+        url: item.logo.file.url(:s300),
         alt_text: item.logo_alt_text,
       }
     end

--- a/app/presenters/publishing_api/topical_event_presenter.rb
+++ b/app/presenters/publishing_api/topical_event_presenter.rb
@@ -38,7 +38,7 @@ module PublishingApi
         details[:about_page_link_text] = item.topical_event_about_page.read_more_link_text if item.topical_event_about_page && item.topical_event_about_page.read_more_link_text
         details[:body] = body
         details[:emphasised_organisations] = item.lead_organisations.map(&:content_id)
-        details[:image] = image if item.logo
+        details[:image] = image if item.logo && item.logo.all_asset_variants_uploaded?
         details[:start_date] = item.start_date.rfc3339 if item.start_date
         details[:end_date] = item.end_date.rfc3339 if item.end_date
         details[:ordered_featured_documents] = ordered_featured_documents

--- a/app/uploaders/featured_image_uploader.rb
+++ b/app/uploaders/featured_image_uploader.rb
@@ -6,7 +6,6 @@ class FeaturedImageUploader < WhitehallUploader
   end
 
   configure do |config|
-    config.remove_previously_stored_files_after_update = false
     config.validate_integrity = true
   end
 

--- a/app/views/admin/topical_events/_form.html.erb
+++ b/app/views/admin/topical_events/_form.html.erb
@@ -42,18 +42,18 @@
   <div class="govuk-!-margin-bottom-8">
     <%= render "components/single-image-upload", {
       title: "Logo",
-      name: "topical_event",
-      image_id: "topical_event_logo",
-      image_name: "topical_event[logo]",
+      name: "topical_event[logo_attributes]",
+      image_id: "topical_event_logo_file",
+      image_name: "topical_event[logo_attributes][file]",
       alt_text_name: "topical_event[logo_alt_text]",
       alt_text_id: "topical_event_logo_alt_text",
       filename: topical_event.logo.filename,
       page_errors: topical_event.errors.any?,
-      error_items: errors_for(topical_event.errors, :logo),
-      image_src: topical_event.logo.url,
+      error_items: errors_for(topical_event.errors, :"logo.file"),
+      image_src: topical_event.logo.file.url,
       image_alt: topical_event.logo_alt_text,
-      image_cache_name: "topical_event[logo_cache]",
-      image_cache: (topical_event.logo.image_cache.presence),
+      image_cache_name: "topical_event[logo_attributes][file_cache]",
+      image_cache: (topical_event.logo.file_cache.presence),
     } %>
   </div>
 

--- a/app/views/admin/topical_events/_form.html.erb
+++ b/app/views/admin/topical_events/_form.html.erb
@@ -40,6 +40,7 @@
   } %>
 
   <div class="govuk-!-margin-bottom-8">
+    <%= hidden_field_tag "topical_event[logo_attributes][id]", topical_event.logo.id %>
     <%= render "components/single-image-upload", {
       title: "Logo",
       name: "topical_event[logo_attributes]",

--- a/db/migrate/20231027134216_drop_featured_image_id_from_topical_events.rb
+++ b/db/migrate/20231027134216_drop_featured_image_id_from_topical_events.rb
@@ -1,0 +1,5 @@
+class DropFeaturedImageIdFromTopicalEvents < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :topical_events, :featured_image_data_id, :bigint
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_27_095017) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_27_134216) do
   create_table "assets", charset: "utf8mb3", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.string "variant", null: false
@@ -1094,8 +1094,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_27_095017) do
     t.date "end_date"
     t.string "content_id"
     t.text "summary"
-    t.bigint "featured_image_data_id"
-    t.index ["featured_image_data_id"], name: "index_topical_events_on_featured_image_data_id"
     t.index ["slug"], name: "index_topical_events_on_slug"
   end
 

--- a/lib/whitehall/asset_manager_storage.rb
+++ b/lib/whitehall/asset_manager_storage.rb
@@ -102,7 +102,7 @@ class Whitehall::AssetManagerStorage < CarrierWave::Storage::Abstract
   def self.use_non_legacy_behaviour?(model)
     return unless model
 
-    return true if model.instance_of?(AttachmentData) || model.instance_of?(ImageData) || model.instance_of?(Organisation)
+    return true if model.instance_of?(AttachmentData) || model.instance_of?(ImageData) || model.instance_of?(Organisation) || model.instance_of?(FeaturedImageData)
 
     model.respond_to?("use_non_legacy_endpoints") && model.use_non_legacy_endpoints
   end

--- a/test/factories/topical_events.rb
+++ b/test/factories/topical_events.rb
@@ -13,5 +13,11 @@ FactoryBot.define do
       logo { build(:featured_image_data) }
       logo_alt_text { "Alternative text" }
     end
+
+    trait :with_social_media_accounts do
+      after :build do |topical_event|
+        topical_event.social_media_accounts << build(:social_media_account)
+      end
+    end
   end
 end

--- a/test/factories/topical_events.rb
+++ b/test/factories/topical_events.rb
@@ -3,9 +3,15 @@ FactoryBot.define do
     sequence(:name) { |index| "topical-event-#{index}" }
     summary { "Topical event summary" }
     description { "Topical event description" }
+
     trait :active do
       start_date { Time.zone.today - 1.month }
       end_date { Time.zone.today + 1.month }
+    end
+
+    trait :with_logo do
+      logo { build(:featured_image_data) }
+      logo_alt_text { "Alternative text" }
     end
   end
 end

--- a/test/functional/admin/topical_events_controller_test.rb
+++ b/test/functional/admin/topical_events_controller_test.rb
@@ -159,11 +159,15 @@ class Admin::TopicalEventsControllerTest < ActionController::TestCase
     assert_equal topical_event, assigns(:topical_event)
   end
 
-  test "DELETE :destroy deletes the topical event" do
-    topical_event = create(:topical_event)
+  test "DELETE :destroy deletes the topical event and dependent classes" do
+    topical_event = create(:topical_event, :with_logo, :with_social_media_accounts)
+    logo = topical_event.logo
+    social_media_account = topical_event.social_media_accounts.first
     delete :destroy, params: { id: topical_event }
 
     assert_response :redirect
-    assert topical_event.reload.deleted?
+    assert_nil TopicalEvent.find_by(id: topical_event.id)
+    assert_nil FeaturedImageData.find_by(id: logo.id)
+    assert_nil SocialMediaAccount.find_by(id: social_media_account.id)
   end
 end

--- a/test/integration/asset_manager_test.rb
+++ b/test/integration/asset_manager_test.rb
@@ -185,6 +185,7 @@ class AssetManagerIntegrationTest
 
     test "sends the new image and its versions to asset manager" do
       expected_number_of_versions = @person.image.versions.size + 1
+      Services.asset_manager.stubs(:whitehall_asset).returns("id" => "http://asset-manager/assets/asset-id")
       Services.asset_manager.expects(:create_whitehall_asset).times(expected_number_of_versions)
 
       @person.image = File.open(fixture_path.join("big-cheese.960x640.jpg"))
@@ -194,8 +195,9 @@ class AssetManagerIntegrationTest
       end
     end
 
-    test "does not remove the original images from asset manager" do
-      Services.asset_manager.expects(:delete_asset).never
+    test "removes the original images from asset manager" do
+      Services.asset_manager.stubs(:whitehall_asset).returns("id" => "http://asset-manager/assets/asset-id")
+      Services.asset_manager.expects(:delete_asset).with("asset-id").times(7)
 
       @person.image = File.open(fixture_path.join("big-cheese.960x640.jpg"))
 

--- a/test/unit/app/models/topical_event_test.rb
+++ b/test/unit/app/models/topical_event_test.rb
@@ -286,23 +286,24 @@ class TopicalEventTest < ActiveSupport::TestCase
 
   test "rejects SVG logo uploads" do
     svg_logo = File.open(Rails.root.join("test/fixtures/images/test-svg.svg"))
-    topical_event = build(:topical_event, logo: svg_logo)
+    logo = build(:featured_image_data, file: svg_logo)
+    topical_event = build(:topical_event, logo:)
 
     assert_not topical_event.valid?
-    assert_equal topical_event.errors.first.full_message, "Logo You are not allowed to upload \"svg\" files, allowed types: jpg, jpeg, gif, png"
+    assert_equal topical_event.errors.first.full_message, "Logo file You are not allowed to upload \"svg\" files, allowed types: jpg, jpeg, gif, png"
   end
 
   test "rejects non-image file uploads" do
     non_image_file = File.open(Rails.root.join("test/fixtures/folders.zip"))
-    topical_event = build(:topical_event, logo: non_image_file)
+    logo = build(:featured_image_data, file: non_image_file)
+    topical_event = build(:topical_event, logo:)
 
     assert_not topical_event.valid?
-    assert_includes topical_event.errors.map(&:full_message), "Logo You are not allowed to upload \"zip\" files, allowed types: jpg, jpeg, gif, png"
+    assert_includes topical_event.errors.map(&:full_message), "Logo file You are not allowed to upload \"zip\" files, allowed types: jpg, jpeg, gif, png"
   end
 
   test "accepts valid image uploads" do
-    jpg_image = File.open(Rails.root.join("test/fixtures/big-cheese.960x640.jpg"))
-    topical_event = build(:topical_event, logo: jpg_image)
+    topical_event = build(:topical_event, :with_logo)
 
     assert topical_event
     assert_empty topical_event.errors

--- a/test/unit/app/presenters/publishing_api/topical_event_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/topical_event_presenter_test.rb
@@ -4,11 +4,10 @@ class PublishingApi::TopicalEventPresenterTest < ActiveSupport::TestCase
   test "presents a valid topical_event content item" do
     topical_event = create(
       :topical_event,
+      :with_logo,
       :active,
       name: "Humans going to Mars",
       description: "A topical event description with [a link](http://www.gov.uk)",
-      logo: upload_fixture("images/960x640_jpeg.jpg", "image/jpeg"),
-      logo_alt_text: "Alternative text",
     )
     create(:topical_event_about_page, topical_event:, read_more_link_text: "Read more about this event")
 
@@ -53,7 +52,7 @@ class PublishingApi::TopicalEventPresenterTest < ActiveSupport::TestCase
         body: Whitehall::GovspeakRenderer.new.govspeak_to_html(topical_event.description),
         emphasised_organisations: [first_lead_org.content_id, second_lead_org.content_id],
         image: {
-          url: topical_event.logo_url(:s300),
+          url: topical_event.logo.file.url(:s300),
           alt_text: topical_event.logo_alt_text,
         },
         start_date: topical_event.start_date.rfc3339,

--- a/test/unit/app/presenters/publishing_api/topical_event_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/topical_event_presenter_test.rb
@@ -159,4 +159,13 @@ class PublishingApi::TopicalEventPresenterTest < ActiveSupport::TestCase
 
     assert_equal FeaturedLink::DEFAULT_SET_SIZE, presenter.content.dig(:details, :ordered_featured_documents).length
   end
+
+  test "it ignores the logo if variants are missing" do
+    topical_event = create(:topical_event, :with_logo)
+    topical_event.logo.assets.destroy_all
+
+    presenter = PublishingApi::TopicalEventPresenter.new(topical_event)
+
+    assert_nil presenter.content.dig(:details, :image)
+  end
 end


### PR DESCRIPTION
This Change makes Topical Events use Asset manager ids instead of legacy url path for Topical Event images. It also shifts the responsiblity for Image configuration into an intermediate class `FeaturedImageData` which is used for all similar use cases in whitehall. This should make things more consistent across these classes.

[Trello](https://trello.com/c/l7AHikFh/233-story-implement-non-legacy-urls-for-topical-event-logo)