### PR TITLE
Upgrade Rails cache format version to 7.1

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -25,7 +25,7 @@ module Whitehall
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.1
 
-    # config.active_support.cache_format_version = 7.1
+    config.active_support.cache_format_version = 7.1
 
     # Disable rails 7.0+ button_to behaviour
     config.action_view.button_to_generates_button_tag = false


### PR DESCRIPTION
This should be safe to do now that Whitehall has been running on Rails 7.1 in production for a week or so.
