### PR TITLE
Extract additional methods out of home_page_list_controller

### DIFF
--- a/app/controllers/admin/contacts_controller.rb
+++ b/app/controllers/admin/contacts_controller.rb
@@ -64,6 +64,21 @@ private
     @contactable
   end
 
+  def publish_container_to_publishing_api
+    home_page_list_container.publish_to_publishing_api
+  end
+
+  def handle_show_on_home_page_param
+    if @show_on_home_page.present?
+      case @show_on_home_page
+      when "1"
+        home_page_list_container.add_contact_to_home_page!(home_page_list_item)
+      when "0"
+        home_page_list_container.remove_contact_from_home_page!(home_page_list_item)
+      end
+    end
+  end
+
   def find_contactable
     @contactable = Organisation.friendly.find(params[:organisation_id])
   end
@@ -77,12 +92,6 @@ private
       if attributes.except(:id).values.all?(&:blank?)
         attributes[:_destroy] = "1"
       end
-    end
-  end
-
-  def handle_show_on_home_page_param
-    if @contactable.respond_to?(:home_page_contacts)
-      super
     end
   end
 

--- a/app/controllers/admin/contacts_controller.rb
+++ b/app/controllers/admin/contacts_controller.rb
@@ -4,7 +4,6 @@ class Admin::ContactsController < Admin::BaseController
   before_action :destroy_blank_contact_numbers, only: %i[create update]
   extend Admin::HomePageListController
   is_home_page_list_controller_for :contacts,
-                                   item_type: Contact,
                                    redirect_to: ->(container, _item) { [:admin, container, Contact] }
 
   def index; end
@@ -81,6 +80,15 @@ private
 
   def extract_show_on_home_page_param
     @show_on_home_page = params[:contact].delete(:show_on_home_page)
+  end
+
+  def extract_items_from_ordering_params
+    item_ordering = params[:ordering] || {}
+    item_ordering.permit!.to_h
+      .map { |item_id, ordering| [Contact.find_by(id: item_id), ordering.to_i] }
+      .sort_by { |_, ordering| ordering }
+      .map { |item, _| item }
+      .compact
   end
 
   def find_contactable

--- a/app/controllers/admin/contacts_controller.rb
+++ b/app/controllers/admin/contacts_controller.rb
@@ -79,6 +79,10 @@ private
     end
   end
 
+  def extract_show_on_home_page_param
+    @show_on_home_page = params[:contact].delete(:show_on_home_page)
+  end
+
   def find_contactable
     @contactable = Organisation.friendly.find(params[:organisation_id])
   end

--- a/app/controllers/admin/home_page_list_controller.rb
+++ b/app/controllers/admin/home_page_list_controller.rb
@@ -22,17 +22,6 @@ module Admin::HomePageListController
         @show_on_home_page = params[params_name].delete(:show_on_home_page)
       end
 
-      define_method(:handle_show_on_home_page_param) do
-        if @show_on_home_page.present?
-          case @show_on_home_page
-          when "1"
-            home_page_list_container.__send__(:"add_#{single_name}_to_home_page!", home_page_list_item)
-          when "0"
-            home_page_list_container.__send__(:"remove_#{single_name}_from_home_page!", home_page_list_item)
-          end
-        end
-      end
-
       define_method(:extract_items_from_ordering_params) do |ids_and_orderings|
         ids_and_orderings.permit!.to_h.
           # convert to useful forms
@@ -43,10 +32,6 @@ module Admin::HomePageListController
           map { |item, _| item }.
           # reject any blank contacts
           compact
-      end
-
-      define_method(:publish_container_to_publishing_api) do
-        home_page_list_container.try(:publish_to_publishing_api)
       end
     end
     include home_page_list_controller_methods

--- a/app/controllers/admin/home_page_list_controller.rb
+++ b/app/controllers/admin/home_page_list_controller.rb
@@ -4,10 +4,8 @@ module Admin::HomePageListController
   def is_home_page_list_controller_for(list_name, opts)
     before_action :extract_show_on_home_page_param, only: %i[create update]
     plural_name = list_name.to_s.downcase
-    single_name = plural_name.singularize
     item_type = opts[:item_type]
     redirect_proc = opts[:redirect_to]
-    params_name = (opts[:params_name] || single_name).to_sym
     home_page_list_controller_methods = Module.new do
       define_method(:reorder_for_home_page) do
         reordered_items = extract_items_from_ordering_params(params[:ordering] || {})
@@ -17,10 +15,6 @@ module Admin::HomePageListController
       end
 
     protected
-
-      define_method(:extract_show_on_home_page_param) do
-        @show_on_home_page = params[params_name].delete(:show_on_home_page)
-      end
 
       define_method(:extract_items_from_ordering_params) do |ids_and_orderings|
         ids_and_orderings.permit!.to_h.

