### PR TITLE
Fix orphaned attachment data error

### DIFF
--- a/app/services/asset_manager/attachment_updater.rb
+++ b/app/services/asset_manager/attachment_updater.rb
@@ -1,12 +1,15 @@
 class AssetManager::AttachmentUpdater
   def self.call(attachment_data)
-    return if attachment_data.deleted? || attachment_data.attachments.first.attachable.nil?
+    return if attachment_data.deleted?
 
     asset_attributes = {
       "access_limited_organisation_ids" => attachment_data.access_limitation,
       "draft" => attachment_data.draft? && !(attachment_data.replaced? || attachment_data.unpublished?),
-      "parent_document_url" => attachment_data.attachable_url,
     }
+
+    unless attachment_data.replaced?
+      asset_attributes.merge!({ "parent_document_url" => attachment_data.attachable_url })
+    end
 
     attachment_data.assets.each do |asset|
       AssetManager::AssetUpdater.call(asset.asset_manager_id, attachment_data, nil, asset_attributes)


### PR DESCRIPTION
Fixes a bug introduced in 78eb085. That commit added a guard clause which was intended to prevent attachments that had become unattached from their edition from being updated in asset manager, but that was based on an incorrect assumption about how the system should behave. As far as we're aware, there shouldn't be attachments without an attachable.

However, we do need to ensure that attachment data records that have been replaced and are therefore no longer associated with any attachments can still be accessed, as they are likely to be associated with a publicly visible attachable. This commit changes the draft attachment data replacement test to ensure that the behaviour matches that of the AttachmentUpdater prior to 78eb085.

Trello: https://trello.com/c/1d36FU0D
Sentry issue: https://govuk.sentry.io/issues/4586842900/
