### PR TITLE
Ensure focus remains on Doc History show select

### DIFF
--- a/app/assets/javascripts/admin/modules/document-history-paginator.js
+++ b/app/assets/javascripts/admin/modules/document-history-paginator.js
@@ -75,6 +75,8 @@ window.GOVUK.Modules = window.GOVUK.Modules || {}
         })
         .then(function (html) {
           module.innerHTML = html
+          const insertedForm = module.querySelector('form.js-filter-form')
+          insertedForm.querySelector('select').focus()
 
           const documentHistoryModule =
             new GOVUK.Modules.DocumentHistoryPaginator(module)


### PR DESCRIPTION
## Description

When you switch between seeing document history, internal notes or both on the select, it loses focus of the element. This is poor behaviour for screen readers as they jump back to the top of the page.

This is untested atm. I've added a card to the backlog to add some [here](https://trello.com/c/Tj7FQ0bP/2248-add-tests-for-doc-history-paginator-js-module) 

## Before

<img width="361" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/dd70f9ff-429a-437a-8a3a-cb6abfd10531">

<img width="357" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/406b39cb-95f2-4e6a-ae78-69e5a90c2b6c">

## After 

<img width="325" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/be734b3c-9954-4c63-9178-cb3651bc95df">

<img width="308" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/70925cc7-8f10-45ba-b270-db2a6b7ca42b">

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
