### PR TITLE
Prepare release and code cleanup header navigation

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -53,11 +53,6 @@ class Admin::BaseController < ApplicationController
     end
   end
 
-  def show_new_header?
-    current_user.can_preview_design_system?
-  end
-  helper_method :show_new_header?
-
 private
 
   def new_design_system?

--- a/app/controllers/admin/more_controller.rb
+++ b/app/controllers/admin/more_controller.rb
@@ -1,22 +1,5 @@
 class Admin::MoreController < Admin::BaseController
-  before_action :check_new_design_system_permissions, only: %i[index]
-  layout :get_layout
+  layout "design_system"
 
   def index; end
-
-private
-
-  def check_new_design_system_permissions
-    forbidden! unless new_design_system?
-  end
-
-  def get_layout
-    design_system_actions = %w[index] if preview_design_system?(next_release: false)
-
-    if design_system_actions&.include?(action_name)
-      "design_system"
-    else
-      "admin"
-    end
-  end
 end

--- a/app/controllers/admin/new_document_controller.rb
+++ b/app/controllers/admin/new_document_controller.rb
@@ -1,7 +1,5 @@
 class Admin::NewDocumentController < Admin::BaseController
-  before_action :check_new_design_system_permissions, only: %i[index]
-
-  layout :get_layout
+  layout "design_system"
 
   def index; end
 

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -17,24 +17,16 @@
 <% end %>
 
 <%= render "govuk_publishing_components/components/layout_for_admin",
-  product_name: "Whitehall Publisher",
-  environment: environment,
-  browser_title: ("Error: " if yield(:error_summary).present?).to_s + sanitize((yield(:page_title).presence || yield(:title))) do %>
+           product_name: "Whitehall Publisher",
+           environment: environment,
+           browser_title: ("Error: " if yield(:error_summary).present?).to_s + sanitize((yield(:page_title).presence || yield(:title))) do %>
 
   <!-- This element exists to initialise the JS module that configures custom Analytics behaviour -->
   <div data-module="app-analytics"></div>
 
   <%= render "govuk_publishing_components/components/skip_link" %>
 
-  <% if show_new_header? %>
-    <%= render partial: "shared/header" %>
-  <% else %>
-    <div class="legacy-whitehall">
-      <div class="environment-<%= environment %> navbar-wrapper">
-        <%= render partial: "shared/legacy_header" %>
-      </div>
-    </div>
-  <% end %>
+  <%= render partial: "shared/header" %>
 
   <div class="govuk-width-container">
     <%= render "shared/phase_banner", {

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,5 +1,4 @@
 <% environment = GovukPublishingComponents::AppHelpers::Environment.current_acceptance_environment %>
-<% admin_template ||= false %>
 <% organisation = current_user&.organisation %>
 <% user = current_user %>
 
@@ -46,9 +45,3 @@
     ],
   } %>
 </div>
-
-<% if admin_template %>
-  <section class="notices">
-    <%= render partial: "shared/notices" %>
-  </section>
-<% end %>

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -17,11 +17,9 @@ module DocumentHelper
   def begin_drafting_document(options)
     create(:organisation) if Organisation.count.zero?
     visit admin_root_path
-    # Make sure the dropdown is visible first, otherwise Capybara won't see the links
-    find("li.create-new a", text: "New document").click
-    within "li.create-new" do
-      click_link options[:type].humanize
-    end
+    find("li.app-c-sub-navigation__list-item a", text: "New document").click
+    page.choose(options[:type].humanize)
+    click_button("Next")
 
     if options[:locale]
       check "Create a foreign language only"

--- a/features/support/person_helper.rb
+++ b/features/support/person_helper.rb
@@ -25,6 +25,7 @@ module PersonHelper
 
   def visit_people_admin
     visit admin_root_path
+    click_link "More"
     click_link "People"
   end
 

