### PR TITLE
Add World Location association for Editionable Worldwide Organisations

### DIFF
--- a/app/models/editionable_worldwide_organisation.rb
+++ b/app/models/editionable_worldwide_organisation.rb
@@ -1,5 +1,6 @@
 class EditionableWorldwideOrganisation < Edition
   include Edition::Organisations
+  include Edition::WorldLocations
 
   def display_type_key
     "editionable_worldwide_organisation"
@@ -11,5 +12,9 @@ class EditionableWorldwideOrganisation < Edition
 
   def base_path
     "/editionable-world/organisations/#{slug}"
+  end
+
+  def skip_world_location_validation?
+    false
   end
 end

--- a/app/presenters/publishing_api/editionable_worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/editionable_worldwide_organisation_presenter.rb
@@ -36,6 +36,7 @@ module PublishingApi
     def links
       {
         sponsoring_organisations: item.organisations.map(&:content_id),
+        world_locations: item.world_locations.map(&:content_id),
       }
     end
   end

--- a/app/views/admin/editionable_worldwide_organisations/_form.html.erb
+++ b/app/views/admin/editionable_worldwide_organisations/_form.html.erb
@@ -6,7 +6,8 @@
     id: "associations",
   } do %>
     <div class="govuk-!-margin-bottom-4">
-      <%= render "organisation_fields", form: form, edition: edition %>
+      <%= render "world_location_fields", form: form, edition: edition %>
+      <%= render "organisation_fields", form: form, edition: edition, required: true %>
     </div>
   <% end %>
 <% end %>

--- a/app/views/admin/editions/_conflict.html.erb
+++ b/app/views/admin/editions/_conflict.html.erb
@@ -20,7 +20,7 @@
 <% if edition.can_be_associated_with_world_locations? %>
   <h2 class="govuk-heading-m">World locations</h2>
   <% if edition.world_locations.any? %>
-    <%= render "world_locations/list", world_locations: edition.world_locations %>
+    <%= render "admin/world_location_news/list", world_locations: edition.world_locations %>
   <% else %>
     <p class="govuk-body">This document isn’t assigned to any world locations.</p>
   <% end %>

--- a/app/views/admin/world_location_news/_list.html.erb
+++ b/app/views/admin/world_location_news/_list.html.erb
@@ -1,7 +1,7 @@
 <ul class="world-locations">
   <% world_locations.each do |world_location| %>
     <%= content_tag_for(:li, world_location) do %>
-      <%= link_to world_location.name, admin_world_locations_path(anchor: "world_location_#{world_location.id}"), class: "location-link" %>
+      <%= link_to world_location.name, admin_world_location_news_path(anchor: "world_location_#{world_location.id}"), class: "location-link" %>
     <% end %>
   <% end %>
 </ul>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -51,6 +51,7 @@ if WorldLocation.where(name: "Test World Location").blank?
   world_location = WorldLocation.create!(
     name: "Test World Location",
     world_location_type: "world_location",
+    active: true,
   )
 
   world_location_news = WorldLocationNews.create!(
@@ -156,6 +157,7 @@ if WorldLocation.where(name: "Test International Delegation").blank?
       summary: "An example worldwide organisation",
       supporting_organisations: [],
       title: "Test Editionable Worldwide Organisation",
+      world_locations: [WorldLocation.first],
     )
   end
 end

--- a/features/editionable-worldwide-organisations.feature
+++ b/features/editionable-worldwide-organisations.feature
@@ -2,7 +2,9 @@ Feature: Editionable worldwide organisations
   Background:
     Given I am a writer
     And The editionable worldwide organisations feature flag is enabled
+    And a world location "United Kingdom" exists
 
   Scenario Outline: Creating a new draft worldwide organisation
-    When I draft a new worldwide organisation "Test Worldwide Organisation"
+    When I draft a new worldwide organisation "Test Worldwide Organisation" assigned to world location "United Kingdom"
     Then the worldwide organisation "Test Worldwide Organisation" should have been created
+    And I should see it has been assigned to the "United Kingdom" world location

--- a/features/editionable-worldwide-organisations.feature
+++ b/features/editionable-worldwide-organisations.feature
@@ -1,0 +1,8 @@
+Feature: Editionable worldwide organisations
+  Background:
+    Given I am a writer
+    And The editionable worldwide organisations feature flag is enabled
+
+  Scenario Outline: Creating a new draft worldwide organisation
+    When I draft a new worldwide organisation "Test Worldwide Organisation"
+    Then the worldwide organisation "Test Worldwide Organisation" should have been created

--- a/features/step_definitions/editionable_worldwide_organisation_steps.rb
+++ b/features/step_definitions/editionable_worldwide_organisation_steps.rb
@@ -3,12 +3,16 @@ Given(/^The editionable worldwide organisations feature flag is (enabled|disable
   @test_strategy.switch!(:editionable_worldwide_organisations, enabled == "enabled")
 end
 
-When(/^I draft a new worldwide organisation "([^"]*)"$/) do |title|
-  begin_drafting_worldwide_organisation(title:)
+When(/^I draft a new worldwide organisation "([^"]*)" assigned to world location "([^"]*)"$/) do |title, world_location|
+  begin_drafting_worldwide_organisation(title:, world_location:)
   click_button "Save and go to document summary"
 end
 
 Then(/^the worldwide organisation "([^"]*)" should have been created$/) do |title|
   @worldwide_organisation = EditionableWorldwideOrganisation.find_by(title:)
   expect(@worldwide_organisation).to be_present
+end
+
+And(/^I should see it has been assigned to the "([^"]*)" world location$/) do |title|
+  expect(@worldwide_organisation.world_locations.first.name).to eq(title)
 end

