### PR TITLE
Add worker that Republishes large pages to Publishing API

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -83,7 +83,7 @@ class Contact < ApplicationRecord
   end
 
   def republish_embassies_index_page_to_publishing_api
-    PresentPageToPublishingApi.new.publish(PublishingApi::EmbassiesIndexPresenter)
+    PresentPageToPublishingApiWorker.perform_async("PublishingApi::EmbassiesIndexPresenter")
   end
 
   def publishing_api_presenter

--- a/app/models/historical_account.rb
+++ b/app/models/historical_account.rb
@@ -39,7 +39,7 @@ class HistoricalAccount < ApplicationRecord
   end
 
   def republish_prime_ministers_index_page_to_publishing_api
-    PresentPageToPublishingApi.new.publish(PublishingApi::HistoricalAccountsIndexPresenter) unless role.slug != "prime-minister"
+    PresentPageToPublishingApiWorker.perform_async("PublishingApi::HistoricalAccountsIndexPresenter") unless role.slug != "prime-minister"
   end
 
   def base_path

--- a/app/models/operational_field.rb
+++ b/app/models/operational_field.rb
@@ -16,7 +16,7 @@ class OperationalField < ApplicationRecord
   after_commit :republish_operational_fields_index_page_to_publishing_api
 
   def republish_operational_fields_index_page_to_publishing_api
-    PresentPageToPublishingApi.new.publish(PublishingApi::OperationalFieldsIndexPresenter)
+    PresentPageToPublishingApiWorker.perform_async("PublishingApi::OperationalFieldsIndexPresenter")
   end
 
   def search_link

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -219,15 +219,15 @@ class Organisation < ApplicationRecord
   end
 
   def republish_how_government_works_page_to_publishing_api
-    PresentPageToPublishingApi.new.publish(PublishingApi::HowGovernmentWorksPresenter)
+    PresentPageToPublishingApiWorker.perform_async("PublishingApi::HowGovernmentWorksPresenter")
   end
 
   def republish_ministers_index_page_to_publishing_api
-    PresentPageToPublishingApi.new.publish(PublishingApi::MinistersIndexPresenter) if ministerial_department?
+    PresentPageToPublishingApiWorker.perform_async("PublishingApi::MinistersIndexPresenter") if ministerial_department?
   end
 
   def republish_organisations_index_page_to_publishing_api
-    PresentPageToPublishingApi.new.publish(PublishingApi::OrganisationsIndexPresenter)
+    PresentPageToPublishingApiWorker.perform_async("PublishingApi::OrganisationsIndexPresenter")
   end
 
   def republish_on_assets_ready

--- a/app/models/role_appointment.rb
+++ b/app/models/role_appointment.rb
@@ -90,13 +90,13 @@ class RoleAppointment < ApplicationRecord
 
   def republish_ministerial_pages_to_publishing_api
     if ministerial?
-      PresentPageToPublishingApi.new.publish(PublishingApi::HowGovernmentWorksPresenter)
-      PresentPageToPublishingApi.new.publish(PublishingApi::MinistersIndexPresenter)
+      PresentPageToPublishingApiWorker.perform_async("PublishingApi::HowGovernmentWorksPresenter")
+      PresentPageToPublishingApiWorker.perform_async("PublishingApi::MinistersIndexPresenter")
     end
   end
 
   def republish_prime_ministers_index_page_to_publishing_api
-    PresentPageToPublishingApi.new.publish(PublishingApi::HistoricalAccountsIndexPresenter) unless current? || role.slug != "prime-minister" || has_historical_account?
+    PresentPageToPublishingApiWorker.perform_async("PublishingApi::HistoricalAccountsIndexPresenter") unless current? || role.slug != "prime-minister" || has_historical_account?
   end
 
   def self.between(start_time, end_time)

--- a/app/models/sitewide_setting.rb
+++ b/app/models/sitewide_setting.rb
@@ -22,6 +22,6 @@ class SitewideSetting < ApplicationRecord
     Services.publishing_api.put_content(payload.content_id, payload.content)
     Services.publishing_api.publish(payload.content_id, nil, locale: "en")
 
-    PresentPageToPublishingApi.new.publish(PublishingApi::HowGovernmentWorksPresenter)
+    PresentPageToPublishingApiWorker.perform_async("PublishingApi::HowGovernmentWorksPresenter")
   end
 end

