### PR TITLE
Add visual editor toggle to Whitehall

### DIFF
--- a/app/assets/javascripts/components/govspeak-editor.js
+++ b/app/assets/javascripts/components/govspeak-editor.js
@@ -9,6 +9,9 @@ window.GOVUK.Modules = window.GOVUK.Modules || {}
     this.previewButton = this.module.querySelector(
       '.js-app-c-govspeak-editor__preview-button'
     )
+    this.visualEditorButton = this.module.querySelector(
+      '.js-app-c-govspeak-editor__visual-editor-button'
+    )
     this.backButton = this.module.querySelector(
       '.js-app-c-govspeak-editor__back-button'
     )
@@ -26,8 +29,15 @@ window.GOVUK.Modules = window.GOVUK.Modules || {}
     this.previewButton.classList.add(
       'app-c-govspeak-editor__preview-button--show'
     )
+    this.visualEditorButton?.classList.add(
+      'app-c-govspeak-editor__visual-editor-button--show'
+    )
 
     this.previewButton.addEventListener('click', this.showPreview.bind(this))
+    this.visualEditorButton?.addEventListener(
+      'click',
+      this.showVisualEditor.bind(this)
+    )
     this.backButton.addEventListener('click', this.hidePreview.bind(this))
   }
 
@@ -86,6 +96,9 @@ window.GOVUK.Modules = window.GOVUK.Modules || {}
     this.previewButton.classList.remove(
       'app-c-govspeak-editor__preview-button--show'
     )
+    this.visualEditorButton?.classList.remove(
+      'app-c-govspeak-editor__visual-editor-button--show'
+    )
 
     this.preview.classList.add('app-c-govspeak-editor__preview--show')
     this.textareaWrapper.classList.add(
@@ -114,12 +127,35 @@ window.GOVUK.Modules = window.GOVUK.Modules || {}
     this.maybeTrackEvent('preview')
   }
 
+  GovspeakEditor.prototype.showVisualEditor = function (event) {
+    event.preventDefault()
+
+    this.backButton.classList.add('app-c-govspeak-editor__back-button--show')
+    this.previewButton.classList.remove(
+      'app-c-govspeak-editor__preview-button--show'
+    )
+    this.visualEditorButton?.classList.remove(
+      'app-c-govspeak-editor__visual-editor-button--show'
+    )
+
+    this.textareaWrapper.classList.add(
+      'app-c-govspeak-editor__textarea--hidden'
+    )
+
+    this.backButton.focus()
+
+    this.maybeTrackEvent('visual')
+  }
+
   GovspeakEditor.prototype.hidePreview = function (event) {
     event.preventDefault()
 
     this.backButton.classList.remove('app-c-govspeak-editor__back-button--show')
     this.previewButton.classList.add(
       'app-c-govspeak-editor__preview-button--show'
+    )
+    this.visualEditorButton?.classList.add(
+      'app-c-govspeak-editor__visual-editor-button--show'
     )
 
     this.preview.classList.remove('app-c-govspeak-editor__preview--show')

--- a/app/assets/javascripts/components/govspeak-editor.js
+++ b/app/assets/javascripts/components/govspeak-editor.js
@@ -6,7 +6,29 @@ window.GOVUK.Modules = window.GOVUK.Modules || {}
   }
 
   GovspeakEditor.prototype.init = function () {
-    this.initPreview()
+    this.previewButton = this.module.querySelector(
+      '.js-app-c-govspeak-editor__preview-button'
+    )
+    this.backButton = this.module.querySelector(
+      '.js-app-c-govspeak-editor__back-button'
+    )
+    this.preview = this.module.querySelector('.app-c-govspeak-editor__preview')
+    this.error = this.module.querySelector('.app-c-govspeak-editor__error')
+    this.textareaWrapper = this.module.querySelector(
+      '.app-c-govspeak-editor__textarea'
+    )
+    this.textarea = this.module.querySelector(
+      this.previewButton.getAttribute('data-content-target')
+    )
+    this.shouldTrackToggle =
+      this.previewButton.getAttribute('data-preview-toggle-tracking') === 'true'
+
+    this.previewButton.classList.add(
+      'app-c-govspeak-editor__preview-button--show'
+    )
+
+    this.previewButton.addEventListener('click', this.showPreview.bind(this))
+    this.backButton.addEventListener('click', this.hidePreview.bind(this))
   }
 
   GovspeakEditor.prototype.getCsrfToken = function () {
@@ -47,63 +69,68 @@ window.GOVUK.Modules = window.GOVUK.Modules || {}
     return data
   }
 
