### PR TITLE
Upgrade carrierwave from 2.x to 3.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,10 +4,11 @@ gem "rails", "7.0.8"
 
 gem "activemodel-serializers-xml"
 gem "addressable"
+gem "after_commit_everywhere"
 gem "babosa"
 gem "bootsnap", require: false
 gem "bootstrap-kaminari-views"
-gem "carrierwave", "< 3" # pin at v2 to avoid breaking changes
+gem "carrierwave"
 gem "carrierwave-i18n"
 gem "chronic"
 gem "dalli"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,9 @@ GEM
     addressable (2.8.5)
       public_suffix (>= 2.0.2, < 6.0)
     afm (0.2.2)
+    after_commit_everywhere (1.3.1)
+      activerecord (>= 4.2)
+      activesupport
     ast (2.4.2)
     autoprefixer-rails (10.4.7.0)
       execjs (~> 2)
@@ -112,13 +115,12 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    carrierwave (2.2.4)
-      activemodel (>= 5.0.0)
-      activesupport (>= 5.0.0)
+    carrierwave (3.0.4)
+      activemodel (>= 6.0.0)
+      activesupport (>= 6.0.0)
       addressable (~> 2.6)
       image_processing (~> 1.1)
       marcel (~> 1.0.0)
-      mini_mime (>= 0.1.3)
       ssrf_filter (~> 1.0)
     carrierwave-i18n (0.3.0)
     chronic (0.10.2)
@@ -832,7 +834,7 @@ GEM
       rexml
     ruby-progressbar (1.13.0)
     ruby-rc4 (0.1.5)
-    ruby-vips (2.1.4)
+    ruby-vips (2.2.0)
       ffi (~> 1.12)
     ruby2_keywords (0.0.5)
     rubyntlm (0.6.3)
@@ -887,7 +889,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    ssrf_filter (1.1.1)
+    ssrf_filter (1.1.2)
     statsd-ruby (1.5.0)
     sync (0.5.0)
     sys-uname (1.2.3)
@@ -949,12 +951,13 @@ PLATFORMS
 DEPENDENCIES
   activemodel-serializers-xml
   addressable
+  after_commit_everywhere
   babosa
   better_errors
   binding_of_caller
   bootsnap
   bootstrap-kaminari-views
-  carrierwave (< 3)
+  carrierwave
   carrierwave-i18n
   chronic
   climate_control

--- a/app/controllers/admin/edition_images_controller.rb
+++ b/app/controllers/admin/edition_images_controller.rb
@@ -28,6 +28,8 @@ class Admin::EditionImagesController < Admin::BaseController
     @new_image.build_image_data(image_params["image_data"])
 
     @new_image.image_data.validate_on_image = @new_image
+    # so that auth_bypass_id is discoverable by AssetManagerStorage
+    @new_image.image_data.images << @new_image
 
     if @new_image.save
       @edition.update_lead_image if @edition.can_have_custom_lead_image?

--- a/app/models/image_data.rb
+++ b/app/models/image_data.rb
@@ -26,9 +26,8 @@ class ImageData < ApplicationRecord
 
   def auth_bypass_ids
     images
-      .joins(:edition)
-      .where("editions.state in (?)", Edition::PRE_PUBLICATION_STATES)
-      .map { |e| e.edition.auth_bypass_id }
+      .filter { |image| Edition::PRE_PUBLICATION_STATES.include? image.edition.state }
+      .map { |image| image.edition.auth_bypass_id }
       .uniq
   end
 

--- a/test/functional/admin/attachments_controller_test.rb
+++ b/test/functional/admin/attachments_controller_test.rb
@@ -170,10 +170,10 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
 
   test "POST :create triggers a job to be queued to store the attachment in Asset Manager" do
     attachment = valid_file_attachment_params
-    variant = Asset.variants[:original]
     model_type = AttachmentData.to_s
 
