### PR TITLE
Ensure that SVGs cannot be selected as a lead image for editions that can have custom lead images

### DIFF
--- a/app/components/admin/edition_images/image_component.html.erb
+++ b/app/components/admin/edition_images/image_component.html.erb
@@ -20,7 +20,7 @@
     <%= link_to("Edit details", edit_admin_edition_image_path(edition, image), class: "govuk-link govuk-!-margin-top-2 app-view-edition-resource__actions__link") %>
     <%= link_to("Delete image", confirm_destroy_admin_edition_image_path(edition, image), class: "govuk-link gem-link--destructive govuk-!-margin-top-2 app-view-edition-resource__actions__link") %>
 
-    <% if edition.can_have_custom_lead_image? %>
+    <% if can_be_custom_lead_image? %>
       <%= form_with url: admin_edition_lead_image_path(edition, image), method: :patch do |form| %>
         <%= render "govuk_publishing_components/components/button", {
           text: "Select as lead image",

--- a/app/components/admin/edition_images/image_component.rb
+++ b/app/components/admin/edition_images/image_component.rb
@@ -38,4 +38,8 @@ private
   def find_image_index
     edition.images.find_index(image)
   end
+
+  def can_be_custom_lead_image?
+    edition.can_have_custom_lead_image? && !image.svg?
+  end
 end

--- a/app/controllers/admin/edition_images_controller.rb
+++ b/app/controllers/admin/edition_images_controller.rb
@@ -69,7 +69,7 @@ private
   end
 
   def find_edition
-    edition = Edition.find(params[:edition_id])
+    edition = Edition.includes(images: :image_data).find(params[:edition_id])
     @edition = LocalisedModel.new(edition, edition.primary_locale)
   end
 

--- a/app/models/edition/custom_lead_image.rb
+++ b/app/models/edition/custom_lead_image.rb
@@ -11,9 +11,9 @@ module Edition::CustomLeadImage
       return
     end
 
-    return if lead_image.present? || images.blank?
+    return if lead_image.present? || non_svg_images.blank?
 
-    edition_lead_image = build_edition_lead_image(image: oldest_image)
+    edition_lead_image = build_edition_lead_image(image: oldest_non_svg_image)
     edition_lead_image.save!
   end
 
@@ -23,8 +23,12 @@ module Edition::CustomLeadImage
 
 private
 
-  def oldest_image
-    images.order(:created_at, :id).first
+  def non_svg_images
+    @non_svg_images ||= images.includes(:image_data).reject(&:svg?)
+  end
+
+  def oldest_non_svg_image
+    non_svg_images.min_by { |image| [image.created_at, image.id] }
   end
 
   def remove_lead_image

--- a/app/models/edition/custom_lead_image.rb
+++ b/app/models/edition/custom_lead_image.rb
@@ -11,10 +11,14 @@ module Edition::CustomLeadImage
       return
     end
 
-    return if lead_image.present? || non_svg_images.blank?
+    return if lead_image.present? || images.blank?
 
-    edition_lead_image = build_edition_lead_image(image: oldest_non_svg_image)
-    edition_lead_image.save!
+    image = oldest_non_svg_image
+
+    if image
+      edition_lead_image = build_edition_lead_image(image:)
+      edition_lead_image.save!
+    end
   end
 
   def non_lead_images
@@ -23,12 +27,8 @@ module Edition::CustomLeadImage
 
 private
 
-  def non_svg_images
-    @non_svg_images ||= images.includes(:image_data).reject(&:svg?)
-  end
-
   def oldest_non_svg_image
-    non_svg_images.min_by { |image| [image.created_at, image.id] }
+    images.includes(:image_data).detect { |image| !image.svg? }
   end
 
   def remove_lead_image

--- a/app/models/edition_lead_image.rb
+++ b/app/models/edition_lead_image.rb
@@ -3,4 +3,13 @@ class EditionLeadImage < ApplicationRecord
   belongs_to :image
 
   accepts_nested_attributes_for :edition
+
+  validates :edition, :image, presence: true
+  validate :image_is_not_svg, if: -> { image.present? }
+
+private
+
+  def image_is_not_svg
+    errors.add(:base, "Lead image can not be an SVG.") if image.svg?
+  end
 end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -14,8 +14,14 @@ class Image < ApplicationRecord
 
   default_scope -> { order(:id) }
 
+  SVG_CONTENT_TYPE = "image/svg+xml".freeze
+
   def url(*args)
     image_data.file_url(*args)
+  end
+
+  def svg?
+    content_type == SVG_CONTENT_TYPE
   end
 
 private

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -10,18 +10,12 @@ class Image < ApplicationRecord
 
   accepts_nested_attributes_for :image_data
 
-  delegate :filename, :content_type, :width, :height, :bitmap?, to: :image_data
+  delegate :filename, :content_type, :width, :height, :bitmap?, :svg?, to: :image_data
 
   default_scope -> { order(:id) }
 
-  SVG_CONTENT_TYPE = "image/svg+xml".freeze
-
   def url(*args)
     image_data.file_url(*args)
-  end
-
-  def svg?
-    content_type == SVG_CONTENT_TYPE
   end
 
 private

--- a/app/models/image_data.rb
+++ b/app/models/image_data.rb
@@ -5,6 +5,7 @@ class ImageData < ApplicationRecord
 
   VALID_WIDTH = 960
   VALID_HEIGHT = 640
+  SVG_CONTENT_TYPE = "image/svg+xml".freeze
 
   has_many :images
   has_many :assets,
@@ -40,6 +41,10 @@ class ImageData < ApplicationRecord
     required_variants = bitmap? ? ImageUploader.versions.keys.push(:original) : [Asset.variants[:original].to_sym]
 
     (required_variants - asset_variants).empty?
+  end
+
+  def svg?
+    content_type == SVG_CONTENT_TYPE
   end
 
 private

--- a/db/data_migration/20231115101909_remove_svg_lead_images.rb
+++ b/db/data_migration/20231115101909_remove_svg_lead_images.rb
@@ -1,0 +1,7 @@
+edition_lead_images = EditionLeadImage.joins(image: :image_data).where("carrierwave_image LIKE '%.svg'")
+
+edition_lead_images.each do |edition_lead_image|
+  edition = edition_lead_image
+  edition_lead_image.destroy!
+  edition.update_lead_image
+end

--- a/test/components/admin/edition_images/image_component_test.rb
+++ b/test/components/admin/edition_images/image_component_test.rb
@@ -40,6 +40,15 @@ class Admin::EditionImages::ImageComponentTest < ViewComponent::TestCase
     end
   end
 
+  test "does not render a button to update the image to the lead image if the image is an SVG for case studies" do
+    svg_image_data = build(:image_data, file: File.open(Rails.root.join("test/fixtures/images/test-svg.svg")))
+    image = build_stubbed(:image, caption: "caption", alt_text: "alt text", image_data: svg_image_data)
+    edition = build_stubbed(:draft_case_study, images: [image])
+    render_inline(Admin::EditionImages::ImageComponent.new(edition:, image:, last_image: false))
+
+    assert_selector ".govuk-button", text: "Select as lead image", count: 0
+  end
+
   test "image filename markdown displayed" do
     jpeg = upload_fixture("images/960x640_jpeg.jpg")
     gif = upload_fixture("images/960x640_gif.gif")

--- a/test/unit/app/models/edition/custom_lead_image_test.rb
+++ b/test/unit/app/models/edition/custom_lead_image_test.rb
@@ -35,14 +35,15 @@ class Edition::CustomLeadImageTest < ActiveSupport::TestCase
     assert body_text_valid("foo\[Image: non_lead_image.jpg]\nbar")
   end
 
-  test "#update_lead_image updates the lead_image association to the oldest image" do
-    image1 = build(:image)
-    image2 = build(:image)
-    edition = create(:news_article, images: [image1, image2])
+  test "#update_lead_image updates the lead_image association to the oldest non-svg image" do
+    svg_image_data = build(:image_data, file: File.open(Rails.root.join("test/fixtures/images/test-svg.svg")))
+    jpeg_image = build(:image, created_at: 1.minute.ago)
+    sgv_image = build(:image, image_data: svg_image_data, created_at: 2.minutes.ago)
+    edition = create(:news_article, images: [sgv_image, jpeg_image])
 
     edition.update_lead_image
 
-    assert_equal image1, edition.reload.lead_image
+    assert_equal jpeg_image, edition.reload.lead_image
   end
 
   test "#update_lead_image deletes the associated edition_lead_image if image_display_option is 'no_image'" do

--- a/test/unit/app/models/edition_lead_image_test.rb
+++ b/test/unit/app/models/edition_lead_image_test.rb
@@ -14,7 +14,7 @@ class EditionLeadImageTest < ActiveSupport::TestCase
   test "is invalid when the image is an svg" do
     svg_image_data = build(:image_data, file: File.open(Rails.root.join("test/fixtures/images/test-svg.svg")))
     image = build(:image, image_data: svg_image_data)
-    edition_lead_image = build(:edition_lead_image, image: image)
+    edition_lead_image = build(:edition_lead_image, image:)
 
     assert_not edition_lead_image.valid?
     assert_equal "Lead image can not be an SVG.", edition_lead_image.errors.first.full_message

--- a/test/unit/app/models/edition_lead_image_test.rb
+++ b/test/unit/app/models/edition_lead_image_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+
+class EditionLeadImageTest < ActiveSupport::TestCase
+  test "is invalid without an edition" do
+    edition_lead_image = build(:edition_lead_image, edition: nil)
+    assert_not edition_lead_image.valid?
+  end
+
+  test "is invalid without an image" do
+    edition_lead_image = build(:edition_lead_image, image: nil)
+    assert_not edition_lead_image.valid?
+  end
+
+  test "is invalid when the image is an svg" do
+    svg_image_data = build(:image_data, file: File.open(Rails.root.join("test/fixtures/images/test-svg.svg")))
+    image = build(:image, image_data: svg_image_data)
+    edition_lead_image = build(:edition_lead_image, image: image)
+
+    assert_not edition_lead_image.valid?
+    assert_equal "Lead image can not be an SVG.", edition_lead_image.errors.first.full_message
+  end
+end

--- a/test/unit/app/models/image_data_test.rb
+++ b/test/unit/app/models/image_data_test.rb
@@ -104,6 +104,18 @@ class ImageDataTest < ActiveSupport::TestCase
     assert_not image_data.all_asset_variants_uploaded?
   end
 
+  test ".svg? returns true when the carrierwave image filename ends with .svg" do
+    image_data = build(:image_data, file: File.open(Rails.root.join("test/fixtures/images/test-svg.svg")))
+
+    assert image_data.svg?
+  end
+
+  test ".svg? returns true when the carrierwave image filename does not end with .svg" do
+    image_data = build(:image_data)
+
+    assert_not image_data.svg?
+  end
+
   def build_example(file_name)
     file = File.open(Rails.root.join("test/fixtures/images", file_name))
     build(:image_data, file:)

--- a/test/unit/app/models/image_test.rb
+++ b/test/unit/app/models/image_test.rb
@@ -53,4 +53,17 @@ class ImageTest < ActiveSupport::TestCase
     assert_equal 640, image.height
     assert image.bitmap?
   end
+
+  test ".svg? returns true when the carrierwave image filename ends with .svg" do
+    image_data = build(:image_data, file: File.open(Rails.root.join("test/fixtures/images/test-svg.svg")))
+    image = build(:image, image_data:)
+
+    assert image.svg?
+  end
+
+  test ".svg? returns true when the carrierwave image filename does not end with .svg" do
+    image = build(:image)
+
+    assert_not image.svg?
+  end
 end

--- a/test/unit/app/models/image_test.rb
+++ b/test/unit/app/models/image_test.rb
@@ -52,18 +52,6 @@ class ImageTest < ActiveSupport::TestCase
     assert_equal 960, image.width
     assert_equal 640, image.height
     assert image.bitmap?
-  end
-
-  test ".svg? returns true when the carrierwave image filename ends with .svg" do
-    image_data = build(:image_data, file: File.open(Rails.root.join("test/fixtures/images/test-svg.svg")))
-    image = build(:image, image_data:)
-
-    assert image.svg?
-  end
-
-  test ".svg? returns true when the carrierwave image filename does not end with .svg" do
-    image = build(:image)
-
     assert_not image.svg?
   end
 end


### PR DESCRIPTION
## Description

At the moment, an SVG is set to the lead image for news articles and case studies in the following contexts.

case studies:

- user selects a SVG as the lead image via the images index page

News articles 

- users first image they upload is a SVG
- user selects SVG as the lead image

I've added a data migration to clean up the 5 editions which have SVGs as lead editions. I'll run this once this PR is merged

## Screenshots of current behaviour 

### SVGs are set as lead image on creation for news articles 

<img width="746" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/896d09ee-cb6d-4bdf-9bfe-783416466971">

### SVGs can be selected as lead image from Images index page


<img width="956" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/5dc1b735-dcdb-4ed3-a581-000bb006c7db">

### SVGs blow up when they are selected as lead image

<img width="600" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/4e6f4da1-450b-4212-851c-111c6f9a2bd7">

## Screenshots of new behaviour

### No ability so select SVG as lead image

<img width="641" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/a7863d31-3d1f-43ed-b24d-f12aa9c1082e">

### Not set as lead image when current lead image is deleted

<img width="731" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/d60fb3f7-35c4-41e2-bda0-c28372376048">

### Not set as lead image when first image uploaded is SVG

<img width="738" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/8763caf9-7032-4124-b16a-4243bc66cac5">

## Trello card

https://trello.com/c/To2f26k4/2166-fix-svg-lead-image-behaviour


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
