### PR TITLE
Fix caching for consultation response form data.

### DIFF
--- a/app/controllers/admin/consultations_controller.rb
+++ b/app/controllers/admin/consultations_controller.rb
@@ -14,8 +14,7 @@ private
     # but just does a simple attribute value overwrite (e.g. a normal
     # update). This is because consultation_participation objects are not
     # (yet) versioned with their editions like attachments are.
-    return unless edition_params[:consultation_participation_attributes] &&
-      edition_params[:consultation_participation_attributes][:consultation_response_form_attributes]
+    return unless edition_params.dig(:consultation_participation_attributes, :consultation_response_form_attributes)
 
     response_form_params = edition_params[:consultation_participation_attributes][:consultation_response_form_attributes]
 

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -5,6 +5,7 @@ class Admin::EditionsController < Admin::BaseController
   before_action :remove_blank_parameters
   before_action :clean_edition_parameters, only: %i[create update]
   before_action :clear_scheduled_publication_if_not_activated, only: %i[create update]
+  before_action :clear_response_form_file_cache, only: %i[create update]
   before_action :find_edition, only: %i[show edit update revise diff confirm_destroy destroy update_bypass_id update_image_display_option]
   before_action :prevent_modification_of_unmodifiable_edition, only: %i[edit update]
   before_action :delete_absent_edition_organisations, only: %i[create update]
@@ -458,6 +459,13 @@ private
         end
       end
       edition_params[:scheduled_publication] = nil
+    end
+  end
+
+  def clear_response_form_file_cache
+    response_form_params = edition_params.dig(:consultation_participation_attributes, :consultation_response_form_attributes, :consultation_response_form_data_attributes)
+    if response_form_params&.dig(:file).present? && response_form_params&.dig(:file_cache).present?
+      response_form_params.delete(:file_cache)
     end
   end
 


### PR DESCRIPTION
Scenario:
CREATE a consultation with a consultation response form(file-1) 
EDIT the consultation and replace the consultation response form (file-2) 
REMOVE title from the form to cause a validation error(or cause any validation error) 
REPLACE the consultation response form (file-3) and fix the validation error 
SAVE the consultation.
Given above steps currently it saves and renders file-2 whereas the last uploaded is file-3. this is due to caching file not being replaced by the actual final file. This fix is to allow to save file over cache-file if present. This fix is across Attachments and Images too.

[Trello](https://trello.com/c/dD8j8HqT/239-story-consultation-response-form-to-use-asset-ids)
