### PR TITLE
Strip 'editionable' from titles of newly editionable content

### DIFF
--- a/app/helpers/admin/new_document_helper.rb
+++ b/app/helpers/admin/new_document_helper.rb
@@ -18,7 +18,7 @@ module Admin::NewDocumentHelper
       .select { |edition_type| can?(:create, edition_type) }
       .map do |edition_type|
       title_value = edition_type.name.underscore
-      title_label = title_value.humanize
+      title_label = title_value.gsub("editionable_", "").humanize
       {
         value: title_value,
         text: title_label,

--- a/app/models/editionable_worldwide_organisation.rb
+++ b/app/models/editionable_worldwide_organisation.rb
@@ -22,6 +22,10 @@ class EditionableWorldwideOrganisation < Edition
     "editionable_worldwide_organisation"
   end
 
+  def self.format_name
+    "worldwide organisation"
+  end
+
   alias_method :original_main_office, :main_office
 
   extend HomePageList::Container

--- a/app/views/admin/editions/new.html.erb
+++ b/app/views/admin/editions/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :page_title, "New #{@edition.type.titleize}" %>
+<% content_for :page_title, "New #{@edition.format_name.titleize}" %>
 <% content_for :title, "New #{@edition.format_name}" %>
 <% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @edition, parent_class: "edition")) %>
 

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -18,7 +18,7 @@ module DocumentHelper
     create(:organisation) if Organisation.count.zero?
     visit admin_root_path
     find("li.app-c-sub-navigation__list-item a", text: "New document").click
-    page.choose(options[:type].humanize)
+    page.choose(options[:type].gsub("editionable_", "").humanize)
     click_button("Next")
 
     if options[:locale]


### PR DESCRIPTION
This generically removes the term "editionable" from the beginning of strings when creating new documents. We've had to do this because in order to make rework worldwide orgs we created a new "editionable_worldwide_organisation" content type. Whitehall uses this to display things which would have created a bit of confusion after going live (see screenshots)

I've chosen to do this generically so that we have choice over whether to change the content type name in the future. If we don't change it, it means that anyone editionablising the rest of the uneditionable things will be able to create a similar "editionable_content_type" name and have it display as expected. 

Trello - https://trello.com/c/ARFqTgZi/996-display-the-name-of-the-worldwide-orgs-without-editionable

## Before
<img width="557" alt="Screenshot 2024-01-05 at 15 16 56" src="https://github.com/alphagov/whitehall/assets/24547207/710a20ed-2434-4efa-85af-b8adbd46cbdb">
<img width="815" alt="Screenshot 2024-01-05 at 15 17 05" src="https://github.com/alphagov/whitehall/assets/24547207/33468fcf-b64a-40a0-af4c-af55e3eff1f1">


## After
<img width="734" alt="Screenshot 2024-01-05 at 15 11 36" src="https://github.com/alphagov/whitehall/assets/24547207/a42081a0-2ff7-4120-bcb1-aa51258e8031">
<img width="754" alt="Screenshot 2024-01-05 at 15 07 22" src="https://github.com/alphagov/whitehall/assets/24547207/c704998b-269e-4f97-a42b-8d9d75882026">

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