--- a/app/controllers/admin/home_page_list_controller.rb
+++ b/app/controllers/admin/home_page_list_controller.rb
@@ -4,28 +4,13 @@ module Admin::HomePageListController
   def is_home_page_list_controller_for(list_name, opts)
     before_action :extract_show_on_home_page_param, only: %i[create update]
     plural_name = list_name.to_s.downcase
-    item_type = opts[:item_type]
     redirect_proc = opts[:redirect_to]
     home_page_list_controller_methods = Module.new do
       define_method(:reorder_for_home_page) do
-        reordered_items = extract_items_from_ordering_params(params[:ordering] || {})
+        reordered_items = extract_items_from_ordering_params
         home_page_list_container.__send__(:"reorder_#{plural_name}_on_home_page!", reordered_items)
         publish_container_to_publishing_api
         redirect_to redirect_proc.call(home_page_list_container, home_page_list_item), notice: %(#{plural_name.titleize} on home page reordered successfully)
-      end
-
-    protected
-
-      define_method(:extract_items_from_ordering_params) do |ids_and_orderings|
-        ids_and_orderings.permit!.to_h.
-          # convert to useful forms
-          map { |item_id, ordering| [item_type.find_by(id: item_id), ordering.to_i] }.
-          # sort by ordering
-          sort_by { |_, ordering| ordering }.
-          # discard ordering
-          map { |item, _| item }.
-          # reject any blank contacts
-          compact
       end
     end
     include home_page_list_controller_methods

--- a/app/controllers/admin/worldwide_offices_controller.rb
+++ b/app/controllers/admin/worldwide_offices_controller.rb
@@ -67,6 +67,21 @@ private
     @worldwide_organisation
   end
 
+  def publish_container_to_publishing_api
+    home_page_list_container.try(:publish_to_publishing_api)
+  end
+
+  def handle_show_on_home_page_param
+    if @show_on_home_page.present?
+      case @show_on_home_page
+      when "1"
+        home_page_list_container.add_office_to_home_page!(home_page_list_item)
+      when "0"
+        home_page_list_container.remove_office_from_home_page!(home_page_list_item)
+      end
+    end
+  end
+
   def find_worldwide_organisation
     @worldwide_organisation = if Flipflop.editionable_worldwide_organisations?
                                 Edition.find(params[:worldwide_organisation_id])

--- a/app/controllers/admin/worldwide_offices_controller.rb
+++ b/app/controllers/admin/worldwide_offices_controller.rb
@@ -4,8 +4,7 @@ class Admin::WorldwideOfficesController < Admin::BaseController
   extend Admin::HomePageListController
   is_home_page_list_controller_for :offices,
                                    item_type: WorldwideOffice,
-                                   redirect_to: ->(container, _item) { admin_worldwide_organisation_worldwide_offices_path(container) },
-                                   params_name: :worldwide_office
+                                   redirect_to: ->(container, _item) { admin_worldwide_organisation_worldwide_offices_path(container) }
 
   def index; end
 
@@ -81,6 +80,11 @@ private
       end
     end
   end
+
+  def extract_show_on_home_page_param
+    @show_on_home_page = params[:worldwide_office].delete(:show_on_home_page)
+  end
+
 
   def find_worldwide_organisation
     @worldwide_organisation = if Flipflop.editionable_worldwide_organisations?

--- a/app/controllers/admin/worldwide_offices_controller.rb
+++ b/app/controllers/admin/worldwide_offices_controller.rb
@@ -3,9 +3,7 @@ class Admin::WorldwideOfficesController < Admin::BaseController
   before_action :find_worldwide_office, only: %i[edit update confirm_destroy destroy]
   extend Admin::HomePageListController
   is_home_page_list_controller_for :offices,
-                                   item_type: WorldwideOffice,
                                    redirect_to: ->(container, _item) { admin_worldwide_organisation_worldwide_offices_path(container) }
-
   def index; end
 
   def new
@@ -81,10 +79,18 @@ private
     end
   end
 
+  def extract_items_from_ordering_params
+    item_ordering = params[:ordering] || {}
+    item_ordering.permit!.to_h
+      .map { |item_id, ordering| [WorldwideOffice.find_by(id: item_id), ordering.to_i] }
+      .sort_by { |_, ordering| ordering }
+      .map { |item, _| item }
+      .compact
+  end
+
   def extract_show_on_home_page_param
     @show_on_home_page = params[:worldwide_office].delete(:show_on_home_page)
   end
-
 
   def find_worldwide_organisation
     @worldwide_organisation = if Flipflop.editionable_worldwide_organisations?


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

# What
Extract the following methods from `home_page_list_controller`:
- `publish_container_to_publishing_api`
- `handle_show_on_home_page_param`
- `extract_show_on_home_page_param`
- `extract_items_from_ordering_params`

# Why
We want to delete `home_page_list_controller`
