### PR TITLE
Update govuk_publishing_components to fix zip attachment component

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -243,7 +243,7 @@ GEM
     google-protobuf (3.25.1-aarch64-linux)
     google-protobuf (3.25.1-arm64-darwin)
     google-protobuf (3.25.1-x86_64-linux)
-    googleapis-common-protos-types (1.10.0)
+    googleapis-common-protos-types (1.11.0)
       google-protobuf (~> 3.18)
     govspeak (8.3.1)
       actionview (>= 6)
@@ -278,7 +278,7 @@ GEM
     govuk_personalisation (0.15.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
-    govuk_publishing_components (36.0.1)
+    govuk_publishing_components (36.0.3)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown
@@ -427,7 +427,7 @@ GEM
     net-smtp (0.4.0)
       net-protocol
     netrc (0.11.0)
-    nio4r (2.6.1)
+    nio4r (2.7.0)
     nokogiri (1.15.5)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)


### PR DESCRIPTION
Update to fix issues like: https://govuk.zendesk.com/agent/tickets/5564670 (attachment components not handling zip files correctly). Once this is released to production, some rake tasks will have to be run to update the rendered components.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
