### PR TITLE
Refactor factories to use filename method instead of hardcoded file name

### DIFF
--- a/app/models/image_data.rb
+++ b/app/models/image_data.rb
@@ -22,7 +22,7 @@ class ImageData < ApplicationRecord
   delegate :content_type, to: :file
 
   def filename
-    file.file.filename
+    file&.file&.filename
   end
 
   def auth_bypass_ids

--- a/test/factories/attachment_data.rb
+++ b/test/factories/attachment_data.rb
@@ -6,8 +6,8 @@ FactoryBot.define do
       content_type { AttachmentUploader::PDF_CONTENT_TYPE }
 
       after(:build) do |attachment_data|
-        attachment_data.assets << build(:asset, asset_manager_id: "asset_manager_id_original", variant: Asset.variants[:original], filename: "greenpaper.pdf")
-        attachment_data.assets << build(:asset, asset_manager_id: "asset_manager_id_thumbnail", variant: Asset.variants[:thumbnail], filename: "thumbnail_greenpaper.pdf.png")
+        attachment_data.assets << build(:asset, asset_manager_id: "asset_manager_id_original", variant: Asset.variants[:original], filename: attachment_data.filename)
+        attachment_data.assets << build(:asset, asset_manager_id: "asset_manager_id_thumbnail", variant: Asset.variants[:thumbnail], filename: "thumbnail_#{attachment_data.filename}.png")
       end
     end
 
@@ -15,7 +15,7 @@ FactoryBot.define do
       file { File.open(Rails.root.join("test/fixtures/sample.docx")) }
 
       after(:build) do |attachment_data|
-        attachment_data.assets << build(:asset, asset_manager_id: "asset_manager_id", variant: Asset.variants[:original], filename: "sample.docx")
+        attachment_data.assets << build(:asset, asset_manager_id: "asset_manager_id", variant: Asset.variants[:original], filename: attachment_data.filename)
       end
     end
 
@@ -23,7 +23,7 @@ FactoryBot.define do
       file { File.open(Rails.root.join("test/fixtures/sample.csv")) }
 
       after(:build) do |attachment_data|
-        attachment_data.assets << build(:asset, asset_manager_id: "asset_manager_id", variant: Asset.variants[:original], filename: "sample.csv")
+        attachment_data.assets << build(:asset, asset_manager_id: "asset_manager_id", variant: Asset.variants[:original], filename: attachment_data.filename)
       end
     end
   end

--- a/test/factories/call_for_evidence_response_form_data.rb
+++ b/test/factories/call_for_evidence_response_form_data.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     file { File.open(Rails.root.join("test/fixtures/two-pages.pdf")) }
 
     after(:build) do |call_for_evidence_response_form_data|
-      call_for_evidence_response_form_data.assets << build(:asset, asset_manager_id: "asset_manager_id_original", variant: Asset.variants[:original], filename: "two-pages.pdf")
+      call_for_evidence_response_form_data.assets << build(:asset, asset_manager_id: "asset_manager_id_original", variant: Asset.variants[:original], filename: call_for_evidence_response_form_data.filename)
     end
   end
 end

--- a/test/factories/consultation_response_form_data.rb
+++ b/test/factories/consultation_response_form_data.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     file { File.open(Rails.root.join("test/fixtures/two-pages.pdf")) }
 
     after(:build) do |consultation_response_form_data|
-      consultation_response_form_data.assets << build(:asset, asset_manager_id: "asset_manager_id_original", variant: Asset.variants[:original], filename: "two-pages.pdf")
+      consultation_response_form_data.assets << build(:asset, asset_manager_id: "asset_manager_id_original", variant: Asset.variants[:original], filename: consultation_response_form_data.filename)
     end
   end
 end

--- a/test/factories/image_data.rb
+++ b/test/factories/image_data.rb
@@ -4,13 +4,13 @@ FactoryBot.define do
 
     trait(:jpg) do
       after(:build) do |image_data|
