### PR TITLE
Use summary card component to render edition attachment collection

### DIFF
--- a/app/components/admin/editions/show/attachments_summary_card_component.erb
+++ b/app/components/admin/editions/show/attachments_summary_card_component.erb
@@ -1,0 +1,7 @@
+<section class="app-view-summary__section app-view-summary__section--attachments">
+  <%= render "components/summary_card", {
+    title: "Attachments",
+    summary_card_actions: summary_card_actions,
+    rows: rows,
+  } %>
+</section>

--- a/app/components/admin/editions/show/attachments_summary_card_component.rb
+++ b/app/components/admin/editions/show/attachments_summary_card_component.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+class Admin::Editions::Show::AttachmentsSummaryCardComponent < ViewComponent::Base
+  def initialize(edition:)
+    @edition = edition
+  end
+
+  def rows
+    @edition.attachments.map do |attachment|
+      {
+        key: attachment.title,
+        value: "#{attachment.readable_type.upcase_first} attachment",
+        actions: row_actions(attachment),
+      }
+    end
+  end
+
+  def summary_card_actions
+    if @edition.editable?
+      [
+        {
+          label: "Manage attachments",
+          href: admin_edition_attachments_path(@edition),
+        },
+      ]
+    else
+      []
+    end
+  end
+
+private
+
+  def row_actions(attachment)
+    if @edition.editable?
+      [
+        {
+          label: "View",
+          href: attachment.url(full_url: true),
+        },
+        {
+          label: "Edit",
+          href: edit_admin_edition_attachment_path(@edition, attachment),
+        },
+      ]
+    else
+      [
+        {
+          label: "View",
+          href: attachment.url(full_url: true),
+        },
+      ]
+    end
+  end
+end

--- a/app/views/admin/editions/show/_main.html.erb
+++ b/app/views/admin/editions/show/_main.html.erb
@@ -201,53 +201,57 @@
   <% end %>
 
   <% if @edition.allows_attachments? %>
