### PR TITLE
Refactor cabinet ministers controller

### DIFF
--- a/app/controllers/admin/cabinet_ministers_controller.rb
+++ b/app/controllers/admin/cabinet_ministers_controller.rb
@@ -12,6 +12,14 @@ class Admin::CabinetMinistersController < Admin::BaseController
     @roles = MinisterialRole.includes(:translations).where(cabinet_member: true).order(:seniority)
   end
 
+  def order_cabinet_minister_roles
+    params["ordering"].each do |id, ordering|
+      Role.find(id).update_column(:seniority, ordering)
+    end
+
+    redirect_to admin_cabinet_ministers_path(anchor: "cabinet_minister")
+  end
+
   def reorder_also_attends_cabinet_roles
     @roles = MinisterialRole.includes(:translations).also_attends_cabinet.order(:seniority)
   end
@@ -42,8 +50,6 @@ private
     return "" if request.referer.blank?
 
     case URI(request.referer).path
-    when reorder_cabinet_minister_roles_admin_cabinet_ministers_path
-      "#cabinet_minister"
     when reorder_also_attends_cabinet_roles_admin_cabinet_ministers_path
       "#also_attends_cabinet"
     when reorder_whip_roles_admin_cabinet_ministers_path

--- a/app/controllers/admin/cabinet_ministers_controller.rb
+++ b/app/controllers/admin/cabinet_ministers_controller.rb
@@ -24,6 +24,14 @@ class Admin::CabinetMinistersController < Admin::BaseController
     @roles = MinisterialRole.includes(:translations).also_attends_cabinet.order(:seniority)
   end
 
+  def order_also_attends_cabinet_roles
+    params["ordering"].each do |id, ordering|
+      Role.find(id).update_column(:seniority, ordering)
+    end
+
+    redirect_to admin_cabinet_ministers_path(anchor: "also_attends_cabinet")
+  end
+
   def reorder_whip_roles
     @roles = MinisterialRole.includes(:translations).whip.order(:whip_ordering)
   end
@@ -50,8 +58,6 @@ private
     return "" if request.referer.blank?
 
     case URI(request.referer).path
-    when reorder_also_attends_cabinet_roles_admin_cabinet_ministers_path
-      "#also_attends_cabinet"
     when reorder_whip_roles_admin_cabinet_ministers_path
       "#whips"
     when reorder_ministerial_organisations_admin_cabinet_ministers_path

--- a/app/controllers/admin/cabinet_ministers_controller.rb
+++ b/app/controllers/admin/cabinet_ministers_controller.rb
@@ -36,6 +36,14 @@ class Admin::CabinetMinistersController < Admin::BaseController
     @roles = MinisterialRole.includes(:translations).whip.order(:whip_ordering)
   end
 
+  def order_whip_roles
+    params["ordering"].each do |id, ordering|
+      Role.find(id).update_column(:whip_ordering, ordering)
+    end
+
+    redirect_to admin_cabinet_ministers_path(anchor: "whips")
+  end
+
   def reorder_ministerial_organisations
     @organisations = Organisation.ministerial_departments.excluding_govuk_status_closed.order(:ministerial_ordering)
   end
@@ -58,8 +66,6 @@ private
     return "" if request.referer.blank?
 
     case URI(request.referer).path
-    when reorder_whip_roles_admin_cabinet_ministers_path
-      "#whips"
     when reorder_ministerial_organisations_admin_cabinet_ministers_path
       "#organisations"
     else

