### PR TITLE
Refactor UploadedImagesComponent

### DIFF
--- a/app/components/admin/edition_images/image_component.html.erb
+++ b/app/components/admin/edition_images/image_component.html.erb
@@ -1,0 +1,28 @@
+ <li class="govuk-grid-row">
+  <div class="govuk-grid-column-one-third">
+    <img src="<%= image.url %>" alt="<%= preview_alt_text %>" class="app-view-edition-resource__preview">
+    <% unless image.image_data&.all_asset_variants_uploaded? %>
+      <span class="govuk-tag govuk-tag--green">Processing</span>
+    <% end %>
+  </div>
+
+  <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-body"><strong>Caption: </strong><%= caption %></p>
+    <p class="govuk-body"><strong>Alt text: </strong><%= alt_text %></p>
+    <%= render "govuk_publishing_components/components/copy_to_clipboard", {
+      label: tag.strong("Markdown code:"),
+      copyable_content: image_markdown,
+      button_text: "Copy Markdown",
+    } %>
+  </div>
+
+  <div class="app-view-edition-resource__actions govuk-grid-column-full govuk-button-group">
+    <% links.each do |link| %>
+      <%= link %>
+    <% end %>
+  </div>
+</li>
+
+<% unless last_image %>
+  <li aria-hidden="true"><hr class="app-view-edition-resource__section-break govuk-section-break govuk-section-break--visible"></li>
+<% end %>

--- a/app/components/admin/edition_images/image_component.rb
+++ b/app/components/admin/edition_images/image_component.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+class Admin::EditionImages::ImageComponent < ViewComponent::Base
+  def initialize(edition:, image:, last_image:)
+    @edition = edition
+    @image = image
+    @last_image = last_image
+  end
+
+private
+
+  attr_reader :edition, :image, :last_image
+
+  def preview_alt_text
+    "Image #{find_index_from_non_lead_images + 1}"
+  end
+
+  def caption
+    image.caption.presence || "None"
+  end
+
+  def alt_text
+    image.alt_text.presence || "None"
+  end
+
+  def image_markdown
+    edition.images_have_unique_filenames? ? "[Image: #{image.filename}]" : "!!#{find_image_index + 1}"
+  end
+
+  def find_index_from_non_lead_images
+    if edition.respond_to?(:non_lead_images)
+      edition.non_lead_images.find_index(image)
+    else
+      edition.images.find_index(image)
+    end
+  end
+
+  def find_image_index
+    edition.images.find_index(image)
+  end
+
+  def links
+    links = []
+    links << link_to("Edit details", edit_admin_edition_image_path(@edition, image), class: "govuk-link")
+    links << link_to("Delete image", confirm_destroy_admin_edition_image_path(@edition, image), class: "govuk-link gem-link--destructive")
+    links
+  end
+end

--- a/app/components/admin/edition_images/lead_image_component.html.erb
+++ b/app/components/admin/edition_images/lead_image_component.html.erb
@@ -1,0 +1,55 @@
+<%= render "govuk_publishing_components/components/heading", {
+  text: "Lead image",
+  font_size: "m",
+  padding: true,
+} %>
+
+<%= render "govuk_publishing_components/components/details", {
+  title: "Using a lead image",
+} do %>
+  <% lead_image_guidance %>
+<% end %>
+
+<% if lead_image.present? || case_study? %>
+  <div class="govuk-grid-row">
+    <% if lead_image.present? %>
+      <div class="app-c-edition-images-lead-image-component__lead_image">
+        <div class="govuk-grid-column-one-third">
+          <img src="<%= lead_image.url %>" alt="Lead image" class="app-view-edition-resource__preview">
+          <% unless lead_image.image_data&.all_asset_variants_uploaded? %>
+            <span class="govuk-tag govuk-tag--green">Processing</span>
+          <% end %>
+        </div>
+
+        <div class="govuk-grid-column-two-thirds">
+          <p class="govuk-body"><strong>Caption: </strong><%= caption %></p>
+          <p class="govuk-body"><strong>Alt text: </strong><%= alt_text %></p>
+        </div>
+      </div>
+    <% end %>
+
+    <div class="app-view-edition-resource__actions govuk-grid-column-full govuk-button-group">
+      <% if case_study? %>
+        <%= form_with(url: update_image_display_option_admin_edition_path(edition), method: :patch) do |form| %>
+          <%= hidden_field_tag "edition[image_display_option]", new_image_display_option %>
+
+          <%= render "govuk_publishing_components/components/button", {
+            text: update_image_display_option_button_text,
+            secondary_solid: true,
+            margin_bottom: 4,
+          } %>
+
+          <% if lead_image.present? %>
+            <% links.each do |link| %>
+              <%= link %>
+            <% end %>
+          <% end %>
+        <% end %>
+      <% elsif lead_image.present? %>
+        <% links.each do |link| %>
+          <%= link %>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
+<% end %>

