### PR TITLE
Allow for nil image

### DIFF
--- a/app/presenters/publishing_api/featured_documents_presenter.rb
+++ b/app/presenters/publishing_api/featured_documents_presenter.rb
@@ -3,7 +3,7 @@ module PublishingApi
     def featured_documents(featurable_item, document_limit)
       featurable_item
         .feature_list_for_locale(I18n.locale).current.limit(document_limit)
-        .select { |feature| feature.image.all_asset_variants_uploaded? }
+        .select { |feature| feature.image&.all_asset_variants_uploaded? }
         .map do |feature|
           if feature.document
             featured_documents_editioned(feature)


### PR DESCRIPTION
We have had cases where the featured item of an organisation returns nil, this alerts us via sentry and is not an immediately actionable alert. This changes the code to allow for a nil image once it has reached this point so we are not alerted unduly

Trello card: https://trello.com/c/prZOCIqa/2255-investigate-no-method-errors-on-sentry