-        image_data.assets << build(:asset, asset_manager_id: "asset_manager_id_original", variant: Asset.variants[:original], filename: "minister-of-funk.960x640.jpg")
-        image_data.assets << build(:asset, asset_manager_id: "asset_manager_id_s960", variant: Asset.variants[:s960], filename: "s960_minister-of-funk.960x640.jpg")
-        image_data.assets << build(:asset, asset_manager_id: "asset_manager_id_s712", variant: Asset.variants[:s712], filename: "s712_minister-of-funk.960x640.jpg")
-        image_data.assets << build(:asset, asset_manager_id: "asset_manager_id_s630", variant: Asset.variants[:s630], filename: "s630_minister-of-funk.960x640.jpg")
-        image_data.assets << build(:asset, asset_manager_id: "asset_manager_id_s465", variant: Asset.variants[:s465], filename: "s465_minister-of-funk.960x640.jpg")
-        image_data.assets << build(:asset, asset_manager_id: "asset_manager_id_s300", variant: Asset.variants[:s300], filename: "s300_minister-of-funk.960x640.jpg")
-        image_data.assets << build(:asset, asset_manager_id: "asset_manager_id_s216", variant: Asset.variants[:s216], filename: "s216_minister-of-funk.960x640.jpg")
+        image_data.assets << build(:asset, asset_manager_id: "asset_manager_id_original", variant: Asset.variants[:original], filename: image_data.filename)
+        image_data.assets << build(:asset, asset_manager_id: "asset_manager_id_s960", variant: Asset.variants[:s960], filename: "s960_#{image_data.filename}")
+        image_data.assets << build(:asset, asset_manager_id: "asset_manager_id_s712", variant: Asset.variants[:s712], filename: "s712_#{image_data.filename}")
+        image_data.assets << build(:asset, asset_manager_id: "asset_manager_id_s630", variant: Asset.variants[:s630], filename: "s630_#{image_data.filename}")
+        image_data.assets << build(:asset, asset_manager_id: "asset_manager_id_s465", variant: Asset.variants[:s465], filename: "s465_#{image_data.filename}")
+        image_data.assets << build(:asset, asset_manager_id: "asset_manager_id_s300", variant: Asset.variants[:s300], filename: "s300_#{image_data.filename}")
+        image_data.assets << build(:asset, asset_manager_id: "asset_manager_id_s216", variant: Asset.variants[:s216], filename: "s216_#{image_data.filename}")
       end
     end
 
@@ -18,7 +18,7 @@ FactoryBot.define do
       file { File.open(Rails.root.join("test/fixtures/images/test-svg.svg")) }
 
       after(:build) do |image_data|
-        image_data.assets << build(:asset, asset_manager_id: "asset_manager_id", variant: Asset.variants[:original], filename: "test-svg.svg")
+        image_data.assets << build(:asset, asset_manager_id: "asset_manager_id", variant: Asset.variants[:original], filename: image_data.filename)
       end
     end
   end

--- a/test/factories/organisations.rb
+++ b/test/factories/organisations.rb
@@ -16,7 +16,7 @@ FactoryBot.define do
       logo { image_fixture_file }
 
       after :build do |organisation|
-        organisation.assets.build(asset_manager_id: "logo_asset_manager_id", variant: Asset.variants[:original], filename: "960x640_jpeg.jpg")
+        organisation.assets.build(asset_manager_id: "logo_asset_manager_id", variant: Asset.variants[:original], filename: organisation.logo.file.filename)
       end
     end
 

--- a/test/factories/promotional_feature_items.rb
+++ b/test/factories/promotional_feature_items.rb
@@ -8,13 +8,16 @@ FactoryBot.define do
       image_alt_text { "Image alt text" }
 
       after :build do |item|
-        item.assets << build(:asset, asset_manager_id: "asset_manager_id_original", variant: Asset.variants[:original], filename: "minister-of-funk.960x640.jpg")
-        item.assets << build(:asset, asset_manager_id: "asset_manager_id_s960", variant: Asset.variants[:s960], filename: "s960_minister-of-funk.960x640.jpg")
-        item.assets << build(:asset, asset_manager_id: "asset_manager_id_s712", variant: Asset.variants[:s712], filename: "s712_minister-of-funk.960x640.jpg")
-        item.assets << build(:asset, asset_manager_id: "asset_manager_id_s630", variant: Asset.variants[:s630], filename: "s630_minister-of-funk.960x640.jpg")
-        item.assets << build(:asset, asset_manager_id: "asset_manager_id_s465", variant: Asset.variants[:s465], filename: "s465_minister-of-funk.960x640.jpg")
-        item.assets << build(:asset, asset_manager_id: "asset_manager_id_s300", variant: Asset.variants[:s300], filename: "s300_minister-of-funk.960x640.jpg")
-        item.assets << build(:asset, asset_manager_id: "asset_manager_id_s216", variant: Asset.variants[:s216], filename: "s216_minister-of-funk.960x640.jpg")
+        next if item.image.blank?
+
+        filename = item.image.file.filename
+        item.assets << build(:asset, asset_manager_id: "asset_manager_id_original", variant: Asset.variants[:original], filename:)
+        item.assets << build(:asset, asset_manager_id: "asset_manager_id_s960", variant: Asset.variants[:s960], filename: "s960_#{filename}")
+        item.assets << build(:asset, asset_manager_id: "asset_manager_id_s712", variant: Asset.variants[:s712], filename: "s712_#{filename}")
+        item.assets << build(:asset, asset_manager_id: "asset_manager_id_s630", variant: Asset.variants[:s630], filename: "s630_#{filename}")
+        item.assets << build(:asset, asset_manager_id: "asset_manager_id_s465", variant: Asset.variants[:s465], filename: "s465_#{filename}")
+        item.assets << build(:asset, asset_manager_id: "asset_manager_id_s300", variant: Asset.variants[:s300], filename: "s300_#{filename}")
+        item.assets << build(:asset, asset_manager_id: "asset_manager_id_s216", variant: Asset.variants[:s216], filename: "s216_#{filename}")
       end
     end
 

