### PR TITLE
Remove release flag for world location news feature documents list

### DIFF
--- a/app/controllers/admin/world_location_news_controller.rb
+++ b/app/controllers/admin/world_location_news_controller.rb
@@ -28,7 +28,7 @@ class Admin::WorldLocationNewsController < Admin::BaseController
     filter_params = default_filter_params.merge(
       optional_filter_params,
       state: "published",
-      per_page: preview_design_system?(next_release: false) ? Admin::EditionFilter::GOVUK_DESIGN_SYSTEM_PER_PAGE : nil,
+      per_page: Admin::EditionFilter::GOVUK_DESIGN_SYSTEM_PER_PAGE,
     )
 
     @filter = Admin::EditionFilter.new(Edition, current_user, filter_params)


### PR DESCRIPTION
Currently users see all of the documents on their featured documents search results paginated to the default amount of documents. Removing this flag will allow users to see the pagination at 15 documents per page.

https://trello.com/c/xNKBRV85/607-investigate-and-remove-usages-of-preview-design-toggles

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
