### PR TITLE
Use summary card for translations section on document summary page

### DIFF
--- a/app/components/admin/editions/show/translations_summary_card_component.html.erb
+++ b/app/components/admin/editions/show/translations_summary_card_component.html.erb
@@ -1,4 +1,5 @@
 <%= render "components/summary_card_component", {
   title: "Translations",
   summary_card_actions: summary_card_actions,
+  rows: rows,
 } %>

--- a/app/components/admin/editions/show/translations_summary_card_component.html.erb
+++ b/app/components/admin/editions/show/translations_summary_card_component.html.erb
@@ -1,3 +1,4 @@
 <%= render "components/summary_card_component", {
   title: "Translations",
+  summary_card_actions: summary_card_actions,
 } %>

--- a/app/components/admin/editions/show/translations_summary_card_component.html.erb
+++ b/app/components/admin/editions/show/translations_summary_card_component.html.erb
@@ -1,0 +1,3 @@
+<%= render "components/summary_card_component", {
+  title: "Translations",
+} %>

--- a/app/components/admin/editions/show/translations_summary_card_component.rb
+++ b/app/components/admin/editions/show/translations_summary_card_component.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class Admin::Editions::Show::TranslationsSummaryCardComponent < ViewComponent::Base
+  def initialize(edition:)
+    @edition = edition
+  end
+
+  def render?
+    edition.translatable?
+  end
+
+private
+
+  attr_reader :edition
+end

--- a/app/components/admin/editions/show/translations_summary_card_component.rb
+++ b/app/components/admin/editions/show/translations_summary_card_component.rb
@@ -23,4 +23,14 @@ private
       },
     ]
   end
+
+  def rows
+    edition.non_english_translations.map { |translation|
+      [
+        key: Locale.new(translation.locale).native_and_english_language_name,
+        value: translation.title,
+      ]
+    }
+    .flatten
+  end
 end

--- a/app/components/admin/editions/show/translations_summary_card_component.rb
+++ b/app/components/admin/editions/show/translations_summary_card_component.rb
@@ -29,8 +29,26 @@ private
       [
         key: Locale.new(translation.locale).native_and_english_language_name,
         value: translation.title,
+        actions: row_actions(edition, translation),
       ]
     }
+    .flatten
+  end
+
+  def row_actions(edition, translation)
+    return [] unless edition.editable?
+
+    [
+      {
+        label: "Edit",
+        href: edit_admin_edition_translation_path(edition, translation.locale),
+      },
+      {
+        label: "Delete",
+        href: confirm_destroy_admin_edition_translation_path(edition, translation.locale),
+        destructive: true,
+      },
+    ]
     .flatten
   end
 end

--- a/app/components/admin/editions/show/translations_summary_card_component.rb
+++ b/app/components/admin/editions/show/translations_summary_card_component.rb
@@ -12,4 +12,15 @@ class Admin::Editions::Show::TranslationsSummaryCardComponent < ViewComponent::B
 private
 
   attr_reader :edition
+
+  def summary_card_actions
+    return {} unless edition.editable? && edition.missing_translations.any?
+
+    [
+      {
+        label: "Add translation",
+        href: new_admin_edition_translation_path(edition),
+      },
+    ]
+  end
 end

--- a/app/views/admin/editions/show/_main.html.erb
+++ b/app/views/admin/editions/show/_main.html.erb
@@ -249,7 +249,10 @@
       <% end %>
     </section>
   <% end %>
