### PR TITLE
Refactor has many associations to use extension with shared reorder! method

### DIFF
--- a/app/controllers/admin/document_collection_group_memberships_controller.rb
+++ b/app/controllers/admin/document_collection_group_memberships_controller.rb
@@ -44,9 +44,7 @@ class Admin::DocumentCollectionGroupMembershipsController < Admin::BaseControlle
   def reorder; end
 
   def order
-    params[:ordering].each do |membership_ids, ordering|
-      @group.memberships.find(membership_ids).update_column(:ordering, ordering)
-    end
+    @group.memberships.reorder!(order_params)
 
     flash_message = "Document has been reordered"
     redirect_to admin_document_collection_group_document_collection_group_memberships_path(@collection), notice: flash_message
@@ -72,5 +70,9 @@ private
       redirect_to admin_document_collection_groups_path(@collection),
                   alert: "We couldn't find a document titled '#{params[:title]}'"
     end
+  end
+
+  def order_params
+    params.require(:document_collection_group_memberships)["ordering"]
   end
 end

--- a/app/controllers/admin/document_collection_groups_controller.rb
+++ b/app/controllers/admin/document_collection_groups_controller.rb
@@ -42,9 +42,7 @@ class Admin::DocumentCollectionGroupsController < Admin::BaseController
   def reorder; end
 
   def order
-    params[:ordering].each do |group_id, ordering|
-      @collection.groups.find(group_id).update_column(:ordering, ordering)
-    end
+    @collection.groups.reorder!(order_params)
 
     flash_message = "Group has been reordered"
     redirect_to admin_document_collection_groups_path(@collection), notice: flash_message
@@ -73,5 +71,9 @@ private
 
   def document_collection_group_params
     params.require(:document_collection_group).permit(:body, :heading)
+  end
+
+  def order_params
+    params.require(:document_collection_groups)["ordering"]
   end
 end

--- a/app/controllers/admin/organisation_people_controller.rb
+++ b/app/controllers/admin/organisation_people_controller.rb
@@ -18,10 +18,7 @@ class Admin::OrganisationPeopleController < Admin::BaseController
   end
 
   def order
-    params[:ordering].each do |organisation_role_id, ordering|
-      @organisation.organisation_roles.find(organisation_role_id).update_column(:ordering, ordering)
-    end
-
+    @organisation.organisation_roles.reorder!(order_params)
     Whitehall::PublishingApi.republish_async(@organisation)
 
     redirect_to admin_organisation_people_path(@organisation), notice: "#{params[:type].capitalize.gsub('_', ' ')} roles re-ordered"
@@ -40,5 +37,9 @@ private
 
   def load_organisation
     @organisation = Organisation.friendly.find(params[:organisation_id])
+  end
+
+  def order_params
+    params.require(:organisation_people)["ordering"]
   end
 end

--- a/app/controllers/admin/people_controller.rb
+++ b/app/controllers/admin/people_controller.rb
@@ -55,12 +55,9 @@ class Admin::PeopleController < Admin::BaseController
 
   def update_order_role_appointments
     current_role_appointment_orderings = @person.current_role_appointments.map(&:ordering)
+    new_ordering = map_ordering_to_current_role_appointment_ordering_values(current_role_appointment_orderings)
 
-    params[:ordering].each do |appointment_row|
-      id, ordering = appointment_row
-      role_appointment = @person.role_appointments.find(id)
-      role_appointment.update!(ordering: current_role_appointment_orderings[ordering.to_i - 1])
-    end
+    @person.role_appointments.reorder!(new_ordering)
 
     flash[:notice] = "Role appointments reordered successfully"
     redirect_to admin_person_path(@person)
@@ -104,5 +101,15 @@ private
     if person_params.dig(:image_attributes, :file_cache).present? && person_params.dig(:image_attributes, :file).present?
       person_params[:image_attributes].delete(:file_cache)
     end
+  end
+
+  def map_ordering_to_current_role_appointment_ordering_values(current_role_appointment_orderings)
+    update_order_role_appointments_params.transform_values do |value|
+      current_role_appointment_orderings[value.to_i - 1]
+    end
+  end
+
+  def update_order_role_appointments_params
+    params.require(:role_appointments)["ordering"]
   end
 end

--- a/app/controllers/admin/promotional_features_controller.rb
+++ b/app/controllers/admin/promotional_features_controller.rb
@@ -53,7 +53,7 @@ class Admin::PromotionalFeaturesController < Admin::BaseController
   end
 
   def update_order
