### PR TITLE
Promotional feature item to use assets

### DIFF
--- a/app/controllers/admin/promotional_feature_items_controller.rb
+++ b/app/controllers/admin/promotional_feature_items_controller.rb
@@ -26,15 +26,8 @@ class Admin::PromotionalFeatureItemsController < Admin::BaseController
   end
 
   def update
-    legacy_image_url = @promotional_feature_item.image.file&.instance_variable_get("@legacy_url_path")
-
     if @promotional_feature_item.update(promotional_feature_item_params)
       Whitehall::PublishingApi.republish_async(@organisation)
-      if legacy_image_url.present?
-        current_legacy_image_url = @promotional_feature_item.image.file&.instance_variable_get("@legacy_url_path")
-        AssetManager::AssetDeleter.call(legacy_image_url, nil) if legacy_image_url != current_legacy_image_url
-      end
-
       redirect_to_feature "Feature item updated."
     else
       @promotional_feature_item.links.build if @promotional_feature_item.links.blank?

--- a/app/controllers/admin/promotional_feature_items_controller.rb
+++ b/app/controllers/admin/promotional_feature_items_controller.rb
@@ -2,7 +2,8 @@ class Admin::PromotionalFeatureItemsController < Admin::BaseController
   before_action :load_organisation
   before_action :load_promotional_feature
   before_action :load_promotional_feature_item, only: %i[edit update destroy confirm_destroy]
-  before_action :clean_image_or_youtube_video_url_param, only: %i[create update]
+  before_action :clean_promotional_feature_item_params, only: %i[create update]
+
   layout "design_system"
 
   def new
@@ -76,6 +77,11 @@ private
     )
   end
 
+  def clean_promotional_feature_item_params
+    clean_image_or_youtube_video_url_param
+    clear_file_cache
+  end
+
   def clean_image_or_youtube_video_url_param
     feature_item_type = promotional_feature_item_params.delete(:image_or_youtube_video_url)
 
@@ -85,6 +91,12 @@ private
     else
       promotional_feature_item_params["youtube_video_url"] = nil
       promotional_feature_item_params["youtube_video_alt_text"] = nil
+    end
+  end
+
+  def clear_file_cache
+    if promotional_feature_item_params[:image].present? && promotional_feature_item_params[:image_cache].present?
+      promotional_feature_item_params.delete(:image_cache)
     end
   end
 end

--- a/app/controllers/admin/promotional_feature_items_controller.rb
+++ b/app/controllers/admin/promotional_feature_items_controller.rb
@@ -14,7 +14,6 @@ class Admin::PromotionalFeatureItemsController < Admin::BaseController
   def create
     @promotional_feature_item = @promotional_feature.promotional_feature_items.build(promotional_feature_item_params)
     if @promotional_feature_item.save
-      Whitehall::PublishingApi.republish_async(@organisation)
       redirect_to_feature "Feature item added."
     else
       @promotional_feature_item.links.build if @promotional_feature_item.links.blank?
@@ -28,7 +27,6 @@ class Admin::PromotionalFeatureItemsController < Admin::BaseController
 
   def update
     if @promotional_feature_item.update(promotional_feature_item_params)
-      Whitehall::PublishingApi.republish_async(@organisation)
       redirect_to_feature "Feature item updated."
     else
       @promotional_feature_item.links.build if @promotional_feature_item.links.blank?
@@ -38,7 +36,6 @@ class Admin::PromotionalFeatureItemsController < Admin::BaseController
 
   def destroy
     @promotional_feature_item.destroy!
-    Whitehall::PublishingApi.republish_async(@organisation)
     redirect_to_feature "Feature item deleted."
   end
 

