### PR TITLE
Improve accessibility of search results

### DIFF
--- a/app/views/admin/editions/_search_results.html.erb
+++ b/app/views/admin/editions/_search_results.html.erb
@@ -46,6 +46,7 @@
             },
           ]
         end,
+      first_cell_is_header: true,
     } %>
   </div>
 

--- a/app/views/admin/editions/_search_results.html.erb
+++ b/app/views/admin/editions/_search_results.html.erb
@@ -6,8 +6,6 @@
     <p class="govuk-heading-s govuk-!-margin-bottom-3"><%= pluralize(number_with_delimiter(@filter.editions.total_count), "document") %></p>
 <% end %>
 
-<hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
-
 <% if filter.editions.blank? %>
   <p class="govuk-body app-view-edition-search-results__no_documents">No documents found</p>
 <% else %>

--- a/app/views/admin/editions/index.html.erb
+++ b/app/views/admin/editions/index.html.erb
@@ -7,7 +7,7 @@
     <%= render "filter_options", filter_action: admin_editions_path %>
   </div>
   <div class="govuk-grid-column-two-thirds">
-    <div class="app-view-edition-index__table">
+    <div class="app-view-edition-index__table" aria-label="Search results">
       <%= render "search_results", filter: @filter, paginator: @filter.editions, show_export: true %>
     </div>
   </div>

--- a/app/views/admin/featurable_editions/_search_results.html.erb
+++ b/app/views/admin/featurable_editions/_search_results.html.erb
@@ -39,6 +39,7 @@
           },
         ]
       end,
+    first_cell_is_header: true,
   } %>
 
   <%= paginate(paginator, anchor: anchor, theme: "govuk_paginator") %>

--- a/app/views/admin/shared/_featurable_editions.html.erb
+++ b/app/views/admin/shared/_featurable_editions.html.erb
@@ -8,7 +8,7 @@
     <%= render "admin/editions/filter_options", filter_by:, filter_action:, anchor: %>
   </div>
   <div class="govuk-grid-column-two-thirds">
-    <div class="app-view-features-search-results__table">
+    <div class="app-view-features-search-results__table" aria-label="Search results">
       <%= render "admin/featurable_editions/search_results", featurable_editions:, paginator:, anchor:, feature_path: %>
     </div>
   </div>

--- a/app/views/admin/statistics_announcements/_search_results.html.erb
+++ b/app/views/admin/statistics_announcements/_search_results.html.erb
@@ -49,6 +49,7 @@
             },
           ]
         end,
+      first_cell_is_header: true,
     } %>
   </div>
 

--- a/app/views/admin/statistics_announcements/index.html.erb
+++ b/app/views/admin/statistics_announcements/index.html.erb
@@ -28,7 +28,7 @@
     <%= render "filter_options" %>
   </div>
   <div class="govuk-grid-column-two-thirds">
-    <div class="app-view-edition-index__table">
+    <div class="app-view-edition-index__table" aria-label="Search results">
       <%= render "search_results", filter: @filter, paginator: @statistics_announcements, show_export: true %>
     </div>
   </div>

--- a/test/functional/admin/editions_controller_test.rb
+++ b/test/functional/admin/editions_controller_test.rb
@@ -164,7 +164,7 @@ class Admin::EditionsControllerTest < ActionController::TestCase
     get :index, params: { state: :published, type: :publication }
 
     assert_select ".govuk-table__row" do
-      assert_select ".govuk-table__cell:nth-child(1)", text: publication.title
+      assert_select ".govuk-table__header:nth-child(1)", text: publication.title
       assert_select ".govuk-table__cell:nth-child(3)", text: "Published"
     end
   end
@@ -174,7 +174,7 @@ class Admin::EditionsControllerTest < ActionController::TestCase
     get :index, params: { state: :published, type: :publication }
 
     assert_select ".govuk-table__row" do
-      assert_select ".govuk-table__cell:nth-child(1)", text: publication.title
+      assert_select ".govuk-table__header:nth-child(1)", text: publication.title
       assert_select ".govuk-table__cell:nth-child(3)", text: "Force published"
     end
   end
@@ -184,7 +184,7 @@ class Admin::EditionsControllerTest < ActionController::TestCase
     get :index, params: { state: :force_published, type: :publication }
 
     assert_select ".govuk-table__row" do
-      assert_select ".govuk-table__cell:nth-child(1)", text: publication.title
+      assert_select ".govuk-table__header:nth-child(1)", text: publication.title
       assert_select ".govuk-table__cell:nth-child(3)", text: "Force published"
     end
   end
@@ -198,25 +198,25 @@ class Admin::EditionsControllerTest < ActionController::TestCase
     get :index, params: { state: :active }
 
     assert_select ".govuk-table__row" do
-      assert_select ".govuk-table__cell:nth-child(1)", text: draft_edition.title do |cell|
+      assert_select ".govuk-table__header:nth-child(1)", text: draft_edition.title do |cell|
         cell.first.parent.xpath("td[3]").text.strip == "Draft"
       end
     end
 
     assert_select ".govuk-table__row" do
-      assert_select ".govuk-table__cell:nth-child(1)", text: submitted_edition.title do |cell|
+      assert_select ".govuk-table__header:nth-child(1)", text: submitted_edition.title do |cell|
         cell.first.parent.xpath("td[3]").text.strip == "Submitted"
       end
     end
 
     assert_select ".govuk-table__row" do
-      assert_select ".govuk-table__cell:nth-child(1)", text: rejected_edition.title do |cell|
+      assert_select ".govuk-table__header:nth-child(1)", text: rejected_edition.title do |cell|
         cell.first.parent.xpath("td[3]").text.strip == "Rejected"
       end
     end
 
     assert_select ".govuk-table__row" do
-      assert_select ".govuk-table__cell:nth-child(1)", text: published_edition.title do |cell|
+      assert_select ".govuk-table__header:nth-child(1)", text: published_edition.title do |cell|
         cell.first.parent.xpath("td[3]").text.strip == "Published"
       end
     end
@@ -236,9 +236,9 @@ class Admin::EditionsControllerTest < ActionController::TestCase
     get :index, params: { state: :active }
 
     accessible.each do |edition|
-      assert_select ".govuk-table__cell:nth-child(1)", text: edition.title
+      assert_select ".govuk-table__header:nth-child(1)", text: edition.title
     end
-    refute_select ".govuk-table__cell:nth-child(1)", text: inaccessible.title
+    refute_select ".govuk-table__header:nth-child(1)", text: inaccessible.title
   end
 
   view_test "index should indicate the protected status of limited access editions which I do have access to" do
@@ -249,7 +249,7 @@ class Admin::EditionsControllerTest < ActionController::TestCase
     get :index, params: { state: :active }
 
     assert_select ".govuk-table__row" do
-      assert_select ".govuk-table__cell:nth-child(1)", text: publication.title
+      assert_select ".govuk-table__header:nth-child(1)", text: publication.title
       assert_select ".govuk-table__cell:nth-child(3)", text: "Draft Limited access"
     end
   end


### PR DESCRIPTION
Part of fixes emerging from the accessibility review:
1. Add an aria-label to better identify the search results -> in editions, features and statistics announcements.
2. Make the cells in the first column of the search results table into headers.

Resulting table structure after 2) changes:

![Screenshot 2023-12-19 at 12 09 33](https://github.com/alphagov/whitehall/assets/91544378/4242e810-4ecb-4479-a210-64008bd52206)


[Trello card](https://trello.com/c/zIYMTayy/2207-improve-accessibility-of-document-search-results)