### PR TITLE
Ux changes to images

### DIFF
--- a/app/components/admin/edition_images/image_component.html.erb
+++ b/app/components/admin/edition_images/image_component.html.erb
@@ -1,7 +1,8 @@
  <li class="govuk-grid-row">
   <div class="govuk-grid-column-one-third">
-    <img src="<%= image.url %>" alt="<%= preview_alt_text %>" class="app-view-edition-resource__preview">
-    <% unless image.image_data&.all_asset_variants_uploaded? %>
+    <% if image.image_data&.all_asset_variants_uploaded? %>
+      <img src="<%= image.url %>" alt="<%= preview_alt_text %>" class="app-view-edition-resource__preview">
+    <% else %>
       <span class="govuk-tag govuk-tag--green">Processing</span>
     <% end %>
   </div>

--- a/app/components/admin/edition_images/lead_image_component.html.erb
+++ b/app/components/admin/edition_images/lead_image_component.html.erb
@@ -14,8 +14,9 @@
   <div class="app-c-edition-images-lead-image-component__lead_image">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-one-third">
-        <img src="<%= lead_image.url %>" alt="Lead image" class="app-view-edition-resource__preview">
-        <% unless lead_image.image_data&.all_asset_variants_uploaded? %>
+        <% if lead_image.image_data&.all_asset_variants_uploaded? %>
+          <img src="<%= lead_image.url %>" alt="Lead image" class="app-view-edition-resource__preview">
+        <% else %>
           <span class="govuk-tag govuk-tag--green">Processing</span>
         <% end %>
       </div>

--- a/app/components/admin/organisations/show/summary_list_component.rb
+++ b/app/components/admin/organisations/show/summary_list_component.rb
@@ -89,7 +89,7 @@ private
 
     {
       field: "Default news image",
-      value: image_tag(organisation.default_news_image.file.url(:s300)),
+      value: organisation.default_news_image.all_asset_variants_uploaded? ? image_tag(organisation.default_news_image.file.url(:s300)) : tag.span("Processing", class: "govuk-tag govuk-tag--green"),
     }
   end
 

--- a/app/components/admin/worldwide_organisations/show/summary_list_component.rb
+++ b/app/components/admin/worldwide_organisations/show/summary_list_component.rb
@@ -89,7 +89,7 @@ private
 
     {
       field: "Default news image",
-      value: image_tag(worldwide_organisation.default_news_image.file.url(:s300)),
+      value: worldwide_organisation.default_news_image.all_asset_variants_uploaded? ? image_tag(worldwide_organisation.default_news_image.file.url(:s300)) : tag.span("Processing", class: "govuk-tag govuk-tag--green"),
     }
   end
 

--- a/app/controllers/admin/edition_images_controller.rb
+++ b/app/controllers/admin/edition_images_controller.rb
@@ -47,7 +47,10 @@ class Admin::EditionImagesController < Admin::BaseController
     end
   end
 
-  def edit; end
+  def edit
+    image = Image.find(params[:id])
+    flash.now.notice = "The image is being processed. Try refreshing the page." unless image&.image_data&.all_asset_variants_uploaded?
+  end
 
 private
 

--- a/app/controllers/admin/organisations_controller.rb
+++ b/app/controllers/admin/organisations_controller.rb
@@ -17,14 +17,18 @@ class Admin::OrganisationsController < Admin::BaseController
 
     if @organisation.save
       publish_services_and_information_page
-      redirect_to admin_organisations_path
+      redirect_to admin_organisations_path, notice: "Organisation created successfully."
     else
       build_dependencies
       render :new
     end
   end
 
-  def show; end
+  def show
+    if @organisation.default_news_image && !@organisation.default_news_image&.all_asset_variants_uploaded?
+      flash.now.notice = "#{flash[:notice]} The image is being processed. Try refreshing the page."
+    end
+  end
 
   def features
     @feature_list = @organisation.load_or_create_feature_list(params[:locale])
@@ -54,7 +58,7 @@ class Admin::OrganisationsController < Admin::BaseController
     delete_absent_topical_event_organisations
     if @organisation.update(organisation_params)
       publish_services_and_information_page
-      redirect_to admin_organisation_path(@organisation)
+      redirect_to admin_organisation_path(@organisation), notice: "Organisation updated successfully."
     else
       build_dependencies
       render :edit

--- a/app/controllers/admin/people_controller.rb
+++ b/app/controllers/admin/people_controller.rb
@@ -20,7 +20,11 @@ class Admin::PeopleController < Admin::BaseController
     end
   end
 
-  def show; end
+  def show
+    if @person.image && !@person.image&.all_asset_variants_uploaded?
+      flash.now.notice = "#{flash[:notice]} The image is being processed. Try refreshing the page."
+    end
+  end
 
   def edit; end
 

--- a/app/controllers/admin/promotional_features_controller.rb
+++ b/app/controllers/admin/promotional_features_controller.rb
@@ -25,7 +25,11 @@ class Admin::PromotionalFeaturesController < Admin::BaseController
     end
   end
 
-  def show; end
+  def show
+    if @promotional_feature.promotional_feature_items.select { |pfi| pfi.image.present? && !pfi.all_asset_variants_uploaded? }.any?
+      flash.now.notice = "#{flash[:notice]} The image is being processed. Try refreshing the page."
+    end
+  end
 
   def edit; end
 

--- a/app/controllers/admin/worldwide_organisations_controller.rb
+++ b/app/controllers/admin/worldwide_organisations_controller.rb
@@ -17,7 +17,7 @@ class Admin::WorldwideOrganisationsController < Admin::BaseController
 
   def create
     if @worldwide_organisation.update(worldwide_organisation_params)
-      redirect_to admin_worldwide_organisation_path(@worldwide_organisation), notice: "Organisation created successfully"
+      redirect_to admin_worldwide_organisation_path(@worldwide_organisation), notice: "Organisation created successfully."
     else
       @worldwide_organisation.build_default_news_image if @worldwide_organisation.default_news_image.blank?
       render :new
@@ -30,7 +30,7 @@ class Admin::WorldwideOrganisationsController < Admin::BaseController
 
   def update
     if @worldwide_organisation.update(worldwide_organisation_params)
-      redirect_to admin_worldwide_organisation_path(@worldwide_organisation), notice: "Organisation updated successfully"
+      redirect_to admin_worldwide_organisation_path(@worldwide_organisation), notice: "Organisation updated successfully."
     else
       @worldwide_organisation.build_default_news_image if @worldwide_organisation.default_news_image.blank?
       render :edit
