### PR TITLE
Add page title and context to legend for better accessibility

### DIFF
--- a/app/assets/stylesheets/admin/views/_document-collection-group-document-search-search-title-slug.scss
+++ b/app/assets/stylesheets/admin/views/_document-collection-group-document-search-search-title-slug.scss
@@ -1,3 +1,9 @@
+.app-view-document_collection_group_document_search {
+  .govuk-fieldset__heading {
+    @include govuk-responsive-margin(3, "bottom");
+  }
+}
+
 .app-view-document-collection-document-search-results__table {
   .govuk-table__cell:nth-child(2) {
     white-space: nowrap;

--- a/app/views/admin/document_collection_group_document_search/search_options.html.erb
+++ b/app/views/admin/document_collection_group_document_search/search_options.html.erb
@@ -4,9 +4,6 @@
   } %>
 <% end %>
 <% content_for :page_title, "Add document" %>
-<% content_for :title, "Add document" %>
-<% content_for :context, @group.heading %>
-<% content_for :title_margin_bottom, 6 %>
 
 <%
   search_options = [
@@ -22,10 +19,13 @@
 %>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-column-two-thirds app-view-document_collection_group_document_search">
     <%= form_with url: admin_document_collection_group_search_options_path(@collection, @group) do %>
       <%= render "govuk_publishing_components/components/radio", {
         name: "search_option",
+        heading: "Add document",
+        heading_caption: @group.heading,
+        heading_level: 1,
         id: "search_option",
         items: search_options,
       } %>


### PR DESCRIPTION
[Trello](https://trello.com/c/UQud03Sn/599-accessibility-improvement-on-document-collections-adding-by-url-title-section)

This change makes a small change to the Document Collections search options page. For improved accessibility it adds the page title to the `<legend>` element. This improves context for assistive technology. 

It also required a small piece of additional CSS to retain the spacing from the design. 

![Screenshot 2023-10-27 at 13 36 40](https://github.com/alphagov/whitehall/assets/6080548/eb06aab6-207a-46c8-bae7-5a3198bfd237)
