### PR TITLE
Republish prime ministers page when person is updated

### DIFF
--- a/app/controllers/admin/people_controller.rb
+++ b/app/controllers/admin/people_controller.rb
@@ -26,6 +26,7 @@ class Admin::PeopleController < Admin::BaseController
 
   def update
     if @person.update(person_params)
+      PresentPageToPublishingApiWorker.perform_async("PublishingApi::HistoricalAccountsIndexPresenter") if @person.current_or_previous_prime_minister?
       redirect_to [:admin, @person], notice: %("#{@person.name}" saved.)
     else
       render :edit

--- a/app/controllers/admin/people_controller.rb
+++ b/app/controllers/admin/people_controller.rb
@@ -26,7 +26,11 @@ class Admin::PeopleController < Admin::BaseController
 
   def update
     if @person.update(person_params)
-      PresentPageToPublishingApiWorker.perform_async("PublishingApi::HistoricalAccountsIndexPresenter") if @person.current_or_previous_prime_minister?
+      if @person.current_or_previous_prime_minister?
+        @person.historical_account.republish_to_publishing_api_async if @person.historical_account.present?
+        PresentPageToPublishingApiWorker.perform_async("PublishingApi::HistoricalAccountsIndexPresenter")
+      end
+
       redirect_to [:admin, @person], notice: %("#{@person.name}" saved.)
     else
       render :edit

--- a/test/functional/admin/people_controller_test.rb
+++ b/test/functional/admin/people_controller_test.rb
@@ -150,7 +150,6 @@ class Admin::PeopleControllerTest < ActionController::TestCase
     assert_equal "960x640_jpeg.jpg", person.reload.image.filename
   end
 
-
   test "PUT :update does not republish the past prime ministers page if the person has not been the prime minister" do
     person = create(:person)
 
@@ -166,9 +165,11 @@ class Admin::PeopleControllerTest < ActionController::TestCase
     end
   end
 
-  test "PUT :update republishes the past prime ministers page if the person is or has been the prime minister" do
+  test "PUT :update republishes the past prime ministers page & the persons historical account if the person is or has been the prime minister" do
     login_as :gds_admin
-    person = create(:pm)
+    historical_account = build(:historical_account)
+    person = create(:pm, historical_account:)
+
     service = mock
 
     PresentPageToPublishingApi
@@ -180,6 +181,11 @@ class Admin::PeopleControllerTest < ActionController::TestCase
     .expects(:publish)
     .once
     .with(PublishingApi::HistoricalAccountsIndexPresenter)
+
+    HistoricalAccount
+    .any_instance
+    .expects(:republish_to_publishing_api_async)
+    .once
 
     Sidekiq::Testing.inline! do
       put :update, params: {

--- a/test/functional/admin/people_controller_test.rb
+++ b/test/functional/admin/people_controller_test.rb
@@ -150,6 +150,45 @@ class Admin::PeopleControllerTest < ActionController::TestCase
     assert_equal "960x640_jpeg.jpg", person.reload.image.filename
   end
 
+
+  test "PUT :update does not republish the past prime ministers page if the person has not been the prime minister" do
+    person = create(:person)
+
+    PresentPageToPublishingApi
+    .expects(:new)
+    .never
+
+    Sidekiq::Testing.inline! do
+      put :update, params: {
+        id: person.id,
+        person: attributes_for(:person),
+      }
+    end
+  end
+
+  test "PUT :update republishes the past prime ministers page if the person is or has been the prime minister" do
+    login_as :gds_admin
+    person = create(:pm)
+    service = mock
+
+    PresentPageToPublishingApi
+    .expects(:new)
+    .once
+    .returns(service)
+
+    service
+    .expects(:publish)
+    .once
+    .with(PublishingApi::HistoricalAccountsIndexPresenter)
+
+    Sidekiq::Testing.inline! do
+      put :update, params: {
+        id: person.id,
+        person: attributes_for(:person),
+      }
+    end
+  end
+
   test "should be able to destroy a destroyable person" do
     person = create(:person, forename: "Dave")
     delete :destroy, params: { id: person.id }


### PR DESCRIPTION
## Description

We've had an issue on 2ndline where a GDS Content Designer has made updates to prime ministers names in Whitehall & expected these changes to be reflected in the [Past Prime Ministers page](https://www.gov.uk/government/history/past-prime-ministers) & the [historical account page ](https://www.gov.uk/government/history/past-prime-ministers/tony-blair)for the person.

To get these pages to republish downstream you would have to go into a historical account if one is present and click save.

If the person doesn't have a historical account like [Boris Johnson](https://whitehall-admin.integration.publishing.service.gov.uk/government/admin/people/boris-johnson/historical_accounts) then there's no way via the ui to republish the Past Prime Ministers page without finding someone who has a historical account and clicking save.

This is confusing behaviour.

This updates the people update action to republish the past prime ministers page & the persons historical account if they are currently or were previously the PM.



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