--- a/app/views/admin/cabinet_ministers/_reorder.html.erb
+++ b/app/views/admin/cabinet_ministers/_reorder.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_with url: admin_cabinet_ministers_path, method: :patch do %>
+    <%= form_with url: form_url, method: :patch do %>
       <%= render "govuk_publishing_components/components/hint", {
         text: "Use the up and down buttons to reorder attachments, or select and hold on an attachment to reorder using drag and drop.",
         margin_bottom: 4,

--- a/app/views/admin/cabinet_ministers/_reorder.html.erb
+++ b/app/views/admin/cabinet_ministers/_reorder.html.erb
@@ -9,7 +9,6 @@
       } %>
 
       <%= render "govuk_publishing_components/components/reorderable_list", {
-        input_name: name,
         items: list.map do |item|
           {
             id: item.id,

--- a/app/views/admin/cabinet_ministers/reorder_also_attends_cabinet_roles.html.erb
+++ b/app/views/admin/cabinet_ministers/reorder_also_attends_cabinet_roles.html.erb
@@ -1,4 +1,8 @@
 <% content_for :page_title, "Reorder also attends cabinet ordering" %>
 <% content_for :context, "Also attends cabinet ordering" %>
 
-<%= render "reorder", list: @roles, name: "roles[ordering]", form_url: admin_cabinet_ministers_path, cancel_path: "#{admin_cabinet_ministers_path}#also_attends_cabinet" %>
+<%= render "reorder",
+  list: @roles,
+  name: "ordering",
+  form_url: order_also_attends_cabinet_roles_admin_cabinet_ministers_path,
+  cancel_path: admin_cabinet_ministers_path(anchor: "also_attends_cabinet") %>

--- a/app/views/admin/cabinet_ministers/reorder_also_attends_cabinet_roles.html.erb
+++ b/app/views/admin/cabinet_ministers/reorder_also_attends_cabinet_roles.html.erb
@@ -1,4 +1,4 @@
 <% content_for :page_title, "Reorder also attends cabinet ordering" %>
 <% content_for :context, "Also attends cabinet ordering" %>
 
-<%= render "reorder", list: @roles, name: "roles[ordering]", cancel_path: "#{admin_cabinet_ministers_path}#also_attends_cabinet" %>
+<%= render "reorder", list: @roles, name: "roles[ordering]", form_url: admin_cabinet_ministers_path, cancel_path: "#{admin_cabinet_ministers_path}#also_attends_cabinet" %>

--- a/app/views/admin/cabinet_ministers/reorder_also_attends_cabinet_roles.html.erb
+++ b/app/views/admin/cabinet_ministers/reorder_also_attends_cabinet_roles.html.erb
@@ -3,6 +3,5 @@
 
 <%= render "reorder",
   list: @roles,
-  name: "ordering",
   form_url: order_also_attends_cabinet_roles_admin_cabinet_ministers_path,
   cancel_path: admin_cabinet_ministers_path(anchor: "also_attends_cabinet") %>

--- a/app/views/admin/cabinet_ministers/reorder_cabinet_minister_roles.html.erb
+++ b/app/views/admin/cabinet_ministers/reorder_cabinet_minister_roles.html.erb
@@ -1,4 +1,4 @@
 <% content_for :page_title, "Reorder Cabinet minister ordering" %>
 <% content_for :context, "Cabinet minister ordering" %>
 
-<%= render "reorder", list: @roles, name: "roles[ordering]", cancel_path: "#{admin_cabinet_ministers_path}#cabinet_minister" %>
+<%= render "reorder", list: @roles, name: "roles[ordering]", form_url: admin_cabinet_ministers_path, cancel_path: "#{admin_cabinet_ministers_path}#cabinet_minister" %>

--- a/app/views/admin/cabinet_ministers/reorder_cabinet_minister_roles.html.erb
+++ b/app/views/admin/cabinet_ministers/reorder_cabinet_minister_roles.html.erb
@@ -1,4 +1,8 @@
 <% content_for :page_title, "Reorder Cabinet minister ordering" %>
 <% content_for :context, "Cabinet minister ordering" %>
 
-<%= render "reorder", list: @roles, name: "roles[ordering]", form_url: admin_cabinet_ministers_path, cancel_path: "#{admin_cabinet_ministers_path}#cabinet_minister" %>
+<%= render "reorder",
+  list: @roles,
+  name: "ordering",
+  form_url: order_cabinet_minister_roles_admin_cabinet_ministers_path,
+  cancel_path: admin_cabinet_ministers_path(anchor: "cabinet_minister") %>

--- a/app/views/admin/cabinet_ministers/reorder_cabinet_minister_roles.html.erb
+++ b/app/views/admin/cabinet_ministers/reorder_cabinet_minister_roles.html.erb
@@ -3,6 +3,5 @@
 
 <%= render "reorder",
   list: @roles,
-  name: "ordering",
   form_url: order_cabinet_minister_roles_admin_cabinet_ministers_path,
   cancel_path: admin_cabinet_ministers_path(anchor: "cabinet_minister") %>

--- a/app/views/admin/cabinet_ministers/reorder_ministerial_organisations.html.erb
+++ b/app/views/admin/cabinet_ministers/reorder_ministerial_organisations.html.erb
@@ -1,4 +1,7 @@
-<% content_for :page_title, "Reorder Whip ordering" %>
-<% content_for :context, "Whip ordering" %>
+<% content_for :page_title, "Reorder Ministerial organisations ordering" %>
+<% content_for :context, "Ministerial organisations ordering" %>
 
-<%= render "reorder", list: @organisations, name: "organisation[ordering]", form_url: admin_cabinet_ministers_path, cancel_path: "#{admin_cabinet_ministers_path}#organisations" %>
+<%= render "reorder",
+  list: @organisations,
+  form_url: order_ministerial_organisations_admin_cabinet_ministers_path,
+  cancel_path: admin_cabinet_ministers_path(anchor: "organisations") %>

--- a/app/views/admin/cabinet_ministers/reorder_ministerial_organisations.html.erb
+++ b/app/views/admin/cabinet_ministers/reorder_ministerial_organisations.html.erb
@@ -1,4 +1,4 @@
 <% content_for :page_title, "Reorder Whip ordering" %>
 <% content_for :context, "Whip ordering" %>
 
-<%= render "reorder", list: @organisations, name: "organisation[ordering]", cancel_path: "#{admin_cabinet_ministers_path}#organisations" %>
+<%= render "reorder", list: @organisations, name: "organisation[ordering]", form_url: admin_cabinet_ministers_path, cancel_path: "#{admin_cabinet_ministers_path}#organisations" %>

--- a/app/views/admin/cabinet_ministers/reorder_whip_roles.html.erb
+++ b/app/views/admin/cabinet_ministers/reorder_whip_roles.html.erb
@@ -1,4 +1,7 @@
 <% content_for :page_title, "Reorder Whips ordering" %>
 <% content_for :context, "Whips ordering" %>
 
-<%= render "reorder", list: @roles, name: "whips[ordering]", form_url: admin_cabinet_ministers_path, cancel_path: "#{admin_cabinet_ministers_path}#whips" %>
+<%= render "reorder",
+  list: @roles,
+  form_url: order_cabinet_minister_roles_admin_cabinet_ministers_path,
+  cancel_path: admin_cabinet_ministers_path(anchor: "whips") %>

--- a/app/views/admin/cabinet_ministers/reorder_whip_roles.html.erb
+++ b/app/views/admin/cabinet_ministers/reorder_whip_roles.html.erb
@@ -1,4 +1,4 @@
 <% content_for :page_title, "Reorder Whips ordering" %>
 <% content_for :context, "Whips ordering" %>
 
-<%= render "reorder", list: @roles, name: "whips[ordering]", cancel_path: "#{admin_cabinet_ministers_path}#whips" %>
+<%= render "reorder", list: @roles, name: "whips[ordering]", form_url: admin_cabinet_ministers_path, cancel_path: "#{admin_cabinet_ministers_path}#whips" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -303,7 +303,7 @@ Whitehall::Application.routes.draw do
         get :confirm_destroy, on: :member
       end
 
-      resource :cabinet_ministers, only: %i[show update] do
+      resource :cabinet_ministers, only: %i[show] do
         get :reorder_cabinet_minister_roles
         patch :order_cabinet_minister_roles
 
@@ -314,6 +314,7 @@ Whitehall::Application.routes.draw do
         patch :order_whip_roles
 
         get :reorder_ministerial_organisations
+        patch :order_ministerial_organisations
       end
 
       resources :roles, except: [:show] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -305,6 +305,8 @@ Whitehall::Application.routes.draw do
 
       resource :cabinet_ministers, only: %i[show update] do
         get :reorder_cabinet_minister_roles
+        patch :order_cabinet_minister_roles
+
         get :reorder_also_attends_cabinet_roles
         get :reorder_whip_roles
         get :reorder_ministerial_organisations

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -304,10 +304,10 @@ Whitehall::Application.routes.draw do
       end
 
       resource :cabinet_ministers, only: %i[show update] do
-        get :reorder_cabinet_minister_roles, on: :member
-        get :reorder_also_attends_cabinet_roles, on: :member
-        get :reorder_whip_roles, on: :member
-        get :reorder_ministerial_organisations, on: :member
+        get :reorder_cabinet_minister_roles
+        get :reorder_also_attends_cabinet_roles
+        get :reorder_whip_roles
+        get :reorder_ministerial_organisations
       end
 
       resources :roles, except: [:show] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -311,6 +311,8 @@ Whitehall::Application.routes.draw do
         patch :order_also_attends_cabinet_roles
 
         get :reorder_whip_roles
+        patch :order_whip_roles
+
         get :reorder_ministerial_organisations
       end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -308,6 +308,8 @@ Whitehall::Application.routes.draw do
         patch :order_cabinet_minister_roles
 
         get :reorder_also_attends_cabinet_roles
+        patch :order_also_attends_cabinet_roles
+
         get :reorder_whip_roles
         get :reorder_ministerial_organisations
       end

--- a/features/cabinet-ministers.feature
+++ b/features/cabinet-ministers.feature
@@ -10,7 +10,7 @@ Feature: Reordering of Cabinet ministers and Organisations
     Given there are multiple Cabinet minister roles
     When I visit the Cabinet ministers order page
     And I click the reorder link in the "#cabinet_minister" tab
-    And I set the order of the roles for the "roles" ordering field to:
+    And I set the order of the roles to:
       | name   | order |
       | Role 2 | 0     |
       | Role 1 | 1     |
@@ -23,7 +23,7 @@ Feature: Reordering of Cabinet ministers and Organisations
     Given there are multiple Also attends cabinet roles
     When I visit the Cabinet ministers order page
     And I click the reorder link in the "#also_attends_cabinet" tab
-    And I set the order of the roles for the "roles" ordering field to:
+    And I set the order of the roles to:
       | name   | order |
       | Role 2 | 0     |
       | Role 1 | 1     |
@@ -36,7 +36,7 @@ Feature: Reordering of Cabinet ministers and Organisations
     Given there are multiple Whip roles
     When I visit the Cabinet ministers order page
     And I click the reorder link in the "#whips" tab
-    And I set the order of the roles for the "whips" ordering field to:
+    And I set the order of the roles to:
       | name   | order |
       | Role 2 | 0     |
       | Role 1 | 1     |
@@ -49,7 +49,7 @@ Feature: Reordering of Cabinet ministers and Organisations
     Given there are multiple organisations with ministerial ordering
     When I visit the Cabinet ministers order page
     And I click the reorder link in the "#organisations" tab
-    And I set the order of the organisations for the "organisation" ordering field to:
+    And I set the order of the organisations to:
       | name   | order |
       | Org 2 | 0     |
       | Org 1 | 1     |

--- a/features/step_definitions/cabinet_ministers_steps.rb
+++ b/features/step_definitions/cabinet_ministers_steps.rb
@@ -14,7 +14,7 @@ When(/^I click the reorder link in the "([^"]*)" tab$/) do |tab|
   end
 end
 
-And(/^I set the order of the (roles|organisations) for the "([^"]*)" ordering field to:$/) do |type, name, ordering|
+And(/^I set the order of the (roles|organisations) to:$/) do |type, ordering|
   ordering.hashes.each do |hash|
     model = if type == "roles"
               Role.find_by!(name: hash[:name])
