### PR TITLE
Remove "tabs" from secondary nav aria labels

### DIFF
--- a/app/views/admin/attachments/index.html.erb
+++ b/app/views/admin/attachments/index.html.erb
@@ -9,7 +9,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render "components/secondary_navigation", {
-      aria_label: "Document navigation tabs",
+      aria_label: "Document navigation",
       items: secondary_navigation_tabs_items(attachment.attachable, request.path),
     } %>
 

--- a/app/views/admin/call_for_evidence_responses/show.html.erb
+++ b/app/views/admin/call_for_evidence_responses/show.html.erb
@@ -6,7 +6,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render "components/secondary_navigation", {
-      aria_label: "Document navigation tabs",
+      aria_label: "Document navigation",
       items: secondary_navigation_tabs_items(@edition, request.path),
     } %>
 

--- a/app/views/admin/consultation_responses/show.html.erb
+++ b/app/views/admin/consultation_responses/show.html.erb
@@ -6,7 +6,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render "components/secondary_navigation", {
-      aria_label: "Document navigation tabs",
+      aria_label: "Document navigation",
       items: secondary_navigation_tabs_items(@edition, request.path),
     } %>
 

--- a/app/views/admin/contacts/index.html.erb
+++ b/app/views/admin/contacts/index.html.erb
@@ -13,7 +13,7 @@
 </p>
 
 <%= render "components/secondary_navigation", {
-  aria_label: "Organisation navigation tabs",
+  aria_label: "Organisation navigation",
   items: secondary_navigation_tabs_items(@contactable, request.path),
 } %>
 

--- a/app/views/admin/corporate_information_pages/index.html.erb
+++ b/app/views/admin/corporate_information_pages/index.html.erb
@@ -11,7 +11,7 @@
 <p class="govuk-body"><%= view_on_website_link_for @organisation, class: "govuk-link" %></p>
 
 <%= render "components/secondary_navigation", {
-  aria_label: "Organisation navigation tabs",
+  aria_label: "Organisation navigation",
   items: secondary_navigation_tabs_items(@organisation, request.path),
 } %>
 

--- a/app/views/admin/corporate_information_pages/new.html.erb
+++ b/app/views/admin/corporate_information_pages/new.html.erb
@@ -5,7 +5,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render "components/secondary_navigation", {
-      aria_label: "Organisation navigation tabs",
+      aria_label: "Organisation navigation",
       items: secondary_navigation_tabs_items(@edition, request.path),
     } %>
 

--- a/app/views/admin/document_collection_email_subscriptions/edit.html.erb
+++ b/app/views/admin/document_collection_email_subscriptions/edit.html.erb
@@ -13,7 +13,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render "components/secondary_navigation", {
-      aria_label: "Document navigation tabs",
+      aria_label: "Document navigation",
       items: secondary_navigation_tabs_items(@collection, request.path),
     } %>
 

--- a/app/views/admin/document_collection_group_memberships/index.html.erb
+++ b/app/views/admin/document_collection_group_memberships/index.html.erb
@@ -19,7 +19,7 @@
     </p>
 
     <%= render "components/secondary_navigation", {
-      aria_label: "Document collection group navigation tabs",
+      aria_label: "Document collection group navigation",
       items: secondary_navigation_tabs_items(@group, request.path),
     } %>
 

--- a/app/views/admin/document_collection_groups/index.html.erb
+++ b/app/views/admin/document_collection_groups/index.html.erb
@@ -5,7 +5,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render "components/secondary_navigation", {
-      aria_label: "Document navigation tabs",
+      aria_label: "Document navigation",
       items: secondary_navigation_tabs_items(@collection, request.path),
     } %>
 

--- a/app/views/admin/document_collection_groups/show.html.erb
+++ b/app/views/admin/document_collection_groups/show.html.erb
@@ -15,7 +15,7 @@
     </p>
 
     <%= render "components/secondary_navigation", {
-      aria_label: "Document collection group navigation tabs",
+      aria_label: "Document collection group navigation",
       items: secondary_navigation_tabs_items(@group, request.path),
     } %>
 

--- a/app/views/admin/edition_images/index.html.erb
+++ b/app/views/admin/edition_images/index.html.erb
@@ -6,7 +6,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render "components/secondary_navigation", {
-      aria_label: "Document navigation tabs",
+      aria_label: "Document navigation",
       items: secondary_navigation_tabs_items(@edition, request.path),
     } %>
 

--- a/app/views/admin/editions/edit.html.erb
+++ b/app/views/admin/editions/edit.html.erb
@@ -26,7 +26,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <%= render "components/secondary_navigation", {
-        aria_label: "Document navigation tabs",
+        aria_label: "Document navigation",
         items: secondary_navigation_tabs_items(@edition, request.path),
       } %>
 

