### PR TITLE
Person to use featured image data with assets

### DIFF
--- a/app/controllers/admin/organisations_controller.rb
+++ b/app/controllers/admin/organisations_controller.rb
@@ -117,8 +117,6 @@ private
       topical_event_organisations_attributes: %i[topical_event_id ordering id _destroy],
       featured_links_attributes: %i[title url _destroy id],
     )
-
-    clear_file_cache(@organisation_params)
   end
 
   def build_topical_event_organisations
@@ -165,6 +163,7 @@ private
 
     clean_logo_params
     clean_non_departmental_public_body_params
+    clear_file_cache
   end
 
   def clean_logo_params
@@ -187,14 +186,13 @@ private
     organisation_params[:regulatory_function] = nil
   end
 
-  def clear_file_cache(organisation_params)
+  def clear_file_cache
     if organisation_params[:logo].present? && organisation_params[:logo_cache].present?
       organisation_params.delete(:logo_cache)
     end
+
     if organisation_params.dig(:default_news_image_attributes, :file_cache).present? && organisation_params.dig(:default_news_image_attributes, :file).present?
       organisation_params[:default_news_image_attributes].delete(:file_cache)
     end
-
-    organisation_params
   end
 end

--- a/app/controllers/admin/people_controller.rb
+++ b/app/controllers/admin/people_controller.rb
@@ -1,15 +1,15 @@
 class Admin::PeopleController < Admin::BaseController
+  before_action :build_person, only: %i[new]
   before_action :load_person, only: %i[show edit update destroy reorder_role_appointments update_order_role_appointments confirm_destroy]
   before_action :enforce_permissions!, only: %i[edit update destroy reorder_role_appointments update_order_role_appointments confirm_destroy]
+  before_action :build_dependencies, only: %i[new edit]
   layout "design_system"
 
   def index
     @people = Person.order(:surname, :forename).includes(:translations)
   end
 
-  def new
-    @person = Person.new
-  end
+  def new; end
 
   def create
     @person = Person.new(person_params)
@@ -75,7 +75,7 @@ private
       :letters,
       :biography,
       :privy_counsellor,
-      image_attributes: %i[file id],
+      image_attributes: %i[file file_cache id],
     )
   end
 
@@ -85,5 +85,13 @@ private
     else
       enforce_permission!(:edit, @person)
     end
+  end
+
+  def build_person
+    @person = Person.new
+  end
+
+  def build_dependencies
+    @person.build_image if @person.image.blank?
   end
 end

--- a/app/controllers/admin/people_controller.rb
+++ b/app/controllers/admin/people_controller.rb
@@ -73,9 +73,9 @@ private
       :forename,
       :surname,
       :letters,
-      :image,
       :biography,
       :privy_counsellor,
+      image_attributes: %i[file id],
     )
   end
 

--- a/app/controllers/admin/people_controller.rb
+++ b/app/controllers/admin/people_controller.rb
@@ -3,6 +3,7 @@ class Admin::PeopleController < Admin::BaseController
   before_action :load_person, only: %i[show edit update destroy reorder_role_appointments update_order_role_appointments confirm_destroy]
   before_action :enforce_permissions!, only: %i[edit update destroy reorder_role_appointments update_order_role_appointments confirm_destroy]
   before_action :build_dependencies, only: %i[new edit]
+  before_action :clean_person_params, only: %i[create update]
   layout "design_system"
 
   def index
@@ -68,7 +69,7 @@ private
   end
 
   def person_params
