### PR TITLE
Editionable worldwide organisation logo formatted name

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -228,6 +228,7 @@ private
       :read_consultation_principles,
       :all_nation_applicability,
       :speaker_radios,
+      :logo_formatted_name,
       {
         all_nation_applicability: [],
         secondary_specialist_sector_tags: [],

--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -15,6 +15,14 @@ module OrganisationHelper
     end
   end
 
+  def worldwide_organisation_logo_name(organisation)
+    if I18n.locale == :en && organisation.logo_formatted_name.present?
+      format_with_html_line_breaks(ERB::Util.html_escape(organisation.logo_formatted_name))
+    else
+      organisation.title
+    end
+  end
+
   def organisation_type_name(organisation)
     ActiveSupport::Inflector.singularize(organisation.organisation_type.name.downcase)
   end

--- a/app/models/worldwide_organisation.rb
+++ b/app/models/worldwide_organisation.rb
@@ -72,6 +72,10 @@ class WorldwideOrganisation < ApplicationRecord
              content: :summary,
              format: "worldwide_organisation"
 
+  def title
+    name
+  end
+
   def display_name
     name
   end

--- a/app/presenters/publishing_api/editionable_worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/editionable_worldwide_organisation_presenter.rb
@@ -25,7 +25,7 @@ module PublishingApi
             crest: "single-identity",
           },
         },
-        document_type: item.class.name.underscore,
+        document_type: "worldwide_organisation",
         public_updated_at: item.updated_at,
         rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
         schema_name: "worldwide_organisation",

--- a/app/presenters/publishing_api/editionable_worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/editionable_worldwide_organisation_presenter.rb
@@ -2,6 +2,8 @@ module PublishingApi
   class EditionableWorldwideOrganisationPresenter
     include Rails.application.routes.url_helpers
     include ActionView::Helpers::UrlHelper
+    include ApplicationHelper
+    include OrganisationHelper
 
     attr_accessor :item, :update_type, :state
 
@@ -23,6 +25,7 @@ module PublishingApi
         details: {
           logo: {
             crest: "single-identity",
+            formatted_title: worldwide_organisation_logo_name(item),
           },
         },
         document_type: "worldwide_organisation",

--- a/app/presenters/publishing_api/worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/worldwide_organisation_presenter.rb
@@ -2,6 +2,8 @@ module PublishingApi
   class WorldwideOrganisationPresenter
     include Rails.application.routes.url_helpers
     include ActionView::Helpers::UrlHelper
+    include ApplicationHelper
+    include OrganisationHelper
 
     attr_accessor :item, :update_type, :state
 
@@ -26,7 +28,7 @@ module PublishingApi
           body:,
           logo: {
             crest: "single-identity",
-            formatted_title: item.logo_formatted_name,
+            formatted_title: worldwide_organisation_logo_name(item),
           },
           ordered_corporate_information_pages:,
           secondary_corporate_information_pages:,

--- a/app/views/admin/editionable_worldwide_organisations/_form.html.erb
+++ b/app/views/admin/editionable_worldwide_organisations/_form.html.erb
@@ -1,4 +1,16 @@
 <%= standard_edition_form(edition) do |form| %>
+  <%= render "govuk_publishing_components/components/textarea", {
+    label: {
+      text: "Logo formatted name",
+      heading_size: "l",
+    },
+    name: "edition[logo_formatted_name]",
+    id: "edition_logo_formatted_name",
+    value: edition.logo_formatted_name,
+    error_items: errors_for(edition.errors, :logo_formatted_name),
+    rows: 4,
+  } %>
+
   <%= render "govuk_publishing_components/components/fieldset", {
     legend_text: "Associations",
     heading_level: 2,

--- a/db/migrate/20231228163205_add_logo_formatted_name_to_editions.rb
+++ b/db/migrate/20231228163205_add_logo_formatted_name_to_editions.rb
@@ -1,0 +1,5 @@
+class AddLogoFormattedNameToEditions < ActiveRecord::Migration[7.0]
+  def change
+    add_column :editions, :logo_formatted_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_19_154010) do
+ActiveRecord::Schema[7.0].define(version: 2023_12_28_163205) do
   create_table "assets", charset: "utf8mb3", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.string "variant", null: false
