### PR TITLE
Fix test file naming as it makes CI fail the test run

### DIFF
--- a/test/views/components/summary_card_list_test.rb
+++ b/test/views/components/summary_card_list_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class SummaryCardTest < ActionView::TestCase
+class SummaryCardListTest < ActionView::TestCase
   test "the component requires a title to render" do
     error = assert_raises ActionView::Template::Error do
       render("components/summary_card_list")


### PR DESCRIPTION
When tests are run in parallel, no 2 tests can have the same name.