@@ -22,7 +22,7 @@ And(/^I set the order of the (roles|organisations) for the "([^"]*)" ordering fi
               Organisation.find_by!(name: hash[:name])
             end
 
-    fill_in "#{name}[ordering][#{model.id}]", with: hash[:order]
+    fill_in "ordering[#{model.id}]", with: hash[:order]
   end
 
   click_button "Update order"

--- a/test/functional/admin/cabinet_ministers_controller_test.rb
+++ b/test/functional/admin/cabinet_ministers_controller_test.rb
@@ -60,23 +60,20 @@ class Admin::CabinetMinistersControllerTest < ActionController::TestCase
     assert_redirected_to admin_cabinet_ministers_path(anchor: "whips")
   end
 
-  test "should reorder ministerial organisations" do
-    @request.env["HTTP_REFERER"] = Plek.website_root + reorder_ministerial_organisations_admin_cabinet_ministers_path
+  test "PATCH :order_ministerial_organisations should reorder ministerial organisations" do
     org2 = create(:organisation)
     org1 = create(:organisation)
 
-    put :update,
+    put :order_ministerial_organisations,
         params: {
-          organisation: {
-            ordering: {
-              org1.id.to_s => 0,
-              org2.id.to_s => 1,
-            },
+          ordering: {
+            org1.id.to_s => 0,
+            org2.id.to_s => 1,
           },
         }
 
     assert_equal Organisation.order(:ministerial_ordering), [org1, org2]
-    assert_redirected_to "#{admin_cabinet_ministers_path}#organisations"
+    assert_redirected_to admin_cabinet_ministers_path(anchor: "organisations")
   end
 
   view_test "should list cabinet ministers and ministerial organisations in separate tabs, in the correct order, with reorder links" do

--- a/test/functional/admin/cabinet_ministers_controller_test.rb
+++ b/test/functional/admin/cabinet_ministers_controller_test.rb
@@ -40,27 +40,24 @@ class Admin::CabinetMinistersControllerTest < ActionController::TestCase
           }
 
     assert_equal MinisterialRole.also_attends_cabinet.order(:seniority), [role1, role2]