--- a/app/presenters/publishing_api/organisation_presenter.rb
+++ b/app/presenters/publishing_api/organisation_presenter.rb
@@ -283,7 +283,7 @@ module PublishingApi
       item.promotional_features.map do |promotional_feature|
         {
           title: promotional_feature.title,
-          items: promotional_feature.items.map do |promotional_feature_item|
+          items: promotional_feature.items.select { |item| item.youtube_video_id.present? || item.all_asset_variants_uploaded? }.map do |promotional_feature_item|
             if promotional_feature_item.youtube_video_id.present?
               promotional_feature_item_youtube_hash(promotional_feature_item)
             else

--- a/app/uploaders/featured_image_uploader.rb
+++ b/app/uploaders/featured_image_uploader.rb
@@ -10,7 +10,7 @@ class FeaturedImageUploader < WhitehallUploader
     # The issue with removing previous images is that the documents using them may have associations that also use the images.
     # Therefore, when the images get deleted from asset-manager, the associated published documents will 404 for the image, unless
     # an intentional update is run to inform the association that a new image has been provided.
-    # Such an example is Speech document and the relates Person who made the speech. Speech page shows the image of the person.
+    # Such an example is Speech document and the related Person who made the speech. Speech page shows the image of the person.
     # When Person updates the picture, Speech needs to be republished as well, otherwise it will try to show the old image (404 if deletion enabled).
     config.remove_previously_stored_files_after_update = false
     config.validate_integrity = true

--- a/app/views/admin/promotional_feature_items/_form_fields.html.erb
+++ b/app/views/admin/promotional_feature_items/_form_fields.html.erb
@@ -50,7 +50,7 @@
         page_errors: form.object.errors.any?,
         error_items: errors_for(form.object.errors, :image),
         filename: form.object.image.filename,
-        image_cache: (form.object.image.image_cache.presence),
+        image_cache: form.object.image_cache.presence,
         image_src: form.object.image.url,
         image_alt: form.object.image_alt_text,
       }),

--- a/lib/whitehall/asset_manager_storage.rb
+++ b/lib/whitehall/asset_manager_storage.rb
@@ -102,7 +102,7 @@ class Whitehall::AssetManagerStorage < CarrierWave::Storage::Abstract
   def self.use_non_legacy_behaviour?(model)
     return unless model
 
-    return true if model.instance_of?(AttachmentData) || model.instance_of?(ImageData) || model.instance_of?(Organisation) || model.instance_of?(FeaturedImageData) || model.instance_of?(TopicalEventFeaturingImageData)
+    return true if model.instance_of?(AttachmentData) || model.instance_of?(ImageData) || model.instance_of?(Organisation) || model.instance_of?(FeaturedImageData) || model.instance_of?(TopicalEventFeaturingImageData) || model.instance_of?(PromotionalFeatureItem)
 
     model.respond_to?("use_non_legacy_endpoints") && model.use_non_legacy_endpoints
   end

--- a/test/factories/promotional_feature_items.rb
+++ b/test/factories/promotional_feature_items.rb
@@ -1,15 +1,29 @@
 FactoryBot.define do
-  factory :promotional_feature_item do
+  factory :generic_promotional_feature_item, class: PromotionalFeatureItem do
     association :promotional_feature
     summary { "Summary text" }
-    image { image_fixture_file }
-    image_alt_text { "Image alt text" }
+
+    trait(:with_image) do
+      image { image_fixture_file }
+      image_alt_text { "Image alt text" }
+
+      after :build do |item|
+        item.assets << build(:asset, asset_manager_id: "asset_manager_id_original", variant: Asset.variants[:original], filename: "minister-of-funk.960x640.jpg")
+        item.assets << build(:asset, asset_manager_id: "asset_manager_id_s960", variant: Asset.variants[:s960], filename: "s960_minister-of-funk.960x640.jpg")
+        item.assets << build(:asset, asset_manager_id: "asset_manager_id_s712", variant: Asset.variants[:s712], filename: "s712_minister-of-funk.960x640.jpg")
+        item.assets << build(:asset, asset_manager_id: "asset_manager_id_s630", variant: Asset.variants[:s630], filename: "s630_minister-of-funk.960x640.jpg")
+        item.assets << build(:asset, asset_manager_id: "asset_manager_id_s465", variant: Asset.variants[:s465], filename: "s465_minister-of-funk.960x640.jpg")
+        item.assets << build(:asset, asset_manager_id: "asset_manager_id_s300", variant: Asset.variants[:s300], filename: "s300_minister-of-funk.960x640.jpg")
+        item.assets << build(:asset, asset_manager_id: "asset_manager_id_s216", variant: Asset.variants[:s216], filename: "s216_minister-of-funk.960x640.jpg")
+      end
+    end
 
     trait(:with_youtube_video_url) do