--- a/features/support/topical_events_helper.rb
+++ b/features/support/topical_events_helper.rb
@@ -6,6 +6,7 @@ ParameterType(
 module TopicalEventsHelper
   def create_topical_event_and_stub_in_content_store(options = {})
     visit admin_root_path
+    click_link "More"
     click_link "Topical events"
     click_link "Create topical event"
     fill_in "Name", with: options[:name] || "topic-name"

--- a/test/functional/admin/base_controller_test.rb
+++ b/test/functional/admin/base_controller_test.rb
@@ -167,16 +167,6 @@ class Admin::BaseControllerTest < ActionController::TestCase
     assert_select ".app-c-sub-navigation__list .app-c-sub-navigation__list-item a[href=\"/government/admin/more\"]"
   end
 
-  view_test "renders legacy header component if login as a non design system user" do
-    login_as :gds_editor
-    @controller = Admin::NewDocumentController.new
-
-    get :index
-
-    assert_select ".govuk-header__navigation-item", false
-    assert_select ".nav.navbar-nav", text: /Dashboard/
-  end
-
 private
 
   def assert_not_current_item(path)

--- a/test/functional/admin/base_controller_test.rb
+++ b/test/functional/admin/base_controller_test.rb
@@ -147,26 +147,6 @@ class Admin::BaseControllerTest < ActionController::TestCase
     assert_not_current_item("/government/admin/organisations/my-test-org/features")
   end
 
-  view_test "only renders non-organisation header links if not logged in" do
-    # It's not possible, at the moment, to show the new design system layout if no user is signed in,
-    # but once we remove the legacy layout, the design system will be the default layout. In order to
-    # test this for now we stub some BaseController methods—this stubbing won't be necessary once the
-    # design system transition has been completed.
-    Admin::BaseController.any_instance.stubs(:show_new_header?).returns(true)
-    Admin::BaseController.any_instance.stubs(:preview_design_system?).returns(true)
-    @controller = Admin::NewDocumentController.new
-
-    get :index
-
-    assert_select ".app-c-sub-navigation__list .app-c-sub-navigation__list-item a[href=\"/government/admin/organisations/my-test-org/features\"]", false
-    assert_select ".app-c-sub-navigation__list .app-c-sub-navigation__list-item a[href=\"/government/admin/organisations/my-test-org/corporate_information_pages\"]", false
-
-    assert_select ".app-c-sub-navigation__list .app-c-sub-navigation__list-item a[href=\"/government/admin/new-document\"]"
-    assert_select ".app-c-sub-navigation__list .app-c-sub-navigation__list-item a[href=\"/government/admin/editions\"]"
-    assert_select ".app-c-sub-navigation__list .app-c-sub-navigation__list-item a[href=\"/government/admin/statistics_announcements\"]"
-    assert_select ".app-c-sub-navigation__list .app-c-sub-navigation__list-item a[href=\"/government/admin/more\"]"
-  end
-
 private
 
   def assert_not_current_item(path)

--- a/test/functional/admin/more_controller_test.rb
+++ b/test/functional/admin/more_controller_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class Admin::MoreControllerTest < ActionController::TestCase
   setup do
-    login_as_preview_design_system_user :writer
+    login_as :writer
   end
 
   view_test "GET #index renders the 'More' page with a correctly formatted list of links" do

--- a/test/functional/admin/new_document_controller_test.rb
+++ b/test/functional/admin/new_document_controller_test.rb
@@ -52,12 +52,6 @@ class Admin::NewDocumentControllerTest < ActionController::TestCase
     assert_select ".govuk-radios__item input[type=radio][name=new_document_options][value=fatality_notice]", count: 1
   end
 
-  test "access to the New document index page is forbidden for users without design system permissions" do
-    login_as :writer
-    get :index
-    assert_response :forbidden
-  end
-
   test "POST #new_document_options_redirect redirects each radio buttons to their expected paths" do
     redirect_options.each do |selected_option, expected_path|
       request_params = {


### PR DESCRIPTION
This PR prepares header navigation for release and remove legacy code.
It does the following

- Update header partial to have design system content.
- Update design layout view to always render new header.
- remove legacy tests for header navigation.
- Update New Document controller to render design system.
- Update More controller to render design system.

**Trello:**
https://trello.com/c/WsD20PgJ/574-prepare-release-code-cleanup-for-header-navigation