-    assert_redirected_to "#{admin_cabinet_ministers_path}#also_attends_cabinet"
+    assert_redirected_to admin_cabinet_ministers_path(anchor: "also_attends_cabinet")
   end
 
-  test "should reorder whips as part of the same request" do
-    @request.env["HTTP_REFERER"] = Plek.website_root + reorder_whip_roles_admin_cabinet_ministers_path
+  test "PATCH :order_whip_roles should reorder whips" do
     role2 = create(:ministerial_role, name: "Whip 1", whip_organisation_id: 2, organisations: [organisation])
     role1 = create(:ministerial_role, name: "Whip 2", whip_organisation_id: 2, organisations: [organisation])
 
-    put :update,
-        params: {
-          whips: {
+    patch :order_whip_roles,
+          params: {
             ordering: {
               role1.id.to_s => 0,
               role2.id.to_s => 1,
             },
-          },
-        }
+          }
 
-    assert_equal MinisterialRole.whip.order(:seniority).to_a, [role2, role1]
-    assert_equal MinisterialRole.whip.order(:whip_ordering).to_a, [role1, role2]
-    assert_redirected_to "#{admin_cabinet_ministers_path}#whips"
+    assert_equal MinisterialRole.whip.order(:seniority), [role2, role1]
+    assert_equal MinisterialRole.whip.order(:whip_ordering), [role1, role2]
+    assert_redirected_to admin_cabinet_ministers_path(anchor: "whips")
   end
 
   test "should reorder ministerial organisations" do

