### PR TITLE
Remove access limited from edition rake task

### DIFF
--- a/docs/remove_access_limited.md
+++ b/docs/remove_access_limited.md
@@ -1,0 +1,19 @@
+# Access limited
+Whitehall offers an “access limiting” feature on editions. This makes documents that are sensitive only viewable by the
+owning organisation while in draft. This works by checking the edition organisations ids against the user's organisation id.
+
+The access limited attribute can be set on the edition edit page. It is a check box near the bottom of the page.
+
+# Know user issues and fixes
+
+Sometimes users set an edition to be access limited, but are not members of the owning organisation so they can no longer
+view the document, in this case (if the user agrees) we can make the document un-access-limited so it is viewable by everyone,
+and it can be edited again.
+
+A rake task was introduced to aid 2nd-line to temporarily remove the access.
+It can be be used in the following way:
+
+```
+# Given an Edition of ID 12345
+rake remove_access_limiting[12345]
+```

--- a/lib/tasks/remove_access_limiting.rake
+++ b/lib/tasks/remove_access_limiting.rake
@@ -1,0 +1,12 @@
+desc "Set access limited to false for selected edition "
+task :remove_access_limiting, %i[edition_id] => :environment do |_, args|
+  id = args[:edition_id]
+  edition = Edition.where(id:).first
+
+  raise "Cannot find edition of ID #{id}." unless edition
+
+  edition.access_limited = false
+  edition.save!
+
+  puts "Access limited successfully set to false for edition of ID #{id}."
+end

--- a/test/unit/lib/tasks/remove_access_limiting_test.rb
+++ b/test/unit/lib/tasks/remove_access_limiting_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+require "rake"
+
+class RemoveAccessLimitingTest < ActiveSupport::TestCase
+  teardown do
+    Rake::Task["remove_access_limiting"].reenable
+  end
+
+  test "sets access limited to false for selected edition" do
+    edition = create(:draft_edition, :access_limited)
+
+    assert_output(/Access limited successfully set to false for edition of ID #{edition.id}./) { Rake.application.invoke_task("remove_access_limiting[#{edition.id}]") }
+
+    edition.reload
+    assert_equal false, edition.access_limited
+  end
+
+  test "raises error if edition cannot be found" do
+    assert_raises(StandardError, "Cannot find edition of ID 12345.") do
+      Rake.application.invoke_task("remove_access_limiting[12345]")
+    end
+  end
+end


### PR DESCRIPTION
There have been cases of users accidentally removing their own access by not setting the correct organisations, thus making it impossible for themselves to publish. Adding rake task to temporarily remove access limited from editions so that the users can fix the organisation.

[Trello card](https://trello.com/c/DKQPwuNN/2273-add-a-rake-task-to-disable-access-limiting-for-an-edition)