### PR TITLE
Ensure content type guidance links to the correct page

### DIFF
--- a/app/views/admin/new_document/index.html.erb
+++ b/app/views/admin/new_document/index.html.erb
@@ -11,7 +11,7 @@
         items: new_document_type_list,
       } %>
       <%= render "govuk_publishing_components/components/inset_text", {
-        text: sanitize("Check the #{link_to("content types guidance", admin_whats_new_path, {class: "govuk-link"})}" +
+        text: sanitize("Check the #{link_to("content types guidance", "#{Plek.website_root}/guidance/content-design/content-types", class: "govuk-link")}" +
                          " if you need more help in choosing a content type."),
       } %>
 

--- a/test/functional/admin/new_document_controller_test.rb
+++ b/test/functional/admin/new_document_controller_test.rb
@@ -13,7 +13,9 @@ class Admin::NewDocumentControllerTest < ActionController::TestCase
     radio_button_values.each do |value|
       assert_select_radio_button(value)
     end
-    assert_select ".govuk-inset-text", text: "Check the content types guidance if you need more help in choosing a content type."
+    assert_select ".govuk-inset-text", text: "Check the content types guidance if you need more help in choosing a content type." do
+      assert_select "a[href='#{Plek.website_root}/guidance/content-design/content-types']", text: "content types guidance"
+    end
   end
 
   view_test "GET #index renders Fatality Notice radio button when the user has GDS Editor permission and organisation is GDS" do


### PR DESCRIPTION
## Description

Currently this is linking to the What's new page. This updates it to link to the correct page on GOV.UK


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
