### PR TITLE
Remove unused boostrap tabs code

### DIFF
--- a/app/helpers/admin/organisation_helper.rb
+++ b/app/helpers/admin/organisation_helper.rb
@@ -15,28 +15,6 @@ module Admin::OrganisationHelper
     end
   end
 
-  def organisation_tabs(organisation)
-    tabs = {
-      "Details" => admin_organisation_path(organisation),
-      "Contacts" => admin_organisation_contacts_path(organisation),
-    }
-    if organisation.type.allowed_promotional?
-      tabs["Promotional features"] = admin_organisation_promotional_features_path(organisation)
-    end
-
-    tabs["Features"] = features_admin_organisation_path(organisation, locale: I18n.default_locale)
-    organisation.non_english_translated_locales.each do |locale|
-      tabs["Features (#{locale.native_language_name})"] = features_admin_organisation_path(organisation, locale: locale.code)
-    end
-    tabs["Corporate information pages"] = admin_organisation_corporate_information_pages_path(organisation)
-    tabs["More"] = {
-      "Social media accounts" => admin_organisation_social_media_accounts_path(organisation),
-      "People" => admin_organisation_people_path(organisation),
-      "Translations" => admin_organisation_translations_path(organisation),
-    }
-    tabs
-  end
-
   def organisation_nav_items(organisation, current_path)
     tabs = [
       {

--- a/app/helpers/admin/topical_event_helper.rb
+++ b/app/helpers/admin/topical_event_helper.rb
@@ -1,12 +1,4 @@
 module Admin::TopicalEventHelper
-  def topical_event_tabs(topical_event)
-    {
-      "Details" => url_for([:admin, topical_event]),
-      "About page" => url_for([:admin, topical_event, :topical_event_about_pages]),
-      "Features" => url_for([:admin, topical_event, :topical_event_featurings]),
-    }
-  end
-
   def topical_event_nav_items(topical_event, current_path)
     [
       {

--- a/app/helpers/admin/world_location_helper.rb
+++ b/app/helpers/admin/world_location_helper.rb
@@ -25,16 +25,4 @@ module Admin::WorldLocationHelper
       end,
     ].flatten.compact
   end
-
-  def world_location_news_tabs(world_location)
-    tabs = {
-      "Details" => admin_world_location_news_path(world_location),
-      "Translations" => admin_world_location_news_translations_path(world_location),
-      "Features (#{Locale.new(:en).native_language_name})" => features_admin_world_location_news_path(world_location, locale: I18n.default_locale),
-    }
-    world_location.non_english_translated_locales.each do |locale|
-      tabs["Features (#{locale.native_language_name})"] = features_admin_world_location_news_path(world_location, locale: locale.code)
-    end
-    tabs
-  end
 end

--- a/app/helpers/admin/worldwide_organisations_helper.rb
+++ b/app/helpers/admin/worldwide_organisations_helper.rb
@@ -1,15 +1,4 @@
 module Admin::WorldwideOrganisationsHelper
-  def worldwide_organisation_tabs(worldwide_organisation)
-    {
-      "Details" => admin_worldwide_organisation_path(worldwide_organisation),
-      "Translations" => admin_worldwide_organisation_translations_path(worldwide_organisation),
-      "Offices" => admin_worldwide_organisation_worldwide_offices_path(worldwide_organisation),
-      "Access and opening times" => access_info_admin_worldwide_organisation_path(worldwide_organisation),
-      "Social media accounts" => admin_worldwide_organisation_social_media_accounts_path(worldwide_organisation),
-      "Corporate information pages" => admin_worldwide_organisation_corporate_information_pages_path(worldwide_organisation),
-    }
-  end
-
   def worldwide_organisation_nav_items(worldwide_organisation, current_path)
     [
       {


### PR DESCRIPTION
## Description

While doing some work to remove financial reports form the codebase i noticed some unused legacy code. This is the Boostrap implantation of the sub navigation tabs. It's no longer being used and can be removed.


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
