### PR TITLE
Revert the addition of published edition scoping

### DIFF
--- a/app/controllers/admin/document_collection_group_document_search_controller.rb
+++ b/app/controllers/admin/document_collection_group_document_search_controller.rb
@@ -19,7 +19,7 @@ class Admin::DocumentCollectionGroupDocumentSearchController < Admin::BaseContro
   def add_by_title
     flash.now[:alert] = "Please enter a search query" if params[:title] && params[:title].empty?
     if params[:title].present?
-      results = Edition.published.with_title_containing(params[:title].strip)
+      results = Edition.with_title_containing(params[:title].strip)
       @editions = results
                     .page(params[:page])
                     .per(Admin::EditionFilter::GOVUK_DESIGN_SYSTEM_PER_PAGE)

--- a/test/functional/admin/document_collection_group_document_search_controller_test.rb
+++ b/test/functional/admin/document_collection_group_document_search_controller_test.rb
@@ -104,13 +104,15 @@ class Admin::DocumentCollectionGroupDocumentSearchControllerTest < ActionControl
     assert_select "nav.govuk-pagination", count: 0
   end
 
-  view_test "GET :add_by_title with search value only returns published editions" do
+  # TODO: research into whether we should be able to search published and unpublished editions
+  view_test "GET :add_by_title with search value only returns published and unpublished editions" do
     create(:published_edition, title: "Something published")
     create(:edition, title: "Something unpublished")
     @request_params[:title] = "Something "
 
     get :add_by_title, params: @request_params
-    assert_select ".govuk-heading-s", "1 document"
+    assert_select ".govuk-heading-s", "2 documents"
     assert_select ".govuk-table tr", text: /Something published/
+    assert_select ".govuk-table tr", text: /Something unpublished/
   end
 end


### PR DESCRIPTION
We seem to have received Zendesk ticket requests for the unpublished scope since people actually seem to be adding draft documents to document collections. User journey research probably needs to be re-looked at for document collections Unblocking users by putting scope back to how it was.

https://govuk.zendesk.com/agent/tickets/5590617

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
