### PR TITLE
Add analytics identifier for Editionable Worldwide Organisations

### DIFF
--- a/app/models/editionable_worldwide_organisation.rb
+++ b/app/models/editionable_worldwide_organisation.rb
@@ -8,6 +8,9 @@ class EditionableWorldwideOrganisation < Edition
   include Edition::Roles
   include Edition::WorldLocations
 
+  include AnalyticsIdentifierPopulator
+  self.analytics_prefix = "WO"
+
   def base_path
     "/editionable-world/organisations/#{slug}"
   end

--- a/app/presenters/publishing_api/editionable_worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/editionable_worldwide_organisation_presenter.rb
@@ -37,6 +37,7 @@ module PublishingApi
         schema_name: "worldwide_organisation",
       )
       content.merge!(PayloadBuilder::PolymorphicPath.for(item))
+      content.merge!(PayloadBuilder::AnalyticsIdentifier.for(item))
     end
 
     def links

--- a/db/migrate/20240103112519_add_analytics_identifier_to_editions.rb
+++ b/db/migrate/20240103112519_add_analytics_identifier_to_editions.rb
@@ -1,0 +1,5 @@
+class AddAnalyticsIdentifierToEditions < ActiveRecord::Migration[7.1]
+  def change
+    add_column :editions, :analytics_identifier, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_02_114732) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_03_112519) do
   create_table "assets", charset: "utf8mb3", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.string "variant", null: false
@@ -397,6 +397,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_02_114732) do
     t.string "mapped_specialist_topic_content_id"
     t.string "taxonomy_topic_email_override"
     t.string "logo_formatted_name"
+    t.string "analytics_identifier"
     t.index ["alternative_format_provider_id"], name: "index_editions_on_alternative_format_provider_id"
     t.index ["closing_at"], name: "index_editions_on_closing_at"
     t.index ["document_id"], name: "index_editions_on_document_id"

--- a/test/unit/app/models/editionable_worldwide_organisation_test.rb
+++ b/test/unit/app/models/editionable_worldwide_organisation_test.rb
@@ -1,6 +1,11 @@
 require "test_helper"
 
 class EditionableWorldwideOrganisationTest < ActiveSupport::TestCase
+  test "should set an analytics identifier on create" do
+    worldwide_organisation = create(:editionable_worldwide_organisation)
+    assert_equal "WO#{worldwide_organisation.id}", worldwide_organisation.analytics_identifier
+  end
+
   test "an ambassadorial role is a primary role and not a secondary one" do
     worldwide_organisation = create(:editionable_worldwide_organisation)
 

--- a/test/unit/app/presenters/publishing_api/editionable_worldwide_organisation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/editionable_worldwide_organisation_presenter_test.rb
@@ -8,7 +8,8 @@ class PublishingApi::EditionableWorldwideOrganisationPresenterTest < ActiveSuppo
   test "presents a Worldwide Organisation ready for adding to the publishing API" do
     worldwide_org = create(:editionable_worldwide_organisation,
                            :with_role,
-                           :with_social_media_account)
+                           :with_social_media_account,
+                           analytics_identifier: "WO123")
 
     primary_role = create(:ambassador_role)
     ambassador = create(:person)
@@ -53,6 +54,7 @@ class PublishingApi::EditionableWorldwideOrganisationPresenterTest < ActiveSuppo
           },
         ],
       },
+      analytics_identifier: "WO123",
       update_type: "major",
     }
 


### PR DESCRIPTION
This adds analytics identifiers to Editionable Worldwide Organisations, in the same way as they are associated to editionable Worldwide Organisations.

[Trello card](https://trello.com/c/zITYCrxl)