### PR TITLE
Update what's new page to have lead images changes

### DIFF
--- a/config/locales/en/admin/whats_new.yml
+++ b/config/locales/en/admin/whats_new.yml
@@ -7,7 +7,7 @@ en:
       title: What’s new in Whitehall Publisher
       summary: |
         Summary of updates from the GOV.UK publishing teams on Whitehall Publisher, the roadmap, and getting involved
-      last_updated: Last updated 8 September 2023
+      last_updated: Last updated 7 November 2023
       introduction:
         heading: Our roadmap
         body_govspeak: |
@@ -30,6 +30,15 @@ en:
       recent_changes:
         heading: Recent changes
         updates:
+          - heading: Changes to adding lead images in Whitehall
+            area: Creating and updating documents
+            type: improvement
+            date: 7 November 2023
+            body_govspeak: |
+              We've made some changes to adding lead images in Whitehall:
+
+              - for Case Studies you can use your organisations default news image or any uploaded image as your lead image
+              - for News Articles you can choose any of the uploaded images as the lead image
           - heading: Unpublishing documents puts them into a new "Unpublished" state
             area: Creating and updating documents
             type: change

--- a/config/locales/en/admin/whats_new.yml
+++ b/config/locales/en/admin/whats_new.yml
@@ -1,9 +1,9 @@
 en:
   admin:
     feedback:
-      show_banner: false
-    whats_new:
       show_banner: true
+    whats_new:
+      show_banner: false
       title: What’s new in Whitehall Publisher
       summary: |
         Summary of updates from the GOV.UK publishing teams on Whitehall Publisher, the roadmap, and getting involved


### PR DESCRIPTION
## Description

We recently made some changes allowing users to select any uploaded image as the lead image for news articles &
the ability to select any uploaded image or the orgs default news image as the lead image for case studies.

This updates the what's new page to reflect these changes.

It also toggles off the banner as discussed at planning this morning.

## Screenshot

<img width="564" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/ad0b3d3e-f57b-471c-b697-48eddb9ad482">

## before 

<img width="588" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/7b3c363e-f6c8-4f8a-b809-29bb5769922c">

## after

<img width="547" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/d3b60bf8-3553-47bb-99b4-948035877e28">


## Trello card

https://trello.com/c/ARss9Wfv/2183-update-whats-new-banner-wording

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