--- a/app/models/world_location.rb
+++ b/app/models/world_location.rb
@@ -89,8 +89,8 @@ class WorldLocation < ApplicationRecord
   friendly_id
 
   def republish_index_pages_to_publishing_api
-    PresentPageToPublishingApi.new.publish(PublishingApi::EmbassiesIndexPresenter)
-    PresentPageToPublishingApi.new.publish(PublishingApi::WorldIndexPresenter) if I18n.locale == :en
+    PresentPageToPublishingApiWorker.perform_async("PublishingApi::EmbassiesIndexPresenter")
+    PresentPageToPublishingApiWorker.perform_async("PublishingApi::WorldIndexPresenter") if I18n.locale == :en
   end
 
   def publishing_api_presenter

--- a/app/models/worldwide_office.rb
+++ b/app/models/worldwide_office.rb
@@ -40,7 +40,7 @@ class WorldwideOffice < ApplicationRecord
   end
 
   def republish_embassies_index_page_to_publishing_api
-    PresentPageToPublishingApi.new.publish(PublishingApi::EmbassiesIndexPresenter)
+    PresentPageToPublishingApiWorker.perform_async("PublishingApi::EmbassiesIndexPresenter")
   end
 
   def base_path

--- a/app/models/worldwide_organisation.rb
+++ b/app/models/worldwide_organisation.rb
@@ -121,7 +121,7 @@ class WorldwideOrganisation < ApplicationRecord
   end
 
   def republish_embassies_index_page_to_publishing_api
-    PresentPageToPublishingApi.new.publish(PublishingApi::EmbassiesIndexPresenter)
+    PresentPageToPublishingApiWorker.perform_async("PublishingApi::EmbassiesIndexPresenter")
   end
 
   def republish_worldwide_offices

--- a/app/workers/present_page_to_publishing_api_worker.rb
+++ b/app/workers/present_page_to_publishing_api_worker.rb
@@ -1,0 +1,5 @@
+class PresentPageToPublishingApiWorker < WorkerBase
+  def perform(presenter)
+    PresentPageToPublishingApi.new.publish(presenter.constantize)
+  end
+end

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -70,37 +70,37 @@ namespace :publishing_api do
 
     desc "Republish the past prime ministers index page to Publishing API"
     task republish_past_prime_ministers_index: :environment do
-      PresentPageToPublishingApi.new.publish(PublishingApi::HistoricalAccountsIndexPresenter)
+      PresentPageToPublishingApiWorker.perform_async("PublishingApi::HistoricalAccountsIndexPresenter")
     end
 
     desc "Republish the how government works page to Publishing API"
     task republish_how_government_works: :environment do
-      PresentPageToPublishingApi.new.publish(PublishingApi::HowGovernmentWorksPresenter)
+      PresentPageToPublishingApiWorker.perform_async("PublishingApi::HowGovernmentWorksPresenter")
     end
 
     desc "Republish the fields of operation index page to Publishing API"
     task republish_operational_fields_index: :environment do
-      PresentPageToPublishingApi.new.publish(PublishingApi::OperationalFieldsIndexPresenter)
+      PresentPageToPublishingApiWorker.perform_async("PublishingApi::OperationalFieldsIndexPresenter")
     end
 
     desc "Republish the ministers index page to Publishing API"
     task republish_ministers_index: :environment do
-      PresentPageToPublishingApi.new.publish(PublishingApi::MinistersIndexPresenter)
+      PresentPageToPublishingApiWorker.perform_async("PublishingApi::MinistersIndexPresenter")
     end
 
     desc "Republish the embassies index page to Publishing API"
     task republish_embassies_index: :environment do
-      PresentPageToPublishingApi.new.publish(PublishingApi::EmbassiesIndexPresenter)
+      PresentPageToPublishingApiWorker.perform_async("PublishingApi::EmbassiesIndexPresenter")
     end
 
     desc "Republish the world index page to Publishing API"
     task republish_world_index: :environment do
-      PresentPageToPublishingApi.new.publish(PublishingApi::WorldIndexPresenter)
+      PresentPageToPublishingApiWorker.perform_async("PublishingApi::WorldIndexPresenter")
     end
 
     desc "Republish the organisations index page to Publishing API"
     task republish_organisations_index: :environment do
