### PR TITLE
Take part page to use featured image data with assets

### DIFF
--- a/app/controllers/admin/take_part_pages_controller.rb
+++ b/app/controllers/admin/take_part_pages_controller.rb
@@ -1,5 +1,7 @@
 class Admin::TakePartPagesController < Admin::BaseController
   before_action :enforce_permissions!
+  before_action :clean_take_part_page_params, only: %i[create update]
+
   layout "design_system"
 
   def enforce_permissions!
@@ -62,12 +64,18 @@ class Admin::TakePartPagesController < Admin::BaseController
 private
 
   def take_part_page_params
-    params.require(:take_part_page).permit(
+    @take_part_page_params ||= params.require(:take_part_page).permit(
       :title,
       :summary,
       :body,
       :image_alt_text,
       image_attributes: %i[file file_cache id],
     )
+  end
+
+  def clean_take_part_page_params
+    if take_part_page_params.dig(:image_attributes, :file_cache).present? && take_part_page_params.dig(:image_attributes, :file).present?
+      take_part_page_params[:image_attributes].delete(:file_cache)
+    end
   end
 end

--- a/app/controllers/admin/take_part_pages_controller.rb
+++ b/app/controllers/admin/take_part_pages_controller.rb
@@ -12,6 +12,7 @@ class Admin::TakePartPagesController < Admin::BaseController
 
   def new
     @take_part_page = TakePartPage.new
+    @take_part_page.build_image if @take_part_page.image.blank?
   end
 
   def create
@@ -19,12 +20,14 @@ class Admin::TakePartPagesController < Admin::BaseController
     if @take_part_page.save
       redirect_to [:admin, TakePartPage], notice: %(Take part page "#{@take_part_page.title}" created!)
     else
+      @take_part_page.build_image if @take_part_page.image.blank?
       render :new
     end
   end
 
   def edit
     @take_part_page = TakePartPage.friendly.find(params[:id])
+    @take_part_page.build_image if @take_part_page.image.blank?
   end
 
   def update
@@ -60,7 +63,11 @@ private
 
   def take_part_page_params
     params.require(:take_part_page).permit(
-      :title, :summary, :body, :image, :image_alt_text, :image_cache
+      :title,
+      :summary,
+      :body,
+      :image_alt_text,
+      image_attributes: %i[file file_cache id],
     )
   end
 end

--- a/app/models/take_part_page.rb
+++ b/app/models/take_part_page.rb
@@ -13,12 +13,11 @@ class TakePartPage < ApplicationRecord
 
   include PublishesToPublishingApi
 
-  mount_uploader :image, FeaturedImageUploader, mount_on: :carrierwave_image
-  has_one :image_new, class_name: "FeaturedImageData", as: :featured_imageable, inverse_of: :featured_imageable
+  has_one :image, class_name: "FeaturedImageData", as: :featured_imageable, inverse_of: :featured_imageable
+  accepts_nested_attributes_for :image, reject_if: :all_blank
 
-  validates :image, presence: true, on: :create
+  validate :image_is_present, on: :create
   validates :image_alt_text, presence: true, allow_blank: true, length: { maximum: 255 }, on: :create
-  validates_with ImageValidator, method: :image, size: [960, 640], if: :image_changed?
 
   include Searchable
   searchable title: :title,
@@ -66,10 +65,6 @@ class TakePartPage < ApplicationRecord
 
 protected
 
-  def image_changed?
-    changes["carrierwave_image"].present?
-  end
-
   def ensure_ordering!
     self.ordering = TakePartPage.next_ordering if ordering.nil?
   end
@@ -84,5 +79,9 @@ protected
         take_part_pages: pages,
       },
     )
+  end
+
+  def image_is_present
+    errors.add(:"image.file", "can't be blank") if image.blank?
   end
 end

