### PR TITLE
Revert "Bump govspeak from 8.3.1 to 8.3.2"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -245,7 +245,7 @@ GEM
     google-protobuf (3.25.1-x86_64-linux)
     googleapis-common-protos-types (1.11.0)
       google-protobuf (~> 3.18)
-    govspeak (8.3.2)
+    govspeak (8.3.1)
       actionview (>= 6)
       addressable (>= 2.3.8, < 3)
       govuk_publishing_components (>= 35.1)


### PR DESCRIPTION
## Description

testing to see if this fixes the feature specs on ci
Reverts alphagov/whitehall#8629