### PR TITLE
Add social media accounts to editionable worldwide organisations

### DIFF
--- a/app/controllers/admin/editionable_social_media_accounts_controller.rb
+++ b/app/controllers/admin/editionable_social_media_accounts_controller.rb
@@ -1,17 +1,25 @@
 class Admin::EditionableSocialMediaAccountsController < Admin::BaseController
   before_action :find_edition
-  before_action :find_social_media_account, except: [:index]
+  before_action :find_social_media_account, only: %i[edit update]
+
+  def create
+    social_media_account = SocialMediaAccount.create(social_media_account_params)
+
+    if social_media_account.persisted?
+      redirect_to admin_edition_social_media_accounts_path(@edition), notice: "Social media account '#{social_media_account.title}' created"
+    else
+      render :new
+    end
+  end
 
   def edit; end
 
   def index; end
 
+  def new; end
+
   def update
-    @social_media_account.attributes = params.fetch(:social_media_account, {}).permit(
-      :social_media_service_id,
-      :title,
-      :url,
-    )
+    @social_media_account.attributes = social_media_account_params
 
     if @social_media_account.save
       redirect_to admin_edition_social_media_accounts_path(@edition), notice: "Social media account '#{@social_media_account.title}' updated"
@@ -28,5 +36,15 @@ private
 
   def find_social_media_account
     @social_media_account = SocialMediaAccount.find(params[:id])
+  end
+
+  def social_media_account_params
+    params.fetch(:social_media_account, {}).permit(
+      :social_media_service_id,
+      :title,
+      :url,
+    ).merge(
+      socialable: @edition,
+    )
   end
 end

--- a/app/controllers/admin/editionable_social_media_accounts_controller.rb
+++ b/app/controllers/admin/editionable_social_media_accounts_controller.rb
@@ -1,0 +1,11 @@
+class Admin::EditionableSocialMediaAccountsController < Admin::BaseController
+  before_action :find_edition
+
+  def index; end
+
+private
+
+  def find_edition
+    @edition = Edition.find(params[:edition_id])
+  end
+end

--- a/app/controllers/admin/editionable_social_media_accounts_controller.rb
+++ b/app/controllers/admin/editionable_social_media_accounts_controller.rb
@@ -1,6 +1,8 @@
 class Admin::EditionableSocialMediaAccountsController < Admin::BaseController
   before_action :find_edition
-  before_action :find_social_media_account, only: %i[edit update]
+  before_action :find_social_media_account, only: %i[confirm_destroy destroy edit update]
+
+  def confirm_destroy; end
 
   def create
     social_media_account = SocialMediaAccount.create(social_media_account_params)
@@ -9,6 +11,14 @@ class Admin::EditionableSocialMediaAccountsController < Admin::BaseController
       redirect_to admin_edition_social_media_accounts_path(@edition), notice: "Social media account '#{social_media_account.title}' created"
     else
       render :new
+    end
+  end
+
+  def destroy
+    if @social_media_account.destroy
+      redirect_to admin_edition_social_media_accounts_path(@edition), notice: "#{@social_media_account.service_name} account deleted successfully"
+    else
+      render :edit
     end
   end
 

--- a/app/controllers/admin/editionable_social_media_accounts_controller.rb
+++ b/app/controllers/admin/editionable_social_media_accounts_controller.rb
@@ -1,11 +1,32 @@
 class Admin::EditionableSocialMediaAccountsController < Admin::BaseController
   before_action :find_edition
+  before_action :find_social_media_account, except: [:index]
+
+  def edit; end
 
   def index; end
+
+  def update
+    @social_media_account.attributes = params.fetch(:social_media_account, {}).permit(
+      :social_media_service_id,
+      :title,
+      :url,
+    )
+
+    if @social_media_account.save
+      redirect_to admin_edition_social_media_accounts_path(@edition), notice: "Social media account '#{@social_media_account.title}' updated"
+    else
+      render :edit
+    end
+  end
 
 private
 
   def find_edition
     @edition = Edition.find(params[:edition_id])