--- a/app/components/admin/edition_images/lead_image_component.rb
+++ b/app/components/admin/edition_images/lead_image_component.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+class Admin::EditionImages::LeadImageComponent < ViewComponent::Base
+  def initialize(edition:)
+    @edition = edition
+  end
+
+  def render?
+    edition.can_have_custom_lead_image?
+  end
+
+private
+
+  attr_reader :edition
+
+  def lead_image_guidance
+    if case_study?
+      tag.p("Using a lead image is optional and can be shown or hidden. The first image you upload is used as the lead image.", class: "govuk-body") + tag.p("The lead image appears at the top of the document. The same image cannot be used in the body text.", class: "govuk-body")
+    else
+      tag.p("The first image you upload is used as the lead image.", class: "govuk-body") + tag.p("The lead image appears at the top of the document. The same image cannot be used in the body text.", class: "govuk-body")
+    end
+  end
+
+  def case_study?
+    edition.type == "CaseStudy"
+  end
+
+  def lead_image
+    @lead_image ||= edition.lead_image
+  end
+
+  def caption
+    lead_image.caption.presence || "None"
+  end
+
+  def alt_text
+    lead_image.alt_text.presence || "None"
+  end
+
+  def new_image_display_option
+    @new_image_display_option ||= if image_display_option_is_no_image? && edition_has_images?
+                                    "custom_image"
+                                  elsif image_display_option_is_no_image?
+                                    "organisation_image"
+                                  else
+                                    "no_image"
+                                  end
+  end
+
+  def image_display_option_is_no_image?
+    edition.image_display_option == "no_image"
+  end
+
+  def update_image_display_option_button_text
+    return image_display_option_button_text_when_image_has_been_uploaded if edition_has_images?
+
+    image_display_option_button_text_when_no_images_uploaded
+  end
+
+  def image_display_option_button_text_when_image_has_been_uploaded
+    return "Hide lead image" if new_image_display_option_is_no_image?
+
+    "Show lead image"
+  end
+
+  def image_display_option_button_text_when_no_images_uploaded
+    return "Remove lead image" if new_image_display_option_is_no_image?
+
+    "Use default image"
+  end
+
+  def new_image_display_option_is_no_image?
+    new_image_display_option == "no_image"
+  end
+
+  def edition_has_images?
+    edition.images.present?
+  end
+
+  def links
+    links = []
+    links << link_to("Edit details", edit_admin_edition_image_path(edition, lead_image), class: "govuk-link")
+    links << link_to("Delete image", confirm_destroy_admin_edition_image_path(edition, lead_image), class: "govuk-link gem-link--destructive")
+    links
+  end
+end

--- a/app/components/admin/edition_images/uploaded_images_component.html.erb
+++ b/app/components/admin/edition_images/uploaded_images_component.html.erb
@@ -3,7 +3,7 @@
   font_size: "l",
 } %>
 
-<%= render Admin::EditionImages::LeadImageComponent.new(edition: @edition) %>
+<%= render Admin::EditionImages::LeadImageComponent.new(edition: edition) %>
 
 <%= render "govuk_publishing_components/components/heading", {
   text: "Images available to use in document",
@@ -11,7 +11,7 @@
   padding: true,
 } %>
 
