### PR TITLE
Ensure alternate email label links to select

### DIFF
--- a/app/views/admin/editions/_accessible_attachment_field.html.erb
+++ b/app/views/admin/editions/_accessible_attachment_field.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-!-margin-bottom-6">
   <% if edition.respond_to?(:alternative_format_provider) %>
     <div class="govuk-form-group gem-c-select">
-      <label class="govuk-label govuk-label--m govuk-!-font-weight-bold" for="alternative_format_provider_id">
+      <label class="govuk-label govuk-label--m govuk-!-font-weight-bold" for="edition_alternative_format_provider_id">
         Email address for ordering attachment files in an alternative format <%= "(required)" if edition.alternative_format_provider_required? %>
       </label>
 


### PR DESCRIPTION
## Description

The accessibility audit covered labels linking correctly to inputs/selects. This label came back as not working correctly. This is due to the for value not being the same as the selects id.

## Trello card

https://trello.com/c/CR3r7Eu9/2209-associate-alternative-attachment-format-email-label-with-select-element

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