+  end
+
+  def find_social_media_account
+    @social_media_account = SocialMediaAccount.find(params[:id])
   end
 end

--- a/app/helpers/admin/tabbed_nav_helper.rb
+++ b/app/helpers/admin/tabbed_nav_helper.rb
@@ -20,6 +20,7 @@ module Admin::TabbedNavHelper
     nav_items << consultation_nav_items(edition, current_path) if edition.persisted? && edition.is_a?(Consultation)
     nav_items << call_for_evidence_nav_items(edition, current_path) if edition.persisted? && edition.is_a?(CallForEvidence)
     nav_items << document_collection_nav_items(edition, current_path) if edition.persisted? && edition.is_a?(DocumentCollection)
+    nav_items << social_media_nav_items(edition, current_path) if edition.persisted? && edition.can_be_associated_with_social_media_accounts?
     nav_items.flatten
   end
 
@@ -106,6 +107,16 @@ module Admin::TabbedNavHelper
         label: "Group details",
         href: admin_document_collection_group_path(group.document_collection, group),
         current: current_path == admin_document_collection_group_path(group.document_collection, group),
+      },
+    ]
+  end
+
+  def social_media_nav_items(edition, current_path)
+    [
+      {
+        label: "Social media accounts",
+        href: admin_edition_social_media_accounts_path(edition),
+        current: current_path == admin_edition_social_media_accounts_path(edition),
       },
     ]
   end

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -379,6 +379,10 @@ EXISTS (
   end
 
   # @group Overwritable permission methods
+  def can_be_associated_with_social_media_accounts?
+    false
+  end
+
   def can_be_associated_with_topical_events?
     false
   end

--- a/app/models/edition/social_media_accounts.rb
+++ b/app/models/edition/social_media_accounts.rb
@@ -1,0 +1,11 @@
+module Edition::SocialMediaAccounts
+  extend ActiveSupport::Concern
+
+  included do
+    has_many :social_media_accounts, as: :socialable, dependent: :destroy, autosave: true
+  end
+
+  def can_be_associated_with_social_media_accounts?
+    true
+  end
+end

--- a/app/models/editionable_worldwide_organisation.rb
+++ b/app/models/editionable_worldwide_organisation.rb
@@ -1,4 +1,5 @@
 class EditionableWorldwideOrganisation < Edition
+  include Edition::SocialMediaAccounts
   include Edition::Organisations
   include Edition::Roles
   include Edition::WorldLocations

--- a/app/presenters/publishing_api/editionable_worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/editionable_worldwide_organisation_presenter.rb
@@ -27,6 +27,7 @@ module PublishingApi
             crest: "single-identity",
             formatted_title: worldwide_organisation_logo_name(item),
           },
+          social_media_links:,
         },
         document_type: "worldwide_organisation",
         public_updated_at: item.updated_at,
@@ -42,6 +43,20 @@ module PublishingApi
         sponsoring_organisations: item.organisations.map(&:content_id),
         world_locations: item.world_locations.map(&:content_id),
       }
+    end
+
+  private
+
+    def social_media_links
+      return [] unless item.social_media_accounts.any?
+
+      item.social_media_accounts.map do |social_media_account|
+        {
+          href: social_media_account.url,
+          service_type: social_media_account.service_name.parameterize,
+          title: social_media_account.display_name,
+        }
+      end
     end
   end
 end

