### PR TITLE
Revert Document Collections

### DIFF
--- a/app/controllers/admin/document_collection_group_document_search_controller.rb
+++ b/app/controllers/admin/document_collection_group_document_search_controller.rb
@@ -1,8 +1,8 @@
 class Admin::DocumentCollectionGroupDocumentSearchController < Admin::BaseController
   before_action :load_document_collection
   before_action :load_document_collection_group
-
-  layout "design_system"
+  before_action :check_new_design_system_permissions
+  layout :get_layout
 
   def search_options; end
 
@@ -43,6 +43,14 @@ private
           .merge(
             per_page: Admin::EditionFilter::GOVUK_DESIGN_SYSTEM_PER_PAGE,
           )
+  end
+
+  def check_new_design_system_permissions
+    forbidden! unless new_design_system?
+  end
+
+  def get_layout
+    preview_design_system?(next_release: false) ? "design_system" : "admin"
   end
 
   def load_document_collection

--- a/app/helpers/admin/tabbed_nav_helper.rb
+++ b/app/helpers/admin/tabbed_nav_helper.rb
@@ -79,7 +79,7 @@ module Admin::TabbedNavHelper
 
   def document_collection_nav_items(edition, current_path)
     {
-      label: "Collections",
+      label: "Collection documents",
       href: admin_document_collection_groups_path(edition),
       current: current_path == admin_document_collection_groups_path(edition),
     }

--- a/app/models/document_collection_group.rb
+++ b/app/models/document_collection_group.rb
@@ -36,7 +36,7 @@ class DocumentCollectionGroup < ApplicationRecord
   end
 
   def self.default_attributes
-    { heading: "Collection" }
+    { heading: "Documents" }
   end
 
   def editable_members

--- a/config/cucumber.yml
+++ b/config/cucumber.yml
@@ -5,7 +5,7 @@ rerun_opts = rerun.empty? ? "--format #{ENV['CUCUMBER_FORMAT'] || 'progress'} fe
 std_opts = "--format #{ENV['CUCUMBER_FORMAT'] || 'progress'} --strict --tags 'not @wip'"
 
 default_tags = "--tags 'not @design-system-only'"
-design_system_tags = "--tags 'not @bootstrap-only'"
+design_system_tags = "--tags 'not (@design-system-wip or @bootstrap-only)'"
 %>
 default: <%= std_opts %> <%= default_tags %> features --publish-quiet
 preview_design_system: <%= std_opts %> <%= design_system_tags %> CUCUMBER_PREVIEW_DESIGN_SYSTEM=true features --publish-quiet

--- a/features/document-collections.feature
+++ b/features/document-collections.feature
@@ -6,6 +6,47 @@ Feature: Grouping documents into a collection
   Background:
     Given I am a writer in the organisation "Government Department"
 
+  @javascript @design-system-wip
+  Scenario: Admin creates a document collection.
+    Given a published document "Wombats of Wimbledon" exists
+    When I draft a new document collection called "Wildlife of Wimbledon Common"
+    And I add the document "Wombats of Wimbledon" to the document collection
+    Then I can see in the admin that "Wombats of Wimbledon" is part of the document collection
+
+  @javascript @design-system-wip
+  Scenario: Admin creates a document collection in another language
+    Given a published publication "Wombats of Wimbledon" with locale "cy" exists
+    When I draft a new "Cymraeg" language document collection called "Wildlife of Wimbledon Common"
+    And I add the document "Wombats of Wimbledon" to the document collection
+    Then I can see in the admin that "Wombats of Wimbledon" is part of the document collection
+    And I can see the primary locale for document collection "Wildlife of Wimbledon Common" is "cy"
+
+  @javascript @design-system-wip
+  Scenario: Admin creates a document collection with non whitehall links.
+    Given a document collection "Some super collection" exists
+    And I add the non whitehall url "https://www.gov.uk/king-content-publisher" for "King Content Publisher" to the document collection
+    Then I can see in the admin that "King Content Publisher" is part of the document collection
+
+  @javascript @design-system-wip
+  Scenario: Removing documents from a collection
+    Given a published publication called "May 2012 Update" in a published document collection
+    When I redraft the document collection and remove "May 2012 Update" from it
+    Then I can see in the admin that "May 2012 Update" does not appear
+
+  @javascript @design-system-wip
+  Scenario: Reordering documents in a document collection
+    Given a published document "Wombats of Wimbledon" exists
+    And a published document "Feeding Wombats" exists
+    And a published document "The nocturnal habits of Wombats" exists
+    When I draft a new document collection called "Wildlife of Wimbledon Common"
+    And I add the document "Wombats of Wimbledon" to the document collection
+    And I add the document "Feeding Wombats" to the document collection
+    And I add the document "The nocturnal habits of Wombats" to the document collection
+    And I move "Feeding Wombats" before "Wombats of Wimbledon" in the document collection
+    Then I can view the document collection in the admin
+    And I see that "Feeding Wombats" is before "Wombats of Wimbledon" in the document collection
+    And I see that "Wombats of Wimbledon" is before "The nocturnal habits of Wombats" in the document collection
+
   @design-system-only
   Scenario: Deleting a group
     Given a document collection "May 2012 Update" exists
