### PR TITLE
Add edition_lead_image joins table and model associations

### DIFF
--- a/app/models/edition/lead_image.rb
+++ b/app/models/edition/lead_image.rb
@@ -1,6 +1,11 @@
 module Edition::LeadImage
   extend ActiveSupport::Concern
 
+  included do
+    has_one :edition_lead_image, foreign_key: :edition_id, dependent: :destroy
+    has_one :lead_image, through: :edition_lead_image, source: :image
+  end
+
   def has_lead_image?
     !image_data.nil?
   end

--- a/app/models/edition_lead_image.rb
+++ b/app/models/edition_lead_image.rb
@@ -1,0 +1,4 @@
+class EditionLeadImage < ApplicationRecord
+  belongs_to :edition
+  belongs_to :image
+end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,6 +1,7 @@
 class Image < ApplicationRecord
   belongs_to :image_data
   belongs_to :edition
+  has_one :edition_lead_image, dependent: :destroy
 
   validates :alt_text, presence: true, allow_blank: true, length: { maximum: 255 }, unless: :skip_main_validation?
   validates :image_data, presence: { message: "must be present" }

--- a/db/migrate/20231030075543_create_edition_lead_images.rb
+++ b/db/migrate/20231030075543_create_edition_lead_images.rb
@@ -1,0 +1,11 @@
+class CreateEditionLeadImages < ActiveRecord::Migration[7.0]
+  def change
+    create_table :edition_lead_images do |t|
+      t.integer "edition_id", foreign_key: true
+      t.integer "image_id", foreign_key: true
+      t.index %w[edition_id], name: "index_lead_image_on_edition_id", unique: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_10_27_134216) do
+ActiveRecord::Schema[7.0].define(version: 2023_10_30_075543) do
   create_table "assets", charset: "utf8mb3", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.string "variant", null: false
@@ -262,6 +262,14 @@ ActiveRecord::Schema[7.0].define(version: 2023_10_27_134216) do
     t.integer "dependable_id"
     t.string "dependable_type"
     t.index ["dependable_id", "dependable_type", "edition_id"], name: "index_edition_dependencies_on_dependable_and_edition", unique: true
+  end
+
+  create_table "edition_lead_images", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.integer "edition_id"
+    t.integer "image_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["edition_id"], name: "index_lead_image_on_edition_id", unique: true
   end
 
   create_table "edition_organisations", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|


### PR DESCRIPTION
## Description

We're going to add in functionality for users to select a lead image. An approach has been agreed in this PR https://github.com/alphagov/whitehall/pull/8416.

The approach will be to create an  lead_image table, which contains and image_id and edition_id. This PR adds a migration for this table, adds the EditionLeadImage model and adds the relevant associations in the models edition and image models.

This should be a has_one as an edition should only ever be able to have one lead image. I've added a unique constraint to on edition_id to enforce this.

## Trello card

https://trello.com/c/5vCiIxeQ/1064-lead-image-handling-backend-work

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
