### PR TITLE
Enable translations for editionable worldwide organisations

### DIFF
--- a/app/controllers/admin/editionable_social_media_accounts_controller.rb
+++ b/app/controllers/admin/editionable_social_media_accounts_controller.rb
@@ -22,7 +22,11 @@ class Admin::EditionableSocialMediaAccountsController < Admin::BaseController
     end
   end
 
-  def edit; end
+  def edit
+    I18n.with_locale(params[:locale] || I18n.default_locale) do
+      render :edit
+    end
+  end
 
   def index
     @editionable_social_media_accounts_index_presenter = EditionableSocialMediaAccountsIndexPresenter.new(@edition)
@@ -52,6 +56,7 @@ private
 
   def social_media_account_params
     params.fetch(:social_media_account, {}).permit(
+      :locale,
       :social_media_service_id,
       :title,
       :url,

--- a/app/controllers/admin/editionable_social_media_accounts_controller.rb
+++ b/app/controllers/admin/editionable_social_media_accounts_controller.rb
@@ -24,7 +24,9 @@ class Admin::EditionableSocialMediaAccountsController < Admin::BaseController
 
   def edit; end
 
-  def index; end
+  def index
+    @editionable_social_media_accounts_index_presenter = EditionableSocialMediaAccountsIndexPresenter.new(@edition)
+  end
 
   def new; end
 

--- a/app/models/editionable_worldwide_organisation.rb
+++ b/app/models/editionable_worldwide_organisation.rb
@@ -69,4 +69,8 @@ class EditionableWorldwideOrganisation < Edition
   def skip_world_location_validation?
     false
   end
+
+  def translatable?
+    true
+  end
 end

--- a/app/presenters/editionable_social_media_accounts_index_presenter.rb
+++ b/app/presenters/editionable_social_media_accounts_index_presenter.rb
@@ -12,6 +12,7 @@ class EditionableSocialMediaAccountsIndexPresenter
       {
         title: social_media_account.service_name,
         rows: social_media_account_rows(social_media_account),
+        summary_card_actions: summary_card_actions(social_media_account),
       }
     end
   end
@@ -28,13 +29,18 @@ private
             label: "Edit",
             href: edit_admin_edition_social_media_account_path(@edition, social_media_account, locale:),
           },
-          {
-            label: "Delete",
-            href: confirm_destroy_admin_edition_social_media_account_path(edition, social_media_account),
-            destructive: true,
-          },
         ],
       }
     end
+  end
+
+  def summary_card_actions(social_media_account)
+    [
+      {
+        label: "Delete",
+        href: confirm_destroy_admin_edition_social_media_account_path(@edition, social_media_account),
+        destructive: true,
+      },
+    ]
   end
 end

--- a/app/presenters/editionable_social_media_accounts_index_presenter.rb
+++ b/app/presenters/editionable_social_media_accounts_index_presenter.rb
@@ -19,14 +19,14 @@ class EditionableSocialMediaAccountsIndexPresenter
 private
 
   def social_media_account_rows(social_media_account)
-    [
+    edition.translations.pluck(:locale).map do |locale|
       {
-        key: "Account",
-        value: social_media_account.title,
+        key: "#{Locale.new(locale).english_language_name} Account",
+        value: I18n.with_locale(locale) { social_media_account.title },
         actions: [
           {
             label: "Edit",
-            href: edit_admin_edition_social_media_account_path(edition, social_media_account),
+            href: edit_admin_edition_social_media_account_path(@edition, social_media_account, locale:),
           },
           {
             label: "Delete",
@@ -35,6 +35,6 @@ private
           },
         ],
       }
-    ]
+    end
   end
 end

--- a/app/presenters/editionable_social_media_accounts_index_presenter.rb
+++ b/app/presenters/editionable_social_media_accounts_index_presenter.rb
@@ -1,0 +1,40 @@
+class EditionableSocialMediaAccountsIndexPresenter
+  include Rails.application.routes.url_helpers
+
+  attr_accessor :edition
+
+  def initialize(edition)
+    @edition = edition
+  end
+
+  def social_media_accounts
+    edition.social_media_accounts.map do |social_media_account|
+      {
+        title: social_media_account.service_name,
+        rows: social_media_account_rows(social_media_account),
+      }
+    end
+  end
+
+private
+
+  def social_media_account_rows(social_media_account)
+    [
+      {
+        key: "Account",
+        value: social_media_account.title,
+        actions: [
+          {
+            label: "Edit",
+            href: edit_admin_edition_social_media_account_path(edition, social_media_account),
+          },
+          {
+            label: "Delete",
+            href: confirm_destroy_admin_edition_social_media_account_path(edition, social_media_account),
+            destructive: true,
+          },
+        ],
+      }
+    ]
+  end
+end