-<% if document_images %>
+<% if document_images.present? %>
   <%= render "govuk_publishing_components/components/inset_text", {
     text: "Copy the image markdown code to add images to the document body.",
     margin_top: 0,
@@ -19,27 +19,7 @@
 
   <ul class="govuk-list">
     <% document_images.each do |image| %>
-      <li class="govuk-grid-row">
-        <div class="govuk-grid-column-one-third">
-          <img src="<%= image[:url] %>" alt="<%= image[:preview_alt_text] %>" class="app-view-edition-resource__preview">
-          <% unless image[:all_image_asset_variants_uploaded] %><span class="govuk-tag govuk-tag--green">Processing</span><% end %>
-        </div>
-        <div class="govuk-grid-column-two-thirds">
-          <p class="govuk-body"><strong>Caption: </strong><%= image[:caption] %></p>
-          <p class="govuk-body"><strong>Alt text: </strong><%= image[:alt_text] %></p>
-          <%= render "govuk_publishing_components/components/copy_to_clipboard", {
-            label: tag.strong("Markdown code:"),
-            copyable_content: image[:markdown],
-            button_text: "Copy Markdown",
-          } %>
-        </div>
-        <div class="app-view-edition-resource__actions govuk-grid-column-full govuk-button-group">
-          <% image[:links].each do |link| %><%= link %><% end %>
-        </div>
-      </li>
-      <% if image != document_images.last %>
-        <li aria-hidden="true"><hr class="app-view-edition-resource__section-break govuk-section-break govuk-section-break--visible"></li>
-      <% end %>
+      <%= render Admin::EditionImages::ImageComponent.new(edition: edition, image: image, last_image: image == document_images.last) %>
     <% end %>
   </ul>
 <% else %>

--- a/app/components/admin/edition_images/uploaded_images_component.html.erb
+++ b/app/components/admin/edition_images/uploaded_images_component.html.erb
@@ -3,52 +3,7 @@
   font_size: "l",
 } %>
 
