### PR TITLE
Remove release flag for offsite link path redirect anchor

### DIFF
--- a/app/controllers/admin/offsite_links_controller.rb
+++ b/app/controllers/admin/offsite_links_controller.rb
@@ -58,9 +58,9 @@ private
 
   def offsite_links_path
     if @parent.is_a? TopicalEvent
-      polymorphic_path([:admin, @parent, :topical_event_featurings], anchor: preview_design_system?(next_release: false) ? "non_govuk_government_links_tab" : nil)
+      polymorphic_path([:admin, @parent, :topical_event_featurings], anchor: "non_govuk_government_links_tab")
     else
-      polymorphic_path([:features, :admin, @parent], anchor: preview_design_system?(next_release: false) ? "non_govuk_government_links_tab" : nil)
+      polymorphic_path([:features, :admin, @parent], anchor: "non_govuk_government_links_tab")
     end
   end
 


### PR DESCRIPTION
Currently users after successful creation of Offsite links, will be redirected back to the features page. With the removal of this flag, they will be redirected to the correct tab on the features page.

https://trello.com/c/xNKBRV85/607-investigate-and-remove-usages-of-preview-design-toggles

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