--- a/test/functional/admin/cabinet_ministers_controller_test.rb
+++ b/test/functional/admin/cabinet_ministers_controller_test.rb
@@ -11,23 +11,20 @@ class Admin::CabinetMinistersControllerTest < ActionController::TestCase
     @organisation ||= create(:organisation)
   end
 
-  test "should reorder ministerial roles" do
-    @request.env["HTTP_REFERER"] = Plek.website_root + reorder_cabinet_minister_roles_admin_cabinet_ministers_path
+  test "PATCH :order_cabinet_minister_roles should reorder ministerial roles" do
     role2 = create(:ministerial_role, name: "Non-Executive Director", cabinet_member: true, organisations: [organisation])
     role1 = create(:ministerial_role, name: "Prime Minister", cabinet_member: true, organisations: [organisation])
 
-    put :update,
-        params: {
-          roles: {
+    patch :order_cabinet_minister_roles,
+          params: {
             ordering: {
               role1.id.to_s => 0,
               role2.id.to_s => 1,
             },
-          },
-        }
+          }
 
-    assert_equal MinisterialRole.cabinet.order(:seniority).to_a, [role1, role2]
-    assert_redirected_to "#{admin_cabinet_ministers_path}#cabinet_minister"
+    assert_equal MinisterialRole.cabinet.order(:seniority), [role1, role2]
+    assert_redirected_to admin_cabinet_ministers_path(anchor: "cabinet_minister")
   end
 
   test "should reorder people who also attend cabinet" do

