### PR TITLE
Remove release flag for feature documents pagination

### DIFF
--- a/app/controllers/admin/organisations_controller.rb
+++ b/app/controllers/admin/organisations_controller.rb
@@ -39,7 +39,7 @@ class Admin::OrganisationsController < Admin::BaseController
                           .merge(
                             state: "published",
                             organisation: filtering_organisation,
-                            per_page: preview_design_system?(next_release: false) ? Admin::EditionFilter::GOVUK_DESIGN_SYSTEM_PER_PAGE : nil,
+                            per_page: Admin::EditionFilter::GOVUK_DESIGN_SYSTEM_PER_PAGE,
                           )
 
     @filter = Admin::EditionFilter.new(Edition, current_user, filter_params)


### PR DESCRIPTION
Currently users see all of the documents on their featured documents search results paginated to the default amount of documents. Removing this flag will allow users to see the pagination at 15 documents per page.

https://trello.com/c/xNKBRV85/607-investigate-and-remove-usages-of-preview-design-toggles


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
