### PR TITLE
Update New Document Page to show document type option based on user permission & organisation.

### DIFF
--- a/app/controllers/admin/new_document_controller.rb
+++ b/app/controllers/admin/new_document_controller.rb
@@ -6,22 +6,9 @@ class Admin::NewDocumentController < Admin::BaseController
   def index; end
 
   def new_document_options_redirect
-    redirect_options = {
-      "call-for-evidence": new_admin_call_for_evidence_path,
-      "case-study": new_admin_case_study_path,
-      "consultation": new_admin_consultation_path,
-      "detailed-guide": new_admin_detailed_guide_path,
-      "document-collection": new_admin_document_collection_path,
-      "fatality-notice": new_admin_fatality_notice_path,
-      "news-article": new_admin_news_article_path,
-      "publication": new_admin_publication_path,
-      "speech": new_admin_speech_path,
-      "statistical-data-set": new_admin_statistical_data_set_path,
-    }
-
     if params[:new_document_options].present?
-      selected_option = params.require(:new_document_options).to_sym
-      redirect_to redirect_options[selected_option]
+      new_document_type = params.require(:new_document_options).to_sym
+      redirect_to redirect_path(new_document_type)
     else
       redirect_to admin_new_document_path, alert: "Please select a new document option"
     end
@@ -41,5 +28,21 @@ private
     else
       "admin"
     end
+  end
+
+  def redirect_path(new_document_type)
+    redirect_options = {
+      call_for_evidence: new_admin_call_for_evidence_path,
+      case_study: new_admin_case_study_path,
+      consultation: new_admin_consultation_path,
+      detailed_guide: new_admin_detailed_guide_path,
+      document_collection: new_admin_document_collection_path,
+      fatality_notice: new_admin_fatality_notice_path,
+      news_article: new_admin_news_article_path,
+      publication: new_admin_publication_path,
+      speech: new_admin_speech_path,
+      statistical_data_set: new_admin_statistical_data_set_path,
+    }
+    redirect_options[new_document_type]
   end
 end

--- a/app/helpers/admin/new_document_helper.rb
+++ b/app/helpers/admin/new_document_helper.rb
@@ -1,0 +1,47 @@
+module Admin::NewDocumentHelper
+  NEW_DOCUMENT_LIST = [
+    Consultation,
+    Publication,
+    NewsArticle,
+    Speech,
+    DetailedGuide,
+    DocumentCollection,
+    FatalityNotice,
+    CaseStudy,
+    StatisticalDataSet,
+    CallForEvidence,
+  ].freeze
+
+  def new_document_type_list
+    NEW_DOCUMENT_LIST
+      .select { |edition_type| can?(:create, edition_type) }
+      .map do |edition_type|
+      title_value = edition_type.name.underscore
+      title_label = title_value.humanize
+      {
+        value: title_value,
+        text: title_label,
+        bold: true,
+        hint_text: hint_text(title_value.to_sym),
+      }
+    end
+  end
+
+private
+
+  def hint_text(new_document_type)
+    hint_text = {
+      call_for_evidence: "Use this to request people's views when it is not a consultation.",
+      case_study: "Use this to share real examples that help users understand a process or an important aspect of government policy covered on GOV.UK.",
+      consultation: "Use this for documents requiring a collective agreement across government, and requests for people's view on a question with an outcome.",
+      detailed_guide: "Use this to tell users the steps they need to take to complete a clearly defined task. They are usually aimed at specialist or professional audiences.",
+      document_collection: "Use this to group related documents on a single page for a specific audience or around a specific theme.",
+      fatality_notice: "Use this to provide official confirmation of the death of a member of the armed forces while on deployment. Ministry of Defence only.",
+      news_article: "Use this for news story, press release, government response, and world news story.",
+      publication: "Use this for standalone government documents, white papers, strategy documents, and reports.",
+      speech: "Use this for speeches by ministers or other named spokespeople, and ministerial statements to Parliament.",
+      statistical_data_set: "Use this for data that you publish monthly or more often without analysis.",
+    }
+    hint_text[new_document_type]
+  end
+end

--- a/app/views/admin/new_document/index.html.erb
+++ b/app/views/admin/new_document/index.html.erb
@@ -1,71 +1,5 @@
 <% content_for :page_title, "New document" %>
 
