### PR TITLE
Ensure edition is republished when assoication is updated

### DIFF
--- a/app/controllers/admin/call_for_evidence_responses_controller.rb
+++ b/app/controllers/admin/call_for_evidence_responses_controller.rb
@@ -13,6 +13,7 @@ class Admin::CallForEvidenceResponsesController < Admin::BaseController
     @response = response_class.new(response_params)
     @response.call_for_evidence = @edition
     if @response.save
+      PublishingApiDocumentRepublishingWorker.perform_async(@edition.document_id)
       redirect_to [:admin, @edition, @response.singular_routing_symbol], notice: "#{@response.friendly_name.capitalize} saved"
     else
       render :show
@@ -23,6 +24,7 @@ class Admin::CallForEvidenceResponsesController < Admin::BaseController
 
   def update
     if @response.update(response_params)
+      PublishingApiDocumentRepublishingWorker.perform_async(@edition.document_id)
       redirect_to [:admin, @edition, @response.singular_routing_symbol], notice: "#{@response.friendly_name.capitalize} updated"
     else
       render :edit

--- a/app/controllers/admin/consultation_responses_controller.rb
+++ b/app/controllers/admin/consultation_responses_controller.rb
@@ -13,6 +13,7 @@ class Admin::ConsultationResponsesController < Admin::BaseController
     @response = response_class.new(response_params)
     @response.consultation = @edition
     if @response.save
+      PublishingApiDocumentRepublishingWorker.perform_async(@edition.document_id)
       redirect_to [:admin, @edition, @response.singular_routing_symbol], notice: "#{@response.friendly_name.capitalize} saved"
     else
       render :show
@@ -23,6 +24,7 @@ class Admin::ConsultationResponsesController < Admin::BaseController
 
   def update
     if @response.update(response_params)
+      PublishingApiDocumentRepublishingWorker.perform_async(@edition.document_id)
       redirect_to [:admin, @edition, @response.singular_routing_symbol], notice: "#{@response.friendly_name.capitalize} updated"
     else
       render :edit

--- a/app/controllers/admin/document_collection_group_memberships_controller.rb
+++ b/app/controllers/admin/document_collection_group_memberships_controller.rb
@@ -10,6 +10,7 @@ class Admin::DocumentCollectionGroupMembershipsController < Admin::BaseControlle
     membership = DocumentCollectionGroupMembership.new(document: @document, document_collection_group: @group)
     redirect_path = admin_document_collection_group_document_collection_group_memberships_path(@collection, @group)
     if membership.save
+      PublishingApiDocumentRepublishingWorker.perform_async(@collection.document_id)
       title = @document.latest_edition.title
       redirect_to redirect_path,
                   notice: "'#{title}' added to '#{@group.heading}'"
@@ -25,6 +26,7 @@ class Admin::DocumentCollectionGroupMembershipsController < Admin::BaseControlle
       document_collection_group: @group,
     )
     if govuk_link.save
+      PublishingApiDocumentRepublishingWorker.perform_async(@collection.document_id)
       redirect_to admin_document_collection_group_document_collection_group_memberships_path(@collection, @group),
                   notice: "'#{govuk_link.title}' added to '#{@group.heading}'"
     else
@@ -37,6 +39,7 @@ class Admin::DocumentCollectionGroupMembershipsController < Admin::BaseControlle
 
   def destroy
     @membership.destroy!
+    PublishingApiDocumentRepublishingWorker.perform_async(@collection.document_id)
     redirect_to admin_document_collection_group_document_collection_group_memberships_path(@collection, @group),
                 notice: "Document has been removed from the group"
   end
@@ -45,6 +48,7 @@ class Admin::DocumentCollectionGroupMembershipsController < Admin::BaseControlle
 
   def order
     @group.memberships.reorder!(order_params)
+    PublishingApiDocumentRepublishingWorker.perform_async(@collection.document_id)
 
     flash_message = "Document has been reordered"
     redirect_to admin_document_collection_group_document_collection_group_memberships_path(@collection), notice: flash_message

--- a/app/controllers/admin/document_collection_groups_controller.rb
+++ b/app/controllers/admin/document_collection_groups_controller.rb
@@ -20,6 +20,7 @@ class Admin::DocumentCollectionGroupsController < Admin::BaseController
   def create
     @group = @collection.groups.build(document_collection_group_params)
     if @group.save
+      PublishingApiDocumentRepublishingWorker.perform_async(@collection.document_id)
       flash_message = "New group has been created"
       redirect_to admin_document_collection_groups_path(@collection),
                   notice: flash_message
@@ -32,6 +33,7 @@ class Admin::DocumentCollectionGroupsController < Admin::BaseController
 
   def update
     @group.update!(document_collection_group_params)
+    PublishingApiDocumentRepublishingWorker.perform_async(@collection.document_id)
     flash_message = "Group details have been updated"
     redirect_to admin_document_collection_groups_path(@collection),
                 notice: flash_message