--- a/app/views/admin/editionable_social_media_accounts/_form.html.erb
+++ b/app/views/admin/editionable_social_media_accounts/_form.html.erb
@@ -39,6 +39,8 @@
         error_items: errors_for(social_media_account.errors, :title),
       } %>
 
+      <%= form.hidden_field :locale, value: I18n.locale %>
+
       <div class="govuk-button-group govuk-!-margin-top-8">
         <%= render "govuk_publishing_components/components/button", {
           text: "Save",

--- a/app/views/admin/editionable_social_media_accounts/index.html.erb
+++ b/app/views/admin/editionable_social_media_accounts/index.html.erb
@@ -25,26 +25,10 @@
     } %>
 
     <% if @edition.social_media_accounts.any? %>
-      <% @edition.social_media_accounts.each do |social_media_account| %>
+      <% @editionable_social_media_accounts_index_presenter.social_media_accounts.each do |social_media_account| %>
         <%= render "components/summary_card", {
-          title: social_media_account.service_name,
-          rows: [
-            {
-              key: "Account",
-              value: social_media_account.title,
-              actions: [
-                {
-                  label: "Edit",
-                  href: edit_admin_edition_social_media_account_path(@edition, social_media_account),
-                },
-                {
-                  label: "Delete",
-                  href: confirm_destroy_admin_edition_social_media_account_path(@edition, social_media_account),
-                  destructive: true,
-                },
-              ],
-            },
-          ],
+          title: social_media_account[:title],
+          rows: social_media_account[:rows],
         } %>
       <% end %>
     <% else %>

--- a/app/views/admin/editionable_social_media_accounts/index.html.erb
+++ b/app/views/admin/editionable_social_media_accounts/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title, "Social media accounts for #{@edition.title}" %>
-<% content_for :title, "Social media accounts for for #{@edition.title}" %>
+<% content_for :title, "Social media accounts for #{@edition.title}" %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/admin/editionable_social_media_accounts/index.html.erb
+++ b/app/views/admin/editionable_social_media_accounts/index.html.erb
@@ -29,6 +29,7 @@
         <%= render "components/summary_card", {
           title: social_media_account[:title],
           rows: social_media_account[:rows],
+          summary_card_actions: social_media_account[:summary_card_actions],
         } %>
       <% end %>
     <% else %>

--- a/features/editionable-worldwide-organisations.feature
+++ b/features/editionable-worldwide-organisations.feature
@@ -10,6 +10,11 @@ Feature: Editionable worldwide organisations
     And I should see it has been assigned to the "United Kingdom" world location
     And I should see the editionable worldwide organisation "Test Worldwide Organisation" in the list of draft documents
 
+  Scenario Outline: Adding a translation to an existing worldwide organisation
+    When I draft a new worldwide organisation "Test Worldwide Organisation" assigned to world location "United Kingdom"
+    And I add a Welsh translation of the worldwide organisation "Test Worldwide Organisation" named "Translated Name"
+    Then I should see the Welsh translated title "Translated Name" for the "Test Worldwide Organisation" worldwide organisation
+
   Scenario Outline: Assigning a role to a worldwide organisation
     Given a role "Prime Minister" exists
     When I draft a new worldwide organisation "Test Worldwide Organisation" assigned to world location "United Kingdom"

--- a/features/step_definitions/editionable_worldwide_organisation_steps.rb
+++ b/features/step_definitions/editionable_worldwide_organisation_steps.rb
@@ -98,6 +98,23 @@ And(/^I should see it has been assigned to the "([^"]*)" world location$/) do |t
   expect(@worldwide_organisation.world_locations.first.name).to eq(title)
 end
 
