### PR TITLE
Raise if the person presenter attempts to present carrierwave temp URL to Publishing API

### DIFF
--- a/app/presenters/publishing_api/person_presenter.rb
+++ b/app/presenters/publishing_api/person_presenter.rb
@@ -35,6 +35,8 @@ module PublishingApi
       details_hash = {}
 
       if item.image&.all_asset_variants_uploaded? && item.image&.url(:s465)
+        raise "person image path should not use carrierwave path" if item.image.url(:s465).include?("carrierwave-tmp")
+
         details_hash[:image] = { url: item.image.url(:s465), alt_text: item.name }
       end
 

--- a/test/unit/app/presenters/publishing_api/person_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/person_presenter_test.rb
@@ -118,4 +118,16 @@ class PublishingApi::PersonPresenterTest < ActiveSupport::TestCase
 
     assert_nil presented_item.content.dig(:details, :image)
   end
+
+  test "it raises if a carrierwave path is used for the image path" do
+    person = build(:person)
+
+    image = build(:featured_image_data)
+    image.expects(:url).twice.with(:s465).returns("/uploads/carrierwave-tmp/1704204355-973510646575090-0009-0387/s465_test-img.jpg")
+    person.image = image
+
+    assert_raises do
+      present(person).content
+    end
+  end
 end


### PR DESCRIPTION
This is a temporary measure to make sure we get a good error report when this happens in production. Currently the error is difficult to diagnose because we don't have a stack trace, as we don't know that there's a problem until the user reports that the image is not being rendered on the frontend.

Trello: https://trello.com/c/OOVmXm5F
