### PR TITLE
Add ability for user to select lead image for case studies and news articles

### DIFF
--- a/app/assets/stylesheets/admin/views/_edition-resource.scss
+++ b/app/assets/stylesheets/admin/views/_edition-resource.scss
@@ -15,4 +15,8 @@
 .app-view-edition-resource__actions {
   margin-top: govuk-spacing(2);
   margin-bottom: 0;
+
+  .app-view-edition-resource__actions__link {
+    align-self: center;
+  }
 }

--- a/app/components/admin/edition_images/image_component.html.erb
+++ b/app/components/admin/edition_images/image_component.html.erb
@@ -16,9 +16,18 @@
     } %>
   </div>
 
-  <div class="app-view-edition-resource__actions govuk-grid-column-full govuk-button-group">
-    <% links.each do |link| %>
-      <%= link %>
+  <div class="app-view-edition-resource__actions govuk-grid-column-full govuk-button-group govuk-!-margin-top-4">
+    <%= link_to("Edit details", edit_admin_edition_image_path(edition, image), class: "govuk-link govuk-!-margin-top-2 app-view-edition-resource__actions__link") %>
+    <%= link_to("Delete image", confirm_destroy_admin_edition_image_path(edition, image), class: "govuk-link gem-link--destructive govuk-!-margin-top-2 app-view-edition-resource__actions__link") %>
+
+    <% if edition.can_have_custom_lead_image? %>
+      <%= form_with url: admin_edition_lead_image_path(edition, image), method: :patch do |form| %>
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Select as lead image",
+          secondary_solid: true,
+          margin_bottom: 4,
+        } %>
+      <% end %>
     <% end %>
   </div>
 </li>

--- a/app/components/admin/edition_images/image_component.rb
+++ b/app/components/admin/edition_images/image_component.rb
@@ -38,11 +38,4 @@ private
   def find_image_index
     edition.images.find_index(image)
   end
-
-  def links
-    links = []
-    links << link_to("Edit details", edit_admin_edition_image_path(@edition, image), class: "govuk-link")
-    links << link_to("Delete image", confirm_destroy_admin_edition_image_path(@edition, image), class: "govuk-link gem-link--destructive")
-    links
-  end
 end

--- a/app/components/admin/edition_images/lead_image_component.html.erb
+++ b/app/components/admin/edition_images/lead_image_component.html.erb
@@ -38,17 +38,12 @@
             secondary_solid: true,
             margin_bottom: 4,
           } %>
+        <% end %>
+      <% end %>
 
-          <% if lead_image.present? %>
-            <% links.each do |link| %>
-              <%= link %>
-            <% end %>
-          <% end %>
-        <% end %>
-      <% elsif lead_image.present? %>
-        <% links.each do |link| %>
-          <%= link %>
-        <% end %>
+      <% if lead_image.present? %>
+        <%= link_to("Edit details", edit_admin_edition_image_path(edition, lead_image), class: "govuk-link app-view-edition-resource__actions__link") %>
+        <%= link_to("Delete image", confirm_destroy_admin_edition_image_path(edition, lead_image), class: "govuk-link gem-link--destructive app-view-edition-resource__actions__link") %>
       <% end %>
     </div>
   </div>

--- a/app/components/admin/edition_images/lead_image_component.html.erb
+++ b/app/components/admin/edition_images/lead_image_component.html.erb
@@ -10,24 +10,35 @@
   <% lead_image_guidance %>
 <% end %>
 
-<% if lead_image.present? || case_study? %>
-  <div class="govuk-grid-row">
-    <% if lead_image.present? %>
-      <div class="app-c-edition-images-lead-image-component__lead_image">
-        <div class="govuk-grid-column-one-third">
-          <img src="<%= lead_image.url %>" alt="Lead image" class="app-view-edition-resource__preview">
-          <% unless lead_image.image_data&.all_asset_variants_uploaded? %>
-            <span class="govuk-tag govuk-tag--green">Processing</span>
-          <% end %>
-        </div>
-
-        <div class="govuk-grid-column-two-thirds">
-          <p class="govuk-body"><strong>Caption: </strong><%= caption %></p>
-          <p class="govuk-body"><strong>Alt text: </strong><%= alt_text %></p>
-        </div>
+<% if lead_image.present? %>
+  <div class="app-c-edition-images-lead-image-component__lead_image">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-one-third">
+        <img src="<%= lead_image.url %>" alt="Lead image" class="app-view-edition-resource__preview">
+        <% unless lead_image.image_data&.all_asset_variants_uploaded? %>
+          <span class="govuk-tag govuk-tag--green">Processing</span>
+        <% end %>
       </div>
