### PR TITLE
Fix Document Collections to only search for published editions

### DIFF
--- a/test/functional/admin/document_collection_group_document_search_controller_test.rb
+++ b/test/functional/admin/document_collection_group_document_search_controller_test.rb
@@ -50,28 +50,14 @@ class Admin::DocumentCollectionGroupDocumentSearchControllerTest < ActionControl
     assert_redirected_to admin_document_collection_group_add_by_url_path(@collection, @group)
   end
 
-  test "GET #add_by_title without query renders search for title  page with no results section" do
+  test "GET #add_by_title without query renders search for title page with no results section" do
     get :add_by_title, params: @request_params
 
     assert_template "document_collection_group_document_search/add_by_title"
     assert_select ".app-view-document-collection-document-search-results", count: 0
   end
 
-  test "GET :add_by_title with search value passes title and default params to filter" do
-    stub_filter = stub_edition_filter({ editions: [], options: { per_page: 15 } })
-    edition_scope = Edition.with_translations(I18n.locale)
-    default_filter_params_with_title = @default_filter_params.merge(title: "Something")
-    @request_params[:title] = "Something"
-    Admin::EditionFilter.expects(:new).with(edition_scope, @user, default_filter_params_with_title).returns(stub_filter)
-
-    get :add_by_title, params: @request_params
-    assert_template "document_collection_group_document_search/add_by_title"
-  end
-
-  view_test "GET #add_by_title with a query that returns no results renders empty results list" do
-    editions = []
-    stub_filter = stub_edition_filter({ editions:, options: { per_page: 15 } })
-    Admin::EditionFilter.stubs(:new).returns(stub_filter)
+  view_test "GET #add_by_title with a query that returns no results renders message to redirect to #add_by_url" do
     @request_params[:title] = "Something "
 
     get :add_by_title, params: @request_params
@@ -93,12 +79,7 @@ class Admin::DocumentCollectionGroupDocumentSearchControllerTest < ActionControl
   end
 
   view_test "GET :add_by_title with search value renders paginated results" do
-    editions = []
-    edition = build(:news_article, title: "Something", document: build(:document, slug: "something"))
-    16.times { editions << edition }
-
-    stub_filter = stub_edition_filter({ editions:, options: { per_page: 15 } })
-    Admin::EditionFilter.stubs(:new).returns(stub_filter)
+    16.times { create(:published_edition, title: "Something") }
     @request_params[:title] = "Something "
 
     get :add_by_title, params: @request_params
@@ -106,19 +87,12 @@ class Admin::DocumentCollectionGroupDocumentSearchControllerTest < ActionControl
     assert_template "document_collection_group_document_search/add_by_title"
     assert_select "input[name='title']"
     assert_select ".govuk-heading-s", "16 documents"
-    assert_select ".govuk-table" do
-      assert_select "tr", count: 15
-    end
+    assert_select ".govuk-table tr", count: 15
     assert_select "nav.govuk-pagination"
   end
 
   view_test "GET :add_by_title with search value renders results without pagination if length of result is 15" do
-    editions = []
-    edition = build(:news_article, title: "Something", document: build(:document, slug: "something"))
-    15.times { editions << edition }
-
-    stub_filter = stub_edition_filter({ editions:, options: { per_page: 15 } })
-    Admin::EditionFilter.stubs(:new).returns(stub_filter)
+    15.times { create(:published_edition, title: "Something") }
     @request_params[:title] = "Something "
 
     get :add_by_title, params: @request_params
@@ -126,23 +100,17 @@ class Admin::DocumentCollectionGroupDocumentSearchControllerTest < ActionControl
     assert_template "document_collection_group_document_search/add_by_title"
     assert_select "input[name='title']"
     assert_select ".govuk-heading-s", "15 documents"
-    assert_select ".govuk-table" do
-      assert_select "tr", count: 15
-    end
+    assert_select ".govuk-table tr", count: 15
     assert_select "nav.govuk-pagination", count: 0
   end
 
-private
+  view_test "GET :add_by_title with search value only returns published editions" do
+    create(:published_edition, title: "Something published")
+    create(:edition, title: "Something unpublished")
+    @request_params[:title] = "Something "
 
-  def stub_edition_filter(attributes = {})
-    default_attributes = {
-      editions: Kaminari.paginate_array(attributes[:editions] || [], limit: attributes[:options][:per_page]).page(1),
-      page_title: "",
-      edition_state: "",
-      valid?: true,
-      options: {},
-      hide_type: false,
-    }
-    stub("edition filter", default_attributes.merge(attributes.except(:editions)))
+    get :add_by_title, params: @request_params
+    assert_select ".govuk-heading-s", "1 document"
+    assert_select ".govuk-table tr", text: /Something published/
   end
 end


### PR DESCRIPTION
When we introduced pagination, we inadvertently removed the scope of published editions. In addition to putting the scope back to how it was, we also removed the filtering since we didn't need to do any other filtering other than search via title. This should simplify both the code and performance. Hopefully the scoping will also be helpful for search performance in production as well.

https://trello.com/c/fEbWtdv8/2280-document-collections-add-by-title-scoping-to-only-published-editions

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