@@ -42,6 +42,10 @@ class Admin::WorldwideOrganisationsController < Admin::BaseController
                   .versions_desc
                   .page(params[:page])
                   .per(VERSIONS_PER_PAGE)
+
+    if @worldwide_organisation.default_news_image && !@worldwide_organisation.default_news_image&.all_asset_variants_uploaded?
+      flash.now.notice = "#{flash[:notice]} The image is being processed. Try refreshing the page."
+    end
   end
 
   def choose_main_office; end

--- a/app/models/call_for_evidence_response_form_data.rb
+++ b/app/models/call_for_evidence_response_form_data.rb
@@ -17,10 +17,16 @@ class CallForEvidenceResponseFormData < ApplicationRecord
     asset_variants = assets.map(&:variant).map(&:to_sym)
     required_variants = [Asset.variants[:original].to_sym]
 
-    (required_variants - asset_variants).empty?
+    return false if (required_variants - asset_variants).any?
+
+    assets_match_updated_image_filename
   end
 
   def filename
     file.present? && file.file.filename
+  end
+
+  def assets_match_updated_image_filename
+    assets.reject { |asset| asset.filename.include?(carrierwave_file) }.empty?
   end
 end

--- a/app/models/consultation_response_form_data.rb
+++ b/app/models/consultation_response_form_data.rb
@@ -20,10 +20,16 @@ class ConsultationResponseFormData < ApplicationRecord
     asset_variants = assets.map(&:variant).map(&:to_sym)
     required_variants = [Asset.variants[:original].to_sym]
 
-    (required_variants - asset_variants).empty?
+    return false if (required_variants - asset_variants).any?
+
+    assets_match_updated_image_filename
   end
 
   def filename
     file.present? && file.file.filename
+  end
+
+  def assets_match_updated_image_filename
+    assets.reject { |asset| asset.filename.include?(carrierwave_file) }.empty?
   end
 end

--- a/app/models/featured_image_data.rb
+++ b/app/models/featured_image_data.rb
@@ -22,7 +22,9 @@ class FeaturedImageData < ApplicationRecord
     asset_variants = assets.map(&:variant).map(&:to_sym)
     required_variants = FeaturedImageUploader.versions.keys.push(:original)
 
-    (required_variants - asset_variants).empty?
+    return false if (required_variants - asset_variants).any?
+
+    assets_match_updated_image_filename
   end
 
   def republish_on_assets_ready
@@ -31,5 +33,11 @@ class FeaturedImageData < ApplicationRecord
       featured_imageable.republish_to_publishing_api_async if featured_imageable.respond_to? :republish_to_publishing_api_async
       featured_imageable.republish_dependent_documents if featured_imageable.respond_to? :republish_dependent_documents
     end
+  end
+
+private
+
+  def assets_match_updated_image_filename
+    assets.reject { |asset| asset.filename.include?(carrierwave_image) }.empty?
   end
 end

--- a/app/models/promotional_feature_item.rb
+++ b/app/models/promotional_feature_item.rb
@@ -41,7 +41,9 @@ class PromotionalFeatureItem < ApplicationRecord
     asset_variants = assets.map(&:variant).map(&:to_sym)
     required_variants = FeaturedImageUploader.versions.keys.push(:original)
 
-    (required_variants - asset_variants).empty?
+    return false if (required_variants - asset_variants).any?
+
+    assets_match_updated_image_filename
   end
 
   def republish_on_assets_ready
@@ -58,5 +60,9 @@ private
 
   def republish_organisation
     organisation.republish_to_publishing_api_async
+  end
+
+  def assets_match_updated_image_filename
+    assets.reject { |asset| asset.filename.include?(self[:image]) }.empty?
   end
 end

--- a/app/views/admin/edition_images/_image_information.html.erb
+++ b/app/views/admin/edition_images/_image_information.html.erb
@@ -1,6 +1,12 @@
 <section class="govuk-grid-column-one-third">
   <% if image.persisted? %>
-    <img src="<%= image.url %>" alt="Image preview" class="app-view-edition-resource__preview govuk-!-margin-bottom-4">
+    <% if image.image_data&.all_asset_variants_uploaded? %>
+      <img src="<%= image.url %>" alt="Image preview" class="app-view-edition-resource__preview govuk-!-margin-bottom-4">
+    <% else %>
+      <div class="govuk-!-margin-bottom-4">
+        <span class="govuk-tag govuk-tag--green">Processing</span>
+      </div>
+    <% end %>
   <% end %>
   <h2 class="govuk-heading-m">Image information</h2>
   <ul class="govuk-list">

--- a/app/views/admin/organisations/_form.html.erb
+++ b/app/views/admin/organisations/_form.html.erb
@@ -67,6 +67,7 @@
       image_src: organisation.logo.url,
       image_cache_name: "organisation[logo_cache]",
       image_cache: organisation.logo_cache.presence,
+      image_uploaded: organisation.all_asset_variants_uploaded?,
     } %>
   </div>
 
@@ -100,6 +101,7 @@
       image_src: organisation.default_news_image.url,
       image_cache_name: "organisation[default_news_image_attributes][file_cache]",
       image_cache: (organisation.default_news_image.file_cache.presence),
+      image_uploaded: organisation.default_news_image.all_asset_variants_uploaded?,
     } %>
   <% end %>
 

--- a/app/views/admin/people/_form.html.erb
+++ b/app/views/admin/people/_form.html.erb
@@ -71,6 +71,7 @@
       image_src: person.image.url,
       image_cache_name: "person[image_attributes][file_cache]",
       image_cache: person.image.file_cache.presence,
+      image_uploaded: person.image.all_asset_variants_uploaded?,
     } %>
   <% end %>
 

--- a/app/views/admin/people/show.html.erb
+++ b/app/views/admin/people/show.html.erb
@@ -51,7 +51,9 @@
           },
           {
             field: "Image",
-            value: (image_tag(@person.image.url(:s300)) + tag.span("Image present", class: "govuk-visually-hidden") if @person.image&.url),
+            value: if @person.image&.url
+                     @person.image.all_asset_variants_uploaded? ? (image_tag(@person.image.url(:s300)) + tag.span("Image present", class: "govuk-visually-hidden")) : tag.span("Processing", class: "govuk-tag govuk-tag--green")
+                   end,
           },
           {
             field: "Biography",

--- a/app/views/admin/promotional_feature_items/_form_fields.html.erb
+++ b/app/views/admin/promotional_feature_items/_form_fields.html.erb
@@ -53,6 +53,7 @@
         image_cache: form.object.image_cache.presence,
         image_src: form.object.image.url,
         image_alt: form.object.image_alt_text,
+        image_uploaded: form.object.all_asset_variants_uploaded?,
       }),
     },
     {

--- a/app/views/admin/promotional_feature_items/_promotional_feature_item.html.erb
+++ b/app/views/admin/promotional_feature_items/_promotional_feature_item.html.erb
@@ -34,7 +34,7 @@
         if promotional_feature_item.image.s300.url
           [{
              key: "Image",
-             value: image_tag(promotional_feature_item.image.s300.url),
+             value: promotional_feature_item.all_asset_variants_uploaded? ? image_tag(promotional_feature_item.image.s300.url) : tag.span("Processing", class: "govuk-tag govuk-tag--green"),
            }]
         end),
 

