### PR TITLE
Created document hub feature flag

### DIFF
--- a/config/features.rb
+++ b/config/features.rb
@@ -20,4 +20,5 @@ Flipflop.configure do
   # feature :world_domination,
   #   default: true,
   #   description: "Take over the world."
+  feature :document_hub, description: "Enables the document summary as a hub design"
 end


### PR DESCRIPTION
**What**

Add a feature flag for the document hub summary work

**Why**

We want to be able to deploy the work to redesign the document summary page without releasing it to users

Trello: https://trello.com/c/8f9xSARb