-    params.require(:person).permit(
+    @person_params ||= params.require(:person).permit(
       :title,
       :forename,
       :surname,
@@ -93,5 +94,11 @@ private
 
   def build_dependencies
     @person.build_image if @person.image.blank?
+  end
+
+  def clean_person_params
+    if person_params.dig(:image_attributes, :file_cache).present? && person_params.dig(:image_attributes, :file).present?
+      person_params[:image_attributes].delete(:file_cache)
+    end
   end
 end

--- a/app/controllers/admin/worldwide_organisations_controller.rb
+++ b/app/controllers/admin/worldwide_organisations_controller.rb
@@ -5,6 +5,7 @@ class Admin::WorldwideOrganisationsController < Admin::BaseController
 
   before_action :find_worldwide_organisation, except: %i[index new create]
   before_action :build_worldwide_organisation, only: %i[new create]
+  before_action :clean_worldwide_organisation_params, only: %i[create update]
 
   layout "design_system"
 
@@ -77,16 +78,12 @@ private
       sponsoring_organisation_ids: [],
       default_news_image_attributes: %i[file file_cache id],
     )
-
-    clear_file_cache(@worldwide_organisation_params)
   end
 
-  def clear_file_cache(params)
-    if params.dig(:default_news_image_attributes, :file).present? && params.dig(:default_news_image_attributes, :file_cache).present?
-      params[:default_news_image_attributes].delete(:file_cache)
+  def clean_worldwide_organisation_params
+    if worldwide_organisation_params.dig(:default_news_image_attributes, :file).present? && worldwide_organisation_params.dig(:default_news_image_attributes, :file_cache).present?
+      worldwide_organisation_params[:default_news_image_attributes].delete(:file_cache)
     end
-
-    params
   end
 
   def main_office_params

--- a/app/models/featured_image_data.rb
+++ b/app/models/featured_image_data.rb
@@ -12,6 +12,8 @@ class FeaturedImageData < ApplicationRecord
 
   validates_with ImageValidator, size: [960, 640]
 
+  delegate :url, to: :file
+
   def filename
     file&.file&.filename
   end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -121,6 +121,12 @@ class Person < ApplicationRecord
     PublishingApi::PersonPresenter
   end
 
+  def republish_dependent_documents
+    speeches.map { |speech| Whitehall::PublishingApi.republish_document_async(speech.document) }
+
+    historical_account&.publish_to_publishing_api_async
+  end
+
 private
 
   def name_as_words(*elements)

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -1,8 +1,6 @@
 class Person < ApplicationRecord
   include PublishesToPublishingApi
 
-  mount_uploader :image, FeaturedImageUploader, mount_on: :carrierwave_image
-
   has_many :role_appointments, -> { order(:order) }
   has_many :current_role_appointments,
            -> { where(RoleAppointment::CURRENT_CONDITION).order(:order) },
@@ -21,20 +19,19 @@ class Person < ApplicationRecord
   has_many :organisations, through: :organisation_roles
 
   has_one :historical_account, inverse_of: :person
-  has_one :image_new, class_name: "FeaturedImageData", as: :featured_imageable, inverse_of: :featured_imageable
+
+  has_one :image, class_name: "FeaturedImageData", as: :featured_imageable, inverse_of: :featured_imageable
+
+  accepts_nested_attributes_for :image, reject_if: :all_blank
 
   validates :name, presence: true
   validates_with SafeHtmlValidator
-
-  validates_with ImageValidator, method: :image, size: [960, 640], if: :image_changed?
 
   extend FriendlyId
   friendly_id :slug_name
 
   include TranslatableModel
   translates :biography
-
-  delegate :url, to: :image, prefix: :image
 
   before_destroy :prevent_destruction_if_appointed
   after_update :touch_role_appointments
@@ -128,10 +125,6 @@ private
 
   def name_as_words(*elements)
     elements.select(&:present?).map(&:strip).join(" ")
-  end
-
-  def image_changed?
-    changes["carrierwave_image"].present?
   end
 
   def slug_name

--- a/app/models/topical_event_featuring_image_data.rb
+++ b/app/models/topical_event_featuring_image_data.rb
@@ -10,6 +10,8 @@ class TopicalEventFeaturingImageData < ApplicationRecord
 
   validates_with ImageValidator, size: [960, 640]
 
+  delegate :url, to: :file
+
   def filename
     file&.file&.filename
   end

--- a/app/presenters/publishing_api/historical_accounts_index_presenter.rb
+++ b/app/presenters/publishing_api/historical_accounts_index_presenter.rb
@@ -40,7 +40,7 @@ module PublishingApi
         { title: person.name,
           dates_in_office: person.previous_dates_in_office_for_role(role),
           image: {
-            url: person.image_url,
+            url: person.image&.url,
             alt_text: person.name,
           } }
       end

--- a/app/presenters/publishing_api/historical_accounts_index_presenter.rb
+++ b/app/presenters/publishing_api/historical_accounts_index_presenter.rb
@@ -36,14 +36,7 @@ module PublishingApi
     def appointments_without_historical_accounts
       role = Role.friendly.find("prime-minister")
       people_to_present = (role.role_appointments.historic.map(&:person) - HistoricalAccount.all.map(&:person)).uniq
-      people_to_present.map do |person|
-        { title: person.name,
-          dates_in_office: person.previous_dates_in_office_for_role(role),
-          image: {
-            url: person.image&.url,
-            alt_text: person.name,
-          } }
-      end
+      people_to_present.map { |person| compose_person person, role }
     end
 
     def base_path
@@ -55,6 +48,22 @@ module PublishingApi
         historical_accounts: HistoricalAccount.all.map(&:content_id),
         parent: [HISTORY_OF_THE_UK_GOVERNMENT_CONTENT_ID],
       }
+    end
+
+    def compose_person(person, role)
+      person_attributes = {
+        title: person.name,
+        dates_in_office: person.previous_dates_in_office_for_role(role),
+      }
+
+      if person.image&.all_asset_variants_uploaded?
+        return person_attributes.merge({ image: {
+          url: person.image&.url,
+          alt_text: person.name,
+        } })
+      end
+
+      person_attributes
     end
   end
 end

--- a/app/presenters/publishing_api/organisation_presenter.rb
+++ b/app/presenters/publishing_api/organisation_presenter.rb
@@ -421,7 +421,7 @@ module PublishingApi
     end
 
     def default_news_image_url(size = nil)
-      size ? item.default_news_image.file.url(size) : item.default_news_image.file.url
+      size ? item.default_news_image.url(size) : item.default_news_image.url
     end
   end
 end