-    <% end %>
 
+      <div class="govuk-grid-column-two-thirds">
+        <p class="govuk-body"><strong>Caption: </strong><%= caption %></p>
+        <p class="govuk-body"><strong>Alt text: </strong><%= alt_text %></p>
+      </div>
+    </div>
+  </div>
+<% elsif show_default_lead_image? %>
+  <div class="app-c-edition-images-lead-image-component__default_lead_image">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-one-third">
+        <img src="<%= edition.lead_image_url %>" alt="Default organisation image" class="app-view-edition-resource__preview">
+      </div>
+    </div>
+    <p class="govuk-hint govuk-!-margin-top-2">Default image for your organisation</p>
+  </div>
+<% end %>
+
+<% if render_resource_actions? %>
+  <div class="govuk-grid-row">
     <div class="app-view-edition-resource__actions govuk-grid-column-full govuk-button-group">
       <% if case_study? %>
         <%= form_with(url: update_image_display_option_admin_edition_path(edition), method: :patch) do |form| %>

--- a/app/components/admin/edition_images/lead_image_component.rb
+++ b/app/components/admin/edition_images/lead_image_component.rb
@@ -40,13 +40,7 @@ private
   end
 
   def new_image_display_option
-    @new_image_display_option ||= if image_display_option_is_no_image? && edition_has_images?
-                                    "custom_image"
-                                  elsif image_display_option_is_no_image?
-                                    "organisation_image"
-                                  else
-                                    "no_image"
-                                  end
+    @new_image_display_option ||= image_display_option_is_no_image? ? "organisation_image" : "no_image"
   end
 
   def image_display_option_is_no_image?
@@ -54,21 +48,7 @@ private
   end
 
   def update_image_display_option_button_text
-    return image_display_option_button_text_when_image_has_been_uploaded if edition_has_images?
-
-    image_display_option_button_text_when_no_images_uploaded
-  end
-
-  def image_display_option_button_text_when_image_has_been_uploaded
-    return "Hide lead image" if new_image_display_option_is_no_image?
-
-    "Show lead image"
-  end
-
-  def image_display_option_button_text_when_no_images_uploaded
-    return "Remove lead image" if new_image_display_option_is_no_image?
-
-    "Use default image"
+    new_image_display_option_is_no_image? ? "Remove lead image" : "Use default image"
   end
 
   def new_image_display_option_is_no_image?

--- a/app/components/admin/edition_images/lead_image_component.rb
+++ b/app/components/admin/edition_images/lead_image_component.rb
@@ -27,6 +27,10 @@ private
     edition.type == "CaseStudy"
   end
 
+  def news_article?
+    edition.type == "NewsArticle"
+  end
+
   def lead_image
     @lead_image ||= edition.lead_image
   end
@@ -37,6 +41,14 @@ private
 
   def alt_text
     lead_image.alt_text.presence || "None"
+  end
+
+  def show_default_lead_image?
+    if case_study?
+      edition.emphasised_organisation_default_image_available? && [nil, "organisation_image"].include?(edition.image_display_option)
+    elsif news_article?
+      edition.has_lead_image?
+    end
   end
 
   def new_image_display_option
@@ -53,6 +65,10 @@ private
 
   def new_image_display_option_is_no_image?
     new_image_display_option == "no_image"
+  end
+
+  def render_resource_actions?
+    case_study? || lead_image.present?
   end
 
   def edition_has_images?

--- a/app/components/admin/edition_images/lead_image_component.rb
+++ b/app/components/admin/edition_images/lead_image_component.rb
@@ -15,9 +15,11 @@ private
 
   def lead_image_guidance
     if case_study?