--- a/app/views/admin/editionable_social_media_accounts/_form.html.erb
+++ b/app/views/admin/editionable_social_media_accounts/_form.html.erb
@@ -1,0 +1,51 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_for social_media_account, url: admin_edition_social_media_account_path(edition, social_media_account) do |form| %>
+      <%= render "components/select_with_search", {
+        label: "Service (required)",
+        id: "social_media_account_social_media_service_id",
+        name: "social_media_account[social_media_service_id]",
+        heading_size: "l",
+        include_blank: true,
+        error_message: errors_for_input(social_media_account.errors, :social_media_service_id),
+        options: SocialMediaService.all.map do |service|
+          {
+            text: service.name,
+            value: service.id,
+            selected: social_media_account.social_media_service_id == service.id,
+          }
+        end,
+      } %>
+
+      <%= render "govuk_publishing_components/components/input", {
+        label: {
+          text: "URL (required)",
+        },
+        id: "social_media_account_url",
+        name: "social_media_account[url]",
+        value: social_media_account.url,
+        heading_size: "l",
+        error_items: errors_for(social_media_account.errors, :url),
+      } %>
+
+      <%= render "govuk_publishing_components/components/input", {
+        label: {
+          text: "Title",
+        },
+        id: "social_media_account_title",
+        name: "social_media_account[title]",
+        value: social_media_account.title,
+        heading_size: "l",
+        error_items: errors_for(social_media_account.errors, :title),
+      } %>
+
+      <div class="govuk-button-group govuk-!-margin-top-8">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Save",
+        } %>
+
+        <%= link_to("Cancel", admin_edition_social_media_accounts_path(edition), class: "govuk-link govuk-link--no-visited-state") %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/editionable_social_media_accounts/_form.html.erb
+++ b/app/views/admin/editionable_social_media_accounts/_form.html.erb
@@ -1,6 +1,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= form_for social_media_account, url: admin_edition_social_media_account_path(edition, social_media_account) do |form| %>
+    <%= form_for social_media_account, url: destination do |form| %>
       <%= render "components/select_with_search", {
         label: "Service (required)",
         id: "social_media_account_social_media_service_id",

--- a/app/views/admin/editionable_social_media_accounts/confirm_destroy.html.erb
+++ b/app/views/admin/editionable_social_media_accounts/confirm_destroy.html.erb
@@ -1,0 +1,21 @@
+<% content_for :context, @social_media_account.service_name %>
+<% content_for :page_title, "Delete social media account" %>
+<% content_for :title, "Delete social media account" %>
+<% content_for :title_margin_bottom, 6 %>
+
+<div class="govuk-grid-row">
+  <section class="govuk-grid-column-two-thirds">
+    <%= form_with url: admin_edition_social_media_account_path(@edition, @social_media_account), method: :delete do %>
+      <p class="govuk-body govuk-!-margin-bottom-7">Are you sure you want to delete "<%= @social_media_account.title %>"?</p>
+
+      <div class="govuk-button-group">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Delete",
+          destructive: true,
+        } %>
+
+        <%= link_to("Cancel", admin_edition_social_media_accounts_path(@edition), class: "govuk-link govuk-link--no-visited-state") %>
+      </div>
+    <% end %>
+  </section>
+</div>

--- a/app/views/admin/editionable_social_media_accounts/edit.html.erb
+++ b/app/views/admin/editionable_social_media_accounts/edit.html.erb
@@ -3,6 +3,6 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render("form", edition: @edition, social_media_account: @social_media_account) %>
+    <%= render("form", edition: @edition, social_media_account: @social_media_account, destination: admin_edition_social_media_account_path(@edition, @social_media_account)) %>
   </div>
 </div>

--- a/app/views/admin/editionable_social_media_accounts/edit.html.erb
+++ b/app/views/admin/editionable_social_media_accounts/edit.html.erb
@@ -1,0 +1,8 @@
+<% content_for :page_title, "Edit social media account for #{@edition.title}" %>
+<% content_for :title, "Edit social media account for #{@edition.title}" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render("form", edition: @edition, social_media_account: @social_media_account) %>
+  </div>
+</div>

--- a/app/views/admin/editionable_social_media_accounts/index.html.erb
+++ b/app/views/admin/editionable_social_media_accounts/index.html.erb
@@ -32,6 +32,12 @@
             {
               key: "Account",
               value: social_media_account.title,
+              actions: [
+                {
+                  label: "Edit",
+                  href: edit_admin_edition_social_media_account_path(@edition, social_media_account),
+                },
+              ],
             },
           ],
         } %>

--- a/app/views/admin/editionable_social_media_accounts/index.html.erb
+++ b/app/views/admin/editionable_social_media_accounts/index.html.erb
@@ -37,6 +37,11 @@
                   label: "Edit",
                   href: edit_admin_edition_social_media_account_path(@edition, social_media_account),
                 },