-    AssetManagerCreateAssetWorker.expects(:perform_async).with(anything, has_entries("assetable_id" => kind_of(Integer), "asset_variant" => variant, "assetable_type" => model_type), anything, @edition.class.to_s, @edition.id, [@edition.auth_bypass_id])
+    AssetManagerCreateAssetWorker.expects(:perform_async).with(anything, has_entries("assetable_id" => kind_of(Integer), "asset_variant" => Asset.variants[:original], "assetable_type" => model_type), anything, @edition.class.to_s, @edition.id, [@edition.auth_bypass_id]).once
+    AssetManagerCreateAssetWorker.expects(:perform_async).with(anything, has_entries("assetable_id" => kind_of(Integer), "asset_variant" => Asset.variants[:thumbnail], "assetable_type" => model_type), anything, @edition.class.to_s, @edition.id, [@edition.auth_bypass_id])
 
     post :create, params: { edition_id: @edition.id, type: "file", attachment: }
   end
@@ -347,10 +347,10 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
 
   test "PUT :update with a file triggers a job to be queued to store the attachment in Asset Manager" do
     attachment = create(:file_attachment, attachable: @edition)
-    variant = Asset.variants[:original]
     model_type = attachment.attachment_data.class.to_s
 
-    AssetManagerCreateAssetWorker.expects(:perform_async).with(anything, has_entries("assetable_id" => kind_of(Integer), "asset_variant" => variant, "assetable_type" => model_type), anything, @edition.class.to_s, @edition.id, [@edition.auth_bypass_id])
+    AssetManagerCreateAssetWorker.expects(:perform_async).with(anything, has_entries("assetable_id" => kind_of(Integer), "asset_variant" => Asset.variants[:original], "assetable_type" => model_type), anything, @edition.class.to_s, @edition.id, [@edition.auth_bypass_id])
+    AssetManagerCreateAssetWorker.expects(:perform_async).with(anything, has_entries("assetable_id" => kind_of(Integer), "asset_variant" => Asset.variants[:thumbnail], "assetable_type" => model_type), anything, @edition.class.to_s, @edition.id, [@edition.auth_bypass_id])
 
     put :update,
         params: {

--- a/test/functional/admin/worldwide_organisations_controller_test.rb
+++ b/test/functional/admin/worldwide_organisations_controller_test.rb
@@ -182,6 +182,26 @@ class Admin::WorldwideOrganisationsControllerTest < ActionController::TestCase
     assert_equal cached_filename, WorldwideOrganisation.last.default_news_image.filename
   end
 
+  test "PUT :update uses the file cache if present" do
+    worldwide_organisation = create(:worldwide_organisation, :with_default_news_image)
+    default_news_image_id = worldwide_organisation.default_news_image.id
+
+    cached_filename = "big-cheese.960x640.jpg"
+    cached_default_news_image = build(:featured_image_data, file: upload_fixture(cached_filename))
+
+    put :update, params: {
+      id: worldwide_organisation.id,
+      worldwide_organisation: {
+        default_news_image_attributes: {
+          id: default_news_image_id,
+          file_cache: cached_default_news_image.file_cache,
+        },
+      },
+    }
+
+    assert_equal cached_filename, worldwide_organisation.reload.default_news_image.filename
+  end
+
   test "POST :create discards the file cache if file is present" do
     cached_filename = "big-cheese.960x640.jpg"
     cached_default_news_image = build(:featured_image_data, file: upload_fixture(cached_filename))

--- a/test/unit/app/models/edition/images_test.rb
+++ b/test/unit/app/models/edition/images_test.rb
@@ -131,7 +131,7 @@ class Edition::ImagesTest < ActiveSupport::TestCase
     edition_lead_image = EditionLeadImage.find_by!(edition_id: draft_edition.id)
 
     assert_not_equal image2.id, edition_lead_image.image_id
-    assert_equal image2.image_data.images.last.id, edition_lead_image.image_id
+    assert_equal image2.reload.image_data.images.last.id, edition_lead_image.image_id
   end
 
   test "captions for images can be changed between versions" do

--- a/test/unit/app/presenters/publishing_api/call_for_evidence_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/call_for_evidence_presenter_test.rb
@@ -255,7 +255,7 @@ module PublishingApi::CallForEvidencePresenterTest
         call_for_evidence_response_form_data_attributes: response_form_data_attributes,
       )
 
