### PR TITLE
Transition fo sub navigation bar to design system

### DIFF
--- a/app/helpers/admin/sub_nav_helper.rb
+++ b/app/helpers/admin/sub_nav_helper.rb
@@ -1,0 +1,9 @@
+module Admin::SubNavHelper
+  def sub_nav_item(name, path)
+    {
+      label: name,
+      href: path,
+      current: request.path.start_with?(path),
+    }
+  end
+end

--- a/app/views/components/_sub_navigation.html.erb
+++ b/app/views/components/_sub_navigation.html.erb
@@ -1,20 +1,16 @@
 <%
   items ||= []
 %>
-<%= tag.div class: "govuk-grid-row app-c-sub-navigation" do %>
-  <%= tag.div class: "govuk-grid-column-full" do %>
-    <%= tag.nav role: "navigation", aria: { label: "Sub Navigation" } do %>
-      <%= tag.ul class: "app-c-sub-navigation__list" do %>
-        <% items.each do |item| %>
-          <%
-            item_classes = %w( app-c-sub-navigation__list-item )
-            item_classes << "app-c-sub-navigation__list-item--current" if item[:current]
-            item_aria_attributes = { current: "page" } if item[:current]
-          %>
-          <%= tag.li class: item_classes do %>
-            <%= link_to item[:label], item[:href], class: "govuk-link govuk-link--no-visited-state govuk-link--no-underline app-c-sub-navigation__list-item-link", data: item[:data_attributes], aria: item_aria_attributes %>
-          <% end %>
-        <% end %>
+<%= tag.nav class: "app-c-sub-navigation", role: "navigation", aria: { label: "Sub Navigation" } do %>
+  <%= tag.ul class: "app-c-sub-navigation__list" do %>
+    <% items.each do |item| %>
+      <%
+        item_classes = %w( app-c-sub-navigation__list-item )
+        item_classes << "app-c-sub-navigation__list-item--current" if item[:current]
+        item_aria_attributes = { current: "page" } if item[:current]
+      %>
+      <%= tag.li class: item_classes do %>
+        <%= link_to item[:label], item[:href], class: "govuk-link govuk-link--no-visited-state govuk-link--no-underline app-c-sub-navigation__list-item-link", data: item[:data_attributes], aria: item_aria_attributes %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,71 +1,61 @@
 <% environment = GovukPublishingComponents::AppHelpers::Environment.current_acceptance_environment %>
 <% admin_template ||= false %>
+<% organisation = current_user&.organisation %>
 