-  GovspeakEditor.prototype.initPreview = function () {
-    const previewToggle = this.module.querySelector(
-      '.js-app-c-govspeak-editor__preview-button'
+  GovspeakEditor.prototype.maybeTrackEvent = function (label) {
+    if (this.shouldTrackToggle) {
+      GOVUK.analytics.trackEvent(
+        this.previewButton.getAttribute('data-preview-toggle-track-category'),
+        this.previewButton.getAttribute('data-preview-toggle-track-action'),
+        { label }
+      )
+    }
+  }
+
+  GovspeakEditor.prototype.showPreview = function (event) {
+    event.preventDefault()
+
+    this.backButton.classList.add('app-c-govspeak-editor__back-button--show')
+    this.previewButton.classList.remove(
+      'app-c-govspeak-editor__preview-button--show'
     )
-    const trackToggle =
-      previewToggle.getAttribute('data-preview-toggle-tracking') === 'true'
-    const preview = this.module.querySelector('.app-c-govspeak-editor__preview')
-    const error = this.module.querySelector('.app-c-govspeak-editor__error')
-    const textareaWrapper = this.module.querySelector(
-      '.app-c-govspeak-editor__textarea'
-    )
-    const textarea = this.module.querySelector(
-      previewToggle.getAttribute('data-content-target')
+
+    this.preview.classList.add('app-c-govspeak-editor__preview--show')
+    this.textareaWrapper.classList.add(
+      'app-c-govspeak-editor__textarea--hidden'
     )
 
-    previewToggle.addEventListener(
-      'click',
-      function (e) {
-        e.preventDefault()
+    this.backButton.focus()
 
-        const previewMode = previewToggle.innerText === 'Preview'
+    this.getRenderedGovspeak(this.textarea.value, (event) => {
+      const response = event.currentTarget
 
-        previewToggle.innerText = previewMode ? 'Back to edit' : 'Preview'
-        textareaWrapper.classList.toggle(
-          'app-c-govspeak-editor__textarea--hidden'
-        )
+      if (response.readyState !== 4) {
+        return
+      }
 
-        if (previewMode) {
-          preview.classList.add('app-c-govspeak-editor__preview--show')
-          this.getRenderedGovspeak(textarea.value, function (event) {
-            const response = event.currentTarget
+      switch (response.status) {
+        case 200:
+          this.preview.innerHTML = response.responseText
+          break
+        case 403:
+          this.preview.classList.remove('app-c-govspeak-editor__preview--show')
+          this.error.classList.add('app-c-govspeak-editor__error--show')
+      }
+    })
 
-            if (response.readyState === 4) {
-              if (response.status === 200) {
-                preview.innerHTML = response.responseText
-              }
+    this.maybeTrackEvent('preview')
+  }
 
-              if (response.status === 403) {
-                error.classList.add('app-c-govspeak-editor__error--show')
-                preview.classList.remove('app-c-govspeak-editor__preview--show')
-              }
-            }
-          })
-        } else {
-          preview.classList.remove('app-c-govspeak-editor__preview--show')
-          error.classList.remove('app-c-govspeak-editor__error--show')
-        }
+  GovspeakEditor.prototype.hidePreview = function (event) {
+    event.preventDefault()
 
-        if (trackToggle) {
-          GOVUK.analytics.trackEvent(
-            previewToggle.getAttribute('data-preview-toggle-track-category'),
-            previewToggle.getAttribute('data-preview-toggle-track-action'),
-            { label: previewMode ? 'preview' : 'edit' }
-          )
-        }
-      }.bind(this)
+    this.backButton.classList.remove('app-c-govspeak-editor__back-button--show')
+    this.previewButton.classList.add(
+      'app-c-govspeak-editor__preview-button--show'
     )
+
+    this.preview.classList.remove('app-c-govspeak-editor__preview--show')
+    this.error.classList.remove('app-c-govspeak-editor__error--show')
+    this.textareaWrapper.classList.remove(
+      'app-c-govspeak-editor__textarea--hidden'
+    )
+
+    this.textarea.focus()
+
+    this.maybeTrackEvent('edit')
   }
 
   GovspeakEditor.prototype.getImageIds = function () {

--- a/app/assets/stylesheets/components/_govspeak-editor.scss
+++ b/app/assets/stylesheets/components/_govspeak-editor.scss
@@ -20,6 +20,7 @@
 
 .app-c-govspeak-editor__preview,
 .app-c-govspeak-editor__error,
+.js-app-c-govspeak-editor__visual-editor-button,
 .js-app-c-govspeak-editor__preview-button,
 .js-app-c-govspeak-editor__back-button {
   display: none;
@@ -27,6 +28,7 @@
 
 .app-c-govspeak-editor__preview--show,
 .app-c-govspeak-editor__error--show,
+.app-c-govspeak-editor__visual-editor-button--show,
 .app-c-govspeak-editor__preview-button--show,
 .app-c-govspeak-editor__back-button--show {
   display: block;

--- a/app/assets/stylesheets/components/_govspeak-editor.scss
+++ b/app/assets/stylesheets/components/_govspeak-editor.scss
@@ -4,6 +4,9 @@
 
 .app-c-govspeak-editor__preview-button-wrapper {
   text-align: right;
+  display: flex;
+  justify-content: end;
+  gap: govuk-spacing(2);
 }
 
 .app-c-govspeak-editor__textarea--hidden {
@@ -11,19 +14,20 @@
 }
 
 .app-c-govspeak-editor__preview {
-  display: none;
   border: 1px solid $govuk-border-colour;
   padding: govuk-spacing(4);
 }
 
-.app-c-govspeak-editor__preview--show {
-  display: block;
-}
-
-.app-c-govspeak-editor__error {
+.app-c-govspeak-editor__preview,
+.app-c-govspeak-editor__error,
+.js-app-c-govspeak-editor__preview-button,
+.js-app-c-govspeak-editor__back-button {
   display: none;
 }
 
-.app-c-govspeak-editor__error--show {
+.app-c-govspeak-editor__preview--show,
+.app-c-govspeak-editor__error--show,
+.app-c-govspeak-editor__preview-button--show,
+.app-c-govspeak-editor__back-button--show {
   display: block;
 }

--- a/app/views/admin/editions/_standard_fields.html.erb
+++ b/app/views/admin/editions/_standard_fields.html.erb
@@ -65,6 +65,7 @@
 
   <div class="govuk-!-margin-bottom-8 js-locale-switcher-field">
     <%= render "components/govspeak_editor", {
+      show_visual_editor: Flipflop.govspeak_visual_editor?,
       label: {
         text: "Body" + "#{' (required)' if form.object.body_required?}",
         heading_size: "m",

--- a/app/views/components/_govspeak_editor.html.erb
+++ b/app/views/components/_govspeak_editor.html.erb
@@ -47,12 +47,21 @@
         hint_text: hint,
       }.merge(label.symbolize_keys) %>
     </div>
-    <div class="govuk-grid-column-one-quarter app-c-govspeak-editor__preview-button-wrapper">
       <%= render "govuk_publishing_components/components/button", {
         text: "Preview",
         secondary_quiet: true,
         margin_bottom: hint ? 5 : 2,
         classes: "js-app-c-govspeak-editor__preview-button",
+        data_attributes: preview_button_data_attributes,
+        aria_controls: preview_id,
+        aria_describedby: label_id,
+        type: "button",
+      } %>
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Back to edit",
+        secondary_quiet: true,
+        margin_bottom: hint ? 5 : 2,
+        classes: "js-app-c-govspeak-editor__back-button",
         data_attributes: preview_button_data_attributes,
         aria_controls: preview_id,
         aria_describedby: label_id,

--- a/app/views/components/_govspeak_editor.html.erb
+++ b/app/views/components/_govspeak_editor.html.erb
@@ -1,4 +1,6 @@
 <%
+  show_visual_editor ||= false
+
   id ||= "#{name}-#{SecureRandom.hex(4)}"
   preview_id = "#{id}-preview"
   error_id = "#{id}-error"
@@ -39,7 +41,7 @@
 
 <%= tag.div class: classes, data: data_attributes do %>
   <div class="govuk-grid-row">
-    <div class="govuk-grid-column-three-quarters ">
+    <div class="govuk-grid-column-one-half ">
       <%= render "govuk_publishing_components/components/label", {
         id: label_id,
         html_for: id,
@@ -47,6 +49,14 @@
         hint_text: hint,
       }.merge(label.symbolize_keys) %>
     </div>
+    <div class="govuk-grid-column-one-half app-c-govspeak-editor__preview-button-wrapper">
+      <%= render "govuk_publishing_components/components/button", {
+        text: sanitize("Visual Editor #{tag.span("Alpha", class: 'govuk-tag app-view-summary__tag')}"),
+        secondary_quiet: true,
+        margin_bottom: hint ? 5 : 2,
+        classes: "js-app-c-govspeak-editor__visual-editor-button",
+        type: "button",
+      } if show_visual_editor %>
       <%= render "govuk_publishing_components/components/button", {
         text: "Preview",
         secondary_quiet: true,

--- a/app/views/components/docs/govspeak_editor.yml
+++ b/app/views/components/docs/govspeak_editor.yml
@@ -80,3 +80,12 @@ examples:
         This is an attachment: !@1
 
         This is an image: !!1
+
+
+  with_visual_editor:
+    data:
+      label:
+        text: "Document content body"
+        bold: true
+      name: "with_visual_editor"
+      show_visual_editor: true

--- a/config/features.rb
+++ b/config/features.rb
@@ -21,4 +21,5 @@ Flipflop.configure do
   #   default: true,
   #   description: "Take over the world."
   feature :editionable_worldwide_organisations, description: "Enables editionable worldwide organisations", default: false
+  feature :govspeak_visual_editor, description: "Enables a visual editor for Govspeak fields", default: false
 end

--- a/spec/javascripts/components/govspeak-editor-spec.js
+++ b/spec/javascripts/components/govspeak-editor-spec.js
@@ -22,6 +22,20 @@ describe('GOVUK.Modules.GovspeakEditor', function () {
     previewButton.setAttribute('data-content-target', '#textarea_id')
     previewButton.innerText = 'Preview'
 
+    const backButton = document.createElement('button')
+    backButton.classList.add('js-app-c-govspeak-editor__back-button')
+    backButton.setAttribute('data-preview-toggle-tracking', true)
+    backButton.setAttribute(
+      'data-preview-toggle-track-category',
+      'govspeak-editor'
+    )
+    backButton.setAttribute(
+      'data-preview-toggle-track-action',
+      'pressed-preview-button'
+    )
+    backButton.setAttribute('data-content-target', '#textarea_id')
+    backButton.innerText = 'Back to edit'
+
     // Textarea
     const textareaSection = document.createElement('div')
     textareaSection.classList.add('app-c-govspeak-editor__textarea')
@@ -41,6 +55,7 @@ describe('GOVUK.Modules.GovspeakEditor', function () {
 
     // Append to component
     component.appendChild(previewButton)
+    component.appendChild(backButton)
     component.appendChild(textareaSection)
     component.appendChild(previewSection)
     component.appendChild(errorSection)
@@ -98,6 +113,9 @@ describe('GOVUK.Modules.GovspeakEditor', function () {
     const previewButton = component.querySelector(
       '.js-app-c-govspeak-editor__preview-button'
     )
+    const backButton = component.querySelector(
+      '.js-app-c-govspeak-editor__back-button'
+    )
     const textareaSection = component.querySelector(
       '.app-c-govspeak-editor__textarea'
     )
@@ -118,12 +136,18 @@ describe('GOVUK.Modules.GovspeakEditor', function () {
       'app-c-govspeak-editor__textarea--hidden'
     )
     expect(previewSection).toHaveClass('app-c-govspeak-editor__preview--show')
-    expect(previewButton.innerText).toEqual('Back to edit')
+    expect(previewButton).not.toHaveClass(
+      'app-c-govspeak-editor__preview-button--show'
+    )
+    expect(backButton).toHaveClass('app-c-govspeak-editor__back-button--show')
   })
 
   it('shows textarea section when you toggle back to edit', function () {
     const previewButton = component.querySelector(
       '.js-app-c-govspeak-editor__preview-button'
+    )
+    const backButton = component.querySelector(
+      '.js-app-c-govspeak-editor__back-button'
     )
     const textareaSection = component.querySelector(
       '.app-c-govspeak-editor__textarea'
@@ -146,9 +170,12 @@ describe('GOVUK.Modules.GovspeakEditor', function () {
       'app-c-govspeak-editor__textarea--hidden'
     )
     expect(previewSection).toHaveClass('app-c-govspeak-editor__preview--show')
-    expect(previewButton.innerText).toEqual('Back to edit')
+    expect(previewButton).not.toHaveClass(
+      'app-c-govspeak-editor__preview-button--show'
+    )
+    expect(backButton).toHaveClass('app-c-govspeak-editor__back-button--show')
 
-    previewButton.dispatchEvent(new Event('click'))
+    backButton.dispatchEvent(new Event('click'))
 
     expect(textareaSection).not.toHaveClass(
       'app-c-govspeak-editor__textarea--hidden'
@@ -224,17 +251,16 @@ describe('GOVUK.Modules.GovspeakEditor', function () {
   })
 
   it('hides the error message when the user returns to the editor view', function () {
-    const previewButton = component.querySelector(
-      '.js-app-c-govspeak-editor__preview-button'
+    const backButton = component.querySelector(
+      '.js-app-c-govspeak-editor__back-button'
     )
     const errorSection = component.querySelector(
       '.app-c-govspeak-editor__error'
     )
 
-    previewButton.innerText = 'Back to edit'
     errorSection.classList.add('app-c-govspeak-editor__error--show')
 
-    previewButton.dispatchEvent(new Event('click'))
+    backButton.dispatchEvent(new Event('click'))
 
     expect(errorSection.classList).not.toContain(
       'app-c-govspeak-editor__error--show'
@@ -320,7 +346,11 @@ describe('GOVUK.Modules.GovspeakEditor', function () {
       { label: 'preview' }
     )
 
-    previewButton.dispatchEvent(new Event('click'))
+    const backButton = component.querySelector(
+      '.js-app-c-govspeak-editor__back-button'
+    )
+
+    backButton.dispatchEvent(new Event('click'))
 
     expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
       'govspeak-editor',

--- a/spec/javascripts/components/govspeak-editor-spec.js
+++ b/spec/javascripts/components/govspeak-editor-spec.js
@@ -59,321 +59,385 @@ describe('GOVUK.Modules.GovspeakEditor', function () {
     component.appendChild(textareaSection)
     component.appendChild(previewSection)
     component.appendChild(errorSection)
-
-    module = new GOVUK.Modules.GovspeakEditor(component)
-    module.init()
-
-    spyOn(module, 'getCsrfToken').and.returnValue('a-csrf-token')
-
-    jasmine.Ajax.install()
   })
 
-  afterEach(function () {
-    jasmine.Ajax.uninstall()
-  })
+  describe('without visual editor', function () {
+    beforeEach(function () {
+      module = new GOVUK.Modules.GovspeakEditor(component)
+      module.init()
 
-  it('renders component correctly', function () {
-    expect(
-      component.querySelectorAll('.js-app-c-govspeak-editor__preview-button')
-        .length
-    ).toEqual(1)
-    expect(
-      component
-        .querySelector('.js-app-c-govspeak-editor__preview-button')
-        .getAttribute('data-preview-toggle-tracking')
-    ).toEqual('true')
+      spyOn(module, 'getCsrfToken').and.returnValue('a-csrf-token')
 
-    expect(
-      component.querySelectorAll('.app-c-govspeak-editor__textarea').length
-    ).toEqual(1)
-    expect(
-      component.querySelectorAll('.app-c-govspeak-editor__textarea textarea')
-        .length
-    ).toEqual(1)
-    expect(
-      component.querySelector('.app-c-govspeak-editor__textarea')
-    ).not.toHaveClass('app-c-govspeak-editor__textarea--hidden')
-
-    expect(
-      component.querySelectorAll('.app-c-govspeak-editor__preview').length
-    ).toEqual(1)
-    expect(
-      component.querySelector('.app-c-govspeak-editor__preview')
-    ).not.toHaveClass('app-c-govspeak-editor__preview--show')
-
-    expect(
-      component.querySelectorAll('.app-c-govspeak-editor__error').length
-    ).toEqual(1)
-    expect(
-      component.querySelector('.app-c-govspeak-editor__error')
-    ).not.toHaveClass('app-c-govspeak-editor__error--show')
-  })
-
-  it('shows preview section when button clicked', function () {
-    const previewButton = component.querySelector(
-      '.js-app-c-govspeak-editor__preview-button'
-    )
-    const backButton = component.querySelector(
-      '.js-app-c-govspeak-editor__back-button'
-    )
-    const textareaSection = component.querySelector(
-      '.app-c-govspeak-editor__textarea'
-    )
-    const previewSection = component.querySelector(
-      '.app-c-govspeak-editor__preview'
-    )
-
-    expect(textareaSection).not.toHaveClass(
-      'app-c-govspeak-editor__textarea--hidden'
-    )
-    expect(previewSection).not.toHaveClass(
-      'app-c-govspeak-editor__preview--show'
-    )
-
-    previewButton.dispatchEvent(new Event('click'))
-
-    expect(textareaSection).toHaveClass(
-      'app-c-govspeak-editor__textarea--hidden'
-    )
-    expect(previewSection).toHaveClass('app-c-govspeak-editor__preview--show')
-    expect(previewButton).not.toHaveClass(
-      'app-c-govspeak-editor__preview-button--show'
-    )
-    expect(backButton).toHaveClass('app-c-govspeak-editor__back-button--show')
-  })
-
-  it('shows textarea section when you toggle back to edit', function () {
-    const previewButton = component.querySelector(
-      '.js-app-c-govspeak-editor__preview-button'
-    )
-    const backButton = component.querySelector(
-      '.js-app-c-govspeak-editor__back-button'
-    )
-    const textareaSection = component.querySelector(
-      '.app-c-govspeak-editor__textarea'
-    )
-    const previewSection = component.querySelector(
-      '.app-c-govspeak-editor__preview'
-    )
-
-    expect(textareaSection).not.toHaveClass(
-      'app-c-govspeak-editor__textarea--hidden'
-    )
-    expect(previewSection).not.toHaveClass(
-      'app-c-govspeak-editor__preview--show'
-    )
-    expect(previewButton.innerText).toEqual('Preview')
-
-    previewButton.dispatchEvent(new Event('click'))
-
-    expect(textareaSection).toHaveClass(
-      'app-c-govspeak-editor__textarea--hidden'
-    )
-    expect(previewSection).toHaveClass('app-c-govspeak-editor__preview--show')
-    expect(previewButton).not.toHaveClass(
-      'app-c-govspeak-editor__preview-button--show'
-    )
-    expect(backButton).toHaveClass('app-c-govspeak-editor__back-button--show')
-
-    backButton.dispatchEvent(new Event('click'))
-
-    expect(textareaSection).not.toHaveClass(
-      'app-c-govspeak-editor__textarea--hidden'
-    )
-    expect(previewSection).not.toHaveClass(
-      'app-c-govspeak-editor__preview--show'
-    )
-    expect(previewButton.innerText).toEqual('Preview')
-  })
-
-  it('renders govspeak correctly on preview', function () {
-    const previewButton = component.querySelector(
-      '.js-app-c-govspeak-editor__preview-button'
-    )
-    const previewSection = component.querySelector(
-      '.app-c-govspeak-editor__preview'
-    )
-    const html = [
-      '<section class="document_page">',
-      '<article class="document">',
-      '<div class="body">',
-      '<div class="govspeak">',
-      '<h2>Hello</h2>',
-      '</div>',
-      '</div>',
-      '</article>',
-      '</section>'
-    ].join('')
-
-    jasmine.Ajax.stubRequest(
-      '/government/admin/preview',
-      null,
-      'POST'
-    ).andReturn({
-      status: 200,
-      contentType: 'text/html',
-      responseText: html
+      jasmine.Ajax.install()
     })
 
-    previewButton.dispatchEvent(new Event('click'))
-
-    expect(previewSection.innerHTML).toEqual(html)
-  })
-
-  it('renders an error message when the govspeak service returns a 403 "forbidden" response', function () {
-    const previewButton = component.querySelector(
-      '.js-app-c-govspeak-editor__preview-button'
-    )
-    const previewSection = component.querySelector(
-      '.app-c-govspeak-editor__preview'
-    )
-    const errorSection = component.querySelector(
-      '.app-c-govspeak-editor__error'
-    )
-
-    jasmine.Ajax.stubRequest(
-      '/government/admin/preview',
-      null,
-      'POST'
-    ).andReturn({
-      status: 403,
-      contentType: 'text/html'
+    afterEach(function () {
+      jasmine.Ajax.uninstall()
     })
 
-    previewButton.dispatchEvent(new Event('click'))
+    it('renders component correctly', function () {
+      expect(
+        component.querySelectorAll('.js-app-c-govspeak-editor__preview-button')
+          .length
+      ).toEqual(1)
+      expect(
+        component
+          .querySelector('.js-app-c-govspeak-editor__preview-button')
+          .getAttribute('data-preview-toggle-tracking')
+      ).toEqual('true')
 
-    expect(errorSection.classList).toContain(
-      'app-c-govspeak-editor__error--show'
-    )
-    expect(previewSection.classList).not.toContain(
-      'app-c-govspeak-editor__preview--show'
-    )
-  })
+      expect(
+        component.querySelectorAll('.app-c-govspeak-editor__textarea').length
+      ).toEqual(1)
+      expect(
+        component.querySelectorAll('.app-c-govspeak-editor__textarea textarea')
+          .length
+      ).toEqual(1)
+      expect(
+        component.querySelector('.app-c-govspeak-editor__textarea')
+      ).not.toHaveClass('app-c-govspeak-editor__textarea--hidden')
 
-  it('hides the error message when the user returns to the editor view', function () {
-    const backButton = component.querySelector(
-      '.js-app-c-govspeak-editor__back-button'
-    )
-    const errorSection = component.querySelector(
-      '.app-c-govspeak-editor__error'
-    )
+      expect(
+        component.querySelectorAll('.app-c-govspeak-editor__preview').length
+      ).toEqual(1)
+      expect(
+        component.querySelector('.app-c-govspeak-editor__preview')
+      ).not.toHaveClass('app-c-govspeak-editor__preview--show')
 
-    errorSection.classList.add('app-c-govspeak-editor__error--show')
-
-    backButton.dispatchEvent(new Event('click'))
-
-    expect(errorSection.classList).not.toContain(
-      'app-c-govspeak-editor__error--show'
-    )
-  })
-
-  it('renders govspeak correctly with changing content', function () {
-    const previewButton = component.querySelector(
-      '.js-app-c-govspeak-editor__preview-button'
-    )
-    const textarea = component.querySelector('#textarea_id')
-    const previewSection = component.querySelector(
-      '.app-c-govspeak-editor__preview'
-    )
-    const html = [
-      '<section class="document_page">',
-      '<article class="document">',
-      '<div class="body">',
-      '<div class="govspeak">',
-      '<h2>Hello</h2>',
-      '</div>',
-      '</div>',
-      '</article>',
-      '</section>'
-    ].join('')
-
-    jasmine.Ajax.stubRequest(
-      '/government/admin/preview',
-      null,
-      'POST'
-    ).andReturn({
-      status: 200,
-      contentType: 'text/html',
-      responseText: html
+      expect(
+        component.querySelectorAll('.app-c-govspeak-editor__error').length
+      ).toEqual(1)
+      expect(
+        component.querySelector('.app-c-govspeak-editor__error')
+      ).not.toHaveClass('app-c-govspeak-editor__error--show')
     })
 
-    previewButton.dispatchEvent(new Event('click'))
+    it('shows preview section when button clicked', function () {
+      const previewButton = component.querySelector(
+        '.js-app-c-govspeak-editor__preview-button'
+      )
+      const backButton = component.querySelector(
+        '.js-app-c-govspeak-editor__back-button'
+      )
+      const textareaSection = component.querySelector(
+        '.app-c-govspeak-editor__textarea'
+      )
+      const previewSection = component.querySelector(
+        '.app-c-govspeak-editor__preview'
+      )
 
-    expect(previewSection.innerHTML).toEqual(html)
+      expect(textareaSection).not.toHaveClass(
+        'app-c-govspeak-editor__textarea--hidden'
+      )
+      expect(previewSection).not.toHaveClass(
+        'app-c-govspeak-editor__preview--show'
+      )
 
-    // back to edit
-    previewButton.dispatchEvent(new Event('click'))
+      previewButton.dispatchEvent(new Event('click'))
 
-    textarea.innerText = '## Hello this is a heading'
-    const newHtml = [
-      '<section class="document_page">',
-      '<article class="document">',
-      '<div class="body">',
-      '<div class="govspeak">',
-      '<h2>Hello this is a heading</h2>',
-      '</div>',
-      '</div>',
-      '</article>',
-      '</section>'
-    ].join('')
-
-    jasmine.Ajax.stubRequest(
-      '/government/admin/preview',
-      null,
-      'POST'
-    ).andReturn({
-      status: 200,
-      contentType: 'text/html',
-      responseText: newHtml
+      expect(textareaSection).toHaveClass(
+        'app-c-govspeak-editor__textarea--hidden'
+      )
+      expect(previewSection).toHaveClass('app-c-govspeak-editor__preview--show')
+      expect(previewButton).not.toHaveClass(
+        'app-c-govspeak-editor__preview-button--show'
+      )
+      expect(backButton).toHaveClass('app-c-govspeak-editor__back-button--show')
     })
 
-    previewButton.dispatchEvent(new Event('click'))
+    it('shows textarea section when you toggle back to edit', function () {
+      const previewButton = component.querySelector(
+        '.js-app-c-govspeak-editor__preview-button'
+      )
+      const backButton = component.querySelector(
+        '.js-app-c-govspeak-editor__back-button'
+      )
+      const textareaSection = component.querySelector(
+        '.app-c-govspeak-editor__textarea'
+      )
+      const previewSection = component.querySelector(
+        '.app-c-govspeak-editor__preview'
+      )
 
-    expect(previewSection.innerHTML).toEqual(newHtml)
+      expect(textareaSection).not.toHaveClass(
+        'app-c-govspeak-editor__textarea--hidden'
+      )
+      expect(previewSection).not.toHaveClass(
+        'app-c-govspeak-editor__preview--show'
+      )
+      expect(previewButton.innerText).toEqual('Preview')
+
+      previewButton.dispatchEvent(new Event('click'))
+
+      expect(textareaSection).toHaveClass(
+        'app-c-govspeak-editor__textarea--hidden'
+      )
+      expect(previewSection).toHaveClass('app-c-govspeak-editor__preview--show')
+      expect(previewButton).not.toHaveClass(
+        'app-c-govspeak-editor__preview-button--show'
+      )
+      expect(backButton).toHaveClass('app-c-govspeak-editor__back-button--show')
+
+      backButton.dispatchEvent(new Event('click'))
+
+      expect(textareaSection).not.toHaveClass(
+        'app-c-govspeak-editor__textarea--hidden'
+      )
+      expect(previewSection).not.toHaveClass(
+        'app-c-govspeak-editor__preview--show'
+      )
+      expect(previewButton.innerText).toEqual('Preview')
+    })
+
+    it('renders govspeak correctly on preview', function () {
+      const previewButton = component.querySelector(
+        '.js-app-c-govspeak-editor__preview-button'
+      )
+      const previewSection = component.querySelector(
+        '.app-c-govspeak-editor__preview'
+      )
+      const html = [
+        '<section class="document_page">',
+        '<article class="document">',
+        '<div class="body">',
+        '<div class="govspeak">',
+        '<h2>Hello</h2>',
+        '</div>',
+        '</div>',
+        '</article>',
+        '</section>'
+      ].join('')
+
+      jasmine.Ajax.stubRequest(
+        '/government/admin/preview',
+        null,
+        'POST'
+      ).andReturn({
+        status: 200,
+        contentType: 'text/html',
+        responseText: html
+      })
+
+      previewButton.dispatchEvent(new Event('click'))
+
+      expect(previewSection.innerHTML).toEqual(html)
+    })
+
+    it('renders an error message when the govspeak service returns a 403 "forbidden" response', function () {
+      const previewButton = component.querySelector(
+        '.js-app-c-govspeak-editor__preview-button'
+      )
+      const previewSection = component.querySelector(
+        '.app-c-govspeak-editor__preview'
+      )
+      const errorSection = component.querySelector(
+        '.app-c-govspeak-editor__error'
+      )
+
+      jasmine.Ajax.stubRequest(
+        '/government/admin/preview',
+        null,
+        'POST'
+      ).andReturn({
+        status: 403,
+        contentType: 'text/html'
+      })
+
+      previewButton.dispatchEvent(new Event('click'))
+
+      expect(errorSection.classList).toContain(
+        'app-c-govspeak-editor__error--show'
+      )
+      expect(previewSection.classList).not.toContain(
+        'app-c-govspeak-editor__preview--show'
+      )
+    })
+
+    it('hides the error message when the user returns to the editor view', function () {
+      const backButton = component.querySelector(
+        '.js-app-c-govspeak-editor__back-button'
+      )
+      const errorSection = component.querySelector(
+        '.app-c-govspeak-editor__error'
+      )
+
+      errorSection.classList.add('app-c-govspeak-editor__error--show')
+
+      backButton.dispatchEvent(new Event('click'))
+
+      expect(errorSection.classList).not.toContain(
+        'app-c-govspeak-editor__error--show'
+      )
+    })
+
+    it('renders govspeak correctly with changing content', function () {
+      const previewButton = component.querySelector(
+        '.js-app-c-govspeak-editor__preview-button'
+      )
+      const textarea = component.querySelector('#textarea_id')
+      const previewSection = component.querySelector(
+        '.app-c-govspeak-editor__preview'
+      )
+      const html = [
+        '<section class="document_page">',
+        '<article class="document">',
+        '<div class="body">',
+        '<div class="govspeak">',
+        '<h2>Hello</h2>',
+        '</div>',
+        '</div>',
+        '</article>',
+        '</section>'
+      ].join('')
+
+      jasmine.Ajax.stubRequest(
+        '/government/admin/preview',
+        null,
+        'POST'
+      ).andReturn({
+        status: 200,
+        contentType: 'text/html',
+        responseText: html
+      })
+
+      previewButton.dispatchEvent(new Event('click'))
+
+      expect(previewSection.innerHTML).toEqual(html)
+
+      // back to edit
+      previewButton.dispatchEvent(new Event('click'))
+
+      textarea.innerText = '## Hello this is a heading'
+      const newHtml = [
+        '<section class="document_page">',
+        '<article class="document">',
+        '<div class="body">',
+        '<div class="govspeak">',
+        '<h2>Hello this is a heading</h2>',
+        '</div>',
+        '</div>',
+        '</article>',
+        '</section>'
+      ].join('')
+
+      jasmine.Ajax.stubRequest(
+        '/government/admin/preview',
+        null,
+        'POST'
+      ).andReturn({
+        status: 200,
+        contentType: 'text/html',
+        responseText: newHtml
+      })
+
+      previewButton.dispatchEvent(new Event('click'))
+
+      expect(previewSection.innerHTML).toEqual(newHtml)
+    })
+
+    it('sends tracking events correctly', function () {
+      spyOn(GOVUK.analytics, 'trackEvent')
+      const previewButton = component.querySelector(
+        '.js-app-c-govspeak-editor__preview-button'
+      )
+
+      previewButton.dispatchEvent(new Event('click'))
+
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+        'govspeak-editor',
+        'pressed-preview-button',
+        { label: 'preview' }
+      )
+
+      const backButton = component.querySelector(
+        '.js-app-c-govspeak-editor__back-button'
+      )
+
+      backButton.dispatchEvent(new Event('click'))
+
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+        'govspeak-editor',
+        'pressed-preview-button',
+        { label: 'edit' }
+      )
+    })
+
+    it('generates form data correctly', function () {
+      const formData = module.generateFormData('some text')
+
+      expect(Array.from(formData.entries())).toEqual([
+        ['body', 'some text'],
+        ['authenticity_token', 'a-csrf-token'],
+        ['alternative_format_provider_id', '11'],
+        ['image_ids[]', '1'],
+        ['image_ids[]', '2'],
+        ['image_ids[]', '3'],
+        ['image_ids[]', '4'],
+        ['attachment_ids[]', '5'],
+        ['attachment_ids[]', '6'],
+        ['attachment_ids[]', '7'],
+        ['attachment_ids[]', '8']
+      ])
+    })
   })
 
-  it('sends tracking events correctly', function () {
-    spyOn(GOVUK.analytics, 'trackEvent')
-    const previewButton = component.querySelector(
-      '.js-app-c-govspeak-editor__preview-button'
-    )
+  describe('with visual editor', function () {
+    beforeEach(function () {
+      const visualEditorButton = document.createElement('button')
+      visualEditorButton.classList.add(
+        'js-app-c-govspeak-editor__visual-editor-button'
+      )
+      visualEditorButton.innerText = 'Visual editor'
+      component.appendChild(visualEditorButton)
 
-    previewButton.dispatchEvent(new Event('click'))
+      module = new GOVUK.Modules.GovspeakEditor(component)
+      module.init()
 
-    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
-      'govspeak-editor',
-      'pressed-preview-button',
-      { label: 'preview' }
-    )
+      spyOn(module, 'getCsrfToken').and.returnValue('a-csrf-token')
 
-    const backButton = component.querySelector(
-      '.js-app-c-govspeak-editor__back-button'
-    )
+      jasmine.Ajax.install()
+    })
 
-    backButton.dispatchEvent(new Event('click'))
+    afterEach(function () {
+      jasmine.Ajax.uninstall()
+    })
 
-    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
-      'govspeak-editor',
-      'pressed-preview-button',
-      { label: 'edit' }
-    )
-  })
+    it('renders component correctly', function () {
+      expect(
+        component.querySelector('.js-app-c-govspeak-editor__preview-button')
+      ).toHaveClass('app-c-govspeak-editor__preview-button--show')
 
-  it('generates form data correctly', function () {
-    const formData = module.generateFormData('some text')
+      expect(
+        component.querySelector(
+          '.js-app-c-govspeak-editor__visual-editor-button'
+        )
+      ).toHaveClass('app-c-govspeak-editor__visual-editor-button--show')
+    })
 
-    expect(Array.from(formData.entries())).toEqual([
-      ['body', 'some text'],
-      ['authenticity_token', 'a-csrf-token'],
-      ['alternative_format_provider_id', '11'],
-      ['image_ids[]', '1'],
-      ['image_ids[]', '2'],
-      ['image_ids[]', '3'],
-      ['image_ids[]', '4'],
-      ['attachment_ids[]', '5'],
-      ['attachment_ids[]', '6'],
-      ['attachment_ids[]', '7'],
-      ['attachment_ids[]', '8']
-    ])
+    it('hides textarea when visual editor button clicked', function () {
+      const visualEditorButton = component.querySelector(
+        '.js-app-c-govspeak-editor__visual-editor-button'
+      )
+      const backButton = component.querySelector(
+        '.js-app-c-govspeak-editor__back-button'
+      )
+      const textareaSection = component.querySelector(
+        '.app-c-govspeak-editor__textarea'
+      )
+
+      expect(textareaSection).not.toHaveClass(
+        'app-c-govspeak-editor__textarea--hidden'
+      )
+
+      visualEditorButton.dispatchEvent(new Event('click'))
+
+      expect(textareaSection).toHaveClass(
+        'app-c-govspeak-editor__textarea--hidden'
+      )
+      expect(visualEditorButton).not.toHaveClass(
+        'app-c-govspeak-editor__visual-editor--show'
+      )
+      expect(backButton).toHaveClass('app-c-govspeak-editor__back-button--show')
+    })
   })
 })


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

# What
- Refactor govspeak editor component to make it more extensible
- Only show preview button when the user has javascript enabled
- Add a FlipFlop feature flag for the visual editor
- Use the feature flag to toggle the display of a visual editor button in the govspeak editor
- Hide the textarea when the button is clicked (does not display the visual editor yet)

# Why
- The first step of visual editor testing will be adding it as a button to the govspeak field
- https://trello.com/c/zG5zD2r2/2227-add-the-editor-to-whitehall

# Screenshot
<img width="791" alt="Screenshot 2024-01-05 at 16 15 44" src="https://github.com/alphagov/whitehall/assets/9594455/a7386738-b1ee-4d17-872e-e32146680466">
