### PR TITLE
Add an index to the asset manager ID column on the assets table

### DIFF
--- a/db/migrate/20240102114732_add_asset_manager_id_index_to_assets_table.rb
+++ b/db/migrate/20240102114732_add_asset_manager_id_index_to_assets_table.rb
@@ -1,0 +1,5 @@
+class AddAssetManagerIdIndexToAssetsTable < ActiveRecord::Migration[7.1]
+  def change
+    add_index :assets, :asset_manager_id, if_not_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_12_28_163205) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_02_114732) do
   create_table "assets", charset: "utf8mb3", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.string "variant", null: false
@@ -19,6 +19,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_12_28_163205) do
     t.string "assetable_type"
     t.bigint "assetable_id"
     t.string "filename"
+    t.index ["asset_manager_id"], name: "index_assets_on_asset_manager_id"
     t.index ["assetable_type", "assetable_id"], name: "index_assets_on_assetable"
   end
 


### PR DESCRIPTION
This is a re-opening of #8672. I initially closed that PR because I thought it might be possible to make the index unique, and to change the asset deletion code to load a single record. However, I have discovered that in some cases multiple asset records share an Asset Manager ID. There was also a question about whether adding an index would deliver the expected performance improvements, but I think it will if I have read the MySQL docs correctly.

Here is the explanation for this PR:

The lack of an index on the asset manager ID column was causing lock timeout errors occasionally during concurrent delete operations.

The asset deletion worker runs a query to delete all assets matching a particular ID in asset manager. For delete queries, InnoDB will issue a lock for each record that is scanned, regardless of whether or not that record will subsequently be deleted. Consequently, adding an index to reduce the number of records scanned will reduce the risk of locks caused by concurrent deletes.

Trello: https://trello.com/c/13dDUcoj