-    <section class="app-view-summary__section app-view-summary__section--attachments">
-      <%= render "govuk_publishing_components/components/heading", {
-        text: "Attachments",
-        heading_level: 2,
-        font_size: "l",
-        margin_bottom: 3,
-      } %>
-
-      <% if @edition.editable? %>
-        <p class="govuk-body">
-          <%= link_to("#{@edition.attachments.any? ? "Modify" : "Add"} attachments",
-                      admin_edition_attachments_path(@edition.id),
-                      class: "govuk-link",
-                      data: {
-                        module: "gem-track-click",
-                        "track-category": "button-clicked",
-                        "track-action": "#{@edition.model_name.singular.dasherize}-button",
-                        "track-label": "Modify attachments",
-                      }) %>
-        </p>
-      <% end %>
-
-      <% if @edition.attachments.any? %>
-        <%= render "govuk_publishing_components/components/table", {
-          head: [
-            {
-              text: "Title",
-            },
-            {
-              text: "Filename",
-            },
-            @edition.editable? ? {
-              text: "Actions",
-            } : nil,
-          ].compact,
-          rows: @edition.attachments.map do | attachment |
-            [
-              { text: attachment[:title] },
-              { text: link_to_attachment(attachment, preview: !@edition.published?, full_url: true, class: "govuk-link") },
-              @edition.editable? ? { text: link_to("Edit", edit_admin_edition_attachment_path(@edition.id, attachment[:id]), class: "govuk-link") } : nil,
-            ].compact
-          end,
+    <% if Flipflop.document_hub? %>
+      <%= render Admin::Editions::Show::AttachmentsSummaryCardComponent.new(edition: @edition) %>
+    <% else %>
+      <section class="app-view-summary__section app-view-summary__section--attachments">
+        <%= render "govuk_publishing_components/components/heading", {
+          text: "Attachments",
+          heading_level: 2,
+          font_size: "l",
+          margin_bottom: 3,
         } %>
-      <% else %>
-        <p class="govuk-body">No attachments for this document</p>
-      <% end %>
-    </section>
+
+        <% if @edition.editable? %>
+          <p class="govuk-body">
+            <%= link_to("#{@edition.attachments.any? ? "Modify" : "Add"} attachments",
+                        admin_edition_attachments_path(@edition.id),
+                        class: "govuk-link",
+                        data: {
+                          module: "gem-track-click",
+                          "track-category": "button-clicked",
+                          "track-action": "#{@edition.model_name.singular.dasherize}-button",
+                          "track-label": "Modify attachments",
+                        }) %>
+          </p>
+        <% end %>
+
+        <% if @edition.attachments.any? %>
+          <%= render "govuk_publishing_components/components/table", {
+            head: [
+              {
+                text: "Title",
+              },
+              {
+                text: "Filename",
+              },
+              @edition.editable? ? {
+                text: "Actions",
+              } : nil,
+            ].compact,
+            rows: @edition.attachments.map do | attachment |
+              [
+                { text: attachment[:title] },
+                { text: link_to_attachment(attachment, preview: !@edition.published?, full_url: true, class: "govuk-link") },
+                @edition.editable? ? { text: link_to("Edit", edit_admin_edition_attachment_path(@edition.id, attachment[:id]), class: "govuk-link") } : nil,
+              ].compact
+            end,
+          } %>
+        <% else %>
+          <p class="govuk-body">No attachments for this document</p>
+        <% end %>
+      </section>
+    <% end %>
   <% end %>
 
   <% if Flipflop.document_hub? %>

--- a/features/admin-excluded-nations.feature
+++ b/features/admin-excluded-nations.feature
@@ -3,9 +3,15 @@ Feature: Marking a publication with excluded nations
   In order to increase the relevancy of content to users
   I want to be able to exclude content from one or more nation
 
-  Scenario: Creating a new draft publication that applies to multiple nations
+  Scenario Outline: Creating a new draft publication that applies to multiple nations
     Given I am a writer
+    And the document hub feature flag is <document_hub_enabled>
     When I draft a new publication "something" that does not apply to the nations:
       | Scotland | Wales |
     Then the publication should be excluded from these nations:
       | Scotland | Wales |
+
+  Examples:
+    | document_hub_enabled |
+    | enabled |
+    | disabled |

--- a/features/admin-filtering-documents.feature
+++ b/features/admin-filtering-documents.feature
@@ -1,7 +1,8 @@
 Feature: Filtering documents by author in admin
 
-  Scenario: Viewing only documents written by me
+  Scenario Outline: Viewing only documents written by me
     Given I am a writer
+    And the document hub feature flag is <document_hub_enabled>
     And I draft a new publication "My Publication"
     And a draft publication "Another Publication" exists
     And I visit the list of draft documents
@@ -9,6 +10,11 @@ Feature: Filtering documents by author in admin
     When I filter by author "Me"
     Then I should see the publication "My Publication"
     And I should not see the publication "Another Publication"
+
+  Examples:
+    | document_hub_enabled |
+    | enabled |
+    | disabled |
 
   Scenario: Viewing only publications written by me
     Given I am a writer

--- a/features/admin-statistical-data-sets.feature
+++ b/features/admin-statistical-data-sets.feature
@@ -3,8 +3,14 @@ Feature: Adding stastical data set references to a publication
   In order to reference relevant stastics
   I want to be able to add those references to a publication
 
-  Scenario: Creating a new draft publication that references statistical data sets
+  Scenario Outline: Creating a new draft publication that references statistical data sets
     Given I am an editor
+    And the document hub feature flag is <document_hub_enabled>
     And a published statistical data set "Historical Beard Lengths"
     When I draft a new publication "Beard Lengths 2012" referencing the data set "Historical Beard Lengths"
     Then the publication should reference the "Historical Beard Lengths" data set
+
+  Examples:
+    | document_hub_enabled |
+    | enabled |
+    | disabled |

--- a/features/admin-world-locations.feature
+++ b/features/admin-world-locations.feature
@@ -3,8 +3,14 @@ Feature: Tagging world locations to publications
   In order to show which location a publication is about
   I want to be able to tag world locations to publications
 
-  Scenario: The publication is about a country
+  Scenario Outline: The publication is about a country
     Given I am an editor
+    And the document hub feature flag is <document_hub_enabled>
     And a world location "British Antarctic Territory" exists
     When I draft a new publication "Penguins have rights too" about the world location "British Antarctic Territory"
     Then the publication should be about the "British Antarctic Territory" world location
+
+  Examples:
+    | document_hub_enabled |
+    | enabled |
+    | disabled |

--- a/features/edition-attachments.feature
+++ b/features/edition-attachments.feature
@@ -4,8 +4,9 @@ Feature: Managing attachments on editions
   I want to attach files and additional HTML content to publications and consultations
   In order to support the publications and consultations with statistics and other relevant documents
 
-  Scenario: Adding and reordering attachments
+  Scenario Outline: Adding and reordering attachments
     Given I am an writer
+    And the document hub feature flag is <document_hub_enabled>
     And I start drafting a new publication "Standard Beard Lengths"
     When I start editing the attachments from the publication page
     And I upload a file attachment with the title "Beard Length Statistics 2014" and the file "dft_statistical_data_set_sample.csv"
@@ -23,8 +24,14 @@ Feature: Managing attachments on editions
       | Beard Length Statistics 2014 |
       | Beard Length Illustrations   |
 
-  Scenario: Previewing HTML attachment
+  Examples:
+    | document_hub_enabled |
+    | enabled |
+    | disabled |
+
+  Scenario Outline: Previewing HTML attachment
     Given I am an writer
+    And the document hub feature flag is <document_hub_enabled>
     And I start drafting a new publication "Standard Beard Lengths"
     When I start editing the attachments from the publication page
     And I begin editing an html attachment with the title "Beard Length Graphs 2012" and the body "Example text"
@@ -34,6 +41,11 @@ Feature: Managing attachments on editions
     And I can see the preview link to the attachment "HTML attachment"
     When I edit the attachment
     Then I can see a preview link
+
+  Examples:
+    | document_hub_enabled |
+    | enabled |
+    | disabled |
 
   Scenario: Previewing HTML attachment on consultation responses
     Given I am a writer
@@ -55,11 +67,17 @@ Feature: Managing attachments on editions
     And I upload a file attachment with the title "Beard Length Statistics 2014" and the file "dft_statistical_data_set_sample.csv"
     Then the outcome for the consultation should have the attachment "Beard Length Statistics 2014"
 
-  Scenario: Attempting to save attachment after validation failure
+  Scenario Outline: Attempting to save attachment after validation failure
     Given I am a writer
+    And the document hub feature flag is <document_hub_enabled>
     And a draft publication "Standards on Beard Grooming" exists
     When I try and upload an attachment but there are validation errors
     Then I should be able to submit the attachment without re-uploading the file
+
+  Examples:
+    | document_hub_enabled |
+    | enabled |
+    | disabled |
 
   Scenario: Attempting to publish attachment which is still being uploaded to the asset manager
     Given I am an editor
@@ -69,10 +87,16 @@ Feature: Managing attachments on editions
     And I try to publish the draft edition
     Then I see a validation error for uploading attachments
 
-  Scenario: Editing metadata on attachments
+  Scenario Outline: Editing metadata on attachments
     Given I am an writer
+    And the document hub feature flag is <document_hub_enabled>
     And I start drafting a new publication "Standard Beard Lengths"
     When I start editing the attachments from the publication page
     And I upload an html attachment with the title "Beard Length Graphs 2012" and the isbn "9781474127783"
     And I publish the draft edition for publication "Standard Beard Lengths"
     Then the html attachment "Beard Length Graphs 2012" includes the isbn "9781474127783"
+
+  Examples:
+    | document_hub_enabled |
+    | enabled |
+    | disabled |

--- a/features/force-publishing-editions.feature
+++ b/features/force-publishing-editions.feature
@@ -4,13 +4,25 @@ Feature: Force Publishing editions
     Given I am an editor
 
   @not-quite-as-fake-search
-  Scenario: Force-publishing a submitted edition
+  Scenario Outline: Force-publishing a submitted edition
     Given I draft a new publication "Ban Beards"
+    And the document hub feature flag is <document_hub_enabled>
     When I force publish the publication "Ban Beards"
     Then the publication "Ban Beards" should have a force publish reason
 
-  Scenario: Retrospective second-pair of eyes
+  Examples:
+    | document_hub_enabled |
+    | enabled |
+    | disabled |
+
+  Scenario Outline: Retrospective second-pair of eyes
     Given I draft a new publication "Ban Beards"
+    And the document hub feature flag is <document_hub_enabled>
     And I force publish the publication "Ban Beards"
     When another editor retrospectively approves the "Ban Beards" publication
     Then the "Ban Beards" publication should not be flagged as force-published any more
+
+  Examples:
+    | document_hub_enabled |
+    | enabled |
+    | disabled |

--- a/features/preview-unpublished-editions.feature
+++ b/features/preview-unpublished-editions.feature
@@ -1,12 +1,24 @@
 Feature: Previewing unpublished editions
 
-  Scenario: Unpublished editions link to preview
+  Scenario Outline: Unpublished editions link to preview
     Given I am an editor
+    And the document hub feature flag is <document_hub_enabled>
     When I draft a new publication "Test publication"
     Then I should see a link to the preview version of the publication "Test publication"
 
-  Scenario: Unpublished editions link to preview from the edit page
+    Examples:
+      | document_hub_enabled |
+      | enabled |
+      | disabled |
+
+  Scenario Outline: Unpublished editions link to preview from the edit page
     Given I am an editor
+    And the document hub feature flag is <document_hub_enabled>
     When I draft a new publication "Test publication"
     When I am on the edit page for publication "Test publication"
     Then I should see a link to the preview version of the publication "Test publication"
+
+    Examples:
+      | document_hub_enabled |
+      | enabled |
+      | disabled |

--- a/features/publications.feature
+++ b/features/publications.feature
@@ -6,21 +6,33 @@ Feature: Publications
   Background:
     Given I am a writer
 
-  Scenario: Creating a new draft publication
+  Scenario Outline: Creating a new draft publication
     When I draft a new publication "Standard Beard Lengths"
+    And the document hub feature flag is <document_hub_enabled>
     Then I should see the publication "Standard Beard Lengths" in the list of draft documents
+
+    Examples:
+      | document_hub_enabled |
+      | enabled |
+      | disabled |
 
   Scenario: Submitting a draft publication to a second pair of eyes
     Given a draft publication "Standard Beard Lengths" exists
     When I submit the publication "Standard Beard Lengths"
     Then I should see the publication "Standard Beard Lengths" in the list of submitted documents
 
-  Scenario: Publishing an edition I submitted is forbidden
+  Scenario Outline: Publishing an edition I submitted is forbidden
     Given I am an editor
+    And the document hub feature flag is <document_hub_enabled>
     And there is a user called "Beardy"
     And "Beardy" drafts a new publication "Britain's Hairiest Ministers"
     When I submit the publication "Britain's Hairiest Ministers"
     Then I should not be able to publish the publication "Britain's Hairiest Ministers"
+
+    Examples:
+      | document_hub_enabled |
+      | enabled |
+      | disabled |
 
   @not-quite-as-fake-search
   Scenario: Publishing an edition I created but did not submit

--- a/features/step_definitions/attachment_steps.rb
+++ b/features/step_definitions/attachment_steps.rb
@@ -3,7 +3,7 @@ When(/^the attachment has been uploaded to the asset-manager$/) do
 end
 
 When(/^I start editing the attachments from the .*? page$/) do
-  click_on "Add attachment"
+  click_on Flipflop.document_hub? ? "Manage attachments" : "Add attachment"
 end
 
 When(/^I upload a file attachment with the title "(.*?)" and the file "(.*?)"$/) do |title, fixture_file_name|
@@ -42,7 +42,7 @@ end
 
 When(/^I try and upload an attachment but there are validation errors$/) do
   ensure_path admin_publication_path(Publication.last)
-  click_on "Modify attachments"
+  click_on Flipflop.document_hub? ? "Manage attachments" : "Modify attachments"
   click_on "Upload new file attachment"
   attach_file "File", Rails.root.join("test/fixtures/greenpaper.pdf")
   click_on "Save"

--- a/features/step_definitions/document_steps.rb
+++ b/features/step_definitions/document_steps.rb
@@ -144,3 +144,8 @@ When(/^I check "([^"]*)" adheres to the consultation principles$/) do |title|
   edition.read_consultation_principles = true
   edition.save!
 end
