### PR TITLE
Refactor asset updater

### DIFF
--- a/app/services/asset_manager/asset_updater.rb
+++ b/app/services/asset_manager/asset_updater.rb
@@ -1,15 +1,9 @@
 class AssetManager::AssetUpdater
   include AssetManager::ServiceHelper
 
-  class AssetAlreadyDeleted < StandardError
-    def initialize(identifier, asset_data_id)
-      super("Asset '#{identifier}' for Attachment Data #{asset_data_id} expected not to be deleted in Asset Manager")
-    end
-  end
-
   class AssetAttributesEmpty < StandardError
-    def initialize(identifier, asset_data_id)
-      super("Attempting to update '#{identifier}' for Attachment Data #{asset_data_id} with empty attachment attributes")
+    def initialize(asset_manager_id)
+      super("Attempting to update Asset with asset_manager_id: '#{asset_manager_id}' with empty attachment attributes")
     end
   end
 
@@ -17,20 +11,20 @@ class AssetManager::AssetUpdater
     new.call(*args)
   end
 
-  def call(asset_manager_id, asset_data, new_attributes = {})
-    update_with_asset_manager_id(asset_manager_id, asset_data, new_attributes)
+  def call(asset_manager_id, new_attributes)
+    update_with_asset_manager_id(asset_manager_id, new_attributes)
   end
 
 private
 
-  def update_with_asset_manager_id(asset_manager_id, asset_data, new_attributes)
-    raise AssetAttributesEmpty.new(asset_manager_id, asset_data.id) if new_attributes.empty?
+  def update_with_asset_manager_id(asset_manager_id, new_attributes)
+    raise AssetAttributesEmpty, asset_manager_id if new_attributes.empty?
 
     attributes = find_asset_by_id(asset_manager_id)
     asset_deleted = attributes["deleted"]
 
     if asset_deleted
-      raise AssetAlreadyDeleted.new(asset_manager_id, asset_data.id)
+      logger.warn("Asset with asset_manager_id: '#{asset_manager_id}' expected not to be deleted in Asset Manager")
     end
 
     keys = new_attributes.keys

--- a/app/services/asset_manager/attachment_updater.rb
+++ b/app/services/asset_manager/attachment_updater.rb
@@ -12,7 +12,7 @@ class AssetManager::AttachmentUpdater
     end
 
     attachment_data.assets.each do |asset|
-      AssetManager::AssetUpdater.call(asset.asset_manager_id, attachment_data, asset_attributes)
+      AssetManager::AssetUpdater.call(asset.asset_manager_id, asset_attributes)
     end
   end
 
@@ -24,7 +24,7 @@ class AssetManager::AttachmentUpdater
 
       next if replacement_id.nil?
 
-      AssetManager::AssetUpdater.call(asset.asset_manager_id, attachment_data, { "replacement_id" => replacement_id })
+      AssetManager::AssetUpdater.call(asset.asset_manager_id, { "replacement_id" => replacement_id })
     end
   end
 
@@ -32,7 +32,7 @@ class AssetManager::AttachmentUpdater
     return if attachment_data.deleted?
 
     attachment_data.assets.each do |asset|
-      AssetManager::AssetUpdater.call(asset.asset_manager_id, attachment_data, { "redirect_url" => attachment_data.redirect_url })
+      AssetManager::AssetUpdater.call(asset.asset_manager_id, { "redirect_url" => attachment_data.redirect_url })
     end
   end
 end

--- a/app/workers/asset_manager_update_asset_worker.rb
+++ b/app/workers/asset_manager_update_asset_worker.rb
@@ -5,10 +5,9 @@ class AssetManagerUpdateAssetWorker < WorkerBase
     model = klass.constantize.find(id)
     asset_data = GlobalID::Locator.locate(model.to_global_id)
     asset_data.assets.each do |asset|
-      AssetManager::AssetUpdater.call(asset.asset_manager_id, asset_data, attributes)
+      AssetManager::AssetUpdater.call(asset.asset_manager_id, attributes)
     end
   rescue AssetManager::ServiceHelper::AssetNotFound,
