### PR TITLE
Add Summary Card List Whitehall Publishing Component

### DIFF
--- a/app/views/components/_summary_card_list.html.erb
+++ b/app/views/components/_summary_card_list.html.erb
@@ -1,0 +1,46 @@
+<%
+  id ||= nil
+  data_attributes ||= {}
+  summary_card_actions ||= []
+  rows ||=[]
+%>
+
+<%= tag.div class: "app-c-summary-card-list", id: id, data: data_attributes do %>
+  <div class="govuk-summary-card">
+    <div class="govuk-summary-card__title-wrapper">
+      <h2 class="govuk-summary-card__title"><%= title %></h2>
+      <ul class="govuk-summary-card__actions">
+        <% summary_card_actions.each do |action| %>
+          <li class="govuk-summary-card__action">
+            <%= link_to sanitize(action[:label] + tag.span(" #{title}", class: "govuk-visually-hidden")), action[:href], class: "govuk-link govuk-link--no-visited-state #{"gem-link--destructive govuk-!-font-weight-bold" if action[:destructive]}".strip %>
+          </li>
+        <% end %>
+      </ul>
+    </div>
+
+    <% if rows.present? %>
+      <div class="govuk-summary-card__content">
+        <ol class="gem-c-list govuk-summary-list">
+          <% rows.each do |row| %>
+            <li class="govuk-summary-list__row">
+              <div class="govuk-summary-list__value">
+                <%= row[:text] %>
+              </div>
+              <% if row[:actions].present? %>
+                <div class="govuk-summary-list__actions">
+                  <% row[:actions].each do |action| %>
+                    <% if action[:opens_in_new_tab] %>
+                      <%= link_to sanitize(action[:label] + tag.span(" #{row[:text]} (opens in new tab)", class: "govuk-visually-hidden")), action[:href], class: "govuk-link govuk-link--no-visited-state govuk-!-margin-left-2", rel: "noreferrer noopener", target: "_blank" %>
+                    <% else %>
+                      <%= link_to sanitize(action[:label] + tag.span(" #{row[:text]}", class: "govuk-visually-hidden")), action[:href], class: "govuk-link govuk-link--no-visited-state govuk-!-margin-left-2 #{"gem-link--destructive" if action[:destructive]}".strip %>
+                    <% end %>
+                  <% end %>
+                </div>
+              <% end %>
+            </li>
+          <% end %>
+        </ol>
+      </div>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/components/docs/summary_card_list.yml
+++ b/app/views/components/docs/summary_card_list.yml
@@ -1,0 +1,90 @@
+name: Summary Card List
+description: Similar to the Summary Card Component, but renders an ordered list in place of a descriptive list with a key value pair.
+accessibility_criteria: |
+  - accept focus
+  - be focusable with a keyboard
+  - be usable with a keyboard
+  - indicate when it has focus
+examples:
+  default:
+    data:
+      title: Title
+      rows:
+        - text: value1
+        - text: value2
+  with_custom-id:
+    data:
+      id: custom_id
+      title: Title
+      rows:
+        - text: value1
+        - text: value2
+  with_tracking:
+    data:
+      data_attributes:
+        tracking: GTM-123AB
+      title: Title
+      rows:
+        - key: key one
+          text: value1
+        - key: key two
+          text: value2
+  with_actions:
+    data:
+      title: Title
+      rows:
+        - text: value1
+        - text: value2
+      summary_card_actions:
+        - label: View
+          href: "#1"
+        - label: Edit
+          href: "#2"
+  with_destructive_action:
+    data:
+      title: Title
+      rows:
+        - text: value1
+        - text: value2
+      summary_card_actions:
+        - label: Delete
+          href: "#1"
+          destructive: true
+  with_row_actions:
+    data:
+      title: Title
+      rows:
+        - text: value1
+          actions:
+            - label: View
+              href: "#1"
+            - label: Edit
+              href: "#2"
+        - text: value2
+          actions:
+            - label: View
+              href: "#1"
+            - label: Edit
+              href: "#2"
+  with_row_destructive_action:
+    data:
+      title: Title
+      rows:
+        - text: value
+          actions:
+            - label: View
+              href: "#1"
+            - label: Edit
+              href: "#2"
+            - label: Delete
+              href: "#3"
+              destructive: true
+  with_row_action_that_opens_in_new_tab:
+    data:
+      title: Title
+      rows:
+        - text: value
+          actions:
+            - label: View
+              href: "#1"
+              opens_in_new_tab: true