-      PresentPageToPublishingApi.new.publish(PublishingApi::OrganisationsIndexPresenter)
+      PresentPageToPublishingApiWorker.perform_async("PublishingApi::OrganisationsIndexPresenter")
     end
   end
 

--- a/test/unit/app/models/contact_test.rb
+++ b/test/unit/app/models/contact_test.rb
@@ -163,7 +163,9 @@ class ContactTest < ActiveSupport::TestCase
   test "republishes embassies index page on creation of contact" do
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter)
 
-    create(:contact)
+    Sidekiq::Testing.inline! do
+      create(:contact)
+    end
   end
 
   test "republishes embassies index page on update of contact" do
@@ -171,7 +173,9 @@ class ContactTest < ActiveSupport::TestCase
 
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter)
 
-    contact.update!(locality: "new-locality")
+    Sidekiq::Testing.inline! do
+      contact.update!(locality: "new-locality")
+    end
   end
 
   test "republishes embassies index page on deletion of contact" do
@@ -179,7 +183,9 @@ class ContactTest < ActiveSupport::TestCase
 
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter)
 
-    contact.destroy!
+    Sidekiq::Testing.inline! do
+      contact.destroy!
+    end
   end
 
   test "republishes worldwide office on creation of related contact" do
@@ -187,7 +193,9 @@ class ContactTest < ActiveSupport::TestCase
 
     Whitehall::PublishingApi.expects(:republish_async).with(worldwide_office).once
 
-    create(:contact, contactable: worldwide_office)
+    Sidekiq::Testing.inline! do
+      create(:contact, contactable: worldwide_office)
+    end
   end
 
   test "republishes worldwide office on update of related contact" do

--- a/test/unit/app/models/historical_account_test.rb
+++ b/test/unit/app/models/historical_account_test.rb
@@ -105,7 +105,9 @@ class HistoricalAccountTest < ActiveSupport::TestCase
     test "republishes the past prime ministers page on create" do
       PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::HistoricalAccountsIndexPresenter)
 
-      create(:historical_account, person: @person, role: @pm_role)
+      Sidekiq::Testing.inline! do
+        create(:historical_account, person: @person, role: @pm_role)
+      end
     end
 
     test "republishes the past prime ministers page on update" do
@@ -113,7 +115,9 @@ class HistoricalAccountTest < ActiveSupport::TestCase
 
       PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::HistoricalAccountsIndexPresenter)
 
-      account.update!(born: "2000")
+      Sidekiq::Testing.inline! do
+        account.update!(born: "2000")
+      end
     end
 
     test "republishes the past prime ministers page on destroy" do
@@ -121,7 +125,9 @@ class HistoricalAccountTest < ActiveSupport::TestCase
 
       PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::HistoricalAccountsIndexPresenter)
 
-      account.destroy!
+      Sidekiq::Testing.inline! do
+        account.destroy!
+      end
     end
   end
 end

--- a/test/unit/app/models/operational_field_test.rb
+++ b/test/unit/app/models/operational_field_test.rb
@@ -35,7 +35,9 @@ class OperationalFieldTest < ActiveSupport::TestCase
   test "should send the fields of operation index page to publishing api when a field of operation is created" do
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::OperationalFieldsIndexPresenter)
 
-    create(:operational_field)
+    Sidekiq::Testing.inline! do
+      create(:operational_field)
+    end
   end
 
   test "should send the fields of operation index page to publishing api when a field of operation is updated" do
@@ -43,7 +45,9 @@ class OperationalFieldTest < ActiveSupport::TestCase
 
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::OperationalFieldsIndexPresenter)
 
-    field.update!(name: "New Field Name")
+    Sidekiq::Testing.inline! do
+      field.update!(name: "New Field Name")
+    end
   end
 
   test "should send the fields of operation index page to publishing api when a field of operation is destroyed" do
@@ -51,6 +55,8 @@ class OperationalFieldTest < ActiveSupport::TestCase
 
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::OperationalFieldsIndexPresenter)
 
-    field.destroy!
+    Sidekiq::Testing.inline! do
+      field.destroy!
+    end
   end
 end

