### PR TITLE
Use dummy base secret key for precompiling assets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY package.json yarn.lock ./
 RUN yarn install --production --frozen-lockfile --non-interactive --link-duplicates
 COPY . .
 RUN bootsnap precompile --gemfile .
-RUN rails assets:precompile && rm -fr log
+RUN SECRET_KEY_BASE_DUMMY=1 rails assets:precompile && rm -fr log
 
 
 FROM $base_image


### PR DESCRIPTION
As per https://guides.rubyonrails.org/asset_pipeline.html#local-precompilation, we can use a randomly generated secret key base stored in a temporary file to precompile assets.
