### PR TITLE
Disable legacy worldwide organisations when editionable worldwide organisation feature flag is enabled

### DIFF
--- a/app/controllers/admin/worldwide_organisations_controller.rb
+++ b/app/controllers/admin/worldwide_organisations_controller.rb
@@ -3,6 +3,7 @@ class Admin::WorldwideOrganisationsController < Admin::BaseController
 
   respond_to :html
 
+  before_action :check_worldwide_organisation_feature_flag
   before_action :find_worldwide_organisation, except: %i[index new create]
   before_action :build_worldwide_organisation, only: %i[new create]
   before_action :clean_worldwide_organisation_params, only: %i[create update]
@@ -56,6 +57,10 @@ class Admin::WorldwideOrganisationsController < Admin::BaseController
   end
 
 private
+
+  def check_worldwide_organisation_feature_flag
+    forbidden! if Flipflop.editionable_worldwide_organisations?
+  end
 
   def find_worldwide_organisation
     @worldwide_organisation = WorldwideOrganisation.friendly.find(params[:id])

--- a/app/helpers/admin/url_helper.rb
+++ b/app/helpers/admin/url_helper.rb
@@ -16,7 +16,7 @@ module Admin::UrlHelper
   end
 
   def admin_worldwide_organisations_link
-    admin_link "Worldwide organisations", admin_worldwide_organisations_path
+    admin_link "Worldwide organisations", admin_worldwide_organisations_path unless Flipflop.editionable_worldwide_organisations?
   end
 
   def admin_world_location_news_link

--- a/test/functional/admin/more_controller_test.rb
+++ b/test/functional/admin/more_controller_test.rb
@@ -46,4 +46,22 @@ class Admin::MoreControllerTest < ActionController::TestCase
     refute_select "a.govuk-link", text: "Fields of operation"
     refute_select "a.govuk-link", text: "Sitewide settings"
   end
+
+  view_test "GET #index renders Worldwide Organisations when the editionable_worldwide_organisations feature flag is switched off" do
+    feature_flags.switch! :editionable_worldwide_organisations, false
+
+    get :index
+
+    assert_select ".govuk-list"
+    assert_select "a.govuk-link", text: "Worldwide organisations"
+  end
+
+  view_test "GET #index does not render Worldwide Organisations when the editionable_worldwide_organisations feature flag is switched on" do
+    feature_flags.switch! :editionable_worldwide_organisations, true
+
+    get :index
+
+    assert_select ".govuk-list"
+    refute_select "a.govuk-link", text: "Worldwide organisations"
+  end
 end

--- a/test/functional/admin/worldwide_organisations_controller_test.rb
+++ b/test/functional/admin/worldwide_organisations_controller_test.rb
@@ -7,6 +7,15 @@ class Admin::WorldwideOrganisationsControllerTest < ActionController::TestCase
 
   should_be_an_admin_controller
 
+  test "actions are forbidden when the editionable_worldwide_organisations feature flag is enabled" do
+    feature_flags.switch! :editionable_worldwide_organisations, true
+    worldwide_organisation = create(:worldwide_organisation)
+
+    get :show, params: { id: worldwide_organisation.id }
+
+    assert_response :forbidden
+  end
+
   test "shows a list of worldwide organisations" do
     organisation = create(:worldwide_organisation)
     get :index


### PR DESCRIPTION
This prevents access to the legacy (non-editionable) worldwide organisations when the feature flag to enable editionable worldwide organisations is enabled.

[Trello card](https://trello.com/c/rVBE4iPR)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