@@ -15,8 +56,8 @@ Feature: Grouping documents into a collection
 
   @design-system-only
   Scenario: Adding a new group
-    When I draft a new document collection called "May 2012 Update"
-    And I add the group "Brand new group"
+    Given a document collection "May 2012 Update" exists
+    When I add the group "Brand new group"
     Then I can see that the group "Brand new group" has been added
 
   @design-system-only

--- a/features/step_definitions/document_collection_steps.rb
+++ b/features/step_definitions/document_collection_steps.rb
@@ -32,7 +32,7 @@ end
 When(/^I add the non whitehall url "(.*?)" for "(.*?)" to the document collection$/) do |url, title|
   visit admin_document_collection_path(@document_collection)
   click_on "Edit draft"
-  click_on "Collections"
+  click_on "Collection documents"
 
   base_path = URI.parse(url).path
   content_id = SecureRandom.uuid
@@ -63,7 +63,7 @@ When(/^I add the document "(.*?)" to the document collection$/) do |document_tit
   visit admin_document_collection_path(@document_collection)
 
   click_on "Edit draft"
-  click_on "Collections"
+  click_on "Collection documents"
 
   fill_in "title", with: document_title
   click_on "Find"
@@ -80,7 +80,7 @@ When(/^I move "(.*?)" before "(.*?)" in the document collection$/) do |doc_title
 
   visit admin_document_collection_path(@document_collection)
   click_on "Edit draft"
-  click_on "Collections"
+  click_on "Collection documents"
 
   # Simulate drag-droping document.
   execute_script %{
@@ -105,7 +105,7 @@ Then(/^I (?:can )?view the document collection in the admin$/) do
 
   visit admin_document_collection_path(@document_collection)
   click_on "Edit draft"
-  click_on "Collections"
+  click_on "Collection documents"
 
   expect(page).to have_selector("h1", text: @document_collection.title)
 end
@@ -123,7 +123,7 @@ end
 Then(/^I can see in the admin that "(.*?)" is part of the document collection$/) do |document_title|
   visit admin_document_collection_path(@document_collection)
   click_on "Edit draft"
-  click_on "Collections"
+  click_on "Collection documents"
 
   assert_document_is_part_of_document_collection(document_title)
 end
@@ -149,7 +149,7 @@ When(/^I redraft the document collection and remove "(.*?)" from it$/) do |docum
   save_screenshot
 
   click_on "Edit draft"
-  click_on "Collections"
+  click_on "Collection documents"
 
   check document_title
   click_on "Remove"

--- a/test/functional/admin/document_collection_group_document_search_controller_test.rb
+++ b/test/functional/admin/document_collection_group_document_search_controller_test.rb
@@ -9,7 +9,7 @@ class Admin::DocumentCollectionGroupDocumentSearchControllerTest < ActionControl
       state: "active",
       per_page: 15,
     }
-    @user = login_as :gds_editor
+    @user = login_as_preview_design_system_user :gds_editor
   end
 
   should_be_an_admin_controller

