### PR TITLE
Full text document title search

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -76,9 +76,14 @@ class Edition < ApplicationRecord
           like_clause = "%#{escaped_like_expression}%"
 
           scope = in_default_locale.includes(:document)
-          scope
-            .where("edition_translations.title LIKE :like_clause", like_clause:)
-            .or(scope.where(document: { slug: keywords }))
+
+          if Flipflop.fulltext_document_search?
+            raise "Fulltext document search has not been implemented"
+          else
+            scope
+              .where("edition_translations.title LIKE :like_clause", like_clause:)
+              .or(scope.where(document: { slug: keywords }))
+          end
         }
 
   scope :in_pre_publication_state, -> { where(state: Edition::PRE_PUBLICATION_STATES) }

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -64,11 +64,7 @@ class Edition < ApplicationRecord
   POST_PUBLICATION_STATES = %w[published superseded withdrawn unpublished].freeze
   PUBLICLY_VISIBLE_STATES = %w[published withdrawn].freeze
 
-  scope :with_title_or_summary_containing,
-        lambda { |*keywords|
-          pattern = "(#{keywords.map { |k| Regexp.escape(k) }.join('|')})"
-          in_default_locale.where("edition_translations.title REGEXP :pattern OR edition_translations.summary REGEXP :pattern", pattern:)
-        }
+
 
   scope :with_title_containing,
         lambda { |keywords|

--- a/config/features.rb
+++ b/config/features.rb
@@ -21,4 +21,5 @@ Flipflop.configure do
   #   default: true,
   #   description: "Take over the world."
   feature :editionable_worldwide_organisations, description: "Enables editionable worldwide organisations", default: false
+  feature :fulltext_document_search, description: "Enables true full text document search", default: false
 end

--- a/db/migrate/20240109115405_add_full_text_index_for_edition_titles.rb
+++ b/db/migrate/20240109115405_add_full_text_index_for_edition_titles.rb
@@ -1,0 +1,5 @@
+class AddFullTextIndexForEditionTitles < ActiveRecord::Migration[7.1]
+  def change
+    add_index :edition_translations, :title, type: :fulltext, if_not_exists: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_03_112519) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_09_115405) do
   create_table "assets", charset: "utf8mb3", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.string "variant", null: false
@@ -327,6 +327,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_03_112519) do
     t.datetime "updated_at", precision: nil
     t.index ["edition_id"], name: "index_edition_translations_on_edition_id"
     t.index ["locale"], name: "index_edition_translations_on_locale"
+    t.index ["title"], name: "index_edition_translations_on_title", type: :fulltext
   end
 
   create_table "edition_world_locations", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|

--- a/test/unit/app/models/edition_test.rb
+++ b/test/unit/app/models/edition_test.rb
@@ -583,17 +583,6 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal [feb], Edition.published_after("2011-01-29").load
   end
 
-  test "should find editions with summary containing keyword" do
-    edition_with_first_keyword = create(:edition, summary: "klingons")
-    _edition_without_first_keyword = create(:edition, summary: "this document is about muppets")
-    assert_equal [edition_with_first_keyword], Edition.with_title_or_summary_containing("klingons")
-  end
-
-  test "should find editions with summary containing regular expression characters" do
-    edition_with_nasty_characters = create(:edition, summary: "summary with [stuff in brackets]")
-    assert_equal [edition_with_nasty_characters], Edition.with_title_or_summary_containing("[stuff")
-  end
-
   test "should find editions with title containing keyword" do
     edition_with_first_keyword = create(:edition, title: "klingons")
     _edition_without_first_keyword = create(:edition, title: "this document is about muppets")
@@ -660,17 +649,6 @@ class EditionTest < ActiveSupport::TestCase
     with_locale(:en) { create(:edition, title: "english-title-a") }
 
     assert_equal %w[english-title-a english-title-b], Edition.alphabetical.map(&:title)
-  end
-
-  test "should only consider english titles for Edition.with_title_or_summary_containing" do
-    edition = build(:edition)
-    with_locale(:en) { edition.title = "english-title-b" }
-    with_locale(:es) { edition.title = "spanish-title-b" }
-    edition.save!
-    with_locale(:es) { create(:edition, title: "spanish-title-a") }
-    with_locale(:en) { create(:edition, title: "english-title-a") }
-
-    assert_same_elements %w[english-title-a english-title-b], Edition.with_title_or_summary_containing("title").map(&:title)
   end
 
   test "should only consider english titles for Edition.with_title_containing" do


### PR DESCRIPTION
### What

This is an initial attempt to apply a full text index to Whitehall's document search.

### Why

Whitehall's document search is extremely slow if we are not able to use an index. This change will make it possible to search documents quickly using a full text index on the document title.

### Problems

It isn't possible to write automated tests for code that uses the fulltext index without disabling the automatic transaction wrapping behaviour. Currently I am working around that by using a feature flag to swap out the implementation when unit testing, but we wouldn't be able to remove the feature flag without rewriting a lot of the test code for tests such as test/functional/admin/document_collection_group_document_search_controller_test.rb. I don't imagine stubbing the scope would be very easy.

Trello: https://trello.com/c/Qkl62e4y
