### PR TITLE
Make the Person field in the Role Appointments form default to empty

### DIFF
--- a/app/views/admin/role_appointments/_form.html.erb
+++ b/app/views/admin/role_appointments/_form.html.erb
@@ -3,16 +3,18 @@
   label: "Person (required)",
   heading_size: "l",
   name: "role_appointment[person_id]",
-  options:
-    disambiguated_people_names.map { |person_name, person_id|
+  options: (
+    [{ text: "", value: "", selected: false }] +
+    disambiguated_people_names.map do |person_name, person_id|
       {
         text: person_name,
         value: person_id,
         selected: form.object.person_id == person_id,
       }
-    }.select do |option|
-      form.object.new_record? || option[:selected]
-    end,
+    end
+  ).select do |option|
+    form.object.new_record? || option[:selected]
+  end,
   error_message: errors_for_input(form.object.errors, :person_id),
 } %>
 


### PR DESCRIPTION
This field currently defaults to David Cameron, which could potentially lead to mistakes if the user isn't careful when creating new role appointments.

This PR changes the field to default to empty, as requested in [this Zendesk ticket](https://govuk.zendesk.com/agent/tickets/5553865) and [this Slack thread](https://gds.slack.com/archives/CADKZN519/p1699955183392289).

This has been tested in integration:

<details><summary>Screenshot</summary>
<img width="796" alt="Screenshot 2023-11-14 at 15 53 42" src="https://github.com/alphagov/whitehall/assets/657807/d2a5ec88-96ab-4982-a3cd-f91ab6d30678">
</details>

If the user leaves this field blank, they receive a validation error as expected:

<details><summary>Screenshot</summary>
<img width="779" alt="Screenshot 2023-11-14 at 15 56 46" src="https://github.com/alphagov/whitehall/assets/657807/b5588519-7987-419e-91db-235c89182057">
</details>

When editing an existing role appointment, the user is not able to select a different option, and the empty default option is omitted, as expected:

<details><summary>Screenshot</summary>
<img width="778" alt="Screenshot 2023-11-14 at 15 57 23" src="https://github.com/alphagov/whitehall/assets/657807/eb4826c7-392b-42df-b471-35cd2d7396ab">
</details>

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