--- a/app/presenters/publishing_api/take_part_presenter.rb
+++ b/app/presenters/publishing_api/take_part_presenter.rb
@@ -36,7 +36,7 @@ module PublishingApi
       {
         body: Whitehall::GovspeakRenderer.new.govspeak_to_html(item.body),
         image: {
-          url: item.image_url(:s300),
+          url: item.image&.url(:s300),
           alt_text: item.image_alt_text,
         },
         ordering: item.ordering,

--- a/app/presenters/publishing_api/take_part_presenter.rb
+++ b/app/presenters/publishing_api/take_part_presenter.rb
@@ -36,11 +36,24 @@ module PublishingApi
       {
         body: Whitehall::GovspeakRenderer.new.govspeak_to_html(item.body),
         image: {
-          url: item.image&.url(:s300),
+          url: image_url,
           alt_text: item.image_alt_text,
         },
         ordering: item.ordering,
       }
+    end
+
+    def image_url
+      return item.image.url(:s300) if item.image&.all_asset_variants_uploaded? && item.image&.url(:s300)
+
+      placeholder_image_url
+    end
+
+    def placeholder_image_url
+      ActionController::Base.helpers.image_url(
+        "placeholder.jpg",
+        host: Whitehall.public_root,
+      )
     end
   end
 end

--- a/app/views/admin/take_part_pages/_form.html.erb
+++ b/app/views/admin/take_part_pages/_form.html.erb
@@ -49,16 +49,25 @@
         error_items: errors_for(form.object.errors, :body),
       } %>
 
