### PR TITLE
Fix bug where Confirm Destroy and Reorder pages don't render for Non …

### DIFF
--- a/app/views/admin/document_collection_group_memberships/confirm_destroy.html.erb
+++ b/app/views/admin/document_collection_group_memberships/confirm_destroy.html.erb
@@ -5,7 +5,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with url: admin_document_collection_group_document_collection_group_membership_path(@collection, @group, @membership), method: :delete do |form| %>
-      <p class="govuk-body govuk-!-margin-bottom-6">Are you sure you want to remove "<%= @membership.document.latest_edition.title %>" from this collection?</p>
+      <p class="govuk-body govuk-!-margin-bottom-6">Are you sure you want to remove "<%= document_collection_group_member_title(@membership) %>" from this collection?</p>
 
        <div class="govuk-button-group">
         <%= render "govuk_publishing_components/components/button", {

--- a/app/views/admin/document_collection_group_memberships/reorder.html.erb
+++ b/app/views/admin/document_collection_group_memberships/reorder.html.erb
@@ -13,7 +13,7 @@
         items: @group.memberships.map do |membership|
           {
             id: membership.id,
-            title: membership.document.latest_edition.title,
+            title: document_collection_group_member_title(membership),
           }
         end,
       } %>

--- a/features/document-collections.feature
+++ b/features/document-collections.feature
@@ -78,18 +78,20 @@ Feature: Grouping documents into a collection
     Then I should see "Document 1" in the list for the collection group "Group"
 
   @design-system-only
-  Scenario: Adding a document to a group via URL
+  Scenario: Adding and Removing a document to a group via URL
     Given a document collection "Collection" exists
     And the document collection "Collection" has a group with the heading "Group"
     And a GovUK Url exists "https://www.gov.uk/document-1" with title "Document 1"
     When I select to add a new document to the collection group "By URL"
     And I add URL "https://www.gov.uk/document-1" to the document collection
     Then I should see "Document 1" in the list for the collection group "Group"
+    When I remove the document "Document 1" from the group
+    Then I can see that "Document 1" has been removed from the group
 
   @design-system-only
   Scenario: Removing a document from a group
     Given a published publication called "Document to be removed" in a published document collection
-    When I remove the publication "Document to be removed" from the group
+    When I remove the document "Document to be removed" from the group
     Then I can see that "Document to be removed" has been removed from the group
 
   @design-system-only
@@ -120,9 +122,9 @@ Feature: Grouping documents into a collection
     And I search by "title" for "Document 1"
     And I add "Document 1" to the document collection
     Then I should see "Document 1" in the list for the collection group "Group"
-    When I select to add a new document to the collection group "By title"
-    And I search by "title" for "Document 2"
-    And I add "Document 2" to the document collection
+    Given a GovUK Url exists "https://www.gov.uk/document-2" with title "Document 2"
+    When I select to add a new document to the collection group "By URL"
+    And I add URL "https://www.gov.uk/document-2" to the document collection
     Then I should see "Document 2" in the list for the collection group "Group"
     Then I visit the Reorder document page
     And within the "Collection" "Group" I set the order of the documents to:

--- a/features/step_definitions/document_collection_steps.rb
+++ b/features/step_definitions/document_collection_steps.rb
@@ -206,7 +206,7 @@ Then(/^I can see that the heading has been updated to "(.*?)"$/) do |heading|
   expect(find(".govuk-summary-card")).to have_content heading
 end
 
-When(/^I remove the publication "(.*?)" from the group$/) do |title|
+When(/^I remove the document "(.*?)" from the group$/) do |title|
   visit admin_document_collection_group_document_collection_group_memberships_path(@document_collection, @group)
   click_link "Remove #{title}"
   click_button "Remove"
@@ -231,7 +231,6 @@ end
 
 When(/^I visit the Reorder document page/) do
   visit admin_document_collection_group_document_collection_group_memberships_path(@document_collection, @group)
-  page.should have_content "Reorder document"
   click_link("Reorder document")
 end
 
@@ -250,8 +249,11 @@ And(/^within the "([^"]*)" "([^"]*)" I set the order of the documents to:$/) do 
   collection = DocumentCollection.find_by!(title: collection_title)
   group = collection.groups.find_by!(heading: group_title)
   order.hashes.each do |hash|
-    membership = group.memberships.select { |f| f.document.latest_edition.title == hash[:name] }.first
-    fill_in "ordering[#{membership.id}]", with: hash[:order]
+    member_id = group.memberships.select { |member|
+      title = member.non_whitehall_link ? member.non_whitehall_link.title : member.document.latest_edition.title
+      title == hash[:name]
+    }.first.id
+    fill_in "ordering[#{member_id}]", with: hash[:order]
   end
 
   click_button "Save"


### PR DESCRIPTION
…Whitehall Link members

Document Collections Confirm Destroy and Reorder pages for Group Members were breaking due to the fact that it was expecting a document membership and loading the latest edition. When in the case of being added by URL, the structure is different and title needs to be loaded differently.

Fixed by using the helper that has been created for this purpose.

https://trello.com/c/FdV1Rssa/606-fix-document-collection-confirm-destroy-and-reorder-pages-for-documents-added-via-url

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