-    @organisation.reorder_promotional_features(params[:ordering])
+    @organisation.promotional_features.reorder!(ordering_params)
     Whitehall::PublishingApi.republish_async(@organisation)
     flash[:notice] = "Promotional features reordered successfully"
 
@@ -86,6 +86,10 @@ private
         { links_attributes: %i[url text _destroy] },
       ],
     )
+  end
+
+  def ordering_params
+    params.require(:promotional_features)["ordering"]
   end
 
   def clean_image_or_youtube_video_url_param

--- a/app/controllers/admin/topical_event_featurings_controller.rb
+++ b/app/controllers/admin/topical_event_featurings_controller.rb
@@ -43,10 +43,7 @@ class Admin::TopicalEventFeaturingsController < Admin::BaseController
   def reorder; end
 
   def order
-    params[:ordering].each do |topical_event_featuring_id, ordering|
-      @topical_event.topical_event_featurings.find(topical_event_featuring_id).update_column(:ordering, ordering)
-    end
-
+    @topical_event.topical_event_featurings.reorder_without_callbacks!(order_params)
     Whitehall::PublishingApi.republish_async(@topical_event)
 
     redirect_to polymorphic_path([:admin, @topical_event, :topical_event_featurings]), notice: "Featured items re-ordered"
@@ -105,5 +102,9 @@ private
       :offsite_link_id,
       image_attributes: %i[file],
     )
+  end
+
+  def order_params
+    params.require(:topical_event_featurings)["ordering"]
   end
 end

--- a/app/controllers/admin/topical_event_organisations_controller.rb
+++ b/app/controllers/admin/topical_event_organisations_controller.rb
@@ -6,9 +6,7 @@ class Admin::TopicalEventOrganisationsController < Admin::BaseController
   def reorder; end
 
   def order
-    params[:ordering].each do |topical_event_organisation_id, ordering|
-      @topical_event.topical_event_organisations.where(lead: true).find(topical_event_organisation_id).update_column(:lead_ordering, ordering)
-    end
+    @topical_event.topical_event_organisations.reorder_without_callbacks!(order_params, :lead_ordering)
 
     Whitehall::PublishingApi.republish_async(@topical_event)
 
@@ -31,5 +29,9 @@ private
 
   def load_topical_event
     @topical_event = TopicalEvent.find(params[:topical_event_id])
+  end
+
+  def order_params
+    params.require(:topical_event_lead_organisations)["ordering"]
   end
 end

--- a/app/models/document_collection.rb
+++ b/app/models/document_collection.rb
@@ -5,7 +5,10 @@ class DocumentCollection < Edition
   include Edition::TopicalEvents
 
   has_many :groups,
-           -> { order("document_collection_groups.ordering") },
+           lambda {
+             (extending UserOrderableExtension)
+             .order("document_collection_groups.ordering")
+           },
            class_name: "DocumentCollectionGroup",
            dependent: :destroy,
            inverse_of: :document_collection

--- a/app/models/document_collection_group.rb
+++ b/app/models/document_collection_group.rb
@@ -1,7 +1,10 @@
 class DocumentCollectionGroup < ApplicationRecord
   belongs_to :document_collection, inverse_of: :groups, touch: true
   has_many :memberships,
-           -> { order("document_collection_group_memberships.ordering") },
+           lambda {
+             (extending UserOrderableExtension)
+             .order("document_collection_group_memberships.ordering")
+           },
            class_name: "DocumentCollectionGroupMembership",
            inverse_of: :document_collection_group,
            dependent: :destroy

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -1,7 +1,10 @@
 class Person < ApplicationRecord
   include PublishesToPublishingApi
 
-  has_many :role_appointments, -> { order(:ordering) }
+  has_many :role_appointments,
+           lambda {
+             (extending UserOrderableExtension).order(:ordering)
+           }
   has_many :current_role_appointments,
            -> { where(RoleAppointment::CURRENT_CONDITION).order(:ordering) },
            class_name: "RoleAppointment"

--- a/app/models/topical_event.rb
+++ b/app/models/topical_event.rb
@@ -33,15 +33,16 @@ class TopicalEvent < ApplicationRecord
   has_many :offsite_links, as: :parent
   has_many :social_media_accounts, as: :socialable, dependent: :destroy
 
