### PR TITLE
Ensure document retains slug when edition title has special chars

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -86,6 +86,11 @@ class Document < ApplicationRecord
     candidate_slug = normalize_friendly_id(new_title)
     unless candidate_slug == slug
       update!(sluggable_string: new_title)
+      # when special characters or scipts are used from the non-latin alphabets
+      # friendly_id sets the documents slug to nil. This ensures that it
+      # retains the default behaviour id of the document as the slug rather than being nil
+      # as implemented in the #ensure_document_has_a_slug after_create callback
+      ensure_document_has_a_slug
     end
   end
 

--- a/db/data_migration/20231219193828_backfill_documents_with_blank_slugs.rb
+++ b/db/data_migration/20231219193828_backfill_documents_with_blank_slugs.rb
@@ -1,0 +1,3 @@
+Document.where(slug: nil).each do |document|
+  document.update_column(:slug, document.id.to_s)
+end

--- a/test/unit/app/models/document_test.rb
+++ b/test/unit/app/models/document_test.rb
@@ -350,4 +350,28 @@ class DocumentTest < ActiveSupport::TestCase
     assert_nil unpublished.document.live_edition
     assert_nil draft.document.live_edition
   end
+
+  test "#update_slug_if_possible updates the slug to the title passed maps to a diffrent slug" do
+    document = build(:document)
+    new_slug = "new_slug"
+    document.expects(:update!).with(sluggable_string: new_slug).once
+
+    document.update_slug_if_possible(new_slug)
+  end
+
+  test "#update_slug_if_possible does nothing to the slug if the title passed in maps to the current slug" do
+    document = build_stubbed(:document)
+    document.expects(:update!).never
+
+    document.update_slug_if_possible(document.slug)
+  end
+
+  test "#update_slug_if_possible ensures that the slug is set to the documents id if the new title contains special characters" do
+    document = create(:document, slug: nil)
+    slug_with_special_characters = "首次中英高级别安全"
+
+    document.update_slug_if_possible(slug_with_special_characters)
+
+    assert_equal document.id.to_s, document.reload.slug
+  end
 end


### PR DESCRIPTION
## Description

We've been doing some investigative work into a bunch of sentry errors. I've gone down a bit of a rabbit hole and came across some fairly strange behaviour.

There are a subset of documents in our database that don't have a slug. This is despite their being an after create for document which sets the slug to the documents id if one is not set based on the title of the first edition for whatever reason.

This is being overridden by the #update_slug_if_possible method which is triggered by the #update_document_slug before_validation method. This updates the slug to the downcased and underscored edition title.

The title is passed to the #update_slug_if_possible as an arg. If it contains special character or characters from other languages with different alphabets friendly_id  updates the documents slug to nil.

We want to retain the default behaviour of the slug being defaulted to the id of the document. This commit ensures that's the case.

## Trello card

https://trello.com/c/ocdba6KI/2254-investigate-gdsapi-httpunprocceessibleentity-errors-on-sentry

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
