### PR TITLE
Add missing attributes to Editionable Worldwide Organisation content item

### DIFF
--- a/app/models/editionable_worldwide_organisation.rb
+++ b/app/models/editionable_worldwide_organisation.rb
@@ -1,19 +1,35 @@
 class EditionableWorldwideOrganisation < Edition
+  PRIMARY_ROLES = [AmbassadorRole, HighCommissionerRole, GovernorRole].freeze
+  SECONDARY_ROLES = [DeputyHeadOfMissionRole].freeze
+  OFFICE_ROLES = [WorldwideOfficeStaffRole].freeze
+
   include Edition::SocialMediaAccounts
   include Edition::Organisations
   include Edition::Roles
   include Edition::WorldLocations
 
+  def base_path
+    "/editionable-world/organisations/#{slug}"
+  end
+
   def display_type_key
     "editionable_worldwide_organisation"
+  end
+
+  def office_staff_roles
+    roles.occupied.where(type: OFFICE_ROLES.map(&:name))
+  end
+
+  def primary_role
+    roles.occupied.find_by(type: PRIMARY_ROLES.map(&:name))
   end
 
   def publishing_api_presenter
     PublishingApi::EditionableWorldwideOrganisationPresenter
   end
 
-  def base_path
-    "/editionable-world/organisations/#{slug}"
+  def secondary_role
+    roles.occupied.find_by(type: SECONDARY_ROLES.map(&:name))
   end
 
   def skip_world_location_validation?

--- a/app/presenters/publishing_api/editionable_worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/editionable_worldwide_organisation_presenter.rb
@@ -41,7 +41,10 @@ module PublishingApi
 
     def links
       {
+        office_staff:,
+        primary_role_person:,
         roles: item.roles.map(&:content_id),
+        secondary_role_person:,
         sponsoring_organisations: item.organisations.map(&:content_id),
         world_locations: item.world_locations.map(&:content_id),
       }
@@ -51,6 +54,22 @@ module PublishingApi
 
     def body
       Whitehall::GovspeakRenderer.new.govspeak_edition_to_html(item)
+    end
+
+    def office_staff
+      item.office_staff_roles.map(&:current_person).map(&:content_id)
+    end
+
+    def primary_role_person
+      return [] unless item.primary_role
+
+      [item.primary_role.current_person.content_id]
+    end
+
+    def secondary_role_person
+      return [] unless item.secondary_role
+
+      [item.secondary_role.current_person.content_id]
     end
 
     def social_media_links

--- a/app/presenters/publishing_api/editionable_worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/editionable_worldwide_organisation_presenter.rb
@@ -29,6 +29,7 @@ module PublishingApi
             formatted_title: worldwide_organisation_logo_name(item),
           },
           social_media_links:,
+          world_location_names:,
         },
         document_type: "worldwide_organisation",
         public_updated_at: item.updated_at,
@@ -60,6 +61,17 @@ module PublishingApi
           href: social_media_account.url,
           service_type: social_media_account.service_name.parameterize,
           title: social_media_account.display_name,
+        }
+      end
+    end
+
+    def world_location_names
+      return [] unless item.world_locations.any?
+
+      item.world_locations.map do |world_location|
+        {
+          content_id: world_location.content_id,
+          name: world_location.name,
         }
       end
     end

