### PR TITLE
Refactor body_does_not_contain_lead_image validator

### DIFF
--- a/app/helpers/govspeak_helper.rb
+++ b/app/helpers/govspeak_helper.rb
@@ -52,7 +52,7 @@ module GovspeakHelper
       .select { |image| image.image_data&.all_asset_variants_uploaded? }
       .map do |image|
       {
-        id: image.image_data.carrierwave_image,
+        id: image.filename,
         image_data_id: image.image_data_id,
         edition_id: image.edition_id,
         alt_text: image.alt_text,

--- a/test/unit/app/helpers/govspeak_helper_test.rb
+++ b/test/unit/app/helpers/govspeak_helper_test.rb
@@ -268,15 +268,15 @@ class GovspeakHelperTest < ActionView::TestCase
   test "embeds images using !!number syntax" do
     edition = build(:published_news_article, body: "!!1")
     image_data = create(:image_data, id: 1)
-    edition.stubs(:images).returns([OpenStruct.new(alt_text: "My Alt", url: "https://some.cdn.com/image.jpg", image_data: ImageData.find(image_data.id))])
+    edition.stubs(:images).returns([OpenStruct.new(alt_text: "My Alt", url: "https://some.cdn.com/image.jpg", filename: "image.jpg", image_data: ImageData.find(image_data.id))])
     html = govspeak_edition_to_html(edition)
     assert_select_within_html html, ".govspeak figure.image.embedded img[src='https://some.cdn.com/image.jpg']"
   end
 
   test "embeds images using [Image:] syntax" do
-    edition = build(:published_news_article, body: "[Image: minister-of-funk.960x640.jpg]")
+    edition = build(:published_news_article, body: "[Image: image.jpg]")
     image_data = create(:image_data, id: 1)
-    edition.stubs(:images).returns([OpenStruct.new(alt_text: "My Alt", url: "https://some.cdn.com/image.jpg", image_data: ImageData.find(image_data.id))])
+    edition.stubs(:images).returns([OpenStruct.new(alt_text: "My Alt", url: "https://some.cdn.com/image.jpg", filename: "image.jpg", image_data: ImageData.find(image_data.id))])
     html = govspeak_edition_to_html(edition)
     assert_select_within_html html, ".govspeak figure.image.embedded img[src='https://some.cdn.com/image.jpg']"
   end

--- a/test/unit/lib/whitehall/govspeak_renderer_test.rb
+++ b/test/unit/lib/whitehall/govspeak_renderer_test.rb
@@ -20,8 +20,8 @@ class Whitehall::GovspeakRendererTest < ActiveSupport::TestCase
 
   test "interpolates images into rendered HTML when using filename as a markdown" do
     image_data = create(:image_data, id: 1)
-    image = OpenStruct.new(alt_text: "My Alt", url: "http://example.com/image.jpg", image_data: ImageData.find(image_data.id))
-    edition = build(:edition, body: "Some content with an image.\n\n[Image: minister-of-funk.960x640.jpg]")
+    image = OpenStruct.new(alt_text: "My Alt", url: "http://example.com/image.jpg", filename: "image.jpg", image_data: ImageData.find(image_data.id))
+    edition = build(:edition, body: "Some content with an image.\n\n[Image: image.jpg]")
     edition.stubs(:images).returns([image])
 
     assert_equivalent_html govspeak_with_image_html(image),


### PR DESCRIPTION
This commit refactors the `body_does_not_contain_lead_image` custom validation method to reduce its coupling to Govspeak.

Right now it uses regular expressions to check if the lead image has been embedded into the document body. This relies upon the validator knowing the specific Govspeak syntax that would be used to embed the image (of which there are two different variants).

This refactor takes a more 'black box' approach by rendering the Govspeak as HTML, and then inspecting the output to see if it contains the lead image. This way the validator doesn't need to parse the Govspeak syntax directly – making it more robust against future changes to the syntax.

I imagine this new approach is slightly less performant. It now renders and inspects the resultant HTML, rather than simply matching a regex against the raw Govspeak. However I expect this will have negligible overall impact on performance, so would be a net benefit given the improvements to code readability and cleanliness.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
