### PR TITLE
Fix organisation update and destroy

### DIFF
--- a/app/models/featured_image_data.rb
+++ b/app/models/featured_image_data.rb
@@ -22,4 +22,11 @@ class FeaturedImageData < ApplicationRecord
 
     (required_variants - asset_variants).empty?
   end
+
+  def republish_on_assets_ready
+    if all_asset_variants_uploaded?
+      featured_imageable.publish_to_publishing_api_async if featured_imageable.respond_to? :publish_to_publishing_api_async
+      featured_imageable.republish_dependent_documents if featured_imageable.respond_to? :republish_dependent_documents
+    end
+  end
 end

--- a/app/models/featured_image_data.rb
+++ b/app/models/featured_image_data.rb
@@ -1,5 +1,6 @@
 class FeaturedImageData < ApplicationRecord
   mount_uploader :file, FeaturedImageUploader, mount_on: :carrierwave_image
+
   belongs_to :featured_imageable, polymorphic: true
 
   has_many :assets,
@@ -7,6 +8,8 @@ class FeaturedImageData < ApplicationRecord
            inverse_of: :assetable
 
   validates :file, presence: true
+  validates :featured_imageable, presence: true
+
   validates_with ImageValidator, size: [960, 640]
 
   def filename

--- a/app/views/admin/organisations/_form.html.erb
+++ b/app/views/admin/organisations/_form.html.erb
@@ -86,7 +86,7 @@
     end,
   } %>
 
-  <%= form.fields_for :default_news_image do |image_fields| %>
+  <%= form.fields_for :default_news_image do |_image_fields| %>
     <%= render "components/single-image-upload", {
       title: "Default news image",
       name: "organisation[default_news_image_attributes]",

--- a/app/views/admin/organisations/_form.html.erb
+++ b/app/views/admin/organisations/_form.html.erb
@@ -96,7 +96,7 @@
       remove_alt_text_field: true,
       filename: organisation.default_news_image.file.identifier,
       page_errors: organisation.errors.any?,
-      error_items: errors_for(organisation.default_news_image.errors, :default_news_image),
+      error_items: errors_for(organisation.errors, :"default_news_image.file"),
       image_src: organisation.default_news_image.file.url,
       image_cache_name: "organisation[default_news_image_attributes][file_cache]",
       image_cache: (organisation.default_news_image.file_cache.presence),

--- a/app/views/admin/topical_events/_form.html.erb
+++ b/app/views/admin/topical_events/_form.html.erb
@@ -40,22 +40,23 @@
   } %>
 
   <div class="govuk-!-margin-bottom-8">
-    <%= hidden_field_tag "topical_event[logo_attributes][id]", topical_event.logo.id %>
-    <%= render "components/single-image-upload", {
-      title: "Logo",
-      name: "topical_event[logo_attributes]",
-      image_id: "topical_event_logo_file",
-      image_name: "topical_event[logo_attributes][file]",
-      alt_text_name: "topical_event[logo_alt_text]",
-      alt_text_id: "topical_event_logo_alt_text",
-      filename: topical_event.logo.filename,
-      page_errors: topical_event.errors.any?,
-      error_items: errors_for(topical_event.errors, :"logo.file"),
-      image_src: topical_event.logo.file.url,
-      image_alt: topical_event.logo_alt_text,
-      image_cache_name: "topical_event[logo_attributes][file_cache]",
-      image_cache: (topical_event.logo.file_cache.presence),
-    } %>
+    <%= form.fields_for :logo do |_image_fields| %>
+      <%= render "components/single-image-upload", {
+        title: "Logo",
+        name: "topical_event[logo_attributes]",
+        image_id: "topical_event_logo_file",
+        image_name: "topical_event[logo_attributes][file]",
+        alt_text_name: "topical_event[logo_alt_text]",
+        alt_text_id: "topical_event_logo_alt_text",
+        filename: topical_event.logo.filename,
+        page_errors: topical_event.errors.any?,
+        error_items: errors_for(topical_event.errors, :"logo.file"),
+        image_src: topical_event.logo.file.url,
+        image_alt: topical_event.logo_alt_text,
+        image_cache_name: "topical_event[logo_attributes][file_cache]",
+        image_cache: (topical_event.logo.file_cache.presence),
+      } %>
+    <% end %>
   </div>
 
   <div class="govuk-!-margin-bottom-8">

--- a/lib/publishes_to_publishing_api.rb
+++ b/lib/publishes_to_publishing_api.rb
@@ -12,6 +12,12 @@ module PublishesToPublishingApi
     persisted?
   end
 
+  def publish_to_publishing_api_async
+    if can_publish_to_publishing_api?
+      PublishingApiWorker.perform_async(self.class.to_s, id)
+    end
+  end
+
   def publish_to_publishing_api
     run_callbacks :published do
       Whitehall::PublishingApi.patch_links(self)

