### PR TITLE
Add searchable filter to roles table

### DIFF
--- a/app/assets/stylesheets/admin/views/_roles.scss
+++ b/app/assets/stylesheets/admin/views/_roles.scss
@@ -1,5 +1,19 @@
-.app-view-roles__page-list {
-  .govuk-table__header:last-child {
-    width: 10%;
-  }
+.app-view-roles-index__table .govuk-table__row .govuk-table__header:nth-child(1) {
+  width: 30%;
+}
+
+.app-view-roles-index__table .govuk-table__row .govuk-table__header:nth-child(2) {
+  width: 25%;
+}
+
+.app-view-roles-index__table .govuk-table__row .govuk-table__header:nth-child(3) {
+  width: 25%;
+}
+
+.app-view-roles-index__table .govuk-table__row .govuk-table__header:nth-child(4) {
+  width: 10%;
+}
+
+.app-view-roles-index__table .govuk-table__row .govuk-table__header:nth-child(5) {
+  width: 10%;
 }

--- a/app/views/admin/roles/index.html.erb
+++ b/app/views/admin/roles/index.html.erb
@@ -14,56 +14,60 @@
   href: new_admin_role_path,
   margin_bottom: 6,
 } %>
-<div class="app-view-roles__page-list">
-<%= render "govuk_publishing_components/components/table", {
-  head: [
-    {
-      text: "Name",
-    },
-    {
-      text: "Organisations",
-    },
-    {
-      text: "Currently appointed",
-    },
-    {
-      text: "Translations",
-    },
-    {
-      text: tag.span("Actions", class: "govuk-visually-hidden"),
-    },
-  ],
-  rows: @roles.map do |role|
-    [
+
+<div class="app-c-govuk-table--filterable govuk-table--with-actions app-view-roles-index__table">
+  <%= render "govuk_publishing_components/components/table", {
+    filterable: true,
+    label: "Filter roles",
+    head: [
       {
-        text: tag.span(role.name, class: "govuk-!-font-weight-bold"),
+        text: "Name",
       },
       {
-        text: role.organisation_names,
+        text: "Organisations",
       },
       {
-        text:
-          if role.current_person_name.eql?("No one is assigned to this role")
-            ""
-          else
-            role.current_person_name
-          end,
+        text: "Currently appointed",
       },
       {
-        text:
-          content_tag_for(:div, role) do
-            link_to(sanitize("Manage #{tag.span(role.name, class: "govuk-visually-hidden")}"), admin_role_translations_path(role), title: "Manage translations of #{role.name}", class: "govuk-link")
-          end,
+        text: "Translations",
       },
       {
-        text: link_to(sanitize("Edit #{tag.span(role.name, class: "govuk-visually-hidden")}"), edit_admin_role_path(role), title: "Edit role #{role.name}", class: "govuk-link") +
-          if role.destroyable?
-            link_to(sanitize("Delete #{tag.span(role.name, class: "govuk-visually-hidden")}"), confirm_destroy_admin_role_path(role), class: "govuk-link govuk-link--no-visited-state gem-link--destructive govuk-!-margin-left-2")
-          else
-            ""
-          end,
+        text: tag.span("Actions", class: "govuk-visually-hidden"),
       },
-    ]
-  end,
-} %>
+    ],
+    rows: @roles.map do |role|
+      [
+        {
+          text: tag.span(role.name, class: "govuk-!-font-weight-bold"),
+        },
+        {
+          text: role.organisation_names,
+        },
+        {
+          text:
+            if role.current_person_name.eql?("No one is assigned to this role")
+              tag.span("Vacant", class: "govuk-!-font-weight-bold")
+            else
+              role.current_person_name
+            end,
+
+        },
+        {
+          text:
+            content_tag_for(:div, role) do
+              link_to(sanitize("Manage #{tag.span(role.name, class: "govuk-visually-hidden")}"), admin_role_translations_path(role), title: "Manage translations of #{role.name}", class: "govuk-link")
+            end,
+        },
+        {
+          text: link_to(sanitize("Edit #{tag.span(role.name, class: "govuk-visually-hidden")}"), edit_admin_role_path(role), title: "Edit role #{role.name}", class: "govuk-link") +
+            if role.destroyable?
+              link_to(sanitize("Delete #{tag.span(role.name, class: "govuk-visually-hidden")}"), confirm_destroy_admin_role_path(role), class: "govuk-link govuk-link--no-visited-state gem-link--destructive govuk-!-margin-left-2")
+            else
+              ""
+            end,
+        },
+      ]
+    end,
+  } %>
 </div>

--- a/test/functional/admin/roles_controller_test.rb
+++ b/test/functional/admin/roles_controller_test.rb
@@ -27,17 +27,17 @@ class Admin::RolesControllerTest < ActionController::TestCase
       assert_select "tr:nth-child(2)" do
         assert_select "td:nth-child(1).govuk-table__cell", "chief-professional-officer-role"
         assert_select "td:nth-child(2).govuk-table__cell", "org-one"
-        assert_select "td:nth-child(3).govuk-table__cell", ""
+        assert_select "td:nth-child(3).govuk-table__cell", "Vacant"
       end
       assert_select "tr:nth-child(3)" do
         assert_select "td:nth-child(1).govuk-table__cell", "management-role"
         assert_select "td:nth-child(2).govuk-table__cell", "org-one"
-        assert_select "td:nth-child(3).govuk-table__cell", ""
+        assert_select "td:nth-child(3).govuk-table__cell", "Vacant"
       end
       assert_select "tr:nth-child(4)" do
         assert_select "td:nth-child(1).govuk-table__cell", "military-role"
         assert_select "td:nth-child(2).govuk-table__cell", "org-two"
-        assert_select "td:nth-child(3).govuk-table__cell", ""
+        assert_select "td:nth-child(3).govuk-table__cell", "Vacant"
       end
     end
   end


### PR DESCRIPTION
## Description

This adds a searchable filter which allows users to search on the name of the role, the current appointee etc.

We've been asked to do this as part of our work on gift week to make our Content Designers lives easier.

We've added some text when there's no appointment so that users can filter for vacant appointments and clean them up, which is a common task.

## Video 


https://github.com/alphagov/whitehall/assets/42515961/107b6d43-ad62-4763-870c-621e16408995


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