-         AssetManager::AssetUpdater::AssetAlreadyDeleted,
          ActiveRecord::RecordNotFound => e
     logger.error "AssetManagerUpdateAssetWorker: #{e.message}"
   end

--- a/app/workers/asset_manager_update_whitehall_asset_worker.rb
+++ b/app/workers/asset_manager_update_whitehall_asset_worker.rb
@@ -6,7 +6,7 @@ class AssetManagerUpdateWhitehallAssetWorker < WorkerBase
     asset_data = GlobalID::Locator.locate(model.to_global_id)
 
     asset_data.assets.each do |asset|
-      AssetManager::AssetUpdater.call(asset.asset_manager_id, asset_data, attributes)
+      AssetManager::AssetUpdater.call(asset.asset_manager_id, attributes)
     end
   rescue AssetManager::ServiceHelper::AssetNotFound,
          AssetManager::AssetUpdater::AssetAlreadyDeleted,

--- a/test/unit/app/services/asset_manager/asset_updater_test.rb
+++ b/test/unit/app/services/asset_manager/asset_updater_test.rb
@@ -6,130 +6,129 @@ class AssetManager::AssetUpdaterTest < ActiveSupport::TestCase
   setup do
     @asset_manager_id = "asset-id"
     @asset_url = "http://asset-manager/assets/#{@asset_manager_id}"
-    @worker = AssetManager::AssetUpdater.new
+    @asset_updater = AssetManager::AssetUpdater.new
     @redirect_url = "https://www.test.gov.uk/example"
     @attachment_data = FactoryBot.build(:attachment_data)
   end
 
   test "updates auth_bypass_ids for ImageData" do
-    image_data = build(:image_data)
-    @worker.stubs(:find_asset_by_id).with(@asset_manager_id)
+    @asset_updater.stubs(:find_asset_by_id).with(@asset_manager_id)
            .returns("id" => @asset_manager_id, "draft" => true)
 
     Services.asset_manager.expects(:update_asset).with(@asset_manager_id, { "auth_bypass_ids" => [] })
 
-    @worker.call(@asset_manager_id, image_data, { "auth_bypass_ids" => [] })
+    @asset_updater.call(@asset_manager_id, { "auth_bypass_ids" => [] })
   end
 
-  test "raises exception if asset has been deleted in asset manager and attachment_data isn't deleted" do
-    @worker.stubs(:find_asset_by_id).with(@asset_manager_id)
+  test "warns if asset has been deleted in asset manager and attachment_data isn't deleted" do
+    @asset_updater.stubs(:find_asset_by_id).with(@asset_manager_id)
            .returns("id" => @asset_url, "deleted" => true)
     @attachment_data.stubs(:deleted?).returns(false)
 
-    assert_raises(AssetManager::AssetUpdater::AssetAlreadyDeleted) do
-      @worker.call(@asset_manager_id, @attachment_data, { "draft" => false })
-    end
+    Logger.any_instance.stubs(:warn).with("Asset with asset_manager_id: '#{@asset_manager_id}' expected not to be deleted in Asset Manager").once
+
+    @asset_updater.call(@asset_manager_id, { "draft" => false })
   end
 
   test "does not update asset if no attributes are supplied" do
     assert_raises(AssetManager::AssetUpdater::AssetAttributesEmpty) do
-      @worker.call(@asset_manager_id, @attachment_data)
+      @asset_updater.call(@asset_manager_id, {})
     end
   end
 
   test "marks draft asset as published" do
-    @worker.stubs(:find_asset_by_id).with(@asset_manager_id)
+    @asset_updater.stubs(:find_asset_by_id).with(@asset_manager_id)
            .returns("id" => @asset_manager_id, "draft" => true)
     Services.asset_manager.expects(:update_asset).with(@asset_manager_id, { "draft" => false })
 
-    @worker.call(@asset_manager_id, @attachment_data, { "draft" => false })
+    @asset_updater.call(@asset_manager_id, { "draft" => false })
   end
 
   test "does not mark asset as published if already published" do
