### PR TITLE
Cleanup regarding Orphan Document fix for Document Collections

### DIFF
--- a/app/helpers/admin/document_collection_group_memberships_helper.rb
+++ b/app/helpers/admin/document_collection_group_memberships_helper.rb
@@ -1,9 +1,26 @@
 module Admin::DocumentCollectionGroupMembershipsHelper
+  UNAVAILABLE_DOCUMENT_TITLE = "Unavailable Document".freeze
+
   def document_collection_group_member_title(membership)
     return membership.non_whitehall_link.title if membership.non_whitehall_link
+    return unavailable_document_title_tag unless membership.document&.latest_edition
 
     membership.document.latest_edition.title
   end
+
+  def document_collection_group_member_links(collection, group, membership)
+    links = [remove_link(collection, group, membership)]
+    links.prepend(view_link(membership)) unless document_collection_group_member_unavailable?(membership)
+    sanitize(links.join)
+  end
+
+  def unavailable_document_count(memberships)
+    memberships.count do |membership|
+      document_collection_group_member_unavailable?(membership)
+    end
+  end
+
+private
 
   def document_collection_group_member_url(membership)
     return Plek.website_root + membership.non_whitehall_link.base_path if membership.non_whitehall_link
@@ -11,13 +28,27 @@ module Admin::DocumentCollectionGroupMembershipsHelper
     membership.document.latest_edition.public_url
   end
 
+  def unavailable_document_title_tag
+    tag.span(UNAVAILABLE_DOCUMENT_TITLE, class: "govuk-!-font-weight-bold")
+  end
+
   def document_collection_group_member_unavailable?(membership)
     !membership.non_whitehall_link && !membership.document&.latest_edition
   end
 
-  def unavailable_document_count(memberships)
-    memberships.count do |membership|
-      document_collection_group_member_unavailable?(membership)
-    end
+  def view_link(membership)
+    link_to(
+      sanitize("View #{tag.span(document_collection_group_member_title(membership), class: 'govuk-visually-hidden')}"),
+      document_collection_group_member_url(membership),
+      class: "govuk-link",
+    )
+  end
+
+  def remove_link(collection, group, membership)
+    link_to(
+      sanitize("Remove #{tag.span(document_collection_group_member_title(membership), class: 'govuk-visually-hidden')}"),
+      confirm_destroy_admin_document_collection_group_document_collection_group_membership_path(collection, group, membership),
+      class: "govuk-link gem-link--destructive govuk-!-margin-left-3",
+    )
   end
 end

--- a/app/views/admin/document_collection_group_memberships/_unavailable_document_banner.html.erb
+++ b/app/views/admin/document_collection_group_memberships/_unavailable_document_banner.html.erb
@@ -1,0 +1,13 @@
+<% document_counter = pluralize(unavailable_document_count, "unavailable document") %>
+<%
+  content_for :banner, render("govuk_publishing_components/components/notice", {
+    title: "Remove #{document_counter} within the group.",
+    show_banner_title: true,
+    data_attributes: {
+      module: "gem-track-click",
+      "track-category": "important-banner",
+      "track-action": "unavailable-documents-exist-in-document-collection-group",
+      "track-label": "Important",
+    },
+  })
+%>