--- a/test/unit/app/models/organisation_test.rb
+++ b/test/unit/app/models/organisation_test.rb
@@ -1037,7 +1037,10 @@ class OrganisationTest < ActiveSupport::TestCase
 
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::HowGovernmentWorksPresenter)
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::OrganisationsIndexPresenter)
-    organisation.save!
+
+    Sidekiq::Testing.inline! do
+      organisation.save!
+    end
   end
 
   test "#save does not trigger organisation with a changed chart url to republish about page if it does not exist" do
@@ -1144,7 +1147,9 @@ class OrganisationTest < ActiveSupport::TestCase
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::MinistersIndexPresenter).never
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::OrganisationsIndexPresenter)
 
-    create(:organisation)
+    Sidekiq::Testing.inline! do
+      create(:organisation)
+    end
   end
 
   test "should send related pages to publishing api when a non-ministerial department is updated" do
@@ -1154,7 +1159,9 @@ class OrganisationTest < ActiveSupport::TestCase
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::MinistersIndexPresenter).never
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::OrganisationsIndexPresenter)
 
-    organisation.update!(name: "New department name")
+    Sidekiq::Testing.inline! do
+      organisation.update!(name: "New department name")
+    end
   end
 
   test "should send related pages to publishing api when a ministerial department is created" do
@@ -1162,7 +1169,9 @@ class OrganisationTest < ActiveSupport::TestCase
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::MinistersIndexPresenter)
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::OrganisationsIndexPresenter)
 
-    create(:ministerial_department)
+    Sidekiq::Testing.inline! do
+      create(:ministerial_department)
+    end
   end
 
   test "should send related pages to publishing api when a ministerial department is updated" do
@@ -1172,7 +1181,9 @@ class OrganisationTest < ActiveSupport::TestCase
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::MinistersIndexPresenter)
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::OrganisationsIndexPresenter)
 
-    organisation.update!(name: "New department name")
+    Sidekiq::Testing.inline! do
+      organisation.update!(name: "New department name")
+    end
   end
 
   test "should send related pages to publishing api when a ministerial department is deleted" do
@@ -1181,7 +1192,9 @@ class OrganisationTest < ActiveSupport::TestCase
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::MinistersIndexPresenter)
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::OrganisationsIndexPresenter)
 
-    organisation.destroy!
+    Sidekiq::Testing.inline! do
+      organisation.destroy!
+    end
   end
 
   test "#all_asset_variants_uploaded? returns true if all asset variants present" do

--- a/test/unit/app/models/role_appointment_test.rb
+++ b/test/unit/app/models/role_appointment_test.rb
@@ -419,16 +419,20 @@ class RoleAppointmentTest < ActiveSupport::TestCase
 
     PresentPageToPublishingApi.any_instance.expects(:publish).at_least_once
 
-    create(:historic_role_appointment, person: create(:person), role:, started_at: Date.civil(1950), ended_at: Date.civil(1960))
+    Sidekiq::Testing.inline! do
+      create(:historic_role_appointment, person: create(:person), role:, started_at: Date.civil(1950), ended_at: Date.civil(1960))
+    end
   end
 
   test "should send the prime ministers index page to publishing api when a destroyed role is a past prime minister" do
     role = create(:prime_minister_role)
     past_pm_appointment = create(:historic_role_appointment, person: create(:person), role:, started_at: Date.civil(1950), ended_at: Date.civil(1960))
 
-    PresentPageToPublishingApi.any_instance.expects(:publish)
+    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::HistoricalAccountsIndexPresenter)
 
-    past_pm_appointment.destroy!
+    Sidekiq::Testing.inline! do
+      past_pm_appointment.destroy!
+    end
   end
 
   test "should send the prime ministers index page to publishing api when the role updated to be a past prime minister" do
@@ -439,7 +443,9 @@ class RoleAppointmentTest < ActiveSupport::TestCase
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::MinistersIndexPresenter)
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::HistoricalAccountsIndexPresenter)
 
-    role_appointment.update!(ended_at: Time.zone.now)
+    Sidekiq::Testing.inline! do
+      role_appointment.update!(ended_at: Time.zone.now)
+    end
   end
 
   test "should not send the prime ministers index page to publishing api when the role created is a current prime minister" do
@@ -449,7 +455,9 @@ class RoleAppointmentTest < ActiveSupport::TestCase
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::MinistersIndexPresenter)
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::HistoricalAccountsIndexPresenter).never
 
