### PR TITLE
Remove graphviz_transitions dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -73,7 +73,6 @@ end
 group :development do
   gem "better_errors"
   gem "binding_of_caller"
-  gem "graphviz_transitions"
   gem "mechanize"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -302,9 +302,6 @@ GEM
       capybara (>= 3.36)
       puma
       selenium-webdriver (>= 4.0)
-    graphviz_transitions (0.1.2)
-      ruby-graphviz
-      transitions
     hashdiff (1.0.1)
     hashery (2.1.2)
     hashie (5.0.0)
@@ -827,8 +824,6 @@ GEM
       rubocop (~> 1.33)
       rubocop-capybara (~> 2.17)
       rubocop-factory_bot (~> 2.22)
-    ruby-graphviz (1.2.5)
-      rexml
     ruby-progressbar (1.13.0)
     ruby-rc4 (0.1.5)
     ruby-vips (2.2.0)
@@ -982,7 +977,6 @@ DEPENDENCIES
   govuk_schemas
   govuk_sidekiq
   govuk_test
-  graphviz_transitions
   i18n-coverage
   inline_svg
   invalid_utf8_rejector


### PR DESCRIPTION
This was added in 2c7c7df4ed, but I suspect nobody knows it's there or how to use it.

The answer is:

```
rake transitions:draw CLASS=Edition
```

Which used to produce a nice PNG image like this:

![edition_transitions](https://github.com/alphagov/whitehall/assets/1696784/ae2018c4-ece8-4c61-a39f-430986889647)


Unfortunately, this has been broken since rails 5 because of a breaking change to the `.parameterize()` method - https://github.com/itkin/graphviz_transitions/pull/1

Less dependencies is better dependencies, so let's bin it.
