### PR TITLE
Update branches shown in the taxonomy topic select in the email override UI for document collections

### DIFF
--- a/app/presenters/topic_list_select_presenter.rb
+++ b/app/presenters/topic_list_select_presenter.rb
@@ -3,21 +3,11 @@ class TopicListSelectPresenter
   #  We are only going to show the branches which the dept has told us they will need to tag to.
   TAGGABLE_BRANCHES = [
     "/business-and-industry",
-    "/business-tax",
-    "/childcare-parenting",
-    "/defence",
-    "/defence-and-armed-forces",
-    "/education",
     "/employment",
-    "/environment",
-    "/government",
-    "/housing-and-local-government",
     "/money",
-    "/regional-and-local-government",
     "/society-and-culture",
-    "/transport",
+    "/environment",
     "/welfare",
-    "/work",
   ].freeze
 
   def initialize(taxonomy_topic_email_override = nil)

--- a/features/document-collection-email-override.feature
+++ b/features/document-collection-email-override.feature
@@ -6,10 +6,10 @@ Feature: Setting the taxonomy topic email override for a document collection
     When I visit the edit document collection page
     Then I click on the tab "Email notifications"
     And I choose "Emails about this topic"
-    And I select "Education"
+    And I select "Employment"
     And I click the checkbox to confirm my selection.
     And I click "Save"
-    Then I see the success message "You’ve selected the email notification settings. You’ve chosen ‘Emails about the topic’ and the topic Education. You will not be able to change these settings after you publish the collection."
+    Then I see the success message "You’ve selected the email notification settings. You’ve chosen ‘Emails about the topic’ and the topic Employment. You will not be able to change these settings after you publish the collection."
 
 
   Scenario: User cannot set the email override without checking the confirmation box.
@@ -18,7 +18,7 @@ Feature: Setting the taxonomy topic email override for a document collection
     When I visit the edit document collection page
     Then I click on the tab "Email notifications"
     And I choose "Emails about this topic"
-    And I select "Education"
+    And I select "Employment"
     And I click "Save"
     Then I see the error "You must confirm you’re happy with the email notification settings" prompting me to confirm my selection.
 

