### PR TITLE
Copy yarn 4 config into Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,9 @@ ENV JWT_AUTH_SECRET=unused_yet_required
 WORKDIR $APP_HOME
 COPY Gemfile* .ruby-version ./
 RUN bundle install
-COPY package.json yarn.lock ./
-RUN yarn install --production --frozen-lockfile --non-interactive --link-duplicates
+COPY package.json yarn.lock .yarnrc.yml ./
+COPY .yarn/releases ./.yarn/releases
+RUN yarn workspaces focus --all --production
 COPY . .
 RUN bootsnap precompile --gemfile .
 RUN rails assets:precompile && rm -fr log


### PR DESCRIPTION
To use Yarn 4 the image must have the configuration file and the release file present. When they are not present the yarn install command fails during the Docker build because the --frozen-lockfile option prevents the Yarn 1 install from rewriting the lockfile to version 1 syntax (which we don't want anyway).

Apparently `yarn workspaces focus` is the new `yarn install -production` 🤷 : https://yarnpkg.com/migration/guide#renamed-commands