-      tag.p("Using a lead image is optional and can be shown or hidden. The first image you upload is used as the lead image.", class: "govuk-body") + tag.p("The lead image appears at the top of the document. The same image cannot be used in the body text.", class: "govuk-body")
+      tag.p("Using a lead image is optional. To use a lead image either select the default image for your organisation or upload an image and select it as the lead image.", class: "govuk-body") +
+        tag.p("The lead image appears at the top of the document. The same image cannot be used in the body text.", class: "govuk-body")
     else
-      tag.p("The first image you upload is used as the lead image.", class: "govuk-body") + tag.p("The lead image appears at the top of the document. The same image cannot be used in the body text.", class: "govuk-body")
+      tag.p("Any image you upload can be selected as the lead image. If you do not select a new lead image, the default image for your organisation will be used.", class: "govuk-body") +
+        tag.p("The lead image appears at the top of the document. The same image cannot be used in the body text.", class: "govuk-body")
     end
   end
 
@@ -75,12 +77,5 @@ private
 
   def edition_has_images?
     edition.images.present?
-  end
-
-  def links
-    links = []
-    links << link_to("Edit details", edit_admin_edition_image_path(edition, lead_image), class: "govuk-link")
-    links << link_to("Delete image", confirm_destroy_admin_edition_image_path(edition, lead_image), class: "govuk-link gem-link--destructive")
-    links
   end
 end

--- a/app/controllers/admin/edition_lead_images_controller.rb
+++ b/app/controllers/admin/edition_lead_images_controller.rb
@@ -1,0 +1,45 @@
+class Admin::EditionLeadImagesController < Admin::BaseController
+  before_action :find_edition, :find_image, :enforce_permissions!
+  layout "design_system"
+
+  def update
+    edition_lead_image = @edition.edition_lead_image || @edition.build_edition_lead_image
+    edition_lead_image.assign_attributes(edition_lead_image_params)
+
+    if updater.can_perform? && edition_lead_image.save!
+      updater.perform!
+      redirect_to admin_edition_images_path(@edition), notice: "Lead image updated to #{@image.image_data.carrierwave_image}"
+    else
+      redirect_to admin_edition_images_path(@edition), alert: updater.failure_reason
+    end
+  end
+
+private
+
+  def find_edition
+    edition = Edition.find(params[:edition_id])
+    @edition = LocalisedModel.new(edition, edition.primary_locale)
+  end
+
+  def find_image
+    @image = @edition.images.find(params[:id])
+  end
+
+  def enforce_permissions!
+    enforce_permission!(:update, @edition)
+  end
+
+  def edition_lead_image_params
+    {
+      image_id: @image.id,
+      edition_attributes: {
+        id: @edition.id,
+        image_display_option: "custom_image",
+      },
+    }
+  end
+
+  def updater
+    @updater ||= Whitehall.edition_services.draft_updater(@edition)
+  end
+end

--- a/app/models/case_study.rb
+++ b/app/models/case_study.rb
@@ -32,4 +32,8 @@ class CaseStudy < Edition
   def publishing_api_presenter
     PublishingApi::CaseStudyPresenter
   end
+
+  def emphasised_organisation_default_image_available?
+    lead_organisations.first&.default_news_image.present?
+  end
 end

--- a/app/models/edition/custom_lead_image.rb
+++ b/app/models/edition/custom_lead_image.rb
@@ -34,12 +34,12 @@ private
   end
 
   def body_does_not_contain_lead_image
-    return if lead_image.blank? || images.none?
+    return if edition_lead_image.blank? || images.none?
 
     html = Whitehall::GovspeakRenderer.new.govspeak_edition_to_html(self)
     doc = Nokogiri::HTML::DocumentFragment.parse(html)
 
-    if doc.css("img").any? { |img| img[:src] == lead_image.url }
+    if doc.css("img").any? { |img| img[:src] == edition_lead_image.image.url }
       errors.add(:body, "cannot have a reference to the lead image in the text")
     end
   end

