### PR TITLE
Create editionable worldwide org

### DIFF
--- a/app/controllers/admin/editionable_worldwide_organisations_controller.rb
+++ b/app/controllers/admin/editionable_worldwide_organisations_controller.rb
@@ -1,0 +1,7 @@
+class Admin::EditionableWorldwideOrganisationsController < Admin::EditionsController
+private
+
+  def edition_class
+    EditionableWorldwideOrganisation
+  end
+end

--- a/app/controllers/admin/new_document_controller.rb
+++ b/app/controllers/admin/new_document_controller.rb
@@ -24,6 +24,7 @@ private
       publication: new_admin_publication_path,
       speech: new_admin_speech_path,
       statistical_data_set: new_admin_statistical_data_set_path,
+      editionable_worldwide_organisation: new_admin_editionable_worldwide_organisation_path,
     }
     redirect_options[new_document_type]
   end

--- a/app/helpers/admin/new_document_helper.rb
+++ b/app/helpers/admin/new_document_helper.rb
@@ -10,6 +10,7 @@ module Admin::NewDocumentHelper
     CaseStudy,
     StatisticalDataSet,
     CallForEvidence,
+    EditionableWorldwideOrganisation,
   ].freeze
 
   def new_document_type_list
@@ -41,6 +42,7 @@ private
       publication: "Use this for standalone government documents, white papers, strategy documents, and reports.",
       speech: "Use this for speeches by ministers or other named spokespeople, and ministerial statements to Parliament.",
       statistical_data_set: "Use this for data that you publish monthly or more often without analysis.",
+      editionable_worldwide_organisation: "Use this for worldwide organisations.",
     }
     hint_text[new_document_type]
   end

--- a/app/models/editionable_worldwide_organisation.rb
+++ b/app/models/editionable_worldwide_organisation.rb
@@ -1,0 +1,7 @@
+class EditionableWorldwideOrganisation < Edition
+  include Edition::Organisations
+
+  def display_type_key
+    "editionable_worldwide_organisation"
+  end
+end

--- a/app/views/admin/editionable_worldwide_organisations/_form.html.erb
+++ b/app/views/admin/editionable_worldwide_organisations/_form.html.erb
@@ -1,0 +1,12 @@
+<%= standard_edition_form(edition) do |form| %>
+  <%= render "govuk_publishing_components/components/fieldset", {
+    legend_text: "Associations",
+    heading_level: 2,
+    heading_size: "l",
+    id: "associations",
+  } do %>
+    <div class="govuk-!-margin-bottom-4">
+      <%= render "organisation_fields", form: form, edition: edition %>
+    </div>
+  <% end %>
+<% end %>

--- a/config/features.rb
+++ b/config/features.rb
@@ -21,4 +21,5 @@ Flipflop.configure do
   #   default: true,
   #   description: "Take over the world."
   feature :document_hub, description: "Enables the document summary as a hub design"
+  feature :editionable_worldwide_organisations, description: "Enables editionable worldwide organisations", default: false
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -290,6 +290,7 @@ Whitehall::Application.routes.draw do
 
       resources :speeches, except: [:index]
       resources :statistical_data_sets, path: "statistical-data-sets", except: [:index]
+      resources :editionable_worldwide_organisations, path: "editionable-worldwide-organisations", except: [:index]
       resources :detailed_guides, path: "detailed-guides", except: [:index]
       resources :people do
         resources :translations, controller: "person_translations" do

--- a/lib/whitehall/authority/enforcer.rb
+++ b/lib/whitehall/authority/enforcer.rb
@@ -47,5 +47,6 @@ module Whitehall::Authority
     "Organisation" => Rules::OrganisationRules,
     "Government" => Rules::GovernmentRules,
     "StatisticsAnnouncement" => Rules::StatisticsAnnouncementRules,
+    "EditionableWorldwideOrganisation" => Rules::EditionableWorldwideOrganisationRules,
   }.freeze
 end

--- a/lib/whitehall/authority/rules/editionable_worldwide_organisation_rules.rb
+++ b/lib/whitehall/authority/rules/editionable_worldwide_organisation_rules.rb
@@ -1,0 +1,7 @@
+module Whitehall::Authority::Rules
+  EditionableWorldwideOrganisationRules = Struct.new(:actor, :subject) do
+    def can?(_action)
+      Flipflop.editionable_worldwide_organisations?
+    end
+  end
+end