+                {
+                  label: "Delete",
+                  href: confirm_destroy_admin_edition_social_media_account_path(@edition, social_media_account),
+                  destructive: true,
+                },
               ],
             },
           ],

--- a/app/views/admin/editionable_social_media_accounts/index.html.erb
+++ b/app/views/admin/editionable_social_media_accounts/index.html.erb
@@ -1,0 +1,43 @@
+<% content_for :page_title, "Social media accounts for #{@edition.title}" %>
+<% content_for :title, "Social media accounts for for #{@edition.title}" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "components/secondary_navigation", {
+      aria_label: "Document navigation",
+      items: secondary_navigation_tabs_items(@edition, request.path),
+    } %>
+
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "Add new social media account",
+      margin_bottom: 2,
+      font_size: "l",
+    } %>
+
+    <p class="govuk-body">
+      <%= link_to "Add new social media account", "#", class: "govuk-link govuk-link--no-visited-state" %>
+    </p>
+
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "Social media accounts",
+      font_size: "l",
+      margin_bottom: 3,
+    } %>
+
+    <% if @edition.social_media_accounts.any? %>
+      <% @edition.social_media_accounts.each do |social_media_account| %>
+        <%= render "components/summary_card", {
+          title: social_media_account.service_name,
+          rows: [
+            {
+              key: "Account",
+              value: social_media_account.title,
+            },
+          ],
+        } %>
+      <% end %>
+    <% else %>
+      <p class="govuk-body">There are no existing social media accounts.</p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/editionable_social_media_accounts/index.html.erb
+++ b/app/views/admin/editionable_social_media_accounts/index.html.erb
@@ -15,7 +15,7 @@
     } %>
 
     <p class="govuk-body">
-      <%= link_to "Add new social media account", "#", class: "govuk-link govuk-link--no-visited-state" %>
+      <%= link_to "Add new social media account", new_admin_edition_social_media_account_path(@edition), class: "govuk-link govuk-link--no-visited-state" %>
     </p>
 
     <%= render "govuk_publishing_components/components/heading", {

--- a/app/views/admin/editionable_social_media_accounts/new.erb
+++ b/app/views/admin/editionable_social_media_accounts/new.erb
@@ -1,0 +1,8 @@
+<% content_for :page_title, "Add social media account for #{@edition.title}" %>
+<% content_for :title, "Add social media account for #{@edition.title}" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render("form", edition: @edition, social_media_account: SocialMediaAccount.new, destination: admin_edition_social_media_accounts_path(@edition)) %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -223,7 +223,7 @@ Whitehall::Application.routes.draw do
           get :confirm_destroy, on: :member
         end
         resources :lead_images, controller: "edition_lead_images", only: %i[update]
-        resources :social_media_accounts, only: %i[edit index update], controller: "editionable_social_media_accounts"
+        resources :social_media_accounts, only: %i[create edit index new update], controller: "editionable_social_media_accounts"
       end
 
       get "/editions/:id" => "editions#show"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -223,6 +223,7 @@ Whitehall::Application.routes.draw do
           get :confirm_destroy, on: :member
         end
         resources :lead_images, controller: "edition_lead_images", only: %i[update]
+        resources :social_media_accounts, only: %i[index], controller: "editionable_social_media_accounts"
       end
 
       get "/editions/:id" => "editions#show"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -223,7 +223,7 @@ Whitehall::Application.routes.draw do
           get :confirm_destroy, on: :member
         end
         resources :lead_images, controller: "edition_lead_images", only: %i[update]
-        resources :social_media_accounts, only: %i[index], controller: "editionable_social_media_accounts"
+        resources :social_media_accounts, only: %i[edit index update], controller: "editionable_social_media_accounts"
       end
 
       get "/editions/:id" => "editions#show"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -223,7 +223,9 @@ Whitehall::Application.routes.draw do
           get :confirm_destroy, on: :member
         end
         resources :lead_images, controller: "edition_lead_images", only: %i[update]
-        resources :social_media_accounts, only: %i[create edit index new update], controller: "editionable_social_media_accounts"
+        resources :social_media_accounts, only: %i[create destroy edit index new update], controller: "editionable_social_media_accounts" do
+          get :confirm_destroy, on: :member
+        end
       end
 
       get "/editions/:id" => "editions#show"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -159,5 +159,20 @@ if WorldLocation.where(name: "Test International Delegation").blank?
       title: "Test Editionable Worldwide Organisation",
       world_locations: [WorldLocation.first],
     )