--- a/app/presenters/publishing_api/person_presenter.rb
+++ b/app/presenters/publishing_api/person_presenter.rb
@@ -34,8 +34,8 @@ module PublishingApi
     def details
       details_hash = {}
 
-      if item.image_url(:s465)
-        details_hash[:image] = { url: item.image_url(:s465), alt_text: item.name }
+      if item.image&.url(:s465)
+        details_hash[:image] = { url: item.image.url(:s465), alt_text: item.name }
       end
 
       details_hash.merge(

--- a/app/presenters/publishing_api/person_presenter.rb
+++ b/app/presenters/publishing_api/person_presenter.rb
@@ -34,7 +34,7 @@ module PublishingApi
     def details
       details_hash = {}
 
-      if item.image&.url(:s465)
+      if item.image&.all_asset_variants_uploaded? && item.image&.url(:s465)
         details_hash[:image] = { url: item.image.url(:s465), alt_text: item.name }
       end
 

--- a/app/presenters/publishing_api/speech_presenter.rb
+++ b/app/presenters/publishing_api/speech_presenter.rb
@@ -47,7 +47,7 @@ module PublishingApi
         speaker_without_profile: item.person_override,
       }.compact_blank
       details.merge!(speech_type_explanation)
-      details.merge!(image_payload) if has_image?
+      details.merge!(image_payload) if has_image? && image_has_all_assets?
       details.merge!(PayloadBuilder::PoliticalDetails.for(item))
       details.merge!(PayloadBuilder::FirstPublicAt.for(item))
     end
@@ -111,7 +111,7 @@ module PublishingApi
     end
 
     def speaker_has_image?
-      speaker && speaker.image && speaker.image.url
+      speaker&.image&.url
     end
 
     def speaker_image
@@ -136,6 +136,12 @@ module PublishingApi
 
     def has_image?
       image.present?
+    end
+
+    def image_has_all_assets?
+      return true unless image.instance_of?(FeaturedImageData)
+
+      image.all_asset_variants_uploaded?
     end
 
     def alt_text

--- a/app/presenters/publishing_api/topical_event_presenter.rb
+++ b/app/presenters/publishing_api/topical_event_presenter.rb
@@ -52,9 +52,9 @@ module PublishingApi
 
     def image
       {
-        url: item.logo.file.url(:s300),
-        medium_resolution_url: item.logo.file.url(:s630),
-        high_resolution_url: item.logo.file.url(:s960),
+        url: item.logo.url(:s300),
+        medium_resolution_url: item.logo.url(:s630),
+        high_resolution_url: item.logo.url(:s960),
         alt_text: item.logo_alt_text,
       }
     end
@@ -70,7 +70,7 @@ module PublishingApi
             title: feature.title,
             href: feature.url,
             image: {
-              url: feature.image.file.url(:s465),
+              url: feature.image.url(:s465),
               alt_text: feature.alt_text,
             },
             summary: feature.summary,

--- a/app/views/admin/organisations/_form.html.erb
+++ b/app/views/admin/organisations/_form.html.erb
@@ -97,7 +97,7 @@
       filename: organisation.default_news_image.file.identifier,
       page_errors: organisation.errors.any?,
       error_items: errors_for(organisation.errors, :"default_news_image.file"),
-      image_src: organisation.default_news_image.file.url,
+      image_src: organisation.default_news_image.url,
       image_cache_name: "organisation[default_news_image_attributes][file_cache]",
       image_cache: (organisation.default_news_image.file_cache.presence),
     } %>

--- a/app/views/admin/people/_form.html.erb
+++ b/app/views/admin/people/_form.html.erb
@@ -61,21 +61,22 @@
     legend_text: "Image",
     heading_size: "l",
   } do %>
-    <% if person.image_url %>
+    <% if person.image&.url %>
       <div class="app-view-edit-person__image">
-        <%= image_tag person.image_url %>
+        <%= image_tag person.image.url %>
       </div>
     <% end %>
 
     <div class="form-group">
+      <%= hidden_field_tag "person[image_attributes][id]", person.image&.id %>
       <%= render "govuk_publishing_components/components/file_upload", {
         label: {
           text: "Upload a file",
           heading_size: "m",
         },
-        name: "person[image]",
-        id: "person_image",
-        error_items: errors_for(person.errors, :image),
+        name: "person[image_attributes][file]",
+        id: "person_image_file",
+        error_items: errors_for(person.errors, :"image.file"),
       } %>
     </div>
   <% end %>

--- a/app/views/admin/people/_form.html.erb
+++ b/app/views/admin/people/_form.html.erb
@@ -57,28 +57,21 @@
     error_items: errors_for(person.errors, :letters),
   } %>
 
