### PR TITLE
Present summary for editionable worldwide organisations

### DIFF
--- a/app/models/editionable_worldwide_organisation.rb
+++ b/app/models/editionable_worldwide_organisation.rb
@@ -70,6 +70,10 @@ class EditionableWorldwideOrganisation < Edition
     false
   end
 
+  def summary_required?
+    false
+  end
+
   def translatable?
     true
   end

--- a/app/presenters/publishing_api/editionable_worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/editionable_worldwide_organisation_presenter.rb
@@ -22,6 +22,7 @@ module PublishingApi
       ).base_attributes
 
       content.merge!(
+        description: item.summary,
         details: {
           body:,
           logo: {

--- a/test/factories/editionable_worldwide_organisations.rb
+++ b/test/factories/editionable_worldwide_organisations.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :editionable_worldwide_organisation, class: EditionableWorldwideOrganisation, parent: :edition_with_organisations do
     title { "Editionable worldwide organisation title" }
     logo_formatted_name { title.to_s.split.join("\n") }
+    summary { "Basic information about the organisation." }
     body { "Information about the organisation with _italics_." }
 
     after :build do |news_article, evaluator|

--- a/test/unit/app/presenters/publishing_api/editionable_worldwide_organisation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/editionable_worldwide_organisation_presenter_test.rb
@@ -35,6 +35,7 @@ class PublishingApi::EditionableWorldwideOrganisationPresenterTest < ActiveSuppo
       public_updated_at: worldwide_org.updated_at,
       routes: [{ path: public_path, type: "exact" }],
       redirects: [],
+      description: worldwide_org.summary,
       details: {
         body: "<div class=\"govspeak\"><p>Information about the organisation with <em>italics</em>.</p>\n</div>",
         logo: {


### PR DESCRIPTION
These were missed when the presenter was added.  Also makes the summary optional, which matches the existing behaviour for non-editionable worldwide organisations.

[Trello card](https://trello.com/c/o0SZZS19)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