-      participation = create(
+      @participation = create(
         :call_for_evidence_participation,
         call_for_evidence_response_form_attributes: response_form_attributes,
         email: "postmaster@example.com",
@@ -271,7 +271,7 @@ module PublishingApi::CallForEvidencePresenterTest
 
       self.call_for_evidence = create(
         :open_call_for_evidence,
-        call_for_evidence_participation: participation,
+        call_for_evidence_participation: @participation,
       )
     end
 
@@ -281,9 +281,10 @@ module PublishingApi::CallForEvidencePresenterTest
 
     test "ways to respond" do
       Plek.any_instance.stubs(:asset_root).returns("https://asset-host.com")
-      expected_id = CallForEvidenceResponseFormData.where(carrierwave_file: "two-pages.pdf").last.id
+      expected_id = @participation.call_for_evidence_response_form.call_for_evidence_response_form_data.id
+      filename = @participation.call_for_evidence_response_form.call_for_evidence_response_form_data.carrierwave_file
       expected_ways_to_respond = {
-        attachment_url: "https://asset-host.com/government/uploads/system/uploads/call_for_evidence_response_form_data/file/#{expected_id}/two-pages.pdf",
+        attachment_url: "https://asset-host.com/government/uploads/system/uploads/call_for_evidence_response_form_data/file/#{expected_id}/#{filename}",
         email: "postmaster@example.com",
         link_url: "http://www.example.com",
         postal_address: <<-ADDRESS.strip_heredoc.chop,

--- a/test/unit/app/presenters/publishing_api/consultation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/consultation_presenter_test.rb
@@ -256,7 +256,7 @@ module PublishingApi::ConsultationPresenterTest
         consultation_response_form_data_attributes: response_form_data_attributes,
       )
 
-      participation = create(
+      @participation = create(
         :consultation_participation,
         consultation_response_form_attributes: response_form_attributes,
         email: "postmaster@example.com",
@@ -272,7 +272,7 @@ module PublishingApi::ConsultationPresenterTest
 
       self.consultation = create(
         :open_consultation,
-        consultation_participation: participation,
+        consultation_participation: @participation,
       )
     end
 
@@ -282,9 +282,10 @@ module PublishingApi::ConsultationPresenterTest
 
     test "ways to respond" do
       Plek.any_instance.stubs(:asset_root).returns("https://asset-host.com")
-      expected_id = ConsultationResponseFormData.where(carrierwave_file: "two-pages.pdf").last.id
+      expected_id = @participation.consultation_response_form.consultation_response_form_data.id
+      expected_filename = @participation.consultation_response_form.consultation_response_form_data.carrierwave_file
       expected_ways_to_respond = {
-        attachment_url: "https://asset-host.com/government/uploads/system/uploads/consultation_response_form_data/file/#{expected_id}/two-pages.pdf",
+        attachment_url: "https://asset-host.com/government/uploads/system/uploads/consultation_response_form_data/file/#{expected_id}/#{expected_filename}",
         email: "postmaster@example.com",
         link_url: "http://www.example.com",
         postal_address: <<-ADDRESS.strip_heredoc.chop,


### PR DESCRIPTION
Inorder to complete the upgrade, we need to:

i> Use TransactionAwareClient for AssetManagerCreateAssetWorker. Because
   Carrierwave has changed the way it hooks with the related ActiveRecord models.
   store-method used to be called on an `after_commit` callback, but it is now invoked
   on the `after_save` callback. Important difference here is that any Database query
   might not have finished yet when the worker runs. Therefore the Worker might not
   have all the necessary information available. In this case we saw that Assetable
   model was not yet available from the database even though saving was successful for
   the ActiveRecord model.

ii> Add missing expectation to failing tests. We're unsure why the tests were passing before.

iii> Carrierwave has a new de-duplication feature for filenames which makes it hard to
     guess resulting filename. This happended with the test
     'call_for_evidence_presenter_test.rb -test "ways to respond"'