--- a/features/step_definitions/document_collection_email_override_steps.rb
+++ b/features/step_definitions/document_collection_email_override_steps.rb
@@ -12,7 +12,7 @@ When(/^I visit the edit document collection page/) do
 end
 
 Then(/^I click on the tab "Email notifications/) do
-  stub_taxonomy_data
+  stub_taxonomy_with_selected_taxons
   expect(page).to have_content("Email notifications")
   click_on("Email notifications")
   expect(page).to have_content("Choose the type of email updates users will get if they sign up for notifications.")
@@ -32,7 +32,7 @@ end
 
 And(/^I click "Save"/) do
   stub_request(:get, %r{\A#{Plek.find('publishing-api')}/v2/content})
-  .to_return(body: { base_path: "/education", content_id: "root", title: "Education" }.to_json)
+  .to_return(body: { base_path: "/employment", content_id: "employment_taxon_content_id", title: "Employment" }.to_json)
   click_on("Save")
 end
 

--- a/test/integration/document_collection_email_override_test.rb
+++ b/test/integration/document_collection_email_override_test.rb
@@ -14,20 +14,20 @@ class DocumentCollectionEmailOverrideTest < ActionDispatch::IntegrationTest
       let(:user_with_permission_to_override) { create(:writer, permissions: [User::Permissions::EMAIL_OVERRIDE_EDITOR]) }
       before do
         login_as(user_with_permission_to_override)
-        stub_taxonomy_with_all_taxons
+        stub_taxonomy_with_selected_taxons
       end
 
       it "updates the taxonomy topic email override" do
-        stub_publishing_api_has_item(content_id: root_taxon_content_id, title: root_taxon["title"])
+        stub_publishing_api_has_item(content_id: employment_taxon_content_id, title: employment_taxon_parent["title"])
         visit edit_admin_document_collection_path(document_collection)
         click_link "Email notifications"
 
         page.choose("Emails about the topic")
-        select root_taxon["title"], from: "selected_taxon_content_id"
+        select employment_taxon_parent["title"], from: "selected_taxon_content_id"
         page.check("Select this box to confirm you're happy with what you've selected.")
         click_button("Save")
         document_collection.reload
-        assert_equal document_collection.taxonomy_topic_email_override, root_taxon_content_id
+        assert_equal document_collection.taxonomy_topic_email_override, employment_taxon_content_id
       end
 
       it "does not update taxonomy topic email if confirmation button is unchecked" do
@@ -35,7 +35,7 @@ class DocumentCollectionEmailOverrideTest < ActionDispatch::IntegrationTest
         click_link "Email notifications"
 
         page.choose("Emails about the topic")
-        select root_taxon["title"], from: "selected_taxon_content_id"
+        select employment_taxon_parent["title"], from: "selected_taxon_content_id"
         click_button("Save")
         document_collection.reload
         assert_nil document_collection.taxonomy_topic_email_override

--- a/test/support/taxonomy_helper.rb
+++ b/test/support/taxonomy_helper.rb
@@ -33,6 +33,14 @@ module TaxonomyHelper
     "grandparent"
   end
 
+  def employment_taxon_content_id
+    "employment_content_id"
+  end
+
+  def employment_taxon_child_content_id
+    "employment_child_content_id"
+  end
+
   def world_taxon_content_id
     "world"
   end
@@ -47,6 +55,10 @@ module TaxonomyHelper
 
   def stub_taxonomy_with_all_taxons
     redis_cache_has_taxons [root_taxon, draft_taxon1, draft_taxon2]
+  end
+
+  def stub_taxonomy_with_selected_taxons
+    redis_cache_has_taxons [root_taxon, employment_taxon_parent]
   end
 
   def stub_taxonomy_with_world_taxons
@@ -218,6 +230,45 @@ private
       title: "Parenting",
       base_path: "/childcare-parenting",
       content_id: draft_taxon_1_content_id,
+    )
+  end
+
+  def employment_taxon_parent
+    FactoryBot.build(
+      :taxon_hash,
+      title: "Employment",
+      base_path: "/employment",
+      content_id: employment_taxon_content_id,
+      children: [employment_taxon_child],
+    )
+  end
+
+  def employment_taxon_child
+    FactoryBot.build(
+      :taxon_hash,
+      title: "Employment is good",
+      base_path: "/employment/is-good",
+      content_id: employment_taxon_child_content_id,
+      children: [employment_taxon_grandchild],
+    )
+  end
+
+  def employment_taxon_grandchild
+    FactoryBot.build(
+      :taxon_hash,
+      title: "If you like your job",
+      base_path: "/employment/is-good/if-you-like-your-job",
+      content_id: employment_taxon_child_content_id,
+      children: [employment_taxon_greatgrandchild],
+    )
+  end
+
+  def employment_taxon_greatgrandchild
+    FactoryBot.build(
+      :taxon_hash,
+      title: "The end",
+      base_path: "/employment/the-end",
+      content_id: employment_taxon_child_content_id,
     )
   end
 

--- a/test/unit/app/presenters/topic_list_select_presenter_test.rb
+++ b/test/unit/app/presenters/topic_list_select_presenter_test.rb
@@ -4,43 +4,32 @@ class TopicListSelectPresenterTest < ActiveSupport::TestCase
   include TaxonomyHelper
 
   test ".grouped_options returns subtopics grouped by their parent topic" do
-    stub_taxonomy_with_all_taxons
-    #  this stubs a taxonomy with three taxons [Education, About your organisation, Parenting]
-    # only Education and Parenting branches are taggable, so About your organisation is hidden
-    #  from the select
+    stub_taxonomy_with_selected_taxons
+    #  this stubs a taxonomy with two taxons [Education, Employment]
+    #  only Employment is taggable, so Education is hidden from the select
 
     expected = [
       [
-        "Education",
+        "Employment",
         [
           {
-            text: "Education",
-            value: root_taxon_content_id,
+            text: "Employment",
+            value: employment_taxon_content_id,
             selected: false,
           },
           {
-            text: "Education > School Curriculum ",
-            value: grandparent_taxon_content_id,
+            text: "Employment > Employment is good ",
+            value: employment_taxon_child_content_id,
             selected: false,
           },
           {
-            text: "Education > School Curriculum > Primary curriculum, key stage 1 ",
-            value: parent_taxon_content_id,
+            text: "Employment > Employment is good > If you like your job ",
+            value: employment_taxon_child_content_id,
             selected: false,
           },
           {
-            text: "Education > School Curriculum > Primary curriculum, key stage 1 > Tests ",
-            value: child_taxon_content_id,
-            selected: false,
-          },
-        ],
-      ],
-      [
-        "Parenting",
-        [
-          {
-            text: "Parenting",
-            value: draft_taxon_1_content_id,
+            text: "Employment > Employment is good > If you like your job > The end ",
+            value: employment_taxon_child_content_id,
             selected: false,
           },
         ],


### PR DESCRIPTION
Update the branches shown to users in the email override taxonomy topic select. This select is part of the Email Notifcations UI for document collection pages. It will be used by HMRC to support a wider piece of work to retire specialist topics. The list of branches has come from the department.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
