### PR TITLE
Fix code injection vulnerability

### DIFF
--- a/app/controllers/admin/organisation_people_controller.rb
+++ b/app/controllers/admin/organisation_people_controller.rb
@@ -4,17 +4,23 @@ class Admin::OrganisationPeopleController < Admin::BaseController
 
   def index
     @render_reorder = can?(:edit, @organisation)
-    @ministerial_organisation_roles = organisation_roles(:ministerial)
-    @management_organisation_roles = organisation_roles(:management)
-    @traffic_commissioner_organisation_roles = organisation_roles(:traffic_commissioner)
-    @military_organisation_roles = organisation_roles(:military)
-    @special_representative_organisation_roles = organisation_roles(:special_representative)
-    @chief_professional_officer_roles = organisation_roles(:chief_professional_officer)
+    @ministerial_organisation_roles = organisation_roles("ministerial")
+    @management_organisation_roles = organisation_roles("management")
+    @traffic_commissioner_organisation_roles = organisation_roles("traffic_commissioner")
+    @military_organisation_roles = organisation_roles("military")
+    @special_representative_organisation_roles = organisation_roles("special_representative")
+    @chief_professional_officer_roles = organisation_roles("chief_professional_officer")
   end
 
   def reorder
     type = params[:type]
-    @organisation_roles = organisation_roles(type)
+    valid_types = %w[ministerial special_representative management traffic_commissioner chief_professional_officer military]
+
+    if valid_types.exclude?(type)
+      render "admin/errors/not_found", status: :not_found
+    else
+      @organisation_roles = organisation_roles(type)
+    end
   end
 
   def order
@@ -27,8 +33,28 @@ class Admin::OrganisationPeopleController < Admin::BaseController
 private
 
   def organisation_roles(type)
-    @organisation.organisation_roles.joins(:role)
-                 .merge(Role.send(type)).order(:ordering)
+    @organisation
+    .organisation_roles
+    .joins(:role)
+    .merge(roles_for_type(type))
+    .order(:ordering)
+  end
+
+  def roles_for_type(type)
+    case type
+    when "ministerial"
+      Role.ministerial
+    when "management"
+      Role.management
+    when "traffic_commissioner"
+      Role.traffic_commissioner
+    when "military"
+      Role.military
+    when "special_representative"
+      Role.special_representative
+    when "chief_professional_officer"
+      Role.chief_professional_officer
+    end
   end
 
   def enforce_permissions!

--- a/test/functional/admin/organisation_people_controller_test.rb
+++ b/test/functional/admin/organisation_people_controller_test.rb
@@ -263,6 +263,19 @@ class Admin::OrganisationPeopleControllerTest < ActionController::TestCase
     assert_equal [organisation_senior_representative_role, organisation_junior_representative_role], assigns(:organisation_roles)
   end
 
+  test "GET on :reorder returns a not_found response if type param is invalid" do
+    junior_ministerial_role = create(:ministerial_role)
+    senior_ministerial_role = create(:ministerial_role)
+    organisation = create(:organisation)
+    create(:organisation_role, organisation:, role: junior_ministerial_role, ordering: 2)
+    create(:organisation_role, organisation:, role: senior_ministerial_role, ordering: 1)
+
+    get :reorder, params: { organisation_id: organisation, type: "invalid_type" }
+
+    assert_response :not_found
+    assert_template "admin/errors/not_found"
+  end
+
   test "PUT on :order reorders and saves the order of people" do
     organisation = create(:organisation)
 


### PR DESCRIPTION
## Description

In the organisation roles controller #send is used directly on the Role class.

This has caused a [security alert](https://github.com/alphagov/whitehall/security/code-scanning/9)

This provides an attack vector for scripting. Particularly because it's using `#send` in place of `#public_send` so it has access to the private interface too.

There's some hidden complexity here because the type param is actually one of 6 scopes called on the Role model.

This is a pretty rough and ready fix and there are probably better solutions. I'd love to give this whole bit of the codebase a refactor as there's a bunch of weird stuff going on, but for now i think this is probably the simplest way to resolve the vulnerability.

Ideally, i think the type query param would move to the path and we could think about using constraints to match on type
https://guides.rubyonrails.org/routing.html#specifying-constraints

We could also potentially add a separate reorder endpoint for each type like we did for the [CabinetMinistersController](https://github.com/alphagov/whitehall/blob/bd0113e7737e1eef73050d808b052e0cf1212f08/app/controllers/admin/cabinet_ministers_controller.rb#L4). But i think that's probably a bit beyond the scope of this investigation & fix.

## Link to security issues for this PR 

You can see that the alert has been resolved by this PR here 

https://github.com/alphagov/whitehall/security/code-scanning?query=is%3Aopen+pr%3A8644


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