--- a/app/models/edition_lead_image.rb
+++ b/app/models/edition_lead_image.rb
@@ -1,4 +1,6 @@
 class EditionLeadImage < ApplicationRecord
   belongs_to :edition
   belongs_to :image
+
+  accepts_nested_attributes_for :edition
 end

--- a/app/presenters/publishing_api/case_study_presenter.rb
+++ b/app/presenters/publishing_api/case_study_presenter.rb
@@ -81,15 +81,11 @@ module PublishingApi
     end
 
     def image_available?
-      item.lead_image.present? || emphasised_organisation_default_image_available?
+      item.lead_image.present? || item.emphasised_organisation_default_image_available?
     end
 
     def image_required?
       item.image_display_option != "no_image"
-    end
-
-    def emphasised_organisation_default_image_available?
-      item.lead_organisations.first.default_news_image.present?
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -234,6 +234,7 @@ Whitehall::Application.routes.draw do
         resources :images, controller: "edition_images", only: %i[create destroy edit update index] do
           get :confirm_destroy, on: :member
         end
+        resources :lead_images, controller: "edition_lead_images", only: %i[update]
       end
 
       get "/editions/:id" => "editions#show"

--- a/features/edition-images.feature
+++ b/features/edition-images.feature
@@ -29,7 +29,7 @@ Feature: Images tab on edit edition
     And a draft case study with images exists
     When I visit the images tab of the document with images
     And I click to hide the lead image
-    Then I should see a button to show the lead image
+    Then I should see a button to select a lead image
 
   Scenario: User selects a new lead image
     And a draft case study with images with the alt text "First image uploaded" and "Second image uploaded" exists

--- a/features/edition-images.feature
+++ b/features/edition-images.feature
@@ -26,10 +26,13 @@ Feature: Images tab on edit edition
     Then I should see the updated image details
 
   Scenario: Lead image setting can be updated from the images tab
-    And a draft case study with images exists
+    And an organisation with a default news image exists
+    And the organisation has a draft case study with images
     When I visit the images tab of the document with images
-    And I click to hide the lead image
-    Then I should see a button to select a lead image
+    Then I should see the organisations default news image
+    When I click to hide the lead image
+    Then I should see a button to select a custom lead image
+    And I should see a button to choose to use the default image
 
   Scenario: User selects a new lead image
     And a draft case study with images with the alt text "First image uploaded" and "Second image uploaded" exists

--- a/features/edition-images.feature
+++ b/features/edition-images.feature
@@ -31,6 +31,14 @@ Feature: Images tab on edit edition
     And I click to hide the lead image
     Then I should see a button to show the lead image
 
+  Scenario: User selects a new lead image
+    And a draft case study with images with the alt text "First image uploaded" and "Second image uploaded" exists
+    When I visit the images tab of the document with images
+    And I make the image with alt text "First image uploaded" the lead image
+    Then I can see that the image with alt text "First image uploaded" is the lead image
+    And I make the image with alt text "Second image uploaded" the lead image
+    Then I can see that the image with alt text "Second image uploaded" is the lead image
+
   Scenario: Image uploaded with no cropping required
     And I start drafting a new publication "Standard Beard Lengths"
     When I visit the images tab of the document "Standard Beard Lengths"

--- a/features/step_definitions/image_steps.rb
+++ b/features/step_definitions/image_steps.rb
@@ -5,7 +5,7 @@ end
 
 Given("a draft case study with images exists") do
   images = [build(:image), build(:image)]
-  @edition = create(:draft_case_study, body: "!!2", images:)
+  @edition = create(:draft_case_study, body: "!!2", images:, lead_image: images.first)
 end
 
 When("I visit the images tab of the document with images") do
@@ -39,7 +39,7 @@ When("I click to edit the details of an image") do
 end
 
 When("I click to hide the lead image") do
-  find("button", text: "Hide lead image").click
+  find("button", text: "Remove lead image").click
 end
 
 When("I confirm the deletion") do
@@ -63,8 +63,8 @@ Then "I should see the updated image details" do
   expect(page).to have_content("Test caption")
 end
 
