### PR TITLE
Transition Authors show page to the new design system

### DIFF
--- a/app/controllers/admin/authors_controller.rb
+++ b/app/controllers/admin/authors_controller.rb
@@ -1,4 +1,6 @@
 class Admin::AuthorsController < Admin::BaseController
+  layout "design_system"
+
   def show
     @user = User.find(params[:id])
   end

--- a/app/views/admin/authors/show.html.erb
+++ b/app/views/admin/authors/show.html.erb
@@ -1,3 +1,9 @@
-<% page_title "Contact details for #{@user.name}" %>
-<h1>Contact details for <%= @user.name %></h1>
-<p class="email"><%= mail_to @user.email %></p>
+<% content_for :page_title, "Contact details for #{@user.name}" %>
+<% content_for :title, "Contact details for #{@user.name}" %>
+<% content_for :title_margin_bottom, 6 %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <p><%= mail_to @user.email %></p>
+  </div>
+</div>

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -36,5 +36,5 @@ Then(/^I should see that I am logged in as a "([^"]*)"$/) do |role|
 end
 
 Then(/^I should see an email address "([^"]*)"$/) do |email_address|
-  expect(page).to have_selector(".email", text: email_address)
+  expect(page).to have_selector(".govuk-grid-column-two-thirds", text: email_address)
 end


### PR DESCRIPTION

https://trello.com/c/zlHNmCYX/636-transition-authors-page-to-new-design-system

New Contact Layout
<img width="1231" alt="image" src="https://github.com/alphagov/whitehall/assets/568730/50a34314-5b68-41ea-85d3-79b28e2ae079">

New Contact Layout if author has no email address
<img width="1224" alt="image" src="https://github.com/alphagov/whitehall/assets/568730/54945046-87fb-4f71-a4f9-e3a0e2493aba">

What it used to look like
<img width="1779" alt="image" src="https://github.com/alphagov/whitehall/assets/568730/da9f1f3f-fc16-4631-b9d7-70863a40431f">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
