### PR TITLE
Update reorder role page to use person name as description

### DIFF
--- a/app/views/admin/cabinet_ministers/_reorder.html.erb
+++ b/app/views/admin/cabinet_ministers/_reorder.html.erb
@@ -10,10 +10,11 @@
 
       <%= render "govuk_publishing_components/components/reorderable_list", {
         input_name: name,
-        items: list.map do |item|
+        items: roles.map do |role|
           {
-            id: item.id,
-            title: item.name,
+            id: role.id,
+            title: role.name,
+            description: role.current_person&.name,
           }
         end,
       } %>

--- a/app/views/admin/cabinet_ministers/reorder_also_attends_cabinet_roles.html.erb
+++ b/app/views/admin/cabinet_ministers/reorder_also_attends_cabinet_roles.html.erb
@@ -2,7 +2,7 @@
 <% content_for :context, "Also attends cabinet ordering" %>
 
 <%= render "reorder",
-  list: @roles,
+  roles: @roles,
   form_url: order_also_attends_cabinet_roles_admin_cabinet_ministers_path,
   cancel_path: admin_cabinet_ministers_path(anchor: "also_attends_cabinet"),
   name: "ministerial_roles[ordering]" %>

--- a/app/views/admin/cabinet_ministers/reorder_cabinet_minister_roles.html.erb
+++ b/app/views/admin/cabinet_ministers/reorder_cabinet_minister_roles.html.erb
@@ -2,7 +2,7 @@
 <% content_for :context, "Cabinet minister ordering" %>
 
 <%= render "reorder",
-  list: @roles,
+  roles: @roles,
   form_url: order_cabinet_minister_roles_admin_cabinet_ministers_path,
   cancel_path: admin_cabinet_ministers_path(anchor: "cabinet_minister"),
   name: "ministerial_roles[ordering]" %>

--- a/app/views/admin/cabinet_ministers/reorder_ministerial_organisations.html.erb
+++ b/app/views/admin/cabinet_ministers/reorder_ministerial_organisations.html.erb
@@ -1,8 +1,32 @@
 <% content_for :page_title, "Reorder Ministerial organisations ordering" %>
 <% content_for :context, "Ministerial organisations ordering" %>
+<% content_for :title, "Reorder list" %>
 
-<%= render "reorder",
-  list: @organisations,
-  form_url: order_ministerial_organisations_admin_cabinet_ministers_path,
-  cancel_path: admin_cabinet_ministers_path(anchor: "organisations"),
-  name: "ministerial_organisations[ordering]" %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with url: order_ministerial_organisations_admin_cabinet_ministers_path, method: :patch do %>
+      <%= render "govuk_publishing_components/components/hint", {
+        text: "Use the up and down buttons to reorder attachments, or select and hold on an attachment to reorder using drag and drop.",
+        margin_bottom: 4,
+      } %>
+
+      <%= render "govuk_publishing_components/components/reorderable_list", {
+        input_name: "ministerial_organisations[ordering]",
+        items: @organisations.map do |organisation|
+          {
+            id: organisation.id,
+            title: organisation.name,
+          }
+        end,
+      } %>
+
+      <div class="govuk-button-group govuk-!-margin-bottom-6">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Update order",
+        } %>
+
+        <%= link_to("Cancel", admin_cabinet_ministers_path(anchor: "organisations"), class: "govuk-link govuk-link--no-visited-state") %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/cabinet_ministers/reorder_whip_roles.html.erb
+++ b/app/views/admin/cabinet_ministers/reorder_whip_roles.html.erb
@@ -2,7 +2,7 @@
 <% content_for :context, "Whips ordering" %>
 
 <%= render "reorder",
-  list: @roles,
+  roles: @roles,
   form_url: order_cabinet_minister_roles_admin_cabinet_ministers_path,
   cancel_path: admin_cabinet_ministers_path(anchor: "whips"),
   name: "ministerial_roles[ordering]" %>


### PR DESCRIPTION
## Description 

There are some duplicate role names which are really hard to reorder as you can't tell which person is currently assigned to which.

This adds the current role appointees name as the description.

## Screenshot

![image](https://github.com/alphagov/whitehall/assets/42515961/a0bbc0b5-5980-433d-81f7-e73d5d8df8ab)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