--- a/test/functional/admin/cabinet_ministers_controller_test.rb
+++ b/test/functional/admin/cabinet_ministers_controller_test.rb
@@ -27,22 +27,19 @@ class Admin::CabinetMinistersControllerTest < ActionController::TestCase
     assert_redirected_to admin_cabinet_ministers_path(anchor: "cabinet_minister")
   end
 
-  test "should reorder people who also attend cabinet" do
-    @request.env["HTTP_REFERER"] = Plek.website_root + reorder_also_attends_cabinet_roles_admin_cabinet_ministers_path
+  test "PATCH :order_also_attends_cabinet_roles should reorder people who also attend cabinet" do
     role2 = create(:ministerial_role, name: "Chief Whip and Parliamentary Secretary to the Treasury", attends_cabinet_type_id: 2, organisations: [organisation])
     role1 = create(:ministerial_role, name: "Minister without Portfolio", attends_cabinet_type_id: 1, organisations: [organisation])
 
-    put :update,
-        params: {
-          roles: {
+    patch :order_also_attends_cabinet_roles,
+          params: {
             ordering: {
               role1.id.to_s => 0,
               role2.id.to_s => 1,
             },
-          },
-        }
+          }
 
-    assert_equal MinisterialRole.also_attends_cabinet.order(:seniority).to_a, [role1, role2]
+    assert_equal MinisterialRole.also_attends_cabinet.order(:seniority), [role1, role2]
     assert_redirected_to "#{admin_cabinet_ministers_path}#also_attends_cabinet"
   end
 


### PR DESCRIPTION
## Description

This breaks out the CabinetMinistersController#update action into 4 separate endpoints which handle updating each of the 4 reorderable lists on the [cabinet ministers show page](https://whitehall-admin.integration.publishing.service.gov.uk/government/admin/cabinet_ministers#cabinet_minister).

Each of these have a separate page to reorder them, but currently share the same endpoint which handles updating them. Due to this there's a bunch of logic that figures out which reorder page has hit the endpoint and uses the referrer to constuct the anchor for the redirect. 

It's pretty hacky and quite tricky to parse. Separate endpoints which handle updating that specific subset of ministerial roles with are slightly more verbose seems preferable.

For now i've left a good amount of duplication in each update order actions. The next thing i'm working on is going to be a refactor for all the reorder endpoints. If i'm unable to refactor the logic from these controller actions elsewhere i'll consider a direct refactor of the endpoints.

## Trello card

https://trello.com/c/JoE5X6uD/2205-at-least-one-workflow-in-whitehall-relies-on-skipping-validations-as-some-organisations-are-known-to-be-invalid


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