--- a/app/presenters/publishing_api/editionable_worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/editionable_worldwide_organisation_presenter.rb
@@ -23,6 +23,7 @@ module PublishingApi
 
       content.merge!(
         details: {
+          body:,
           logo: {
             crest: "single-identity",
             formatted_title: worldwide_organisation_logo_name(item),
@@ -46,6 +47,10 @@ module PublishingApi
     end
 
   private
+
+    def body
+      Whitehall::GovspeakRenderer.new.govspeak_edition_to_html(item)
+    end
 
     def social_media_links
       return [] unless item.social_media_accounts.any?

--- a/test/factories/editionable_worldwide_organisations.rb
+++ b/test/factories/editionable_worldwide_organisations.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :editionable_worldwide_organisation, class: EditionableWorldwideOrganisation, parent: :edition_with_organisations do
     title { "Editionable worldwide organisation title" }
     logo_formatted_name { title.to_s.split.join("\n") }
+    body { "Information about the organisation with _italics_." }
 
     after :build do |news_article, evaluator|
       if evaluator.world_locations.empty?

--- a/test/unit/app/models/editionable_worldwide_organisation_test.rb
+++ b/test/unit/app/models/editionable_worldwide_organisation_test.rb
@@ -1,0 +1,89 @@
+require "test_helper"
+
+class EditionableWorldwideOrganisationTest < ActiveSupport::TestCase
+  test "an ambassadorial role is a primary role and not a secondary one" do
+    worldwide_organisation = create(:worldwide_organisation)
+
+    assert_nil worldwide_organisation.primary_role
+
+    ambassador_role = create(:ambassador_role, :occupied)
+    worldwide_organisation.roles << ambassador_role
+
+    assert_equal ambassador_role, worldwide_organisation.primary_role
+    assert_nil worldwide_organisation.secondary_role
+  end
+
+  test "a high commissioner role is a primary role and not a secondary one" do
+    worldwide_organisation = create(:worldwide_organisation)
+
+    assert_nil worldwide_organisation.primary_role
+
+    high_commissioner_role = create(:high_commissioner_role, :occupied)
+    worldwide_organisation.roles << high_commissioner_role
+
+    assert_equal high_commissioner_role, worldwide_organisation.primary_role
+    assert_nil worldwide_organisation.secondary_role
+  end
+
+  test "a governor role is a primary role and not a secondary one" do
+    worldwide_organisation = create(:worldwide_organisation)
+
+    assert_nil worldwide_organisation.primary_role
+
+    governor_role = create(:governor_role, :occupied)
+    worldwide_organisation.roles << governor_role
+
+    assert_equal governor_role, worldwide_organisation.primary_role
+    assert_nil worldwide_organisation.secondary_role
+  end
+
+  test "a deputy head of mission is second in charge and not a primary one" do
+    worldwide_organisation = create(:worldwide_organisation)
+
+    assert_nil worldwide_organisation.secondary_role
+
+    deputy_role = create(:deputy_head_of_mission_role, :occupied)
+    worldwide_organisation.roles << deputy_role
+
+    assert_equal deputy_role, worldwide_organisation.secondary_role
+    assert_nil worldwide_organisation.primary_role
+  end
+
+  test "office_staff_roles returns worldwide office staff roles" do
+    worldwide_organisation = create(:worldwide_organisation)
+
+    assert_equal [], worldwide_organisation.office_staff_roles
+
+    staff_role1 = create(:worldwide_office_staff_role, :occupied)
+    staff_role2 = create(:worldwide_office_staff_role, :occupied)
+    worldwide_organisation.roles << staff_role1
+    worldwide_organisation.roles << staff_role2
+
+    assert_equal [staff_role1, staff_role2], worldwide_organisation.office_staff_roles
+    assert_nil worldwide_organisation.primary_role
+    assert_nil worldwide_organisation.secondary_role
+  end
+
+  test "primary, secondary and office staff roles return occupied roles only" do
+    worldwide_organisation = create(:worldwide_organisation)
+
+    worldwide_organisation.roles << create(:ambassador_role, :vacant)
+    worldwide_organisation.roles << create(:deputy_head_of_mission_role, :vacant)
+    worldwide_organisation.roles << create(:worldwide_office_staff_role, :vacant)
+
+    assert_nil worldwide_organisation.primary_role
+    assert_nil worldwide_organisation.secondary_role
+    assert_equal [], worldwide_organisation.office_staff_roles
+
+    a = create(:ambassador_role, :occupied)
+    b = create(:deputy_head_of_mission_role, :occupied)
+    c = create(:worldwide_office_staff_role, :occupied)
+    worldwide_organisation.roles << a
+    worldwide_organisation.roles << b
+    worldwide_organisation.roles << c
+
+    assert_equal a, worldwide_organisation.primary_role
+    assert_equal b, worldwide_organisation.secondary_role
+    assert_equal [c], worldwide_organisation.office_staff_roles
+  end
+end

--- a/test/unit/app/presenters/publishing_api/editionable_worldwide_organisation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/editionable_worldwide_organisation_presenter_test.rb
@@ -10,6 +10,16 @@ class PublishingApi::EditionableWorldwideOrganisationPresenterTest < ActiveSuppo
                            :with_role,
                            :with_social_media_account)
 
+    primary_role = create(:ambassador_role)
+    ambassador = create(:person)
+    create(:ambassador_role_appointment, role: primary_role, person: ambassador)
+    worldwide_org.roles << primary_role
+
+    secondary_role = create(:deputy_head_of_mission_role)
+    deputy_head_of_mission = create(:person)
+    create(:deputy_head_of_mission_role_appointment, role: secondary_role, person: deputy_head_of_mission)
+    worldwide_org.roles << secondary_role
+
     public_path = worldwide_org.public_path
 
     expected_hash = {
@@ -47,7 +57,14 @@ class PublishingApi::EditionableWorldwideOrganisationPresenterTest < ActiveSuppo
     }
 
     expected_links = {
+      office_staff: worldwide_org.office_staff_roles.map(&:current_person).map(&:content_id),
+      primary_role_person: [
+        ambassador.content_id,
+      ],
       roles: worldwide_org.roles.map(&:content_id),
+      secondary_role_person: [
+        deputy_head_of_mission.content_id,
+      ],
       sponsoring_organisations: worldwide_org.organisations.map(&:content_id),
       world_locations: worldwide_org.world_locations.map(&:content_id),
     }

--- a/test/unit/app/presenters/publishing_api/editionable_worldwide_organisation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/editionable_worldwide_organisation_presenter_test.rb
@@ -24,6 +24,7 @@ class PublishingApi::EditionableWorldwideOrganisationPresenterTest < ActiveSuppo
       routes: [{ path: public_path, type: "exact" }],
       redirects: [],
       details: {
+        body: "<div class=\"govspeak\"><p>Information about the organisation with <em>italics</em>.</p>\n</div>",
         logo: {
           crest: "single-identity",
           formatted_title: "Editionable<br/>worldwide<br/>organisation<br/>title",

--- a/test/unit/app/presenters/publishing_api/editionable_worldwide_organisation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/editionable_worldwide_organisation_presenter_test.rb
@@ -36,6 +36,12 @@ class PublishingApi::EditionableWorldwideOrganisationPresenterTest < ActiveSuppo
             title: worldwide_org.social_media_accounts.first.display_name,
           },
         ],
+        world_location_names: [
+          {
+            content_id: worldwide_org.world_locations.first.content_id,
+            name: worldwide_org.world_locations.first.name,
+          },
+        ],
       },
       update_type: "major",
     }


### PR DESCRIPTION
These were missed when the other parts of the presenter were added, despite having the data available to us.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