--- a/app/views/admin/editions/new.html.erb
+++ b/app/views/admin/editions/new.html.erb
@@ -5,7 +5,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render "components/secondary_navigation", {
-      aria_label: "Document navigation tabs",
+      aria_label: "Document navigation",
       items: secondary_navigation_tabs_items(@edition, request.path),
     } %>
 

--- a/app/views/admin/financial_reports/index.html.erb
+++ b/app/views/admin/financial_reports/index.html.erb
@@ -15,7 +15,7 @@
 </div>
 
 <%= render "components/secondary_navigation", {
-  aria_label: "Organisation navigation tabs",
+  aria_label: "Organisation navigation",
   items: secondary_navigation_tabs_items(@organisation, request.path),
 } %>
 

--- a/app/views/admin/historical_accounts/index.html.erb
+++ b/app/views/admin/historical_accounts/index.html.erb
@@ -21,7 +21,7 @@
     </p>
 
     <%= render "components/secondary_navigation", {
-     aria_label: "People navigation tabs",
+     aria_label: "People navigation",
      items: secondary_navigation_tabs_items(@person, request.path),
     } %>
 

--- a/app/views/admin/organisation_people/index.html.erb
+++ b/app/views/admin/organisation_people/index.html.erb
@@ -14,7 +14,7 @@
 
 <div class="govuk-!-margin-bottom-6">
   <%= render "components/secondary_navigation", {
-    aria_label: "Organisation navigation tabs",
+    aria_label: "Organisation navigation",
     items: secondary_navigation_tabs_items(@organisation, request.path),
   } %>
   <%= render "govuk_publishing_components/components/heading", {

--- a/app/views/admin/organisation_translations/index.html.erb
+++ b/app/views/admin/organisation_translations/index.html.erb
@@ -15,7 +15,7 @@
     </p>
 
     <%= render "components/secondary_navigation", {
-      aria_label: "Organisation navigation tabs",
+      aria_label: "Organisation navigation",
       items: secondary_navigation_tabs_items(@organisation, request.path),
     } %>
   </div>

--- a/app/views/admin/organisations/features.html.erb
+++ b/app/views/admin/organisations/features.html.erb
@@ -14,7 +14,7 @@
 
 <div class="govuk-!-margin-bottom-8">
   <%= render "components/secondary_navigation", {
-    aria_label: "Organisation navigation tabs",
+    aria_label: "Organisation navigation",
     items: secondary_navigation_tabs_items(@organisation, request.path),
   } %>
 </div>

--- a/app/views/admin/organisations/show.html.erb
+++ b/app/views/admin/organisations/show.html.erb
@@ -11,7 +11,7 @@
 <p class="govuk-body"><%= view_on_website_link_for @organisation, class: "govuk-link", target: "blank" %></p>
 
 <%= render "components/secondary_navigation", {
-  aria_label: "Organisation navigation tabs",
+  aria_label: "Organisation navigation",
   items: secondary_navigation_tabs_items(@organisation, request.path),
 } %>
 

--- a/app/views/admin/organisations_about/show.html.erb
+++ b/app/views/admin/organisations_about/show.html.erb
@@ -13,7 +13,7 @@
 </p>
 
 <%= render "components/secondary_navigation", {
-  aria_label: "Organisation navigation tabs",
+  aria_label: "Organisation navigation",
   items: secondary_navigation_tabs_items(@organisation, request.path),
 } %>
 

--- a/app/views/admin/people/show.html.erb
+++ b/app/views/admin/people/show.html.erb
@@ -19,7 +19,7 @@
     <p class="govuk-body"><%= view_on_website_link_for @person, class: "govuk-link", target: "blank" %></p>
 
     <%= render "components/secondary_navigation", {
-      aria_label: "People navigation tabs",
+      aria_label: "People navigation",
       items: secondary_navigation_tabs_items(@person, request.path),
     } %>
 

--- a/app/views/admin/person_translations/index.html.erb
+++ b/app/views/admin/person_translations/index.html.erb
@@ -21,7 +21,7 @@
     </p>
 
     <%= render "components/secondary_navigation", {
-      aria_label: "People navigation tabs",
+      aria_label: "People navigation",
       items: secondary_navigation_tabs_items(@person, request.path),
     } %>
 

--- a/app/views/admin/policy_groups/edit.html.erb
+++ b/app/views/admin/policy_groups/edit.html.erb
@@ -10,7 +10,7 @@
     } %>
 
     <%= render "components/secondary_navigation", {
-      aria_label: "Policy group navigation tabs",
+      aria_label: "Policy group navigation",
       items: secondary_navigation_tabs_items(@policy_group, request.path),
     } %>
 

