### PR TITLE
Use asset-id for for consultation_response_form_data

### DIFF
--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -13,6 +13,7 @@ class Consultation < Publicationesque
   validates :external_url, presence: true, if: :external?
   validates :external_url, uri: true, allow_blank: true
   validate :validate_consultation_principles, unless: ->(consultation) { Edition::PRE_PUBLICATION_STATES.include? consultation.state }
+  validate :consultation_response_file_uploaded_to_asset_manager!, if: :consultation_response_file_in_asset_manager_check_required?
 
   has_one :outcome, class_name: "ConsultationOutcome", foreign_key: :edition_id, dependent: :destroy
   has_one :public_feedback, class_name: "ConsultationPublicFeedback", foreign_key: :edition_id, dependent: :destroy
@@ -190,5 +191,13 @@ private
     unless read_consultation_principles
       errors.add :read_consultation_principles, "must be ticked"
     end
+  end
+
+  def consultation_response_file_in_asset_manager_check_required?
+    has_consultation_participation? && consultation_participation.has_response_form? && published?
+  end
+
+  def consultation_response_file_uploaded_to_asset_manager!
+    errors.add(:consultation_response_form, "must have finished uploading") unless consultation_participation.consultation_response_form_uploaded_to_asset_manager?
   end
 end

--- a/app/models/consultation_participation.rb
+++ b/app/models/consultation_participation.rb
@@ -26,6 +26,10 @@ class ConsultationParticipation < ApplicationRecord
 
   after_destroy :destroy_form_if_required
 
+  def consultation_response_form_uploaded_to_asset_manager?
+    has_response_form? && consultation_response_form&.consultation_response_form_data&.all_asset_variants_uploaded?
+  end
+
 private
 
   def destroy_form_if_required

--- a/app/models/consultation_response_form_data.rb
+++ b/app/models/consultation_response_form_data.rb
@@ -6,9 +6,20 @@ class ConsultationResponseFormData < ApplicationRecord
            as: :assetable,
            inverse_of: :assetable
 
+  has_many :assets,
+           as: :assetable,
+           inverse_of: :assetable
+
   validates :file, presence: true
 
   def auth_bypass_ids
     [consultation_response_form.consultation_participation.consultation.auth_bypass_id]
+  end
+
+  def all_asset_variants_uploaded?
+    asset_variants = assets.map(&:variant).map(&:to_sym)
+    required_variants = [Asset.variants[:original].to_sym]
+
+    (required_variants - asset_variants).empty?
   end
 end

--- a/app/presenters/publishing_api/consultation_presenter.rb
+++ b/app/presenters/publishing_api/consultation_presenter.rb
@@ -316,7 +316,7 @@ module PublishingApi
       alias_method :participation_response_form, :consultation_response_form
 
       def attachment_url
-        return unless participation.has_response_form?
+        return unless participation.consultation_response_form_uploaded_to_asset_manager?
 
         participation_response_form.file.url
       end

--- a/app/views/admin/consultations/_form.html.erb
+++ b/app/views/admin/consultations/_form.html.erb
@@ -100,11 +100,15 @@
 
           <%= response_form.fields_for :consultation_response_form_data, consultation_response_form_data do |consultation_response_form_data_form| %>
             <%= consultation_response_form_data_form.hidden_field  :file_cache, value: consultation_response_form_data.file_cache %>
-
             <% if consultation_response_form.consultation_response_form_data.try(:persisted?) %>
               <div class="attachment">
