### PR TITLE
Content updates to Document Collections

### DIFF
--- a/app/helpers/admin/tabbed_nav_helper.rb
+++ b/app/helpers/admin/tabbed_nav_helper.rb
@@ -79,7 +79,7 @@ module Admin::TabbedNavHelper
 
   def document_collection_nav_items(edition, current_path)
     {
-      label: "Collection documents",
+      label: "Collections",
       href: admin_document_collection_groups_path(edition),
       current: current_path == admin_document_collection_groups_path(edition),
     }

--- a/app/models/document_collection_group.rb
+++ b/app/models/document_collection_group.rb
@@ -36,7 +36,7 @@ class DocumentCollectionGroup < ApplicationRecord
   end
 
   def self.default_attributes
-    { heading: "Documents" }
+    { heading: "Collection" }
   end
 
   def editable_members

--- a/features/step_definitions/document_collection_steps.rb
+++ b/features/step_definitions/document_collection_steps.rb
@@ -32,7 +32,7 @@ end
 When(/^I add the non whitehall url "(.*?)" for "(.*?)" to the document collection$/) do |url, title|
   visit admin_document_collection_path(@document_collection)
   click_on "Edit draft"
-  click_on "Collection documents"
+  click_on "Collections"
 
   base_path = URI.parse(url).path
   content_id = SecureRandom.uuid
@@ -63,7 +63,7 @@ When(/^I add the document "(.*?)" to the document collection$/) do |document_tit
   visit admin_document_collection_path(@document_collection)
 
   click_on "Edit draft"
-  click_on "Collection documents"
+  click_on "Collections"
 
   fill_in "title", with: document_title
   click_on "Find"
@@ -80,7 +80,7 @@ When(/^I move "(.*?)" before "(.*?)" in the document collection$/) do |doc_title
 
   visit admin_document_collection_path(@document_collection)
   click_on "Edit draft"
-  click_on "Collection documents"
+  click_on "Collections"
 
   # Simulate drag-droping document.
   execute_script %{
@@ -105,7 +105,7 @@ Then(/^I (?:can )?view the document collection in the admin$/) do
 
   visit admin_document_collection_path(@document_collection)
   click_on "Edit draft"
-  click_on "Collection documents"
+  click_on "Collections"
 
   expect(page).to have_selector("h1", text: @document_collection.title)
 end
@@ -123,7 +123,7 @@ end
 Then(/^I can see in the admin that "(.*?)" is part of the document collection$/) do |document_title|
   visit admin_document_collection_path(@document_collection)
   click_on "Edit draft"
-  click_on "Collection documents"
+  click_on "Collections"
 
   assert_document_is_part_of_document_collection(document_title)
 end
@@ -149,7 +149,7 @@ When(/^I redraft the document collection and remove "(.*?)" from it$/) do |docum
   save_screenshot
 
   click_on "Edit draft"
-  click_on "Collection documents"
+  click_on "Collections"
 
   check document_title
   click_on "Remove"

--- a/test/unit/app/helpers/admin/tabbed_nav_helper_test.rb
+++ b/test/unit/app/helpers/admin/tabbed_nav_helper_test.rb
@@ -118,7 +118,7 @@ class Admin::TabbedNavHelperTest < ActionView::TestCase
         current: false,
       },
       {
-        label: "Collection documents",
+        label: "Collections",
         href: admin_document_collection_groups_path(document_collection),
         current: true,
       },

--- a/test/unit/app/models/document_collection_test.rb
+++ b/test/unit/app/models/document_collection_test.rb
@@ -42,7 +42,7 @@ class DocumentCollectionTest < ActiveSupport::TestCase
   test "it should create a group called 'Documents' when created if groups are empty" do
     doc_collection = create(:document_collection, groups: [])
     assert_equal 1, doc_collection.groups.length
-    assert_equal "Documents", doc_collection.groups[0].heading
+    assert_equal "Collection", doc_collection.groups[0].heading
   end
 
   test "it should not create a group if it's already been given one" do


### PR DESCRIPTION
[Trello](https://trello.com/c/NF3mbnla/602-content-update)

These changes make some updates to content on the Document Collections page (screenshots below)
- Update secondary nav tab to "Collections"
- Update default heading attribute to "Collection"
- Update tests to reflect the content changes

|Before|After|
|-|-|
|![Screenshot 2023-11-02 at 17 10 58](https://github.com/alphagov/whitehall/assets/6080548/56c96b7e-977b-4af1-8a05-0ad5af55a3e6)|![Screenshot 2023-11-02 at 17 09 40](https://github.com/alphagov/whitehall/assets/6080548/8282e87a-8500-4b6d-9837-77acdc59ab20)|