+
+    if SocialMediaService.where(name: "Some social media service").blank?
+      SocialMediaService.create!(
+        name: "Some social media service",
+      )
+    end
+
+    if SocialMediaAccount.where(title: "Some social media account").blank?
+      SocialMediaAccount.create!(
+        title: "Some social media account",
+        url: "https://www.social.gov.uk",
+        social_media_service: SocialMediaService.first,
+        socialable: EditionableWorldwideOrganisation.first,
+      )
+    end
   end
 end

--- a/features/editionable-worldwide-organisations.feature
+++ b/features/editionable-worldwide-organisations.feature
@@ -16,3 +16,22 @@ Feature: Editionable worldwide organisations
     And I edit the worldwide organisation "Test Worldwide Organisation" adding the role of "Prime Minister"
     Then I should see the "Prime Minister" role has been assigned to the worldwide organisation "Test Worldwide Organisation"
 
+  Scenario Outline: Adding a social media account to a worldwide organisation
+    Given a social media service "Facebook" exists
+    When I draft a new worldwide organisation "Test Worldwide Organisation" assigned to world location "United Kingdom"
+    And I edit the worldwide organisation "Test Worldwide Organisation" adding the social media service of "Facebook" with title "Our Facebook page" at URL "https://www.social.gov.uk"
+    Then I should see the "Our Facebook page" social media site has been assigned to the worldwide organisation "Test Worldwide Organisation"
+
+  Scenario Outline: Editing a social media account to a worldwide organisation
+    Given a social media service "Facebook" exists
+    When I draft a new worldwide organisation "Test Worldwide Organisation" assigned to world location "United Kingdom"
+    And I edit the worldwide organisation "Test Worldwide Organisation" adding the social media service of "Facebook" with title "Our Facebook page" at URL "https://www.social.gov.uk"
+    And I edit the worldwide organisation "Test Worldwide Organisation" changing the social media account with title "Our Facebook page" to "Our new Facebook page"
+    Then I should see the "Our new Facebook page" social media site has been assigned to the worldwide organisation "Test Worldwide Organisation"
+
+  Scenario Outline: Deleting a social media account assigned to a worldwide organisation
+    Given a social media service "Facebook" exists
+    When I draft a new worldwide organisation "Test Worldwide Organisation" assigned to world location "United Kingdom"
+    And I edit the worldwide organisation "Test Worldwide Organisation" adding the social media service of "Facebook" with title "Our Facebook page" at URL "https://www.social.gov.uk"
+    And I edit the worldwide organisation "Test Worldwide Organisation" deleting the social media account with title "Our Facebook page"
+    Then I should see the worldwide organisation "Test Worldwide Organisation" has no social media accounts

--- a/features/step_definitions/editionable_worldwide_organisation_steps.rb
+++ b/features/step_definitions/editionable_worldwide_organisation_steps.rb
@@ -33,3 +33,42 @@ Then(/^I should see the "([^"]*)" role has been assigned to the worldwide organi
   @worldwide_organisation = EditionableWorldwideOrganisation.find_by(title:)
   expect(@worldwide_organisation.roles.first.name).to eq(role)
 end
