### PR TITLE
Add more descriptive aria labels to page links

### DIFF
--- a/app/helpers/admin/pagination_helper.rb
+++ b/app/helpers/admin/pagination_helper.rb
@@ -99,6 +99,7 @@ module Admin::PaginationHelper
         href: build_path_for(1),
         label: "1",
         current: current_page == 1,
+        aria_label: "Page 1",
       }
     end
 
@@ -114,6 +115,7 @@ module Admin::PaginationHelper
           href: build_path_for(page),
           label: page.to_s,
           current: current_page == page,
+          aria_label: "Page #{page}",
         }
       end
     end
@@ -149,6 +151,7 @@ module Admin::PaginationHelper
         href: build_path_for(total_pages),
         label: total_pages.to_s,
         current: current_page == total_pages,
+        aria_label: "Page #{total_pages}",
       }
     end
   end

--- a/app/views/components/_pagination.html.erb
+++ b/app/views/components/_pagination.html.erb
@@ -1,6 +1,6 @@
 <%
   id ||= "pagination-#{SecureRandom.hex(4)}"
-  aria_label ||= "results"
+  aria_label ||= "Pagination"
   items ||= []
   previous_href ||= false
   next_href ||= false
@@ -13,7 +13,7 @@
         <svg class="govuk-pagination__icon govuk-pagination__icon--prev" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
           <path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
         </svg>
-        <span class="govuk-pagination__link-title">Previous</span>
+        <span class="govuk-pagination__link-title">Previous<span class="govuk-visually-hidden"> page</span></span>
       </a>
     </div>
   <% end %>
@@ -50,7 +50,7 @@
   <% if next_href %>
     <div class="govuk-pagination__next">
       <a class="govuk-link govuk-pagination__link" href="<%= next_href %>" rel="next">
-        <span class="govuk-pagination__link-title">Next</span>
+        <span class="govuk-pagination__link-title">Next<span class="govuk-visually-hidden"> page</span></span>
         <svg class="govuk-pagination__icon govuk-pagination__icon--next" xmlns="http://www.w3.org/2000/svg" height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
           <path d="m8.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
         </svg>

--- a/test/unit/app/helpers/admin/paginator_helper_test.rb
+++ b/test/unit/app/helpers/admin/paginator_helper_test.rb
@@ -50,21 +50,25 @@ class Admin::PaginationHelperTest < ActionView::TestCase
             href: path_for_page(1),
             label: "1",
             current: page == 1,
+            aria_label: "Page 1",
           },
           {
             href: path_for_page(2),
             label: "2",
             current: page == 2,
+            aria_label: "Page 2",
           },
           {
             href: path_for_page(3),
             label: "3",
             current: page == 3,
+            aria_label: "Page 3",
           },
           {
             href: path_for_page(4),
             label: "4",
             current: false,
+            aria_label: "Page 4",
           },
           {
             ellipses: true,
@@ -73,6 +77,7 @@ class Admin::PaginationHelperTest < ActionView::TestCase
             href: path_for_page(10),
             label: "10",
             current: false,
+            aria_label: "Page 10",
           },
         ],
       }
@@ -91,6 +96,7 @@ class Admin::PaginationHelperTest < ActionView::TestCase
             href: path_for_page(1),
             label: "1",
             current: false,
+            aria_label: "Page 1",
           },
           {
             ellipses: true,
@@ -99,16 +105,19 @@ class Admin::PaginationHelperTest < ActionView::TestCase
             href: path_for_page(page - 1),
             label: (page - 1).to_s,
             current: false,
+            aria_label: "Page #{page - 1}",
           },
           {
             href: path_for_page(page),
             label: page.to_s,
             current: true,
+            aria_label: "Page #{page}",
           },
           {
             href: path_for_page(page + 1),
             label: (page + 1).to_s,
             current: false,
+            aria_label: "Page #{page + 1}",
           },
           {
             ellipses: true,
@@ -117,6 +126,7 @@ class Admin::PaginationHelperTest < ActionView::TestCase
             href: path_for_page(10),
             label: "10",
             current: false,
+            aria_label: "Page 10",
           },
         ],
       }
@@ -135,6 +145,7 @@ class Admin::PaginationHelperTest < ActionView::TestCase
             href: path_for_page(1),
             label: "1",
             current: false,
+            aria_label: "Page 1",
           },
           {
             ellipses: true,
@@ -143,21 +154,25 @@ class Admin::PaginationHelperTest < ActionView::TestCase
             href: path_for_page(7),
             label: "7",
             current: page == 7,
+            aria_label: "Page 7",
           },
           {
             href: path_for_page(8),
             label: "8",
             current: page == 8,
+            aria_label: "Page 8",
           },
           {
             href: path_for_page(9),
             label: "9",
             current: page == 9,
+            aria_label: "Page 9",
           },
           {
             href: path_for_page(10),
             label: "10",
             current: page == 10,
+            aria_label: "Page 10",
           },
         ],
       }


### PR DESCRIPTION
[Trello ticket link](https://trello.com/c/5wCEpjGA/2212-make-pagination-links-more-descriptive-for-screenreader-users)

# What
This updates the aria labels of page links so that they are more accessible and descriptive when using a screen reader.

# Why
This was flagged as high priority in the most recent accessibility report.

# Additional information
The accessibility report called for more context on page links when using a screen reader and gave the example of adding the aria label "Page 1 of search results". Myself and @ryanb-gds investigated adding the context of "search results" to the aria label but could not find a clean way to do it. As the `govuk_paginator` theme is used in multiple places, a suitable context would need to be passed in for each use case. However, the paginate method from Kaminari is restrictive in the options you can provide it. For the time being, we propose proceeding without the additional context. The changes proposed in this PR bring the code in line with the Design System which has aria labels like "Page 1".

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