-    @worker.stubs(:find_asset_by_id).with(@asset_manager_id)
+    @asset_updater.stubs(:find_asset_by_id).with(@asset_manager_id)
            .returns("id" => @asset_manager_id, "draft" => false)
     Services.asset_manager.expects(:update_asset).never
 
-    @worker.call(@asset_manager_id, @attachment_data, { "draft" => false })
+    @asset_updater.call(@asset_manager_id, { "draft" => false })
   end
 
   test "mark published asset as draft" do
-    @worker.stubs(:find_asset_by_id).with(@asset_manager_id)
+    @asset_updater.stubs(:find_asset_by_id).with(@asset_manager_id)
            .returns("id" => @asset_manager_id, "draft" => false)
     Services.asset_manager.expects(:update_asset).with(@asset_manager_id, { "draft" => true })
 
-    @worker.call(@asset_manager_id, @attachment_data, { "draft" => true })
+    @asset_updater.call(@asset_manager_id, { "draft" => true })
   end
 
   test "does not mark asset as draft if already draft" do
-    @worker.stubs(:find_asset_by_id).with(@asset_manager_id)
+    @asset_updater.stubs(:find_asset_by_id).with(@asset_manager_id)
            .returns("id" => @asset_manager_id, "draft" => true)
     Services.asset_manager.expects(:update_asset).never
 
-    @worker.call(@asset_manager_id, @attachment_data, { "draft" => true })
+    @asset_updater.call(@asset_manager_id, { "draft" => true })
   end
 
   test "sets redirect_url on asset if not already set" do
-    @worker.stubs(:find_asset_by_id).with(@asset_manager_id)
+    @asset_updater.stubs(:find_asset_by_id).with(@asset_manager_id)
            .returns("id" => @asset_manager_id)
     Services.asset_manager.expects(:update_asset)
             .with(@asset_manager_id, { "redirect_url" => @redirect_url })
 
-    @worker.call(@asset_manager_id, @attachment_data, { "redirect_url" => @redirect_url })
+    @asset_updater.call(@asset_manager_id, { "redirect_url" => @redirect_url })
   end
 
   test "sets redirect_url on asset if already set to different value" do
-    @worker.stubs(:find_asset_by_id).with(@asset_manager_id)
+    @asset_updater.stubs(:find_asset_by_id).with(@asset_manager_id)
            .returns("id" => @asset_manager_id, "redirect_url" => "#{@redirect_url}-another")
     Services.asset_manager.expects(:update_asset)
             .with(@asset_manager_id, { "redirect_url" => @redirect_url })
 
-    @worker.call(@asset_manager_id, @attachment_data, { "redirect_url" => @redirect_url })
+    @asset_updater.call(@asset_manager_id, { "redirect_url" => @redirect_url })
   end
 
   test "does not set redirect_url on asset if already set" do
-    @worker.stubs(:find_asset_by_id).with(@asset_manager_id)
+    @asset_updater.stubs(:find_asset_by_id).with(@asset_manager_id)
            .returns("id" => @asset_manager_id, "redirect_url" => @redirect_url)
     Services.asset_manager.expects(:update_asset).never
 
-    @worker.call(@asset_manager_id, @attachment_data, { "redirect_url" => @redirect_url })
+    @asset_updater.call(@asset_manager_id, { "redirect_url" => @redirect_url })
   end
 
   test "marks asset as access-limited" do
-    @worker.stubs(:find_asset_by_id).with(@asset_manager_id)
+    @asset_updater.stubs(:find_asset_by_id).with(@asset_manager_id)
            .returns("id" => @asset_manager_id)
     Services.asset_manager.expects(:update_asset)
             .with(@asset_manager_id, { "access_limited" => %w[uid-1] })
 
-    @worker.call(@asset_manager_id, @attachment_data, { "access_limited" => %w[uid-1] })
+    @asset_updater.call(@asset_manager_id, { "access_limited" => %w[uid-1] })
   end
 
   test "does not mark asset as access-limited if already set" do