-  has_many :topical_event_organisations
+  has_many :topical_event_organisations, -> { extending UserOrderableExtension }
   has_many :organisations, through: :topical_event_organisations
 
   has_many :topical_event_featurings,
            lambda {
-             where("editions.state = 'published' or topical_event_featurings.edition_id is null")
-               .references(:edition)
-               .includes(edition: :translations)
-               .order("topical_event_featurings.ordering asc")
+             (extending UserOrderableExtension)
+              .where("editions.state = 'published' or topical_event_featurings.edition_id is null")
+                .references(:edition)
+                .includes(edition: :translations)
+                .order("topical_event_featurings.ordering asc")
            },
            foreign_key: :topical_event_id,
            inverse_of: :topical_event

--- a/app/models/user_orderable_extension.rb
+++ b/app/models/user_orderable_extension.rb
@@ -7,9 +7,9 @@ module UserOrderableExtension
     end
   end
 
-  def reorder!(new_order)
+  def reorder!(new_order, column = :ordering)
     new_order.each do |id, ordering|
-      find(id).update!(ordering:)
+      find(id).update!("#{column}": ordering)
     end
   end
 end

--- a/app/models/user_orderable_extension.rb
+++ b/app/models/user_orderable_extension.rb
@@ -1,0 +1,15 @@
+module UserOrderableExtension
+  def reorder_without_callbacks!(new_order, column = :ordering)
+    transaction do
+      new_order.each do |id, ordering|
+        find(id).update_column(column, ordering)
+      end
+    end
+  end
+
+  def reorder!(new_order)
+    new_order.each do |id, ordering|
+      find(id).update!(ordering:)
+    end
+  end
+end