--- a/app/views/admin/take_part_pages/_form.html.erb
+++ b/app/views/admin/take_part_pages/_form.html.erb
@@ -64,6 +64,7 @@
           image_src: form.object.image.url,
           image_cache_name: "take_part_page[image_attributes][file_cache]",
           image_cache: (form.object.image.file_cache.presence),
+          image_uploaded: form.object.image.all_asset_variants_uploaded?,
         } %>
       <% end %>
 

--- a/app/views/admin/topical_events/_form.html.erb
+++ b/app/views/admin/topical_events/_form.html.erb
@@ -54,7 +54,8 @@
         image_src: topical_event.logo.url,
         image_alt: topical_event.logo_alt_text,
         image_cache_name: "topical_event[logo_attributes][file_cache]",
-        image_cache: (topical_event.logo.file_cache.presence),
+        image_cache: topical_event.logo.file_cache.presence,
+        image_uploaded: topical_event.logo.all_asset_variants_uploaded?,
       } %>
     <% end %>
   </div>

--- a/app/views/admin/worldwide_organisations/_form.html.erb
+++ b/app/views/admin/worldwide_organisations/_form.html.erb
@@ -75,7 +75,8 @@
       error_items: errors_for(worldwide_organisation.errors, :"default_news_image.file"),
       image_src: worldwide_organisation.default_news_image.url,
       image_cache_name: "worldwide_organisation[default_news_image_attributes][file_cache]",
-      image_cache: (worldwide_organisation.default_news_image.file_cache.presence),
+      image_cache: worldwide_organisation.default_news_image.file_cache.presence,
+      image_uploaded: worldwide_organisation.default_news_image.all_asset_variants_uploaded?,
     } %>
   <% end %>
 

--- a/app/views/components/_single_image_upload.html.erb
+++ b/app/views/components/_single_image_upload.html.erb
@@ -12,6 +12,7 @@
   image_id ||= "#{id}_image"
   image_cache_name ||= "#{name}[image_cache]"
   remove_alt_text_field ||= false
+  image_uploaded ||= false
 
   root_classes = %w(app-c-single-image-upload govuk-form-group)
 %>
@@ -40,7 +41,11 @@
     <% else %>
       <div class="govuk-grid-row app-c-single-image-upload__uploaded-image">
         <div class="govuk-grid-column-one-quarter">
-          <img src="<%= image_src %>" alt="" class="app-view-edition-resource__preview">
+          <% if image_uploaded %>
+            <img src="<%= image_src %>" alt="" class="app-view-edition-resource__preview">
+          <% else %>
+            <span class="govuk-tag govuk-tag--green">Processing</span>
+          <% end %>
         </div>
         <% unless remove_alt_text_field %>
           <div class="govuk-grid-column-three-quarters">

--- a/app/views/components/docs/single_image_upload.yml
+++ b/app/views/components/docs/single_image_upload.yml
@@ -41,20 +41,21 @@ examples:
     data:
       id: single-image-upload-with-image
       name: single-image-upload-with-image
-      image_src: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/promotional_feature_item/image/5/No10DoorAjar-2.jpg
+      image_src: https://assets.publishing.service.gov.uk/media/11aa22bbbbbb33cccccccccc/No10DoorAjar-2.jpg
       image_alt: Some optional text that describes the image
+      image_uploaded: True if all assets have finished uploading
   with_errors_on_page:
     data:
       id: single-image-upload-with-errors-on-page
       name: single-image-upload-with-errors-on-page
       image_alt: Some optional text that describes the image
       page_errors: true
-      image_src: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/promotional_feature_item/image/5/No10DoorAjar-2.jpg
+      image_src: https://assets.publishing.service.gov.uk/media/11aa22bbbbbb33cccccccccc/No10DoorAjar-2.jpg
       filename: No10DoorAjar-2.jpg,
       image_cache: 1686052895-990540429428995-0004-6416/No10DoorAjar-2.jpg
   with_no_alt_text_fields:
     data:
       id: single-image-upload-with-no-alt-text-field
       name: single-image-upload-with-no-alt-text-field
-      image_src: https://assets.publishing.service.gov.uk/government/uploads/system/uploads/promotional_feature_item/image/5/No10DoorAjar-2.jpg
+      image_src: https://assets.publishing.service.gov.uk/media/11aa22bbbbbb33cccccccccc/No10DoorAjar-2.jpg
       remove_alt_text_field: true

--- a/features/support/asset_manager_helper.rb
+++ b/features/support/asset_manager_helper.rb
@@ -1,10 +1,19 @@
 require_relative "mocha"
 
-Before do
-  asset_manager = stub_everything("asset-manager")
-  non_legacy_asset_details = { "id" => "http://asset-manager/assets/asset-id", "name" => "filename.pdf" }
-  asset_manager.stubs(:create_asset).returns(non_legacy_asset_details)
-  asset_manager.stubs(:asset).returns(non_legacy_asset_details)
+class MockAssetManager
+  def create_asset(*args)
+    { "id" => "http://asset-manager/assets/#{SecureRandom.uuid}", "name" => File.basename(args[0][:file]) }
+  end
 
-  Services.stubs(:asset_manager).returns(asset_manager)
+  def asset(id)
+    { "id" => "http://asset-manager/asset/#{id}", "name" => "filename.pdf" }
+  end
+
+  def delete_asset(*_args); end
+
+  def update_asset(*_args); end
+end
+
+Before do
+  Services.stubs(:asset_manager).returns(MockAssetManager.new)
 end

--- a/test/components/admin/edition_images/image_component_test.rb
+++ b/test/components/admin/edition_images/image_component_test.rb
@@ -6,7 +6,7 @@ class Admin::EditionImages::ImageComponentTest < ViewComponent::TestCase
   include Rails.application.routes.url_helpers
 
   test "renders the correct default fields" do
