### PR TITLE
Add emergency banner publishing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,6 +78,7 @@ group :test do
   gem "database_cleaner-active_record"
   gem "equivalent-xml"
   gem "factory_bot"
+  gem "fakeredis"
   gem "govuk_schemas"
   gem "i18n-coverage"
   gem "maxitest"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -196,6 +196,8 @@ GEM
       parslet
     factory_bot (6.4.5)
       activesupport (>= 5.0.0)
+    fakeredis (0.9.2)
+      redis (~> 4.8)
     faraday (2.7.12)
       base64
       faraday-net_http (>= 2.0, < 3.1)
@@ -969,6 +971,7 @@ DEPENDENCIES
   equivalent-xml
   erb_lint
   factory_bot
+  fakeredis
   flipflop
   fog-aws
   friendly_id

--- a/app/controllers/admin/emergency_banner_controller.rb
+++ b/app/controllers/admin/emergency_banner_controller.rb
@@ -1,15 +1,58 @@
 class Admin::EmergencyBannerController < Admin::BaseController
   before_action :enforce_permissions!
+  before_action :load_current_banner
 
   def enforce_permissions!
     enforce_permission!(:administer, :emergency_banner)
   end
 
-  def show
-    @current_banner = redis_client.hgetall("emergency_banner").try(:symbolize_keys)
+  def show; end
+
+  def edit
+    @errors = {}
+  end
+
+  def update
+    if emergency_banner_params[:campaign_class].present? && emergency_banner_params[:heading].present?
+      redis_client.hmset(
+        :emergency_banner,
+        :campaign_class,
+        emergency_banner_params[:campaign_class],
+        :heading,
+        emergency_banner_params[:heading],
+        :short_description,
+        emergency_banner_params[:short_description],
+        :link,
+        emergency_banner_params[:link],
+        :link_text,
+        emergency_banner_params[:link_text],
+      )
+
+      redirect_to admin_emergency_banner_path, notice: "Emergency banner updated sucessfully"
+    else
+      @errors = {}
+      @errors[:campaign_class] = I18n.t("emergency_banner.errors.campaign_class") if emergency_banner_params[:campaign_class].blank?
+      @errors[:heading] = I18n.t("emergency_banner.errors.heading") if emergency_banner_params[:heading].blank?
+
+      render :edit
+    end
   end
 
 private
+
+  def emergency_banner_params
+    params.fetch(:emergency_banner, {}).permit(
+      :campaign_class,
+      :heading,
+      :short_description,
+      :link,
+      :link_text,
+    )
+  end
+
+  def load_current_banner
+    @current_banner = redis_client.hgetall("emergency_banner").try(:symbolize_keys)
+  end
 
   def redis_client
     Redis.new

--- a/app/controllers/admin/emergency_banner_controller.rb
+++ b/app/controllers/admin/emergency_banner_controller.rb
@@ -6,6 +6,14 @@ class Admin::EmergencyBannerController < Admin::BaseController
     enforce_permission!(:administer, :emergency_banner)
   end
 
+  def confirm_destroy; end
+
+  def destroy
+    redis_client.del(:emergency_banner)
+
+    redirect_to admin_emergency_banner_path
+  end
+
   def show; end
 
   def edit

--- a/app/controllers/admin/emergency_banner_controller.rb
+++ b/app/controllers/admin/emergency_banner_controller.rb
@@ -1,0 +1,17 @@
+class Admin::EmergencyBannerController < Admin::BaseController
+  before_action :enforce_permissions!
+
+  def enforce_permissions!
+    enforce_permission!(:administer, :emergency_banner)
+  end
+
+  def show
+    @current_banner = redis_client.hgetall("emergency_banner").try(:symbolize_keys)
+  end
+
+private
+
+  def redis_client
+    Redis.new
+  end
+end

--- a/app/helpers/admin/url_helper.rb
+++ b/app/helpers/admin/url_helper.rb
@@ -43,6 +43,12 @@ module Admin::UrlHelper
     end
   end
 
+  def admin_emergency_banner_link
+    if can?(:administer, :emergency_banner)
+      admin_link "Emergency banner", admin_emergency_banner_path
+    end
+  end
+
   def admin_sitewide_settings_link
     if can?(:administer, :sitewide_settings_section)
       admin_link "Sitewide settings", admin_sitewide_settings_path

--- a/app/presenters/emergency_banner_presenter.rb
+++ b/app/presenters/emergency_banner_presenter.rb
@@ -1,0 +1,35 @@
+class EmergencyBannerPresenter
+  def initialize(current_banner)
+    @current_banner = current_banner
+  end
+
+  def current_banner_rows
+    [campaign_class_row] + other_rows
+  end
+
+private
+
+  def campaign_class_row
+    [
+      {
+        text: I18n.t("emergency_banner.keys.campaign_class"),
+      },
+      {
+        text: I18n.t("emergency_banner.keys.campaign_classes.#{@current_banner[:campaign_class].underscore}"),
+      },
+    ]
+  end
+
+  def other_rows
+    %i[heading short_description link link_text].map do |key|
+      [
+        {
+          text: I18n.t("emergency_banner.keys.#{key}"),
+        },
+        {
+          text: @current_banner[key],
+        },
+      ]
+    end
+  end
+end

