### PR TITLE
Add overdue scheduled publishing metric

### DIFF
--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -1,2 +1,4 @@
 require "govuk_app_config/govuk_prometheus_exporter"
-GovukPrometheusExporter.configure
+require "collectors/scheduled_publishing_overdue_collector"
+
+GovukPrometheusExporter.configure(collectors: [Collectors::ScheduledPublishingOverdueCollector])

--- a/lib/collectors/scheduled_publishing_overdue_collector.rb
+++ b/lib/collectors/scheduled_publishing_overdue_collector.rb
@@ -1,0 +1,14 @@
+module Collectors
+  class ScheduledPublishingOverdueCollector < PrometheusExporter::Server::CollectorBase
+    def type
+      "whitehall"
+    end
+
+    def metrics
+      whitehall_scheduled_publishing_overdue = PrometheusExporter::Metric::Gauge.new("whitehall_scheduled_publishing_overdue", "Overdue scheduled publications")
+      whitehall_scheduled_publishing_overdue.observe(Edition.due_for_publication.count)
+
+      [whitehall_scheduled_publishing_overdue]
+    end
+  end
+end


### PR DESCRIPTION
This is a replacement for the old overdue scheduled publishing alert in Icinga

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