-  <%= render "govuk_publishing_components/components/fieldset", {
-    legend_text: "Image",
-    heading_size: "l",
-  } do %>
-    <% if person.image&.url %>
-      <div class="app-view-edit-person__image">
-        <%= image_tag person.image.url %>
-      </div>
-    <% end %>
-
-    <div class="form-group">
-      <%= hidden_field_tag "person[image_attributes][id]", person.image&.id %>
-      <%= render "govuk_publishing_components/components/file_upload", {
-        label: {
-          text: "Upload a file",
-          heading_size: "m",
-        },
-        name: "person[image_attributes][file]",
-        id: "person_image_file",
-        error_items: errors_for(person.errors, :"image.file"),
-      } %>
-    </div>
+  <%= form.fields_for :image do |_image_fields| %>
+    <%= render "components/single-image-upload", {
+      title: "Image",
+      name: "person[image_attributes]",
+      id: "person_image",
+      image_id: "person_image_file",
+      image_name: "person[image_attributes][file]",
+      remove_alt_text_field: true,
+      filename: person.image.file.identifier,
+      page_errors: person.errors.any?,
+      error_items: errors_for(person.errors, :"image.file"),
+      image_src: person.image.url,
+      image_cache_name: "person[image_attributes][file_cache]",
+      image_cache: person.image.file_cache.presence,
+    } %>
   <% end %>
 
   <%= render "components/govspeak-editor", {

--- a/app/views/admin/people/show.html.erb
+++ b/app/views/admin/people/show.html.erb
@@ -51,7 +51,7 @@
           },
           {
             field: "Image",
-            value: (image_tag(@person.image.url(:s300)) + tag.span("Image present", class: "govuk-visually-hidden") if @person.image.url),
+            value: (image_tag(@person.image.url(:s300)) + tag.span("Image present", class: "govuk-visually-hidden") if @person.image&.url),
           },
           {
             field: "Biography",

--- a/app/views/admin/topical_events/_form.html.erb
+++ b/app/views/admin/topical_events/_form.html.erb
@@ -51,7 +51,7 @@
         filename: topical_event.logo.filename,
         page_errors: topical_event.errors.any?,
         error_items: errors_for(topical_event.errors, :"logo.file"),
-        image_src: topical_event.logo.file.url,
+        image_src: topical_event.logo.url,
         image_alt: topical_event.logo_alt_text,
         image_cache_name: "topical_event[logo_attributes][file_cache]",
         image_cache: (topical_event.logo.file_cache.presence),

--- a/app/views/admin/worldwide_organisations/_form.html.erb
+++ b/app/views/admin/worldwide_organisations/_form.html.erb
@@ -73,7 +73,7 @@
       filename: worldwide_organisation.default_news_image.file.identifier,
       page_errors: worldwide_organisation.errors.any?,
       error_items: errors_for(worldwide_organisation.errors, :"default_news_image.file"),
-      image_src: worldwide_organisation.default_news_image.file.url,
+      image_src: worldwide_organisation.default_news_image.url,
       image_cache_name: "worldwide_organisation[default_news_image_attributes][file_cache]",
       image_cache: (worldwide_organisation.default_news_image.file_cache.presence),
     } %>

--- a/features/step_definitions/person_steps.rb
+++ b/features/step_definitions/person_steps.rb
@@ -16,7 +16,7 @@ When(/^I add a new person called "([^"]*)"$/) do |name|
   click_link "Create new person"
   fill_in_person_name name
   fill_in "Biography", with: "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-  attach_file "Upload a file", jpg_image
+  attach_file "Upload image", jpg_image
   click_button "Save"
 end
 

--- a/test/factories/people.rb
+++ b/test/factories/people.rb
@@ -3,6 +3,10 @@ FactoryBot.define do
     sequence(:forename) { |index| "George #{index}" }
   end
 
+  trait :with_image do
+    image { build(:featured_image_data) }
+  end
+
   factory :pm, parent: :person do
     after :create do |person, _evaluator|
       role = create(:ministerial_role, slug: "prime-minister")

--- a/test/functional/admin/organisations_controller_test.rb
+++ b/test/functional/admin/organisations_controller_test.rb
@@ -423,7 +423,7 @@ class Admin::OrganisationsControllerTest < ActionController::TestCase
     assert_equal filename, Organisation.last.assets.first.filename
   end
 