+And(/^I add a Welsh translation of the worldwide organisation "([^"]*)" named "([^"]*)"$/) do |title, translated_title|
+  visit_edition_admin(title)
+  click_link "Add translation"
+  select "Cymraeg (Welsh)", from: "Choose language"
+  click_button "Next"
+  fill_in "Translated title (required)", with: translated_title
+  click_button "Save"
+end
+
+Then(/^I should see the Welsh translated title "([^"]*)" for the "([^"]*)" worldwide organisation$/) do |translated_title, title|
+  @worldwide_organisation = EditionableWorldwideOrganisation.find_by(title:)
+
+  I18n.with_locale(:cy) do
+    expect(@worldwide_organisation.title).to eq(translated_title)
+  end
+end
+
 Given(/^a role "([^"]*)" exists$/) do |name|
   create(:role, name:)
 end

--- a/test/functional/admin/editionable_social_media_accounts_controller_test.rb
+++ b/test/functional/admin/editionable_social_media_accounts_controller_test.rb
@@ -40,6 +40,19 @@ class Admin::EditionableSocialMediaAccountsControllerTest < ActionController::Te
     assert_select "input.govuk-input", value: @edition.social_media_accounts.first.title
   end
 
+  view_test "GET :edit displays an existing social media account translation" do
+    get :edit, params: {
+      edition_id: @edition,
+      id: @edition.social_media_accounts.first,
+      locale: "cy",
+    }
+
+    assert_response :success
+    assert_select "select.govuk-select", value: @edition.social_media_accounts.first.social_media_service.name
+    assert_select "input.govuk-input", value: "https://www.newurl.gov.cymru"
+    assert_select "input.govuk-input", value: "Translated title"
+  end
+
   test "PATCH :update updates an existing social media account" do
     patch :update, params: {
       edition_id: @edition,
@@ -53,6 +66,24 @@ class Admin::EditionableSocialMediaAccountsControllerTest < ActionController::Te
     assert_response :redirect
     assert_equal "New title", @edition.social_media_accounts.first.title
     assert_equal "https://www.newurl.gov.uk", @edition.social_media_accounts.first.url
+  end
+
+  test "PATCH :update updates an existing social media account translation" do
+    patch :update, params: {
+      edition_id: @edition,
+      id: @edition.social_media_accounts.first,
+      social_media_account: {
+        title: "New translated title",
+        url: "https://www.newurl.gov.cymru",
+        locale: "cy",
+      },
+    }
+
+    assert_response :redirect
+    I18n.with_locale(:cy) do
+      assert_equal "New translated title", @edition.social_media_accounts.first.title
+      assert_equal "https://www.newurl.gov.cymru", @edition.social_media_accounts.first.url
+    end
   end
 
   test "POST :create creates a social media account" do

--- a/test/functional/admin/editionable_social_media_accounts_controller_test.rb
+++ b/test/functional/admin/editionable_social_media_accounts_controller_test.rb
@@ -5,7 +5,14 @@ class Admin::EditionableSocialMediaAccountsControllerTest < ActionController::Te
 
   setup do
     login_as :gds_editor
-    @edition = create(:editionable_worldwide_organisation, :with_social_media_account)
+    @edition = create(:editionable_worldwide_organisation, :with_social_media_account, translated_into: [:cy])
+
+    I18n.with_locale(:cy) do
+      @edition.social_media_accounts.first.update(
+        title: "Translated title",
+        url: "https://www.newurl.gov.cymru",
+      )
+    end
   end
 
   view_test "GET :index lists the existing social media accounts" do
@@ -13,7 +20,12 @@ class Admin::EditionableSocialMediaAccountsControllerTest < ActionController::Te
 
     assert_response :success
     assert_select "h2.govuk-summary-card__title", text: @edition.social_media_accounts.first.social_media_service.name
-    assert_select "dd.govuk-summary-list__value", text: @edition.social_media_accounts.first.title
+
+    assert_select "div.govuk-summary-list__row:nth-of-type(1) .govuk-summary-list__key", text: "English Account"
+    assert_select "div.govuk-summary-list__row:nth-of-type(1) .govuk-summary-list__value", text: @edition.social_media_accounts.first.title
+
+    assert_select "div.govuk-summary-list__row:nth-of-type(2) .govuk-summary-list__key", text: "Welsh Account"
+    assert_select "div.govuk-summary-list__row:nth-of-type(2) .govuk-summary-list__value", text: "Translated title"
   end
 
   view_test "GET :edit displays an existing social media account" do

--- a/test/unit/app/presenters/editionable_social_media_accounts_index_presenter_test.rb
+++ b/test/unit/app/presenters/editionable_social_media_accounts_index_presenter_test.rb
@@ -21,11 +21,6 @@ class EditionableSocialMediaAccountsIndexPresenterTest < ActiveSupport::TestCase
                 label: "Edit",
                 href: edit_admin_edition_social_media_account_path(editionable_worldwide_organisation, social_media_account_1, locale: :en),
               },
