### PR TITLE
Remove matrix strategy for feature specs workflow

### DIFF
--- a/.github/workflows/cucumber.yml
+++ b/.github/workflows/cucumber.yml
@@ -7,8 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        node_rake_task: ["cucumber:ok"]
     steps:
       - name: Setup MySQL
         id: setup-mysql
@@ -45,7 +43,7 @@ jobs:
         env:
           RAILS_ENV: test
           TEST_DATABASE_URL: ${{ steps.setup-mysql.outputs.db-url }}
-        run: bundle exec rake ${{ matrix.node_rake_task }}
+        run: bundle exec rake cucumber
 
       - name: Upload screenshots
         uses: actions/upload-artifact@v3
@@ -53,10 +51,3 @@ jobs:
         with:
           name: capybara-screenshots
           path: tmp/capybara/capybara-*.png
-
-  run-cucumber:
-    name: Run Cucumber
-    needs: feature-test-matrix
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "All feature tests have passed 🚀"


### PR DESCRIPTION
## Description 

We no longer have the need to run the feature specs more than once so we don't need a matrix strategy anymore


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
