### PR TITLE
Add role association to Editionable Worldwide Organisations

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -234,6 +234,7 @@ private
         lead_organisation_ids: [],
         supporting_organisation_ids: [],
         organisation_ids: [],
+        role_ids: [],
         world_location_ids: [],
         worldwide_organisation_ids: [],
         related_policy_ids: [],

--- a/app/helpers/admin/taggable_content_helper.rb
+++ b/app/helpers/admin/taggable_content_helper.rb
@@ -93,6 +93,14 @@ module Admin::TaggableContentHelper
     end
   end
 
+  # Returns an Array that represents the taggable roles. Each element of the
+  # array consists of two values: the role name and its ID
+  def taggable_roles_container
+    Rails.cache.fetch(taggable_roles_cache_digest, expires_in: 1.day) do
+      Role.order(:name).map { |w| [w.name, w.id] }
+    end
+  end
+
   # Returns an Array that represents the taggable alternative format providers.
   # Each element of the array consists of two values: the label (organisation
   # and the email address if avaiable) and the ID of the organisation.
@@ -181,6 +189,12 @@ module Admin::TaggableContentHelper
   # change if any world locations are added or updated.
   def taggable_world_locations_cache_digest
     @taggable_world_locations_cache_digest ||= calculate_digest(WorldLocation.order(:id), "world-locations")
+  end
+
+  # Returns an MD5 digest representing the taggable roles. This will
+  # change if any world locations are added or updated.
+  def taggable_roles_cache_digest
+    @taggable_roles_cache_digest ||= calculate_digest(Role.order(:id), "roles")
   end
 
   # Returns an MD5 digest representing the taggable alternative format

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -383,6 +383,10 @@ EXISTS (
     false
   end
 
+  def can_be_associated_with_roles?
+    false
+  end
+
   def can_be_associated_with_role_appointments?
     false
   end

--- a/app/models/edition/roles.rb
+++ b/app/models/edition/roles.rb
@@ -1,0 +1,22 @@
+module Edition::Roles
+  extend ActiveSupport::Concern
+
+  class Trait < Edition::Traits::Trait
+    def process_associations_before_save(edition)
+      @edition.edition_roles.each do |association|
+        edition.edition_roles.build(association.attributes.except("id", "edition_id"))
+      end
+    end
+  end
+
+  included do
+    has_many :edition_roles, foreign_key: :edition_id, inverse_of: :edition, dependent: :destroy, autosave: true
+    has_many :roles, through: :edition_roles
+
+    add_trait Trait
+  end
+
+  def can_be_associated_with_roles?
+    true
+  end
+end

--- a/app/models/edition_role.rb
+++ b/app/models/edition_role.rb
@@ -1,0 +1,6 @@
+class EditionRole < ApplicationRecord
+  belongs_to :edition
+  belongs_to :role, inverse_of: :edition_roles
+
+  validates :edition, :role, presence: true
+end

--- a/app/models/editionable_worldwide_organisation.rb
+++ b/app/models/editionable_worldwide_organisation.rb
@@ -1,5 +1,6 @@
 class EditionableWorldwideOrganisation < Edition
   include Edition::Organisations
+  include Edition::Roles
   include Edition::WorldLocations
 
   def display_type_key

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -13,6 +13,9 @@ class Role < ApplicationRecord
     super.reject { |column| %w[name responsibilities].include?(column.name) }
   end
 
+  has_many :edition_roles, inverse_of: :role
+  has_many :editions, through: :edition_roles
+
   has_many :role_appointments, -> { order(started_at: :desc) }
   has_many :people, through: :role_appointments
 
@@ -52,6 +55,8 @@ class Role < ApplicationRecord
   before_destroy :prevent_destruction_unless_destroyable
   after_update :touch_role_appointments
   after_save :republish_organisations_to_publishing_api, :republish_worldwide_organisations_to_publishing_api
+
+  accepts_nested_attributes_for :edition_roles
 
   extend FriendlyId
   friendly_id

--- a/app/presenters/publishing_api/editionable_worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/editionable_worldwide_organisation_presenter.rb
@@ -35,6 +35,7 @@ module PublishingApi
 
     def links
       {
+        roles: item.roles.map(&:content_id),
         sponsoring_organisations: item.organisations.map(&:content_id),
         world_locations: item.world_locations.map(&:content_id),
       }

--- a/app/views/admin/editionable_worldwide_organisations/_form.html.erb
+++ b/app/views/admin/editionable_worldwide_organisations/_form.html.erb
@@ -7,6 +7,7 @@
   } do %>
     <div class="govuk-!-margin-bottom-4">
       <%= render "world_location_fields", form: form, edition: edition %>
