### PR TITLE
Fix selenium based tests failing in CI for an unknown reason

### DIFF
--- a/features/edition-images-javascript.feature
+++ b/features/edition-images-javascript.feature
@@ -1,0 +1,28 @@
+# For an unknown reason selenium driver based image-tests began to fail in the CI workflow when executed in Github
+# Running the tests from a separate feature-file seems to fix the issue
+Feature: Images tab on edit edition
+
+  Background:
+    Given I am a writer
+
+  @javascript
+  Scenario: Image uploaded with cropping required
+    And a draft document with images exists
+    When I visit the images tab of the document with images
+    Then I should see a list with 2 images
+    When I upload a 960x960 image
+    Then I am redirected to a page for image cropping
+    When I click the "Save and continue" button on the crop page
+    And I update the image details and save
+    Then I should see a list with 3 image
+
+  @javascript
+  Scenario: Uploading an oversized file with duplicated filename
+    When a draft document with images exists
+    And I visit the images tab of the document with images
+    And I upload a 960x960 image
+    And I am redirected to a page for image cropping
+    And I click the "Save and continue" button on the crop page
+    And I update the image details and save
+    And I upload a 960x960 image
+    Then I should get 1 error message

--- a/features/edition-images.feature
+++ b/features/edition-images.feature
@@ -49,30 +49,8 @@ Feature: Images tab on edit edition
     And I update the image details and save
     Then I should see a list with 1 image
 
-  @javascript
-  Scenario: Image uploaded with cropping required
-    And a draft document with images exists
-    When I visit the images tab of the document with images
-    Then I should see a list with 2 images
-    When I upload a 960x960 image
-    Then I am redirected to a page for image cropping
-    When I click the "Save and continue" button on the crop page
-    And I update the image details and save
-    Then I should see a list with 3 image
-
   Scenario: No file uploaded
     And I start drafting a new publication "Standard Beard Lengths"
     When I visit the images tab of the document "Standard Beard Lengths"
     And I click upload without attaching a file
     Then I should get the error message "Image data file cannot be uploaded. Choose a valid JPEG, PNG, SVG or GIF."
-
-  @javascript
-  Scenario: Uploading an oversized file with duplicated filename
-    When a draft document with images exists
-    And I visit the images tab of the document with images
-    And I upload a 960x960 image
-    And I am redirected to a page for image cropping
-    And I click the "Save and continue" button on the crop page
-    And I update the image details and save
-    And I upload a 960x960 image
-    Then I should get 1 error message


### PR DESCRIPTION
For an unknown reason selenium driver based image-tests began to fail in the CI workflow when executed in Github. Running the tests from a separate feature-file seems to fix the issue