-    create(:role_appointment, person: create(:person), role:)
+    Sidekiq::Testing.inline! do
+      create(:role_appointment, person: create(:person), role:)
+    end
   end
 
   test "should not send the prime ministers index page to publishing api when a historical account exists" do
@@ -467,7 +475,9 @@ class RoleAppointmentTest < ActiveSupport::TestCase
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::MinistersIndexPresenter)
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::HistoricalAccountsIndexPresenter).never
 
-    create(:historic_role_appointment, person:, role:, started_at: Date.civil(1950), ended_at: Date.civil(1960))
+    Sidekiq::Testing.inline! do
+      create(:historic_role_appointment, person:, role:, started_at: Date.civil(1950), ended_at: Date.civil(1960))
+    end
   end
 
   test "should not send the prime ministers index page to publishing api when the role created is not a prime minister" do
@@ -478,7 +488,9 @@ class RoleAppointmentTest < ActiveSupport::TestCase
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::MinistersIndexPresenter)
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::HistoricalAccountsIndexPresenter).never
 
-    create(:historic_role_appointment, person: create(:person), role:, started_at: Date.civil(1950), ended_at: Date.civil(1960))
+    Sidekiq::Testing.inline! do
+      create(:historic_role_appointment, person: create(:person), role:, started_at: Date.civil(1950), ended_at: Date.civil(1960))
+    end
   end
 
   test "should send the related pages to publishing api when the role created is a current prime minister" do
@@ -487,7 +499,9 @@ class RoleAppointmentTest < ActiveSupport::TestCase
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::HowGovernmentWorksPresenter)
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::MinistersIndexPresenter)
 
-    create(:role_appointment, person: create(:person), role:)
+    Sidekiq::Testing.inline! do
+      create(:role_appointment, person: create(:person), role:)
+    end
   end
 
   test "should send the related pages to publishing api when someone is appointed to a ministerial role" do
@@ -496,7 +510,9 @@ class RoleAppointmentTest < ActiveSupport::TestCase
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::HowGovernmentWorksPresenter)
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::MinistersIndexPresenter)
 
-    create(:role_appointment, person: create(:person), role:)
+    Sidekiq::Testing.inline! do
+      create(:role_appointment, person: create(:person), role:)
+    end
   end
 
   test "should not send the related pages to publishing api when someone is appointed to a non-ministerial role" do
@@ -505,7 +521,9 @@ class RoleAppointmentTest < ActiveSupport::TestCase
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::HowGovernmentWorksPresenter).never
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::MinistersIndexPresenter).never
 
-    create(:role_appointment, person: create(:person), role:)
+    Sidekiq::Testing.inline! do
+      create(:role_appointment, person: create(:person), role:)
+    end
   end
 
   test "republishes a worldwide organisation when a role appointment is created" do

--- a/test/unit/app/models/sitewide_setting_test.rb
+++ b/test/unit/app/models/sitewide_setting_test.rb
@@ -18,7 +18,9 @@ class SitewideSettingTest < ActiveSupport::TestCase
   test "should send the how government works page to publishing api when reshuffle mode is switched on" do
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::HowGovernmentWorksPresenter)
 
-    create(:sitewide_setting, key: :minister_reshuffle_mode, on: true)
+    Sidekiq::Testing.inline! do
+      create(:sitewide_setting, key: :minister_reshuffle_mode, on: true)
+    end
   end
 
   test "should send the how government works page to publishing api when reshuffle mode is switched off" do
@@ -26,6 +28,8 @@ class SitewideSettingTest < ActiveSupport::TestCase
 
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::HowGovernmentWorksPresenter)
 
-    setting.update!(on: false)
+    Sidekiq::Testing.inline! do
+      setting.update!(on: false)
+    end
   end
 end

--- a/test/unit/app/models/world_location_test.rb
+++ b/test/unit/app/models/world_location_test.rb
@@ -115,7 +115,9 @@ class WorldLocationTest < ActiveSupport::TestCase
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter)
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::WorldIndexPresenter)
 
-    create(:world_location)
+    Sidekiq::Testing.inline! do
+      create(:world_location)
+    end
   end
 
   test "republishes embassies and world index pages on update of world location" do
@@ -124,7 +126,9 @@ class WorldLocationTest < ActiveSupport::TestCase
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter)
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::WorldIndexPresenter)
 