--- a/test/functional/admin/document_collection_group_memberships_controller_test.rb
+++ b/test/functional/admin/document_collection_group_memberships_controller_test.rb
@@ -4,7 +4,7 @@ class Admin::DocumentCollectionGroupMembershipsControllerTest < ActionController
   setup do
     @collection = create(:document_collection, :with_group)
     @group = @collection.groups.first
-    login_as :writer
+    login_as_preview_design_system_user :writer
   end
 
   should_be_an_admin_controller

--- a/test/functional/admin/legacy_document_collection_group_document_search_controller_test.rb
+++ b/test/functional/admin/legacy_document_collection_group_document_search_controller_test.rb
@@ -1,0 +1,32 @@
+require "test_helper"
+
+class Admin::LegacyDocumentCollectionGroupDocumentSearchControllerTest < ActionController::TestCase
+  tests Admin::DocumentCollectionGroupDocumentSearchController
+
+  setup do
+    @collection = create(:document_collection, :with_group)
+    @group = @collection.groups.first
+    @request_params = { document_collection_id: @collection, group_id: @group }
+    login_as create(:writer)
+  end
+
+  test "GET #search_options blocks out users with no permissions" do
+    get :search_options, params: @request_params
+    assert_template :forbidden
+  end
+
+  test "POST #search blocks out users with no permissions" do
+    post :search, params: @request_params
+    assert_template :forbidden
+  end
+
+  test "GET #search__by_title blocks out users with no permissions" do
+    get :add_by_title, params: @request_params
+    assert_template :forbidden
+  end
+
+  test "GET #add_by_url blocks out users with no permissions" do
+    get :add_by_url, params: @request_params
+    assert_template :forbidden
+  end
+end