-    @worker.stubs(:find_asset_by_id).with(@asset_manager_id)
+    @asset_updater.stubs(:find_asset_by_id).with(@asset_manager_id)
            .returns("id" => @asset_manager_id, "access_limited" => %w[uid-1])
     Services.asset_manager.expects(:update_asset).never
 
-    @worker.call(@asset_manager_id, @attachment_data, { "access_limited" => %w[uid-1] })
+    @asset_updater.call(@asset_manager_id, { "access_limited" => %w[uid-1] })
   end
 
   test "marks asset as replaced by another asset" do
     replacement_id = "replacement-id"
-    @worker.stubs(:find_asset_by_id).with(@asset_manager_id)
+    @asset_updater.stubs(:find_asset_by_id).with(@asset_manager_id)
            .returns("id" => @asset_manager_id)
     Services.asset_manager.expects(:update_asset)
             .with(@asset_manager_id, { "replacement_id" => replacement_id })
 
     attributes = { "replacement_id" => replacement_id }
-    @worker.call(@asset_manager_id, @attachment_data, attributes)
+    @asset_updater.call(@asset_manager_id, attributes)
   end
 
   test "does not mark asset as replaced if already replaced by same asset" do
     replacement_id = "replacement-id"
-    @worker.stubs(:find_asset_by_id).with(@asset_manager_id)
+    @asset_updater.stubs(:find_asset_by_id).with(@asset_manager_id)
            .returns("id" => @asset_manager_id, "replacement_id" => replacement_id)
     Services.asset_manager.expects(:update_asset).never
 
     attributes = { "replacement_id" => replacement_id }
-    @worker.call(@asset_manager_id, @attachment_data, attributes)
+    @asset_updater.call(@asset_manager_id, attributes)
   end
 end

--- a/test/unit/app/services/asset_manager/attachment_updater_test.rb
+++ b/test/unit/app/services/asset_manager/attachment_updater_test.rb
@@ -16,7 +16,7 @@ class AssetManager::AttachmentUpdaterTest < ActiveSupport::TestCase
         }
 
         attachment.attachment_data.assets.each do |asset|
-          AssetManager::AssetUpdater.expects(:call).with(asset.asset_manager_id, attachment.attachment_data, expected_attribute_hash)
+          AssetManager::AssetUpdater.expects(:call).with(asset.asset_manager_id, expected_attribute_hash)
         end
 
         AssetManager::AttachmentUpdater.call(attachment.attachment_data)
@@ -39,7 +39,7 @@ class AssetManager::AttachmentUpdaterTest < ActiveSupport::TestCase
           }
 
           replaced_attachment_data.assets.each do |asset|
-            AssetManager::AssetUpdater.expects(:call).with(asset.asset_manager_id, replaced_attachment_data, expected_attribute_hash)
+            AssetManager::AssetUpdater.expects(:call).with(asset.asset_manager_id, expected_attribute_hash)
           end
 
           AssetManager::AttachmentUpdater.call(replaced_attachment_data)
@@ -59,7 +59,7 @@ class AssetManager::AttachmentUpdaterTest < ActiveSupport::TestCase
         }
 
         attachment.attachment_data.assets.each do |asset|
-          AssetManager::AssetUpdater.expects(:call).with(asset.asset_manager_id, attachment.attachment_data, expected_attribute_hash)
+          AssetManager::AssetUpdater.expects(:call).with(asset.asset_manager_id, expected_attribute_hash)
         end
 
         AssetManager::AttachmentUpdater.call(attachment.attachment_data)
@@ -78,7 +78,7 @@ class AssetManager::AttachmentUpdaterTest < ActiveSupport::TestCase
         }
 
         attachment.attachment_data.assets.each do |asset|
-          AssetManager::AssetUpdater.expects(:call).with(asset.asset_manager_id, attachment.attachment_data, expected_attribute_hash)
+          AssetManager::AssetUpdater.expects(:call).with(asset.asset_manager_id, expected_attribute_hash)
         end
 
         AssetManager::AttachmentUpdater.call(attachment.attachment_data)
