### PR TITLE
Fix view link for historical accounts

### DIFF
--- a/app/views/admin/historical_accounts/index.html.erb
+++ b/app/views/admin/historical_accounts/index.html.erb
@@ -55,7 +55,7 @@
                   text: @historical_account.summary,
                 },
                 {
-                  text: link_to(sanitize("View #{tag.span(@historical_account.role.name, class: 'govuk-visually-hidden')}"), Whitehall.public_host + @historical_account.public_path, class: "govuk-link") +
+                  text: link_to(sanitize("View #{tag.span(@historical_account.role.name, class: 'govuk-visually-hidden')}"), @historical_account.public_url, class: "govuk-link") +
                     link_to(sanitize("Edit #{tag.span(@historical_account.role.name, class: 'govuk-visually-hidden')}"), edit_admin_person_historical_account_path(@person, @historical_account), class: "govuk-link govuk-!-margin-left-2") +
                     link_to(sanitize("Delete #{tag.span(@historical_account.role.name, class: 'govuk-visually-hidden')}"), confirm_destroy_admin_person_historical_account_path(@person, @historical_account), class: "govuk-link govuk-!-margin-left-2 gem-link--destructive"),
                 },

--- a/test/functional/admin/historical_accounts_controller_test.rb
+++ b/test/functional/admin/historical_accounts_controller_test.rb
@@ -8,19 +8,25 @@ class Admin::HistoricalAccountsControllerTest < ActionController::TestCase
   end
 
   test "GET on :index assigns the person, their historical accounts and renders the :index template" do
-    @historical_account = create(:historical_account, person: @person, role: @role)
+    historical_account = create(:historical_account, person: @person, role: @role)
     get :index, params: { person_id: @person }
 
     assert_response :success
     assert_template :index
     assert_equal @person, assigns(:person)
-    assert_equal @person.historical_account, assigns(:historical_account)
+    assert_equal historical_account, assigns(:historical_account)
   end
-  view_test "GET on :index should not show Create historical accounts button when historical account is already created" do
-    @historical_account = create(:historical_account, person: @person, role: @role)
+
+  view_test "GET on :index should display a historical account's details and prevent creation of a second historical account" do
+    create(:historic_role_appointment, person: @person, role: @role)
+    historical_account = create(:historical_account, person: @person, role: @role)
+
     get :index, params: { person_id: @person }
 
-    assert_select(".govuk-button", text: "Create historical account", count: 0)
+    assert_select ".govuk-table__cell a:nth-child(1)[href='#{historical_account.public_url}']", text: "View #{@role.name}"
+    assert_select ".govuk-table__cell a:nth-child(2)[href='#{edit_admin_person_historical_account_path(@person, historical_account)}']", text: "Edit #{@role.name}"
+    assert_select ".govuk-table__cell a:nth-child(3)[href='#{confirm_destroy_admin_person_historical_account_path(@person, historical_account)}']", text: "Delete #{@role.name}"
+    assert_select ".govuk-button", text: "Create historical account", count: 0
   end
 
   view_test "GET on :index should show Create historical accounts button when historical account is not created" do


### PR DESCRIPTION
## Description

At the moment, the view link for a historical document is broken. I suspect this was probably broken when rendering was pulled out of Whitehall, but it could well have been broken as part of transition.

## Screnshots

### Before

<img width="335" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/5c3f1d1c-f25f-429e-9a4d-6447d8b6fca9">

### After 

<img width="343" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/c1be7640-bab4-4489-ae40-c64907ed767a">

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