-Then "I should see a button to show the lead image" do
-  expect(page).to have_content("Show lead image")
+Then "I should see a button to select a lead image" do
+  assert_selector ".govuk-button", text: "Select as lead image", count: 2
 end
 
 And(/^I upload a (\d+)x(\d+) image$/) do |width, height|

--- a/features/step_definitions/image_steps.rb
+++ b/features/step_definitions/image_steps.rb
@@ -8,6 +8,16 @@ Given("a draft case study with images exists") do
   @edition = create(:draft_case_study, body: "!!2", images:, lead_image: images.first)
 end
 
+Given("an organisation with a default news image exists") do
+  default_news_image = build(:featured_image_data)
+  @organisation = create(:organisation, default_news_image:)
+end
+
+And("the organisation has a draft case study with images") do
+  images = [build(:image), build(:image)]
+  @edition = create(:draft_case_study, images:, lead_organisations: [@organisation])
+end
+
 When("I visit the images tab of the document with images") do
   visit admin_edition_images_path(@edition)
 end
@@ -63,8 +73,12 @@ Then "I should see the updated image details" do
   expect(page).to have_content("Test caption")
 end
 
-Then "I should see a button to select a lead image" do
+Then "I should see a button to select a custom lead image" do
   assert_selector ".govuk-button", text: "Select as lead image", count: 2
+end
+
+And "I should see a button to choose to use the default image" do
+  assert_selector ".govuk-button", text: "Use default image", count: 1
 end
 
 And(/^I upload a (\d+)x(\d+) image$/) do |width, height|
@@ -118,5 +132,11 @@ end
 Then(/^I can see that the image with alt text "([^"]*)" is the lead image$/) do |alt_text|
   within ".app-c-edition-images-lead-image-component__lead_image" do
     expect(page).to have_content alt_text
+  end
+end
+
+Then(/^I should see the organisations default news image$/) do
+  within ".app-c-edition-images-lead-image-component__default_lead_image" do
+    assert_selector "img", count: 1
   end
 end

--- a/features/step_definitions/image_steps.rb
+++ b/features/step_definitions/image_steps.rb
@@ -99,3 +99,24 @@ end
 Then(/^I should get (\d+) error message$/) do |count|
   expect(page).to have_selector(".gem-c-error-summary__list-item", count:)
 end
+
+Given(/^a draft case study with images with the alt text "([^"]*)" and "([^"]*)" exists$/) do |first_alt_text, second_alt_text|
+  # Unfortunately, we have to use alt text here to distinguish between the images. The assets
+  # are overwritten and stubbed out in asset_manager_helper.rb so the filename and url are always the same.
+  images = [build(:image, alt_text: first_alt_text), build(:image, alt_text: second_alt_text)]
+  @edition = create(:draft_case_study, images:)
+end
+
+And(/^I make the image with alt text "([^"]*)" the lead image$/) do |alt_text|
+  image_container = find(".govuk-body", text: alt_text).ancestor("li")
+
+  within image_container do
+    click_button "Select as lead image"
+  end
+end
+
+Then(/^I can see that the image with alt text "([^"]*)" is the lead image$/) do |alt_text|
+  within ".app-c-edition-images-lead-image-component__lead_image" do
+    expect(page).to have_content alt_text
+  end
+end

--- a/test/components/admin/edition_images/image_component_test.rb
+++ b/test/components/admin/edition_images/image_component_test.rb
@@ -17,6 +17,8 @@ class Admin::EditionImages::ImageComponentTest < ViewComponent::TestCase
     assert_selector ".app-view-edition-resource__actions a[href='#{edit_admin_edition_image_path(edition, image)}']", text: "Edit details"
     assert_selector ".app-view-edition-resource__actions a[href='#{confirm_destroy_admin_edition_image_path(edition, image)}']", text: "Delete image"
     assert_selector ".app-view-edition-resource__section-break"
+    assert_selector "form[action='#{admin_edition_lead_image_path(edition, image)}']", count: 0
+    assert_selector ".govuk-button", text: "Select as lead image", count: 0
   end
 
   test "renders placeholder text for caption and alt text when none has been provided" do