-  <% if @edition.translatable? %>
+
+  <% if Flipflop.document_hub? %>
+    <%= render Admin::Editions::Show::TranslationsSummaryCardComponent.new(edition: @edition) %>
+  <% elsif @edition.translatable? %>
     <section class="app-view-summary__section">
       <%= render "govuk_publishing_components/components/heading", {
         text: "Translations",

--- a/app/views/components/_summary_card_component.html.erb
+++ b/app/views/components/_summary_card_component.html.erb
@@ -16,30 +16,32 @@
         <% end %>
       </ul>
     </div>
-    <div class="govuk-summary-card__content">
-      <dl class="govuk-summary-list">
-        <% rows.each do |row| %>
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">
-              <%= row[:key] %>
-            </dt>
-            <dd class="govuk-summary-list__value">
-              <%= row[:value] %>
-            </dd>
-            <% if row[:actions].present? %>
-              <dd class="govuk-summary-list__actions">
-                <% row[:actions].each do |action| %>
-                  <% if action[:opens_in_new_tab] %>
-                    <%= link_to sanitize(action[:label] + tag.span(" #{row[:key]} (opens in new tab)", class: "govuk-visually-hidden")), action[:href], class: "govuk-link govuk-link--no-visited-state govuk-!-margin-left-2", rel: "noreferrer noopener", target: "_blank" %>
-                  <% else %>
-                    <%= link_to sanitize(action[:label] + tag.span(" #{row[:key]}", class: "govuk-visually-hidden")), action[:href], class: "govuk-link govuk-link--no-visited-state govuk-!-margin-left-2 #{"gem-link--destructive" if action[:destructive]}".strip %>
-                  <% end %>
-                <% end %>
+    <% if rows.present? %>
+      <div class="govuk-summary-card__content">
+        <dl class="govuk-summary-list">
+          <% rows.each do |row| %>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">
+                <%= row[:key] %>
+              </dt>
+              <dd class="govuk-summary-list__value">
+                <%= row[:value] %>
               </dd>
-            <% end %>
-          </div>
-        <% end %>
-      </dl>
-    </div>
+              <% if row[:actions].present? %>
+                <dd class="govuk-summary-list__actions">
+                  <% row[:actions].each do |action| %>
+                    <% if action[:opens_in_new_tab] %>
+                      <%= link_to sanitize(action[:label] + tag.span(" #{row[:key]} (opens in new tab)", class: "govuk-visually-hidden")), action[:href], class: "govuk-link govuk-link--no-visited-state govuk-!-margin-left-2", rel: "noreferrer noopener", target: "_blank" %>
+                    <% else %>
+                      <%= link_to sanitize(action[:label] + tag.span(" #{row[:key]}", class: "govuk-visually-hidden")), action[:href], class: "govuk-link govuk-link--no-visited-state govuk-!-margin-left-2 #{"gem-link--destructive" if action[:destructive]}".strip %>
+                    <% end %>
+                  <% end %>
+                </dd>
+              <% end %>
+            </div>
+          <% end %>
+        </dl>
+      </div>
+    <% end %>
   </div>
 <% end %>

--- a/features/step_definitions/translated_content_steps.rb
+++ b/features/step_definitions/translated_content_steps.rb
@@ -28,6 +28,15 @@ Given(/^I have drafted a translatable document "([^"]*)"$/) do |title|
   click_button "Save"
 end
 