--- a/app/views/admin/promotional_features/index.html.erb
+++ b/app/views/admin/promotional_features/index.html.erb
@@ -10,7 +10,7 @@
     </p>
 
     <%= render "components/secondary_navigation", {
-      aria_label: "Organisation navigation tabs",
+      aria_label: "Organisation navigation",
       items: secondary_navigation_tabs_items(@organisation, request.path),
     } %>
   </div>

--- a/app/views/admin/social_media_accounts/index.html.erb
+++ b/app/views/admin/social_media_accounts/index.html.erb
@@ -13,7 +13,7 @@
 </p>
 
 <%= render "components/secondary_navigation", {
-  aria_label: "Organisation navigation tabs",
+  aria_label: "Organisation navigation",
   items: secondary_navigation_tabs_items(@socialable, request.path),
 } %>
 

--- a/app/views/admin/world_location_news/features.html.erb
+++ b/app/views/admin/world_location_news/features.html.erb
@@ -14,7 +14,7 @@
 
 <div class="govuk-!-margin-bottom-8">
   <%= render "components/secondary_navigation", {
-    aria_label: "World location news navigation tabs",
+    aria_label: "World location news navigation",
     items: secondary_navigation_tabs_items(@world_location_news, request.path),
   } %>
 </div>

--- a/app/views/admin/world_location_news/show.html.erb
+++ b/app/views/admin/world_location_news/show.html.erb
@@ -14,7 +14,7 @@
       <%= link_to "View on website", @world_location_news.public_url(cachebust_url_options), class: "govuk-link", target: "_blank", rel: "noopener" %>
     </p>
     <%= render "components/secondary_navigation", {
-      aria_label: "World location news navigation tabs",
+      aria_label: "World location news navigation",
       items: secondary_navigation_tabs_items(@world_location_news, request.path),
     } %>
 

--- a/app/views/admin/world_location_news_translations/index.html.erb
+++ b/app/views/admin/world_location_news_translations/index.html.erb
@@ -16,7 +16,7 @@
       </p>
 
       <%= render "components/secondary_navigation", {
-        aria_label: "World location news navigation tabs",
+        aria_label: "World location news navigation",
         items: secondary_navigation_tabs_items(@world_location_news, request.path),
       } %>
 

--- a/app/views/admin/worldwide_offices/index.html.erb
+++ b/app/views/admin/worldwide_offices/index.html.erb
@@ -15,7 +15,7 @@
     </p>
 
     <%= render "components/secondary_navigation", {
-      aria_label: "Worldwide organisation navigation tabs",
+      aria_label: "Worldwide organisation navigation",
       items: secondary_navigation_tabs_items(@worldwide_organisation, request.path),
     } %>
   </div>

--- a/app/views/admin/worldwide_organisations/show.html.erb
+++ b/app/views/admin/worldwide_organisations/show.html.erb
@@ -15,7 +15,7 @@
     </p>
 
     <%= render "components/secondary_navigation", {
-      aria_label: "Worldwide organisation navigation tabs",
+      aria_label: "Worldwide organisation navigation",
       items: secondary_navigation_tabs_items(@worldwide_organisation, request.path),
     } %>
   </div>

--- a/app/views/admin/worldwide_organisations_about/show.html.erb
+++ b/app/views/admin/worldwide_organisations_about/show.html.erb
@@ -13,7 +13,7 @@
 </p>
 
 <%= render "components/secondary_navigation", {
-  aria_label: "Organisation navigation tabs",
+  aria_label: "Organisation navigation",
   items: secondary_navigation_tabs_items(@worldwide_organisation, request.path),
 } %>
 

--- a/app/views/admin/worldwide_organisations_history/index.html.erb
+++ b/app/views/admin/worldwide_organisations_history/index.html.erb
@@ -13,7 +13,7 @@
 </p>
 
 <%= render "components/secondary_navigation", {
-  aria_label: "Organisation navigation tabs",
+  aria_label: "Organisation navigation",
   items: secondary_navigation_tabs_items(@worldwide_organisation, request.path),
 } %>
 

--- a/app/views/admin/worldwide_organisations_translations/index.html.erb
+++ b/app/views/admin/worldwide_organisations_translations/index.html.erb
@@ -11,7 +11,7 @@
 <p class="govuk-body"><%= view_on_website_link_for @worldwide_organisation, class: "govuk-link" %></p>
 
 <%= render "components/secondary_navigation", {
-  aria_label: "Worldwide organisation navigation tabs",
+  aria_label: "Worldwide organisation navigation",
   items: secondary_navigation_tabs_items(@worldwide_organisation, request.path),
 } %>
 


### PR DESCRIPTION
A recent accessibility review of Whitehall raised a WCAG 2.1 level A failure for secondary navigation within Whitehall. Specifying an aria label using the word "tabs" implied that the secondary navigation links should behave as tabs, instead of as links, which could be confusing for non-sighted users.

Trello: https://trello.com/c/fdYHMbqp
