### PR TITLE
Provide more image sizes for topical events

### DIFF
--- a/app/presenters/publishing_api/topical_event_presenter.rb
+++ b/app/presenters/publishing_api/topical_event_presenter.rb
@@ -53,6 +53,8 @@ module PublishingApi
     def image
       {
         url: item.logo.file.url(:s300),
+        medium_resolution_url: item.logo.file.url(:s630),
+        high_resolution_url: item.logo.file.url(:s960),
         alt_text: item.logo_alt_text,
       }
     end

--- a/test/unit/app/presenters/publishing_api/topical_event_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/topical_event_presenter_test.rb
@@ -53,6 +53,8 @@ class PublishingApi::TopicalEventPresenterTest < ActiveSupport::TestCase
         emphasised_organisations: [first_lead_org.content_id, second_lead_org.content_id],
         image: {
           url: topical_event.logo.file.url(:s300),
+          medium_resolution_url: topical_event.logo.file.url(:s630),
+          high_resolution_url: topical_event.logo.file.url(:s960),
           alt_text: topical_event.logo_alt_text,
         },
         start_date: topical_event.start_date.rfc3339,


### PR DESCRIPTION
Topical Event pages are rendered with a srcset attribute that provides various image sizes for the devices to choose from. In order for the attribute to work, these urls need to be provided by whitehall.

[Trello](https://trello.com/c/l7AHikFh/233-story-implement-non-legacy-urls-for-topical-event-logo)