-    image = build_stubbed(:image, caption: "caption", alt_text: "alt text")
+    image = build_stubbed(:image, image_data: build(:image_data), caption: "caption", alt_text: "alt text")
     edition = build_stubbed(:draft_publication, images: [image])
     render_inline(Admin::EditionImages::ImageComponent.new(edition:, image:, last_image: false))
 
@@ -77,12 +77,13 @@ class Admin::EditionImages::ImageComponentTest < ViewComponent::TestCase
     assert_selector "input[value='!!3']"
   end
 
-  test "renders a processing tag if the lead image if all assets aren't uploaded" do
+  test "renders a processing tag if not all lead image assets are uploaded" do
     image = build_stubbed(:image, image_data: build_stubbed(:image_data_with_no_assets))
     edition = build_stubbed(:draft_news_article, images: [image])
 
     render_inline(Admin::EditionImages::ImageComponent.new(edition:, image:, last_image: false))
 
+    assert_selector ".app-view-edition-resource__preview", count: 0
     assert_selector ".govuk-tag", text: "Processing"
   end
 

--- a/test/components/admin/edition_images/lead_image_component_test.rb
+++ b/test/components/admin/edition_images/lead_image_component_test.rb
@@ -35,7 +35,7 @@ class Admin::EditionImages::LeadImageComponentTest < ViewComponent::TestCase
   end
 
   test "renders the correct default fields when a lead image is present" do
-    image = build_stubbed(:image, caption: "caption", alt_text: "alt text")
+    image = build_stubbed(:image, image_data: build(:image_data), caption: "caption", alt_text: "alt text")
     edition = build_stubbed(:draft_news_article, images: [image], lead_image: image)
     render_inline(Admin::EditionImages::LeadImageComponent.new(edition:))
 
@@ -55,12 +55,13 @@ class Admin::EditionImages::LeadImageComponentTest < ViewComponent::TestCase
     assert_selector ".govuk-grid-row .govuk-grid-column-two-thirds .govuk-body:nth-child(2)", text: "Alt text: None"
   end
 
-  test "renders a processing tag if the lead image if all assets aren't uploaded" do
+  test "renders a processing tag if not all lead image assets are uploaded" do
     image = build_stubbed(:image, image_data: build_stubbed(:image_data_with_no_assets))
     edition = build_stubbed(:draft_news_article, images: [image], lead_image: image)
 
     render_inline(Admin::EditionImages::LeadImageComponent.new(edition:))
 
+    assert_selector ".app-view-edition-resource__preview", count: 0
     assert_selector ".govuk-tag", text: "Processing"
   end
 

--- a/test/components/admin/edition_images/uploaded_images_component_test.rb
+++ b/test/components/admin/edition_images/uploaded_images_component_test.rb
@@ -4,7 +4,7 @@ require "test_helper"
 
 class Admin::EditionImages::UploadedImagesComponentTest < ViewComponent::TestCase
   test "renders correctly for case studies" do
-    images = [build_stubbed(:image), build_stubbed(:image)]
+    images = [build_stubbed(:image, image_data: build(:image_data)), build_stubbed(:image, image_data: build(:image_data))]
     edition = build_stubbed(:draft_case_study, images:, lead_image: images.first)
     render_inline(Admin::EditionImages::UploadedImagesComponent.new(edition:))
 
@@ -14,7 +14,7 @@ class Admin::EditionImages::UploadedImagesComponentTest < ViewComponent::TestCas
   end
 
   test "renders correctly for publications" do
-    images = [build_stubbed(:image), build_stubbed(:image)]
+    images = [build_stubbed(:image, image_data: build(:image_data)), build_stubbed(:image, image_data: build(:image_data))]
     edition = build_stubbed(:draft_publication, images:)
     render_inline(Admin::EditionImages::UploadedImagesComponent.new(edition:))
 

--- a/test/components/admin/organisations/show/summary_list_component_test.rb
+++ b/test/components/admin/organisations/show/summary_list_component_test.rb
@@ -65,7 +65,7 @@ class Admin::Organisations::Show::SummaryListComponentTest < ViewComponent::Test
   end
 
   test "renders default news image row if the organisation has a default news image" do
-    news_image = build_stubbed(:featured_image_data)
+    news_image = build(:featured_image_data)
     organisation = build_stubbed(:ministerial_department, default_news_image: news_image)
 
     render_inline(Admin::Organisations::Show::SummaryListComponent.new(organisation:))

--- a/test/components/admin/worldwide_organisations/show/summary_list_component_test.rb
+++ b/test/components/admin/worldwide_organisations/show/summary_list_component_test.rb
@@ -18,7 +18,7 @@ class Admin::WorldwideOrganisations::Show::SummaryListComponentTest < ViewCompon
   test "renders the correct items when all fields are completed and only 1 world location & sponsoring organisation" do
     world_location = build_stubbed(:world_location)
     sponsoring_organisation = build_stubbed(:organisation)