@@ -395,6 +395,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_19_154010) do
     t.string "auth_bypass_id", null: false
     t.string "mapped_specialist_topic_content_id"
     t.string "taxonomy_topic_email_override"
+    t.string "logo_formatted_name"
     t.index ["alternative_format_provider_id"], name: "index_editions_on_alternative_format_provider_id"
     t.index ["closing_at"], name: "index_editions_on_closing_at"
     t.index ["document_id"], name: "index_editions_on_document_id"

--- a/features/editionable-worldwide-organisations.feature
+++ b/features/editionable-worldwide-organisations.feature
@@ -8,9 +8,11 @@ Feature: Editionable worldwide organisations
     When I draft a new worldwide organisation "Test Worldwide Organisation" assigned to world location "United Kingdom"
     Then the worldwide organisation "Test Worldwide Organisation" should have been created
     And I should see it has been assigned to the "United Kingdom" world location
+    And I should see the editionable worldwide organisation "Test Worldwide Organisation" in the list of draft documents
 
   Scenario Outline: Assigning a role to a worldwide organisation
     Given a role "Prime Minister" exists
     When I draft a new worldwide organisation "Test Worldwide Organisation" assigned to world location "United Kingdom"
     And I edit the worldwide organisation "Test Worldwide Organisation" adding the role of "Prime Minister"
     Then I should see the "Prime Minister" role has been assigned to the worldwide organisation "Test Worldwide Organisation"
+

--- a/features/step_definitions/editionable_worldwide_organisation_steps.rb
+++ b/features/step_definitions/editionable_worldwide_organisation_steps.rb
@@ -10,7 +10,9 @@ end
 
 Then(/^the worldwide organisation "([^"]*)" should have been created$/) do |title|
   @worldwide_organisation = EditionableWorldwideOrganisation.find_by(title:)
+
   expect(@worldwide_organisation).to be_present
+  expect(@worldwide_organisation.logo_formatted_name).to eq("Logo\r\nformatted\r\nname\r\n")
 end
 
 And(/^I should see it has been assigned to the "([^"]*)" world location$/) do |title|

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -114,6 +114,7 @@ module DocumentHelper
 
   def fill_in_worldwide_organisation_fields(world_location: "United Kingdom")
     select world_location, from: "World locations"
+    fill_in "Logo formatted name", with: "Logo\r\nformatted\r\nname\r\n"
   end
 
   def fill_in_news_article_fields(first_published: "2010-01-01", announcement_type: "News story")

--- a/test/factories/editionable_worldwide_organisations.rb
+++ b/test/factories/editionable_worldwide_organisations.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :editionable_worldwide_organisation, class: EditionableWorldwideOrganisation, parent: :edition_with_organisations do
-    title { "editionable-worldwide-organisation-title" }
+    title { "Editionable worldwide organisation title" }
+    logo_formatted_name { title.to_s.split.join("\n") }
 
     after :build do |news_article, evaluator|
       if evaluator.world_locations.empty?

--- a/test/unit/app/models/worldwide_organisation_test.rb
+++ b/test/unit/app/models/worldwide_organisation_test.rb
@@ -382,4 +382,10 @@ class WorldwideOrganisationTest < ActiveSupport::TestCase
 
     organisation.update!(name: "new name")
   end
+
+  test "#title returns the name of the organisation" do
+    organisation = create(:worldwide_organisation)
+
+    assert_equal organisation.name, organisation.title
+  end
 end

--- a/test/unit/app/presenters/publishing_api/editionable_worldwide_organisation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/editionable_worldwide_organisation_presenter_test.rb
@@ -14,7 +14,7 @@ class PublishingApi::EditionableWorldwideOrganisationPresenterTest < ActiveSuppo
       base_path: public_path,
       title: worldwide_org.title,
       schema_name: "worldwide_organisation",
-      document_type: "editionable_worldwide_organisation",
+      document_type: "worldwide_organisation",
       locale: "en",
       publishing_app: Whitehall::PublishingApp::WHITEHALL,
       rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,