@@ -97,7 +97,7 @@ class AssetManager::AttachmentUpdaterTest < ActiveSupport::TestCase
         }
 
         attachment.attachment_data.assets.each do |asset|
-          AssetManager::AssetUpdater.expects(:call).with(asset.asset_manager_id, attachment.attachment_data, expected_attribute_hash)
+          AssetManager::AssetUpdater.expects(:call).with(asset.asset_manager_id, expected_attribute_hash)
         end
 
         AssetManager::AttachmentUpdater.call(attachment.attachment_data)
@@ -116,7 +116,7 @@ class AssetManager::AttachmentUpdaterTest < ActiveSupport::TestCase
         }
 
         attachment.attachment_data.assets.each do |asset|
-          AssetManager::AssetUpdater.expects(:call).with(asset.asset_manager_id, attachment.attachment_data, expected_attribute_hash)
+          AssetManager::AssetUpdater.expects(:call).with(asset.asset_manager_id, expected_attribute_hash)
         end
 
         AssetManager::AttachmentUpdater.call(attachment.attachment_data)
@@ -135,7 +135,7 @@ class AssetManager::AttachmentUpdaterTest < ActiveSupport::TestCase
         }
 
         attachment.attachment_data.assets.each do |asset|
-          AssetManager::AssetUpdater.expects(:call).with(asset.asset_manager_id, attachment.attachment_data, expected_attribute_hash)
+          AssetManager::AssetUpdater.expects(:call).with(asset.asset_manager_id, expected_attribute_hash)
         end
 
         AssetManager::AttachmentUpdater.call(attachment.attachment_data)
@@ -159,9 +159,9 @@ class AssetManager::AttachmentUpdaterTest < ActiveSupport::TestCase
           replacement_thumbnail_attributes = { "replacement_id" => replacement_thumbnail_asset.asset_manager_id }
 
           AssetManager::AssetUpdater.expects(:call)
-                                    .with(attachment.attachment_data.assets.first.asset_manager_id, attachment.attachment_data, replacement_attributes)
+                                    .with(attachment.attachment_data.assets.first.asset_manager_id, replacement_attributes)
           AssetManager::AssetUpdater.expects(:call)
-                                    .with(attachment.attachment_data.assets.last.asset_manager_id, attachment.attachment_data, replacement_thumbnail_attributes)
+                                    .with(attachment.attachment_data.assets.last.asset_manager_id, replacement_thumbnail_attributes)
 
           AssetManager::AttachmentUpdater.replace(attachment.attachment_data)
         end
@@ -177,8 +177,8 @@ class AssetManager::AttachmentUpdaterTest < ActiveSupport::TestCase
 
           replacement_attributes = { "replacement_id" => replacement_original_asset.asset_manager_id }
 
-          AssetManager::AssetUpdater.expects(:call).with(attachment.attachment_data.assets.first.asset_manager_id, attachment.attachment_data, replacement_attributes)
-          AssetManager::AssetUpdater.expects(:call).with(attachment.attachment_data.assets.last.asset_manager_id, attachment.attachment_data, replacement_attributes)
+          AssetManager::AssetUpdater.expects(:call).with(attachment.attachment_data.assets.first.asset_manager_id, replacement_attributes)
+          AssetManager::AssetUpdater.expects(:call).with(attachment.attachment_data.assets.last.asset_manager_id, replacement_attributes)
 
           AssetManager::AttachmentUpdater.replace(attachment.attachment_data)
         end
@@ -208,7 +208,7 @@ class AssetManager::AttachmentUpdaterTest < ActiveSupport::TestCase
         }
 
         attachment.attachment_data.assets.each do |asset|
-          AssetManager::AssetUpdater.expects(:call).with(asset.asset_manager_id, attachment.attachment_data, expected_attribute_hash)
+          AssetManager::AssetUpdater.expects(:call).with(asset.asset_manager_id, expected_attribute_hash)
         end
 
         AssetManager::AttachmentUpdater.redirect(attachment.attachment_data)