+
+Given(/^a social media service "([^"]*)" exists$/) do |name|
+  create(:social_media_service, name:)
+end
+
+And(/^I edit the worldwide organisation "([^"]*)" adding the social media service of "([^"]*)" with title "([^"]*)" at URL "([^"]*)"$/) do |title, social_media_service_name, social_media_title, social_media_url|
+  begin_editing_document(title)
+  click_link "Social media accounts"
+  click_link "Add new social media account"
+  select social_media_service_name, from: "Service (required)"
+  fill_in "URL (required)", with: social_media_url
+  fill_in "Title", with: social_media_title
+  click_button "Save"
+end
+
+And(/^I edit the worldwide organisation "([^"]*)" changing the social media account with title "([^"]*)" to "([^"]*)"$/) do |title, _old_social_media_title, new_social_media_title|
+  begin_editing_document(title)
+  click_link "Social media accounts"
+  click_link "Edit"
+  fill_in "Title", with: new_social_media_title
+  click_button "Save"
+end
+
+And(/^I edit the worldwide organisation "([^"]*)" deleting the social media account with title "([^"]*)"$/) do |title, _social_media_title|
+  begin_editing_document(title)
+  click_link "Social media accounts"
+  click_link "Delete"
+  click_button "Delete"
+end
+
+Then(/^I should see the "([^"]*)" social media site has been assigned to the worldwide organisation "([^"]*)"$/) do |social_media_title, title|
+  @worldwide_organisation = EditionableWorldwideOrganisation.find_by(title:)
+  expect(@worldwide_organisation.social_media_accounts.first.title).to eq(social_media_title)
+end
+
+Then(/^I should see the worldwide organisation "([^"]*)" has no social media accounts$/) do |title|
+  @worldwide_organisation = EditionableWorldwideOrganisation.find_by(title:)
+  expect(@worldwide_organisation.social_media_accounts).to be_empty
+end

--- a/test/components/admin/social_media_accounts/index/summary_card_component_test.rb
+++ b/test/components/admin/social_media_accounts/index/summary_card_component_test.rb
@@ -27,7 +27,7 @@ class Admin::SocialMediaAccounts::Index::SummaryCardComponentTest < ViewComponen
   end
 
   test "renders url as the summary list key if a social media account doesn't have a title" do
-    social_media_account = build_stubbed(:social_media_account, socialable: @socialable)
+    social_media_account = build_stubbed(:social_media_account, socialable: @socialable, title: nil)
 
     render_inline(Admin::SocialMediaAccounts::Index::SummaryCardComponent.new(
                     socialable: @socialable,
@@ -35,12 +35,12 @@ class Admin::SocialMediaAccounts::Index::SummaryCardComponentTest < ViewComponen
                   ))
 
     assert_selector ".govuk-summary-list__key", text: "Account"
-    assert_selector ".govuk-summary-list__value", text: @social_media_account.url
+    assert_selector ".govuk-summary-list__value", text: social_media_account.url
   end
 
   test "renders the summary card with the correct values when the socialable has translations" do
     socialable = create(:organisation, translated_into: %i[es fr])
-    english_social_media_account = create(:social_media_account, translated_into: [:fr], socialable:)
+    english_social_media_account = create(:social_media_account, translated_into: [:fr], socialable:, title: nil)
     french_social_media_account_translation = english_social_media_account.translations.find_by(locale: "fr")
     french_social_media_account_translation.update!(title: "Tweeter", url: "http://example.fr")
 

--- a/test/factories/editionable_worldwide_organisations.rb
+++ b/test/factories/editionable_worldwide_organisations.rb
@@ -14,6 +14,12 @@ FactoryBot.define do
         organisation.roles << create(:ambassador_role)
       end
     end
+
+    trait(:with_social_media_account) do
+      after :create do |organisation, _evaluator|
+        create(:social_media_account, socialable: organisation, social_media_service: create(:social_media_service, name: "Blog"))
+      end
+    end
   end
 
   factory :draft_editionable_worldwide_organisation, parent: :editionable_worldwide_organisation, traits: [:draft]

--- a/test/factories/social_media_accounts.rb
+++ b/test/factories/social_media_accounts.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :social_media_account, traits: [:translated] do
     social_media_service
-    url { "http://example.com" }
+    sequence("url") { |i| "https://www.social-#{i}.gov.uk" }
+    sequence("title") { |i| "Social Media Account #{i}" }
   end
 end