@@ -26,6 +28,16 @@ class Admin::EditionImages::ImageComponentTest < ViewComponent::TestCase
 
     assert_selector ".govuk-grid-row .govuk-grid-column-two-thirds .govuk-body:nth-child(1)", text: "Caption: None"
     assert_selector ".govuk-grid-row .govuk-grid-column-two-thirds .govuk-body:nth-child(2)", text: "Alt text: None"
+  end
+
+  test "renders a form to the update lead image endpoint for case studies" do
+    image = build_stubbed(:image, caption: "caption", alt_text: "alt text")
+    edition = build_stubbed(:draft_case_study, images: [image])
+    render_inline(Admin::EditionImages::ImageComponent.new(edition:, image:, last_image: false))
+
+    assert_selector "form[action='#{admin_edition_lead_image_path(edition, image)}']" do
+      assert_selector ".govuk-button", text: "Select as lead image"
+    end
   end
 
   test "image filename markdown displayed" do

--- a/test/components/admin/edition_images/lead_image_component_test.rb
+++ b/test/components/admin/edition_images/lead_image_component_test.rb
@@ -120,4 +120,51 @@ class Admin::EditionImages::LeadImageComponentTest < ViewComponent::TestCase
     assert_selector "form[action='#{update_image_display_option_admin_edition_path(edition)}']", count: 0
     assert_selector "input[type='hidden'][name='edition[image_display_option]']", visible: :hidden, count: 0
   end
+
+  test "case studies renders the organisations default_lead_image when image_display_option is 'organisation_image'" do
+    image = build(:featured_image_data)
+    organisation = build(:organisation, default_news_image: image)
+    edition = create(:draft_case_study, image_display_option: "organisation_image", lead_organisations: [organisation])
+    render_inline(Admin::EditionImages::LeadImageComponent.new(edition:))
+
+    assert_selector ".app-c-edition-images-lead-image-component__default_lead_image img[alt='Default organisation image']"
+    assert_selector ".app-c-edition-images-lead-image-component__default_lead_image .govuk-hint", text: "Default image for your organisation"
+  end
+
+  test "case studies renders the organisations default_lead_image when image_display_option is nil and no lead image is present" do
+    image = build(:featured_image_data)
+    organisation = build(:organisation, default_news_image: image)
+    edition = create(:draft_case_study, image_display_option: nil, lead_organisations: [organisation])
+    render_inline(Admin::EditionImages::LeadImageComponent.new(edition:))
+
+    assert_selector ".app-c-edition-images-lead-image-component__default_lead_image img[alt='Default organisation image']"
+    assert_selector ".app-c-edition-images-lead-image-component__default_lead_image .govuk-hint", text: "Default image for your organisation"
+  end
+
+  test "case studies doesn't render the organisations default_lead_image when image_display_option is 'no_image'" do
+    image = build(:featured_image_data)
+    organisation = build(:organisation, default_news_image: image)
+    edition = create(:draft_case_study, image_display_option: "no_image", lead_organisations: [organisation])
+    render_inline(Admin::EditionImages::LeadImageComponent.new(edition:))
+
+    assert_selector ".app-c-edition-images-lead-image-component__default_lead_image", count: 0
+  end
+
+  test "news articles renders the organisations default_lead_image no lead image has been selected" do
+    image = build(:featured_image_data)
+    organisation = build(:organisation, default_news_image: image)
+    edition = create(:draft_news_article, lead_organisations: [organisation])
+    render_inline(Admin::EditionImages::LeadImageComponent.new(edition:))
+
+    assert_selector ".app-c-edition-images-lead-image-component__default_lead_image img[alt='Default organisation image']"
+    assert_selector ".app-c-edition-images-lead-image-component__default_lead_image .govuk-hint", text: "Default image for your organisation"
+  end
+
+  test "news articles doesn't render the organisations default_lead_image when one is not present" do
+    organisation = build(:organisation, default_news_image: nil)
+    edition = create(:draft_news_article, lead_organisations: [organisation])
+    render_inline(Admin::EditionImages::LeadImageComponent.new(edition:))
+
+    assert_selector ".app-c-edition-images-lead-image-component__default_lead_image", count: 0
+  end
 end

