### PR TITLE
Use republishing method from Whitehall::PublishingApi instead of calling publishworker directly

### DIFF
--- a/app/models/featured_image_data.rb
+++ b/app/models/featured_image_data.rb
@@ -28,7 +28,7 @@ class FeaturedImageData < ApplicationRecord
   def republish_on_assets_ready
     if all_asset_variants_uploaded?
       logger.info("FeaturedImageData #{id} (#{featured_imageable_type}:#{featured_imageable_id}) republishing after all asset variants are uploaded")
-      featured_imageable.publish_to_publishing_api_async if featured_imageable.respond_to? :publish_to_publishing_api_async
+      featured_imageable.republish_to_publishing_api_async if featured_imageable.respond_to? :republish_to_publishing_api_async
       featured_imageable.republish_dependent_documents if featured_imageable.respond_to? :republish_dependent_documents
     end
   end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -232,7 +232,7 @@ class Organisation < ApplicationRecord
 
   def republish_on_assets_ready
     if all_asset_variants_uploaded?
-      publish_to_publishing_api_async
+      republish_to_publishing_api_async
     end
   end
 

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -124,7 +124,7 @@ class Person < ApplicationRecord
   def republish_dependent_documents
     speeches.map { |speech| Whitehall::PublishingApi.republish_document_async(speech.document) }
 
-    historical_account&.publish_to_publishing_api_async
+    historical_account&.republish_to_publishing_api_async
   end
 
 private

--- a/app/models/promotional_feature_item.rb
+++ b/app/models/promotional_feature_item.rb
@@ -57,6 +57,6 @@ private
   end
 
   def republish_organisation
-    organisation.publish_to_publishing_api_async
+    organisation.republish_to_publishing_api_async
   end
 end

--- a/app/models/topical_event_featuring_image_data.rb
+++ b/app/models/topical_event_featuring_image_data.rb
@@ -25,7 +25,7 @@ class TopicalEventFeaturingImageData < ApplicationRecord
 
   def republish_on_assets_ready
     if all_asset_variants_uploaded?
-      topical_event_featuring.topical_event.publish_to_publishing_api_async
+      topical_event_featuring.topical_event.republish_to_publishing_api_async
     end
   end
 end

--- a/lib/publishes_to_publishing_api.rb
+++ b/lib/publishes_to_publishing_api.rb
@@ -12,9 +12,9 @@ module PublishesToPublishingApi
     persisted?
   end
 
-  def publish_to_publishing_api_async
+  def republish_to_publishing_api_async
     if can_publish_to_publishing_api?
-      PublishingApiWorker.perform_async(self.class.to_s, id)
+      Whitehall::PublishingApi.republish_async(self)
     end
   end
 

--- a/test/unit/app/models/featured_image_data_test.rb
+++ b/test/unit/app/models/featured_image_data_test.rb
@@ -72,8 +72,8 @@ class FeaturedImageDataTest < ActiveSupport::TestCase
     organisation = create(:organisation, :with_default_news_image)
     news_article = create(:news_article, organisations: [organisation])
 
-    PublishingApiWorker.expects(:perform_async).with(Organisation.to_s, organisation.id)
-    Whitehall::PublishingApi.expects(:republish_document_async).with(news_article.document)
+    Whitehall::PublishingApi.expects(:republish_async).with(organisation).once
+    Whitehall::PublishingApi.expects(:republish_document_async).with(news_article.document).once
 
     organisation.default_news_image.republish_on_assets_ready
   end
@@ -82,7 +82,7 @@ class FeaturedImageDataTest < ActiveSupport::TestCase
     worldwide_organisation = create(:worldwide_organisation, :with_default_news_image)
     news_article = create(:news_article_world_news_story, worldwide_organisations: [worldwide_organisation])
 
-    PublishingApiWorker.expects(:perform_async).with(WorldwideOrganisation.to_s, worldwide_organisation.id)
+    Whitehall::PublishingApi.expects(:republish_async).with(worldwide_organisation).once
     Whitehall::PublishingApi.expects(:republish_document_async).with(news_article.document)
 
     worldwide_organisation.default_news_image.republish_on_assets_ready
@@ -91,7 +91,7 @@ class FeaturedImageDataTest < ActiveSupport::TestCase
   test "#republish_on_assets_ready should republish topical event if assets are ready" do
     topical_event = create(:topical_event, :with_logo)
 
-    PublishingApiWorker.expects(:perform_async).with(TopicalEvent.to_s, topical_event.id)
+    Whitehall::PublishingApi.expects(:republish_async).with(topical_event).once
 
     topical_event.logo.republish_on_assets_ready
   end
@@ -101,8 +101,8 @@ class FeaturedImageDataTest < ActiveSupport::TestCase
     speech = create(:speech, role_appointment: create(:role_appointment, role: create(:ministerial_role), person:))
     create(:historical_account, person:)
 
-    PublishingApiWorker.expects(:perform_async).with(Person.to_s, person.id)
-    PublishingApiWorker.expects(:perform_async).with(HistoricalAccount.to_s, person.historical_account.id)
+    Whitehall::PublishingApi.expects(:republish_async).with(person).once
+    Whitehall::PublishingApi.expects(:republish_async).with(person.historical_account).once
     Whitehall::PublishingApi.expects(:republish_document_async).with(speech.document)
 
     person.image.republish_on_assets_ready