-    location.update!(name: "new-name")
+    Sidekiq::Testing.inline! do
+      location.update!(name: "new-name")
+    end
   end
 
   test "republishes embassies and world index pages on deletion of world location" do
@@ -133,6 +137,8 @@ class WorldLocationTest < ActiveSupport::TestCase
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter)
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::WorldIndexPresenter)
 
-    location.destroy!
+    Sidekiq::Testing.inline! do
+      location.destroy!
+    end
   end
 end

--- a/test/unit/app/models/worldwide_office_test.rb
+++ b/test/unit/app/models/worldwide_office_test.rb
@@ -85,7 +85,9 @@ class WorldwideOfficeTest < ActiveSupport::TestCase
 
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter).twice
 
-    create(:worldwide_office, worldwide_organisation:, contact:)
+    Sidekiq::Testing.inline! do
+      create(:worldwide_office, worldwide_organisation:, contact:)
+    end
   end
 
   test "republishes embassies index page on update of worldwide office" do
@@ -93,7 +95,9 @@ class WorldwideOfficeTest < ActiveSupport::TestCase
 
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter)
 
-    office.update!(slug: "new-slug")
+    Sidekiq::Testing.inline! do
+      office.update!(slug: "new-slug")
+    end
   end
 
   test "republishes embassies index page on deletion of worldwide office" do
@@ -101,6 +105,8 @@ class WorldwideOfficeTest < ActiveSupport::TestCase
 
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter).twice
 
-    office.destroy!
+    Sidekiq::Testing.inline! do
+      office.destroy!
+    end
   end
 end

--- a/test/unit/app/models/worldwide_organisation_test.rb
+++ b/test/unit/app/models/worldwide_organisation_test.rb
@@ -341,7 +341,9 @@ class WorldwideOrganisationTest < ActiveSupport::TestCase
   test "republishes embassies index page on creation of worldwide organisation" do
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter)
 
-    create(:worldwide_organisation)
+    Sidekiq::Testing.inline! do
+      create(:worldwide_organisation)
+    end
   end
 
   test "republishes embassies index page on update of worldwide organisation" do
@@ -349,7 +351,9 @@ class WorldwideOrganisationTest < ActiveSupport::TestCase
 
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter)
 
-    organisation.update!(name: "new-name")
+    Sidekiq::Testing.inline! do
+      organisation.update!(name: "new-name")
+    end
   end
 
   test "republishes embassies index page on deletion of worldwide organisation" do
@@ -357,7 +361,9 @@ class WorldwideOrganisationTest < ActiveSupport::TestCase
 
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter)
 
-    organisation.destroy!
+    Sidekiq::Testing.inline! do
+      organisation.destroy!
+    end
   end
 
   test "republishes related offices on change" do

--- a/test/unit/app/workers/present_page_to_publishing_api_worker_test.rb
+++ b/test/unit/app/workers/present_page_to_publishing_api_worker_test.rb
@@ -1,0 +1,12 @@
+require "test_helper"
+
+class PresentPageToPublishingApiWorkerTest < ActiveSupport::TestCase
+  test "instantiates an instance of PresentPageToPublishingApi and calls #publish" do
+    service = mock
+    PresentPageToPublishingApi.expects(:new).returns(service)
+
+    service.expects(:publish).with(PublishingApi::HowGovernmentWorksPresenter)
+
+    PresentPageToPublishingApiWorker.new.perform("PublishingApi::HowGovernmentWorksPresenter")
+  end
+end


### PR DESCRIPTION
## Description

At the moment, we republish large pages like the ministers index page and how government works pages synchronously. These are expensive and when chained together when a collection of models are reordered can lead to page timeouts.

This commit adds a worker which can be used to present these pages downstream async and uses the new worker in place of the sync calls.

## Performance increase

tested on organisation edit page for GDS https://whitehall-admin.integration.publishing.service.gov.uk/government/admin/organisations/government-digital-service

3 saves 

1. 14.55 seconds
2. 10.02 seconds
3. 17.74 seconds

And with this applied

1. 0.9 seconds
2. 0.89 seconds
3. 0.89 seconds


## Trello card

https://trello.com/c/JoE5X6uD/2205-at-least-one-workflow-in-whitehall-relies-on-skipping-validations-as-some-organisations-are-known-to-be-invalid


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