-    news_image = build_stubbed(:featured_image_data)
+    news_image = build(:featured_image_data)
     worldwide_organisation = build_stubbed(
       :worldwide_organisation,
       logo_formatted_name: "Optional log formatted name",

--- a/test/factories/worldwide_organisations.rb
+++ b/test/factories/worldwide_organisations.rb
@@ -39,6 +39,7 @@ FactoryBot.define do
         worldwide_organisation.world_locations << FactoryBot.create(:world_location)
       end
     end
+
     trait(:with_default_news_image) do
       after :build do |organisation|
         organisation.default_news_image = build(:featured_image_data)

--- a/test/functional/admin/edition_images_controller_test.rb
+++ b/test/functional/admin/edition_images_controller_test.rb
@@ -1,49 +1,47 @@
 require "test_helper"
 
-class Admin::EditionImagesControllerTest < ActionDispatch::IntegrationTest
-  extend Minitest::Spec::DSL
-
+class Admin::EditionImagesControllerTest < ActionController::TestCase
   test "forbids unauthorised users from viewing the images index endpoint" do
     edition = create(:draft_publication)
     user = create(:world_editor)
     login_as user
-    get admin_edition_images_path(edition.id)
-    assert_equal 403, status
+    get :index, params: { edition_id: edition.id }
+    assert_equal 403, response.status
   end
 
-  test "edit page displays alt text input for images with alt text" do
+  view_test "edit page displays alt text input for images with alt text" do
     login_authorised_user
-    images = [build(:image)]
-    edition = create(:draft_publication, images:)
-    get edit_admin_edition_image_path(edition, images[0])
+    image = build(:image)
+    edition = create(:draft_publication, images: [image])
+    get :edit, params: { edition_id: edition.id, id: image.id }
     assert_select "#image_alt_text"
   end
 
-  test "edit page shows image if all its assets are uploaded" do
+  view_test "edit page shows image if all its assets are uploaded" do
     login_authorised_user
     image = build(:image)
     edition = create(:draft_publication, images: [image])
 
-    get edit_admin_edition_image_path(edition, image)
+    get :edit, params: { edition_id: edition.id, id: image.id }
 
     assert_select "img:match('src',?)", /media\/asset_manager_id_original\/minister-of-funk.960x640.jpg/, count: 1
   end
 
-  test "edit page shows processing label if some of the image assets haven't finished processing" do
+  view_test "edit page shows processing label if some of the image assets haven't finished processing" do
     login_authorised_user
     image = build(:image_with_no_assets)
     edition = create(:draft_publication, images: [image])
 
-    get edit_admin_edition_image_path(edition, image)
+    get :edit, params: { edition_id: edition.id, id: image.id }
 
     assert_select "span[class='govuk-tag govuk-tag--green']", text: "Processing", count: 1
   end
 
-  test "edit page does not display alt text input where it is blank" do
+  view_test "edit page does not display alt text input where it is blank" do
     login_authorised_user
-    images = [build(:image, alt_text: "")]
-    edition = create(:draft_publication, images:)
-    get edit_admin_edition_image_path(edition, images[0])
+    image = build(:image, alt_text: "")
+    edition = create(:draft_publication, images: [image])
+    get :edit, params: { edition_id: edition.id, id: image.id }
     assert_select "#image_alt_text", count: 0
   end
 
@@ -54,10 +52,9 @@ class Admin::EditionImagesControllerTest < ActionDispatch::IntegrationTest
     file = upload_fixture("images/960x640_jpeg.jpg")
     PublishingApiDocumentRepublishingWorker.expects(:perform_async).with(edition.document_id).once
 
-    post admin_edition_images_path(edition), params: { image: { image_data: { file: } } }
+    post :create, params: { edition_id: edition.id, image: { image_data: { file: } } }
 
-    follow_redirect!
-    assert_equal edit_admin_edition_image_path(edition, edition.images.last), path
+    assert_redirected_to edit_admin_edition_image_path(edition, edition.images.last)
   end
 
   test "#create updates the lead_image association if edition can have a custom lead image" do
@@ -65,17 +62,17 @@ class Admin::EditionImagesControllerTest < ActionDispatch::IntegrationTest
     edition = create(:news_article)
 
     file = upload_fixture("images/960x640_jpeg.jpg")
-    post admin_edition_images_path(edition), params: { image: { image_data: { file: } } }
+    post :create, params: { edition_id: edition.id, image: { image_data: { file: } } }
 
     assert_equal "960x640_jpeg.jpg", edition.reload.lead_image.filename
   end
 
-  test "#create shows the cropping page if image is too large" do
+  view_test "#create shows the cropping page if image is too large" do
     login_authorised_user
     edition = create(:news_article)
 
     filename = "images/960x960_jpeg.jpg"
-    post admin_edition_images_path(edition), params: { image: { image_data: { file: upload_fixture(filename, "image/jpeg") } } }
+    post :create, params: { edition_id: edition.id, image: { image_data: { file: upload_fixture(filename, "image/jpeg") } } }
 
     assert_template "admin/edition_images/crop"
     assert_select "h1", "Crop image"
@@ -85,24 +82,24 @@ class Admin::EditionImagesControllerTest < ActionDispatch::IntegrationTest
     assert_equal expected_data_url, img["src"], "Expected img src to be a Data URL representation of the uploaded file"
   end
 
-  test "#create shows a validation error if image is too small" do
+  view_test "#create shows a validation error if image is too small" do
     login_authorised_user
     edition = create(:news_article)
 
     file = upload_fixture("images/50x33_gif.gif")
-    post admin_edition_images_path(edition), params: { image: { image_data: { file: } } }
+    post :create, params: { edition_id: edition.id, image: { image_data: { file: } } }
 
     assert_template "admin/edition_images/index"
     assert_select ".govuk-error-summary li", "Image data file is too small. Select an image that is 960 pixels wide and 640 pixels tall"
   end
 
-  test "#create shows a validation error if image has a duplicated filename" do
+  view_test "#create shows a validation error if image has a duplicated filename" do
     login_authorised_user
     edition = create(:news_article)
     file = upload_fixture("images/960x640_gif.gif")
     create(:image, edition:, image_data: build(:image_data, file:))
 
-    post admin_edition_images_path(edition), params: { image: { image_data: { file: } } }
+    post :create, params: { edition_id: edition.id, image: { image_data: { file: } } }
 
     assert_template "admin/edition_images/index"
     assert_select ".govuk-error-summary li", "Image data file name is not unique. All your file names must be different. Do not use special characters to create another version of the same file name."
@@ -120,7 +117,7 @@ class Admin::EditionImagesControllerTest < ActionDispatch::IntegrationTest
       .expects(:perform_async)
       .with(anything, has_entries("assetable_id" => kind_of(Integer), "asset_variant" => any_of(*variants), "assetable_type" => model_type), anything, anything, anything, anything).times(7)
 
-    post admin_edition_images_path(edition), params: { image: { image_data: { file: } } }
+    post :create, params: { edition_id: edition.id, image: { image_data: { file: } } }
   end
 
   test "DELETE :destroy when a lead image is present it deletes the edition_lead_image and sets a new lead image" do
@@ -132,11 +129,32 @@ class Admin::EditionImagesControllerTest < ActionDispatch::IntegrationTest
 
     PublishingApiDocumentRepublishingWorker.expects(:perform_async).with(edition.document_id).once
 
-    delete admin_edition_image_path(edition, image1), params: { edition_id: edition.id, id: image1.id }
+    delete :destroy, params: { edition_id: edition.id, id: image1.id }
 
     assert_equal 1, edition.reload.images.count
     assert_equal image2, edition.lead_image
     assert_redirected_to admin_edition_images_path(edition)
+  end
+
+  test "#create shows success message when all image assets are uploaded" do
+    edition = create(:news_article)
+    filename = "big-cheese.960x640.jpg"
+    Services.asset_manager.stubs(:create_asset).returns({ "id" => "http://asset-manager/assets/some_asset_manager_id", "name" => filename })
+
+    post :create, params: { edition_id: edition.id, image: { image_data: { file: upload_fixture(filename, "image/jpeg") } } }
+    AssetManagerCreateAssetWorker.drain
+    get :edit, params: { edition_id: edition.id, id: edition.reload.images.first.id }
+
+    assert_equal "#{filename} successfully uploaded", flash[:notice]
+  end
+
+  test "#create shows 'image is being processed' message when not all image assets are uploaded " do
+    edition = create(:news_article)
+
+    post :create, params: { edition_id: edition.id, image: { image_data: { file: upload_fixture("big-cheese.960x640.jpg", "image/jpeg") } } }
+    get :edit, params: { edition_id: edition.id, id: edition.reload.images.first.id }
+
+    assert_equal "The image is being processed. Try refreshing the page.", flash[:notice]
   end
 
   def login_authorised_user

--- a/test/functional/admin/edition_images_controller_test.rb
+++ b/test/functional/admin/edition_images_controller_test.rb
@@ -19,6 +19,26 @@ class Admin::EditionImagesControllerTest < ActionDispatch::IntegrationTest
     assert_select "#image_alt_text"
   end
 
+  test "edit page shows image if all its assets are uploaded" do
+    login_authorised_user
+    image = build(:image)
+    edition = create(:draft_publication, images: [image])
+
+    get edit_admin_edition_image_path(edition, image)
+
+    assert_select "img:match('src',?)", /media\/asset_manager_id_original\/minister-of-funk.960x640.jpg/, count: 1
+  end
+
+  test "edit page shows processing label if some of the image assets haven't finished processing" do
+    login_authorised_user
+    image = build(:image_with_no_assets)
+    edition = create(:draft_publication, images: [image])
+
+    get edit_admin_edition_image_path(edition, image)
+
+    assert_select "span[class='govuk-tag govuk-tag--green']", text: "Processing", count: 1
+  end
+
   test "edit page does not display alt text input where it is blank" do
     login_authorised_user
     images = [build(:image, alt_text: "")]

--- a/test/functional/admin/organisations_controller_test.rb
+++ b/test/functional/admin/organisations_controller_test.rb
@@ -66,6 +66,7 @@ class Admin::OrganisationsControllerTest < ActionController::TestCase
          }
 
     assert_redirected_to admin_organisations_path