@@ -111,7 +111,7 @@ class FeaturedImageDataTest < ActiveSupport::TestCase
   test "#republish_on_assets_ready should republish take part page if assets are ready" do
     take_part_page = create(:take_part_page)
 
-    PublishingApiWorker.expects(:perform_async).with(TakePartPage.to_s, take_part_page.id)
+    Whitehall::PublishingApi.expects(:republish_async).with(take_part_page).once
 
     take_part_page.image.republish_on_assets_ready
   end
@@ -122,8 +122,8 @@ class FeaturedImageDataTest < ActiveSupport::TestCase
     speech = create(:speech, role_appointment: create(:role_appointment, role: create(:ministerial_role), person:))
     create(:historical_account, person:)
 
-    PublishingApiWorker.expects(:perform_async).with(Person.to_s, person.id).never
-    PublishingApiWorker.expects(:perform_async).with(HistoricalAccount.to_s, person.historical_account.id).never
+    Whitehall::PublishingApi.expects(:republish_async).with(person).never
+    Whitehall::PublishingApi.expects(:republish_async).with(person.historical_account).never
     Whitehall::PublishingApi.expects(:republish_document_async).with(speech.document).never
 
     person.image.republish_on_assets_ready

--- a/test/unit/app/models/organisation_test.rb
+++ b/test/unit/app/models/organisation_test.rb
@@ -1209,7 +1209,7 @@ class OrganisationTest < ActiveSupport::TestCase
   test "#republish_on_assets_ready should republish organisation if logo assets are ready" do
     organisation = create(:organisation, :with_logo_and_assets)
 
-    PublishingApiWorker.expects(:perform_async).with(Organisation.to_s, organisation.id)
+    Whitehall::PublishingApi.expects(:republish_async).with(organisation).once
 
     organisation.republish_on_assets_ready
   end

--- a/test/unit/app/models/promotional_feature_item_test.rb
+++ b/test/unit/app/models/promotional_feature_item_test.rb
@@ -103,23 +103,25 @@ class PromotionalFeatureItemTest < ActiveSupport::TestCase
   test "#republish_on_assets_ready should republish associated organisation if image assets are ready" do
     promotional_feature_item = create(:promotional_feature_item)
 
-    PublishingApiWorker.expects(:perform_async).with(Organisation.to_s, promotional_feature_item.organisation.id)
+    Whitehall::PublishingApi.expects(:republish_async).with(promotional_feature_item.organisation).once
 
     promotional_feature_item.republish_on_assets_ready
   end
 
   test "should republish organisation on save" do
-    promotional_feature_item = build(:promotional_feature_item)
+    promotional_feature_item = create(:promotional_feature_item)
+    organisation = promotional_feature_item.organisation
 
-    Organisation.any_instance.expects(:publish_to_publishing_api_async)
+    organisation.expects(:republish_to_publishing_api_async)
 
     promotional_feature_item.save!
   end
 
   test "should republish organisation on destroy" do
     promotional_feature_item = create(:promotional_feature_item)
+    organisation = promotional_feature_item.organisation
 
-    Organisation.any_instance.expects(:publish_to_publishing_api_async)
+    organisation.expects(:republish_to_publishing_api_async)
 
     promotional_feature_item.destroy!
   end

--- a/test/unit/app/models/publishes_to_publishing_api_test.rb
+++ b/test/unit/app/models/publishes_to_publishing_api_test.rb
@@ -98,4 +98,14 @@ class PublishesToPublishingApiTest < ActiveSupport::TestCase
     test_object.expects(:test_published_gone_handler)
     test_object.publish_gone_to_publishing_api
   end
+
+  test "enqueues a worker to republish the document on request" do
+    test_object = TestObject.new
+    class << test_object
+      include PublishesToPublishingApi
+    end
+
+    Whitehall::PublishingApi.expects(:republish_async).with(test_object).once
+    test_object.republish_to_publishing_api_async
+  end
 end

--- a/test/unit/app/models/topical_event_featuring_image_data_test.rb
+++ b/test/unit/app/models/topical_event_featuring_image_data_test.rb
@@ -42,7 +42,7 @@ class TopicalEventFeaturingImageDataTest < ActiveSupport::TestCase
     topical_event = create(:topical_event)
     topical_event_featuring = topical_event.feature(image: build(:topical_event_featuring_image_data))
 
-    PublishingApiWorker.expects(:perform_async).with(TopicalEvent.to_s, topical_event.id)
+    Whitehall::PublishingApi.expects(:republish_async).with(topical_event).once
 
     topical_event_featuring.image.republish_on_assets_ready
   end


### PR DESCRIPTION
Republish method sets an `update_type: 'republish'` flag on the published content that has different side-effects than the default flag `'major'`. For example on regular publish, a `'major'` value is set as the `update_type` and that causes emails to be sent of the update. Republish uses `'republish'` flag which means that a change note is not required and there are no extra emails sent.

[Trello](https://trello.com/c/6t2gbpLB/241-story-promotional-feature-image-to-use-asset-ids)
