### PR TITLE
Restore `html_safe` to prevent markup being rendered

### DIFF
--- a/app/views/admin/statistics_announcements/_search_results.html.erb
+++ b/app/views/admin/statistics_announcements/_search_results.html.erb
@@ -32,7 +32,7 @@
               text: statistics_announcement.organisations.map(&:name).to_sentence,
             },
             {
-              text: tag.p(statistics_announcement.release_date.to_date.strftime(sanitize("%e&nbsp;%B&nbsp;%Y")), class: "govuk-!-margin-0") +
+              text: tag.p(statistics_announcement.release_date.to_date.strftime("%e&nbsp;%B&nbsp;%Y").html_safe, class: "govuk-!-margin-0") +
                 tag.p(statistics_announcement.release_date.strftime("%l:%M%P"), class: "govuk-!-margin-0") +
                 "(#{statistics_announcement.confirmed? ? 'confirmed' : 'provisional'})",
             },


### PR DESCRIPTION
[Zendesk ticket 5594814](https://govuk.zendesk.com/agent/tickets/5594814)

This change restores the `html_safe` method to the date string in place of `sanitize` in order to maintain the `&nbsp;` character but ensuring it isn't rendered literally. This reverses a previous change that replaced `html_safe` with `sanitize`.

The original reason to use `html_safe` is to allow the string to be rendered without it breaking onto multiple lines. 

Whilst `sanitize` is preferred to `html_safe` it still allows `&nbsp;` to be rendered since it is not a tag or attribute, which is not the desired outcome, so it seems to be the best way Rails-wise to do this. Actually my preferred approach would be to wrap the string in a `<span>` and use CSS to ensure the string doesn't break. This would keep layout concerns out of the markup but might be out of scope as a 2nd line task. 

|Existing|Updated|
|-|-|
|![Screenshot 2024-01-05 at 11 12 47](https://github.com/alphagov/whitehall/assets/6080548/0f1f5c1e-c8c2-48a8-8c7b-af3a0d1ac287)|![Screenshot 2024-01-05 at 11 11 53](https://github.com/alphagov/whitehall/assets/6080548/36dcc21a-0f8f-40cd-aef1-9d76a1ea568d)|