-              {
-                label: "Delete",
-                href: confirm_destroy_admin_edition_social_media_account_path(editionable_worldwide_organisation, social_media_account_1),
-                destructive: true,
-              },
             ],
           },
           {
@@ -36,12 +31,14 @@ class EditionableSocialMediaAccountsIndexPresenterTest < ActiveSupport::TestCase
                 label: "Edit",
                 href: edit_admin_edition_social_media_account_path(editionable_worldwide_organisation, social_media_account_1, locale: :cy),
               },
-              {
-                label: "Delete",
-                href: confirm_destroy_admin_edition_social_media_account_path(editionable_worldwide_organisation, social_media_account_1),
-                destructive: true,
-              },
             ],
+          },
+        ],
+        summary_card_actions: [
+          {
+            label: "Delete",
+            href: confirm_destroy_admin_edition_social_media_account_path(editionable_worldwide_organisation, social_media_account_1),
+            destructive: true,
           },
         ],
       },
@@ -56,11 +53,6 @@ class EditionableSocialMediaAccountsIndexPresenterTest < ActiveSupport::TestCase
                 label: "Edit",
                 href: edit_admin_edition_social_media_account_path(editionable_worldwide_organisation, social_media_account_2, locale: :en),
               },
-              {
-                label: "Delete",
-                href: confirm_destroy_admin_edition_social_media_account_path(editionable_worldwide_organisation, social_media_account_2),
-                destructive: true,
-              },
             ],
           },
           {
@@ -71,12 +63,14 @@ class EditionableSocialMediaAccountsIndexPresenterTest < ActiveSupport::TestCase
                 label: "Edit",
                 href: edit_admin_edition_social_media_account_path(editionable_worldwide_organisation, social_media_account_2, locale: :cy),
               },
-              {
-                label: "Delete",
-                href: confirm_destroy_admin_edition_social_media_account_path(editionable_worldwide_organisation, social_media_account_2),
-                destructive: true,
-              },
             ],
+          },
+        ],
+        summary_card_actions: [
+          {
+            label: "Delete",
+            href: confirm_destroy_admin_edition_social_media_account_path(editionable_worldwide_organisation, social_media_account_2),
+            destructive: true,
           },
         ],
       },

--- a/test/unit/app/presenters/editionable_social_media_accounts_index_presenter_test.rb
+++ b/test/unit/app/presenters/editionable_social_media_accounts_index_presenter_test.rb
@@ -4,7 +4,7 @@ class EditionableSocialMediaAccountsIndexPresenterTest < ActiveSupport::TestCase
   include Rails.application.routes.url_helpers
 
   test "EditionableSocialMediaAccountsIndexPresenter.social_media_accounts should return an array of accounts for the edition" do
-    editionable_worldwide_organisation = create(:editionable_worldwide_organisation)
+    editionable_worldwide_organisation = create(:editionable_worldwide_organisation, translated_into: "cy")
     social_media_account_1 = create(:social_media_account)
     social_media_account_2 = create(:social_media_account)
     editionable_worldwide_organisation.social_media_accounts << [social_media_account_1, social_media_account_2]