-  <%= render "govuk_publishing_components/components/layout_header", {
-    product_name: "Whitehall Publisher",
-    environment: environment,
-    navigation_items: [
-      {
-        text: "Dashboard",
-        href: admin_root_path,
-      },
-      {
-        text: "View website",
-        href: Whitehall.public_root,
-      },
-      {
-        text: "Switch app",
-        href: Plek.external_url_for("signon"),
-      },
+<%= render "govuk_publishing_components/components/layout_header", {
+  product_name: "Whitehall Publisher",
+  environment: environment,
+  navigation_items: [
+    {
+      text: "Dashboard",
+      href: admin_root_path,
+    },
+    {
+      text: "View website",
+      href: Whitehall.public_root,
+    },
+    {
+      text: "Switch app",
+      href: Plek.external_url_for("signon"),
+    },
+    *(
+      if user_signed_in?
+        [{
+           text: current_user.name,
+           href: admin_user_path(current_user),
+         },
+         {
+           text: "Logout",
+           href: "/auth/gds/sign_out",
+         }]
+      end),
+    {
+      text: "All users",
+      href: admin_users_path,
+    },
+  ],
+} %>
+
+<div class="govuk-width-container">
+  <%= render "components/sub_navigation", {
+    items: [
+      sub_nav_item("New document", admin_new_document_path),
+      sub_nav_item("Documents", admin_editions_path),
+      sub_nav_item("Statistics announcements", admin_statistics_announcements_path),
       *(
-        if user_signed_in?
-          [{
-             text: current_user.name,
-             href: admin_user_path(current_user),
-           },
-           {
-             text: "Logout",
-             href: "/auth/gds/sign_out",
-           }]
+        if user_signed_in? && organisation
+          [
+            sub_nav_item("Featured documents", features_admin_organisation_path(organisation, locale: nil)),
+            sub_nav_item("Corporate information", admin_organisation_corporate_information_pages_path(organisation)),
+          ]
         end),
-      {
-        text: "All users",
-        href: admin_users_path,
-      },
+      sub_nav_item("More", admin_more_path),
     ],
   } %>
+</div>
 
-  <div class="container-fluid">
-    <ul id="global-nav" class="masthead-tabs list-unstyled">
-      <li class="masthead-tab-item js-create-new create-new" data-module="navbar-toggle">
-        <a href="#new-document-menu" class="toggler js-navbar-toggle__toggler" id="new-document-label">New document</a>
-        <%= document_creation_dropdown %>
-      </li>
-      <%= admin_documents_header_link %>
-      <%= admin_statistics_announcements_link %>
-      <%= admin_featured_header_link %>
-      <%= admin_user_organisation_header_link %>
-      <li class="js-more-nav masthead-tab-item" data-module="navbar-toggle">
-        <a href="#more-links-menu" id="more-links-label" class="toggler js-navbar-toggle__toggler">More</a>
-        <ul id="more-links-menu" class="masthead-menu masthead-menu-right js-hidden unstyled js-navbar-toggle__menu hide-before-js-module-init" role="menu" aria-labelledby="more-links-label">
-          <%= admin_organisations_header_menu_link %>
-          <%= admin_policy_groups_header_menu_link %>
-          <%= admin_roles_header_menu_link %>
-          <%= admin_people_header_menu_link %>
-          <%= admin_topical_events_header_menu_link %>
-          <%= admin_worldwide_organisations_header_menu_link %>
-          <%= admin_world_location_news_header_menu_link %>
-          <%= admin_fields_of_operation_header_menu_link %>
-          <%= admin_cabinet_ministers_header_menu_link %>
-          <%= admin_get_involved_header_menu_link %>
-          <%= admin_sitewide_settings_header_menu_link %>
-          <%= admin_governments_header_menu_link %>
-        </ul>
-      </li>
-    </ul>
-  </div>
-  <% if admin_template %>
-    <section class="notices">
-      <%= render partial: "shared/notices" %>
-    </section>
-  <% end %>
+<% if admin_template %>
+  <section class="notices">
+    <%= render partial: "shared/notices" %>
+  </section>
+<% end %>

--- a/test/functional/admin/base_controller_test.rb
+++ b/test/functional/admin/base_controller_test.rb
@@ -1,24 +1,156 @@
 require "test_helper"
 
 class Admin::BaseControllerTest < ActionController::TestCase
-  setup do
-    login_as_preview_design_system_user :gds_editor
-  end
+  include GdsApi::TestHelpers::PublishingApi
 
-  view_test "should render new header component if login as a design system user" do
-    @controller = Admin::DashboardController.new
+  view_test "renders new header component if login as a design system user" do
+    login_as_preview_design_system_user :gds_editor, create(:organisation, name: "my-test-org")
+    @controller = Admin::NewDocumentController.new
+
     get :index
 
     assert_select ".gem-c-layout-header__logo", text: /Whitehall Publisher/
     assert_select ".govuk-header__navigation-item", text: "Dashboard"
   end
 
-  view_test "should render legacy header component if login as a non design system user" do
+  view_test "renders new sub-navigation header component if login as a design system user" do
+    login_as_preview_design_system_user :gds_editor, create(:organisation, name: "my-test-org")
+    @controller = Admin::NewDocumentController.new
+
+    get :index
+
+    assert_select ".app-c-sub-navigation", count: 1
+    assert_select ".app-c-sub-navigation__list .app-c-sub-navigation__list-item a[href=\"/government/admin/new-document\"]", text: "New document"
+    assert_select ".app-c-sub-navigation__list .app-c-sub-navigation__list-item a[href=\"/government/admin/editions\"]", text: "Documents"
+    assert_select ".app-c-sub-navigation__list .app-c-sub-navigation__list-item a[href=\"/government/admin/statistics_announcements\"]", text: "Statistics announcements"
+    assert_select ".app-c-sub-navigation__list .app-c-sub-navigation__list-item a[href=\"/government/admin/organisations/my-test-org/features\"]", text: "Featured documents"
+    assert_select ".app-c-sub-navigation__list .app-c-sub-navigation__list-item a[href=\"/government/admin/organisations/my-test-org/corporate_information_pages\"]", text: "Corporate information"
+    assert_select ".app-c-sub-navigation__list .app-c-sub-navigation__list-item a[href=\"/government/admin/more\"]", text: "More"
+  end
+
+  view_test "highlights the 'New documents' tab when it is the currently selected tab" do
+    login_as_preview_design_system_user :gds_editor, create(:organisation, name: "my-test-org")
+    @controller = Admin::NewDocumentController.new
+
+    get :index
+
+    assert_current_item("/government/admin/new-document")
+    assert_not_current_item("/government/admin/editions")
+    assert_not_current_item("/government/admin/statistics_announcements")
+    assert_not_current_item("/government/admin/organisations/my-test-org/features")
+    assert_not_current_item("/government/admin/organisations/my-test-org/corporate_information_pages")
+    assert_not_current_item("/government/admin/more")
+  end
+
+  view_test "highlights the 'Documents' tab when it is the currently selected tab" do
+    login_as_preview_design_system_user :gds_editor, create(:organisation, name: "my-test-org")
+    @controller = Admin::EditionsController.new
+
+    get :index, params: { type: 1 }
+
+    assert_current_item("/government/admin/editions")
+    assert_not_current_item("/government/admin/new-document")
+    assert_not_current_item("/government/admin/statistics_announcements")
+    assert_not_current_item("/government/admin/organisations/my-test-org/features")
+    assert_not_current_item("/government/admin/organisations/my-test-org/corporate_information_pages")
+    assert_not_current_item("/government/admin/more")
+  end
+
+  view_test "highlights the 'Statistics announcements' tab when it is the currently selected tab" do
+    login_as_preview_design_system_user :gds_editor, create(:organisation, name: "my-test-org")
+    @controller = Admin::StatisticsAnnouncementsController.new
+
+    get :index
+
+    assert_current_item("/government/admin/statistics_announcements")
+    assert_not_current_item("/government/admin/new-document")
+    assert_not_current_item("/government/admin/editions")
+    assert_not_current_item("/government/admin/organisations/my-test-org/features")
+    assert_not_current_item("/government/admin/organisations/my-test-org/corporate_information_pages")
+    assert_not_current_item("/government/admin/more")
+  end
+
+  view_test "highlights the 'Features' tab when it is the currently selected tab" do
+    my_test_org = create(:organisation, name: "my-test-org")
+    login_as_preview_design_system_user :gds_editor, my_test_org
+    @controller = Admin::OrganisationsController.new
+
+    get :features, params: { id: my_test_org }
+
+    assert_current_item("/government/admin/organisations/my-test-org/features")
+    assert_not_current_item("/government/admin/new-document")
+    assert_not_current_item("/government/admin/editions")
+    assert_not_current_item("/government/admin/statistics_announcements")
+    assert_not_current_item("/government/admin/organisations/my-test-org/corporate_information_pages")
+    assert_not_current_item("/government/admin/more")
+  end
+
+  view_test "highlights the 'Corporate information pages' tab when it is the currently selected tab" do
+    my_test_org = create(:organisation, name: "my-test-org")
+    login_as_preview_design_system_user :gds_editor, my_test_org
+    @controller = Admin::CorporateInformationPagesController.new
+
+    get :index, params: { organisation_id: my_test_org }
+
+    assert_current_item("/government/admin/organisations/my-test-org/corporate_information_pages")
+    assert_not_current_item("/government/admin/new-document")
+    assert_not_current_item("/government/admin/editions")
+    assert_not_current_item("/government/admin/statistics_announcements")
+    assert_not_current_item("/government/admin/organisations/my-test-org/features")
+    assert_not_current_item("/government/admin/more")
+  end
+
+  view_test "highlights the 'More' tab when it is the currently selected tab" do
+    login_as_preview_design_system_user :gds_editor, create(:organisation, name: "my-test-org")
+    @controller = Admin::MoreController.new
+
+    get :index
+
+    assert_current_item("/government/admin/more")
+    assert_not_current_item("/government/admin/new-document")
+    assert_not_current_item("/government/admin/editions")
+    assert_not_current_item("/government/admin/statistics_announcements")
+    assert_not_current_item("/government/admin/organisations/my-test-org/corporate_information_pages")
+    assert_not_current_item("/government/admin/organisations/my-test-org/features")
+  end
+
+  view_test "only renders non-organisation header links if not logged in" do
+    # It's not possible, at the moment, to show the new design system layout if no user is signed in,
+    # but once we remove the legacy layout, the design system will be the default layout. In order to
+    # test this for now we stub some BaseController methods—this stubbing won't be necessary once the
+    # design system transition has been completed.
+    Admin::BaseController.any_instance.stubs(:show_new_header?).returns(true)
+    Admin::BaseController.any_instance.stubs(:preview_design_system?).returns(true)
+    @controller = Admin::NewDocumentController.new
+
+    get :index
+
+    assert_select ".app-c-sub-navigation__list .app-c-sub-navigation__list-item a[href=\"/government/admin/organisations/my-test-org/features\"]", false
+    assert_select ".app-c-sub-navigation__list .app-c-sub-navigation__list-item a[href=\"/government/admin/organisations/my-test-org/corporate_information_pages\"]", false
+
+    assert_select ".app-c-sub-navigation__list .app-c-sub-navigation__list-item a[href=\"/government/admin/new-document\"]"
+    assert_select ".app-c-sub-navigation__list .app-c-sub-navigation__list-item a[href=\"/government/admin/editions\"]"
+    assert_select ".app-c-sub-navigation__list .app-c-sub-navigation__list-item a[href=\"/government/admin/statistics_announcements\"]"
+    assert_select ".app-c-sub-navigation__list .app-c-sub-navigation__list-item a[href=\"/government/admin/more\"]"
+  end
+
+  view_test "renders legacy header component if login as a non design system user" do
     login_as :gds_editor
-    @controller = Admin::DashboardController.new
+    @controller = Admin::NewDocumentController.new
+
     get :index
 
     assert_select ".govuk-header__navigation-item", false
     assert_select ".nav.navbar-nav", text: /Dashboard/
+  end
+
+private
+
+  def assert_not_current_item(path)
+    assert_select ".app-c-sub-navigation__list-item--current a[href=\"#{path}\"]", false
+  end
+
+  def assert_current_item(path)
+    assert_select ".app-c-sub-navigation__list-item--current a[href=\"#{path}\"]"
   end
 end


### PR DESCRIPTION
## What
This PR transits sub-navigation bar to design system.

It does the following:
- Update the header layout with new sub-nav design layout.
- Update BaseController test with new unit tests for sub-nav.
- Modified Sub-navigation component to have generic styling.
- Highlight the currently selected tab.

## Screenshots
<img width="1358" alt="image" src="https://github.com/alphagov/whitehall/assets/138604938/1bb353e4-1302-4aa1-be7a-dec0ab4bd8b0">

<img width="1382" alt="image" src="https://github.com/alphagov/whitehall/assets/138604938/29025ca7-df84-436d-bc35-b13fe248d160">

<img width="1358" alt="image" src="https://github.com/alphagov/whitehall/assets/138604938/b2cf7597-a004-4bbd-802a-dec89365aa51">

<img width="1344" alt="image" src="https://github.com/alphagov/whitehall/assets/138604938/f704afbe-6adb-47a6-9120-eef2dfad02c5">

<img width="1362" alt="image" src="https://github.com/alphagov/whitehall/assets/138604938/93cadf31-a068-4229-8da9-3f9beaefdf5b">

<img width="1401" alt="image" src="https://github.com/alphagov/whitehall/assets/138604938/4117349a-5c11-4a16-9301-2435f48922a8">


## Trello
https://trello.com/c/LsOoy6Dv/563-transition-sub-navigation-bar-to-the-new-design-system
