### PR TITLE
Remove unneeded instances of ga4_tracking: true

### DIFF
--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -25,7 +25,7 @@
   <% if t('admin.whats_new.show_banner') %>
     <div class="govuk-design-system-styling">
       <div class="<%= yield(:full_width) === "true" ? "app-width-container--full-width" : "container" %>">
-        <%= render "shared/phase_banner", tracking_module: "track-link-click", ga4_tracking: true %>
+        <%= render "shared/phase_banner", tracking_module: "track-link-click" %>
       </div>
     </div>
   <% end %>

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -38,9 +38,8 @@
 
   <div class="govuk-width-container">
     <%= render "shared/phase_banner", {
-        show_feedback_banner: t("admin.feedback.show_banner"),
-        ga4_tracking: true,
-      } %>
+      show_feedback_banner: t("admin.feedback.show_banner"),
+    } %>
 
     <%= yield(:back_link) %>
     <%= yield(:breadcrumbs) %>

--- a/app/views/shared/_phase_banner.html.erb
+++ b/app/views/shared/_phase_banner.html.erb
@@ -4,7 +4,6 @@
 <% if t('admin.whats_new.show_banner') %>
   <%= render "govuk_publishing_components/components/phase_banner", {
       phase: "What's new",
-      ga4_tracking: true,
       message: sanitize("Improvements to the editor workflow -
         #{
           link_to(
@@ -25,7 +24,6 @@
 <% elsif show_feedback_banner %>
   <%= render "govuk_publishing_components/components/phase_banner", {
       phase: "Feedback",
-      ga4_tracking: true,
       message: mail_to(
         "publishing-service-feedback@digital.cabinet-office.gov.uk",
         "Give feedback on the recent changes to Whitehall",


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Remove options passed to components for enabling GA4 tracking. All components referenced now have tracking enabled by default, and this option has been removed.

## Why
Unneeded code.

## Visual changes
None.

Trello card: https://trello.com/c/Xwp7dgJN/294-tracking-auditing-tracking-by-default