--- a/app/views/admin/document_collection_group_memberships/confirm_destroy.html.erb
+++ b/app/views/admin/document_collection_group_memberships/confirm_destroy.html.erb
@@ -5,8 +5,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with url: admin_document_collection_group_document_collection_group_membership_path(@collection, @group, @membership), method: :delete do |_| %>
-      <% title = document_collection_group_member_unavailable?(@membership) ? tag.span("Unavailable Document", class: "govuk-!-font-weight-bold") : document_collection_group_member_title(@membership) %>
-      <p class="govuk-body govuk-!-margin-bottom-6">Are you sure you want to remove "<%= title %>" from this collection?</p>
+      <p class="govuk-body govuk-!-margin-bottom-6">Are you sure you want to remove "<%= document_collection_group_member_title(@membership) %>" from this collection?</p>
 
        <div class="govuk-button-group">
         <%= render "govuk_publishing_components/components/button", {

--- a/app/views/admin/document_collection_group_memberships/index.html.erb
+++ b/app/views/admin/document_collection_group_memberships/index.html.erb
@@ -8,17 +8,8 @@
 <% content_for :context, @collection.title %>
 <% content_for :title_margin_bottom, 4 %>
 
-<% if unavailable_document_count(@group.memberships) > 0 %>
-  <% content_for :banner, render("govuk_publishing_components/components/notice", {
-    title: sanitize("<p>Remove #{unavailable_document_count(@group.memberships)} unavailable document(s) within the group.</p>"),
-    show_banner_title: true,
-    data_attributes: {
-      module: "gem-track-click",
-      "track-category": "important-banner",
-      "track-action": "unavailable-documents-exist-in-document-collection-group",
-      "track-label": "Important",
-    },
-  }) %>
+<% if unavailable_document_count(@group.memberships).positive? %>
+  <%= render "unavailable_document_banner", unavailable_document_count: unavailable_document_count(@group.memberships) %>
 <% end %>
 
 <div class="govuk-grid-row">
@@ -56,19 +47,10 @@
       <div class="govuk-table--with-actions app-view-document-collection-group-memberships-index__table">
         <%= render "govuk_publishing_components/components/table", {
           rows: @group.memberships.map do |membership|
-            if document_collection_group_member_unavailable?(membership)
-              title = tag.span("Unavailable Document", class: "govuk-!-font-weight-bold")
-              remove_link = link_to(sanitize("Remove #{tag.span(title, class: "govuk-visually-hidden")}"), confirm_destroy_admin_document_collection_group_document_collection_group_membership_path(@collection, @group, membership), class: "govuk-link gem-link--destructive govuk-!-margin-left-3")
-              links = remove_link
-            else
-              title = document_collection_group_member_title(membership)
-              url = document_collection_group_member_url(membership)
-              view_link = link_to(sanitize("View #{tag.span(title, class: "govuk-visually-hidden")}"), url, class: "govuk-link")
-              remove_link = link_to(sanitize("Remove #{tag.span(title, class: "govuk-visually-hidden")}"), confirm_destroy_admin_document_collection_group_document_collection_group_membership_path(@collection, @group, membership), class: "govuk-link gem-link--destructive govuk-!-margin-left-3")
-              links = view_link + remove_link
-            end
-
-            [{ text: title }, { text: links } ]
+            [
+              { text: document_collection_group_member_title(membership) },
+              { text: document_collection_group_member_links(@collection, @group, membership) },
+            ]
           end,
         } %>
       </div>

--- a/app/views/admin/document_collection_group_memberships/reorder.html.erb
+++ b/app/views/admin/document_collection_group_memberships/reorder.html.erb
@@ -11,10 +11,9 @@
       } %>
       <%= render "govuk_publishing_components/components/reorderable_list", {
         items: @group.memberships.map do |membership|
-          title = document_collection_group_member_unavailable?(membership) ? tag.span("Unavailable Document", class: "govuk-!-font-weight-bold") : document_collection_group_member_title(membership)
           {
             id: membership.id,
-            title: title,
+            title: document_collection_group_member_title(membership),
           }
         end,
       } %>

--- a/test/functional/admin/document_collection_group_memberships_controller_test.rb
+++ b/test/functional/admin/document_collection_group_memberships_controller_test.rb
@@ -143,7 +143,7 @@ class Admin::DocumentCollectionGroupMembershipsControllerTest < ActionController
     assert_select ".govuk-table__row", { count: 0, text: "View Unavailable Document" }
     assert_select ".govuk-table__row", text: /Remove Unavailable Document/
     assert_select ".govuk-table__row", a: whitehall_confirm_destroy_path