-      image { nil }
-      image_alt_text { nil }
       youtube_video_url { "https://www.youtube.com/watch?v=fFmDQn9Lbl4" }
       youtube_video_alt_text { "YouTube alt text." }
     end
   end
+
+  factory :promotional_feature_item, parent: :generic_promotional_feature_item, traits: [:with_image]
+  factory :promotional_feature_item_with_youtube_video_url, parent: :generic_promotional_feature_item, traits: [:with_youtube_video_url]
 end

--- a/test/functional/admin/organisations_controller_test.rb
+++ b/test/functional/admin/organisations_controller_test.rb
@@ -458,7 +458,6 @@ class Admin::OrganisationsControllerTest < ActionController::TestCase
     filename = "big-cheese.960x640.jpg"
     cached_default_news_image = build(:featured_image_data)
 
-    Services.asset_manager.stubs(:create_asset).returns("id" => "http://asset-manager/assets/asset_manager_id", "name" => filename)
     AssetManagerCreateAssetWorker.expects(:perform_async).with(regexp_matches(/minister-of-funk.960x640/), anything, anything, anything, anything, anything).never
     AssetManagerCreateAssetWorker.expects(:perform_async).with(regexp_matches(/#{filename}/), anything, anything, anything, anything, anything).times(7)
 
@@ -484,7 +483,6 @@ class Admin::OrganisationsControllerTest < ActionController::TestCase
     cached_filename = "big-cheese.960x640.jpg"
     cached_default_news_image = build(:featured_image_data, file: upload_fixture(cached_filename, "image/png"))
 
-    Services.asset_manager.stubs(:create_asset).returns("id" => "http://asset-manager/assets/asset_manager_id", "name" => replacement_filename)
     AssetManagerCreateAssetWorker.expects(:perform_async).with(regexp_matches(/#{replacement_filename}/), anything, anything, anything, anything, anything).times(7)
     AssetManagerCreateAssetWorker.expects(:perform_async).with(regexp_matches(/#{cached_filename}/), anything, anything, anything, anything, anything).never
 

--- a/test/functional/admin/promotional_feature_items_controller_test.rb
+++ b/test/functional/admin/promotional_feature_items_controller_test.rb
@@ -20,9 +20,7 @@ class Admin::PromotionalFeatureItemsControllerTest < ActionController::TestCase
     assert_equal 1, assigns(:promotional_feature_item).links.size
   end
 
-  test "POST :create saves the new promotional item to the feature and republishes the organisation to the PublishingApi" do
-    Whitehall::PublishingApi.expects(:republish_async).once.with(@organisation)
-
+  test "POST :create saves the new promotional item to the feature" do
     post :create,
          params: {
            organisation_id: @organisation,
@@ -73,11 +71,10 @@ class Admin::PromotionalFeatureItemsControllerTest < ActionController::TestCase
     assert link.is_a?(PromotionalFeatureLink)
   end
 
-  test "PUT :update updates the item, does not delete the old image from the asset store and redirects to the feature and republishes the organisation to the PublishingApi" do
+  test "PUT :update updates the item and does not delete the old image from the asset store" do
     link = create(:promotional_feature_link)
     promotional_feature_item = create(:promotional_feature_item, promotional_feature: @promotional_feature, links: [link])
 
-    Whitehall::PublishingApi.expects(:republish_async).once.with(@organisation)
     # We prefer to keep the image so that published docs can render it in case something goes wrong with the republishing.
     AssetManagerDeleteAssetWorker.expects(:perform_async).never
 
@@ -98,7 +95,7 @@ class Admin::PromotionalFeatureItemsControllerTest < ActionController::TestCase
     assert_equal "Feature item updated.", flash[:notice]
   end
 
-  test "PUT :update on a successful update it does not delete the image from the asset store when a YouTube URL is provided and the user has the 'Add youtube urls to promotional features'" do
+  test "PUT :update on a successful update does not delete the image from the asset store when a YouTube URL is provided and the user has the 'Add youtube urls to promotional features'" do
     @current_user.permissions << "Add youtube urls to promotional features"
     link = create(:promotional_feature_link)
     promotional_feature_item = create(:promotional_feature_item, promotional_feature: @promotional_feature, links: [link])
@@ -129,10 +126,9 @@ class Admin::PromotionalFeatureItemsControllerTest < ActionController::TestCase
     assert_equal 1, assigns(:promotional_feature_item).links.size
   end
 
-  test "DELETE :destroy deletes the promotional item, any image assets from asset-manager (if present) and republishes the organisation to the PublishingApi" do
+  test "DELETE :destroy deletes the promotional item and any image assets from asset-manager (if present)" do
     promotional_feature_item = create(:promotional_feature_item, promotional_feature: @promotional_feature)
 
-    Whitehall::PublishingApi.expects(:republish_async).once.with(@organisation)
     promotional_feature_item.assets.each do |asset|
       AssetManagerDeleteAssetWorker.expects(:perform_async).with(nil, asset.asset_manager_id)
     end

--- a/test/unit/app/models/promotional_feature_item_test.rb
+++ b/test/unit/app/models/promotional_feature_item_test.rb
@@ -33,7 +33,7 @@ class PromotionalFeatureItemTest < ActiveSupport::TestCase
 
   test "validates that an image or youtube_video_url is present on save" do
     feature_item_with_image = build(:promotional_feature_item)
-    feature_item_with_youtube_url = build(:promotional_feature_item, :with_youtube_video_url)
+    feature_item_with_youtube_url = build(:promotional_feature_item_with_youtube_video_url)
     invalid_feature_item = build(:promotional_feature_item, image: nil, youtube_video_url: nil)
 
     assert feature_item_with_image.valid?
@@ -51,12 +51,12 @@ class PromotionalFeatureItemTest < ActiveSupport::TestCase
 
   VALID_YOUTUBE_URLS.each do |url|
     test "validates that a youtube_video_url of `#{url}` is valid" do
-      assert build(:promotional_feature_item, :with_youtube_video_url, youtube_video_url: url).valid?
+      assert build(:promotional_feature_item_with_youtube_video_url, youtube_video_url: url).valid?
     end
   end
 
   test "validates that a youtube_video_url of `https://www.gov.uk/government/organisations/government-digital-service` is invalid" do
-    promotional_feature_item = build(:promotional_feature_item, :with_youtube_video_url, youtube_video_url: "https://www.gov.uk/government/organisations/government-digital-service")
+    promotional_feature_item = build(:promotional_feature_item_with_youtube_video_url, youtube_video_url: "https://www.gov.uk/government/organisations/government-digital-service")
 
     assert_not promotional_feature_item.valid?
     assert_equal promotional_feature_item.errors[:youtube_video_url], ["Did not match expected format, please use a https://www.youtube.com/watch?v=MSmotCRFFMc or https://youtu.be/MSmotCRFFMc URL"]
@@ -64,12 +64,12 @@ class PromotionalFeatureItemTest < ActiveSupport::TestCase
 
   VALID_YOUTUBE_URLS.each do |url|
     test "#youtube_video_id returns the youtube_video_id for `#{url}`" do
-      assert_equal build(:promotional_feature_item, :with_youtube_video_url, youtube_video_url: url).youtube_video_id, "fFmDQn9Lbl4"
+      assert_equal build(:promotional_feature_item_with_youtube_video_url, youtube_video_url: url).youtube_video_id, "fFmDQn9Lbl4"
     end
   end
 
   test "#youtube_video_id raises an exception when an youtube_video_id cannot be parsed form the youtube_video_url" do
-    promotional_feature_item = build(:promotional_feature_item, youtube_video_url: "https://www.gov.uk/government/organisations/government-digital-service")
+    promotional_feature_item = build(:promotional_feature_item_with_youtube_video_url, youtube_video_url: "https://www.gov.uk/government/organisations/government-digital-service")
 
     assert_raises "youtube_video_url: #{promotional_feature_item.youtube_video_url} is invalid for PromotionalFeatureItem id: #{promotional_feature_item.id}" do
       promotional_feature_item.youtube_video_id

--- a/test/unit/app/models/promotional_feature_item_test.rb
+++ b/test/unit/app/models/promotional_feature_item_test.rb
@@ -100,6 +100,30 @@ class PromotionalFeatureItemTest < ActiveSupport::TestCase
     assert_empty promotional_feature_item.errors
   end
 
+  test "#republish_on_assets_ready should republish associated organisation if image assets are ready" do
+    promotional_feature_item = create(:promotional_feature_item)
+
+    PublishingApiWorker.expects(:perform_async).with(Organisation.to_s, promotional_feature_item.organisation.id)
+
+    promotional_feature_item.republish_on_assets_ready
+  end
+
+  test "should republish organisation on save" do
+    promotional_feature_item = build(:promotional_feature_item)
+
+    Organisation.any_instance.expects(:publish_to_publishing_api_async)
+
+    promotional_feature_item.save!
+  end
+
+  test "should republish organisation on destroy" do
+    promotional_feature_item = create(:promotional_feature_item)
+
+    Organisation.any_instance.expects(:publish_to_publishing_api_async)
+
+    promotional_feature_item.destroy!
+  end
+
 private
 
   def string_of_length(length)

--- a/test/unit/app/presenters/publishing_api/organisation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/organisation_presenter_test.rb
@@ -230,6 +230,37 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
     assert_equal(expected_output, presented_item.content[:details][:ordered_promotional_features])
   end
 
+  test "filters out images with missing assets for promotional feature items" do
+    promotional_feature = create(:promotional_feature)
+    promotional_feature_item_with_assets = create(:promotional_feature_item, promotional_feature:)
+    promotional_feature_item_with_missing_assets = build(:promotional_feature_item, promotional_feature:)
+    promotional_feature_item_with_missing_assets.assets = []
+    promotional_feature_item_with_missing_assets.save!
+
+    organisation = create(
+      :organisation,
+      organisation_type: OrganisationType.civil_service,
+      promotional_features: [promotional_feature],
+    )
+    presented_item = present(organisation)
+
+    expected_output = [
+      {
+        title: promotional_feature.title,
+        items: [
+          summary: promotional_feature_item_with_assets.summary,
+          image: {
+            url: promotional_feature_item_with_assets.image.url,
+            alt_text: promotional_feature_item_with_assets.image_alt_text,
+          },
+          links: promotional_feature_item_with_assets.links,
+        ],
+      },
+    ]
+
+    assert_equal(expected_output, presented_item.content[:details][:ordered_promotional_features])
+  end
+
   test "does not present an ineligible organisation with promotional features" do
     promotional_feature = create(:promotional_feature)
     organisation = create(

--- a/test/unit/app/presenters/publishing_api/organisation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/organisation_presenter_test.rb
@@ -196,7 +196,7 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
     promotional_feature1 = create(:promotional_feature)
     promotional_feature_item1 = create(:promotional_feature_item, promotional_feature: promotional_feature1)
     promotional_feature2 = create(:promotional_feature)
-    promotional_feature_item2 = create(:promotional_feature_item, :with_youtube_video_url, promotional_feature: promotional_feature2)
+    promotional_feature_item2 = create(:promotional_feature_item_with_youtube_video_url, promotional_feature: promotional_feature2)
 
     organisation = create(
       :organisation,

--- a/test/unit/app/workers/asset_manager_create_asset_worker_test.rb
+++ b/test/unit/app/workers/asset_manager_create_asset_worker_test.rb
@@ -147,7 +147,8 @@ class AssetManagerCreateAssetWorkerTest < ActiveSupport::TestCase
     @worker.perform(@file.path, @asset_params, true, consultation_outcome.class.to_s, consultation_outcome.id)
   end
 
-  test "updates existing asset of same variant if it already exists - for Organisations" do
+  test "updates existing asset of same variant if it already exists" do
+    # This behaviour applies to all models that have a mount_uploader
     filename = "big-cheese.960x640.jpg"
     organisation = FactoryBot.build(
       :organisation,


### PR DESCRIPTION
Replace `legacy_url_path` with urls based on `asset-manager` IDs. This ensures consistency across publishing apps in the way they communicate with `asset-manager`, as well as making changes possible within `whitehall` without affecting anything downstream.

Most changes required to make this work are already in place. These commits whitelist the `PromotionalFeatureItem` class as to enable asset creation, as well as address a few issues around file caching and publishing to `publishing-api`.

[Trello card](https://trello.com/c/6t2gbpLB/241-story-promotional-feature-item-image-to-use-asset-ids)