--- a/app/views/admin/emergency_banner/confirm_destroy.html.erb
+++ b/app/views/admin/emergency_banner/confirm_destroy.html.erb
@@ -1,0 +1,24 @@
+<% content_for :page_title, "Remove emergency banner" %>
+<% content_for :title, "Remove emergency banner" %>
+<% content_for :title_margin_bottom, 6 %>
+
+<div class="govuk-grid-row">
+  <section class="govuk-grid-column-two-thirds">
+    <%= form_with url: admin_emergency_banner_path, method: :delete do %>
+      <p class="govuk-body govuk-!-margin-bottom-7"><%= I18n.t("emergency_banner.actions.confirm_destroy") %></p>
+
+      <%= render "govuk_publishing_components/components/warning_text", {
+        text: I18n.t("emergency_banner.update_information"),
+      } %>
+
+      <div class="govuk-button-group">
+        <%= render "govuk_publishing_components/components/button", {
+          text: I18n.t("emergency_banner.actions.destroy"),
+          destructive: true,
+        } %>
+
+        <%= link_to("Cancel", admin_emergency_banner_path, class: "govuk-link govuk-link--no-visited-state") %>
+      </div>
+    <% end %>
+  </section>
+</div>

--- a/app/views/admin/emergency_banner/edit.html.erb
+++ b/app/views/admin/emergency_banner/edit.html.erb
@@ -1,0 +1,62 @@
+<% content_for :page_title, "Edit emergency banner" %>
+<% content_for :title, "Edit emergency banner" %>
+<% content_for :title_margin_bottom, 4 %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/warning_text", {
+      text: I18n.t("emergency_banner.update_information"),
+    } %>
+    <%= form_for [:admin, :emergency_banner], as: :emergency_banner, url: admin_emergency_banner_path, method: :patch do |form| %>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+
+          <%= render "govuk_publishing_components/components/radio", {
+            heading: I18n.t("emergency_banner.keys.campaign_class"),
+            id: "emergency_banner_campaign_class",
+            name: "emergency_banner[campaign_class]",
+            items: [
+              {
+                value: "local-emergency",
+                text: I18n.t("emergency_banner.keys.campaign_classes.local_emergency"),
+                checked: @current_banner[:campaign_class] == "local-emergency",
+              },
+              {
+                value: "national-emergency",
+                text: I18n.t("emergency_banner.keys.campaign_classes.national_emergency"),
+                checked: @current_banner[:campaign_class] == "national-emergency",
+              },
+              {
+                value: "notable-death",
+                text: I18n.t("emergency_banner.keys.campaign_classes.notable_death"),
+                checked: @current_banner[:campaign_class] == "notable-death",
+              },
+            ],
+            error_message: @errors[:campaign_class],
+          } %>
+
+          <% %i[heading short_description link link_text].map do |key| %>
+            <%= render "govuk_publishing_components/components/input", {
+              label: {
+                text: I18n.t("emergency_banner.keys.#{key}"),
+              },
+              id: "emergency_banner_#{key}",
+              name: "emergency_banner[#{key}]",
+              value: @current_banner[key],
+              heading_size: "l",
+              error_message: @errors[key],
+            } %>
+          <% end %>
+
+          <div class="govuk-button-group">
+            <%= render "govuk_publishing_components/components/button", {
+              text: "Save",
+            } %>
+
+            <%= link_to("Cancel", admin_emergency_banner_path, class: "govuk-link govuk-link--no-visited-state") %>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/emergency_banner/show.html.erb
+++ b/app/views/admin/emergency_banner/show.html.erb
@@ -1,0 +1,25 @@
+<% content_for :page_title, "Emergency banner settings" %>
+<% content_for :title, "Emergency banner settings" %>
+<% content_for :title_margin_bottom, 4 %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <% if @current_banner.present? %>
+      <p class="govuk-body"><%= I18n.t("emergency_banner.status.deployed") %></p>
+
+      <%= render "govuk_publishing_components/components/table", {
+        head: [
+          {
+            text: "Key",
+          },
+          {
+            text: "Value",
+          },
+        ],
+        rows: EmergencyBannerPresenter.new(@current_banner).current_banner_rows,
+      } %>
+    <% else %>
+      <p class="govuk-body"><%= I18n.t("emergency_banner.status.not_deployed") %></p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/emergency_banner/show.html.erb
+++ b/app/views/admin/emergency_banner/show.html.erb
@@ -18,8 +18,18 @@
         ],
         rows: EmergencyBannerPresenter.new(@current_banner).current_banner_rows,
       } %>
+
+      <%= render "govuk_publishing_components/components/button", {
+        text: I18n.t("emergency_banner.actions.edit"),
+        href: edit_admin_emergency_banner_path,
+      } %>
     <% else %>
       <p class="govuk-body"><%= I18n.t("emergency_banner.status.not_deployed") %></p>
+
+      <%= render "govuk_publishing_components/components/button", {
+        text: I18n.t("emergency_banner.actions.create"),
+        href: edit_admin_emergency_banner_path,
+      } %>
     <% end %>
   </div>
 </div>

--- a/app/views/admin/emergency_banner/show.html.erb
+++ b/app/views/admin/emergency_banner/show.html.erb
@@ -23,6 +23,12 @@
         text: I18n.t("emergency_banner.actions.edit"),
         href: edit_admin_emergency_banner_path,
       } %>
+
+      <%= render "govuk_publishing_components/components/button", {
+        text: I18n.t("emergency_banner.actions.destroy"),
+        href: confirm_destroy_admin_emergency_banner_path,
+        destructive: true,
+      } %>
     <% else %>
       <p class="govuk-body"><%= I18n.t("emergency_banner.status.not_deployed") %></p>
 