--- a/test/components/admin/edition_images/lead_image_component_test.rb
+++ b/test/components/admin/edition_images/lead_image_component_test.rb
@@ -16,7 +16,7 @@ class Admin::EditionImages::LeadImageComponentTest < ViewComponent::TestCase
     edition = build_stubbed(:draft_case_study)
     render_inline(Admin::EditionImages::LeadImageComponent.new(edition:))
 
-    first_para = "Using a lead image is optional and can be shown or hidden. The first image you upload is used as the lead image."
+    first_para = "Using a lead image is optional. To use a lead image either select the default image for your organisation or upload an image and select it as the lead image."
     second_para = "The lead image appears at the top of the document. The same image cannot be used in the body text."
 
     assert_selector ".govuk-details__text .govuk-body:nth-child(1)", text: first_para, visible: :hidden
@@ -27,7 +27,7 @@ class Admin::EditionImages::LeadImageComponentTest < ViewComponent::TestCase
     edition = build_stubbed(:draft_news_article)
     render_inline(Admin::EditionImages::LeadImageComponent.new(edition:))
 
-    first_para = "The first image you upload is used as the lead image."
+    first_para = "Any image you upload can be selected as the lead image. If you do not select a new lead image, the default image for your organisation will be used."
     second_para = "The lead image appears at the top of the document. The same image cannot be used in the body text."
 
     assert_selector ".govuk-details__text .govuk-body:nth-child(1)", text: first_para, visible: :hidden

--- a/test/components/admin/edition_images/lead_image_component_test.rb
+++ b/test/components/admin/edition_images/lead_image_component_test.rb
@@ -82,6 +82,15 @@ class Admin::EditionImages::LeadImageComponentTest < ViewComponent::TestCase
     end
   end
 
+  test "case studies has the correct fields when image_display_option is 'no_image' and images have been uploaded" do
+    image = build_stubbed(:image)
+    edition = build_stubbed(:draft_case_study, image_display_option: "no_image", images: [image])
+    render_inline(Admin::EditionImages::LeadImageComponent.new(edition:))
+
+    assert_selector "input[type='hidden'][name='edition[image_display_option]'][value='organisation_image']", visible: :hidden
+    assert_selector ".govuk-button", text: "Use default image"
+  end
+
   test "case studies has the correct fields when image_display_option is 'organisation_image' and no images have been uploaded" do
     edition = build_stubbed(:draft_case_study, image_display_option: "organisation_image")
     render_inline(Admin::EditionImages::LeadImageComponent.new(edition:))
@@ -92,25 +101,14 @@ class Admin::EditionImages::LeadImageComponentTest < ViewComponent::TestCase
     end
   end
 
-  test "case studies has the correct fields when image_display_option is 'no_image' and images have been uploaded" do
-    image = build_stubbed(:image)
-    edition = build_stubbed(:draft_case_study, image_display_option: "no_image", images: [image])
-    render_inline(Admin::EditionImages::LeadImageComponent.new(edition:))
-
-    assert_selector "form[action='#{update_image_display_option_admin_edition_path(edition)}']" do
-      assert_selector "input[type='hidden'][name='edition[image_display_option]'][value='custom_image']", visible: :hidden
-      assert_selector ".govuk-button", text: "Show lead image"
-    end
-  end
-
   test "case studies has the correct fields when image_display_option is 'custom_image' and images have been uploaded" do
     image = build_stubbed(:image)
-    edition = build_stubbed(:draft_case_study, image_display_option: "custom_image", images: [image])
+    edition = build_stubbed(:draft_case_study, image_display_option: "custom_image", images: [image], lead_image: image)
     render_inline(Admin::EditionImages::LeadImageComponent.new(edition:))
 
     assert_selector "form[action='#{update_image_display_option_admin_edition_path(edition)}']" do
       assert_selector "input[type='hidden'][name='edition[image_display_option]'][value='no_image']", visible: :hidden
