### PR TITLE
Spike out rendering readable errors when GovspeakLinkValidator blocks force publishing & force scheduling  

### DIFF
--- a/app/services/edition_publisher.rb
+++ b/app/services/edition_publisher.rb
@@ -10,7 +10,15 @@ class EditionPublisher < EditionService
 
     reasons = []
     reasons << "This edition is invalid: #{edition.errors.full_messages.to_sentence}" unless edition.valid?
-    reasons << "This edition contains links which violate linking guidelines" if govspeak_link_errors.any?
+    if govspeak_link_errors.any?
+      output = "This edition contains links which violate linking guidelines"
+      govspeak_link_errors.each do |error|
+        output << ("<p class='govuk-!-margin-top-4 govuk-!-margin-bottom-2'>Link: <a href='#{error[:link]}' class='govuk-link'>#{error[:link]}</a></p>" \
+          "<p>Fix: #{error[:fix]}</p>")
+      end
+
+      output
+    end
     reasons << "An edition that is #{edition.current_state} cannot be #{past_participle}" unless can_transition?
     reasons << "Scheduled editions cannot be published. This edition is scheduled for publication on #{edition.scheduled_publication}" if scheduled_for_publication?
 

--- a/app/services/edition_publisher.rb
+++ b/app/services/edition_publisher.rb
@@ -10,23 +10,15 @@ class EditionPublisher < EditionService
 
     reasons = []
     reasons << "This edition is invalid: #{edition.errors.full_messages.to_sentence}" unless edition.valid?
-    if govspeak_link_errors.any?
-      output = "This edition contains links which violate linking guidelines"
-      govspeak_link_errors.each do |error|
-        output << ("<p class='govuk-!-margin-top-4 govuk-!-margin-bottom-2'>Link: <a href='#{error[:link]}' class='govuk-link'>#{error[:link]}</a></p>" \
-          "<p>Fix: #{error[:fix]}</p>")
-      end
-
-      output
-    end
+    reasons << govspeak_link_validator.errors_to_html if govspeak_link_validator.errors.any?
     reasons << "An edition that is #{edition.current_state} cannot be #{past_participle}" unless can_transition?
     reasons << "Scheduled editions cannot be published. This edition is scheduled for publication on #{edition.scheduled_publication}" if scheduled_for_publication?
 
     @failure_reasons = reasons
   end
 
-  def govspeak_link_errors
-    @govspeak_link_errors ||= DataHygiene::GovspeakLinkValidator.new(edition.body).errors
+  def govspeak_link_validator
+    @govspeak_link_validator ||= DataHygiene::GovspeakLinkValidator.new(edition.body)
   end
 
   def verb

--- a/app/services/edition_scheduler.rb
+++ b/app/services/edition_scheduler.rb
@@ -18,14 +18,8 @@ class EditionScheduler < EditionService
                           "This edition does not have a scheduled publication date set"
                         elsif scheduled_publication_is_not_within_cache_limit?
                           "Scheduled publication date must be at least #{Whitehall.default_cache_max_age / 60} minutes from now"
-                        elsif govspeak_link_errors.any?
-                          output = "This edition contains links which violate linking guidelines"
-                          govspeak_link_errors.each do |error|
-                            output << ("<p class='govuk-!-margin-top-4 govuk-!-margin-bottom-2'>Link: <a href='#{error[:link]}' class='govuk-link'>#{error[:link]}</a></p>" \
-                              "<p>Fix: #{error[:fix]}</p>")
-                          end
-
-                          output
+                        elsif govspeak_link_validator.errors.any?
+                          govspeak_link_validator.errors_to_html
                         end
   end
 
@@ -40,7 +34,7 @@ private
     edition.scheduled_publication < Whitehall.default_cache_max_age.from_now
   end
 