--- a/test/unit/app/workers/asset_manager_update_asset_worker_test.rb
+++ b/test/unit/app/workers/asset_manager_update_asset_worker_test.rb
@@ -9,8 +9,8 @@ class AssetManagerUpdateAssetWorkerTest < ActiveSupport::TestCase
   let(:attachment_data) { FactoryBot.create(:attachment_data) }
 
   test "updates an attachment and its variant" do
-    AssetManager::AssetUpdater.expects(:call).with("asset_manager_id_original", attachment_data, auth_bypass_id_attributes)
-    AssetManager::AssetUpdater.expects(:call).with("asset_manager_id_thumbnail", attachment_data, auth_bypass_id_attributes)
+    AssetManager::AssetUpdater.expects(:call).with("asset_manager_id_original", auth_bypass_id_attributes)
+    AssetManager::AssetUpdater.expects(:call).with("asset_manager_id_thumbnail", auth_bypass_id_attributes)
 
     AssetManagerUpdateAssetWorker.perform_async_in_queue("asset_manager_updater", "AttachmentData", attachment_data.id, auth_bypass_id_attributes)
     AssetManagerUpdateAssetWorker.drain
@@ -25,25 +25,6 @@ class AssetManagerUpdateAssetWorkerTest < ActiveSupport::TestCase
     AssetManagerUpdateAssetWorker.drain
   end
 
-  test "ignores assets that have been deleted in Asset Manager" do
-    expected_error = AssetManager::AssetUpdater::AssetAlreadyDeleted.new(attachment_data.id, "asset_manager_id_original")
-    AssetManager::AssetUpdater.expects(:call).raises(expected_error)
-    Logger.any_instance.stubs(:error).with(includes(expected_error.message)).once
-
-    AssetManagerUpdateAssetWorker.perform_async_in_queue("asset_manager_updater", "AttachmentData", attachment_data.id, auth_bypass_id_attributes)
-    AssetManagerUpdateAssetWorker.drain
-  end
-
-  test "ignores assets that have been deleted in Whitehall" do
-    attachment_data_id = attachment_data.id
-    attachment_data.destroy!
-
-    Logger.any_instance.stubs(:error).with(includes(attachment_data_id.to_s)).once
-
-    AssetManagerUpdateAssetWorker.perform_async_in_queue("asset_manager_updater", "AttachmentData", attachment_data_id, auth_bypass_id_attributes)
-    AssetManagerUpdateAssetWorker.drain
-  end
-
   test "updates an image and its resized versions" do
     image_data = FactoryBot.create(:image_data)
     %w[
@@ -55,7 +36,7 @@ class AssetManagerUpdateAssetWorkerTest < ActiveSupport::TestCase
       asset_manager_id_s300
       asset_manager_id_s216
     ].each do |asset_manager_id|
-      AssetManager::AssetUpdater.expects(:call).with(asset_manager_id, image_data, @auth_bypass_id_attributes).once
+      AssetManager::AssetUpdater.expects(:call).with(asset_manager_id, @auth_bypass_id_attributes).once
     end
 
     AssetManagerUpdateAssetWorker.perform_async_in_queue("asset_manager_id_original", "ImageData", image_data.id, @auth_bypass_id_attributes)
@@ -66,7 +47,7 @@ class AssetManagerUpdateAssetWorkerTest < ActiveSupport::TestCase
     response_form = FactoryBot.create(:consultation_response_form)
     form_data = response_form.consultation_response_form_data
 
-    AssetManager::AssetUpdater.expects(:call).with("asset_manager_id_original", form_data, @auth_bypass_id_attributes)
+    AssetManager::AssetUpdater.expects(:call).with("asset_manager_id_original", @auth_bypass_id_attributes)
 
     AssetManagerUpdateAssetWorker.perform_async_in_queue("asset_manager_updater", "ConsultationResponseFormData", form_data.id, @auth_bypass_id_attributes)
     AssetManagerUpdateAssetWorker.drain


### PR DESCRIPTION
Stop raising AssetAlreadyDeleted error since nobody is caring about them :( They just cause noise that hides other errors we care about.

[Trello](https://trello.com/c/NpDeRmj6/272-task-stop-raising-assetalreadydeleted)

