### PR TITLE
Remove unused access and opening times route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -137,7 +137,6 @@ Whitehall::Application.routes.draw do
           get :about, to: "worldwide_organisations_about#show", as: :about
           get :history, to: "worldwide_organisations_history#index", as: :history
         end
-        resource :access_and_opening_time, path: "access_info", except: %i[index show new]
         resources :translations, controller: "worldwide_organisations_translations" do
           get :confirm_destroy, on: :member
         end


### PR DESCRIPTION
The access and opening times pages were removed in #8132 and #8149, so this route is no longer needed.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