-  def govspeak_link_errors
-    @govspeak_link_errors ||= DataHygiene::GovspeakLinkValidator.new(edition.body).errors
+  def govspeak_link_validator
+    @govspeak_link_validator ||= DataHygiene::GovspeakLinkValidator.new(edition.body)
   end
 end

--- a/app/views/admin/editions/show/_sidebar_notices.html.erb
+++ b/app/views/admin/editions/show/_sidebar_notices.html.erb
@@ -3,7 +3,7 @@
     <% if force_scheduler.can_transition? && !force_scheduler.can_perform? %>
       <%= render "components/inset_prompt", {
         title: "This edition cannot be scheduled",
-        description: "#{force_scheduler.failure_reason}",
+        description: sanitize(force_scheduler.failure_reason),
         error: true,
       } %>
     <% end %>

--- a/lib/data_hygiene/govspeak_link_validator.rb
+++ b/lib/data_hygiene/govspeak_link_validator.rb
@@ -12,14 +12,14 @@ module DataHygiene
 
         fix = if link.first == "/"
                 unless self.class.is_internal_admin_link?(link)
-                  "Please use either absolute paths for documents created in publisher, e.g. /government/admin/publications/3373, or full URLs for other GOV.UK links"
+                  "Please use either absolute paths for documents created in Whitehall, e.g. /government/admin/publications/3373, or full URLs for other GOV.UK links"
                 end
               elsif self.class.is_internal_admin_link?("/#{link}")
                 "This is an invalid admin link.  Did you mean /#{link} instead of #{link}?"
               elsif !%r{^(?:https?://|mailto:|#)}.match?(link)
                 "Non-document or external links should start with http://, https://, mailto:, or # (for linking to sections on the same page, eg #actions on a policy)"
               elsif link.match?(/whitehall-admin/)
-                "This links to the whitehall-admin domain. Please use paths, eg /government/admin/publications/3373, for documents created in publisher (see guidance on creating links) or full URLs for other GOV.UK links."
+                "This links to the whitehall-admin domain. Please use paths, eg /government/admin/publications/3373, for documents created in Whitehall (see guidance on creating links) or full URLs for other GOV.UK links."
               end
 
         { link:, start: match.begin(0), end: match.end(0), fix: } if fix

--- a/lib/data_hygiene/govspeak_link_validator.rb
+++ b/lib/data_hygiene/govspeak_link_validator.rb
@@ -28,12 +28,19 @@ module DataHygiene
 
     def errors_to_html
       output = "<p>This edition contains links which violate linking guidelines</p>"
+
+      output << "<ul class='gem-c-list govuk-list'>"
+
       errors.each do |error|
         output << (
+          "<li>" \
           "<p class='govuk-!-margin-top-4 govuk-!-margin-bottom-2'>Link: <a href='#{error[:link]}' class='govuk-link'>#{error[:link]}</a></p>" \
-          "<p>Fix: #{error[:fix]}</p>"
+          "<p>Fix: #{error[:fix]}</p>" \
+          "</li>"
         )
       end
+
+      output << "</ul>"
 
       output
     end

--- a/lib/data_hygiene/govspeak_link_validator.rb
+++ b/lib/data_hygiene/govspeak_link_validator.rb
@@ -26,6 +26,18 @@ module DataHygiene
       end
     end
 
+    def errors_to_html
+      output = "<p>This edition contains links which violate linking guidelines</p>"
+      errors.each do |error|
+        output << (
+          "<p class='govuk-!-margin-top-4 govuk-!-margin-bottom-2'>Link: <a href='#{error[:link]}' class='govuk-link'>#{error[:link]}</a></p>" \
+          "<p>Fix: #{error[:fix]}</p>"
+        )
+      end
+
+      output
+    end
+
     def self.is_internal_admin_link?(href)
       return false unless href.is_a? String
 

--- a/test/unit/app/services/edition_scheduler_test.rb
+++ b/test/unit/app/services/edition_scheduler_test.rb
@@ -55,6 +55,11 @@ class EditionSchedulerTest < ActiveSupport::TestCase
     scheduler = EditionScheduler.new(edition)
 
     assert_not scheduler.can_perform?
-    assert_equal "This edition contains links which violate linking guidelines", scheduler.failure_reason
+
+    expected_failure_reason = "This edition contains links which violate linking guidelines" \
+      "<p class='govuk-!-margin-top-4 govuk-!-margin-bottom-2'>Link: <a href='government/admin/editions/12324' class='govuk-link'>government/admin/editions/12324</a></p>" \
+      "<p>Fix: This is an invalid admin link.  Did you mean /government/admin/editions/12324 instead of government/admin/editions/12324?</p>"
+
+    assert_equal expected_failure_reason, scheduler.failure_reason
   end
 end

--- a/test/unit/app/services/edition_scheduler_test.rb
+++ b/test/unit/app/services/edition_scheduler_test.rb
@@ -56,7 +56,7 @@ class EditionSchedulerTest < ActiveSupport::TestCase
 
     assert_not scheduler.can_perform?
 
-    expected_failure_reason = "This edition contains links which violate linking guidelines" \
+    expected_failure_reason = "<p>This edition contains links which violate linking guidelines</p>" \
       "<p class='govuk-!-margin-top-4 govuk-!-margin-bottom-2'>Link: <a href='government/admin/editions/12324' class='govuk-link'>government/admin/editions/12324</a></p>" \
       "<p>Fix: This is an invalid admin link.  Did you mean /government/admin/editions/12324 instead of government/admin/editions/12324?</p>"
 

--- a/test/unit/app/services/edition_scheduler_test.rb
+++ b/test/unit/app/services/edition_scheduler_test.rb
@@ -57,8 +57,12 @@ class EditionSchedulerTest < ActiveSupport::TestCase
     assert_not scheduler.can_perform?
 
     expected_failure_reason = "<p>This edition contains links which violate linking guidelines</p>" \
+      "<ul class='gem-c-list govuk-list'>" \
+      "<li>" \
       "<p class='govuk-!-margin-top-4 govuk-!-margin-bottom-2'>Link: <a href='government/admin/editions/12324' class='govuk-link'>government/admin/editions/12324</a></p>" \
-      "<p>Fix: This is an invalid admin link.  Did you mean /government/admin/editions/12324 instead of government/admin/editions/12324?</p>"
+      "<p>Fix: This is an invalid admin link.  Did you mean /government/admin/editions/12324 instead of government/admin/editions/12324?</p>" \
+      "</li>" \
+      "</ul>"
 
     assert_equal expected_failure_reason, scheduler.failure_reason
   end

--- a/test/unit/lib/data_hygiene/govspeak_link_validator_test.rb
+++ b/test/unit/lib/data_hygiene/govspeak_link_validator_test.rb
@@ -63,4 +63,13 @@ class Edition::GovspeakLinkValidatorTest < ActiveSupport::TestCase
     validator = DataHygiene::GovspeakLinkValidator.new("[example text](#example-section)")
     assert_equal [], validator.errors
   end
+
+  test "#errors_to_html renders errors in a readable format" do
+    validator = DataHygiene::GovspeakLinkValidator.new("[example text](/government/policies)")
+    expected_output = "<p>This edition contains links which violate linking guidelines</p>" \
+      "<p class='govuk-!-margin-top-4 govuk-!-margin-bottom-2'>Link: <a href='/government/policies' class='govuk-link'>/government/policies</a></p>" \
+      "<p>Fix: Please use either absolute paths for documents created in publisher, e.g. /government/admin/publications/3373, or full URLs for other GOV.UK links</p>"
+
+    assert_equal expected_output, validator.errors_to_html
+  end
 end

--- a/test/unit/lib/data_hygiene/govspeak_link_validator_test.rb
+++ b/test/unit/lib/data_hygiene/govspeak_link_validator_test.rb
@@ -67,8 +67,12 @@ class Edition::GovspeakLinkValidatorTest < ActiveSupport::TestCase
   test "#errors_to_html renders errors in a readable format" do
     validator = DataHygiene::GovspeakLinkValidator.new("[example text](/government/policies)")
     expected_output = "<p>This edition contains links which violate linking guidelines</p>" \
+      "<ul class='gem-c-list govuk-list'>" \
+      "<li>" \
       "<p class='govuk-!-margin-top-4 govuk-!-margin-bottom-2'>Link: <a href='/government/policies' class='govuk-link'>/government/policies</a></p>" \
-      "<p>Fix: Please use either absolute paths for documents created in publisher, e.g. /government/admin/publications/3373, or full URLs for other GOV.UK links</p>"
+      "<p>Fix: Please use either absolute paths for documents created in publisher, e.g. /government/admin/publications/3373, or full URLs for other GOV.UK links</p>" \
+      "</li>" \
+      "</ul>"
 
     assert_equal expected_output, validator.errors_to_html
   end

--- a/test/unit/lib/data_hygiene/govspeak_link_validator_test.rb
+++ b/test/unit/lib/data_hygiene/govspeak_link_validator_test.rb
@@ -70,7 +70,7 @@ class Edition::GovspeakLinkValidatorTest < ActiveSupport::TestCase
       "<ul class='gem-c-list govuk-list'>" \
       "<li>" \
       "<p class='govuk-!-margin-top-4 govuk-!-margin-bottom-2'>Link: <a href='/government/policies' class='govuk-link'>/government/policies</a></p>" \
-      "<p>Fix: Please use either absolute paths for documents created in publisher, e.g. /government/admin/publications/3373, or full URLs for other GOV.UK links</p>" \
+      "<p>Fix: Please use either absolute paths for documents created in Whitehall, e.g. /government/admin/publications/3373, or full URLs for other GOV.UK links</p>" \
       "</li>" \
       "</ul>"
 


### PR DESCRIPTION
## Description

We've had a Zendesk ticket come through where a user was unable to force schedule a document for publication due to a link violating our guidelines. Overall the error message is pretty unhelpful 

![image](https://github.com/alphagov/whitehall/assets/42515961/b535aed0-35a9-48dc-b091-3d0394abc543)

The link which triggered the error in this instance is 

```
[Find out about call charges](/call-charges).
```

When the broken link checker runs it says this is a valid link (which it should) as it hits gov.uk/call-charges which returns a 200.

However, when we run our own validations against links in the body, it checks that external links (links to documents created outside of Whitehall, in this case Publisher) use the full URL.

So the user it told there are no broken links and are given no extra details on which link has violated linking guidelines and why.

We have details on which links have caused errors and potential fixes on the validator. This PR spikes out formatting and rendering these in a way that would be helpful to the user

## Implementation

I think the most complete implementation of this would probably be to add a view component which handles rendering the sidebar notices (all the information on why you can't publish a document). This would allow us to use the same pattern in presenting errors as we do in the broken links report.

The problem with that is we would be reliant on parsing the failure reasons from the updater and inferring when the failure is due to a violation of the linking guidance by doing something like 

```
failure_reason == "This edition contains links which violate linking guidelines"
```
which doesn't feel particularly great.

There's some other potential solutions. One of which i've added as the 3rd commit in this PR (i also don't really like this implementation)

I've opened this as a draft just to get some initial feedback. Eager to hear peoples thoughts on this.

## Screenshots

### Before

<img width="362" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/0eb656ba-b64f-46e0-80b1-1362c33f0de0">

<img width="308" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/70dba7ee-8559-475e-ae27-2b7ab5b759ed">


### After 


<img width="280" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/ef6347ae-2a73-4d26-888a-62677a2f8fd5">

<img width="330" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/7c2c2616-d411-4a38-9e2b-318a75162d81">




⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