-                <p class="govuk-body">Current data: <%= link_to File.basename(consultation_response_form_data.file.path), consultation_response_form_data.file.url, class: "govuk-link" %></p>
-
+                  <p class="govuk-body">Current data:
+                    <% if consultation_response_form_data.all_asset_variants_uploaded? %>
+                      <%= link_to File.basename(consultation_response_form_data.file.path), consultation_response_form_data.file.url, class: "govuk-link" %>
+                    <% else %>
+                      <%= File.basename(consultation_response_form_data.file.path) %> <span class="govuk-tag govuk-tag--green">Processing</span>
+                    <% end %>
+                  </p>
                 <%= render "govuk_publishing_components/components/radio", {
                   heading: "Actions:",
                   name: "edition[consultation_participation_attributes][consultation_response_form_attributes][attachment_action]",

--- a/app/workers/asset_manager_update_whitehall_asset_worker.rb
+++ b/app/workers/asset_manager_update_whitehall_asset_worker.rb
@@ -28,6 +28,6 @@ class AssetManagerUpdateWhitehallAssetWorker < WorkerBase
 private
 
   def should_use_non_legacy_endpoints?(asset_data)
-    asset_data.instance_of?(AttachmentData) || asset_data.instance_of?(ImageData)
+    asset_data.instance_of?(AttachmentData) || asset_data.instance_of?(ImageData) || asset_data.instance_of?(ConsultationResponseFormData)
   end
 end

--- a/lib/whitehall/asset_manager_storage.rb
+++ b/lib/whitehall/asset_manager_storage.rb
@@ -102,7 +102,7 @@ class Whitehall::AssetManagerStorage < CarrierWave::Storage::Abstract
   def self.use_non_legacy_behaviour?(model)
     return unless model
 
-    return true if model.instance_of?(AttachmentData) || model.instance_of?(ImageData) || model.instance_of?(Organisation) || model.instance_of?(FeaturedImageData) || model.instance_of?(TopicalEventFeaturingImageData) || model.instance_of?(PromotionalFeatureItem)
+    return true if model.instance_of?(AttachmentData) || model.instance_of?(ImageData) || model.instance_of?(Organisation) || model.instance_of?(FeaturedImageData) || model.instance_of?(TopicalEventFeaturingImageData) || model.instance_of?(PromotionalFeatureItem) || model.instance_of?(ConsultationResponseFormData)
 
     model.respond_to?("use_non_legacy_endpoints") && model.use_non_legacy_endpoints
   end

--- a/test/factories/consultation_response_form_data.rb
+++ b/test/factories/consultation_response_form_data.rb
@@ -1,5 +1,9 @@
 FactoryBot.define do
   factory :consultation_response_form_data do
     file { File.open(Rails.root.join("test/fixtures/two-pages.pdf")) }
+
+    after(:build) do |consultation_response_form_data|
+      consultation_response_form_data.assets << build(:asset, asset_manager_id: "asset_manager_id_original", variant: Asset.variants[:original], filename: "two-pages.pdf")
+    end
   end
 end

--- a/test/functional/admin/consultations_controller_test.rb
+++ b/test/functional/admin/consultations_controller_test.rb
@@ -131,6 +131,17 @@ class Admin::ConsultationsControllerTest < ActionController::TestCase
     end
   end
 
+  view_test "create should show 'Processing' tag if variant is missing" do
+    response_form = create(:consultation_response_form)
+    participation = create(:consultation_participation, consultation_response_form: response_form)
+    consultation = create(:consultation, consultation_participation: participation)
+    response_form.consultation_response_form_data.assets = []
+
+    get :edit, params: { id: consultation }
+
+    assert_select "span[class='govuk-tag govuk-tag--green']", text: "Processing"
+  end
+
   view_test "show renders the summary" do
     draft_consultation = create(:draft_consultation, summary: "a-simple-summary")
     stub_publishing_api_expanded_links_with_taxons(draft_consultation.content_id, [])

--- a/test/integration/asset_access_options_integration_test.rb
+++ b/test/integration/asset_access_options_integration_test.rb
@@ -238,14 +238,12 @@ class AssetAccessOptionsIntegrationTest < ActionDispatch::IntegrationTest
         click_button "Save"
 
         # Note that there is no access limiting applied to non attachments. This is existing behaviour that probably needs changing.
-        Services.asset_manager.expects(:create_whitehall_asset).with(
-          has_entries(
-            legacy_url_path: regexp_matches(/simple\.pdf/),
-            auth_bypass_ids: [edition.auth_bypass_id],
-          ),
-        )
+        Services.asset_manager.expects(:create_asset).with { |args|
+          args[:file].path =~ /simple\.pdf/
+          args[:auth_bypass_ids] == [edition.auth_bypass_id]
+        }.returns(asset_manager_response)
 
-        AssetManagerCreateWhitehallAssetWorker.drain
+        AssetManagerCreateAssetWorker.drain
       end
     end
 

--- a/test/unit/app/models/consultation_response_form_data_test.rb
+++ b/test/unit/app/models/consultation_response_form_data_test.rb
@@ -15,4 +15,17 @@ class ConsultationResponseFormDataTest < ActiveSupport::TestCase
 
     assert_equal consultation_response_form_data.auth_bypass_ids, [auth_bypass_id]
   end
+
+  test "#all_asset_variants_uploaded? should return true when there is an original asset" do
+    consultation_response_form_data = build(:consultation_response_form_data)
+
+    assert consultation_response_form_data.all_asset_variants_uploaded?
+  end
+
+  test "#all_asset_variants_uploaded? should return false when there is no asset" do
+    consultation_response_form_data = build(:consultation_response_form_data)
+    consultation_response_form_data.assets = []
+
+    assert_equal false, consultation_response_form_data.all_asset_variants_uploaded?
+  end
 end

--- a/test/unit/app/models/consultation_test.rb
+++ b/test/unit/app/models/consultation_test.rb
@@ -515,4 +515,15 @@ class ConsultationTest < ActiveSupport::TestCase
       assert_equal consultation.document.slug, consultation.title
     end
   end
+
+  test "is invalid if consultation response form asset is missing" do
+    response_form_data = build(:consultation_response_form_data)
+    response_form_data.assets = []
+    response_form = build(:consultation_response_form, consultation_response_form_data: response_form_data)
+    participation = build(:consultation_participation, consultation_response_form: response_form)
+    consultation = build(:open_consultation, consultation_participation: participation)
+
+    assert_not consultation.valid?
+    assert_includes consultation.errors[:consultation_response_form], "must have finished uploading"
+  end
 end

--- a/test/unit/app/presenters/publishing_api/consultation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/consultation_presenter_test.rb
@@ -282,10 +282,26 @@ module PublishingApi::ConsultationPresenterTest
 
     test "ways to respond" do
       Plek.any_instance.stubs(:asset_root).returns("https://asset-host.com")
-      expected_id = @participation.consultation_response_form.consultation_response_form_data.id
-      expected_filename = @participation.consultation_response_form.consultation_response_form_data.carrierwave_file
+
       expected_ways_to_respond = {
-        attachment_url: "https://asset-host.com/government/uploads/system/uploads/consultation_response_form_data/file/#{expected_id}/#{expected_filename}",
+        attachment_url: "https://asset-host.com/media/asset_manager_id_original/two-pages.pdf",
+        email: "postmaster@example.com",
+        link_url: "http://www.example.com",
+        postal_address: <<-ADDRESS.strip_heredoc.chop,
+                        2 Home Farm Ln
+                        Kirklington
+                        Newark
+                        NG22 8PE
+                        UK
+        ADDRESS
+      }
+
+      assert_details_attribute :ways_to_respond, expected_ways_to_respond
+    end
+
+    test "ways to respond: filters out 'attachment_url' when consultation response form asset is missing" do
+      @participation.consultation_response_form.consultation_response_form_data.assets = []
+      expected_ways_to_respond = {
         email: "postmaster@example.com",
         link_url: "http://www.example.com",
         postal_address: <<-ADDRESS.strip_heredoc.chop,

--- a/test/unit/app/services/editon_auth_bypass_updater_test.rb
+++ b/test/unit/app/services/editon_auth_bypass_updater_test.rb
@@ -98,6 +98,7 @@ class EditionAuthBypassUpdaterTest < ActiveSupport::TestCase
       participation = create(:consultation_participation, consultation: edition)
       consultation_response_form = create(:consultation_response_form, consultation_participation: participation)
 
+      edition.reload
       SecureRandom.stubs(uuid: uid)
       expected_attributes = { "auth_bypass_ids" => [uid] }
 

--- a/test/unit/app/workers/asset_manager_update_whitehall_asset_worker_test.rb
+++ b/test/unit/app/workers/asset_manager_update_whitehall_asset_worker_test.rb
@@ -3,84 +3,72 @@ require "test_helper"
 class AssetManagerUpdateWhitehallAssetWorkerTest < ActiveSupport::TestCase
   extend Minitest::Spec::DSL
 
-  context "using legacy_url_path" do
-    setup do
-      @auth_bypass_id_attributes = { "auth_bypass_ids" => [SecureRandom.uuid] }
-    end
+  let(:auth_bypass_id_attributes) do
+    { "auth_bypass_ids" => [SecureRandom.uuid] }
+  end
+  let(:attachment_data) { FactoryBot.create(:attachment_data) }
 
-    def expected_legacy_url(data_type, data_id, file_name)
-      "/government/uploads/system/uploads/#{data_type}/file/#{data_id}/#{file_name}"
-    end
+  test "updates an attachment and its variant" do
+    AssetManager::AssetUpdater.expects(:call).with("asset_manager_id_original", attachment_data, nil, auth_bypass_id_attributes)
+    AssetManager::AssetUpdater.expects(:call).with("asset_manager_id_thumbnail", attachment_data, nil, auth_bypass_id_attributes)
 
-    test "updates a consultation response form" do
-      response_form = FactoryBot.create(:consultation_response_form)
-      form_data = response_form.consultation_response_form_data
-      expected_legacy_url_path = expected_legacy_url("consultation_response_form_data", form_data.id, "two-pages.pdf")
-      AssetManager::AssetUpdater.expects(:call).with(nil, form_data, expected_legacy_url_path, @auth_bypass_id_attributes)
-
-      AssetManagerUpdateWhitehallAssetWorker.perform_async_in_queue("asset_manager_updater", "ConsultationResponseFormData", form_data.id, @auth_bypass_id_attributes)
-      AssetManagerUpdateWhitehallAssetWorker.drain
-    end
+    AssetManagerUpdateWhitehallAssetWorker.perform_async_in_queue("asset_manager_updater", "AttachmentData", attachment_data.id, auth_bypass_id_attributes)
+    AssetManagerUpdateWhitehallAssetWorker.drain
   end
 
-  context "using asset_manager_id" do
-    let(:auth_bypass_id_attributes) do
-      { "auth_bypass_ids" => [SecureRandom.uuid] }
+  test "ignores missing assets in Asset Manager" do
+    expected_error = AssetManager::ServiceHelper::AssetNotFound.new("asset_manager_id_original")
+    AssetManager::AssetUpdater.expects(:call).once.raises(expected_error)
+    Logger.any_instance.stubs(:error).with(includes(expected_error.message)).once
+
+    AssetManagerUpdateWhitehallAssetWorker.perform_async_in_queue("asset_manager_updater", "AttachmentData", attachment_data.id, auth_bypass_id_attributes)
+    AssetManagerUpdateWhitehallAssetWorker.drain
+  end
+
+  test "ignores assets that have been deleted in Asset Manager" do
+    expected_error = AssetManager::AssetUpdater::AssetAlreadyDeleted.new(attachment_data.id, "asset_manager_id_original")
+    AssetManager::AssetUpdater.expects(:call).raises(expected_error)
+    Logger.any_instance.stubs(:error).with(includes(expected_error.message)).once
+
+    AssetManagerUpdateWhitehallAssetWorker.perform_async_in_queue("asset_manager_updater", "AttachmentData", attachment_data.id, auth_bypass_id_attributes)
+    AssetManagerUpdateWhitehallAssetWorker.drain
+  end
+
+  test "ignores assets that have been deleted in Whitehall" do
+    attachment_data_id = attachment_data.id
+    attachment_data.destroy!
+
+    Logger.any_instance.stubs(:error).with(includes(attachment_data_id.to_s)).once
+
+    AssetManagerUpdateWhitehallAssetWorker.perform_async_in_queue("asset_manager_updater", "AttachmentData", attachment_data_id, auth_bypass_id_attributes)
+    AssetManagerUpdateWhitehallAssetWorker.drain
+  end
+
+  test "updates an image and its resized versions" do
+    image_data = FactoryBot.create(:image_data)
+    %w[
+      asset_manager_id_original
+      asset_manager_id_s960
+      asset_manager_id_s712
+      asset_manager_id_s630
+      asset_manager_id_s465
+      asset_manager_id_s300
+      asset_manager_id_s216
+    ].each do |asset_manager_id|
+      AssetManager::AssetUpdater.expects(:call).with(asset_manager_id, image_data, nil, @auth_bypass_id_attributes).once
     end
-    let(:attachment_data) { FactoryBot.create(:attachment_data) }
 
-    test "updates an attachment and its variant" do
-      AssetManager::AssetUpdater.expects(:call).with("asset_manager_id_original", attachment_data, nil, auth_bypass_id_attributes)
-      AssetManager::AssetUpdater.expects(:call).with("asset_manager_id_thumbnail", attachment_data, nil, auth_bypass_id_attributes)
+    AssetManagerUpdateWhitehallAssetWorker.perform_async_in_queue("asset_manager_updater", "ImageData", image_data.id, @auth_bypass_id_attributes)
+    AssetManagerUpdateWhitehallAssetWorker.drain
+  end
 
-      AssetManagerUpdateWhitehallAssetWorker.perform_async_in_queue("asset_manager_updater", "AttachmentData", attachment_data.id, auth_bypass_id_attributes)
-      AssetManagerUpdateWhitehallAssetWorker.drain
-    end
+  test "updates the consultation response form variant" do
+    response_form = FactoryBot.create(:consultation_response_form)
+    form_data = response_form.consultation_response_form_data
 
-    test "ignores missing assets in Asset Manager" do
-      expected_error = AssetManager::ServiceHelper::AssetNotFound.new("asset_manager_id_original")
-      AssetManager::AssetUpdater.expects(:call).once.raises(expected_error)
-      Logger.any_instance.stubs(:error).with(includes(expected_error.message)).once
+    AssetManager::AssetUpdater.expects(:call).with("asset_manager_id_original", form_data, nil, @auth_bypass_id_attributes)
 
-      AssetManagerUpdateWhitehallAssetWorker.perform_async_in_queue("asset_manager_updater", "AttachmentData", attachment_data.id, auth_bypass_id_attributes)
-      AssetManagerUpdateWhitehallAssetWorker.drain
-    end
-
-    test "ignores assets that have been deleted in Asset Manager" do
-      expected_error = AssetManager::AssetUpdater::AssetAlreadyDeleted.new(attachment_data.id, "asset_manager_id_original")
-      AssetManager::AssetUpdater.expects(:call).raises(expected_error)
-      Logger.any_instance.stubs(:error).with(includes(expected_error.message)).once
-
-      AssetManagerUpdateWhitehallAssetWorker.perform_async_in_queue("asset_manager_updater", "AttachmentData", attachment_data.id, auth_bypass_id_attributes)
-      AssetManagerUpdateWhitehallAssetWorker.drain
-    end
-
-    test "ignores assets that have been deleted in Whitehall" do
-      attachment_data_id = attachment_data.id
-      attachment_data.destroy!
-
-      Logger.any_instance.stubs(:error).with(includes(attachment_data_id.to_s)).once
-
-      AssetManagerUpdateWhitehallAssetWorker.perform_async_in_queue("asset_manager_updater", "AttachmentData", attachment_data_id, auth_bypass_id_attributes)
-      AssetManagerUpdateWhitehallAssetWorker.drain
-    end
-
-    test "updates an image and its resized versions" do
-      image_data = FactoryBot.create(:image_data)
-      %w[
-        asset_manager_id_original
-        asset_manager_id_s960
-        asset_manager_id_s712
-        asset_manager_id_s630
-        asset_manager_id_s465
-        asset_manager_id_s300
-        asset_manager_id_s216
-      ].each do |asset_manager_id|
-        AssetManager::AssetUpdater.expects(:call).with(asset_manager_id, image_data, nil, @auth_bypass_id_attributes).once
-      end
-
-      AssetManagerUpdateWhitehallAssetWorker.perform_async_in_queue("asset_manager_updater", "ImageData", image_data.id, @auth_bypass_id_attributes)
-      AssetManagerUpdateWhitehallAssetWorker.drain
-    end
+    AssetManagerUpdateWhitehallAssetWorker.perform_async_in_queue("asset_manager_updater", "ConsultationResponseFormData", form_data.id, @auth_bypass_id_attributes)
+    AssetManagerUpdateWhitehallAssetWorker.drain
   end
 end

--- a/test/unit/lib/whitehall/asset_manager_storage_test.rb
+++ b/test/unit/lib/whitehall/asset_manager_storage_test.rb
@@ -167,7 +167,7 @@ class Whitehall::AssetManagerStorageTest < ActiveSupport::TestCase
       model.stubs(:auth_bypass_ids).returns([@auth_bypass_id])
       @uploader.stubs(:model).returns(model)
 
-      AssetManagerCreateWhitehallAssetWorker.expects(:perform_async).with(anything, anything, anything, nil, nil, [@auth_bypass_id])
+      AssetManagerCreateAssetWorker.expects(:perform_async).with(anything, anything, anything, nil, nil, [@auth_bypass_id])
 
       @uploader.store!(@file)
     end


### PR DESCRIPTION
In order for consultation_response_form to move away from using legacy_url_path
It needs to use asset-id. This PR creates the relationship to allow consultation_response_form
to use_non_legacy_endpoints and create assets in whitehall.
It also introduces the functionality to publish Consultation only when all the assets related to the
consultation form is uploaded i;e block publishing if assets are not uploaded.

[Trello](https://trello.com/c/dD8j8HqT/239-story-consultation-response-form-to-use-asset-ids)