--- a/test/unit/app/presenters/publishing_api/editionable_worldwide_organisation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/editionable_worldwide_organisation_presenter_test.rb
@@ -24,6 +24,7 @@ class PublishingApi::EditionableWorldwideOrganisationPresenterTest < ActiveSuppo
       details: {
         logo: {
           crest: "single-identity",
+          formatted_title: "Editionable<br/>worldwide<br/>organisation<br/>title",
         },
       },
       update_type: "major",
@@ -41,11 +42,27 @@ class PublishingApi::EditionableWorldwideOrganisationPresenterTest < ActiveSuppo
     assert_equal "major", presented_item.update_type
     assert_equal worldwide_org.content_id, presented_item.content_id
 
-    # TODO: uncomment the below assertion when the editionable_worldwide_organisation model is
-    # finished and all content can be added to this presenter.
-    # assert_valid_against_publisher_schema(presented_item.content, "worldwide_organisation")
+    assert_valid_against_publisher_schema(presented_item.content, "worldwide_organisation")
 
     assert_equal expected_links, presented_item.links
     assert_valid_against_links_schema({ links: presented_item.links }, "worldwide_organisation")
+  end
+
+  test "uses the title for the formatted_title when the locale is not en" do
+    I18n.with_locale(:ar) do
+      worldwide_org = create(:editionable_worldwide_organisation, title: "Consolato Generale Britannico Milano")
+
+      presented_item = present(worldwide_org)
+
+      assert_equal "Consolato Generale Britannico Milano", presented_item.content.dig(:details, :logo, :formatted_title)
+    end
+  end
+
+  test "uses the title for the formatted_title when the the logo_formatted_name is absent" do
+    worldwide_org = create(:editionable_worldwide_organisation, logo_formatted_name: nil)
+
+    presented_item = present(worldwide_org)
+
+    assert_equal "Editionable worldwide organisation title", presented_item.content.dig(:details, :logo, :formatted_title)
   end
 end

--- a/test/unit/app/presenters/publishing_api/worldwide_organisation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/worldwide_organisation_presenter_test.rb
@@ -43,7 +43,7 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
         body: "<div class=\"govspeak\"><p>Some stuff</p>\n</div>",
         logo: {
           crest: "single-identity",
-          formatted_title: "Locationia\nEmbassy",
+          formatted_title: "Locationia<br/>Embassy",
         },
         ordered_corporate_information_pages: [
           {
@@ -158,5 +158,23 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
         { path: "#{worldwide_organisation.base_path}.cy", type: "exact" },
       ], presented_item.content[:routes]
     end
+  end
+
+  test "uses the title for the formatted_title when the locale is not en" do
+    I18n.with_locale(:ar) do
+      worldwide_org = create(:worldwide_organisation, name: "Consolato Generale Britannico Milano")
+
+      presented_item = present(worldwide_org)
+
+      assert_equal "Consolato Generale Britannico Milano", presented_item.content.dig(:details, :logo, :formatted_title)
+    end
+  end
+
+  test "uses the title for the formatted_title when the the logo_formatted_name is absent" do
+    worldwide_org = create(:worldwide_organisation)
+
+    presented_item = present(worldwide_org)
+
+    assert_equal worldwide_org.name, presented_item.content.dig(:details, :logo, :formatted_title)
   end
 end


### PR DESCRIPTION
https://trello.com/c/12wQrTlH

### Add title method to worldwide organisation
The new editionable worldwide organisation model uses the `title` method
instead of `name`.

This adds `title` to the legacy worldwide organisation model so that views and
helpers etc. can be compatible with both model types.

### Use the `worldwide_organisation` document type
We don't need a new document type here, we can use the existing one.

### Add logo formatted name to editions
This is required for editionable worldwide organisations.

### Present logo formatted title for worldwide organisations
These have been broken for some time. They remained broken when the rendering
of these pages was moved to Government Frontend.

Presenting these correctly will allow us to fix them on the frontend and
restore their proper functionality.

### Present logo formatted name for editionable worldwide organisations
The presenter isn't currently valid against the schema because it's missing the
logo formatted name.

### Add logo formatted name textarea for editionable worldwide organisations
This allows users to add a logo formatted name for the new editionable
worldwide organisations.

![image](https://github.com/alphagov/whitehall/assets/47089130/27e333f9-4f3b-46f2-a5a6-43ccc59f32f1)


---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
