### PR TITLE
Remove release flag for speeches speaker parameters

### DIFF
--- a/app/controllers/admin/speeches_controller.rb
+++ b/app/controllers/admin/speeches_controller.rb
@@ -7,16 +7,16 @@ private
 
   def clean_edition_parameters
     super
-    design_system = preview_design_system?(next_release: false)
-
-    if design_system && edition_params[:speaker_radios] == "yes"
-      edition_params[:person_override] = nil
-    elsif design_system && edition_params[:speaker_radios] == "no"
-      edition_params[:role_appointment_id] = nil
-    elsif params[:person_override_active] == "1" || edition_params[:person_override].present?
-      edition_params[:role_appointment_id] = nil
-    end
-
+    edition_params[:person_override] = nil if speaker_has_govuk_profile?
+    edition_params[:role_appointment_id] = nil if speaker_has_no_govuk_profile?
     edition_params.delete(:speaker_radios)
+  end
+
+  def speaker_has_govuk_profile?
+    edition_params[:speaker_radios] == "yes"
+  end
+
+  def speaker_has_no_govuk_profile?
+    edition_params[:speaker_radios] == "no"
   end
 end


### PR DESCRIPTION
Currently should users select speaker as non-govuk profile and then change their mind, because the field has already been filled out, it will override their govuk profile choice. 

By removing this toggle, the parameters will be wiped based on the users' choice of where the speaker will be. 

- parameter 'person_override_active' no longer exists so i've removed it. 
- The logic has been refactored a little bit for readability. 
- person_override presence check seems redundant as it will always be caught by the radio button values. If neither radio buttons are checked, then we shouldn't be wiping anything out as user has not made any choices. 
- If user selects speaker with govuk profile, the person override will be wiped, retaining role_appointment_id
- If user selects speaker with non-govuk profile, the role appointment id will be wiped instead.

https://trello.com/c/xNKBRV85/607-investigate-and-remove-usages-of-preview-design-toggles

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
