### PR TITLE
Render "Upload an image" as a label

### DIFF
--- a/app/views/admin/edition_images/_image_upload.html.erb
+++ b/app/views/admin/edition_images/_image_upload.html.erb
@@ -1,13 +1,13 @@
-<%= render "govuk_publishing_components/components/heading", {
-  text: "Upload an image",
-  font_size: "l",
-} %>
-
 <%= form_tag(
   admin_edition_images_path(@edition),
   multipart: true,
 ) do %>
   <%= render "govuk_publishing_components/components/file_upload", {
+    label: {
+      text: "Upload an image",
+    },
+    heading_level: 2,
+    heading_size: "l",
     name: "image[image_data][file]",
     id: "edition_images_image_data_file",
     hint: raw('Images can be JPEG, PNG, SVG or GIF files. If you are uploading more than one image, <a class="govuk-link" href="https://www.gov.uk/guidance/how-to-publish-on-gov-uk/images-and-videos">read the image guidance</a> on using unique file names.'),


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What

Use the newly introduced heading size and level parameters for the file upload component to display the "Upload an image" label instead of rendering it as a heading.

## Why

This is needed for screenreader users and came up in a recent accessibility audit
https://trello.com/c/JFL2u0u0/2210-add-a-label-for-the-image-upload-input-element