-    assert_select ".govuk-notification-banner__heading", text: "Remove 1 unavailable document(s) within the group."
+    assert_select ".govuk-notification-banner__heading", text: "Remove 1 unavailable document within the group."
   end
 
   view_test "GET #reorder should render 'unavailable documents'" do

--- a/test/unit/app/helpers/admin/document_collection_group_memberships_helper_test.rb
+++ b/test/unit/app/helpers/admin/document_collection_group_memberships_helper_test.rb
@@ -2,83 +2,92 @@ require "test_helper"
 
 class Admin::DocumentCollectionGroupMembershipsHelperTest < ActionView::TestCase
   setup do
-    @document_collection_group = build(:document_collection, :with_group).groups.first
+    @collection = build(:document_collection, :with_group)
+    @group = @collection.groups.first
   end
 
   test "#document_collection_group_member_title should return title if membership is a non_whitehall_link" do
-    non_whitehall_link = DocumentCollectionNonWhitehallLink.new(
+    non_whitehall_link = build(
+      :document_collection_non_whitehall_link,
       base_path: "GOVUK PATH",
       title: "GOVUK TITLE",
     )
-    membership = @document_collection_group.memberships.build(non_whitehall_link:)
+    membership = @group.memberships.build(non_whitehall_link:)
     assert_equal "GOVUK TITLE", document_collection_group_member_title(membership)
   end
 
   test "#document_collection_group_member_title should return title if membership is a document" do
     edition = build(:edition, title: "DOC TITLE")
     document = build(:document, slug: "DOC PATH", latest_edition: edition)
-    membership = @document_collection_group.memberships.build(document:)
+    membership = @group.memberships.build(document:)
     assert_equal "DOC TITLE", document_collection_group_member_title(membership)
   end
 
-  test "#document_collection_group_member_url should return full url if membership is a non_whitehall_link" do
-    non_whitehall_link = DocumentCollectionNonWhitehallLink.new(
+  test "#document_collection_group_member_title should return 'unavailable document' if membership is an unavailable document" do
+    document = build(:document, slug: "DOC PATH", latest_edition: nil)
+    membership = @group.memberships.build(document:)
+    assert_match Admin::DocumentCollectionGroupMembershipsHelper::UNAVAILABLE_DOCUMENT_TITLE, document_collection_group_member_title(membership)
+  end
+
+  test "#document_collection_group_member_links should contain correct view and remove url for a non_whitehall_link" do
+    non_whitehall_link = build(
+      :document_collection_non_whitehall_link,
       base_path: "/GOVUK-PATH",
       title: "GOVUK TITLE",
     )
-    membership = @document_collection_group.memberships.build(non_whitehall_link:)
-    assert_equal "https://www.test.gov.uk/GOVUK-PATH", document_collection_group_member_url(membership)
+    membership = @group.memberships.build(non_whitehall_link:)
+
+    @collection.save && @group.save && membership.save
+    links = document_collection_group_member_links(@collection, @group, membership)
+
+    assert_match "https://www.test.gov.uk/GOVUK-PATH", links
+    assert_match confirm_destroy_admin_document_collection_group_document_collection_group_membership_path(@collection, @group, membership), links
   end
 
-  test "#document_collection_group_member_url should return public url if membership is a document" do
+  test "#document_collection_group_member_links should contain correct view and remove url for a document" do
     edition = build(:edition, title: "DOC TITLE")
     document = build(:document, slug: "DOC-PATH", latest_edition: edition)
-    membership = @document_collection_group.memberships.build(document:)
-    assert_equal "https://www.test.gov.uk/government/generic-editions/DOC-PATH", document_collection_group_member_url(membership)
+    membership = @group.memberships.build(document:)
+
+    @collection.save && @group.save && membership.save
+    links = document_collection_group_member_links(@collection, @group, membership)
+
+    assert_match "https://www.test.gov.uk/government/generic-editions/DOC-PATH", links
+    assert_match confirm_destroy_admin_document_collection_group_document_collection_group_membership_path(@collection, @group, membership), links
   end
 
-  test "#document_collection_group_member_unavailable? should return true if membership is a document without a latest_edition" do
-    document = build(:document, slug: "DOC PATH", latest_edition: nil)
-    membership = @document_collection_group.memberships.build(document:)
-    assert_equal true, document_collection_group_member_unavailable?(membership)
-  end
+  test "#document_collection_group_member_links should contain only remove url for an unavailable document" do
+    document = build(:document, slug: "DOC-PATH", latest_edition: nil)
+    membership = @group.memberships.build(document:)
 
-  test "#document_collection_group_member_unavailable? should return false if membership is a document with a latest_edition" do
-    edition = build(:edition, title: "DOC TITLE")
-    document = build(:document, slug: "DOC PATH", latest_edition: edition)
-    membership = @document_collection_group.memberships.build(document:)
-    assert_equal false, document_collection_group_member_unavailable?(membership)
-  end
+    @collection.save && @group.save && membership.save
+    links = document_collection_group_member_links(@collection, @group, membership)
 
-  test "#document_collection_group_member_unavailable? should return false if membership is a non_whitehall_link" do
-    non_whitehall_link = DocumentCollectionNonWhitehallLink.new(
-      base_path: "GOVUK PATH",
-      title: "GOVUK TITLE",
-    )
-    membership = @document_collection_group.memberships.build(non_whitehall_link:)
-    assert_equal false, document_collection_group_member_unavailable?(membership)
+    assert_no_match "View", links
+    assert_match confirm_destroy_admin_document_collection_group_document_collection_group_membership_path(@collection, @group, membership), links
   end
 
   test "#unavailable_document_count should return the number of documents without editions" do
     document = build(:document, slug: "DOC PATH", latest_edition: nil)
-    @document_collection_group.memberships.build(document:)
-    @document_collection_group.memberships.build(document:)
-    assert_equal 2, unavailable_document_count(@document_collection_group.memberships)
+    @group.memberships.build(document:)
+    @group.memberships.build(document:)
+    assert_equal 2, unavailable_document_count(@group.memberships)
   end
 
   test "#unavailable_document_count should return 0 if there are documents with editions" do
     edition = build(:edition, title: "DOC TITLE")
     document = build(:document, slug: "DOC PATH", latest_edition: edition)
-    @document_collection_group.memberships.build(document:)
-    assert_equal 0, unavailable_document_count(@document_collection_group.memberships)
+    @group.memberships.build(document:)
+    assert_equal 0, unavailable_document_count(@group.memberships)
   end
 
   test "#unavailable_document_count should not count non_whitehall_links" do
-    non_whitehall_link = DocumentCollectionNonWhitehallLink.new(
+    non_whitehall_link = build(
+      :document_collection_non_whitehall_link,
       base_path: "GOVUK PATH",
       title: "GOVUK TITLE",
     )
-    @document_collection_group.memberships.build(non_whitehall_link:)
-    assert_equal 0, unavailable_document_count(@document_collection_group.memberships)
+    @group.memberships.build(non_whitehall_link:)
+    assert_equal 0, unavailable_document_count(@group.memberships)
   end
 end


### PR DESCRIPTION
The fix was pushed out to production so a lot of the refactorings and cleanups had to be pushed to another PR. This is to address some comments that was made on the previous PR, and general refactorings.
- Created new partial for warning banner.
- Moved logic for generating document collection group membership title and links into the helper
- The helper is now responsible for deciding on title and links, smart enough to make the decision based on the membership being whitehall or non-whitehall, with edition or no edition etc.

https://github.com/alphagov/whitehall/pull/8484
https://trello.com/c/QHOvEjag/565-bug-unpublishing-deleting-a-document-after-its-been-added-to-a-document-collection-group-creates-an-error

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
