### PR TITLE
Rename role appointments order column to ordering

### DIFF
--- a/app/controllers/admin/people_controller.rb
+++ b/app/controllers/admin/people_controller.rb
@@ -50,16 +50,16 @@ class Admin::PeopleController < Admin::BaseController
   end
 
   def reorder_role_appointments
-    @role_appointments = RoleAppointment.current.where(person_id: @person.id).order(:order)
+    @role_appointments = RoleAppointment.current.where(person_id: @person.id).order(:ordering)
   end
 
   def update_order_role_appointments
-    current_role_appointment_orders = @person.current_role_appointments.map(&:order)
+    current_role_appointment_orderings = @person.current_role_appointments.map(&:ordering)
 
     params[:ordering].each do |appointment_row|
-      id, order = appointment_row
+      id, ordering = appointment_row
       role_appointment = @person.role_appointments.find(id)
-      role_appointment.update!(order: current_role_appointment_orders[order.to_i - 1])
+      role_appointment.update!(ordering: current_role_appointment_orderings[ordering.to_i - 1])
     end
 
     flash[:notice] = "Role appointments reordered successfully"

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -1,9 +1,9 @@
 class Person < ApplicationRecord
   include PublishesToPublishingApi
 
-  has_many :role_appointments, -> { order(:order) }
+  has_many :role_appointments, -> { order(:ordering) }
   has_many :current_role_appointments,
-           -> { where(RoleAppointment::CURRENT_CONDITION).order(:order) },
+           -> { where(RoleAppointment::CURRENT_CONDITION).order(:ordering) },
            class_name: "RoleAppointment"
   has_many :speeches, through: :role_appointments
   has_many :news_articles, through: :role_appointments

--- a/app/models/role_appointment.rb
+++ b/app/models/role_appointment.rb
@@ -69,7 +69,7 @@ class RoleAppointment < ApplicationRecord
   scope :ascending_start_date, -> { order("started_at DESC") }
   scope :historic, -> { where.not(CURRENT_CONDITION) }
 
-  after_create :set_order
+  after_create :set_ordering
   after_create :make_other_current_appointments_non_current
   before_destroy :prevent_destruction_unless_destroyable
 
@@ -187,8 +187,8 @@ private
     end
   end
 
-  def set_order
-    update_column(:order, person.role_appointments.count)
+  def set_ordering
+    update_column(:ordering, person.role_appointments.count)
   end
 
   def prevent_destruction_unless_destroyable

--- a/app/presenters/publishing_api/role_appointment_presenter.rb
+++ b/app/presenters/publishing_api/role_appointment_presenter.rb
@@ -42,7 +42,7 @@ module PublishingApi
     def details
       {
         current: item.current?,
-        person_appointment_order: item.order,
+        person_appointment_order: item.ordering,
       }.tap do |details|
         details[:started_on] = item.started_at.rfc3339 if item.started_at.present?
         details[:ended_on] = item.ended_at.rfc3339 if item.ended_at.present?

--- a/db/migrate/20231127120936_change_role_appointments_order_column_name.rb
+++ b/db/migrate/20231127120936_change_role_appointments_order_column_name.rb
@@ -1,0 +1,5 @@
+class ChangeRoleAppointmentsOrderColumnName < ActiveRecord::Migration[7.0]
+  def change
+    rename_column :role_appointments, :order, :ordering
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_11_16_151726) do
+ActiveRecord::Schema[7.0].define(version: 2023_11_27_120936) do
   create_table "assets", charset: "utf8mb3", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.string "variant", null: false
@@ -873,7 +873,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_11_16_151726) do
     t.datetime "started_at", precision: nil
     t.datetime "ended_at", precision: nil
     t.string "content_id"
-    t.integer "order"
+    t.integer "ordering"
     t.index ["ended_at"], name: "index_role_appointments_on_ended_at"
     t.index ["person_id"], name: "index_role_appointments_on_person_id"
     t.index ["role_id"], name: "index_role_appointments_on_role_id"

--- a/test/functional/admin/people_controller_test.rb
+++ b/test/functional/admin/people_controller_test.rb
@@ -337,11 +337,11 @@ class Admin::PeopleControllerTest < ActionController::TestCase
       },
     }
 
-    assert_equal 1, role_appointment5.reload.order
-    assert_equal 2, role_appointment4.reload.order
-    assert_equal 3, role_appointment3.reload.order
-    assert_equal 4, role_appointment2.reload.order
-    assert_equal 5, role_appointment1.reload.order
+    assert_equal 1, role_appointment5.reload.ordering
+    assert_equal 2, role_appointment4.reload.ordering
+    assert_equal 3, role_appointment3.reload.ordering
+    assert_equal 4, role_appointment2.reload.ordering
+    assert_equal 5, role_appointment1.reload.ordering
     assert_redirected_to admin_person_url(person)
     assert_equal "Role appointments reordered successfully", flash[:notice]
   end

--- a/test/unit/app/models/role_appointment_test.rb
+++ b/test/unit/app/models/role_appointment_test.rb
@@ -410,8 +410,8 @@ class RoleAppointmentTest < ActiveSupport::TestCase
     role_appointment1 = create(:role_appointment, person:)
     role_appointment2 = create(:role_appointment, person:)
 
-    assert_equal 1, role_appointment1.reload.order
-    assert_equal 2, role_appointment2.reload.order
+    assert_equal 1, role_appointment1.reload.ordering
+    assert_equal 2, role_appointment2.reload.ordering
   end
 
   test "should send the prime ministers index page to publishing api when the role created is a past prime minister" do

--- a/test/unit/app/presenters/publishing_api/role_appointment_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/role_appointment_presenter_test.rb
@@ -33,7 +33,7 @@ class PublishingApi::RoleAppointmentPresenterTest < ActionView::TestCase
       details: {
         started_on: "2011-11-10T11:11:11+00:00",
         current: true,
-        person_appointment_order: role_appointment.order,
+        person_appointment_order: role_appointment.ordering,
       },
     }
     expected_links = {


### PR DESCRIPTION
## Description

There's an established pattern of using an `ordering` column to order associations for a model. This lives in a column on the has many 's table.

Role appointments is the only model which uses a column with a different name and uses an `order` column. This updates the column name to `ordering` and updates the code to use it.

I don't think we need to worry about reordering for this occuring while the migration is running as it's an admin only endpoint and is used extremely sparingly.

## Trello card

https://trello.com/c/JoE5X6uD/2205-at-least-one-workflow-in-whitehall-relies-on-skipping-validations-as-some-organisations-are-known-to-be-invalid

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
