### PR TITLE
Fix `add edition ID to worldwide offices`migration

### DIFF
--- a/db/migrate/20231227134311_add_edition_id_to_worldwide_offices.rb
+++ b/db/migrate/20231227134311_add_edition_id_to_worldwide_offices.rb
@@ -1,6 +1,6 @@
 class AddEditionIdToWorldwideOffices < ActiveRecord::Migration[7.0]
   def change
-    add_reference :worldwide_offices, :edition, type: :integer, index: true, foreign_key: true, name: "index_worldwide_offices_on_edition_id"
+    add_reference :worldwide_offices, :edition, type: :integer, index: true, foreign_key: true
     add_reference :editions, :main_office, type: :integer
   end
 end


### PR DESCRIPTION
This migration is failing. The `name` key isn't available or needed.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