@@ -14,12 +14,27 @@ class EditionableSocialMediaAccountsIndexPresenterTest < ActiveSupport::TestCase
         title: social_media_account_1.service_name,
         rows: [
           {
-            key: "Account",
+            key: "English Account",
             value: social_media_account_1.title,
             actions: [
               {
                 label: "Edit",
-                href: edit_admin_edition_social_media_account_path(editionable_worldwide_organisation, social_media_account_1),
+                href: edit_admin_edition_social_media_account_path(editionable_worldwide_organisation, social_media_account_1, locale: :en),
+              },
+              {
+                label: "Delete",
+                href: confirm_destroy_admin_edition_social_media_account_path(editionable_worldwide_organisation, social_media_account_1),
+                destructive: true,
+              },
+            ],
+          },
+          {
+            key: "Welsh Account",
+            value: social_media_account_1.title,
+            actions: [
+              {
+                label: "Edit",
+                href: edit_admin_edition_social_media_account_path(editionable_worldwide_organisation, social_media_account_1, locale: :cy),
               },
               {
                 label: "Delete",
@@ -34,12 +49,27 @@ class EditionableSocialMediaAccountsIndexPresenterTest < ActiveSupport::TestCase
         title: social_media_account_2.service_name,
         rows: [
           {
-            key: "Account",
+            key: "English Account",
             value: social_media_account_2.title,
             actions: [
               {
                 label: "Edit",
-                href: edit_admin_edition_social_media_account_path(editionable_worldwide_organisation, social_media_account_2),
+                href: edit_admin_edition_social_media_account_path(editionable_worldwide_organisation, social_media_account_2, locale: :en),
+              },
+              {
+                label: "Delete",
+                href: confirm_destroy_admin_edition_social_media_account_path(editionable_worldwide_organisation, social_media_account_2),
+                destructive: true,
+              },
+            ],
+          },
+          {
+            key: "Welsh Account",
+            value: social_media_account_2.title,
+            actions: [
+              {
+                label: "Edit",
+                href: edit_admin_edition_social_media_account_path(editionable_worldwide_organisation, social_media_account_2, locale: :cy),
               },
               {
                 label: "Delete",

--- a/test/unit/app/presenters/editionable_social_media_accounts_index_presenter_test.rb
+++ b/test/unit/app/presenters/editionable_social_media_accounts_index_presenter_test.rb
@@ -1,0 +1,57 @@
+require "test_helper"
+
+class EditionableSocialMediaAccountsIndexPresenterTest < ActiveSupport::TestCase
+  include Rails.application.routes.url_helpers
+
+  test "EditionableSocialMediaAccountsIndexPresenter.social_media_accounts should return an array of accounts for the edition" do
+    editionable_worldwide_organisation = create(:editionable_worldwide_organisation)
+    social_media_account_1 = create(:social_media_account)
+    social_media_account_2 = create(:social_media_account)
+    editionable_worldwide_organisation.social_media_accounts << [social_media_account_1, social_media_account_2]
+
+    expected = [
+      {
+        title: social_media_account_1.service_name,
+        rows: [
+          {
+            key: "Account",
+            value: social_media_account_1.title,
+            actions: [
+              {
+                label: "Edit",
+                href: edit_admin_edition_social_media_account_path(editionable_worldwide_organisation, social_media_account_1),
+              },
+              {
+                label: "Delete",
+                href: confirm_destroy_admin_edition_social_media_account_path(editionable_worldwide_organisation, social_media_account_1),
+                destructive: true,
+              },
+            ],
+          },
+        ],
+      },
+      {
+        title: social_media_account_2.service_name,
+        rows: [
+          {
+            key: "Account",
+            value: social_media_account_2.title,
+            actions: [
+              {
+                label: "Edit",
+                href: edit_admin_edition_social_media_account_path(editionable_worldwide_organisation, social_media_account_2),
+              },
+              {
+                label: "Delete",
+                href: confirm_destroy_admin_edition_social_media_account_path(editionable_worldwide_organisation, social_media_account_2),
+                destructive: true,
+              },
+            ],
+          },
+        ],
+      },
+    ]
+
+    assert_equal expected, EditionableSocialMediaAccountsIndexPresenter.new(editionable_worldwide_organisation).social_media_accounts
+  end
+end


### PR DESCRIPTION
This will allow users to specify the title and body in another language.

## Screenshots
| Feature | Screenshot |
| -- | -- |
| Adding a translation |  ![Screenshot 2024-01-04 at 11 24 52](https://github.com/alphagov/whitehall/assets/6329861/489831c1-dc43-4331-9e21-37dd17d6ca60)  |
| Editing a translation | ![Screenshot 2024-01-04 at 11 25 09](https://github.com/alphagov/whitehall/assets/6329861/76d87971-2231-472c-aebd-94628648fda1) |
| Viewing social media accounts | ![Screenshot 2024-01-04 at 11 24 19](https://github.com/alphagov/whitehall/assets/6329861/27f74b51-0f5a-4bc7-9042-80c610bcb40f) |
| Editing a translated social media account |  ![Screenshot 2024-01-04 at 11 24 29](https://github.com/alphagov/whitehall/assets/6329861/4275fc59-b9f7-4a21-acd2-84c5b972338f) |



[Trello card](https://trello.com/c/QJTXh0No)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
