### PR TITLE
Improve the implementation of the default "Person" option when creating new role appointments

### DIFF
--- a/app/views/admin/role_appointments/_form.html.erb
+++ b/app/views/admin/role_appointments/_form.html.erb
@@ -13,6 +13,7 @@
     }.select do |option|
       form.object.new_record? || option[:selected]
     end,
+  include_blank: form.object.new_record?,
   error_message: errors_for_input(form.object.errors, :person_id),
 } %>
 

--- a/app/views/admin/role_appointments/_form.html.erb
+++ b/app/views/admin/role_appointments/_form.html.erb
@@ -3,18 +3,16 @@
   label: "Person (required)",
   heading_size: "l",
   name: "role_appointment[person_id]",
-  options: (
-    [{ text: "", value: "", selected: false }] +
-    disambiguated_people_names.map do |person_name, person_id|
+  options:
+    disambiguated_people_names.map { |person_name, person_id|
       {
         text: person_name,
         value: person_id,
         selected: form.object.person_id == person_id,
       }
-    end
-  ).select do |option|
-    form.object.new_record? || option[:selected]
-  end,
+    }.select do |option|
+      form.object.new_record? || option[:selected]
+    end,
   error_message: errors_for_input(form.object.errors, :person_id),
 } %>
 

--- a/test/functional/admin/role_appointments_controller_test.rb
+++ b/test/functional/admin/role_appointments_controller_test.rb
@@ -13,6 +13,15 @@ class Admin::RoleAppointmentsControllerTest < ActionController::TestCase
     assert_select "form[action=?]", admin_role_role_appointments_path(role)
   end
 
+  view_test "new should contain a blank option for the person field" do
+    role = create(:role)
+    _person = create(:person)
+    get :new, params: { role_id: role.id }
+    assert_select "select#role_appointment_person_id" do
+      assert_select "option[value='']", text: ""
+    end
+  end
+
   view_test "new should display a form for creating an appointment that will curtail the previous appointment if make_current is set" do
     role = create(:role)
     get :new, params: { role_id: role.id, make_current: true }


### PR DESCRIPTION
This is a rework of #8505, using the `include_blank` option provided by the `SelectWithSearch` component instead of manually adding a blank option.

The rationale behind `include_blank: form.object.new_record?` is that we should only include a blank option on newly created role appointments, because the user cannot change the person field when editing existing ones (and the presence of a blank option would imply that they can remove the person, which they can't).

Also adds a test to make sure this behaviour is working (we don't need to add a corresponding test for the edit action because it's already covered by an existing test case).

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
