### PR TITLE
Add a description to the past prime ministers page

### DIFF
--- a/app/presenters/publishing_api/historical_accounts_index_presenter.rb
+++ b/app/presenters/publishing_api/historical_accounts_index_presenter.rb
@@ -16,6 +16,7 @@ module PublishingApi
       content = BaseItemPresenter.new(
         nil,
         title: "Past Prime Ministers",
+        description: "Read about the life and achievements of our past Prime Ministers.",
         update_type:,
       ).base_attributes
 

--- a/test/unit/app/presenters/publishing_api/historical_accounts_index_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/historical_accounts_index_presenter_test.rb
@@ -22,6 +22,7 @@ class PublishingApi::HistoricalAccountIndexPresenterTest < ActiveSupport::TestCa
       schema_name: "historic_appointments",
       document_type: "historic_appointments",
       title: "Past Prime Ministers",
+      description: "Read about the life and achievements of our past Prime Ministers.",
       locale: "en",
       routes: [
         {


### PR DESCRIPTION
It was pointed out that the past prime ministers page was missing a description. This means that only the title of the page shows up in the search results.

The description has been hard-coded to match the page title, though this content should probably be moved to a locale file or be editable by publishers in the UI.

The content for the description also needs to be checked by a content designer.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
