### PR TITLE
Clone social media accounts when draft edition created

### DIFF
--- a/app/models/edition/social_media_accounts.rb
+++ b/app/models/edition/social_media_accounts.rb
@@ -1,8 +1,18 @@
 module Edition::SocialMediaAccounts
   extend ActiveSupport::Concern
 
+  class Trait < Edition::Traits::Trait
+    def process_associations_before_save(edition)
+      @edition.social_media_accounts.each do |association|
+        edition.social_media_accounts.build(association.attributes.except("id", "socialable_id", "socialable_type"))
+      end
+    end
+  end
+
   included do
     has_many :social_media_accounts, as: :socialable, dependent: :destroy, autosave: true
+
+    add_trait Trait
   end
 
   def can_be_associated_with_social_media_accounts?

--- a/test/unit/app/models/editionable_worldwide_organisation_test.rb
+++ b/test/unit/app/models/editionable_worldwide_organisation_test.rb
@@ -86,4 +86,17 @@ class EditionableWorldwideOrganisationTest < ActiveSupport::TestCase
     assert_equal b, worldwide_organisation.secondary_role
     assert_equal [c], worldwide_organisation.office_staff_roles
   end
+
+  test "should clone social media associations when new draft of published edition is created" do
+    published_worldwide_organisation = create(
+      :editionable_worldwide_organisation,
+      :published,
+      :with_social_media_account,
+    )
+
+    draft_worldwide_organisation = published_worldwide_organisation.create_draft(create(:writer))
+
+    assert_equal published_worldwide_organisation.social_media_accounts.first.title, draft_worldwide_organisation.social_media_accounts.first.title
+    assert_equal published_worldwide_organisation.social_media_accounts.first.url, draft_worldwide_organisation.social_media_accounts.first.url
+  end
 end


### PR DESCRIPTION
When a published edition has a new draft edition created, we copy the associations for that edition and associate them with the new edition.

This was missed for social media accounts in https://github.com/alphagov/whitehall/pull/8681.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