+    assert_equal "Organisation created successfully.", flash[:notice]
     assert organisation = Organisation.last
     assert organisation.topical_event_organisations.map(&:ordering).all?(&:present?), "no ordering"
     assert_equal organisation.topical_event_organisations.map(&:ordering).sort, organisation.topical_event_organisations.map(&:ordering).uniq.sort
@@ -293,6 +294,8 @@ class Admin::OrganisationsControllerTest < ActionController::TestCase
 
     put :update, params: { id: organisation, organisation: organisation_attributes }
 
+    assert_redirected_to admin_organisation_path(organisation)
+    assert_equal "Organisation updated successfully.", flash[:notice]
     organisation.reload
     assert_equal "Ministry of Noise", organisation.name
   end
@@ -333,6 +336,16 @@ class Admin::OrganisationsControllerTest < ActionController::TestCase
 
     assert_response :redirect
     assert_equal "New title", featured_link.reload.title
+  end
+
+  test "GET on :show displays 'image is being processed' flash notice when not all image assets are uploaded" do
+    organisation = build(:organisation, :with_default_news_image)
+    organisation.default_news_image.assets = []
+    organisation.save!
+
+    get :show, params: { id: organisation }
+
+    assert_match(/The image is being processed. Try refreshing the page./, flash[:notice])
   end
 
   view_test "Prevents unauthorized management of homepage priority" do

--- a/test/functional/admin/organisations_controller_test.rb
+++ b/test/functional/admin/organisations_controller_test.rb
@@ -118,6 +118,16 @@ class Admin::OrganisationsControllerTest < ActionController::TestCase
     assert_template :show
   end
 
+  view_test "GET on :show displays processing label if image assets are not available" do
+    organisation = build(:organisation, :with_default_news_image)
+    organisation.default_news_image.assets = []
+    organisation.save!
+
+    get :show, params: { id: organisation }
+
+    assert_select "span[class='govuk-tag govuk-tag--green']", text: "Processing", count: 1
+  end
+
   test "GET on :edit loads the organisation and renders the edit template" do
     organisation = create(:organisation)
     get :edit, params: { id: organisation }
@@ -163,6 +173,17 @@ class Admin::OrganisationsControllerTest < ActionController::TestCase
     expected_hidden_field_name = "organisation[default_news_image_attributes][id]"
     expected_hidden_field_value = organisation.default_news_image.id
     assert_select "input[name='#{expected_hidden_field_name}'][value='#{expected_hidden_field_value}']"
+  end
+
+  view_test "GET :edit shows processing label if logo or default news image assets are not available" do
+    organisation = build(:organisation, :with_default_news_image, :with_logo_and_assets)
+    organisation.assets = []
+    organisation.default_news_image.assets = []
+    organisation.save!
+
+    get :edit, params: { id: organisation }
+
+    assert_select "span[class='govuk-tag govuk-tag--green']", text: "Processing", count: 2
   end
 
   test "PUT on :update allows updating of organisation role ordering" do

--- a/test/functional/admin/people_controller_test.rb
+++ b/test/functional/admin/people_controller_test.rb
@@ -38,6 +38,7 @@ class Admin::PeopleControllerTest < ActionController::TestCase
     assert_equal attributes[:surname], person.surname
     assert_equal attributes[:letters], person.letters
     assert_equal attributes[:biography], person.biography
+    assert_equal "\"#{person.name}\" created.", flash[:notice]
   end
 
   test "creating with valid data redirects to the index" do
@@ -102,6 +103,7 @@ class Admin::PeopleControllerTest < ActionController::TestCase
 
     assert_select ".govuk-summary-list__row .govuk-summary-list__key", text: "Image"
     assert_select "span[class='govuk-tag govuk-tag--green']", text: "Processing", count: 1
+    assert_match(/The image is being processed. Try refreshing the page./, flash[:notice])
   end
 
   view_test "editing shows form for editing a person" do