--- a/app/views/admin/document_collection_group_memberships/reorder.html.erb
+++ b/app/views/admin/document_collection_group_memberships/reorder.html.erb
@@ -10,6 +10,7 @@
         margin_bottom: 4,
       } %>
       <%= render "govuk_publishing_components/components/reorderable_list", {
+        input_name: "document_collection_group_memberships[ordering]",
         items: @group.memberships.map do |membership|
           {
             id: membership.id,

--- a/app/views/admin/document_collection_groups/reorder.html.erb
+++ b/app/views/admin/document_collection_groups/reorder.html.erb
@@ -10,6 +10,7 @@
         margin_bottom: 4,
       } %>
       <%= render "govuk_publishing_components/components/reorderable_list", {
+        input_name: "document_collection_groups[ordering]",
         items: @collection.groups.map do |group|
           {
             id: group.id,

--- a/app/views/admin/organisation_people/reorder.html.erb
+++ b/app/views/admin/organisation_people/reorder.html.erb
@@ -13,6 +13,7 @@
       } %>
 
       <%= render "govuk_publishing_components/components/reorderable_list", {
+        input_name: "organisation_people[ordering]",
         items: @organisation_roles.map do |organisation_role|
           {
             id: organisation_role.id,

--- a/app/views/admin/people/reorder_role_appointments.html.erb
+++ b/app/views/admin/people/reorder_role_appointments.html.erb
@@ -8,6 +8,7 @@
     <% if @role_appointments.many? %>
       <%= form_for @person, url: update_order_role_appointments_admin_person_path(@person), method: :patch do |form| %>
         <%= render "govuk_publishing_components/components/reorderable_list", {
+          input_name: "role_appointments[ordering]",
           items: @role_appointments.map do |role_appointment|
             {
               id: role_appointment.id,

--- a/app/views/admin/promotional_features/reorder.html.erb
+++ b/app/views/admin/promotional_features/reorder.html.erb
@@ -6,6 +6,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_for @organisation, url: update_order_admin_organisation_promotional_features_path(@organisation), method: :patch do |form| %>
       <%= render "govuk_publishing_components/components/reorderable_list", {
+        input_name: "promotional_features[ordering]",
         items: @promotional_features.map do |promotional_feature|
           {
             id: promotional_feature.id,

--- a/app/views/admin/topical_event_featurings/reorder.html.erb
+++ b/app/views/admin/topical_event_featurings/reorder.html.erb
@@ -12,6 +12,7 @@
       } %>
 
       <%= render "govuk_publishing_components/components/reorderable_list", {
+        input_name: "topical_event_featurings[ordering]",
         items: @topical_event.topical_event_featurings.map do |featuring|
           {
             id: featuring.id,

--- a/app/views/admin/topical_event_organisations/reorder.html.erb
+++ b/app/views/admin/topical_event_organisations/reorder.html.erb
@@ -14,6 +14,7 @@
       <%= hidden_field_tag "lead", params[:lead] %>
 
       <%= render "govuk_publishing_components/components/reorderable_list", {
+        input_name: "topical_event_lead_organisations[ordering]",
         items: @topical_event.topical_event_organisations.where(lead: true).order(:lead_ordering).map do |topical_event_organisation|
           {
             id: topical_event_organisation.id,

--- a/features/step_definitions/document_collection_steps.rb
+++ b/features/step_definitions/document_collection_steps.rb
@@ -93,7 +93,7 @@ And(/^I set the order of "([^"]*)" groups to:$/) do |collection_title, order|
 
   order.hashes.each do |hash|
     group = collection.groups.select { |f| f.heading == hash[:name] }.first
-    fill_in "ordering[#{group.id}]", with: hash[:order]
+    fill_in "document_collection_groups[ordering][#{group.id}]", with: hash[:order]
   end
 
   click_button "Save"
@@ -107,7 +107,7 @@ And(/^within the "([^"]*)" "([^"]*)" I set the order of the documents to:$/) do 
       title = member.non_whitehall_link ? member.non_whitehall_link.title : member.document.latest_edition.title
       title == hash[:name]
     }.first.id
-    fill_in "ordering[#{member_id}]", with: hash[:order]
+    fill_in "document_collection_group_memberships[ordering][#{member_id}]", with: hash[:order]
   end
 
   click_button "Save"

--- a/features/step_definitions/organisation_steps.rb
+++ b/features/step_definitions/organisation_steps.rb
@@ -221,7 +221,7 @@ And(/^I set the order of roles for "([^"]*)" to:$/) do |organisation_name, role_
 
   role_order.hashes.each do |hash|
     organisation_role = organisation.organisation_roles.select { |f| f.role.name == hash[:name] }.first
-    fill_in "ordering[#{organisation_role.id}]", with: hash[:order]
+    fill_in "organisation_people[ordering][#{organisation_role.id}]", with: hash[:order]
   end
 
   click_button "Update order"

--- a/features/step_definitions/promotional_features_steps.rb
+++ b/features/step_definitions/promotional_features_steps.rb
@@ -132,7 +132,7 @@ When(/^I set the order of the promotional features to:$/) do |promotional_featur
 
   promotional_feature_order.hashes.each do |promotional_feature_info|
     promotional_feature = PromotionalFeature.find_by(title: promotional_feature_info[:title])
-    fill_in "ordering[#{promotional_feature.id}]", with: promotional_feature_info[:order]
+    fill_in "promotional_features[ordering][#{promotional_feature.id}]", with: promotional_feature_info[:order]
   end
   click_button "Save"
 end

--- a/features/step_definitions/topical_event_featurings_steps.rb
+++ b/features/step_definitions/topical_event_featurings_steps.rb
@@ -24,7 +24,7 @@ And(/^I set the order of the topical event featurings to:$/) do |featurings_orde
 
   featurings_order.hashes.each do |hash|
     featuring = @topical_event.topical_event_featurings.select { |f| f.title == hash[:title] }.first
-    fill_in "ordering[#{featuring.id}]", with: hash[:order]
+    fill_in "topical_event_featurings[ordering][#{featuring.id}]", with: hash[:order]
   end
 
   click_button "Update order"

--- a/features/step_definitions/topical_event_organisations_steps.rb
+++ b/features/step_definitions/topical_event_organisations_steps.rb
@@ -14,14 +14,14 @@ Then(/^I can see the (lead|supporting) organisation with the name "([^"]*)"$/) d
   end
 end
 
-And(/^I set the order of (lead|supporting) organisations to:$/) do |organisation_type, organisations_order|
-  within "##{organisation_type}_organisations" do
+And(/^I set the order of lead organisations to:$/) do |organisations_order|
+  within "#lead_organisations" do
     click_link "Reorder organisations"
   end
 
   organisations_order.hashes.each do |hash|
-    topical_event_organisation = @topical_event.topical_event_organisations.where(lead: organisation_type == "lead").select { |f| f.organisation.name == hash[:name] }.first
-    fill_in "ordering[#{topical_event_organisation.id}]", with: hash[:order]
+    topical_event_organisation = @topical_event.topical_event_organisations.where(lead: true).select { |f| f.organisation.name == hash[:name] }.first
+    fill_in "topical_event_lead_organisations[ordering][#{topical_event_organisation.id}]", with: hash[:order]
   end
 
   click_button "Update order"

--- a/test/functional/admin/organisation_people_controller_test.rb
+++ b/test/functional/admin/organisation_people_controller_test.rb
@@ -24,8 +24,10 @@ class Admin::OrganisationPeopleControllerTest < ActionController::TestCase
     put :order, params: {
       type: "ministerial",
       organisation_id: organisation,
-      ordering: {
-        organisation_role.id.to_s => "1",
+      organisation_people: {
+        ordering: {
+          organisation_role.id.to_s => "1",
+        },
       },
     }
     assert_response :forbidden
@@ -272,9 +274,11 @@ class Admin::OrganisationPeopleControllerTest < ActionController::TestCase
     put :order,
         params: {
           organisation_id: organisation,
-          ordering: {
-            organisation_junior_ministerial_role.id.to_s => "1",
-            organisation_senior_ministerial_role.id.to_s => "2",
+          organisation_people: {
+            ordering: {
+              organisation_junior_ministerial_role.id.to_s => "1",
+              organisation_senior_ministerial_role.id.to_s => "2",
+            },
           },
           type: "ministerial",
         }

--- a/test/functional/admin/people_controller_test.rb
+++ b/test/functional/admin/people_controller_test.rb
@@ -329,11 +329,13 @@ class Admin::PeopleControllerTest < ActionController::TestCase
 
     put :update_order_role_appointments, params: {
       id: person.id,
-      ordering: {
-        "#{role_appointment5.id}": "1",
-        "#{role_appointment4.id}": "2",
-        "#{role_appointment2.id}": "3",
-        "#{role_appointment1.id}": "4",
+      role_appointments: {
+        ordering: {
+          "#{role_appointment5.id}": "1",
+          "#{role_appointment4.id}": "2",
+          "#{role_appointment2.id}": "3",
+          "#{role_appointment1.id}": "4",
+        },
       },
     }
 

--- a/test/functional/admin/topical_event_featurings_controller_test.rb
+++ b/test/functional/admin/topical_event_featurings_controller_test.rb
@@ -86,10 +86,12 @@ class Admin::TopicalEventFeaturingsControllerTest < ActionController::TestCase
 
     put :order,
         params: { topical_event_id: @topical_event,
-                  ordering: {
-                    feature1.id.to_s => "1",
-                    feature2.id.to_s => "2",
-                    feature3.id.to_s => "0",
+                  topical_event_featurings: {
+                    ordering: {
+                      feature1.id.to_s => "1",
+                      feature2.id.to_s => "2",
+                      feature3.id.to_s => "0",
+                    },
                   } }
 
     assert_response :redirect

--- a/test/functional/admin/topical_event_organisations_controller_test.rb
+++ b/test/functional/admin/topical_event_organisations_controller_test.rb
@@ -74,10 +74,12 @@ class Admin::TopicalEventOrganisationsControllerTest < ActionController::TestCas
 
     put :order,
         params: { topical_event_id: @topical_event,
-                  ordering: {
-                    lead_topical_event_organisations[0].id.to_s => "1",
-                    lead_topical_event_organisations[1].id.to_s => "2",
-                    lead_topical_event_organisations[2].id.to_s => "0",
+                  topical_event_lead_organisations: {
+                    ordering: {
+                      lead_topical_event_organisations[0].id.to_s => "1",
+                      lead_topical_event_organisations[1].id.to_s => "2",
+                      lead_topical_event_organisations[2].id.to_s => "0",
+                    },
                   } }
 
     assert_response :redirect

--- a/test/unit/app/models/organisation_test.rb
+++ b/test/unit/app/models/organisation_test.rb
@@ -1090,31 +1090,6 @@ class OrganisationTest < ActiveSupport::TestCase
     organisation.update!(alternative_format_contact_email: "test@test.com")
   end
 
-  test "#reorder_promotional_features reorders a orgs promotional features ordering attribute" do
-    organisation = create(:organisation)
-
-    promotional_feature1 = create(:promotional_feature, organisation:, ordering: 1)
-    promotional_feature2 = create(:promotional_feature, organisation:, ordering: 2)
-    promotional_feature3 = create(:promotional_feature, organisation:, ordering: 4)
-    promotional_feature4 = create(:promotional_feature, organisation:, ordering: 5)
-
-    params = ActionController::Parameters.new({
-      ordering: {
-        "#{promotional_feature3.id}": "1",
-        "#{promotional_feature4.id}": "2",
-        "#{promotional_feature2.id}": "3",
-        "#{promotional_feature1.id}": "4",
-      },
-    })
-
-    organisation.reorder_promotional_features(params[:ordering])
-
-    assert_equal 1, promotional_feature3.reload.ordering
-    assert_equal 2, promotional_feature4.reload.ordering
-    assert_equal 4, promotional_feature2.reload.ordering
-    assert_equal 5, promotional_feature1.reload.ordering
-  end
-
   test "organisations have the correct path generated" do
     org = create(:organisation)
 

--- a/test/unit/app/models/user_orderable_extension_test.rb
+++ b/test/unit/app/models/user_orderable_extension_test.rb
@@ -1,0 +1,57 @@
+require "test_helper"
+
+class UserOrderableExtensionTest < ActiveSupport::TestCase
+  class StubActiveRecordAssociation
+    include UserOrderableExtension
+
+    def transaction
+      yield
+    end
+
+    def find; end
+  end
+
+  class StubModel
+    include ActiveModel::Model
+
+    attr_accessor :id, :ordering, :other_ordering_column
+
+    def update_column; end
+
+    def update!; end
+  end
+
+  setup do
+    @association = StubActiveRecordAssociation.new
+    @stub_model1 = StubModel.new(id: 1)
+    @stub_model2 = StubModel.new(id: 2)
+
+    @association.stubs(:find).with(@stub_model1.id).returns(@stub_model1)
+    @association.stubs(:find).with(@stub_model2.id).returns(@stub_model2)
+  end
+
+  test "#reorder_without_callbacks! reorders the ordering of the collection using #update_column based on the params passed in" do
+    @stub_model2.expects(:update_column).with(:ordering, "1").once
+    @stub_model1.expects(:update_column).with(:ordering, "2").once
+
+    @association.reorder_without_callbacks!(
+      {
+        @stub_model2.id => "1",
+        @stub_model1.id => "2",
+      },
+    )
+  end
+
+  test "#reorder_without_callbacks! handles a different attribute being passed in as an optional argument" do
+    @stub_model2.expects(:update_column).with(:lead_ordering, "1").once
+    @stub_model1.expects(:update_column).with(:lead_ordering, "2").once
+
+    @association.reorder_without_callbacks!(
+      {
+        @stub_model2.id => "1",
+        @stub_model1.id => "2",
+      },
+      :lead_ordering,
+    )
+  end
+end

--- a/test/unit/app/models/user_orderable_extension_test.rb
+++ b/test/unit/app/models/user_orderable_extension_test.rb
@@ -54,4 +54,29 @@ class UserOrderableExtensionTest < ActiveSupport::TestCase
       :lead_ordering,
     )
   end
+
+  test "#reorder! reorders the collection using #update! based on the params passed in" do
+    @stub_model2.expects(:update!).with(ordering: "1").once
+    @stub_model1.expects(:update!).with(ordering: "2").once
+
+    @association.reorder!(
+      {
+        @stub_model2.id => "1",
+        @stub_model1.id => "2",
+      },
+    )
+  end
+
+  test "#reorder! handles a different attribute being passed in as an optional argument" do
+    @stub_model2.expects(:update!).with(lead_ordering: "1").once
+    @stub_model1.expects(:update!).with(lead_ordering: "2").once
+
+    @association.reorder!(
+      {
+        @stub_model2.id => "1",
+        @stub_model1.id => "2",
+      },
+      :lead_ordering,
+    )
+  end
 end


### PR DESCRIPTION
## Description

We've got loads of reordering going on using params[:ordering] with heavy amounts of duplication.

This takes a first step at cleaning some of this up by adding an association extension which handles reordering the `ordering` column for the has_many associations.

It doesn't clean up the cabinet ministers controller duplication, which will come in a follow up PR 

There's quite a lot going on in this PR, i'm going to leave a few comments throughout on areas that i think could use some discussion.

## Trello card

https://trello.com/c/JoE5X6uD/2205-at-least-one-workflow-in-whitehall-relies-on-skipping-validations-as-some-organisations-are-known-to-be-invalid

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