--- a/features/step_definitions/editionable_worldwide_organisation_steps.rb
+++ b/features/step_definitions/editionable_worldwide_organisation_steps.rb
@@ -1,0 +1,14 @@
+Given(/^The editionable worldwide organisations feature flag is (enabled|disabled)$/) do |enabled|
+  @test_strategy ||= Flipflop::FeatureSet.current.test!
+  @test_strategy.switch!(:editionable_worldwide_organisations, enabled == "enabled")
+end
+
+When(/^I draft a new worldwide organisation "([^"]*)"$/) do |title|
+  begin_drafting_worldwide_organisation(title:)
+  click_button "Save and go to document summary"
+end
+
+Then(/^the worldwide organisation "([^"]*)" should have been created$/) do |title|
+  @worldwide_organisation = EditionableWorldwideOrganisation.find_by(title:)
+  expect(@worldwide_organisation).to be_present
+end

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -105,14 +105,16 @@ module DocumentHelper
   def begin_drafting_worldwide_organisation(options)
     begin_drafting_document options.merge(type: "editionable_worldwide_organisation", previously_published: false)
 
-    fill_in_worldwide_organisation_fields
+    fill_in_worldwide_organisation_fields(**options.slice(:world_location))
   end
 
   def pdf_attachment
     Rails.root.join("features/fixtures/attachment.pdf")
   end
 
-  def fill_in_worldwide_organisation_fields; end
+  def fill_in_worldwide_organisation_fields(world_location: "United Kingdom")
+    select world_location, from: "World locations"
+  end
 
   def fill_in_news_article_fields(first_published: "2010-01-01", announcement_type: "News story")
     select announcement_type, from: "News article type"

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -1,6 +1,6 @@
 ParameterType(
   name: "edition",
-  regexp: /the (document|publication|news article|consultation|consultation response|speech|detailed guide|announcement|world location news article|statistical data set|document collection|corporate information page|call for evidence) "([^"]*)"/,
+  regexp: /the (document|publication|news article|consultation|consultation response|speech|detailed guide|announcement|world location news article|statistical data set|document collection|corporate information page|call for evidence|editionable worldwide organisation) "([^"]*)"/,
   transformer: ->(document_type, title) { document_class(document_type).latest_edition.find_by!(title:) },
 )
 
@@ -102,9 +102,17 @@ module DocumentHelper
     begin_drafting_document options.merge(type: "document_collection", previously_published: false)
   end
 
+  def begin_drafting_worldwide_organisation(options)
+    begin_drafting_document options.merge(type: "editionable_worldwide_organisation", previously_published: false)
+
+    fill_in_worldwide_organisation_fields
+  end
+
   def pdf_attachment
     Rails.root.join("features/fixtures/attachment.pdf")
   end
+
+  def fill_in_worldwide_organisation_fields; end
 
   def fill_in_news_article_fields(first_published: "2010-01-01", announcement_type: "News story")
     select announcement_type, from: "News article type"

--- a/test/factories/editionable_worldwide_organisations.rb
+++ b/test/factories/editionable_worldwide_organisations.rb
@@ -1,6 +1,12 @@
 FactoryBot.define do
   factory :editionable_worldwide_organisation, class: EditionableWorldwideOrganisation, parent: :edition_with_organisations do
     title { "editionable-worldwide-organisation-title" }
+
+    after :build do |news_article, evaluator|
+      if evaluator.world_locations.empty?
+        news_article.world_locations << build(:world_location)
+      end
+    end
   end
 
   factory :draft_editionable_worldwide_organisation, parent: :editionable_worldwide_organisation, traits: [:draft]

--- a/test/functional/admin/editionable_worldwide_organisations_controller_test.rb
+++ b/test/functional/admin/editionable_worldwide_organisations_controller_test.rb
@@ -11,6 +11,8 @@ class Admin::EditionableWorldwideOrganisationsControllerTest < ActionController:
   should_allow_creating_of :editionable_worldwide_organisation
   should_allow_editing_of :editionable_worldwide_organisation
 
+  should_allow_association_between_world_locations_and :editionable_worldwide_organisation
+
   test "actions are forbidden when the editionable_worldwide_organisations feature flag is disabled" do
     feature_flags.switch! :editionable_worldwide_organisations, false
     worldwide_organisation = create(:editionable_worldwide_organisation)
@@ -18,5 +20,9 @@ class Admin::EditionableWorldwideOrganisationsControllerTest < ActionController:
     get :show, params: { id: worldwide_organisation.id }
 
     assert_response :forbidden
+  end
+
+  def controller_attributes_for(edition_type, attributes = {})
+    super.merge(world_location_ids: [create(:world_location).id])
   end
 end

--- a/test/unit/app/presenters/publishing_api/editionable_worldwide_organisation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/editionable_worldwide_organisation_presenter_test.rb
@@ -31,6 +31,7 @@ class PublishingApi::EditionableWorldwideOrganisationPresenterTest < ActiveSuppo
 
     expected_links = {
       sponsoring_organisations: worldwide_org.organisations.map(&:content_id),
+      world_locations: worldwide_org.world_locations.map(&:content_id),
     }
 
     presented_item = present(worldwide_org)


### PR DESCRIPTION
This allows World Locations to be assigned to Editionable Worldwide Organisations, in the same way as non-editionable Worldwide Organisations.

Screenshot:
![Screenshot showing the world locations field as a multi-select.  A location ("Test World Location") has already been selected.](https://github.com/alphagov/whitehall/assets/6329861/90120041-7fac-46a9-a630-0f6fc215c217)

[Trello card](https://trello.com/c/G9rDOoC9)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