-<%
-  new_document_radio_items = [
-    {
-      value: "call-for-evidence",
-      text: "Call for evidence",
-      bold: true,
-      hint_text: "Use this to request people's views when it is not a consultation.",
-    },
-    {
-      value: "case-study",
-      text: "Case study",
-      bold: true,
-      hint_text: "Use this to share real examples that help users understand a process or an important" +
-        " aspect of government policy covered on GOV.UK.",
-    },
-    {
-      value: "consultation",
-      text: "Consultation",
-      bold: true,
-      hint_text: "Use this for documents requiring a collective agreement across government, and requests for people's view on a question with an outcome.",
-    },
-    {
-      value: "detailed-guide",
-      text: "Detailed guide",
-      bold: true,
-      hint_text: "Use this to tell users the steps they need to take to complete a clearly defined task. They are usually aimed at specialist or professional audiences.",
-    },
-    {
-      value: "document-collection",
-      text: "Document collection",
-      bold: true,
-      hint_text: "Use this to group related documents on a single page for a specific audience or around a specific theme.",
-    },
-    {
-      value: "fatality-notice",
-      text: "Fatality notice",
-      bold: true,
-      hint_text: "Use this to provide official confirmation of the death of a member of the armed forces while on deployment. Ministry of Defence only.",
-    },
-    {
-      value: "news-article",
-      text: "News article",
-      bold: true,
-      hint_text: "Use this for news story, press release, government response, and world news story.",
-    },
-    {
-      value: "publication",
-      text: "Publication",
-      bold: true,
-      hint_text: "Use this for standalone government documents, white papers, strategy documents, and reports.",
-    },
-    {
-      value: "speech",
-      text: "Speech",
-      bold: true,
-      hint_text: "Use this for speeches by ministers or other named spokespeople, and ministerial statements to Parliament.",
-    },
-    {
-      value: "statistical-data-set",
-      text: "Statistical data set",
-      bold: true,
-      hint_text: "Use this for data that you publish monthly or more often without analysis.",
-    },
-  ]
-%>
-
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with url: admin_new_document_options_path do %>
@@ -74,7 +8,7 @@
         heading_level: 1,
         name: "new_document_options",
         id: "new_document_options",
