### PR TITLE
Further accessibility improvements to secondary navigation usage

### DIFF
--- a/app/views/admin/get_involved/index.html.erb
+++ b/app/views/admin/get_involved/index.html.erb
@@ -9,7 +9,7 @@
     </p>
 
     <%= render "components/secondary_navigation", {
-      aria_label: "Get involved tabs",
+      aria_label: "Get involved navigation",
       items: [
         {
           label: "Get involved",

--- a/app/views/admin/take_part_pages/index.html.erb
+++ b/app/views/admin/take_part_pages/index.html.erb
@@ -13,7 +13,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= render "components/secondary_navigation", {
-      aria_label: "Get involved tabs",
+      aria_label: "Get involved navigation",
       items: [
         {
           label: "Get involved",

--- a/app/views/admin/topical_event_about_pages/show.html.erb
+++ b/app/views/admin/topical_event_about_pages/show.html.erb
@@ -12,7 +12,7 @@
 
 <div class="govuk-!-margin-bottom-8">
   <%= render "components/secondary_navigation", {
-    aria_label: "Topical Events tabs",
+    aria_label: "Topical Events navigation",
     items: topical_event_nav_items(@topical_event, request.path),
   } %>
 </div>

--- a/app/views/admin/topical_event_featurings/index.html.erb
+++ b/app/views/admin/topical_event_featurings/index.html.erb
@@ -14,7 +14,7 @@
 
 <div class="govuk-!-margin-bottom-8">
   <%= render "components/secondary_navigation", {
-    aria_label: "Document tabs",
+    aria_label: "Document navigation",
     items: secondary_navigation_tabs_items(@topical_event, request.path),
   } %>
 </div>

--- a/app/views/admin/topical_event_organisations/index.html.erb
+++ b/app/views/admin/topical_event_organisations/index.html.erb
@@ -12,7 +12,7 @@
 
 <div class="govuk-!-margin-bottom-8">
   <%= render "components/secondary_navigation", {
-    aria_label: "Document tabs",
+    aria_label: "Document navigation",
     items: secondary_navigation_tabs_items(@topical_event, request.path),
   } %>
 </div>

--- a/app/views/admin/topical_events/show.html.erb
+++ b/app/views/admin/topical_events/show.html.erb
@@ -12,7 +12,7 @@
 
 <div class="govuk-!-margin-bottom-8">
   <%= render "components/secondary_navigation", {
-    aria_label: "Topical Events tabs",
+    aria_label: "Topical Events navigation",
     items: topical_event_nav_items(@topical_event, request.path),
   } %>
 </div>

--- a/app/views/components/docs/secondary_navigation.yml
+++ b/app/views/components/docs/secondary_navigation.yml
@@ -9,7 +9,7 @@ shared_accessibility_criteria:
 examples:
   default:
     data:
-      aria_label: Document tabs
+      aria_label: Document navigation
       items:
         - label: Document
           href: government/admin/editions/:id"


### PR DESCRIPTION
A recent accessibility audit of Whitehall returned a level A WCAG failure because navigation menus were labelled as "tabs" on some Whitehall pages. Elements labelled "tabs" should have tab-like behaviour, instead of menu link behaviour. We are therefore removing all mentions of "tabs" from secondary navigation aria labels.

Trello: https://trello.com/c/fdYHMbqp