+
+When(/^the document hub feature flag is (enabled|disabled)$/) do |document_hub_enabled|
+  @test_strategy ||= Flipflop::FeatureSet.current.test!
+  @test_strategy.switch!(:document_hub_enabled, document_hub_enabled == "enabled")
+end

--- a/features/support/attachment_helper.rb
+++ b/features/support/attachment_helper.rb
@@ -33,7 +33,7 @@ module AttachmentHelper
 
   def add_external_attachment
     location = current_url
-    click_link "Add attachment"
+    click_link Flipflop.document_hub? ? "Manage attachments" : "Add attachment"
     create_external_attachment("http://www.example.com/example", "Example doc")
     visit location
   end

--- a/test/components/admin/editions/show/attachments_summary_card_component_test.rb
+++ b/test/components/admin/editions/show/attachments_summary_card_component_test.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "test_helper"
+class Admin::Editions::Show::AttachmentsSummaryCardComponentTest < ViewComponent::TestCase
+  include Rails.application.routes.url_helpers
+
+  test "renders the list of attachments with a view link when the edition is published" do
+    attachments = build_stubbed_list(:file_attachment, 3, attachment_data: build(:attachment_data))
+    edition = build_stubbed(:published_edition, attachments:)
+
+    render_inline(Admin::Editions::Show::AttachmentsSummaryCardComponent.new(edition:))
+
+    attachments.each do |attachment|
+      assert_selector ".govuk-summary-list .govuk-summary-list__row .govuk-summary-list__key", text: attachment.title
+      assert_selector ".govuk-summary-list .govuk-summary-list__row .govuk-summary-list__value", text: "#{attachment.readable_type.upcase_first} attachment"
+      assert_selector ".govuk-summary-list .govuk-summary-list__row .govuk-summary-list__actions a[href=\"#{attachment.url(full_url: true)}\"]", text: "View #{attachment.title}"
+    end
+  end
+
+  test "renders the list of attachments with view and edit links when the edition is editable" do
+    attachments = build_stubbed_list(:file_attachment, 3, attachment_data: build(:attachment_data))
+    edition = build_stubbed(:draft_edition, attachments:)
+
+    render_inline(Admin::Editions::Show::AttachmentsSummaryCardComponent.new(edition:))
+
+    attachments.each do |attachment|
+      edit_href = edit_admin_edition_attachment_path(edition, attachment)
+      assert_selector ".govuk-summary-list .govuk-summary-list__row .govuk-summary-list__key", text: attachment.title
+      assert_selector ".govuk-summary-list .govuk-summary-list__row .govuk-summary-list__value", text: "#{attachment.readable_type.upcase_first} attachment"
+      assert_selector ".govuk-summary-list .govuk-summary-list__row .govuk-summary-list__actions a[href=\"#{attachment.url(full_url: true)}\"]", text: "View #{attachment.title}"
+      assert_selector ".govuk-summary-list .govuk-summary-list__row .govuk-summary-list__actions a[href=\"#{edit_href}\"]", text: "Edit #{attachment.title}"
+    end
+  end
+
+  test "renders a link to the attachments page" do
+    edition = build_stubbed(:draft_edition)
+
+    render_inline(Admin::Editions::Show::AttachmentsSummaryCardComponent.new(edition:))
+
+    assert_selector ".govuk-summary-card__action a[href=\"#{admin_edition_attachments_path(edition)}\"]", text: "Manage attachments"
+  end
+end


### PR DESCRIPTION
### What

Render the edition attachments as a summary card when the document hub feature flag is enabled

### Why

The summary card component was found "to work better for actioning items as individual tasks" in research

### Screenshots

Published edition:
![Screenshot 2023-11-07 at 17 30 21](https://github.com/alphagov/whitehall/assets/137083285/6d34cab6-de06-40d4-a39f-6c270dd0bee2)

Draft edition:
![Screenshot 2023-11-07 at 17 29 58](https://github.com/alphagov/whitehall/assets/137083285/5955c866-e318-4f4e-b5e9-01f87b4d9f16)

Trello: https://trello.com/c/QjVirx5y

Epic Trello: https://trello.com/c/OzWTN7o8