--- a/test/factories/topical_event_featuring_image_data.rb
+++ b/test/factories/topical_event_featuring_image_data.rb
@@ -3,13 +3,13 @@ FactoryBot.define do
     file { image_fixture_file }
 
     after(:build) do |topical_event_featuring_image_data|
-      topical_event_featuring_image_data.assets << build(:asset, asset_manager_id: "asset_manager_id_original", variant: Asset.variants[:original], filename: "minister-of-funk.960x640.jpg")
-      topical_event_featuring_image_data.assets << build(:asset, asset_manager_id: "asset_manager_id_s960", variant: Asset.variants[:s960], filename: "s960_minister-of-funk.960x640.jpg")
-      topical_event_featuring_image_data.assets << build(:asset, asset_manager_id: "asset_manager_id_s712", variant: Asset.variants[:s712], filename: "s712_minister-of-funk.960x640.jpg")
-      topical_event_featuring_image_data.assets << build(:asset, asset_manager_id: "asset_manager_id_s630", variant: Asset.variants[:s630], filename: "s630_minister-of-funk.960x640.jpg")
-      topical_event_featuring_image_data.assets << build(:asset, asset_manager_id: "asset_manager_id_s465", variant: Asset.variants[:s465], filename: "s465_minister-of-funk.960x640.jpg")
-      topical_event_featuring_image_data.assets << build(:asset, asset_manager_id: "asset_manager_id_s300", variant: Asset.variants[:s300], filename: "s300_minister-of-funk.960x640.jpg")
-      topical_event_featuring_image_data.assets << build(:asset, asset_manager_id: "asset_manager_id_s216", variant: Asset.variants[:s216], filename: "s216_minister-of-funk.960x640.jpg")
+      topical_event_featuring_image_data.assets << build(:asset, asset_manager_id: "asset_manager_id_original", variant: Asset.variants[:original], filename: topical_event_featuring_image_data.filename)
+      topical_event_featuring_image_data.assets << build(:asset, asset_manager_id: "asset_manager_id_s960", variant: Asset.variants[:s960], filename: "s960_#{topical_event_featuring_image_data.filename}")
+      topical_event_featuring_image_data.assets << build(:asset, asset_manager_id: "asset_manager_id_s712", variant: Asset.variants[:s712], filename: "s712_#{topical_event_featuring_image_data.filename}")
+      topical_event_featuring_image_data.assets << build(:asset, asset_manager_id: "asset_manager_id_s630", variant: Asset.variants[:s630], filename: "s630_#{topical_event_featuring_image_data.filename}")
+      topical_event_featuring_image_data.assets << build(:asset, asset_manager_id: "asset_manager_id_s465", variant: Asset.variants[:s465], filename: "s465_#{topical_event_featuring_image_data.filename}")
+      topical_event_featuring_image_data.assets << build(:asset, asset_manager_id: "asset_manager_id_s300", variant: Asset.variants[:s300], filename: "s300_#{topical_event_featuring_image_data.filename}")
+      topical_event_featuring_image_data.assets << build(:asset, asset_manager_id: "asset_manager_id_s216", variant: Asset.variants[:s216], filename: "s216_#{topical_event_featuring_image_data.filename}")
     end
   end
 end

--- a/test/unit/app/presenters/publishing_api/organisation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/organisation_presenter_test.rb
@@ -134,7 +134,7 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
     )
     presented_item = present(organisation)
 
-    expected_image_url = "#{Plek.asset_root}/media/logo_asset_manager_id/960x640_jpeg.jpg"
+    expected_image_url = "#{Plek.asset_root}/media/logo_asset_manager_id/minister-of-funk.960x640.jpg"
 
     assert_equal(
       {


### PR DESCRIPTION
Most classes that use assets implement a method called filename which shortens the call to get the filename from the carrierwave file. We can make use of this in the factories, rather than hardcode the filename based on the default file given in the factory.

This enables us to intuitively override the file in a factory - `build(:attachment_data, file: upload_fixture(...))` - whereas before the assets would have stayed hardcoded to the factory value, making certain test scenarios difficult to set up.

[Trello](https://trello.com/c/7LGYxXzv/264-factories-refactor-to-use-filename-in-asset-generation)