-        items: new_document_radio_items,
+        items: new_document_type_list,
       } %>
       <%= render "govuk_publishing_components/components/inset_text", {
         text: sanitize("Check the #{link_to("content types guidance", admin_whats_new_path, {class: "govuk-link"})}" +

--- a/test/functional/admin/more_controller_test.rb
+++ b/test/functional/admin/more_controller_test.rb
@@ -13,4 +13,37 @@ class Admin::MoreControllerTest < ActionController::TestCase
     assert_select ".govuk-list"
     assert_select "a.govuk-link", text: "Cabinet ministers order"
   end
+
+  view_test "GET #index renders Fields of Operation and Sitewide settings list option when the user has GDS Editor permission and organisation is GDS" do
+    organisation = create(:organisation, name: "government-digital-service")
+    login_as_preview_design_system_user(:gds_editor, organisation)
+
+    get :index
+
+    assert_select ".govuk-list"
+    assert_select "a.govuk-link", text: "Fields of operation"
+    assert_select "a.govuk-link", text: "Sitewide settings"
+  end
+
+  view_test "GET #index renders Fields of Operation list option and not show Sitewide settings when the user's organisation is Ministry of Defence" do
+    organisation = create(:organisation, name: "ministry-of-defence", handles_fatalities: true)
+    login_as_preview_design_system_user(:writer, organisation)
+
+    get :index
+
+    assert_select ".govuk-list"
+    assert_select "a.govuk-link", text: "Fields of operation"
+    refute_select "a.govuk-link", text: "Sitewide settings"
+  end
+
+  view_test "GET #index does not renders Fields of Operation and Sitewide settings option when the user's organisation is not GDS nor Ministry of Defence." do
+    organisation = create(:organisation, name: "cabinet-minister")
+    login_as_preview_design_system_user(:writer, organisation)
+
+    get :index
+
+    assert_select ".govuk-list"
+    refute_select "a.govuk-link", text: "Fields of operation"
+    refute_select "a.govuk-link", text: "Sitewide settings"
+  end
 end

--- a/test/functional/admin/new_document_controller_test.rb
+++ b/test/functional/admin/new_document_controller_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class Admin::NewDocumentControllerTest < ActionController::TestCase
   setup do
-    login_as_preview_design_system_user :writer
+    login_as_preview_design_system_user :gds_editor
   end
 
   view_test "GET #index renders the 'New Document' page with the header, all relevant radio selection options and inset text" do
@@ -14,6 +14,42 @@ class Admin::NewDocumentControllerTest < ActionController::TestCase
       assert_select_radio_button(value)
     end
     assert_select ".govuk-inset-text", text: "Check the content types guidance if you need more help in choosing a content type."
+  end
+
+  view_test "GET #index renders Fatality Notice radio button when the user has GDS Editor permission and organisation is GDS" do
+    gds_organisation = create(:organisation, name: "government-digital-service")
+    login_as_preview_design_system_user(:gds_editor, gds_organisation)
+
+    get :index
+
+    assert_select ".govuk-radios__item input[type=radio][name=new_document_options][value=fatality_notice]", count: 1
+  end
+
+  view_test "GET #index does not render Fatality Notice radio button when the user does not have GDS Editor permission and their organisation is GDS" do
+    gds_organisation = create(:organisation, name: "government-digital-service")
+    login_as_preview_design_system_user(:writer, gds_organisation)
+
+    get :index
+
+    refute_select ".govuk-radios__item input[type=radio][name=new_document_options][value=fatality_notice]"
+  end
+
+  view_test "GET #index does not render Fatality Notice radio button when the user does not have GDS Editor permission and their organisation is not GDS" do
+    other_organisation = create(:organisation, name: "cabinet-minister")
+    login_as_preview_design_system_user(:writer, other_organisation)
+
+    get :index
+
+    refute_select ".govuk-radios__item input[type=radio][name=new_document_options][value=fatality_notice]"
+  end
+  view_test "GET #index renders Fatality Notice radio button when the user's organisation is Ministry of Defence" do
+    mod_organisation = create(:organisation, name: "ministry-of-defence", handles_fatalities: true)
+
+    login_as_preview_design_system_user(:writer, mod_organisation)
+
+    get :index
+
+    assert_select ".govuk-radios__item input[type=radio][name=new_document_options][value=fatality_notice]", count: 1
   end
 
   test "access to the New document index page is forbidden for users without design system permissions" do
@@ -48,7 +84,7 @@ class Admin::NewDocumentControllerTest < ActionController::TestCase
 private
 
   def radio_button_values
-    %w[call-for-evidence case-study consultation detailed-guide document-collection fatality-notice news-article publication speech statistical-data-set]
+    %w[call_for_evidence case_study consultation detailed_guide document_collection fatality_notice news_article publication speech statistical_data_set]
   end
 
   def assert_select_radio_button(value)
@@ -57,16 +93,16 @@ private
 
   def redirect_options
     {
-      "call-for-evidence": new_admin_call_for_evidence_path,
-      "case-study": new_admin_case_study_path,
+      "call_for_evidence": new_admin_call_for_evidence_path,
+      "case_study": new_admin_case_study_path,
       "consultation": new_admin_consultation_path,
-      "detailed-guide": new_admin_detailed_guide_path,
-      "document-collection": new_admin_document_collection_path,
-      "fatality-notice": new_admin_fatality_notice_path,
-      "news-article": new_admin_news_article_path,
+      "detailed_guide": new_admin_detailed_guide_path,
+      "document_collection": new_admin_document_collection_path,
+      "fatality_notice": new_admin_fatality_notice_path,
+      "news_article": new_admin_news_article_path,
       "publication": new_admin_publication_path,
       "speech": new_admin_speech_path,
-      "statistical-data-set": new_admin_statistical_data_set_path,
+      "statistical_data_set": new_admin_statistical_data_set_path,
     }
   end
 end


### PR DESCRIPTION
This PR updates the New Document page for header navigation to show document type options based on user permission and organisation.
**It does the following:**

- Updates New Document Page controller and View to show and hide 'Fatality Notice' option based on User permission and Organisation.
- Adds tests to NewDocumentControllerTest to cover the scenarios.
- Adds tests to MoreControllerTest to cover the scenario for user permission and organisation.

**Screen shots:**
**Case 1:** User permission is GDS editor and Organisation is GDS: Fatality Notice is shown

![image](https://github.com/alphagov/whitehall/assets/131259138/f764e798-20f2-4ea7-a247-0a2d5a99c220)

**Case 2:** User Organisation in Ministry Of Defence irrespective of permission
![image](https://github.com/alphagov/whitehall/assets/131259138/0a3937a1-8737-404f-9d80-11f315d4663f)

**Case 3: When organisation is Cabinet Minister and no GDS Editor permission**

![image](https://github.com/alphagov/whitehall/assets/131259138/3314003c-7995-4d96-b7cc-bba0f2b30351)

**Trello:**
https://trello.com/c/eUrMNKbx/629-update-links-based-on-your-organization