--- a/test/functional/admin/editionable_social_media_accounts_controller_test.rb
+++ b/test/functional/admin/editionable_social_media_accounts_controller_test.rb
@@ -42,4 +42,19 @@ class Admin::EditionableSocialMediaAccountsControllerTest < ActionController::Te
     assert_equal "New title", @edition.social_media_accounts.first.title
     assert_equal "https://www.newurl.gov.uk", @edition.social_media_accounts.first.url
   end
+
+  test "POST :create creates a social media account" do
+    post :create, params: {
+      edition_id: @edition,
+      social_media_account: {
+        social_media_service_id: SocialMediaService.first,
+        title: "Account title",
+        url: "https://www.social.gov.uk",
+      },
+    }
+
+    assert_response :redirect
+    assert_equal "Account title", @edition.social_media_accounts.last.title
+    assert_equal "https://www.social.gov.uk", @edition.social_media_accounts.last.url
+  end
 end

--- a/test/functional/admin/editionable_social_media_accounts_controller_test.rb
+++ b/test/functional/admin/editionable_social_media_accounts_controller_test.rb
@@ -1,0 +1,18 @@
+require "test_helper"
+
+class Admin::EditionableSocialMediaAccountsControllerTest < ActionController::TestCase
+  should_be_an_admin_controller
+
+  setup do
+    login_as :gds_editor
+    @edition = create(:editionable_worldwide_organisation, :with_social_media_account)
+  end
+
+  view_test "GET :index lists the existing social media accounts" do
+    get :index, params: { edition_id: @edition }
+
+    assert_response :success
+    assert_select "h2.govuk-summary-card__title", text: @edition.social_media_accounts.first.social_media_service.name
+    assert_select "dd.govuk-summary-list__value", text: @edition.social_media_accounts.first.title
+  end
+end

--- a/test/functional/admin/editionable_social_media_accounts_controller_test.rb
+++ b/test/functional/admin/editionable_social_media_accounts_controller_test.rb
@@ -15,4 +15,31 @@ class Admin::EditionableSocialMediaAccountsControllerTest < ActionController::Te
     assert_select "h2.govuk-summary-card__title", text: @edition.social_media_accounts.first.social_media_service.name
     assert_select "dd.govuk-summary-list__value", text: @edition.social_media_accounts.first.title
   end
+
+  view_test "GET :edit displays an existing social media account" do
+    get :edit, params: {
+      edition_id: @edition,
+      id: @edition.social_media_accounts.first,
+    }
+
+    assert_response :success
+    assert_select "select.govuk-select", value: @edition.social_media_accounts.first.social_media_service.name
+    assert_select "input.govuk-input", value: @edition.social_media_accounts.first.url
+    assert_select "input.govuk-input", value: @edition.social_media_accounts.first.title
+  end
+
+  test "PATCH :update updates an existing social media account" do
+    patch :update, params: {
+      edition_id: @edition,
+      id: @edition.social_media_accounts.first,
+      social_media_account: {
+        title: "New title",
+        url: "https://www.newurl.gov.uk",
+      },
+    }
+
+    assert_response :redirect
+    assert_equal "New title", @edition.social_media_accounts.first.title
+    assert_equal "https://www.newurl.gov.uk", @edition.social_media_accounts.first.url
+  end
 end

--- a/test/functional/admin/editionable_social_media_accounts_controller_test.rb
+++ b/test/functional/admin/editionable_social_media_accounts_controller_test.rb
@@ -57,4 +57,24 @@ class Admin::EditionableSocialMediaAccountsControllerTest < ActionController::Te
     assert_equal "Account title", @edition.social_media_accounts.last.title
     assert_equal "https://www.social.gov.uk", @edition.social_media_accounts.last.url
   end