-      <%= render "components/single-image-upload", {
-        id: "take_part_page",
-        name: "take_part_page",
-        page_errors: form.object.errors.any?,
-        error_items: errors_for(form.object.errors, :image),
-        filename: form.object.image.filename,
-        image_cache: (form.object.image.image_cache.presence),
-        image_src: form.object.image.url,
-        image_alt: form.object.image_alt_text,
-      } %>
+      <%= form.fields_for :image do |_image_fields| %>
+        <%= render "components/single-image-upload", {
+          title: "Image",
+          name: "take_part_page[image_attributes]",
+          id: "take_part_page_image",
+          image_id: "take_part_page_image_file",
+          image_name: "take_part_page[image_attributes][file]",
+          filename: form.object.image.file.identifier,
+          alt_text_name: "take_part_page[image_alt_text]",
+          alt_text_id: "take_part_page_image_alt_text",
+          image_alt: form.object.image_alt_text,
+          page_errors: form.object.errors.any?,
+          error_items: errors_for(form.object.errors, :"image.file"),
+          image_src: form.object.image.url,
+          image_cache_name: "take_part_page[image_attributes][file_cache]",
+          image_cache: (form.object.image.file_cache.presence),
+        } %>
+      <% end %>
+
       <div class="govuk-button-group govuk-!-margin-top-8">
         <%= render "govuk_publishing_components/components/button", {
           text: "Save",

--- a/test/factories/take_part_pages.rb
+++ b/test/factories/take_part_pages.rb
@@ -3,7 +3,10 @@ FactoryBot.define do
     title { "A take part page title" }
     summary { "Summary text" }
     body { "Some govspeak body text" }
-    image { image_fixture_file }
     image_alt_text { "Image alt text" }
+
+    after :build do |take_part_page|
+      take_part_page.image = build(:featured_image_data)
+    end
   end
 end

--- a/test/functional/admin/take_part_pages_controller_test.rb
+++ b/test/functional/admin/take_part_pages_controller_test.rb
@@ -31,16 +31,16 @@ class Admin::TakePartPagesControllerTest < ActionController::TestCase
   test "POST :create saves a new instance with the supplied valid params" do
     take_part_page_attrs = attributes_for(:take_part_page, title: "Wear a monocle!")
                              .merge(
-                               image: upload_fixture(
-                                 "minister-of-funk.960x640.jpg",
-                                 "image/jpg",
-                               ),
+                               image_attributes: {
+                                 file: upload_fixture("minister-of-funk.960x640.jpg", "image/jpg"),
+                               },
                              )
 
     post :create, params: { take_part_page: take_part_page_attrs }
 
     assert assigns(:take_part_page).persisted?
     assert_equal "Wear a monocle!", assigns(:take_part_page).title
+    assert_equal "minister-of-funk.960x640.jpg", assigns(:take_part_page).image.filename
     assert_redirected_to admin_take_part_pages_path
   end
 
@@ -66,10 +66,21 @@ class Admin::TakePartPagesControllerTest < ActionController::TestCase
   test "PUT :update changes the supplied instance with the supplied params" do
     attrs = attributes_for(:take_part_page, title: "Wear a monocle!")
     page = create(:take_part_page, title: "Drink in a gin palace!")
-    post :update, params: { id: page, take_part_page: attrs }
+    image = page.image
+
+    post :update, params: {
+      id: page,
+      take_part_page: attrs.merge(
+        image_attributes: {
+          id: image.id,
+          file: upload_fixture("images/960x640_jpeg.jpg", "image/jpg"),
+        },
+      ),
+    }
 
     assert_equal page, assigns(:take_part_page)
     assert_equal "Wear a monocle!", page.reload.title
+    assert_equal "960x640_jpeg.jpg", page.reload.image.filename
     assert_redirected_to admin_take_part_pages_path
   end
 

--- a/test/unit/app/models/featured_image_data_test.rb
+++ b/test/unit/app/models/featured_image_data_test.rb
@@ -108,6 +108,14 @@ class FeaturedImageDataTest < ActiveSupport::TestCase
     person.image.republish_on_assets_ready
   end
 
+  test "#republish_on_assets_ready should republish take part page if assets are ready" do
+    take_part_page = create(:take_part_page)
+
+    PublishingApiWorker.expects(:perform_async).with(TakePartPage.to_s, take_part_page.id)
+
+    take_part_page.image.republish_on_assets_ready
+  end
+
   test "#republish_on_assets_ready should not run any republishing action if assets are not ready" do
     person = create(:person, :with_image)
     person.image.assets.destroy_all

--- a/test/unit/app/models/take_part_page_test.rb
+++ b/test/unit/app/models/take_part_page_test.rb
@@ -66,7 +66,10 @@ class TakePartPageTest < ActiveSupport::TestCase
   end
 
   test "invalid without image on create" do
-    assert_not build(:take_part_page, image: nil).valid?
+    take_part_page = build(:take_part_page)
+    take_part_page.image = nil
+
+    assert_not take_part_page.valid?
   end
 
   test "valid without image alt text on create" do
@@ -216,30 +219,6 @@ class TakePartPageTest < ActiveSupport::TestCase
   test "public_url returns the correct path for a TakePart object with options" do
     object = create(:take_part_page, slug: "foo")
     assert_equal "https://www.test.gov.uk/government/get-involved/take-part/foo?cachebust=123", object.public_url(cachebust: "123")
-  end
-
-  test "rejects SVG logo uploads" do
-    svg_image = File.open(Rails.root.join("test/fixtures/images/test-svg.svg"))
-    take_part_page = build(:take_part_page, image: svg_image)
-
-    assert_not take_part_page.valid?
-    assert_includes take_part_page.errors.map(&:full_message), "Image You are not allowed to upload \"svg\" files, allowed types: jpg, jpeg, gif, png"
-  end
-
-  test "rejects non-image file uploads" do
-    non_image_file = File.open(Rails.root.join("test/fixtures/folders.zip"))
-    take_part_page = build(:take_part_page, image: non_image_file)
-
-    assert_not take_part_page.valid?
-    assert_includes take_part_page.errors.map(&:full_message), "Image You are not allowed to upload \"zip\" files, allowed types: jpg, jpeg, gif, png"
-  end
-
-  test "accepts valid image uploads" do
-    jpg_image = File.open(Rails.root.join("test/fixtures/big-cheese.960x640.jpg"))
-    take_part_page = build(:take_part_page, image: jpg_image)
-
-    assert take_part_page
-    assert_empty take_part_page.errors
   end
 
   should_not_accept_footnotes_in :body

--- a/test/unit/app/presenters/publishing_api/take_part_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/take_part_presenter_test.rb
@@ -48,4 +48,14 @@ class PublishingApi::TakePartPresenterTest < ActiveSupport::TestCase
 
     assert_equal expected_hash, presented_content
   end
+
+  test "sends a placeholder url if image variants are missing" do
+    take_part_page = build(:take_part_page)
+    take_part_page.image.assets = []
+    take_part_page.save!
+
+    presented_item = present(take_part_page)
+
+    assert_match(/placeholder.jpg$/, presented_item.content.dig(:details, :image, :url))
+  end
 end

--- a/test/unit/app/presenters/publishing_api/take_part_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/take_part_presenter_test.rb
@@ -8,7 +8,7 @@ class PublishingApi::TakePartPresenterTest < ActiveSupport::TestCase
   test "take part presentation includes the correct values" do
     take_part_page = create(:take_part_page, content_id: SecureRandom.uuid)
 
-    image_url = take_part_page.image_url(:s300)
+    image_url = take_part_page.image.url(:s300)
 
     expected_hash = {
       base_path: "/government/get-involved/take-part/#{take_part_page.slug}",


### PR DESCRIPTION
Implement `FeaturedImageData` for `TakePartPage` in order to make it more consistent
with other similar classes that have a carrierwave `mount_uploader` on them, as well as
enabling TakePartPage to use the assets flow rather than legacy url path.