--- a/test/functional/admin/legacy_document_collection_group_memberships_controller_test.rb
+++ b/test/functional/admin/legacy_document_collection_group_memberships_controller_test.rb
@@ -1,0 +1,121 @@
+require "test_helper"
+
+class Admin::LegacyDocumentCollectionGroupMembershipsControllerTest < ActionController::TestCase
+  tests Admin::DocumentCollectionGroupMembershipsController
+
+  setup do
+    @collection = create(:document_collection, :with_group)
+    @group = @collection.groups.first
+    login_as create(:writer)
+  end
+
+  should_be_an_admin_controller
+
+  def id_params
+    { document_collection_id: @collection, group_id: @group }
+  end
+
+  test "POST #create_whitehall_member adds a whitehall document to a group and redirects" do
+    document = create(:publication).document
+    assert_difference "@group.reload.documents.size" do
+      post :create_whitehall_member, params: id_params.merge(document_id: document.id)
+    end
+    assert_redirected_to admin_document_collection_groups_path(@collection)
+  end
+
+  test "POST #create_whitehall_member warns user when document not found" do
+    post :create_whitehall_member, params: id_params.merge(document_id: 1234, title: "blah")
+    assert_match %r{couldn't find.*blah}, flash[:alert]
+  end
+
+  test "POST #create_non_whitehall_member adds a non-whitehall document to a group and redirects" do
+    stub_publishing_api_has_lookups("/government/news/test" => "51ac4247-fd92-470a-a207-6b852a97f2db")
+    res = stub_publishing_api_has_item(
+      content_id: "51ac4247-fd92-470a-a207-6b852a97f2db",
+      base_path: "/government/news/test",
+      publishing_app: "content-publisher",
+      title: "Lots of news",
+    )
+
+    assert_difference "@group.reload.non_whitehall_links.size" do
+      post :create_non_whitehall_member, params: id_params.merge(url: "https://www.gov.uk/government/news/test")
+    end
+    response = JSON.parse(res.response.body)
+
+    assert_match "'#{response['title']}' added to '#{@group.heading}'", flash[:notice]
+    assert_redirected_to admin_document_collection_groups_path(@collection)
+  end
+
+  test "POST #create_non_whitehall_member warns user when url is not from gov.uk" do
+    post :create_non_whitehall_member, params: id_params.merge(url: "https://www.peters-animals.com")
+    assert_match "Url must be a valid GOV.UK URL.", flash[:alert]
+  end
+
+  test "POST #create_non_whitehall_member warns user when url is invalid" do
+    post :create_non_whitehall_member, params: id_params.merge(url: "https://wwww.too-many-dubs.com")
+    assert_match "Url must be a valid GOV.UK URL", flash[:alert]
+  end
+
+  def remove_params
+    id_params.merge(commit: "Remove")
+  end
+
+  def move_params
+    id_params.merge(commit: "Move")
+  end
+
+  view_test "DELETE #destroy removes memberships and redirects when Remove clicked" do
+    memberships = [create(:document_collection_group_membership),
+                   create(:document_collection_group_membership)]
+    @group.memberships << memberships
+    assert_difference "@group.reload.memberships.size", -1 do
+      delete :destroy, params: remove_params.merge(memberships: [memberships.first.id])
+    end
+    assert_redirected_to admin_document_collection_groups_path(@collection)
+    assert_match %r{1 document removed}, flash[:notice]
+  end
+
+  test "DELETE #destroy sets flash message if no documents selected" do
+    delete :destroy, params: remove_params
+    assert_match %r{select one or more documents}i, flash[:alert]
+  end
+
+  test "DELETE #destroy moves documents and redirects when Move clicked" do
+    memberships = [create(:document_collection_group_membership),
+                   create(:document_collection_group_membership)]
+    @group.memberships << memberships
+    new_group = build(:document_collection_group)
+    @collection.groups << new_group
+    assert_difference "new_group.reload.memberships.size", 1 do
+      assert_difference "@group.reload.memberships.size", -1 do
+        delete :destroy,
+               params: move_params.merge(
+                 memberships: [memberships.first.id],
+                 new_group_id: new_group.id,
+               )
+      end
+    end
+    assert_redirected_to admin_document_collection_groups_path(@collection)
+    assert_match %r{1 document moved to '#{new_group.heading}'}, flash[:notice]
+  end
+
+  test "GET #index forbids the user to see anything" do
+    get :index, params: { document_collection_id: @collection, group_id: @group }
+    assert_response :forbidden
+    assert_includes "Sorry, you don’t have access to this document", @response.body
+  end
+
+  test "GET #confirm_destroy forbids the user to see anything" do
+    membership = create(:document_collection_group_membership)
+    @group.memberships << membership
+    get :confirm_destroy, params: { document_collection_id: @collection, group_id: @group, id: membership }
+    assert_response :forbidden
+    assert_includes "Sorry, you don’t have access to this document", @response.body
+  end
+
+  test "GET #create_member_by_govuk_url forbids the user to see anything" do
+    post :create_member_by_govuk_url, params: { document_collection_id: @collection, group_id: @group }
+    assert_response :forbidden
+    assert_includes "Sorry, you don’t have access to this document", @response.body
+  end
+end

--- a/test/functional/admin/legacy_document_collection_groups_controller_test.rb
+++ b/test/functional/admin/legacy_document_collection_groups_controller_test.rb
@@ -1,50 +1,54 @@
 require "test_helper"
 
-class Admin::DocumentCollectionGroupsControllerTest < ActionController::TestCase
+class Admin::LegacyDocumentCollectionGroupsControllerTest < ActionController::TestCase
+  tests Admin::DocumentCollectionGroupsController
+
   setup do
     @collection = create(:document_collection, :with_group)
     @group = @collection.groups.first
-    login_as_preview_design_system_user :writer
+    login_as create(:writer)
   end
 
   should_be_an_admin_controller
   should_render_bootstrap_implementation_with_preview_next_release
 
-  view_test "GET #index lists the default group when no additional groups or memberships have been added" do
-    get :index, params: { document_collection_id: @collection }
-
-    assert_select "h1", text: "Document collections"
-    assert_select ".govuk-summary-card__action a[href='#{new_admin_document_collection_group_path(@collection)}']", text: /Add group/
-    assert_select ".govuk-summary-list__key", text: @group.heading
-    assert_select ".govuk-summary-list__value", text: "0 documents in group"
-    assert_select ".govuk-summary-list__actions a[href='#{admin_document_collection_group_members_path(@collection, @group)}']", text: "View #{@group.heading}"
-  end
-
-  view_test "GET #index shows confirm delete links when 2 or more groups are present" do
-    collection = create(:document_collection, :with_groups)
-    group1 = collection.groups.first
-    group2 = collection.groups.second
-
+  view_test "GET #index lists the groups and memberships in the collection" do
     publication = create(:publication)
-    group1.documents = [publication.document]
-
-    get :index, params: { document_collection_id: collection }
-
-    assert_select ".govuk-summary-list__row:nth-child(1) .govuk-summary-list__key", text: group1.heading
-    assert_select ".govuk-summary-list__row:nth-child(1) .govuk-summary-list__value", text: "1 document in group"
-    assert_select ".govuk-summary-list__row:nth-child(1) .govuk-summary-list__actions a[href='#{admin_document_collection_group_members_path(collection, group1)}']", text: "View #{group1.heading}"
-    assert_select ".govuk-summary-list__row:nth-child(1) .govuk-summary-list__actions a[href='#{confirm_destroy_admin_document_collection_group_path(collection, group1)}']", text: "Delete #{group1.heading}"
-    assert_select ".govuk-summary-list__row:nth-child(2) .govuk-summary-list__key", text: group2.heading
-    assert_select ".govuk-summary-list__row:nth-child(2) .govuk-summary-list__value", text: "0 documents in group"
-    assert_select ".govuk-summary-list__row:nth-child(2) .govuk-summary-list__actions a[href='#{admin_document_collection_group_members_path(collection, group2)}']", text: "View #{group2.heading}"
-    assert_select ".govuk-summary-list__row:nth-child(2) .govuk-summary-list__actions a[href='#{confirm_destroy_admin_document_collection_group_path(collection, group2)}']", text: "Delete #{group2.heading}"
+    @group.documents = [publication.document]
+    get :index, params: { document_collection_id: @collection }
+    assert_select "h2", Regexp.new(@group.heading)
+    assert_select "label", Regexp.new(publication.title)
   end
 
-  view_test "GET #show assigns the correct attributes and renders successfully" do
-    get :show, params: { document_collection_id: @collection, id: @group }
+  view_test "GET #index shows helpful message when a group is empty" do
+    get :index, params: { document_collection_id: @collection }
+    assert_select "section.group .no-content", /No documents in this group/
+  end
+
+  view_test "GET #index lets you move docs to another group" do
+    @group.documents << create(:publication).document
+    @group.documents << create(:corporate_information_page).document
+    @collection.groups << build(:document_collection_group)
+    group1, group2 = @collection.groups
+    get :index, params: { document_collection_id: @collection }
+    assert_select "section.group" do
+      assert_select "option[value='#{group1.id}']", count: 0
+      assert_select "option[value='#{group2.id}']", group2.heading
+    end
+  end
+
+  view_test "GET #index shows a warning if > 50 memberships in collection" do
+    @group.non_whitehall_links = create_list(:document_collection_non_whitehall_link, 51)
+    get :index, params: { document_collection_id: @collection }
     assert_response :ok
-    assert_equal @collection, assigns(:collection)
-    assert_equal @group, assigns(:group)
+    assert_select ".alert-info", text: /it may be slow or impossible to update/
+  end
+
+  view_test "GET #index does not show a warning if <= 50 memberships in collection" do
+    @group.non_whitehall_links = create_list(:document_collection_non_whitehall_link, 50)
+    get :index, params: { document_collection_id: @collection }
+    assert_response :ok
+    assert_select ".alert-info", false, /it may be slow or impossible to update/
   end
 
   view_test "GET #new renders successfully" do
@@ -70,7 +74,7 @@ class Admin::DocumentCollectionGroupsControllerTest < ActionController::TestCase
   view_test "POST #create prompts for missing data if new group invalid" do
     post_create(heading: "")
     assert_response :success
-    assert_select ".govuk-error-summary", text: /Heading/
+    assert_select '.errors li[data-track-action="document-collection-group-error"]', text: /Heading/
   end
 
   view_test "GET #edit renders successfully" do
@@ -93,19 +97,19 @@ class Admin::DocumentCollectionGroupsControllerTest < ActionController::TestCase
   view_test "PUT #update prompts for missing data if group invalid" do
     put_update(heading: "")
     assert_response :success
-    assert_select ".govuk-error-summary", text: /Heading/
+    assert_select ".errors li", text: /Heading/
   end
 
-  test "GET #confirm_destroy redirects to the index page if only 1 group" do
+  view_test "GET #confirm_destroy explains you can't delete the last group" do
     get :confirm_destroy, params: { document_collection_id: @collection, id: @group }
-    assert_redirected_to admin_document_collection_groups_path(@collection)
+    assert_select "div.alert", /can’t\s+delete the last/
+    assert_select 'input[type="submit"]', count: 0
   end
 
-  test "GET #confirm_destroy assigns the correct values" do
+  view_test "GET #confirm_destroy allows you to delete a group" do
     @collection.groups << build(:document_collection_group)
     get :confirm_destroy, params: { document_collection_id: @collection, id: @group }
-    assert_equal @collection, assigns(:collection)
-    assert_equal @group, assigns(:group)
+    assert_select 'input[type="submit"][value="Delete"]'
   end
 
   view_test "DELETE #destroy deletes group and redirects" do
@@ -113,7 +117,6 @@ class Admin::DocumentCollectionGroupsControllerTest < ActionController::TestCase
       delete :destroy, params: { document_collection_id: @collection, id: @group }
     end
     assert_redirected_to admin_document_collection_groups_path(@collection)
-    assert_equal "Group has been deleted", flash[:notice]
   end
 
   test "POST #update_memberships saves the order of group members" do
@@ -240,6 +243,24 @@ class Admin::DocumentCollectionGroupsControllerTest < ActionController::TestCase
     assert_response :success
     assert_equal [@member_1a, @member_1b, @member_2a, @member_2b], @group1.reload.memberships
     assert_empty @group2.reload.memberships
+  end
+
+  test "GET #show forbids the user to see anything" do
+    get :show, params: { document_collection_id: @collection, id: @group }
+    assert_response :forbidden
+    assert_includes "Sorry, you don’t have access to this document", @response.body
+  end
+
+  test "GET #reorder forbids the user to see anything" do
+    get :reorder, params: { document_collection_id: @collection, id: @group }
+    assert_response :forbidden
+    assert_includes "Sorry, you don’t have access to this document", @response.body
+  end
+
+  test "GET #order forbids the user to see anything" do
+    get :order, params: { document_collection_id: @collection, id: @group }
+    assert_response :forbidden
+    assert_includes "Sorry, you don’t have access to this document", @response.body
   end
 
   def given_two_groups_with_memberships

--- a/test/unit/app/helpers/admin/tabbed_nav_helper_test.rb
+++ b/test/unit/app/helpers/admin/tabbed_nav_helper_test.rb
@@ -118,7 +118,7 @@ class Admin::TabbedNavHelperTest < ActionView::TestCase
         current: false,
       },
       {
-        label: "Collections",
+        label: "Collection documents",
         href: admin_document_collection_groups_path(document_collection),
         current: true,
       },

--- a/test/unit/app/models/document_collection_test.rb
+++ b/test/unit/app/models/document_collection_test.rb
@@ -42,7 +42,7 @@ class DocumentCollectionTest < ActiveSupport::TestCase
   test "it should create a group called 'Documents' when created if groups are empty" do
     doc_collection = create(:document_collection, groups: [])
     assert_equal 1, doc_collection.groups.length
-    assert_equal "Collection", doc_collection.groups[0].heading
+    assert_equal "Documents", doc_collection.groups[0].heading
   end
 
   test "it should not create a group if it's already been given one" do


### PR DESCRIPTION
This reverts commit c087b9932749b70bade720ae26afff16988a48ad, reversing changes made to 92014a0c5d5f55ab62aa757eab53bcf9249bf61e.

Reverting Document Collection changes due to bug noticed in release in relation to documents added via URL.
Re-Ordering Collections containing Documents added via URL results in Server Error, as well as removal of Documents that has been added via URL

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
