### PR TITLE
Migrate Feature to use FeaturedImageData with assets

### DIFF
--- a/app/models/feature.rb
+++ b/app/models/feature.rb
@@ -4,6 +4,8 @@ class Feature < ApplicationRecord
   belongs_to :offsite_link
   belongs_to :feature_list
 
+  has_one :image_new, class_name: "FeaturedImageData", as: :featured_imageable, inverse_of: :featured_imageable
+
   mount_uploader :image, FeaturedImageUploader, mount_on: :carrierwave_image
   validates :document, presence: true, unless: ->(feature) { feature.topical_event_id.present? || feature.offsite_link_id.present? }
   validates :started_at, presence: true


### PR DESCRIPTION
Migrating `Feature` to use `FeaturedImageData` as an intermediary class for managing its image associations. The migration also generates assets for each new `FeaturedImageData` so that we can use `asset-manager` IDs instead of `legacy_url_path`.

[Trello card](https://trello.com/c/JYIbvFb0/248-feature-to-use-assetids)