### PR TITLE
Always present /government/organisations in English

### DIFF
--- a/app/models/organisation/organisation_type_concern.rb
+++ b/app/models/organisation/organisation_type_concern.rb
@@ -23,7 +23,7 @@ module Organisation::OrganisationTypeConcern
 
     scope :listable,
           lambda {
-            excluding_govuk_status_closed.with_translations(I18n.locale)
+            excluding_govuk_status_closed.with_translations(:en)
           }
 
     scope :allowed_promotional,

--- a/app/presenters/publishing_api/organisations_index_presenter.rb
+++ b/app/presenters/publishing_api/organisations_index_presenter.rb
@@ -9,6 +9,7 @@ module PublishingApi
         nil,
         title: "Departments, agencies and public bodies",
         update_type: "minor",
+        locale: "en", # NOTE: the organisations index page is only available in english
       ).base_attributes
 
       content.merge!(

--- a/test/unit/app/presenters/publishing_api/organisations_index_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/organisations_index_presenter_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class PublishingApi::OrganisationsPresenterTest < ActiveSupport::TestCase
   extend Minitest::Spec::DSL
 
-  test "presents a valid content item" do
+  def setup
     organisation_one = create(:organisation, organisation_type_key: :executive_office)
     organisation_two = create(:organisation, organisation_type_key: :ministerial_department)
     organisation_three = create(:organisation, organisation_type_key: :non_ministerial_department)
@@ -12,7 +12,7 @@ class PublishingApi::OrganisationsPresenterTest < ActiveSupport::TestCase
     organisation_six = create(:organisation, organisation_type_key: :public_corporation)
     organisation_seven = create(:devolved_administration)
 
-    expected_hash = {
+    @expected_hash = {
       title: "Departments, agencies and public bodies",
       locale: "en",
       publishing_app: Whitehall::PublishingApp::WHITEHALL,
@@ -215,9 +215,11 @@ class PublishingApi::OrganisationsPresenterTest < ActiveSupport::TestCase
         },
       ],
     }
+  end
 
+  test "presents a valid content item" do
     presenter = PublishingApi::OrganisationsIndexPresenter.new
-    assert_equal expected_hash, presenter.content
+    assert_equal @expected_hash, presenter.content
     assert_valid_against_publisher_schema(presenter.content, "organisations_homepage")
   end
 end

--- a/test/unit/app/presenters/publishing_api/organisations_index_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/organisations_index_presenter_test.rb
@@ -222,4 +222,12 @@ class PublishingApi::OrganisationsPresenterTest < ActiveSupport::TestCase
     assert_equal @expected_hash, presenter.content
     assert_valid_against_publisher_schema(presenter.content, "organisations_homepage")
   end
+
+  test "presents content items in English, even when locale is Welsh" do
+    I18n.with_locale(:cy) do
+      presenter = PublishingApi::OrganisationsIndexPresenter.new
+      assert_equal @expected_hash, presenter.content
+      assert_valid_against_publisher_schema(presenter.content, "organisations_homepage")
+    end
+  end
 end


### PR DESCRIPTION
We recently encountered a bug where the /government/organisations page was appearing in Welsh, with many organisations missing.

This was because a Welsh translation of an organisation had been published, which triggered its after_save callback - republish_organisations_index_page_to_publishing_api

In this situation, the pseudo-global I18n.locale is set to :cy, because we're in the process of publishing a Welsh translation of an organisation. However, the /government/organisations page should only ever be presented in English.

We used to have a separate /government/organisations.cy path for the Welsh version of this page, but now OrganisationsIndexPresenter hardcodes the base_path. Because items in content store have to be unique by base_path, publishing a Welsh edition overwrites the English edition.

Additionally, OrganisationsIndexPresenter determines which organisations to list using the listable scope. This was updated to only list organisations with translations for the current locale in ec3979c130, to avoid double counting Organisations which have both English and Welsh translations. This works well if the locale is English, but misses most organisations when the locale is set to Welsh. I've set it to filter to English translations instead, which I think is what we want in every situation that listable is called.

Since the Welsh version of this page has never worked properly, we should restrict it to English editions only. We may decide to revisit this decision later - if so, we should make sure that all the organisations are listed in the Welsh version, even if they haven't got Welsh translations. Just because an Organisation hasn't published a Welsh translation of its home page, doesn't mean it doesn't exist.


