### PR TITLE
Present basic EditionableWorldwideOrgs

### DIFF
--- a/app/models/editionable_worldwide_organisation.rb
+++ b/app/models/editionable_worldwide_organisation.rb
@@ -4,4 +4,12 @@ class EditionableWorldwideOrganisation < Edition
   def display_type_key
     "editionable_worldwide_organisation"
   end
+
+  def publishing_api_presenter
+    PublishingApi::EditionableWorldwideOrganisationPresenter
+  end
+
+  def base_path
+    "/editionable-world/organisations/#{slug}"
+  end
 end

--- a/app/presenters/publishing_api/editionable_worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/editionable_worldwide_organisation_presenter.rb
@@ -1,0 +1,40 @@
+module PublishingApi
+  class EditionableWorldwideOrganisationPresenter
+    include Rails.application.routes.url_helpers
+    include ActionView::Helpers::UrlHelper
+
+    attr_accessor :item, :update_type, :state
+
+    def initialize(item, update_type: nil, state: "published")
+      self.item = item
+      self.update_type = update_type || "major"
+      self.state = state
+    end
+
+    delegate :content_id, to: :item
+
+    def content
+      content = BaseItemPresenter.new(
+        item,
+        update_type:,
+      ).base_attributes
+
+      content.merge!(
+        details: {
+          logo: {
+            crest: "single-identity",
+          },
+        },
+        document_type: item.class.name.underscore,
+        public_updated_at: item.updated_at,
+        rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
+        schema_name: "worldwide_organisation",
+      )
+      content.merge!(PayloadBuilder::PolymorphicPath.for(item))
+    end
+
+    def links
+      {}
+    end
+  end
+end

--- a/app/presenters/publishing_api/editionable_worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/editionable_worldwide_organisation_presenter.rb
@@ -34,7 +34,9 @@ module PublishingApi
     end
 
     def links
-      {}
+      {
+        sponsoring_organisations: item.organisations.map(&:content_id),
+      }
     end
   end
 end

--- a/test/unit/app/presenters/publishing_api/editionable_worldwide_organisation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/editionable_worldwide_organisation_presenter_test.rb
@@ -1,0 +1,42 @@
+require "test_helper"
+
+class PublishingApi::EditionableWorldwideOrganisationPresenterTest < ActiveSupport::TestCase
+  def present(...)
+    PublishingApi::EditionableWorldwideOrganisationPresenter.new(...)
+  end
+
+  test "presents a Worldwide Organisation ready for adding to the publishing API" do
+    worldwide_org = create(:editionable_worldwide_organisation)
+
+    public_path = worldwide_org.public_path
+
+    expected_hash = {
+      base_path: public_path,
+      title: worldwide_org.title,
+      schema_name: "worldwide_organisation",
+      document_type: "editionable_worldwide_organisation",
+      locale: "en",
+      publishing_app: Whitehall::PublishingApp::WHITEHALL,
+      rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
+      public_updated_at: worldwide_org.updated_at,
+      routes: [{ path: public_path, type: "exact" }],
+      redirects: [],
+      details: {
+        logo: {
+          crest: "single-identity",
+        },
+      },
+      update_type: "major",
+    }
+
+    presented_item = present(worldwide_org)
+
+    assert_equal expected_hash, presented_item.content
+    assert_equal "major", presented_item.update_type
+    assert_equal worldwide_org.content_id, presented_item.content_id
+
+    # TODO: uncomment the below assertion when the editionable_worldwide_organisation model is
+    # finished and all content can be added to this presenter.
+    # assert_valid_against_publisher_schema(presented_item.content, "worldwide_organisation")
+  end
+end

--- a/test/unit/app/presenters/publishing_api/editionable_worldwide_organisation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/editionable_worldwide_organisation_presenter_test.rb
@@ -29,6 +29,10 @@ class PublishingApi::EditionableWorldwideOrganisationPresenterTest < ActiveSuppo
       update_type: "major",
     }
 
+    expected_links = {
+      sponsoring_organisations: worldwide_org.organisations.map(&:content_id),
+    }
+
     presented_item = present(worldwide_org)
 
     assert_equal expected_hash, presented_item.content
@@ -38,5 +42,8 @@ class PublishingApi::EditionableWorldwideOrganisationPresenterTest < ActiveSuppo
     # TODO: uncomment the below assertion when the editionable_worldwide_organisation model is
     # finished and all content can be added to this presenter.
     # assert_valid_against_publisher_schema(presented_item.content, "worldwide_organisation")
+
+    assert_equal expected_links, presented_item.links
+    assert_valid_against_links_schema({ links: presented_item.links }, "worldwide_organisation")
   end
 end


### PR DESCRIPTION
Present basic content item to Publishing-api for new EditionableWorldwideOrgs model

Trello: https://trello.com/c/dXOk7nz4/958-present-wworgs-to-the-publishing-api

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