--- a/test/views/components/summary_card_list_test.rb
+++ b/test/views/components/summary_card_list_test.rb
@@ -1,0 +1,165 @@
+require "test_helper"
+
+class SummaryCardTest < ActionView::TestCase
+  test "the component requires a title to render" do
+    error = assert_raises ActionView::Template::Error do
+      render("components/summary_card_list")
+    end
+
+    assert error.message.include?("undefined local variable or method `title'")
+  end
+
+  test "renders a summary card component with a title" do
+    render("components/summary_card_list", {
+      title: "Title",
+    })
+
+    assert_select ".app-c-summary-card-list", count: 1
+    assert_select ".govuk-summary-card__title", text: "Title"
+  end
+
+  test "renders links in the summary card title when passed" do
+    render("components/summary_card_list", {
+      title: "Title",
+      summary_card_actions: [
+        {
+          label: "View",
+          href: "#1",
+        },
+        {
+          label: "Edit",
+          href: "#2",
+        },
+      ],
+    })
+
+    assert_select ".govuk-summary-card__title-wrapper" do
+      assert_select ".govuk-summary-card__action:nth-child(1) a[href='#1']", text: "View Title"
+      assert_select ".govuk-summary-card__action:nth-child(2) a[href='#2']", text: "Edit Title"
+    end
+  end
+
+  test "renders summary card title link with the correct class when destructive: true is passed" do
+    render("components/summary_card_list", {
+      title: "Title",
+      summary_card_actions: [
+        {
+          label: "Delete",
+          href: "#1",
+          destructive: true,
+        },
+      ],
+    })
+
+    assert_select ".govuk-summary-card__title-wrapper" do
+      assert_select ".govuk-summary-card__action .gem-link--destructive", text: "Delete Title"
+    end
+  end
+
+  test "renders a summary card component with a title and a summary list with key value pairs when provided" do
+    render("components/summary_card_list", {
+      title: "Title",
+      rows: [
+        {
+          text: "Value 1",
+        },
+        {
+          text: "Value 2",
+        },
+      ],
+    })
+
+    assert_select ".govuk-summary-card__title", text: "Title"
+    assert_select ".govuk-summary-list .govuk-summary-list__row:nth-child(1) .govuk-summary-list__value", text: "Value 1"
+    assert_select ".govuk-summary-list .govuk-summary-list__row:nth-child(2) .govuk-summary-list__value", text: "Value 2"
+  end
+
+  test "renders summary list links when provided" do
+    render("components/summary_card_list", {
+      title: "Title",
+      rows: [
+        {
+          text: "Value 1",
+          actions: [
+            {
+              label: "View",
+              href: "#1",
+            },
+            {
+              label: "Edit",
+              href: "#2",
+            },
+          ],
+        },
+        {
+          text: "Value 2",
+          actions: [
+            {
+              label: "View",
+              href: "#3",
+            },
+            {
+              label: "Edit",
+              href: "#4",
+            },
+          ],
+        },
+      ],
+    })
+
+    assert_select ".govuk-summary-list__row:nth-child(1)" do
+      assert_select ".govuk-summary-list__actions a:nth-child(1)[href='#1']", text: "View Value 1"
+      assert_select ".govuk-summary-list__actions a:nth-child(2)[href='#2']", text: "Edit Value 1"
+    end
+
+    assert_select ".govuk-summary-list__row:nth-child(2)" do
+      assert_select ".govuk-summary-list__actions a:nth-child(1)[href='#3']", text: "View Value 2"
+      assert_select ".govuk-summary-list__actions a:nth-child(2)[href='#4']", text: "Edit Value 2"
+    end
+  end
+
+  test "renders summary card list action link with the correct class when destructive: true is passed" do
+    render("components/summary_card_list", {
+      title: "Title",
+      rows: [
+        {
+          text: "Value 1",
+          actions: [
+            {
+              label: "Delete",
+              href: "#1",
+              destructive: true,
+            },
+          ],
+        },
+      ],
+    })
+
+    assert_select ".govuk-summary-list__actions .gem-link--destructive", text: "Delete Value 1"
+  end
+
+  test "renders summary card list action link with the correct rel and target when opens_in_new_tab: true is passed" do
+    render("components/summary_card_list", {
+      title: "Title",
+      rows: [
+        {
+          text: "Value 1",
+          actions: [
+            {
+              label: "View",
+              href: "#1",
+              opens_in_new_tab: true,
+            },
+          ],
+        },
+      ],
+    })
+
+    assert_select ".govuk-summary-list__actions .govuk-link" do |link|
+      link = link.first
+      assert_equal "View Value 1 (opens in new tab)", link.text
+      assert_equal "noreferrer noopener", link[:rel]
+      assert_equal "_blank", link[:target]
+    end
+  end
+end


### PR DESCRIPTION
## Description 

This adds a new component which functions almost identically to the summary card component with one notable exception. It uses an ordered list instead of a descriptive list.

This is needed for the document summary page for images, tags and specialist tags.

The summary card component requires key value pairs for summary list items. For this we simply need a value rendered in an ordered list.

## Screenshot

<img width="548" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/13a336d7-d175-4ea1-9ed9-76e5ebf0516a">

## Trello card

https://trello.com/c/n6xpHLB5/1834-images-summary-card-on-summary-page-like-for-like


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
