### PR TITLE
Fix failing data migration on prod

### DIFF
--- a/db/data_migration/20231115101909_remove_svg_lead_images.rb
+++ b/db/data_migration/20231115101909_remove_svg_lead_images.rb
@@ -1,7 +1,7 @@
 edition_lead_images = EditionLeadImage.joins(image: :image_data).where("carrierwave_image LIKE '%.svg'")
 
 edition_lead_images.each do |edition_lead_image|
-  edition = edition_lead_image
+  edition = edition_lead_image.edition
   edition_lead_image.destroy!
   edition.update_lead_image
 end


### PR DESCRIPTION
## Description

This data migration was added a while ago i'm pretty sure by me. It was a bit of faulty logic in it. I thought i'd run it on prod successfully, but apparently not!

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