+
+  view_test "GET :confirm_destroy shows a confirmation before deletion" do
+    get :confirm_destroy, params: {
+      edition_id: @edition,
+      id: @edition.social_media_accounts.first,
+    }
+
+    assert_response :success
+    assert_select "p.govuk-body", text: "Are you sure you want to delete \"#{@edition.social_media_accounts.first.title}\"?"
+  end
+
+  test "DELETE :destroy creates a social media account" do
+    delete :destroy, params: {
+      edition_id: @edition,
+      id: @edition.social_media_accounts.first,
+    }
+
+    assert_response :redirect
+    assert_empty @edition.social_media_accounts
+  end
 end

--- a/test/unit/app/helpers/admin/tabbed_nav_helper_test.rb
+++ b/test/unit/app/helpers/admin/tabbed_nav_helper_test.rb
@@ -370,4 +370,23 @@ class Admin::TabbedNavHelperTest < ActionView::TestCase
 
     assert_equal expected_output, secondary_navigation_tabs_items(group, admin_document_collection_group_path(document_collection, group))
   end
+
+  test "#secondary_navigation_tabs_items for editionable worldwide organisations" do
+    edition = build_stubbed(:editionable_worldwide_organisation)
+
+    expected_output = [
+      {
+        label: "Document",
+        href: edit_admin_editionable_worldwide_organisation_path(edition),
+        current: true,
+      },
+      {
+        label: "Social media accounts",
+        href: admin_edition_social_media_accounts_path(edition),
+        current: false,
+      },
+    ]
+
+    assert_equal expected_output, secondary_navigation_tabs_items(edition, edit_admin_editionable_worldwide_organisation_path(edition))
+  end
 end

--- a/test/unit/app/presenters/publishing_api/editionable_worldwide_organisation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/editionable_worldwide_organisation_presenter_test.rb
@@ -6,7 +6,9 @@ class PublishingApi::EditionableWorldwideOrganisationPresenterTest < ActiveSuppo
   end
 
   test "presents a Worldwide Organisation ready for adding to the publishing API" do
-    worldwide_org = create(:editionable_worldwide_organisation, :with_role)
+    worldwide_org = create(:editionable_worldwide_organisation,
+                           :with_role,
+                           :with_social_media_account)
 
     public_path = worldwide_org.public_path
 
@@ -26,6 +28,13 @@ class PublishingApi::EditionableWorldwideOrganisationPresenterTest < ActiveSuppo
           crest: "single-identity",
           formatted_title: "Editionable<br/>worldwide<br/>organisation<br/>title",
         },
+        social_media_links: [
+          {
+            href: worldwide_org.social_media_accounts.first.url,
+            service_type: worldwide_org.social_media_accounts.first.service_name.parameterize,
+            title: worldwide_org.social_media_accounts.first.display_name,
+          },
+        ],
       },
       update_type: "major",
     }


### PR DESCRIPTION
This allows social media accounts to be added to editionable worldwide organisations.

The association has been made generic, so social media accounts can be added to any editionable content by adding `include Edition::SocialMediaAccounts` in the model.

[Trello card](https://trello.com/c/tPbBsPnj)

## Screenshots
| Action | Example |
| -- | -- |
| Viewing social media account | ![Screenshot showing the existing social media accounts for a worldwide organisation.](https://github.com/alphagov/whitehall/assets/6329861/14860b6d-c699-4b32-bdcb-80c07e1c7953) |
| Editing an existing social media account | ![Screenshot showing the form to edit an existing social media account.  There are three fields: the first a dropdown to allow the site to be selected, then URL and name as text inputs.](https://github.com/alphagov/whitehall/assets/6329861/454ce0a0-1a9e-40e2-97d8-274b2c85319c) |
| Adding a new social media account | ![Screenshot showing the form to add a new social media account.  There are three fields: the first a dropdown to allow the site to be selected, then URL and name as text inputs.](https://github.com/alphagov/whitehall/assets/6329861/80cbe6bf-b7a0-4f0e-91a3-b22d8bad36f0) |
| Deleting a social media account | ![Screenshot showing the confirmation screen for deleting a social media account.](https://github.com/alphagov/whitehall/assets/6329861/78bf9f05-0348-4123-ba96-97cb2664fc5e) |