-<% if can_have_lead_image? %>
-  <%= render "govuk_publishing_components/components/heading", {
-    text: "Lead image",
-    font_size: "m",
-    padding: true,
-  } %>
-
-  <%= render "govuk_publishing_components/components/details", {
-        title: "Using a lead image",
-      } do %>
-    <% lead_image_guidance %>
-  <% end %>
-<% end %>
-
-<div class="govuk-grid-row">
-  <% if lead_image_hash %>
-    <div class="govuk-grid-column-one-third">
-      <img src="<%= lead_image_hash[:url] %>" alt="<%= lead_image_hash[:preview_alt_text] %>" class="app-view-edition-resource__preview">
-      <% unless lead_image_hash[:all_image_asset_variants_uploaded] %><span class="govuk-tag govuk-tag--green">Processing</span><% end %>
-    </div>
-    <div class="govuk-grid-column-two-thirds">
-      <p class="govuk-body"><strong>Caption: </strong><%= lead_image_hash[:caption] %></p>
-      <p class="govuk-body"><strong>Alt text: </strong><%= lead_image_hash[:alt_text] %></p>
-    </div>
-  <% end %>
-
-  <% if lead_image_hash || @edition.type == "CaseStudy" %>
-    <%= form_with(url: update_image_display_option_admin_edition_path(@edition), method: :patch) do |form| %>
-      <div class="app-view-edition-resource__actions govuk-grid-column-full govuk-button-group">
-        <% if @edition.type == "CaseStudy" %>
-          <%= hidden_field_tag "edition[image_display_option]", new_image_display_option %>
-          <%= render "govuk_publishing_components/components/button", {
-            text: update_image_display_option_button_text,
-            secondary_solid: true,
-            margin_bottom: 4,
-          } %>
-        <% end %>
-
-        <% if lead_image_hash %>
-          <% lead_image_hash[:links].each do |link| %><%= link %><% end %>
-        <% end %>
-      </div>
-    <% end %>
-  <% end %>
-
-</div>
+<%= render Admin::EditionImages::LeadImageComponent.new(edition: @edition) %>
 
 <%= render "govuk_publishing_components/components/heading", {
   text: "Images available to use in document",

--- a/app/components/admin/edition_images/uploaded_images_component.rb
+++ b/app/components/admin/edition_images/uploaded_images_component.rb
@@ -13,39 +13,9 @@ class Admin::EditionImages::UploadedImagesComponent < ViewComponent::Base
     @lead_image ||= can_have_lead_image? ? @edition.lead_image : nil
   end
 
-  def lead_image_hash
-    image_to_hash(lead_image, 0) if lead_image
-  end
-
   def document_images
     @document_images ||= (@edition.images - [lead_image].compact)
                           .map.with_index(1) { |image, index| image_to_hash(image, index) }
-  end
-
-  def new_image_display_option
-    if @edition.image_display_option == "no_image" && @edition.images.present?
-      "custom_image"
-    elsif @edition.image_display_option == "no_image"
-      "organisation_image"
-    else
-      "no_image"
-    end
-  end
-
-  def update_image_display_option_button_text
-    if @edition.images.present?
-      return "#{new_image_display_option == 'no_image' ? 'Hide' : 'Show'} lead image"
-    end
-
-    "#{new_image_display_option == 'no_image' ? 'Remove lead' : 'Use default'} image"
-  end
-
-  def lead_image_guidance
-    if @edition.type == "CaseStudy"
-      tag.p("Using a lead image is optional and can be shown or hidden. The first image you upload is used as the lead image.", class: "govuk-body") + tag.p("The lead image appears at the top of the document. The same image cannot be used in the body text.", class: "govuk-body")
-    else
-      tag.p("The first image you upload is used as the lead image.", class: "govuk-body") + tag.p("The lead image appears at the top of the document. The same image cannot be used in the body text.", class: "govuk-body")
-    end
   end
 
 private

--- a/app/components/admin/edition_images/uploaded_images_component.rb
+++ b/app/components/admin/edition_images/uploaded_images_component.rb
@@ -5,48 +5,13 @@ class Admin::EditionImages::UploadedImagesComponent < ViewComponent::Base
     @edition = edition
   end
 
-  def can_have_lead_image?
-    @edition.can_have_custom_lead_image?
-  end
-
-  def lead_image
-    @lead_image ||= can_have_lead_image? ? @edition.lead_image : nil
-  end
-
-  def document_images
-    @document_images ||= (@edition.images - [lead_image].compact)
-                          .map.with_index(1) { |image, index| image_to_hash(image, index) }
-  end
-
 private
 
-  def all_image_asset_variants_uploaded?(image)
-    image.image_data.all_asset_variants_uploaded? if image.image_data.present?
-  end
+  attr_reader :edition
 
-  def image_to_hash(image, index)
-    {
-      url: image.url,
-      preview_alt_text: lead_image == image ? "Lead image" : "Image #{index}",
-      caption: image.caption.presence || "None",
-      alt_text: image.alt_text.presence || "None",
-      markdown: unique_names? ? "[Image: #{image.filename}]" : "!!#{index}",
-      links: links_for_image(image),
-      all_image_asset_variants_uploaded: all_image_asset_variants_uploaded?(image),
-    }
-  end
+  def document_images
+    return edition.images unless edition.can_have_custom_lead_image?
 
-  def unique_names?
-    return @unique_names if defined? @unique_names
-
-    names = @edition.images.map(&:filename)
-    @unique_names = (names.uniq.length == names.length)
-  end
-
-  def links_for_image(image)
-    links = []
-    links << link_to("Edit details", edit_admin_edition_image_path(@edition, image), class: "govuk-link")
-    links << link_to("Delete image", confirm_destroy_admin_edition_image_path(@edition, image), class: "govuk-link gem-link--destructive")
-    links
+    edition.images - [edition.lead_image].compact
   end
 end

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -720,6 +720,11 @@ EXISTS (
     is_a?(Edition::CustomLeadImage)
   end
 
+  def images_have_unique_filenames?
+    names = images.map(&:filename)
+    names.uniq.length == names.length
+  end
+
 private
 
   def date_for_government

--- a/app/models/edition/custom_lead_image.rb
+++ b/app/models/edition/custom_lead_image.rb
@@ -17,6 +17,10 @@ module Edition::CustomLeadImage
     edition_lead_image.save!
   end
 
+  def non_lead_images
+    images - [lead_image].compact
+  end
+
 private
 
   def oldest_image

--- a/test/components/admin/edition_images/image_component_test.rb
+++ b/test/components/admin/edition_images/image_component_test.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Admin::EditionImages::ImageComponentTest < ViewComponent::TestCase
+  include Rails.application.routes.url_helpers
+
+  test "renders the correct default fields" do
+    image = build_stubbed(:image, caption: "caption", alt_text: "alt text")
+    edition = build_stubbed(:draft_publication, images: [image])
+    render_inline(Admin::EditionImages::ImageComponent.new(edition:, image:, last_image: false))
+
+    assert_selector ".govuk-grid-row .govuk-grid-column-one-third img[alt='Image 1']"
+    assert_selector ".govuk-grid-row .govuk-grid-column-two-thirds .govuk-body:nth-child(1)", text: "Caption: caption"
+    assert_selector ".govuk-grid-row .govuk-grid-column-two-thirds .govuk-body:nth-child(2)", text: "Alt text: alt text"
+    assert_selector "input[value='[Image: minister-of-funk.960x640.jpg]']"
+    assert_selector ".app-view-edition-resource__actions a[href='#{edit_admin_edition_image_path(edition, image)}']", text: "Edit details"
+    assert_selector ".app-view-edition-resource__actions a[href='#{confirm_destroy_admin_edition_image_path(edition, image)}']", text: "Delete image"
+    assert_selector ".app-view-edition-resource__section-break"
+  end
+
+  test "renders placeholder text for caption and alt text when none has been provided" do
+    image = build_stubbed(:image, caption: nil, alt_text: nil)
+    edition = build_stubbed(:draft_publication, images: [image])
+    render_inline(Admin::EditionImages::ImageComponent.new(edition:, image:, last_image: false))
+
+    assert_selector ".govuk-grid-row .govuk-grid-column-two-thirds .govuk-body:nth-child(1)", text: "Caption: None"
+    assert_selector ".govuk-grid-row .govuk-grid-column-two-thirds .govuk-body:nth-child(2)", text: "Alt text: None"
+  end
+
+  test "image filename markdown displayed" do
+    jpeg = upload_fixture("images/960x640_jpeg.jpg")
+    gif = upload_fixture("images/960x640_gif.gif")
+    jpeg_image_data = build_stubbed(:image_data, file: jpeg)
+    gif_image_data = build_stubbed(:image_data, file: gif)
+    images = [build_stubbed(:image, image_data: jpeg_image_data), build_stubbed(:image, image_data: gif_image_data)]
+    edition = build_stubbed(:draft_publication, images:)
+    render_inline(Admin::EditionImages::ImageComponent.new(edition:, image: images.first, last_image: false))
+
+    assert_selector "input[value='[Image: 960x640_jpeg.jpg]']"
+  end
+
+  test "image index markdown used when edition has duplicate image filenames" do
+    images = [build_stubbed(:image), build_stubbed(:image)]
+    edition = build_stubbed(:draft_publication, images:)
+    render_inline(Admin::EditionImages::ImageComponent.new(edition:, image: images.first, last_image: false))
+
+    assert_selector "input[value='!!1']"
+  end
+
+  test "image index markdown handles a lead image being present correctly" do
+    images = [build_stubbed(:image), build_stubbed(:image), build_stubbed(:image)]
+    edition = build_stubbed(:draft_news_article, images:, lead_image: images.second)
+    render_inline(Admin::EditionImages::ImageComponent.new(edition:, image: images.third, last_image: false))
+
+    assert_selector "input[value='!!3']"
+  end
+
+  test "renders a processing tag if the lead image if all assets aren't uploaded" do
+    image = build_stubbed(:image, image_data: build_stubbed(:image_data_with_no_assets))
+    edition = build_stubbed(:draft_news_article, images: [image])
+
+    render_inline(Admin::EditionImages::ImageComponent.new(edition:, image:, last_image: false))
+
+    assert_selector ".govuk-tag", text: "Processing"
+  end
+
+  test "does not render a line break if last_image parameter is true " do
+    image = build_stubbed(:image)
+    edition = build_stubbed(:draft_news_article, images: [image])
+
+    render_inline(Admin::EditionImages::ImageComponent.new(edition:, image:, last_image: true))
+
+    assert_selector ".app-view-edition-resource__section-break", count: 0
+  end
+end

--- a/test/components/admin/edition_images/lead_image_component_test.rb
+++ b/test/components/admin/edition_images/lead_image_component_test.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Admin::EditionImages::LeadImageComponentTest < ViewComponent::TestCase
+  include Rails.application.routes.url_helpers
+
+  test "doesn't render if the edition cannot have a custom lead image" do
+    edition = build(:edition)
+    render_inline(Admin::EditionImages::LeadImageComponent.new(edition:))
+
+    assert_empty page.text
+  end
+
+  test "renders the correct lead image guidance for case studies" do
+    edition = build_stubbed(:draft_case_study)
+    render_inline(Admin::EditionImages::LeadImageComponent.new(edition:))
+
+    first_para = "Using a lead image is optional and can be shown or hidden. The first image you upload is used as the lead image."
+    second_para = "The lead image appears at the top of the document. The same image cannot be used in the body text."
+
+    assert_selector ".govuk-details__text .govuk-body:nth-child(1)", text: first_para, visible: :hidden
+    assert_selector ".govuk-details__text .govuk-body:nth-child(2)", text: second_para, visible: :hidden
+  end
+
+  test "renders the correct lead image guidance for other edition types" do
+    edition = build_stubbed(:draft_news_article)
+    render_inline(Admin::EditionImages::LeadImageComponent.new(edition:))
+
+    first_para = "The first image you upload is used as the lead image."
+    second_para = "The lead image appears at the top of the document. The same image cannot be used in the body text."
+
+    assert_selector ".govuk-details__text .govuk-body:nth-child(1)", text: first_para, visible: :hidden
+    assert_selector ".govuk-details__text .govuk-body:nth-child(2)", text: second_para, visible: :hidden
+  end
+
+  test "renders the correct default fields when a lead image is present" do
+    image = build_stubbed(:image, caption: "caption", alt_text: "alt text")
+    edition = build_stubbed(:draft_news_article, images: [image], lead_image: image)
+    render_inline(Admin::EditionImages::LeadImageComponent.new(edition:))
+
+    assert_selector ".govuk-grid-row .govuk-grid-column-one-third img[alt='Lead image']"
+    assert_selector ".govuk-grid-row .govuk-grid-column-two-thirds .govuk-body:nth-child(1)", text: "Caption: caption"
+    assert_selector ".govuk-grid-row .govuk-grid-column-two-thirds .govuk-body:nth-child(2)", text: "Alt text: alt text"
+    assert_selector ".app-view-edition-resource__actions a[href='#{edit_admin_edition_image_path(edition, image)}']", text: "Edit details"
+    assert_selector ".app-view-edition-resource__actions a[href='#{confirm_destroy_admin_edition_image_path(edition, image)}']", text: "Delete image"
+  end
+
+  test "renders placeholder text for caption and alt text when none has been provided" do
+    image = build_stubbed(:image, caption: nil, alt_text: nil)
+    edition = build_stubbed(:draft_news_article, images: [image], lead_image: image)
+    render_inline(Admin::EditionImages::LeadImageComponent.new(edition:))
+
+    assert_selector ".govuk-grid-row .govuk-grid-column-two-thirds .govuk-body:nth-child(1)", text: "Caption: None"
+    assert_selector ".govuk-grid-row .govuk-grid-column-two-thirds .govuk-body:nth-child(2)", text: "Alt text: None"
+  end
+
+  test "renders a processing tag if the lead image if all assets aren't uploaded" do
+    image = build_stubbed(:image, image_data: build_stubbed(:image_data_with_no_assets))
+    edition = build_stubbed(:draft_news_article, images: [image], lead_image: image)
+
+    render_inline(Admin::EditionImages::LeadImageComponent.new(edition:))
+
+    assert_selector ".govuk-tag", text: "Processing"
+  end
+
+  test "does not render information on lead image if no lead image is present" do
+    edition = build_stubbed(:draft_news_article)
+    render_inline(Admin::EditionImages::LeadImageComponent.new(edition:))
+
+    assert_selector ".app-c-edition-images-lead-image-component__lead_image", count: 0
+    assert_selector ".app-view-edition-resource__actions", count: 0
+  end
+
+  test "case studies has the correct fields when image_display_option is 'no_image' and no images have been uploaded" do
+    edition = build_stubbed(:draft_case_study, image_display_option: "no_image")
+    render_inline(Admin::EditionImages::LeadImageComponent.new(edition:))
+
+    assert_selector "form[action='#{update_image_display_option_admin_edition_path(edition)}']" do
+      assert_selector "input[type='hidden'][name='edition[image_display_option]'][value='organisation_image']", visible: :hidden
+      assert_selector ".govuk-button", text: "Use default image"
+    end
+  end
+
+  test "case studies has the correct fields when image_display_option is 'organisation_image' and no images have been uploaded" do
+    edition = build_stubbed(:draft_case_study, image_display_option: "organisation_image")
+    render_inline(Admin::EditionImages::LeadImageComponent.new(edition:))
+
+    assert_selector "form[action='#{update_image_display_option_admin_edition_path(edition)}']" do
+      assert_selector "input[type='hidden'][name='edition[image_display_option]'][value='no_image']", visible: :hidden
+      assert_selector ".govuk-button", text: "Remove lead image"
+    end
+  end
+
+  test "case studies has the correct fields when image_display_option is 'no_image' and images have been uploaded" do
+    image = build_stubbed(:image)
+    edition = build_stubbed(:draft_case_study, image_display_option: "no_image", images: [image])
+    render_inline(Admin::EditionImages::LeadImageComponent.new(edition:))
+
+    assert_selector "form[action='#{update_image_display_option_admin_edition_path(edition)}']" do
+      assert_selector "input[type='hidden'][name='edition[image_display_option]'][value='custom_image']", visible: :hidden
+      assert_selector ".govuk-button", text: "Show lead image"
+    end
+  end
+
+  test "case studies has the correct fields when image_display_option is 'custom_image' and images have been uploaded" do
+    image = build_stubbed(:image)
+    edition = build_stubbed(:draft_case_study, image_display_option: "custom_image", images: [image])
+    render_inline(Admin::EditionImages::LeadImageComponent.new(edition:))
+
+    assert_selector "form[action='#{update_image_display_option_admin_edition_path(edition)}']" do
+      assert_selector "input[type='hidden'][name='edition[image_display_option]'][value='no_image']", visible: :hidden
+      assert_selector ".govuk-button", text: "Hide lead image"
+    end
+  end
+
+  test "other types of edition do not render image display information" do
+    image = build_stubbed(:image)
+    edition = build_stubbed(:draft_news_article, image_display_option: "custom_image", images: [image])
+    render_inline(Admin::EditionImages::LeadImageComponent.new(edition:))
+
+    assert_selector "form[action='#{update_image_display_option_admin_edition_path(edition)}']", count: 0
+    assert_selector "input[type='hidden'][name='edition[image_display_option]']", visible: :hidden, count: 0
+  end
+end

--- a/test/components/admin/edition_images/uploaded_images_component_test.rb
+++ b/test/components/admin/edition_images/uploaded_images_component_test.rb
@@ -14,28 +14,6 @@ class Admin::EditionImages::UploadedImagesComponentTest < ViewComponent::TestCas
     assert_selector "input[type='hidden'][name='edition[image_display_option]'][value='no_image']", visible: :hidden
   end
 
-  test "has the correct hidden field for toggling 'image_display_option' when it's 'no_image' and no images have been to the case study" do
-    edition = build_stubbed(:draft_case_study, image_display_option: "no_image")
-    render_inline(Admin::EditionImages::UploadedImagesComponent.new(edition:))
-
-    assert_selector "input[type='hidden'][name='edition[image_display_option]'][value='organisation_image']", visible: :hidden
-  end
-
-  test "has the correct hidden field for toggling 'image_display_option' when it's 'organisation_image' and no images have been to the case study" do
-    edition = build_stubbed(:draft_case_study, image_display_option: "organisation_image")
-    render_inline(Admin::EditionImages::UploadedImagesComponent.new(edition:))
-
-    assert_selector "input[type='hidden'][name='edition[image_display_option]'][value='no_image']", visible: :hidden
-  end
-
-  test "has the correct hidden field for toggling 'image_display_option' when it's 'no_image' and an image has been to the case study" do
-    image = build_stubbed(:image)
-    edition = build_stubbed(:draft_case_study, image_display_option: "no_image", images: [image])
-    render_inline(Admin::EditionImages::UploadedImagesComponent.new(edition:))
-
-    assert_selector "input[type='hidden'][name='edition[image_display_option]'][value='custom_image']", visible: :hidden
-  end
-
   test "lead image not rendered for publication" do
     images = [build_stubbed(:image), build_stubbed(:image)]
     edition = build_stubbed(:draft_publication, images:)

--- a/test/components/admin/edition_images/uploaded_images_component_test.rb
+++ b/test/components/admin/edition_images/uploaded_images_component_test.rb
@@ -3,7 +3,7 @@
 require "test_helper"
 
 class Admin::EditionImages::UploadedImagesComponentTest < ViewComponent::TestCase
-  test "lead image rendered for case study with default hidden field that toggles organisation image off" do
+  test "renders correctly for case studies" do
     images = [build_stubbed(:image), build_stubbed(:image)]
     edition = build_stubbed(:draft_case_study, images:, lead_image: images.first)
     render_inline(Admin::EditionImages::UploadedImagesComponent.new(edition:))
@@ -11,10 +11,9 @@ class Admin::EditionImages::UploadedImagesComponentTest < ViewComponent::TestCas
     assert_selector "img", count: 2
     assert_selector "img[alt='Lead image']"
     assert_selector "img[alt='Image 1']"
-    assert_selector "input[type='hidden'][name='edition[image_display_option]'][value='no_image']", visible: :hidden
   end
 
-  test "lead image not rendered for publication" do
+  test "renders correctly for publications" do
     images = [build_stubbed(:image), build_stubbed(:image)]
     edition = build_stubbed(:draft_publication, images:)
     render_inline(Admin::EditionImages::UploadedImagesComponent.new(edition:))
@@ -24,41 +23,11 @@ class Admin::EditionImages::UploadedImagesComponentTest < ViewComponent::TestCas
     assert_selector "img[alt='Image 2']"
   end
 
-  test "image filename markdown displayed" do
-    jpeg = upload_fixture("images/960x640_jpeg.jpg")
-    gif = upload_fixture("images/960x640_gif.gif")
-    jpeg_image_data = build_stubbed(:image_data, file: jpeg)
-    gif_image_data = build_stubbed(:image_data, file: gif)
-    images = [build_stubbed(:image, image_data: jpeg_image_data), build_stubbed(:image, image_data: gif_image_data)]
-    edition = build_stubbed(:draft_publication, images:)
+  test "renders correctly when edition has no images" do
+    edition = build_stubbed(:draft_case_study)
     render_inline(Admin::EditionImages::UploadedImagesComponent.new(edition:))
 
-    assert_selector "input[value='[Image: 960x640_jpeg.jpg]']"
-    assert_selector "input[value='[Image: 960x640_gif.gif]']"
-  end
-
-  test "image index markdown used for duplicate filenames" do
-    images = [build_stubbed(:image), build_stubbed(:image)]
-    edition = build_stubbed(:draft_publication, images:)
-    render_inline(Admin::EditionImages::UploadedImagesComponent.new(edition:))
-
-    assert_selector "input[value='!!1']"
-    assert_selector "input[value='!!2']"
-  end
-
-  test "shows \"Processing\" label where image assets (variants) are still uploading" do
-    lead_image_data_with_no_assets = build(:image_data_with_no_assets)
-    regular_image_data_with_no_assets = build(:image_data_with_no_assets)
-    regular_image_data_with_assets = build(:image_data)
-    images = [
-      build_stubbed(:image, image_data: lead_image_data_with_no_assets),
-      build_stubbed(:image, image_data: regular_image_data_with_no_assets),
-      build_stubbed(:image, image_data: regular_image_data_with_assets),
-    ]
-    edition = build_stubbed(:draft_publication, images:)
-
-    render_inline(Admin::EditionImages::UploadedImagesComponent.new(edition:))
-
-    assert_text "Processing", count: 2
+    assert_selector "img", count: 0
+    assert_selector ".govuk-body", text: "No images uploaded"
   end
 end

--- a/test/unit/app/models/edition/custom_lead_image_test.rb
+++ b/test/unit/app/models/edition/custom_lead_image_test.rb
@@ -88,4 +88,12 @@ class Edition::CustomLeadImageTest < ActiveSupport::TestCase
 
     assert_nil edition.update_lead_image
   end
+
+  test "#non_lead_images returns images which are not lead images" do
+    image1 = build(:image)
+    image2 = build(:image)
+    edition = build(:news_article, images: [image1, image2], lead_image: image1)
+
+    assert_equal [image2], edition.non_lead_images
+  end
 end

--- a/test/unit/app/models/edition_test.rb
+++ b/test/unit/app/models/edition_test.rb
@@ -978,6 +978,22 @@ class EditionTest < ActiveSupport::TestCase
     assert_not edition.can_have_custom_lead_image?
   end
 
+  test "images_have_unique_filenames? returns true if image filenames are unique" do
+    image1 = build(:image)
+    image2 = build(:image, image_data: build(:image_data, file: upload_fixture("big-cheese.960x640.jpg")))
+    edition = build(:draft_news_article, images: [image1, image2])
+
+    assert_equal true, edition.images_have_unique_filenames?
+  end
+
+  test "images_have_unique_filenames? returns false if some images have duplicate filenames" do
+    image1 = build(:image)
+    image2 = build(:image)
+    edition = build(:draft_news_article, images: [image1, image2])
+
+    assert_equal false, edition.images_have_unique_filenames?
+  end
+
   def decoded_token_payload(token)
     payload, _header = JWT.decode(
       token,


### PR DESCRIPTION
## Description

At the moment, the UploadedImagesComponent does a lot. It handles rendering the lead image and associated guidance, in addition to all the images that can be used inline within the body.

This adds two additional components which handle rendering the lead image and other images. I've added a bunch of unit tests for both. There's definitely some duplication, particularly around displaying the image itself, but overall i think it's the lesser evil.

## Trello card

https://trello.com/c/5vCiIxeQ/1064-lead-image-handling-backend-work

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
