### PR TITLE
Fix bug with update_lead_image method

### DIFF
--- a/app/models/edition/custom_lead_image.rb
+++ b/app/models/edition/custom_lead_image.rb
@@ -15,7 +15,10 @@ module Edition::CustomLeadImage
   end
 
   def update_lead_image
-    remove_lead_image and return if %w[no_image organisation_image].include?(image_display_option)
+    if %w[no_image organisation_image].include?(image_display_option)
+      remove_lead_image
+      return
+    end
 
     return if lead_image.present? || images.blank?
 

--- a/test/unit/app/models/edition/custom_lead_image_test.rb
+++ b/test/unit/app/models/edition/custom_lead_image_test.rb
@@ -55,9 +55,15 @@ class Edition::CustomLeadImageTest < ActiveSupport::TestCase
     edition_lead_image = build(:edition_lead_image)
     edition = build(:news_article, image_display_option: "no_image", edition_lead_image:)
 
+    edition.stubs(:images).returns([edition_lead_image.image])
+
     edition_lead_image
     .expects(:destroy!)
     .once
+
+    edition
+    .expects(:build_edition_lead_image)
+    .never
 
     edition.update_lead_image
   end
@@ -65,24 +71,38 @@ class Edition::CustomLeadImageTest < ActiveSupport::TestCase
   test "#update_lead_image deletes the associated edition_lead_image if image_display_option is 'organisation_image'" do
     edition_lead_image = build(:edition_lead_image)
     edition = build(:news_article, image_display_option: "organisation_image", edition_lead_image:)
+    edition.stubs(:images).returns([edition_lead_image.image])
 
     edition_lead_image
     .expects(:destroy!)
     .once
+
+    edition
+    .expects(:build_edition_lead_image)
+    .never
 
     edition.update_lead_image
   end
 
   test "#update_lead_image returns nil if lead_image is present" do
     edition = build(:news_article)
-    build(:image)
-    edition.stubs(:lead_image).returns(edition)
+    image = build(:image)
+    edition.stubs(:lead_image).returns(image)
+
+    edition
+    .expects(:build_edition_lead_image)
+    .never
 
     assert_nil edition.update_lead_image
   end
 
   test "#update_lead_image returns nil if no images are present" do
     edition = build(:news_article)
+
+    edition
+    .expects(:build_edition_lead_image)
+    .never
+
     assert_nil edition.update_lead_image
   end
 end


### PR DESCRIPTION
## Description

The 'and return if' isn't returning when the `image_display_option` is `no_image` or `organisation_image`.

This means that when an image is created and the lead_image isn't set the association is created.

It still wouldn't be pushed downstream to Publishing API as the presenter handles passing the image based on the `image_display_option`, but we shouldn't have lead images sitting in the db when there isn't a lead image.

This updates the method to explicitly call return within the conditional which resolves the issue.

## Trello card

https://trello.com/c/5vCiIxeQ/1064-lead-image-handling-backend-work

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