--- a/test/factories/featured_image_data.rb
+++ b/test/factories/featured_image_data.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :featured_image_data do
     file { image_fixture_file }
+    featured_imageable { build(:topical_event) }
 
     after(:build) do |featured_image_data|
       featured_image_data.assets << build(:asset, asset_manager_id: "asset_manager_id_original", variant: Asset.variants[:original], filename: "minister-of-funk.960x640.jpg")

--- a/test/unit/app/models/featured_image_data_test.rb
+++ b/test/unit/app/models/featured_image_data_test.rb
@@ -60,4 +60,11 @@ class FeaturedImageDataTest < ActiveSupport::TestCase
 
     featured_image_data.update!(file: upload_fixture("images/960x640_jpeg.jpg"))
   end
+
+  test "should be invalid without a featured_imageable" do
+    featured_image_data = build(:featured_image_data, featured_imageable: nil)
+
+    assert_not featured_image_data.valid?
+    assert_equal featured_image_data.errors.messages[:featured_imageable], ["can't be blank"]
+  end
 end

--- a/test/unit/app/models/organisation_test.rb
+++ b/test/unit/app/models/organisation_test.rb
@@ -1196,4 +1196,13 @@ class OrganisationTest < ActiveSupport::TestCase
 
     assert_not organisation.all_asset_variants_uploaded?
   end
+
+  test "should not delete default news image on destroy because news articles might depend on it" do
+    organisation = create(:organisation_with_default_news_image)
+    default_news_image = organisation.default_news_image
+
+    organisation.destroy!
+
+    assert FeaturedImageData.find_by(id: default_news_image.id)
+  end
 end

--- a/test/unit/app/workers/asset_manager_create_asset_worker_test.rb
+++ b/test/unit/app/workers/asset_manager_create_asset_worker_test.rb
@@ -180,7 +180,7 @@ class AssetManagerCreateAssetWorkerTest < ActiveSupport::TestCase
     @worker.perform(@file.path, @asset_params, true, consultation.class.to_s, consultation.id)
   end
 
-  test "should publish model when the last file is created if the model inherits PublishesToPublishingApi module" do
+  test "should publish the Organisation when the last asset of the default news image is uploaded to Asset Manager" do
     organisation = create(:organisation, :with_default_news_image)
     last_asset = organisation.default_news_image.assets.last.destroy
     asset_params = {
@@ -213,7 +213,7 @@ class AssetManagerCreateAssetWorkerTest < ActiveSupport::TestCase
     @worker.perform(@file.path, asset_params, true, nil, nil)
   end
 
-  test "should not publish model if all assets variant are not uploaded and the model inherits PublishesToPublishingApi module" do
+  test "should not publish model unless all assets variant are ready" do
     organisation = create(:organisation, :with_default_news_image)
     last_asset = organisation.default_news_image.assets.destroy_all.last
     asset_params = {

--- a/test/unit/lib/tasks/republish_attachments_test.rb
+++ b/test/unit/lib/tasks/republish_attachments_test.rb
@@ -24,7 +24,7 @@ class RepublishAttachmentsRake < ActiveSupport::TestCase
     expect_csv_attachment.once
     expect_old_csv_edition.once
 
-    Rake.application.invoke_task "republish_attachments"
+    assert_output(/3 items to republish/) { Rake.application.invoke_task "republish_attachments" }
   end
 
   test "it selects documents with only the given attachment content type to be republished" do
@@ -32,7 +32,7 @@ class RepublishAttachmentsRake < ActiveSupport::TestCase
     expect_csv_attachment.once
     expect_old_csv_edition.once
 
-    Rake.application.invoke_task "republish_attachments[text/csv]"
+    assert_output(/2 items to republish/) { Rake.application.invoke_task "republish_attachments[text/csv]" }
   end
 
   test "it selects documents that are newer than the provided weeks_ago value" do
@@ -40,7 +40,7 @@ class RepublishAttachmentsRake < ActiveSupport::TestCase
     expect_csv_attachment.once
     expect_old_csv_edition.never
 
-    Rake.application.invoke_task "republish_attachments[text/csv,3]"
+    assert_output(/1 items to republish/) { Rake.application.invoke_task "republish_attachments[text/csv,3]" }
   end
 
   def expect_pdf_attachment


### PR DESCRIPTION
This PR contains various small improvements that make Organisation, Topical Event and related images work a bit more consistently.

* Fix error border for Default News Image field for Organisations
* Remove responsibility of knowing what needs to be republished form  Create Asset Worker 
* Silence console output from rake tasks tests
* Fix file caching behaviour for organisation default news image

[Trello](https://trello.com/c/ugSN4MXG/243-task-fix-update-destroy-in-organisation-caching-bug-in-prod)