+Given(/^I have drafted a translatable document "([^"]*)" with a french translation with the title "([^"]*)"$/) do |title, translation_title|
+  create(:draft_case_study, title:, translated_into: [:fr])
+  edition = Edition.find_by!(title:)
+  I18n.with_locale :fr do
+    edition.title = translation_title
+    edition.save!
+  end
+end
+
 When(/^I add a french translation "([^"]*)" to the "([^"]*)" document$/) do |french_title, english_title|
   visit admin_edition_path(Edition.find_by!(title: english_title))
   click_link "Add translation"
@@ -40,9 +49,31 @@ When(/^I add a french translation "([^"]*)" to the "([^"]*)" document$/) do |fre
   click_button "Save"
 end
 
+When(/^I edit "([^"]*)"'s french translation's title to "([^"]*)"$/) do |english_title, new_title|
+  edition = Edition.find_by!(title: english_title)
+  visit admin_edition_path(edition)
+  find("a[href='#{edit_admin_edition_translation_path(edition, :fr)}']").click
+
+  fill_in "Translated title (required)", with: new_title
+  click_button "Save"
+end
+
+When(/^I delete "([^"]*)"'s french translation$/) do |english_title|
+  edition = Edition.find_by!(title: english_title)
+  visit admin_edition_path(edition)
+  find("a[href='#{confirm_destroy_admin_edition_translation_path(edition, :fr)}']").click
+
+  click_button "Delete translation"
+end
+
 Then(/^I should see on the admin edition page that "([^"]*)" has a french translation "([^"]*)"$/) do |english_title, french_title|
   visit admin_edition_path(Edition.find_by!(title: english_title))
   expect(page).to have_content(french_title)
+end
+
+Then(/^I should see on the admin edition page that "([^"]*)"'s french translation "([^"]*)" has been deleted$/) do |english_title, french_title|
+  visit admin_edition_path(Edition.find_by!(title: english_title))
+  expect(page).not_to have_content(french_title)
 end
 
 Given(/^the organisation "(.*?)" is translated into Welsh and has a contact "(.*?)"$/) do |organisation_name, contact_title|

--- a/features/translated-content.feature
+++ b/features/translated-content.feature
@@ -9,6 +9,18 @@ Feature: Providing translated content from gov.uk/government
     When I add a french translation "Échange officier de l'armée" to the "Military officer exchange" document
     Then I should see on the admin edition page that "Military officer exchange" has a french translation "Échange officier de l'armée"
 
+  Scenario: Editing a translation for draft translatable document
+    Given I am a GDS editor
+    And I have drafted a translatable document "Military officer exchange" with a french translation with the title "Échange officier de l'armée"
+    When I edit "Military officer exchange"'s french translation's title to "Ministre de l'Éducation nationale"
+    Then I should see on the admin edition page that "Military officer exchange" has a french translation "Ministre de l'Éducation nationale"
+
+  Scenario: Deleting a translation for draft translatable document
+    Given I am a GDS editor
+    And I have drafted a translatable document "Military officer exchange" with a french translation with the title "Échange officier de l'armée"
+    When I delete "Military officer exchange"'s french translation
+    Then I should see on the admin edition page that "Military officer exchange"'s french translation "Échange officier de l'armée" has been deleted
+
   Scenario: Adding a translation for contact details
     Given I am a GDS editor
     And the organisation "Wales Office" is translated into Welsh and has a contact "Wales Office, Cardiff"

--- a/test/components/admin/editions/show/translations_summary_card_component_test.rb
+++ b/test/components/admin/editions/show/translations_summary_card_component_test.rb
@@ -41,4 +41,17 @@ class Admin::Editions::Show::TranslationsSummaryCardComponentTest < ViewComponen
 
     assert_selector ".govuk-summary-card__action a[href='#{new_admin_edition_translation_path(edition)}']", text: "Add translation", count: 0
   end
+
+  test "renders a summary list component with the translation name & translated title when translations exist" do
+    edition = create(:draft_publication, translated_into: %i[es fr])
+    render_inline(Admin::Editions::Show::TranslationsSummaryCardComponent.new(edition:))
+
+    spanish_translation = edition.translations.find_by(locale: "es")
+    french_translation = edition.translations.find_by(locale: "fr")
+
+    assert_selector ".govuk-summary-list .govuk-summary-list__row:nth-child(1) .govuk-summary-list__key", text: "Español (Spanish)"
+    assert_selector ".govuk-summary-list .govuk-summary-list__row:nth-child(1) .govuk-summary-list__value", text: spanish_translation.title
+    assert_selector ".govuk-summary-list .govuk-summary-list__row:nth-child(2) .govuk-summary-list__key", text: "Français (French)"
+    assert_selector ".govuk-summary-list .govuk-summary-list__row:nth-child(2) .govuk-summary-list__value", text: french_translation.title
+  end
 end

--- a/test/components/admin/editions/show/translations_summary_card_component_test.rb
+++ b/test/components/admin/editions/show/translations_summary_card_component_test.rb
@@ -19,4 +19,26 @@ class Admin::Editions::Show::TranslationsSummaryCardComponentTest < ViewComponen
     assert_selector ".govuk-summary-card__title", text: "Translations"
     assert_selector ".govuk-summary-card__content", count: 0
   end
+
+  test "renders a link to add translations when edition is editable and there are missing translations" do
+    edition = build_stubbed(:draft_publication)
+    render_inline(Admin::Editions::Show::TranslationsSummaryCardComponent.new(edition:))
+
+    assert_selector ".govuk-summary-card__action a[href='#{new_admin_edition_translation_path(edition)}']", text: "Add translation"
+  end
+
+  test "does not render a link to add translations when edition is not editable (post publication state)" do
+    edition = build_stubbed(:published_publication)
+    render_inline(Admin::Editions::Show::TranslationsSummaryCardComponent.new(edition:))
+
+    assert_selector ".govuk-summary-card__action a[href='#{new_admin_edition_translation_path(edition)}']", text: "Add translation", count: 0
+  end
+
+  test "does not render a link to add translations when edition has no missing translations" do
+    edition = build_stubbed(:draft_publication)
+    edition.stubs(:missing_translations).returns([])
+    render_inline(Admin::Editions::Show::TranslationsSummaryCardComponent.new(edition:))
+
+    assert_selector ".govuk-summary-card__action a[href='#{new_admin_edition_translation_path(edition)}']", text: "Add translation", count: 0
+  end
 end

--- a/test/components/admin/editions/show/translations_summary_card_component_test.rb
+++ b/test/components/admin/editions/show/translations_summary_card_component_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Admin::Editions::Show::TranslationsSummaryCardComponentTest < ViewComponent::TestCase
+  include Rails.application.routes.url_helpers
+
+  test "doesn't render unless edition is translatable" do
+    edition = build_stubbed(:edition)
+    render_inline(Admin::Editions::Show::TranslationsSummaryCardComponent.new(edition:))
+
+    assert_empty page.text
+  end
+
+  test "renders a summary card component with a title and no content if no translations are present" do
+    edition = build_stubbed(:draft_publication)
+    render_inline(Admin::Editions::Show::TranslationsSummaryCardComponent.new(edition:))
+
+    assert_selector ".govuk-summary-card__title", text: "Translations"
+    assert_selector ".govuk-summary-card__content", count: 0
+  end
+end

--- a/test/components/admin/editions/show/translations_summary_card_component_test.rb
+++ b/test/components/admin/editions/show/translations_summary_card_component_test.rb
@@ -42,8 +42,8 @@ class Admin::Editions::Show::TranslationsSummaryCardComponentTest < ViewComponen
     assert_selector ".govuk-summary-card__action a[href='#{new_admin_edition_translation_path(edition)}']", text: "Add translation", count: 0
   end
 
-  test "renders a summary list component with the translation name & translated title when translations exist" do
-    edition = create(:draft_publication, translated_into: %i[es fr])
+  test "renders a summary list component with no edit or delete links when edition is not editable" do
+    edition = create(:published_publication, translated_into: %i[es fr])
     render_inline(Admin::Editions::Show::TranslationsSummaryCardComponent.new(edition:))
 
     spanish_translation = edition.translations.find_by(locale: "es")
@@ -53,5 +53,21 @@ class Admin::Editions::Show::TranslationsSummaryCardComponentTest < ViewComponen
     assert_selector ".govuk-summary-list .govuk-summary-list__row:nth-child(1) .govuk-summary-list__value", text: spanish_translation.title
     assert_selector ".govuk-summary-list .govuk-summary-list__row:nth-child(2) .govuk-summary-list__key", text: "Français (French)"
     assert_selector ".govuk-summary-list .govuk-summary-list__row:nth-child(2) .govuk-summary-list__value", text: french_translation.title
+    assert_selector ".govuk-summary-list__actions a", count: 0
+  end
+
+  test "renders links to edit and delete translations when edition is editable" do
+    edition = create(:draft_publication, translated_into: %i[es fr])
+    render_inline(Admin::Editions::Show::TranslationsSummaryCardComponent.new(edition:))
+
+    spanish_edit_href = edit_admin_edition_translation_path(edition, :es)
+    spanish_confirm_destroy_href = confirm_destroy_admin_edition_translation_path(edition, :es)
+    french_edit_href = edit_admin_edition_translation_path(edition, :fr)
+    french_confirm_destroy_href = confirm_destroy_admin_edition_translation_path(edition, :fr)
+
+    assert_selector ".govuk-summary-list__row:nth-child(1) .govuk-summary-list__actions a:nth-child(1)[href='#{spanish_edit_href}']", text: "Edit Español (Spanish)"
+    assert_selector ".govuk-summary-list__row:nth-child(1) .govuk-summary-list__actions a:nth-child(2)[href='#{spanish_confirm_destroy_href}']", text: "Delete Español (Spanish)"
+    assert_selector ".govuk-summary-list__row:nth-child(2) .govuk-summary-list__actions a:nth-child(1)[href='#{french_edit_href}']", text: "Edit Français (French)"
+    assert_selector ".govuk-summary-list__row:nth-child(2) .govuk-summary-list__actions a:nth-child(2)[href='#{french_confirm_destroy_href}']", text: "Delete Français (French)"
   end
 end


### PR DESCRIPTION
## Description

This ports the translations section of the document summary page to use the summary card component. It's behind the `document_hub` feature flag.

I've chosen not to duplicate these view_tests https://github.com/alphagov/whitehall/blob/e958a8cb68e5178f9a3d4a0447381a8299ce26b5/test/functional/admin/generic_editions_controller_tests/translation_test.rb#L3 

as the view component now tests this functionality. I think this file can be removed once we remove the feature flag. Interested to see what approach people think we should use in this situation though.

Currently, if we merge this the tests will continue to pass until we remove the `document_hub` feature flag, at which point they'll fail. Is that okay? Should we indicate/record somewhere that this file should be removed at that point? If this is a common occurrence, then many tests will fail at the same when the flag is removed. Is that a problem? 

## Screenshots

### With no translations and edition is pre-publication

<img width="535" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/6572cb90-b7fa-4c6a-930e-32fd2ed7d693">

### With translation and edition is pre-publication

<img width="553" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/9bccb6c0-fb2b-4bab-b118-7eb9ece37a24">

### With no translations and edition has been published

<img width="543" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/d4bce61a-2497-48a4-a799-184d17ea08d0">

### With translations and edition has been published

<img width="537" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/b30aa82a-fd38-427a-b62a-d4d0b9d8244c">


## Trello card

https://trello.com/c/2NUrOcjY/1835-translations-summary-card-on-summary-page-like-for-like

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