-  test "POST: update - discards logo cache if file is present" do
+  test "PUT: update - discards logo cache if file is present" do
     organisation = FactoryBot.create(
       :organisation_with_logo_and_assets,
       logo: upload_fixture("big-cheese.960x640.jpg", "image/png"),
@@ -440,13 +440,13 @@ class Admin::OrganisationsControllerTest < ActionController::TestCase
     AssetManagerCreateAssetWorker.expects(:perform_async).with(regexp_matches(/#{replacement_filename}/), anything, anything, anything, anything, anything).times(1)
     AssetManagerCreateAssetWorker.expects(:perform_async).with(regexp_matches(/#{cached_filename}/), anything, anything, anything, anything, anything).never
 
-    post :update,
-         params: { id: organisation.id,
-                   organisation: {
-                     organisation_logo_type_id: OrganisationLogoType::CustomLogo.id,
-                     logo: upload_fixture(replacement_filename, "image/png"),
-                     logo_cache: cached_organisation.logo_cache,
-                   } }
+    put :update,
+        params: { id: organisation.id,
+                  organisation: {
+                    organisation_logo_type_id: OrganisationLogoType::CustomLogo.id,
+                    logo: upload_fixture(replacement_filename, "image/png"),
+                    logo_cache: cached_organisation.logo_cache,
+                  } }
 
     AssetManagerCreateAssetWorker.drain
 
@@ -476,7 +476,7 @@ class Admin::OrganisationsControllerTest < ActionController::TestCase
          })
   end
 
-  test "POST: update - discards default news image cache if file is present" do
+  test "PUT: update - discards default news image cache if file is present" do
     organisation = FactoryBot.create(:organisation_with_default_news_image)
     default_news_image = organisation.default_news_image
 
@@ -488,16 +488,16 @@ class Admin::OrganisationsControllerTest < ActionController::TestCase
     AssetManagerCreateAssetWorker.expects(:perform_async).with(regexp_matches(/#{replacement_filename}/), anything, anything, anything, anything, anything).times(7)
     AssetManagerCreateAssetWorker.expects(:perform_async).with(regexp_matches(/#{cached_filename}/), anything, anything, anything, anything, anything).never
 
-    post :update,
-         params: {
-           id: organisation.id,
-           organisation: {
-             default_news_image_attributes: {
-               id: default_news_image.id,
-               file: upload_fixture(replacement_filename, "image/png"),
-               file_cache: cached_default_news_image.file_cache,
-             },
-           },
-         }
+    put :update,
+        params: {
+          id: organisation.id,
+          organisation: {
+            default_news_image_attributes: {
+              id: default_news_image.id,
+              file: upload_fixture(replacement_filename, "image/png"),
+              file_cache: cached_default_news_image.file_cache,
+            },
+          },
+        }
   end
 end

--- a/test/unit/app/models/featured_image_data_test.rb
+++ b/test/unit/app/models/featured_image_data_test.rb
@@ -67,4 +67,57 @@ class FeaturedImageDataTest < ActiveSupport::TestCase
     assert_not featured_image_data.valid?
     assert_equal featured_image_data.errors.messages[:featured_imageable], ["can't be blank"]
   end
+
+  test "#republish_on_assets_ready should republish organisation and associations if assets are ready" do
+    organisation = create(:organisation, :with_default_news_image)
+    news_article = create(:news_article, organisations: [organisation])
+
+    PublishingApiWorker.expects(:perform_async).with(Organisation.to_s, organisation.id)
+    Whitehall::PublishingApi.expects(:republish_document_async).with(news_article.document)
+
+    organisation.default_news_image.republish_on_assets_ready
+  end
+
+  test "#republish_on_assets_ready should republish worldwide organisation and associations if assets are ready" do
+    worldwide_organisation = create(:worldwide_organisation, :with_default_news_image)
+    news_article = create(:news_article_world_news_story, worldwide_organisations: [worldwide_organisation])
+
+    PublishingApiWorker.expects(:perform_async).with(WorldwideOrganisation.to_s, worldwide_organisation.id)
+    Whitehall::PublishingApi.expects(:republish_document_async).with(news_article.document)
+
+    worldwide_organisation.default_news_image.republish_on_assets_ready
+  end
+
+  test "#republish_on_assets_ready should republish topical event if assets are ready" do
+    topical_event = create(:topical_event, :with_logo)
+
+    PublishingApiWorker.expects(:perform_async).with(TopicalEvent.to_s, topical_event.id)
+
+    topical_event.logo.republish_on_assets_ready
+  end
+
+  test "#republish_on_assets_ready should republish person and associations if assets are ready" do
+    person = create(:person, :with_image)
+    speech = create(:speech, role_appointment: create(:role_appointment, role: create(:ministerial_role), person:))
+    create(:historical_account, person:)
+
+    PublishingApiWorker.expects(:perform_async).with(Person.to_s, person.id)
+    PublishingApiWorker.expects(:perform_async).with(HistoricalAccount.to_s, person.historical_account.id)
+    Whitehall::PublishingApi.expects(:republish_document_async).with(speech.document)
+
+    person.image.republish_on_assets_ready
+  end
+
+  test "#republish_on_assets_ready should not run any republishing action if assets are not ready" do
+    person = create(:person, :with_image)
+    person.image.assets.destroy_all
+    speech = create(:speech, role_appointment: create(:role_appointment, role: create(:ministerial_role), person:))
+    create(:historical_account, person:)
+
+    PublishingApiWorker.expects(:perform_async).with(Person.to_s, person.id).never
+    PublishingApiWorker.expects(:perform_async).with(HistoricalAccount.to_s, person.historical_account.id).never
+    Whitehall::PublishingApi.expects(:republish_document_async).with(speech.document).never
+
+    person.image.republish_on_assets_ready
+  end
 end

--- a/test/unit/app/models/organisation_test.rb
+++ b/test/unit/app/models/organisation_test.rb
@@ -1205,4 +1205,12 @@ class OrganisationTest < ActiveSupport::TestCase
 
     assert FeaturedImageData.find_by(id: default_news_image.id)
   end
+
+  test "#republish_on_assets_ready should republish organisation if logo assets are ready" do
+    organisation = create(:organisation, :with_logo_and_assets)
+
+    PublishingApiWorker.expects(:perform_async).with(Organisation.to_s, organisation.id)
+
+    organisation.republish_on_assets_ready
+  end
 end

--- a/test/unit/app/models/topical_event_featuring_image_data_test.rb
+++ b/test/unit/app/models/topical_event_featuring_image_data_test.rb
@@ -42,7 +42,7 @@ class TopicalEventFeaturingImageDataTest < ActiveSupport::TestCase
     topical_event = create(:topical_event)
     topical_event_featuring = topical_event.feature(image: build(:topical_event_featuring_image_data))
 
-    TopicalEvent.any_instance.expects(:publish_to_publishing_api_async).once
+    PublishingApiWorker.expects(:perform_async).with(TopicalEvent.to_s, topical_event.id)
 
     topical_event_featuring.image.republish_on_assets_ready
   end

--- a/test/unit/app/presenters/publishing_api/historical_accounts_index_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/historical_accounts_index_presenter_test.rb
@@ -49,7 +49,7 @@ class PublishingApi::HistoricalAccountIndexPresenterTest < ActiveSupport::TestCa
   end
 
   test "when a historic role appointment does not yet have a historic account created, presents these in the details hash" do
-    person_without_historic_account = create(:person, forename: "A", surname: "Person without a historic account yet", image: File.open(Rails.root.join("test/fixtures/minister-of-funk.960x640.jpg")))
+    person_without_historic_account = create(:person, :with_image, forename: "A", surname: "Person without a historic account yet")
     create(:historic_role_appointment, person: person_without_historic_account, role: @role, started_at: Date.civil(1960), ended_at: Date.civil(1970))
     create(:historic_role_appointment, person: person_without_historic_account, role: @role, started_at: Date.civil(1990), ended_at: Date.civil(2000))
     create(:historic_role_appointment, person: person_without_historic_account, role: create(:role), started_at: Date.civil(1970), ended_at: Date.civil(1980))
@@ -76,7 +76,7 @@ class PublishingApi::HistoricalAccountIndexPresenterTest < ActiveSupport::TestCa
 
           ],
           image: {
-            url: person_without_historic_account.image_url,
+            url: person_without_historic_account.image.url,
             alt_text: "A Person without a historic account yet",
           },
         },

--- a/test/unit/app/presenters/publishing_api/historical_accounts_index_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/historical_accounts_index_presenter_test.rb
@@ -101,4 +101,22 @@ class PublishingApi::HistoricalAccountIndexPresenterTest < ActiveSupport::TestCa
 
     assert_equal expected_details, actual_details
   end
+
+  test "it filters out people images with missing assets" do
+    person_without_historic_account = build(:person, :with_image, forename: "A", surname: "Person without a historic account yet")
+    person_without_historic_account.image.assets = []
+    person_without_historic_account.save!
+    create(:role_appointment, person: person_without_historic_account, role: @role, started_at: Date.civil(2001), ended_at: Date.civil(2002))
+
+    expected_details = { appointments_without_historical_accounts: [
+      {
+        title: "A Person without a historic account yet",
+        dates_in_office: [{ start_year: 2001, end_year: 2002 }],
+      },
+    ] }
+
+    actual_details = PublishingApi::HistoricalAccountsIndexPresenter.new.content[:details]
+
+    assert_equal expected_details, actual_details
+  end
 end

--- a/test/unit/app/presenters/publishing_api/person_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/person_presenter_test.rb
@@ -10,12 +10,12 @@ class PublishingApi::PersonPresenterTest < ActiveSupport::TestCase
   test "presents a Person ready for adding to the publishing API" do
     person = create(
       :person,
+      :with_image,
       title: "Sir",
       forename: "Winston",
       surname: "Churchill",
       letters: "PM",
       privy_counsellor: true,
-      image: upload_fixture("minister-of-funk.960x640.jpg", "image/jpg"),
       biography: "Sir Winston Churchill was a Prime Minister.",
     )
 
@@ -37,7 +37,7 @@ class PublishingApi::PersonPresenterTest < ActiveSupport::TestCase
         full_name: "Sir Winston Churchill PM",
         privy_counsellor: true,
         image: {
-          url: person.image_url(:s465),
+          url: person.image.url(:s465),
           alt_text: "The Rt Hon Sir Winston Churchill PM",
         },
         body: [

--- a/test/unit/app/presenters/publishing_api/person_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/person_presenter_test.rb
@@ -109,4 +109,13 @@ class PublishingApi::PersonPresenterTest < ActiveSupport::TestCase
       ], presented_item.content[:routes]
     end
   end
+
+  test "it filters out images with missing assets" do
+    person = create(:person, :with_image)
+    person.image.assets.destroy_all
+
+    presented_item = present(person)
+
+    assert_nil presented_item.content.dig(:details, :image)
+  end
 end

--- a/test/unit/app/presenters/publishing_api/speech_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/speech_presenter_test.rb
@@ -62,17 +62,17 @@ class PublishingApi::SpeechPresenterTest < ActiveSupport::TestCase
       end
 
       it "contains the expected values" do
-        assert_equal("Speech title",                      presented.content[:title])
-        assert_equal("The description",                   presented.content[:description])
+        assert_equal("Speech title", presented.content[:title])
+        assert_equal("The description", presented.content[:description])
         assert_equal(Whitehall::PublishingApp::WHITEHALL, presented.content[:publishing_app])
-        assert_equal("government-frontend",               presented.content[:rendering_app])
-        assert_equal([speech.auth_bypass_id],             presented.content[:auth_bypass_ids])
+        assert_equal("government-frontend", presented.content[:rendering_app])
+        assert_equal([speech.auth_bypass_id], presented.content[:auth_bypass_ids])
 
         details = presented.content[:details]
         assert_not(details[:political])
-        assert_equal(expected_body,     details[:body])
-        assert_match(iso8601_regex,     details[:delivered_on])
-        assert_match("A location",      details[:location])
+        assert_equal(expected_body, details[:body])
+        assert_match(iso8601_regex, details[:delivered_on])
+        assert_match("A location", details[:location])
         assert_equal("Transcript of the speech, exactly as it was delivered", details[:speech_type_explanation])
 
         assert_equal("Tony", details[:image][:alt_text])
@@ -192,13 +192,7 @@ class PublishingApi::SpeechPresenterTest < ActiveSupport::TestCase
     end
 
     describe "image" do
-      let(:person) do
-        create(
-          :person,
-          :with_image,
-          forename: "Tony",
-        )
-      end
+      let(:person) { create(:person, :with_image, forename: "Tony") }
 
       let(:speech) do
         create(
@@ -245,6 +239,14 @@ class PublishingApi::SpeechPresenterTest < ActiveSupport::TestCase
           details = presented.content[:details]
           assert_equal("Tony", details[:image][:alt_text])
           assert_match(/minister-of-funk.960x640.jpg$/, details[:image][:url])
+        end
+
+        test "it filters out the person image if it has missing assets" do
+          person.image.assets.destroy_all
+
+          details = presented.content[:details]
+
+          assert_nil details[:image]
         end
       end
     end

--- a/test/unit/app/presenters/publishing_api/speech_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/speech_presenter_test.rb
@@ -36,10 +36,8 @@ class PublishingApi::SpeechPresenterTest < ActiveSupport::TestCase
       let(:person) do
         create(
           :person,
+          :with_image,
           forename: "Tony",
-          image: File.open(
-            Rails.root.join("test/fixtures/images/960x640_gif.gif"),
-          ),
         )
       end
 
@@ -77,8 +75,8 @@ class PublishingApi::SpeechPresenterTest < ActiveSupport::TestCase
         assert_match("A location",      details[:location])
         assert_equal("Transcript of the speech, exactly as it was delivered", details[:speech_type_explanation])
 
-        assert_equal("Tony",             details[:image][:alt_text])
-        assert_match(/960x640_gif.gif$/, details[:image][:url])
+        assert_equal("Tony", details[:image][:alt_text])
+        assert_match(/minister-of-funk.960x640.jpg$/, details[:image][:url])
       end
     end
 
@@ -197,10 +195,8 @@ class PublishingApi::SpeechPresenterTest < ActiveSupport::TestCase
       let(:person) do
         create(
           :person,
+          :with_image,
           forename: "Tony",
-          image: File.open(
-            Rails.root.join("test/fixtures/images/960x640_gif.gif"),
-          ),
         )
       end
 
@@ -248,7 +244,7 @@ class PublishingApi::SpeechPresenterTest < ActiveSupport::TestCase
         it "presents the speaker image" do
           details = presented.content[:details]
           assert_equal("Tony", details[:image][:alt_text])
-          assert_match(/960x640_gif.gif$/, details[:image][:url])
+          assert_match(/minister-of-funk.960x640.jpg$/, details[:image][:url])
         end
       end
     end

--- a/test/unit/app/workers/asset_manager_create_asset_worker_test.rb
+++ b/test/unit/app/workers/asset_manager_create_asset_worker_test.rb
@@ -180,111 +180,21 @@ class AssetManagerCreateAssetWorkerTest < ActiveSupport::TestCase
     @worker.perform(@file.path, @asset_params, true, consultation.class.to_s, consultation.id)
   end
 
-  test "should publish the Organisation when the last asset of the default news image is uploaded to Asset Manager" do
+  test "should enqueue republishing of assetable" do
+    # We enqueue the republishing of all assetables that implement :republish_on_assets_ready.
+    # These are all the classes that use FeaturedImageData to manage their assets, such as
+    # Organisation, Worldwide Organisation, TopicalEvent, Person etc.
     organisation = create(:organisation, :with_default_news_image)
-    last_asset = organisation.default_news_image.assets.last.destroy
     asset_params = {
       assetable_id: organisation.default_news_image.id,
-      asset_variant: last_asset.variant,
-      assetable_type: FeaturedImageData.to_s,
-    }.deep_stringify_keys
-
-    asset_manager_response_with_new_id = { "id" => "http://asset-manager/assets/some_asset_manager_id", "name" => File.basename(@file) }
-    Services.asset_manager.stubs(:create_asset).returns(asset_manager_response_with_new_id)
-
-    PublishingApiWorker.expects(:perform_async).with("Organisation", organisation.id)
-
-    @worker.perform(@file.path, asset_params, true, nil, nil)
-  end
-
-  test "should publish the Organisation when the last asset of the logo is uploaded to Asset Manager" do
-    organisation = create(:organisation, :with_logo)
-    asset_params = {
-      assetable_id: organisation.id,
       asset_variant: Asset.variants[:original],
-      assetable_type: Organisation.to_s,
-    }.deep_stringify_keys
-
-    asset_manager_response_with_new_id = { "id" => "http://asset-manager/assets/some_asset_manager_id", "name" => File.basename(@file) }
-    Services.asset_manager.stubs(:create_asset).returns(asset_manager_response_with_new_id)
-
-    PublishingApiWorker.expects(:perform_async).with("Organisation", organisation.id)
-
-    @worker.perform(@file.path, asset_params, true, nil, nil)
-  end
-
-  test "should not publish model unless all assets variant are ready" do
-    organisation = create(:organisation, :with_default_news_image)
-    last_asset = organisation.default_news_image.assets.destroy_all.last
-    asset_params = {
-      assetable_id: organisation.default_news_image.id,
-      asset_variant: last_asset.variant,
       assetable_type: FeaturedImageData.to_s,
     }.deep_stringify_keys
 
     asset_manager_response_with_new_id = { "id" => "http://asset-manager/assets/some_asset_manager_id", "name" => File.basename(@file) }
     Services.asset_manager.stubs(:create_asset).returns(asset_manager_response_with_new_id)
 
-    PublishingApiWorker.expects(:perform_async).never
-
-    @worker.perform(@file.path, asset_params, true, nil, nil)
-  end
-
-  test "should republish all related news article for organisations if featured image changes" do
-    organisation = create(:organisation, :with_default_news_image)
-    last_asset = organisation.default_news_image.assets.last
-    news_article = create(:news_article, organisations: [organisation])
-
-    asset_params = {
-      assetable_id: organisation.default_news_image.id,
-      asset_variant: last_asset.variant,
-      assetable_type: FeaturedImageData.to_s,
-    }.deep_stringify_keys
-
-    asset_manager_response_with_new_id = { "id" => "http://asset-manager/assets/some_asset_manager_id", "name" => File.basename(@file) }
-    Services.asset_manager.stubs(:create_asset).returns(asset_manager_response_with_new_id)
-
-    Whitehall::PublishingApi.expects(:republish_document_async).with(news_article.document)
-
-    @worker.perform(@file.path, asset_params, true, nil, nil)
-  end
-
-  test "should republish all related news article for worldwide-organisations if featured image changes" do
-    worldwide_organisation = create(:worldwide_organisation, :with_default_news_image)
-    last_asset = worldwide_organisation.default_news_image.assets.last
-    news_article = create(:news_article_world_news_story, worldwide_organisations: [worldwide_organisation])
-
-    asset_params = {
-      assetable_id: worldwide_organisation.default_news_image.id,
-      asset_variant: last_asset.variant,
-      assetable_type: FeaturedImageData.to_s,
-    }.deep_stringify_keys
-
-    asset_manager_response_with_new_id = { "id" => "http://asset-manager/assets/some_asset_manager_id", "name" => File.basename(@file) }
-    Services.asset_manager.stubs(:create_asset).returns(asset_manager_response_with_new_id)
-
-    Whitehall::PublishingApi.expects(:republish_document_async).with(news_article.document)
-
-    @worker.perform(@file.path, asset_params, true, nil, nil)
-  end
-
-  test "should republish all related speeches and historical accounts if person featured image changes" do
-    person = create(:person, :with_image)
-    last_asset = person.image.assets.last
-    speech = create(:speech, role_appointment: create(:role_appointment, role: create(:ministerial_role), person:))
-    create(:historical_account, person:)
-
-    asset_params = {
-      assetable_id: person.image.id,
-      asset_variant: last_asset.variant,
-      assetable_type: FeaturedImageData.to_s,
-    }.deep_stringify_keys
-
-    asset_manager_response_with_new_id = { "id" => "http://asset-manager/assets/some_asset_manager_id", "name" => File.basename(@file) }
-    Services.asset_manager.stubs(:create_asset).returns(asset_manager_response_with_new_id)
-
-    Whitehall::PublishingApi.expects(:republish_document_async).with(speech.document)
-    HistoricalAccount.any_instance.expects(:publish_to_publishing_api_async).once
+    FeaturedImageData.any_instance.expects(:republish_on_assets_ready).once
 
     @worker.perform(@file.path, asset_params, true, nil, nil)
   end


### PR DESCRIPTION
This PR implements `FeaturedImageData` for `Person` to make it more consistent with other similar classes that have a carrierwave `mount_uploader` on them, as well as enabling `Person` to use the assets flow rather than legacy url path.


[Trello card](https://trello.com/c/L3apD4Cf/240-story-person-image-to-use-asset-ids)