+      <%= render "role_fields", form: form, edition: edition %>
       <%= render "organisation_fields", form: form, edition: edition, required: true %>
     </div>
   <% end %>

--- a/app/views/admin/editions/_conflict.html.erb
+++ b/app/views/admin/editions/_conflict.html.erb
@@ -26,6 +26,15 @@
   <% end %>
 <% end %>
 
+<% if edition.can_be_associated_with_roles? %>
+  <h2 class="govuk-heading-m">Roles</h2>
+  <% if edition.roles.any? %>
+    <%= render "admin/roles/list", roles: edition.roles %>
+  <% else %>
+    <p class="govuk-body">This document isn’t assigned to any roles.</p>
+  <% end %>
+<% end %>
+
 <% if edition.can_apply_to_subset_of_nations? %>
   <h2 class="govuk-heading-m">Excluded nations</h2>
   <% if edition.nation_inapplicabilities.any? %>

--- a/app/views/admin/editions/_role_fields.html.erb
+++ b/app/views/admin/editions/_role_fields.html.erb
@@ -1,0 +1,23 @@
+<% required = false unless defined?(required) %>
+
+<% cache_if edition.role_ids.empty?, "#{taggable_roles_cache_digest}-design-system" do %>
+  <%= render "components/autocomplete", {
+    id: "edition_roles",
+    name: "edition[role_ids][]",
+    error_items: errors_for(edition.errors, :roles),
+    label: {
+      text: "Roles" + "#{' (required)' if required}",
+      heading_size: "m",
+    },
+    select: {
+      options: taggable_roles_container,
+      multiple: true,
+      selected: edition.role_ids,
+    },
+    data: {
+        module: "track-select-click",
+        track_category: "worldLocationSelection",
+        track_label: request.path,
+    },
+  } %>
+<% end %>

--- a/app/views/admin/roles/_list.html.erb
+++ b/app/views/admin/roles/_list.html.erb
@@ -1,0 +1,7 @@
+<ul class="roles">
+  <% roles.each do |role| %>
+    <%= content_tag_for(:li, roles) do %>
+      <%= link_to role.name, admin_role_path(anchor: "role_#{role.id}"), class: "location-link" %>
+    <% end %>
+  <% end %>
+</ul>

--- a/db/migrate/20231219154010_add_edition_roles.rb
+++ b/db/migrate/20231219154010_add_edition_roles.rb
@@ -1,0 +1,5 @@
+class AddEditionRoles < ActiveRecord::Migration[7.0]
+  def change
+    create_join_table :edition, :roles, &:timestamps
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_12_165213) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_19_154010) do
   create_table "assets", charset: "utf8mb3", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.string "variant", null: false
@@ -300,6 +300,13 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_12_165213) do
     t.integer "role_appointment_id"
     t.index ["edition_id"], name: "index_edition_role_appointments_on_edition_id"
     t.index ["role_appointment_id"], name: "index_edition_role_appointments_on_role_appointment_id"
+  end
+
+  create_table "edition_roles", id: false, charset: "utf8mb3", force: :cascade do |t|
+    t.bigint "edition_id", null: false
+    t.bigint "role_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "edition_statistical_data_sets", id: :integer, charset: "utf8mb3", force: :cascade do |t|

--- a/features/editionable-worldwide-organisations.feature
+++ b/features/editionable-worldwide-organisations.feature
@@ -8,3 +8,9 @@ Feature: Editionable worldwide organisations
     When I draft a new worldwide organisation "Test Worldwide Organisation" assigned to world location "United Kingdom"
     Then the worldwide organisation "Test Worldwide Organisation" should have been created
     And I should see it has been assigned to the "United Kingdom" world location