@@ -43,6 +45,7 @@ class Admin::DocumentCollectionGroupsController < Admin::BaseController
 
   def order
     @collection.groups.reorder!(order_params)
+    PublishingApiDocumentRepublishingWorker.perform_async(@collection.document_id)
 
     flash_message = "Group has been reordered"
     redirect_to admin_document_collection_groups_path(@collection), notice: flash_message
@@ -50,6 +53,7 @@ class Admin::DocumentCollectionGroupsController < Admin::BaseController
 
   def destroy
     @group.destroy!
+    PublishingApiDocumentRepublishingWorker.perform_async(@collection.document_id)
     flash_message = "Group has been deleted"
     redirect_to admin_document_collection_groups_path(@collection),
                 notice: flash_message

--- a/app/workers/publishing_api_document_republishing_worker.rb
+++ b/app/workers/publishing_api_document_republishing_worker.rb
@@ -103,6 +103,8 @@ private
   end
 
   def send_draft_edition
+    return unless pre_publication_edition.valid?
+
     Whitehall::PublishingApi.save_draft(
       pre_publication_edition,
       "republish",

--- a/test/functional/admin/call_for_evidence_responses_controller_test.rb
+++ b/test/functional/admin/call_for_evidence_responses_controller_test.rb
@@ -38,6 +38,8 @@ class Admin::CallForEvidenceResponsesControllerTest < ActionController::TestCase
   end
 
   test "POST :create with valid outcome params saves the outcome and redirects" do
+    PublishingApiDocumentRepublishingWorker.expects(:perform_async).with(@call_for_evidence.document_id).once
+
     post :create, params: { call_for_evidence_id: @call_for_evidence, call_for_evidence_outcome: { summary: "Outcome summary", published_on: Time.zone.today }, type: "CallForEvidenceOutcome" }
 
     assert_response :redirect
@@ -59,6 +61,7 @@ class Admin::CallForEvidenceResponsesControllerTest < ActionController::TestCase
   end
 
   test "PUT :update with valid outcome params saves the changes to the outcome" do
+    PublishingApiDocumentRepublishingWorker.expects(:perform_async).with(@call_for_evidence.document_id).once
     outcome = create_outcome
     put :update, params: { call_for_evidence_id: @call_for_evidence, call_for_evidence_outcome: { summary: "New summary", published_on: Time.zone.today }, type: "CallForEvidenceOutcome" }
     assert_response :redirect

--- a/test/functional/admin/consultation_responses_controller_test.rb
+++ b/test/functional/admin/consultation_responses_controller_test.rb
@@ -54,6 +54,8 @@ class Admin::ConsultationResponsesControllerTest < ActionController::TestCase
   end
 
   test "POST :create with valid outcome params saves the outcome and redirects" do
+    PublishingApiDocumentRepublishingWorker.expects(:perform_async).with(@consultation.document_id).once
+
     post :create, params: { consultation_id: @consultation, consultation_outcome: { summary: "Outcome summary", published_on: Time.zone.today }, type: "ConsultationOutcome" }
 
     assert_response :redirect
@@ -62,6 +64,8 @@ class Admin::ConsultationResponsesControllerTest < ActionController::TestCase
   end
 
   test "POST :create with valid feedback params saves the feedback and redirects" do
+    PublishingApiDocumentRepublishingWorker.expects(:perform_async).with(@consultation.document_id).once
+
     post :create, params: { consultation_id: @consultation, consultation_public_feedback: { summary: "Feedback summary", published_on: Time.zone.today }, type: "ConsultationPublicFeedback" }
 
     assert_response :redirect
@@ -89,15 +93,21 @@ class Admin::ConsultationResponsesControllerTest < ActionController::TestCase
   end
 
   test "PUT :update with valid outcome params saves the changes to the outcome" do
+    PublishingApiDocumentRepublishingWorker.expects(:perform_async).with(@consultation.document_id).once
     outcome = create_outcome
+
     put :update, params: { consultation_id: @consultation, consultation_outcome: { summary: "New summary", published_on: Time.zone.today }, type: "ConsultationOutcome" }
+
     assert_response :redirect
     assert_equal "New summary", outcome.reload.summary
   end
 
   test "PUT :update with valid feedback params saves the changes to the feedback" do
     feedback = create_feedback
+    PublishingApiDocumentRepublishingWorker.expects(:perform_async).with(@consultation.document_id).once
+
     put :update, params: { consultation_id: @consultation, consultation_public_feedback: { summary: "New summary", published_on: Time.zone.today }, type: "ConsultationPublicFeedback" }
+
     assert_response :redirect
     assert_equal "New summary", feedback.reload.summary
   end

--- a/test/functional/admin/document_collection_group_memberships_controller_test.rb
+++ b/test/functional/admin/document_collection_group_memberships_controller_test.rb
@@ -47,6 +47,8 @@ class Admin::DocumentCollectionGroupMembershipsControllerTest < ActionController
 
   test "POST #create_whitehall_member adds a whitehall document to a group and redirects" do
     document = create(:publication).document
+    PublishingApiDocumentRepublishingWorker.expects(:perform_async).with(@collection.document_id).once
+
     assert_difference "@group.reload.documents.size" do
       post :create_whitehall_member, params: id_params.merge(document_id: document.id)
     end

--- a/test/functional/admin/document_collection_groups_controller_test.rb
+++ b/test/functional/admin/document_collection_groups_controller_test.rb
@@ -57,6 +57,7 @@ class Admin::DocumentCollectionGroupsControllerTest < ActionController::TestCase
   end
 
   test "POST #create creates a new group from valid data and redirects" do
+    PublishingApiDocumentRepublishingWorker.expects(:perform_async).with(@collection.document_id).once
     assert_difference("@collection.groups.count") do
       post_create(heading: "New group", body: "Group body")
     end
@@ -82,6 +83,7 @@ class Admin::DocumentCollectionGroupsControllerTest < ActionController::TestCase
   end
 
   test "PUT #update modifies the group and redirects" do
+    PublishingApiDocumentRepublishingWorker.expects(:perform_async).with(@collection.document_id).once
     put_update(heading: "New heading", body: "New body")
     @group.reload
     assert_equal "New heading", @group.heading
@@ -107,7 +109,8 @@ class Admin::DocumentCollectionGroupsControllerTest < ActionController::TestCase
     assert_equal @group, assigns(:group)
   end
 
-  view_test "DELETE #destroy deletes group and redirects" do
+  test "DELETE #destroy deletes group and redirects" do
+    PublishingApiDocumentRepublishingWorker.expects(:perform_async).with(@collection.document_id).once
     assert_difference "@collection.groups.count", -1 do
       delete :destroy, params: { document_collection_id: @collection, id: @group }
     end

--- a/test/functional/admin/edition_images_controller_test.rb
+++ b/test/functional/admin/edition_images_controller_test.rb
@@ -32,6 +32,8 @@ class Admin::EditionImagesControllerTest < ActionDispatch::IntegrationTest
     edition = create(:news_article)
 
     file = upload_fixture("images/960x640_jpeg.jpg")
+    PublishingApiDocumentRepublishingWorker.expects(:perform_async).with(edition.document_id).once
+
     post admin_edition_images_path(edition), params: { image: { image_data: { file: } } }
 
     follow_redirect!
@@ -107,6 +109,8 @@ class Admin::EditionImagesControllerTest < ActionDispatch::IntegrationTest
     image2 = build(:image)
     edition = create(:draft_case_study, images: [image1, image2])
     create(:edition_lead_image, edition:, image: image1)
+
+    PublishingApiDocumentRepublishingWorker.expects(:perform_async).with(edition.document_id).once
 
     delete admin_edition_image_path(edition, image1), params: { edition_id: edition.id, id: image1.id }
 

--- a/test/functional/admin/edition_lead_images_controller_test.rb
+++ b/test/functional/admin/edition_lead_images_controller_test.rb
@@ -7,11 +7,7 @@ class Admin::EditionLeadImagesControllerTest < ActionController::TestCase
     image = build(:image)
     edition = create(:draft_case_study, images: [image])
 
-    Whitehall::PublishingApi
-    .expects(:save_draft)
-    .with(edition)
-    .returns(true)
-    .once
+    PublishingApiDocumentRepublishingWorker.expects(:perform_async).with(edition.document_id).once
 
     get :update, params: { edition_id: edition.id, id: image.id }
 
@@ -30,10 +26,6 @@ class Admin::EditionLeadImagesControllerTest < ActionController::TestCase
     edition.change_note = nil
     edition.save!(validate: false)
 
-    Whitehall::PublishingApi
-    .expects(:save_draft)
-    .never
-
     get :update, params: { edition_id: edition.id, id: image.id }
 
     assert_nil edition.reload.lead_image
@@ -47,10 +39,6 @@ class Admin::EditionLeadImagesControllerTest < ActionController::TestCase
     published_edition = create(:published_case_study)
     image = build(:image)
     edition = create(:draft_case_study, images: [image], document: published_edition.document, body: "!!1")
-
-    Whitehall::PublishingApi
-    .expects(:save_draft)
-    .never
 
     get :update, params: { edition_id: edition.id, id: image.id }
 


### PR DESCRIPTION
## Description

We want to be able to republish documents when an editions associations are updated. At the moment, we often don't do this which is unintuitive to the user. To get round this they can go to the edit edition page and click save to send the changes downstream, but it's no ideal behaviour.

We've had quite a few 2ndline tickets come in around this issue across Whitehall.

This updates the PublishingApiDocumentRepublishingWorker to not publish a draft edition downstream if it is invalid, then calls it in the controllers where associations are created/updated/deleted etc.

The edition largely is only invalid when it's carried over from a post publication state to draft as we skip validations while duping the edition and it's associations.

## Trello card

https://trello.com/c/HqQvJOq3/2259-ensure-draft-content-store-is-updated-when-a-user-saves-a-page

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
