### PR TITLE
Inform the user that an invalid last updated date filter has not been applied

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -48,8 +48,12 @@ class Admin::EditionsController < Admin::BaseController
       session[:document_filters] = params_filters
       render :index
     elsif session_filters.any?
+      flash[:html_safe] = true
+      flash[:alert] = filter.errors.join("<br>") if filter&.errors&.any?
       redirect_to session_filters
     else
+      flash[:html_safe] = true
+      flash[:alert] = filter.errors.join("<br>") if filter&.errors&.any?
       redirect_to default_filters
     end
   end

--- a/test/functional/admin/editions_controller_test.rb
+++ b/test/functional/admin/editions_controller_test.rb
@@ -150,6 +150,7 @@ class Admin::EditionsControllerTest < ActionController::TestCase
     session[:document_filters] = { "state" => "submitted", "author" => current_user.to_param, "organisation" => organisation.to_param }
     get :index, params: { author: "invalid" }
     assert_redirected_to admin_editions_path(state: :submitted, author: current_user, organisation:)
+    assert_equal "Author not found", flash[:alert]
   end
 
   test "index should redirect to department if logged in with no remembered filters" do
@@ -157,6 +158,15 @@ class Admin::EditionsControllerTest < ActionController::TestCase
     login_as create(:departmental_editor, organisation:)
     get :index
     assert_redirected_to admin_editions_path(organisation: organisation.id, state: :active)
+  end
+
+  test "index should redirect to default filtered options if filter is invalid and there are no remembered filters" do
+    organisation = create(:organisation)
+    login_as create(:departmental_editor, organisation:)
+    get :index, params: { from_date: "45/22/2222", to_date: "45/22/2222" }
+    assert_redirected_to admin_editions_path(organisation: organisation.id, state: :active)
+    assert_includes flash[:alert], "The 'From date' is incorrect. It should be dd/mm/yyyy"
+    assert_includes flash[:alert], "The 'To date' is incorrect. It should be dd/mm/yyyy"
   end
 
   view_test "should not show published editions as force published" do

--- a/test/unit/app/models/admin/edition_filter_test.rb
+++ b/test/unit/app/models/admin/edition_filter_test.rb
@@ -255,11 +255,37 @@ class Admin::EditionFilterTest < ActiveSupport::TestCase
   test "should be invalid if author can't be found" do
     filter = Admin::EditionFilter.new(Edition, @current_user, author: "invalid")
     assert_not filter.valid?
+    assert_equal 1, filter.errors.count
+    assert_includes filter.errors, "Author not found"
   end
 
   test "should be invalid if organisation can't be found" do
     filter = Admin::EditionFilter.new(Edition, @current_user, organisation: "invalid")
     assert_not filter.valid?
+    assert_equal 1, filter.errors.count
+    assert_includes filter.errors, "Organisation not found"
+  end
+
+  test "should be invalid if organisation and author can't be found" do
+    filter = Admin::EditionFilter.new(Edition, @current_user, organisation: "invalid", author: "invalid")
+    assert_not filter.valid?
+    assert_equal 2, filter.errors.count
+    assert_includes filter.errors, "Author not found"
+    assert_includes filter.errors, "Organisation not found"
+  end
+
+  test "should be invalid if from_date is incorrect" do
+    filter = Admin::EditionFilter.new(Edition, @current_user, from_date: "33/33/3333")
+    assert_not filter.valid?
+    assert_equal 1, filter.errors.count
+    assert_includes filter.errors, "The 'From date' is incorrect. It should be dd/mm/yyyy"
+  end
+
+  test "should be invalid if to_date is incorrect" do
+    filter = Admin::EditionFilter.new(Edition, @current_user, to_date: "33/33/3333")
+    assert_not filter.valid?
+    assert_equal 1, filter.errors.count
+    assert_includes filter.errors, "The 'To date' is incorrect. It should be dd/mm/yyyy"
   end
 
   test "should generate page title when there are no filter options" do


### PR DESCRIPTION
There was no validation on last updated `from_date` and `to_date` filters. As a result, the user was redirected to session stored filters or default filter (organisation and active state), without being notified that their filtering was not successful.

Adding a validation check and notice to inform them that the filter has not been applied.

[Trello card](https://trello.com/c/dPoVTx0z/2272-improve-handling-of-invalid-date-format-in-whitehall-document-last-updated-date-filter-input)