+
+  Scenario Outline: Assigning a role to a worldwide organisation
+    Given a role "Prime Minister" exists
+    When I draft a new worldwide organisation "Test Worldwide Organisation" assigned to world location "United Kingdom"
+    And I edit the worldwide organisation "Test Worldwide Organisation" adding the role of "Prime Minister"
+    Then I should see the "Prime Minister" role has been assigned to the worldwide organisation "Test Worldwide Organisation"

--- a/features/step_definitions/editionable_worldwide_organisation_steps.rb
+++ b/features/step_definitions/editionable_worldwide_organisation_steps.rb
@@ -16,3 +16,18 @@ end
 And(/^I should see it has been assigned to the "([^"]*)" world location$/) do |title|
   expect(@worldwide_organisation.world_locations.first.name).to eq(title)
 end
+
+Given(/^a role "([^"]*)" exists$/) do |name|
+  create(:role, name:)
+end
+
+And(/^I edit the worldwide organisation "([^"]*)" adding the role of "([^"]*)"$/) do |title, role|
+  begin_editing_document(title)
+  select role, from: "Roles"
+  click_button "Save and go to document summary"
+end
+
+Then(/^I should see the "([^"]*)" role has been assigned to the worldwide organisation "([^"]*)"$/) do |role, title|
+  @worldwide_organisation = EditionableWorldwideOrganisation.find_by(title:)
+  expect(@worldwide_organisation.roles.first.name).to eq(role)
+end

--- a/test/factories/edition_roles.rb
+++ b/test/factories/edition_roles.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :edition_role do
+    edition
+    role
+  end
+end

--- a/test/factories/editionable_worldwide_organisations.rb
+++ b/test/factories/editionable_worldwide_organisations.rb
@@ -7,6 +7,12 @@ FactoryBot.define do
         news_article.world_locations << build(:world_location)
       end
     end
+
+    trait(:with_role) do
+      after :create do |organisation, _evaluator|
+        organisation.roles << create(:ambassador_role)
+      end
+    end
   end
 
   factory :draft_editionable_worldwide_organisation, parent: :editionable_worldwide_organisation, traits: [:draft]

--- a/test/functional/admin/editionable_worldwide_organisations_controller_test.rb
+++ b/test/functional/admin/editionable_worldwide_organisations_controller_test.rb
@@ -11,6 +11,7 @@ class Admin::EditionableWorldwideOrganisationsControllerTest < ActionController:
   should_allow_creating_of :editionable_worldwide_organisation
   should_allow_editing_of :editionable_worldwide_organisation
 
+  should_allow_association_between_roles_and :editionable_worldwide_organisation
   should_allow_association_between_world_locations_and :editionable_worldwide_organisation
 
   test "actions are forbidden when the editionable_worldwide_organisations feature flag is disabled" do
@@ -23,6 +24,9 @@ class Admin::EditionableWorldwideOrganisationsControllerTest < ActionController:
   end
 
   def controller_attributes_for(edition_type, attributes = {})
-    super.merge(world_location_ids: [create(:world_location).id])
+    super.merge(
+      role_ids: [create(:role).id],
+      world_location_ids: [create(:world_location).id],
+    )
   end
 end

--- a/test/support/admin_edition_roles_behaviour.rb
+++ b/test/support/admin_edition_roles_behaviour.rb
@@ -1,0 +1,76 @@
+module AdminEditionRolesBehaviour
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    def should_allow_association_between_roles_and(document_type)
+      edition_class = class_for(document_type)
+
+      view_test "new displays document form with roles field" do
+        get :new
+
+        assert_select "form#new_edition" do
+          assert_select "label[for=edition_roles]", text: "Roles"
+          assert_select "#edition_roles" do |elements|
+            assert_equal 1, elements.length
+          end
+        end
+      end
+
+      test "creating should create a new document with roles" do
+        role1 = create(:role)
+        role2 = create(:role)
+        attributes = controller_attributes_for(document_type)
+
+        post :create,
+             params: {
+               edition: attributes.merge(
+                 role_ids: [role1.id, role2.id],
+               ),
+             }
+
+        assert document = edition_class.last
+        assert_equal [role1, role2], document.roles
+      end
+
+      view_test "edit displays document form with roles field" do
+        edition = create(document_type) # rubocop:disable Rails/SaveBang
+        get :edit, params: { id: edition }
+
+        assert_select "form#edit_edition" do
+          assert_select "label[for=edition_roles]", text: "Roles"
+
+          assert_select "#edition_roles" do |elements|
+            assert_equal 1, elements.length
+          end
+        end
+      end
+
+      test "updating should save modified document attributes with roles" do
+        role1 = create(:role)
+        role2 = create(:role)
+        document = create(document_type, roles: [role2])
+
+        put :update,
+            params: { id: document,
+                      edition: {
+                        role_ids: [role1.id],
+                      } }
+
+        document = document.reload
+        assert_equal [role1], document.roles
+      end
+
+      view_test "updating a stale document should render edit page with conflicting document and its roles" do
+        document = create(document_type) # rubocop:disable Rails/SaveBang
+        lock_version = document.lock_version
+        document.touch
+
+        put :update, params: { id: document, edition: { lock_version: } }
+
+        assert_select ".conflict" do
+          assert_select "h2", "Roles"
+        end
+      end
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -197,6 +197,7 @@ class ActionController::TestCase
   include AdminControllerTestHelpers
   include AdminEditionControllerTestHelpers
   include AdminEditionControllerScheduledPublishingTestHelpers
+  include AdminEditionRolesBehaviour
   include AdminEditionWorldLocationsBehaviour
   include DocumentControllerTestHelpers
   include ControllerTestHelpers

--- a/test/unit/app/models/edition_role_test.rb
+++ b/test/unit/app/models/edition_role_test.rb
@@ -1,0 +1,17 @@
+require "test_helper"
+
+class EditionRoleTest < ActiveSupport::TestCase
+  include ActionDispatch::TestProcess
+
+  test "should be invalid without an edition" do
+    edition_role = build(:edition_role, edition: nil)
+    assert_not edition_role.valid?
+    assert edition_role.errors[:edition].present?
+  end
+
+  test "should be invalid without an role" do
+    edition_role = build(:edition_role, role: nil)
+    assert_not edition_role.valid?
+    assert edition_role.errors[:role].present?
+  end
+end

--- a/test/unit/app/presenters/publishing_api/editionable_worldwide_organisation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/editionable_worldwide_organisation_presenter_test.rb
@@ -6,7 +6,7 @@ class PublishingApi::EditionableWorldwideOrganisationPresenterTest < ActiveSuppo
   end
 
   test "presents a Worldwide Organisation ready for adding to the publishing API" do
-    worldwide_org = create(:editionable_worldwide_organisation)
+    worldwide_org = create(:editionable_worldwide_organisation, :with_role)
 
     public_path = worldwide_org.public_path
 
@@ -30,6 +30,7 @@ class PublishingApi::EditionableWorldwideOrganisationPresenterTest < ActiveSuppo
     }
 
     expected_links = {
+      roles: worldwide_org.roles.map(&:content_id),
       sponsoring_organisations: worldwide_org.organisations.map(&:content_id),
       world_locations: worldwide_org.world_locations.map(&:content_id),
     }


### PR DESCRIPTION
This allows Roles to be assigned to Editionable Worldwide Organisations during the edit workflow.

This is a change from the current behaviour, as the worldwide organisations are currently assigned on the role's edit page (rather than the organisation's edit page)

By moving this to be the other way round (i.e. the edit is made on the worldwide organisation itself), the option is more obvious to the user and allows the change to be made in advance (e.g. as part of scheduled publishing).

Screenshot:
![Screenshot showing the roles field as a multi-select.  A role ("Prime Minister") has already been selected.](https://github.com/alphagov/whitehall/assets/6329861/b682cef5-81fb-4765-8b49-e8d78e301604)

[Trello card](https://trello.com/b/G9rDOoC9)