--- a/test/factories/editionable_worldwide_organisations.rb
+++ b/test/factories/editionable_worldwide_organisations.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :editionable_worldwide_organisation, class: EditionableWorldwideOrganisation, parent: :edition_with_organisations do
+    title { "editionable-worldwide-organisation-title" }
+  end
+
+  factory :draft_editionable_worldwide_organisation, parent: :editionable_worldwide_organisation, traits: [:draft]
+end

--- a/test/functional/admin/editionable_worldwide_organisations_controller_test.rb
+++ b/test/functional/admin/editionable_worldwide_organisations_controller_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+
+class Admin::EditionableWorldwideOrganisationsControllerTest < ActionController::TestCase
+  setup do
+    feature_flags.switch! :editionable_worldwide_organisations, true
+    login_as :writer
+  end
+
+  should_be_an_admin_controller
+
+  should_allow_creating_of :editionable_worldwide_organisation
+  should_allow_editing_of :editionable_worldwide_organisation
+
+  test "actions are forbidden when the editionable_worldwide_organisations feature flag is disabled" do
+    feature_flags.switch! :editionable_worldwide_organisations, false
+    worldwide_organisation = create(:editionable_worldwide_organisation)
+
+    get :show, params: { id: worldwide_organisation.id }
+
+    assert_response :forbidden
+  end
+end

--- a/test/functional/admin/new_document_controller_test.rb
+++ b/test/functional/admin/new_document_controller_test.rb
@@ -42,6 +42,7 @@ class Admin::NewDocumentControllerTest < ActionController::TestCase
 
     refute_select ".govuk-radios__item input[type=radio][name=new_document_options][value=fatality_notice]"
   end
+
   view_test "GET #index renders Fatality Notice radio button when the user's organisation is Ministry of Defence" do
     mod_organisation = create(:organisation, name: "ministry-of-defence", handles_fatalities: true)
 
@@ -50,6 +51,22 @@ class Admin::NewDocumentControllerTest < ActionController::TestCase
     get :index
 
     assert_select ".govuk-radios__item input[type=radio][name=new_document_options][value=fatality_notice]", count: 1
+  end
+
+  view_test "GET #index renders Worldwide Organisation Edition when the editionable_worldwide_organisations feature flag is enabled" do
+    feature_flags.switch! :editionable_worldwide_organisations, true
+
+    get :index
+
+    assert_select ".govuk-radios__item input[type=radio][name=new_document_options][value=editionable_worldwide_organisation]", count: 1
+  end
+
+  view_test "GET #index does not render Worldwide Organisation Edition when the editionable_worldwide_organisations feature flag is not enabled" do
+    feature_flags.switch! :editionable_worldwide_organisations, false
+
+    get :index
+
+    refute_select ".govuk-radios__item input[type=radio][name=new_document_options][value=editionable_worldwide_organisation]"
   end
 
   test "POST #new_document_options_redirect redirects each radio buttons to their expected paths" do
@@ -97,6 +114,7 @@ private
       "publication": new_admin_publication_path,
       "speech": new_admin_speech_path,
       "statistical_data_set": new_admin_statistical_data_set_path,
+      "editionable_worldwide_organisation": new_admin_editionable_worldwide_organisation_path,
     }
   end
 end


### PR DESCRIPTION
https://trello.com/c/3WmL0sbs

### Add feature flag for editionable worldwide organisations

### Add basic editionable worldwide organisation
The existing worldwide organisation modelling presents various issues.
Worldwide organisations surface the main body of their content through an
associated corporate information about us page. Issues include:
- Draft pages don't update correctly #8358
- We redirect from the base path of the corporate information page back to the
  worldwide organisation #8037

We want to add new "editionable" worldwide organisations in order to improve
this area of Whitehall. The intention being that these eventually replace the
existing worldwide organisation models.

This adds the basic routes, model and controller actions. The actions are
behind a feature flag.

No publishing API presenter is configured yet.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
