### PR TITLE
Keep Topical Event logo alive even after topical event is destroyed

### DIFF
--- a/app/models/topical_event.rb
+++ b/app/models/topical_event.rb
@@ -73,7 +73,7 @@ class TopicalEvent < ApplicationRecord
            -> { where("editions.state" => "published") },
            through: :topical_event_memberships
 
-  has_one :logo, class_name: "FeaturedImageData", as: :featured_imageable, inverse_of: :featured_imageable, dependent: :destroy
+  has_one :logo, class_name: "FeaturedImageData", as: :featured_imageable, inverse_of: :featured_imageable
 
   accepts_nested_attributes_for :logo, reject_if: :all_blank
 

--- a/test/functional/admin/topical_events_controller_test.rb
+++ b/test/functional/admin/topical_events_controller_test.rb
@@ -171,7 +171,7 @@ class Admin::TopicalEventsControllerTest < ActionController::TestCase
     assert_equal topical_event, assigns(:topical_event)
   end
 
-  test "DELETE :destroy deletes the topical event and dependent classes" do
+  test "DELETE :destroy deletes the topical event but keeps the logo image as some other pages might depend on it" do
     topical_event = create(:topical_event, :with_logo, :with_social_media_accounts)
     logo = topical_event.logo
     social_media_account = topical_event.social_media_accounts.first
@@ -179,7 +179,7 @@ class Admin::TopicalEventsControllerTest < ActionController::TestCase
 
     assert_response :redirect
     assert_nil TopicalEvent.find_by(id: topical_event.id)
-    assert_nil FeaturedImageData.find_by(id: logo.id)
     assert_nil SocialMediaAccount.find_by(id: social_media_account.id)
+    assert FeaturedImageData.find_by(id: logo.id)
   end
 end


### PR DESCRIPTION
It is safest to keep images alive even after the main document is destroyed becuase some other documents can depend on the images being available from AssetManager.