--- a/app/views/admin/more/index.html.erb
+++ b/app/views/admin/more/index.html.erb
@@ -7,6 +7,7 @@
     <%= render "govuk_publishing_components/components/list", {
       items: [
         admin_cabinet_ministers_link,
+        admin_emergency_banner_link,
         admin_fields_of_operation_link,
         admin_get_involved_link,
         admin_governments_link,

--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -49,6 +49,8 @@ ar:
       unique_reference: المرجع الفريد للمرفق
       unnumbered_hoc_paper: ورقة مجلس عموم غير مرقمة
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -699,6 +701,29 @@ ar:
         two:
         zero:
     updated: تاريخ التحديث
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: rtl
   language_names:

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -49,6 +49,8 @@ az:
       unique_reference: Əlavə üçün unikal istinad
       unnumbered_hoc_paper: İcmalar palatasının nömrələnməmiş sənədi
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -378,6 +380,29 @@ az:
         one: Parlamentə yazılı müraciət
         other: Parlamentə yazılı müraciətlər
     updated: yenilənib
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -49,6 +49,8 @@ be:
       unique_reference: Унікальная спасылка на дадатак
       unnumbered_hoc_paper: Ненумераваны дакумент Палаты абшчын
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -537,6 +539,29 @@ be:
         one: Пісьмовая заява ў парламенце
         other: Пісьмовыя заявы ў парламенце
     updated: Адноўлена
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -49,6 +49,8 @@ bg:
       unique_reference: Уникална референция на прикачения файл
       unnumbered_hoc_paper: Документ без номер на Камарата на общините
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -377,6 +379,29 @@ bg:
         one: Писмено изявление в Парламента
         other: Писмени изявления в Парламента
     updated: актуализиран
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -49,6 +49,8 @@ bn:
       unique_reference: সংযুক্তির অনন্য সূত্র
       unnumbered_hoc_paper: নম্বরবিহীন হাউজ অব কমন্সের পেপার
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -377,6 +379,29 @@ bn:
         one: সংসদে লিখিত বিবৃতি
         other: সংসদে লিখিত বিবৃতিসমূহ
     updated: হালনাগাদ করা হয়েছে
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -49,6 +49,8 @@ cs:
       unique_reference: Jedinečný odkaz na přílohu
       unnumbered_hoc_paper: Nečíslovaný dokument Dolní sněmovny
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -459,6 +461,29 @@ cs:
         one: Písemné prohlášení pro Parlament
         other: Písemná prohlášení pro Parlament
     updated: aktualizováno
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -49,6 +49,8 @@ cy:
       unique_reference: Cyfeirnod unigryw yr atodiad
       unnumbered_hoc_paper: Papur Tŷ'r Cyffredin heb rif
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -701,6 +703,29 @@ cy:
         two:
         zero:
     updated: diweddarwyd
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/da.yml
+++ b/config/locales/da.yml
@@ -49,6 +49,8 @@ da:
       unique_reference: Entydig reference til vedhæftet fil
       unnumbered_hoc_paper: Unummereret dokument fra Underhuset
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -378,6 +380,29 @@ da:
         one: Mundtlig erklæring til Parlamentet
         other: Mundtlige erklæring til Parlamentet
     updated: Opdateret
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -49,6 +49,8 @@ de:
       unique_reference: Anhang eindeutige Referenz
       unnumbered_hoc_paper: Nicht nummeriertes Unterhauspapier
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -377,6 +379,29 @@ de:
         one: Schriftliche Erklärung vor dem Parlament
         other: Schriftliche Erklärungen vor dem Parlament
     updated: aktualisiert
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -49,6 +49,8 @@ dr:
       unique_reference: رفرنس مخصوص ضمیمه
       unnumbered_hoc_paper: مجلس اوراق بدون شماره
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -378,6 +380,29 @@ dr:
         one: بیانیهء کتبی به پارلمان
         other: بیانیه هایی کتبی به پارلمان
     updated: آپدیت شد
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: rtl
   language_names:

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -49,6 +49,8 @@ el:
       unique_reference: Μοναδική αναφορά συνημμένου
       unnumbered_hoc_paper: Μη αριθμημένο έγγραφο της Βουλής των Κοινοτήτων
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -377,6 +379,29 @@ el:
         one: Γραπτή δήλωση στη Βουλή
         other: Γραπτές δηλώσεις στη Βουλή
     updated: ενημερωμένο
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -363,6 +363,12 @@ en:
         other: Written statements to Parliament
     updated: updated
   emergency_banner:
+    actions:
+      create: Deploy banner
+      edit: Edit
+    errors:
+      campaign_class: Select a campaign class
+      heading: Enter a heading
     keys:
       campaign_class: Campaign class
       campaign_classes:
@@ -376,6 +382,7 @@ en:
     status:
       deployed: The emergency banner is currently deployed with the following content.
       not_deployed: The emergency banner is not currently deployed.
+    update_information: Changes to the emergency banner appear instantly on the live site, subject to a cache period of 5 minutes per page.
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -362,6 +362,20 @@ en:
         one: Written statement to Parliament
         other: Written statements to Parliament
     updated: updated
+  emergency_banner:
+    keys:
+      campaign_class: Campaign class
+      campaign_classes:
+        local_emergency: Local emergency
+        national_emergency: National emergency
+        notable_death: Notable death
+      heading: Heading
+      link: Link URL (optional)
+      link_text: Link text (optional)
+      short_description: Short description (optional)
+    status:
+      deployed: The emergency banner is currently deployed with the following content.
+      not_deployed: The emergency banner is not currently deployed.
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -364,7 +364,9 @@ en:
     updated: updated
   emergency_banner:
     actions:
+      confirm_destroy: Are you sure you want to remove the emergency banner?
       create: Deploy banner
+      destroy: Remove banner
       edit: Edit
     errors:
       campaign_class: Select a campaign class

--- a/config/locales/en/admin/whats_new.yml
+++ b/config/locales/en/admin/whats_new.yml
@@ -45,7 +45,7 @@ en:
             date: 19 October 2023
             body_govspeak: |
               The “Unpublish” document button no longer changes a published document back into a draft. Instead, the document is put into a new “Unpublished” state.
-              
+           
               This means that unpublished documents will no longer appear in your “My Draft Documents” area of the dashboard. You can also filter the documents list for unpublished documents.
           - heading: Pasting tables to markdown in the document body editor
             area: Creating and updating documents
@@ -53,7 +53,7 @@ en:
             date: 29 September 2023
             body_govspeak: |
               There is now experimental support for pasting tables from other applications into the body editor and having them automatically translated to markdown. Note that this feature may not always behave as expected, especially in cases where the table cells contain multiples lines of content, and you should check the table is rendered correctly using the preview before publishing. Please let us know if you encounter cases where the generated markdown could be improved.
-          - heading:  
+          - heading:
             area: Creating and updating documents
             type: new
             date: 8 September

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -49,6 +49,8 @@ es-419:
       unique_reference: Referencia única del adjunto
       unnumbered_hoc_paper: Documento no numerado de la Cámara de los Comunes
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -378,6 +380,29 @@ es-419:
         one: Declaración escrita ante el Parlamento
         other: Declaraciones escritas ante el Parlamento
     updated: actualizado
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -49,6 +49,8 @@ es:
       unique_reference: Referencia única del adjunto
       unnumbered_hoc_paper: Documento de la Cámara de los Comunes sin numerar
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -375,6 +377,29 @@ es:
         one: Declaración escrita
         other: Declaraciones escritas
     updated: Actualizado
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -49,6 +49,8 @@ et:
       unique_reference: Manuse unikaalne viide
       unnumbered_hoc_paper: Nummerdamata alamkoja dokument
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -377,6 +379,29 @@ et:
         one: Kirjalik avaldus parlamendile
         other: Kirjalikud avaldused parlamendile
     updated: uuendatud
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -49,6 +49,8 @@ fa:
       unique_reference: شناسه مرجع یکتای پیوست
       unnumbered_hoc_paper: سند بدون شماره مجلس عوام
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -377,6 +379,29 @@ fa:
         one: بیانیه کتبی به پارلمان
         other: بیانیه‌های کتبی به پارلمان
     updated: بروز شده
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: rtl
   language_names:

--- a/config/locales/fi.yml
+++ b/config/locales/fi.yml
@@ -49,6 +49,8 @@ fi:
       unique_reference: Liitteen yksilöllinen viite
       unnumbered_hoc_paper: Alahuoneen numeroimaton asiakirja
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -378,6 +380,29 @@ fi:
         one: Kirjallinen lausuma parlamentille
         other: Kirjallinen lausumat parlamentille
     updated: päivitetty
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -49,6 +49,8 @@ fr:
       unique_reference: Référence unique de la pièce jointe
       unnumbered_hoc_paper: Document non numéroté de la Chambre des Communes
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -378,6 +380,29 @@ fr:
         one: Déclaration écrite au Parlement
         other: Déclarations écrites au Parlement
     updated: mis à jour
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/gd.yml
+++ b/config/locales/gd.yml
@@ -49,6 +49,8 @@ gd:
       unique_reference: Tagairt a bhaineann go sonrach le ceangaltán
       unnumbered_hoc_paper: Doiciméad gan uimhir Theach na dTeachtaí
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -539,6 +541,29 @@ gd:
         other: Ráitis i scríbhinn don Pharlaimint
         two:
     updated: arna chur suas
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/gu.yml
+++ b/config/locales/gu.yml
@@ -49,6 +49,8 @@ gu:
       unique_reference: એટેચમેંટ યુનિક સંદર્ભ
       unnumbered_hoc_paper: સંખ્યા વિનાના હાઉસ ઓફ કૉમન્સ પેપર
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -377,6 +379,29 @@ gu:
         one: સંસદમાં લેખિત નિવેદન
         other: સંસદમાં લેખિત નિવેદનો
     updated: અપડેટ કરેલ
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -49,6 +49,8 @@ he:
       unique_reference: 'התייחסות ייחודית לקובץ המצורף '
       unnumbered_hoc_paper: נייר של בית הנבחרים ללא מספר
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -378,6 +380,29 @@ he:
         one: הצהרה בכתב לפרלמנט
         other: הצהרות בכתב לפרלמנט
     updated: מעודכן
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: rtl
   language_names:

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -49,6 +49,8 @@ hi:
       unique_reference: अनुलग्नक अनूठा संदर्भ
       unnumbered_hoc_paper: संख्यारहित हाउस ऑफ कॉमन्स पेपर
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -378,6 +380,29 @@ hi:
         one: संसद में लिखित बयान
         other: संसद में लिखित बयान
     updated: अपडेट किया गया
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/hr.yml
+++ b/config/locales/hr.yml
@@ -49,6 +49,8 @@ hr:
       unique_reference: Jedinstvena referenca privitka
       unnumbered_hoc_paper: Nebrojeni papir Donjeg doma
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -459,6 +461,29 @@ hr:
         one: Pismena izjava Parlamentu
         other: Pismene izjave Parlamentu
     updated: ažurirano
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -49,6 +49,8 @@ hu:
       unique_reference: Csatolmány egyedi referenciája
       unnumbered_hoc_paper: Számozatlan Angol Alsóházi lap
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -377,6 +379,29 @@ hu:
         one: Írásbeli parlamenti nyilatkozat
         other: Írásbeli parlamenti nyilatkozatok
     updated: frissítve
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -49,6 +49,8 @@ hy:
       unique_reference: Կցորդի հատուկ հղումը
       unnumbered_hoc_paper: Համայնքների պալատի չհամարակալված փաստաթուղթ
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -378,6 +380,29 @@ hy:
         one: Խորհրդարանին ուղղված գրավոր հայտարարություն
         other: Խորհրդարանին ուղղված գրավոր հայտարարություններ
     updated: Թարմացված
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -49,6 +49,8 @@ id:
       unique_reference: Referensi unik lampiran
       unnumbered_hoc_paper: Surat House of Commons tidak bernomor
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -296,6 +298,29 @@ id:
       written_statement:
         other: Pernyataan tertulis kepada Parlemen
     updated: diperbarui
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/is.yml
+++ b/config/locales/is.yml
@@ -49,6 +49,8 @@ is:
       unique_reference: Einkvæmt auðkenni viðhengis
       unnumbered_hoc_paper: Ónúmerað skjal neðri deildar þingsins
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -377,6 +379,29 @@ is:
         one: Skrifleg yfirlýsing til Þingsins
         other: Skriflegar yfirlýsingar til Þingsins
     updated: uppfært
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -49,6 +49,8 @@ it:
       unique_reference: Riferimento univoco dell’allegato
       unnumbered_hoc_paper: Carta della Camera dei Comuni non numerata
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -378,6 +380,29 @@ it:
         one: Dichiarazione scritta al Parlamento
         other: Dichiarazioni scritte al Parlamento
     updated: aggiornato
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -49,6 +49,8 @@ ja:
       unique_reference: 添付固有の参照
       unnumbered_hoc_paper: 番号のない庶民院書類
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -294,6 +296,29 @@ ja:
       written_statement:
         other: 議会への書面による声明
     updated: 更新済み
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -49,6 +49,8 @@ ka:
       unique_reference: დანართის უნიკალური მითითება
       unnumbered_hoc_paper: თემთა პალატის დაუნომრავი დოკუმენტი
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -378,6 +380,29 @@ ka:
         one: წერილობითი განცხადება პარლამენტში
         other: წერილობითი განცხადებები პარლამენტში
     updated: განახლებულია
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/kk.yml
+++ b/config/locales/kk.yml
@@ -49,6 +49,8 @@ kk:
       unique_reference: Тіркеменің бірегей сілтемесі
       unnumbered_hoc_paper: Қауымдар палатасының нөмірленбеген саяси құжаты
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -377,6 +379,29 @@ kk:
         one: Парламентке жазбаша мәлімдеме
         other: Парламентке жазбаша мәлімдемелер
     updated: жаңартылды
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -49,6 +49,8 @@ ko:
       unique_reference: 첨부 고유 참조
       unnumbered_hoc_paper: 번호를 매기지 않은 하원 문서
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -296,6 +298,29 @@ ko:
       written_statement:
         other: 국회로 서면 성명
     updated: 업데이트
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -49,6 +49,8 @@ lt:
       unique_reference: Unikali priedo nuoroda
       unnumbered_hoc_paper: Nenumeruotas Bendruomenių rūmų dokumentas
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -456,6 +458,29 @@ lt:
         one: Rašytinis kreipimasis į parlamentą
         other: Rašytiniai kreipimaisi į parlamentą
     updated: atnaujinta
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -49,6 +49,8 @@ lv:
       unique_reference: Pielikuma unikālā atsauce
       unnumbered_hoc_paper: Pārstāvju palātas dokuments bez numura
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -375,6 +377,29 @@ lv:
         one: Rakstisks ziņojums parlamentam
         other: Rakstiski ziņojumi parlamentam
     updated: atjaunināts
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -49,6 +49,8 @@ ms:
       unique_reference: Rujukan unik lampiran
       unnumbered_hoc_paper: Kertas Dewan Rakyat tidak bernombor
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -297,6 +299,29 @@ ms:
       written_statement:
         other: Kenyataan bertulis kepada Parlimen
     updated: dikemas kini
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/mt.yml
+++ b/config/locales/mt.yml
@@ -49,6 +49,8 @@ mt:
       unique_reference: Referenza unika tal-anness
       unnumbered_hoc_paper: Dokument mhux innumerat tal-House of Commons
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -537,6 +539,29 @@ mt:
         one: Dikjarazzjoni miktuba lill-Parlament
         other: Dikjarazzjonijiet miktuba lill-Parlament
     updated: aġġornat
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/ne.yml
+++ b/config/locales/ne.yml
@@ -49,6 +49,8 @@ ne:
       unique_reference: संलग्न विशिष्ट सन्दर्भ
       unnumbered_hoc_paper: संख्या नभएको हाउस अफ कमन्स पृष्ठ
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -377,6 +379,29 @@ ne:
         one: संसदमा लिखित वक्तव्य
         other: संसदमा लिखित वक्तव्यहरू
     updated: अद्यावधिक गरियो
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -49,6 +49,8 @@ nl:
       unique_reference: Unieke referentie bijvoegsel
       unnumbered_hoc_paper: Ongenummerd Lagerhuisdocument
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -375,6 +377,29 @@ nl:
         one: Schriftelijke verklaring aan het Parlement
         other: Schriftelijke verklaringen aan het Parlement
     updated: bijgewerkt
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/no.yml
+++ b/config/locales/no.yml
@@ -49,6 +49,8 @@
       unique_reference: Unik referanse for vedlegg
       unnumbered_hoc_paper: Unummerert skriv i Underhuset
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -378,6 +380,29 @@
         one: Skriftlig uttalelse til Stortinget
         other: Skriftlige uttalelser til Stortinget
     updated: oppdatert
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/pa-pk.yml
+++ b/config/locales/pa-pk.yml
@@ -49,6 +49,8 @@ pa-pk:
       unique_reference: اٹیچمینٹ دا  وکھرا حوالہ
       unnumbered_hoc_paper: اَن نمبرڈ ہاؤس آف کامننز پیپر
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -375,6 +377,29 @@ pa-pk:
         one: قومی مجلس دے سامنے تحریری بیان
         other: قومی مجلس دے سامنے تحریری بیانات
     updated: تازہ ترین حال
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: rtl
   language_names:

--- a/config/locales/pa.yml
+++ b/config/locales/pa.yml
@@ -49,6 +49,8 @@ pa:
       unique_reference: ਅਟੈਚਮੈਂਟ ਵਿਲੱਖਣ ਹਵਾਲਾ
       unnumbered_hoc_paper: ਅਣਗਿਣਤ ਹਾਊਸ ਆਫ਼ ਕਾਮਨਜ਼ ਪੇਪਰ
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -378,6 +380,29 @@ pa:
         one: ਸੰਸਦ ਨੂੰ ਲਿਖਤੀ ਬਿਆਨ
         other: ਸੰਸਦ ਨੂੰ ਲਿਖਤੀ ਬਿਆਨ ਦਿੱਤੇ
     updated: ਅੱਪਡੇਟ ਕੀਤਾ
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -49,6 +49,8 @@ pl:
       unique_reference: Niepowtarzalny numer referencyjny załącznika
       unnumbered_hoc_paper: Nienumerowany dokument Izby Gmin
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -537,6 +539,29 @@ pl:
         one: Pisemne oświadczenie przed parlamentem
         other: Pisemne oświadczenia przed parlamentem
     updated: Zaktualizowany
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -49,6 +49,8 @@ ps:
       unique_reference: ضمیمه ځانګړې حواله
       unnumbered_hoc_paper: د کامنز بې شمیره کاغذ
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -378,6 +380,29 @@ ps:
         one: پارلمان ته لیکلې وینا
         other: پارلمان ته لیکلي بیانونه
     updated: تازه شوی
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: rtl
   language_names:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -49,6 +49,8 @@ pt:
       unique_reference: Referência única do anexo
       unnumbered_hoc_paper: Papel não numerado da Câmara dos Comuns
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -378,6 +380,29 @@ pt:
         one: Declaração escrita ao Parlamento
         other: Declarações escritas ao Parlamento
     updated: atualizado em
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -49,6 +49,8 @@ ro:
       unique_reference: Referință unică atașament
       unnumbered_hoc_paper: Document nenumerotat de la Camera Comunelor
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -458,6 +460,29 @@ ro:
         one: Declarație scrisă către Parlament
         other: Declarații scrise către Parlament
     updated: actualizat
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -49,6 +49,8 @@ ru:
       unique_reference: Уникальная ссылка приложения
       unnumbered_hoc_paper: Документ Палаты общин без номера
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -537,6 +539,29 @@ ru:
         one: Письменное заявление Парламенту
         other: Письменные заявления Парламенту
     updated: обновлено
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -49,6 +49,8 @@ si:
       unique_reference: ඇමුණුමේ අද්විතීය යොමුව
       unnumbered_hoc_paper: අංකනය නොකළ මහජන මන්ත්‍රී මණ්ඩල පත්‍රිකාව
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -377,6 +379,29 @@ si:
         one: පාර්ලිමේන්තුව වෙත ලිඛිත ප්රකාශය
         other: පාර්ලිමේන්තුව වෙත ලිඛිත ප්රකාශ
     updated: යාවත්කාලීන කෙරිණි
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -49,6 +49,8 @@ sk:
       unique_reference: Jedinečný odkaz na prílohu
       unnumbered_hoc_paper: Nečíslovaný dokument Dolnej snemovne
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -459,6 +461,29 @@ sk:
         one: Písomné vyhlásenie pre Parlament
         other: Písomné vyhlásenia pre Parlament
     updated: aktualizované
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/sl.yml
+++ b/config/locales/sl.yml
@@ -49,6 +49,8 @@ sl:
       unique_reference: Edinstvena referenca priloge
       unnumbered_hoc_paper: Neoštevilčen dokument britanskega parlamenta
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -540,6 +542,29 @@ sl:
         other: Pisne izjave za parlament
         two:
     updated: posodobljeno
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -49,6 +49,8 @@ so:
       unique_reference: Tixraaca gaarka ah ee lifaaqa
       unnumbered_hoc_paper: Warqada aan lambarka lahayn ee guriga Commons
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -377,6 +379,29 @@ so:
         one: Bayaan qoran oo loogu talogalay Baarlamaanka
         other: Bayaanada qoran ee loogu talogalay Baarlamaanka
     updated: la cusboonaysiiyay
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -49,6 +49,8 @@ sq:
       unique_reference: Referenca unike e bashkëngjitjes
       unnumbered_hoc_paper: Letër e panumëruar e Dhomës së Komuneve
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -378,6 +380,29 @@ sq:
         one: Deklaratë me shkrim në Parlament
         other: Deklarata me shkrim në Parlament
     updated: përditësuar
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -49,6 +49,8 @@ sr:
       unique_reference: Jedinstvena referenca priloga
       unnumbered_hoc_paper: Nenumerisani dokument Donjeg doma skupštine
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -459,6 +461,29 @@ sr:
         one: Pismena predstavka Parlamentu
         other: Pismene predstavke Parlamentu
     updated: ažurirano
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/sv.yml
+++ b/config/locales/sv.yml
@@ -49,6 +49,8 @@ sv:
       unique_reference: Bilagans unika referens
       unnumbered_hoc_paper: Onumrerad artikel från underhuset
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -378,6 +380,29 @@ sv:
         one: Skriftligt uttalande till parlamentet
         other: Skriftliga uttalanden till parlamentet
     updated: uppdaterad
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -49,6 +49,8 @@ sw:
       unique_reference: Nambari maalum ya marejeleo ya kiambatisho
       unnumbered_hoc_paper: Hati ya House of Commons isiyo na nambari
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -377,6 +379,29 @@ sw:
         one: Taarifa ya Maandishi kwa Bunge
         other: Taarifa za Maandishi kwa Bunge
     updated: ilisasishwa
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -49,6 +49,8 @@ ta:
       unique_reference: தலைப்பு பிரத்யேகப் பார்வை
       unnumbered_hoc_paper: எண்ணிடப்படாத கீழ்ச்சபை ஆவணம்
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -377,6 +379,29 @@ ta:
         one: பாராளுமன்றத்துக்கு எழுத்துப்பூர்வ அறிவிப்பு
         other: பாராளுமன்றத்துக்கு எழுத்துப்பூர்வ அறிவிப்புகள்
     updated: புதுப்பிக்கப்பட்டது
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -49,6 +49,8 @@ th:
       unique_reference: รหัสอ้างอิงเฉพาะของเอกสารแนบ
       unnumbered_hoc_paper: เอกสารสภาสามัญที่ไม่มีเลขที่
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -296,6 +298,29 @@ th:
       written_statement:
         other: แถลงการณ์เป็นลายลักษณ์อักษรต่อรัฐสภา
     updated: อัปเดตแล้ว
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -49,6 +49,8 @@ tk:
       unique_reference: Goşundy ýeketäk salgylanmasy
       unnumbered_hoc_paper: Jemgyýetçilik palatasy belisiz kagyzy
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -377,6 +379,29 @@ tk:
         one: Mejlise ýazmaça beýan
         other: Mejlise ýazmaça beýanlar
     updated: täzelenen
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -49,6 +49,8 @@ tr:
       unique_reference: Ek benzersiz referans
       unnumbered_hoc_paper: Sayı Verilmemiş Avam Kamarası evrakı
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -377,6 +379,29 @@ tr:
         one: Parlamentoya yazılı açıklama
         other: Parlamentoya yazılı açıklamalar
     updated: güncellenen
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -49,6 +49,8 @@ uk:
       unique_reference: Унікальний номер додатку
       unnumbered_hoc_paper: Документ Палати громад без номеру
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -539,6 +541,29 @@ uk:
         one: Письмова заява до Парламенту
         other: Письмові заяви до Парламенту
     updated: оновлено
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -49,6 +49,8 @@ ur:
       unique_reference: منسلکہ کا منفرد حوالہ
       unnumbered_hoc_paper: غیر نمبر شدہ ہاؤس آف کامنز کا صفحہ
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -377,6 +379,29 @@ ur:
         one: پالیمان کے لیے تحریری بیان
         other: پالیمان کے لیے تحریری بیانات
     updated: اپ ڈیٹ کردہ
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: rtl
   language_names:

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -49,6 +49,8 @@ uz:
       unique_reference: Илованинг махсус ҳаволаси
       unnumbered_hoc_paper: Жамоат Палатасининг рақамсиз ҳужжати
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -377,6 +379,29 @@ uz:
         one: Парламентга ёзма баёнот
         other: Парламентга ёзма баёнотлар
     updated: янгиланди
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -49,6 +49,8 @@ vi:
       unique_reference: Tham chiếu duy nhất của tệp đính kèm
       unnumbered_hoc_paper: Văn kiện của Hạ viện không được đánh số
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -296,6 +298,29 @@ vi:
       written_statement:
         other: Tuyên bố bằng văn bản trước Quốc hội
     updated: đã cập nhật
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/yi.yml
+++ b/config/locales/yi.yml
@@ -49,6 +49,8 @@ yi:
       unique_reference:
       unnumbered_hoc_paper:
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -375,6 +377,29 @@ yi:
         one:
         other:
     updated:
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: rtl
   language_names:

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -49,6 +49,8 @@ zh-hk:
       unique_reference: 附件單一參考
       unnumbered_hoc_paper: 未編號之下議院文書
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -296,6 +298,29 @@ zh-hk:
       written_statement:
         other: 提交國會的書面聲明
     updated: 已更新
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -49,6 +49,8 @@ zh-tw:
       unique_reference: 附件專用參考
       unnumbered_hoc_paper: 未編碼的下議院文件
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -296,6 +298,29 @@ zh-tw:
       written_statement:
         other: 對議會的書面聲明
     updated: 更新
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: ltr
   language_names:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -49,6 +49,8 @@ zh:
       unique_reference: 附件唯一参考
       unnumbered_hoc_paper: 未编号的下议院文件
   admin:
+    feedback:
+      show_banner:
     whats_new:
       guidance:
         body_govspeak:
@@ -296,6 +298,29 @@ zh:
       written_statement:
         other: 议会口头声明
     updated: 已更新
+  emergency_banner:
+    actions:
+      confirm_destroy:
+      create:
+      destroy:
+      edit:
+    errors:
+      campaign_class:
+      heading:
+    keys:
+      campaign_class:
+      campaign_classes:
+        local_emergency:
+        national_emergency:
+        notable_death:
+      heading:
+      link:
+      link_text:
+      short_description:
+    status:
+      deployed:
+      not_deployed:
+    update_information:
   i18n:
     direction: ltr
   language_names:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -369,7 +369,9 @@ Whitehall::Application.routes.draw do
       end
 
       resources :sitewide_settings
-      resource :emergency_banner, controller: "emergency_banner"
+      resource :emergency_banner, controller: "emergency_banner" do
+        get :confirm_destroy
+      end
       post "/link-checker-api-callback" => "link_checker_api#callback"
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -369,6 +369,7 @@ Whitehall::Application.routes.draw do
       end
 
       resources :sitewide_settings
+      resource :emergency_banner, controller: "emergency_banner"
       post "/link-checker-api-callback" => "link_checker_api#callback"
     end
   end

--- a/lib/whitehall/authority/rules/miscellaneous_rules.rb
+++ b/lib/whitehall/authority/rules/miscellaneous_rules.rb
@@ -8,6 +8,10 @@ module Whitehall::Authority::Rules
       end
     end
 
+    def can_for_emergency_banner?(_action)
+      actor.gds_admin?
+    end
+
     def can_for_get_involved_section?(_action)
       actor.gds_editor?
     end

--- a/test/functional/admin/emergency_banner_controller_test.rb
+++ b/test/functional/admin/emergency_banner_controller_test.rb
@@ -1,0 +1,70 @@
+require "fakeredis/minitest"
+require "test_helper"
+
+class Admin::EmergencyBannerControllerTest < ActionController::TestCase
+  extend Minitest::Spec::DSL
+
+  setup do
+    login_as :gds_admin
+    @controller = Admin::EmergencyBannerController.new
+  end
+
+  should_be_an_admin_controller
+
+  %i[show].each do |action_method|
+    test "#{action_method} action is not permitted to non-GDS admins" do
+      login_as :departmental_editor
+      get action_method
+      assert_response :forbidden
+    end
+  end
+
+  context "when the banner is disabled" do
+    view_test "GET :show does not list the current banner" do
+      get :show
+
+      assert_response :success
+      assert_select "p.govuk-body", text: "The emergency banner is not currently deployed."
+    end
+  end
+
+  context "when the banner is enabled" do
+    before do
+      Redis.new.hmset(
+        :emergency_banner,
+        :campaign_class,
+        "national-emergency",
+        :heading,
+        "Some important information",
+        :short_description,
+        "Something important has happened",
+        :link,
+        "https://www.emergency.gov.uk",
+        :link_text,
+        "See more",
+      )
+    end
+
+    view_test "GET :show lists the current banner" do
+      get :show
+
+      assert_response :success
+      assert_select "p.govuk-body", text: "The emergency banner is currently deployed with the following content."
+
+      assert_select "tr.govuk-table__row:nth-of-type(1) td", text: "Campaign class"
+      assert_select "tr.govuk-table__row:nth-of-type(1) td", text: "National emergency"
+
+      assert_select "tr.govuk-table__row:nth-of-type(2) td", text: "Heading"
+      assert_select "tr.govuk-table__row:nth-of-type(2) td", text: "Some important information"
+
+      assert_select "tr.govuk-table__row:nth-of-type(3) td", text: "Short description (optional)"
+      assert_select "tr.govuk-table__row:nth-of-type(3) td", text: "Something important has happened"
+
+      assert_select "tr.govuk-table__row:nth-of-type(4) td", text: "Link URL (optional)"
+      assert_select "tr.govuk-table__row:nth-of-type(4) td", text: "https://www.emergency.gov.uk"
+
+      assert_select "tr.govuk-table__row:nth-of-type(5) td", text: "Link text (optional)"
+      assert_select "tr.govuk-table__row:nth-of-type(5) td", text: "See more"
+    end
+  end
+end

--- a/test/functional/admin/more_controller_test.rb
+++ b/test/functional/admin/more_controller_test.rb
@@ -64,4 +64,24 @@ class Admin::MoreControllerTest < ActionController::TestCase
     assert_select ".govuk-list"
     refute_select "a.govuk-link", text: "Worldwide organisations"
   end
+
+  view_test "GET #index does not render Emergency Banner option when the user is not a GDS Admin." do
+    organisation = create(:organisation, name: "cabinet-minister")
+    login_as(:writer, organisation)
+
+    get :index
+
+    assert_select ".govuk-list"
+    refute_select "a.govuk-link", text: "Emergency banner"
+  end
+
+  view_test "GET #index renders Emergency Banner option when the user is a GDS Admin." do
+    organisation = create(:organisation, name: "government-digital-service")
+    login_as(:gds_admin, organisation)
+
+    get :index
+
+    assert_select ".govuk-list"
+    assert_select "a.govuk-link", text: "Emergency banner"
+  end
 end


### PR DESCRIPTION
The emergency banner is currently published and unpublished using [a rake task in the static application](https://github.com/alphagov/static/blob/6d606f04a7b09ae57008b528eb7e30652d40e287/lib/tasks/emergency_banner.rake#L4-L18). 

This adds a user interface, so the banner can be deployed without needing developer intervention.

I've avoided adding any models (as this complicated things where we're not using the same data store for this as the rest of Whitehall's data) so needed to add a tiny bit of custom error handling into the controller.

This can be made compliant with [RFC-143](https://github.com/alphagov/govuk-rfcs/blob/main/rfc-143-split-database-instances.md) by simply adding a second Redis adapter, when we get round to splitting the shared Redis instance by app.

## Screenshots

| Action | Screenshot |
| -- | -- |
| No emergency banner currently deployed | ![Screenshot 2024-01-09 at 09 47 58](https://github.com/alphagov/whitehall/assets/6329861/b418e11a-404d-4a4c-92e9-40d5dbdb6c44) |
| Adding or editing the banner | ![Screenshot 2024-01-09 at 09 48 12](https://github.com/alphagov/whitehall/assets/6329861/d2ecc310-671d-4ef5-8a48-8ac47e591e19) | 
| After editing the banner | ![Screenshot 2024-01-09 at 09 48 45](https://github.com/alphagov/whitehall/assets/6329861/59da8597-8da6-4b05-9a03-77e0e325e073) | 
| Removing the banner | ![Screenshot 2024-01-09 at 09 48 51](https://github.com/alphagov/whitehall/assets/6329861/7c6b954d-e61f-4ac6-ad0c-53776560ae86) |

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