--- a/test/functional/admin/people_controller_test.rb
+++ b/test/functional/admin/people_controller_test.rb
@@ -67,8 +67,8 @@ class Admin::PeopleControllerTest < ActionController::TestCase
   view_test "GET on :show displays the users information in a summary list component and renders delete and edit link" do
     person = create(
       :person,
-      forename: "Rishi",
-      surname: "Sunak",
+      forename: "Dave",
+      surname: "David",
       privy_counsellor: true,
       title: "Mr",
       letters: "OBE",
@@ -82,15 +82,26 @@ class Admin::PeopleControllerTest < ActionController::TestCase
     assert_select ".govuk-summary-list__row:nth-child(2) .govuk-summary-list__key", text: "Title"
     assert_select ".govuk-summary-list__row:nth-child(2) .govuk-summary-list__value", text: "Mr"
     assert_select ".govuk-summary-list__row:nth-child(3) .govuk-summary-list__key", text: "Forename"
-    assert_select ".govuk-summary-list__row:nth-child(3) .govuk-summary-list__value", text: "Rishi"
+    assert_select ".govuk-summary-list__row:nth-child(3) .govuk-summary-list__value", text: "Dave"
     assert_select ".govuk-summary-list__row:nth-child(4) .govuk-summary-list__key", text: "Surname"
-    assert_select ".govuk-summary-list__row:nth-child(4) .govuk-summary-list__value", text: "Sunak"
+    assert_select ".govuk-summary-list__row:nth-child(4) .govuk-summary-list__value", text: "David"
     assert_select ".govuk-summary-list__row:nth-child(5) .govuk-summary-list__key", text: "Letters"
     assert_select ".govuk-summary-list__row:nth-child(5) .govuk-summary-list__value", text: "OBE"
     assert_select ".govuk-summary-list__row:nth-child(6) .govuk-summary-list__key", text: "Biography"
     assert_select ".govuk-summary-list__row:nth-child(6) .govuk-summary-list__value", text: "He is the PM."
     assert_select ".govuk-summary-list__actions-list a[href='#{edit_admin_person_path(person)}']", text: /Edit Details/
     assert_select ".govuk-summary-list__actions-list a[href='#{confirm_destroy_admin_person_path(person)}']", text: "Delete Details"
+  end
+
+  view_test "GET on :show displays the image row with a processing label if image assets are still uploading" do
+    person = build(:person, :with_image, forename: "Forename", surname: "Surname")
+    person.image.assets = []
+    person.save!
+
+    get :show, params: { id: person }
+
+    assert_select ".govuk-summary-list__row .govuk-summary-list__key", text: "Image"
+    assert_select "span[class='govuk-tag govuk-tag--green']", text: "Processing", count: 1
   end
 
   view_test "editing shows form for editing a person" do
@@ -112,6 +123,16 @@ class Admin::PeopleControllerTest < ActionController::TestCase
     get :edit, params: { id: person }
 
     assert_select "img[src='#{person.image.url}']"
+  end
+
+  view_test "editing shows processing label if image assets are not available" do
+    person = build(:person, :with_image)
+    person.image.assets = []
+    person.save!
+
+    get :edit, params: { id: person }
+
+    assert_select "span[class='govuk-tag govuk-tag--green']", text: "Processing", count: 1
   end
 
   view_test "updating with invalid data shows errors" do

--- a/test/functional/admin/promotional_feature_items_controller_test.rb
+++ b/test/functional/admin/promotional_feature_items_controller_test.rb
@@ -71,6 +71,16 @@ class Admin::PromotionalFeatureItemsControllerTest < ActionController::TestCase
     assert link.is_a?(PromotionalFeatureLink)
   end
 
+  view_test "GET :edit shows processing label if image assets are not available" do
+    promotional_feature_item = build(:promotional_feature_item, promotional_feature: @promotional_feature)
+    promotional_feature_item.assets = []
+    promotional_feature_item.save!
+
+    get :edit, params: { organisation_id: @organisation, promotional_feature_id: @promotional_feature, id: promotional_feature_item }
+
+    assert_select "span[class='govuk-tag govuk-tag--green']", text: "Processing", count: 1
+  end
+
   test "PUT :update updates the item and does not delete the old image from the asset store" do
     link = create(:promotional_feature_link)
     promotional_feature_item = create(:promotional_feature_item, promotional_feature: @promotional_feature, links: [link])

--- a/test/functional/admin/promotional_features_controller_test.rb
+++ b/test/functional/admin/promotional_features_controller_test.rb
@@ -62,6 +62,7 @@ class Admin::PromotionalFeaturesControllerTest < ActionController::TestCase
     get :show, params: { organisation_id: @organisation, id: promotional_feature }
 
     assert_select "span[class='govuk-tag govuk-tag--green']", text: "Processing", count: 1
+    assert_match(/The image is being processed. Try refreshing the page./, flash[:notice])
   end
 
   test "GET :edit loads the promotional feature and renders the template" do

--- a/test/functional/admin/promotional_features_controller_test.rb
+++ b/test/functional/admin/promotional_features_controller_test.rb
@@ -53,6 +53,17 @@ class Admin::PromotionalFeaturesControllerTest < ActionController::TestCase
     assert_equal promotional_feature, assigns(:promotional_feature)
   end
 
+  view_test "GET :show displays processing label if item image assets are not available" do
+    promotional_feature = create(:promotional_feature, organisation: @organisation)
+    promotional_feature_item = build(:promotional_feature_item, promotional_feature:, summary: "Old summary")
+    promotional_feature_item.assets = []
+    promotional_feature_item.save!
+
+    get :show, params: { organisation_id: @organisation, id: promotional_feature }
+
+    assert_select "span[class='govuk-tag govuk-tag--green']", text: "Processing", count: 1
+  end
+
   test "GET :edit loads the promotional feature and renders the template" do
     promotional_feature = create(:promotional_feature, organisation: @organisation)
     get :edit, params: { organisation_id: @organisation, id: promotional_feature }

--- a/test/functional/admin/take_part_pages_controller_test.rb
+++ b/test/functional/admin/take_part_pages_controller_test.rb
@@ -66,6 +66,17 @@ class Admin::TakePartPagesControllerTest < ActionController::TestCase
     assert_template "edit"
   end
 
+  view_test "GET :edit shows processing label if image assets are not available" do
+    page = build(:take_part_page)
+    page.image.assets = []
+    page.save!
+
+    get :edit, params: { id: page }
+
+    refute_select "img[src='#{page.image.url}']"
+    assert_select "span[class='govuk-tag govuk-tag--green']", text: "Processing", count: 1
+  end
+
   test "PUT :update changes the supplied instance with the supplied params" do
     attrs = attributes_for(:take_part_page, title: "Wear a monocle!")
     page = create(:take_part_page, title: "Drink in a gin palace!")

--- a/test/functional/admin/topical_events_controller_test.rb
+++ b/test/functional/admin/topical_events_controller_test.rb
@@ -119,6 +119,16 @@ class Admin::TopicalEventsControllerTest < ActionController::TestCase
     assert_select "input[name='#{expected_hidden_field_name}'][value='#{expected_hidden_field_value}']"
   end
 
+  view_test "GET :edit shows processing label if logo assets are not available" do
+    topical_event = build(:topical_event, :with_logo)
+    topical_event.logo.assets = []
+    topical_event.save!
+
+    get :edit, params: { id: topical_event }
+
+    assert_select "span[class='govuk-tag govuk-tag--green']", text: "Processing", count: 1
+  end
+
   test "PUT :update saves changes to the topical event" do
     topical_event = create(:topical_event, :with_logo)
     logo = topical_event.logo

--- a/test/functional/admin/worldwide_organisations_controller_test.rb
+++ b/test/functional/admin/worldwide_organisations_controller_test.rb
@@ -51,6 +51,16 @@ class Admin::WorldwideOrganisationsControllerTest < ActionController::TestCase
     get :edit, params: { id: organisation.id }
   end
 
+  view_test "GET :edit shows processing label if default news image assets are not available" do
+    organisation = build(:worldwide_organisation, :with_default_news_image)
+    organisation.default_news_image.assets = []
+    organisation.save!
+
+    get :edit, params: { id: organisation }
+
+    assert_select "span[class='govuk-tag govuk-tag--green']", text: "Processing", count: 1
+  end
+
   test "updates an existing objects with new values" do
     organisation = create(:worldwide_organisation)
     put :update,
@@ -138,6 +148,16 @@ class Admin::WorldwideOrganisationsControllerTest < ActionController::TestCase
 
     assert_response :success
     assert_equal organisation, assigns(:worldwide_organisation)
+  end
+
+  view_test "GET on :show displays processing label if image assets are not available" do
+    organisation = build(:worldwide_organisation, :with_default_news_image)
+    organisation.default_news_image.assets = []
+    organisation.save!
+
+    get :show, params: { id: organisation }
+
+    assert_select "span[class='govuk-tag govuk-tag--green']", text: "Processing", count: 1
   end
 
   test "PUT :update - discards default new organisation image cache if file is present " do

--- a/test/functional/admin/worldwide_organisations_controller_test.rb
+++ b/test/functional/admin/worldwide_organisations_controller_test.rb
@@ -29,7 +29,7 @@ class Admin::WorldwideOrganisationsControllerTest < ActionController::TestCase
 
     worldwide_organisation = WorldwideOrganisation.last
     assert_kind_of WorldwideOrganisation, worldwide_organisation
-    assert_equal "Organisation created successfully", flash[:notice]
+    assert_equal "Organisation created successfully.", flash[:notice]
     assert_equal "Organisation", worldwide_organisation.name
 
     assert_redirected_to admin_worldwide_organisation_path(worldwide_organisation)
@@ -76,7 +76,7 @@ class Admin::WorldwideOrganisationsControllerTest < ActionController::TestCase
     worldwide_organisation = WorldwideOrganisation.last
     assert_equal "New name", worldwide_organisation.name
     assert_equal "minister-of-funk.960x640.jpg", worldwide_organisation.default_news_image.file.file.filename
-    assert_equal "Organisation updated successfully", flash[:notice]
+    assert_equal "Organisation updated successfully.", flash[:notice]
     assert_redirected_to admin_worldwide_organisation_path(worldwide_organisation)
   end
 
@@ -158,6 +158,7 @@ class Admin::WorldwideOrganisationsControllerTest < ActionController::TestCase
     get :show, params: { id: organisation }
 
     assert_select "span[class='govuk-tag govuk-tag--green']", text: "Processing", count: 1
+    assert_match(/The image is being processed. Try refreshing the page./, flash[:notice])
   end
 
   test "PUT :update - discards default new organisation image cache if file is present " do

--- a/test/unit/app/presenters/publishing_api/call_for_evidence_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/call_for_evidence_presenter_test.rb
@@ -246,18 +246,14 @@ module PublishingApi::CallForEvidencePresenterTest
 
   class OpenCallForEvidenceWithParticipationTest < TestCase
     setup do
-      response_form_data_attributes = attributes_for(
-        :call_for_evidence_response_form_data,
-      )
+      response_form_data = build(:call_for_evidence_response_form_data)
 
-      response_form_attributes = attributes_for(
-        :call_for_evidence_response_form,
-        call_for_evidence_response_form_data_attributes: response_form_data_attributes,
-      )
+      response_form = build(:call_for_evidence_response_form,
+                            call_for_evidence_response_form_data: response_form_data)
 
-      @participation = create(
+      @participation = build(
         :call_for_evidence_participation,
-        call_for_evidence_response_form_attributes: response_form_attributes,
+        call_for_evidence_response_form: response_form,
         email: "postmaster@example.com",
         link_url: "http://www.example.com",
         postal_address: <<-ADDRESS.strip_heredoc.chop,

--- a/test/unit/app/presenters/publishing_api/consultation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/consultation_presenter_test.rb
@@ -247,18 +247,14 @@ module PublishingApi::ConsultationPresenterTest
 
   class OpenConsultationWithParticipationTest < TestCase
     setup do
-      response_form_data_attributes = attributes_for(
-        :consultation_response_form_data,
-      )
+      response_form_data = build(:consultation_response_form_data)
 
-      response_form_attributes = attributes_for(
-        :consultation_response_form,
-        consultation_response_form_data_attributes: response_form_data_attributes,
-      )
+      response_form = build(:consultation_response_form,
+                            consultation_response_form_data: response_form_data)
 
-      @participation = create(
+      @participation = build(
         :consultation_participation,
-        consultation_response_form_attributes: response_form_attributes,
+        consultation_response_form: response_form,
         email: "postmaster@example.com",
         link_url: "http://www.example.com",
         postal_address: <<-ADDRESS.strip_heredoc.chop,


### PR DESCRIPTION
Adding some UX fixes to ensure that users are informed with regards to the state of uploading assets. 

- add processing labels on all document types that have images rendering in whitehall (typically in a `_form` partial) - this includes edition images edit and index page, as well as non-editioned doc types
- add processing label to summary pages - for `Person`, `PromotionalFeatureItem`, `Organisation`, `WorldwideOrganisation`
- improve how we check that all assets are uploaded - include filename checks to ensure that the correct assets are considered on file updates
- improve flash notification messages for edition images and `Person`, to include information about the state of asset uploads

[Trello card](https://trello.com/b/zKiroi2H/govuk-asset-management-in-whitehall)
