### PR TITLE
Add an index to the asset manager ID column on the assets table

### DIFF
--- a/db/migrate/20231222142808_add_index_to_asset_manager_id.rb
+++ b/db/migrate/20231222142808_add_index_to_asset_manager_id.rb
@@ -1,0 +1,5 @@
+class AddIndexToAssetManagerId < ActiveRecord::Migration[7.0]
+  def change
+    add_index :assets, :asset_manager_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_19_154010) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_22_142808) do
   create_table "assets", charset: "utf8mb3", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.string "variant", null: false
@@ -19,6 +19,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_19_154010) do
     t.string "assetable_type"
     t.bigint "assetable_id"
     t.string "filename"
+    t.index ["asset_manager_id"], name: "index_assets_on_asset_manager_id"
     t.index ["assetable_type", "assetable_id"], name: "index_assets_on_assetable"
   end
 


### PR DESCRIPTION
The lack of an index was causing lock timeout errors occasionally during concurrent delete operations.

The asset deletion worker runs a query to delete all assets matching a particular ID in asset manager. For delete queries, [InnoDB will issue a lock for each record that is scanned](https://dev.mysql.com/doc/refman/8.0/en/innodb-locks-set.html), regardless of whether or not that record will subsequently be deleted. Consequently, adding an index to reduce the number of records scanned will reduce the risk of locks caused by concurrent deletes, as well as improving the performance of the deletion operation.

Sentry error: https://govuk.sentry.io/issues/4576917256/events/d6e232ea8f844b0f9e004190ecda16ed/
