### PR TITLE
cleanup WorldwideOrganisations

### DIFF
--- a/db/migrate/20231107102144_remove_default_news_organisation_image_data_from_worldwide_organisations.rb
+++ b/db/migrate/20231107102144_remove_default_news_organisation_image_data_from_worldwide_organisations.rb
@@ -1,0 +1,5 @@
+class RemoveDefaultNewsOrganisationImageDataFromWorldwideOrganisations < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :worldwide_organisations, :default_news_organisation_image_data_id, :integer
+  end
+end


### PR DESCRIPTION
This is a cleanup commit to be able to remove DefaultNewsOrganisationImageData from WorldwideOrganisations

This is a side-effect from https://github.com/alphagov/whitehall/pull/8443