-      assert_selector ".govuk-button", text: "Hide lead image"
+      assert_selector ".govuk-button", text: "Remove lead image"
     end
   end
 

--- a/test/functional/admin/edition_lead_images_controller_test.rb
+++ b/test/functional/admin/edition_lead_images_controller_test.rb
@@ -1,0 +1,53 @@
+require "test_helper"
+
+class Admin::EditionLeadImagesControllerTest < ActionController::TestCase
+  test "PATCH :update successfully updates the lead image and republishes the draft edition" do
+    login_as :writer
+
+    image = build(:image)
+    edition = create(:draft_case_study, images: [image])
+
+    Whitehall::PublishingApi
+    .expects(:save_draft)
+    .with(edition)
+    .returns(true)
+    .once
+
+    get :update, params: { edition_id: edition.id, id: image.id }
+
+    assert_equal image, edition.reload.lead_image
+    assert_redirected_to admin_edition_images_path(edition)
+    assert_equal "Lead image updated to minister-of-funk.960x640.jpg", flash[:notice]
+  end
+
+  test "PATCH :update does not update the lead image when the edition is invalid " do
+    login_as :writer
+
+    published_edition = create(:published_case_study)
+    image = build(:image)
+    edition = create(:draft_case_study, images: [image], document: published_edition.document)
+
+    edition.change_note = nil
+    edition.save!(validate: false)
+
+    Whitehall::PublishingApi
+    .expects(:save_draft)
+    .never
+
+    get :update, params: { edition_id: edition.id, id: image.id }
+
+    assert_nil edition.reload.lead_image
+    assert_redirected_to admin_edition_images_path(edition)
+    assert_equal "This edition is invalid: Change note can't be blank", flash[:alert]
+  end
+
+  test "PATCH :update forbids unauthorised users" do
+    login_as :world_editor
+    image = build(:image)
+    edition = create(:draft_case_study, images: [image])
+
+    get :update, params: { edition_id: edition.id, id: image.id }
+
+    assert_response :forbidden
+  end
+end


### PR DESCRIPTION
## Description

This adds the ability to select a lead image for news articles and case studies. It does the following:

- adds a feature spec for updating the lead image
- adds a route for updating the lead image
- adds an edition_lead_images_controller with an update action
- updates the image_component to render a form/button for each non-lead
image which hits the new endpoint
- updates the copy in the lead image guidance
- updates the UI so the user can select between no lead image, the orgs default lead image or a custom lead image for case studies
- actually renders the orgs default image if one is present and the user is using it
- ensures that the draft is passed down to publishing API when the lead image is updated so it works on the preview

## Screenshots

### Case studies

#### With default image and no uploaded images

<img width="652" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/0b2f84d2-153e-4e01-b698-5f16ea5e1487">

#### With no image & no uploaded images

<img width="673" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/960cdbd5-32ef-4d5d-b8c3-da2138a7cd03">

#### WIth no images and images uploaded 

<img width="683" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/ef174b2f-fbcd-41d7-84f1-b40f1e2bcb48">

#### With default image and images uploaded

<img width="789" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/469be750-ddda-48ef-b778-3671a10101f5">

#### With custom image

<img width="760" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/9377947c-82b7-4c3b-9526-6cc26104b91f">


### News articles

#### With no image uploaded it shows default org image 

<img width="554" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/88a31b2b-29e3-4b8a-9960-303728fdce36">

#### With image uploaded

<img width="590" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/67627927-61ee-44dd-9601-fc247cfb1a29">

#### With multiple images uploaded 

<img width="730" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/65083cab-c9a2-4d8e-b3c5-b1a97e3b0faf">


## Video of implementation 

https://github.com/alphagov/whitehall/assets/42515961/e3296d63-fa8b-40fd-930b-5ab378fb3d8f

## Trello card

https://trello.com/c/QB4hHGwB/2164-lead-image-handling-selecting-a-new-lead-image

## Designs 

https://docs.google.com/document/d/14Xz67PJYrh3dKgtDaJXDM3MiWR3G8Rm4YThpggvQSG0/edit#heading=h.614wri5x7vxr
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
