### PR TITLE
Add component testing

### DIFF
--- a/app/assets/stylesheets/components/_autocomplete.scss
+++ b/app/assets/stylesheets/components/_autocomplete.scss
@@ -96,14 +96,6 @@ $app-focus-colour: $govuk-focus-colour;
   }
 }
 
-.app-c-autocomplete--narrow {
-  max-width: 200px;
-
-  @include govuk-media-query($from: tablet) {
-    max-width: 230px;
-  }
-}
-
 .js-enabled {
   .app-c-autocomplete {
     .govuk-select[multiple] {

--- a/app/views/components/_datetime_fields.html.erb
+++ b/app/views/components/_datetime_fields.html.erb
@@ -16,11 +16,14 @@
   time_hint = time_hint ||= nil
   time_hint_id = "time-hint-#{SecureRandom.hex(4)}"
 
-  year ||= {}
-
-  month ||= {}
-
-  day ||= {}
+  year ||= nil
+  month ||= nil
+  day ||= nil
+  date_input_items = []
+  date_input_items << year if year
+  date_input_items << month if month
+  date_input_items << day if day
+  date_input_items = nil unless date_input_items.any?
 
   hour ||= {}
   hour_value = hour[:value]
@@ -51,7 +54,7 @@
     id: date_id,
     hint: date_hint,
     error_items: error_items,
-    items: [day, month, year],
+    items: date_input_items,
   } %>
 
   <% unless date_only %>

--- a/app/views/components/_datetime_fields.html.erb
+++ b/app/views/components/_datetime_fields.html.erb
@@ -1,6 +1,6 @@
 <%
-  prefix = prefix
-  field_name = field_name
+  prefix ||= nil
+  field_name ||= nil
   id = id
   date_id = "#{id}_date"
   date_only ||= false
@@ -39,83 +39,84 @@
   root_classes << "govuk-form-group--error" if error_items.present?
   data_attributes ||= {}
 %>
-
-<%= tag.div class: root_classes, data: data_attributes, id: id do %>
-  <% unless date_only && !date_heading %>
-    <%= render "govuk_publishing_components/components/heading", {
-      text: date_heading || "Date (required)",
-      heading_level: heading_level || 3,
-      font_size: heading_size || "m",
-      padding: true,
-    } %>
-  <% end %>
-
-  <%= render "govuk_publishing_components/components/date_input", {
-    id: date_id,
-    hint: date_hint,
-    error_items: error_items,
-    items: date_input_items,
-  } %>
-
-  <% unless date_only %>
-    <div class="govuk-!-margin-top-3">
+<% if prefix && field_name %>
+  <%= tag.div class: root_classes, data: data_attributes, id: id do %>
+    <% unless date_only && !date_heading %>
       <%= render "govuk_publishing_components/components/heading", {
-        text: "Time",
+        text: date_heading || "Date (required)",
         heading_level: heading_level || 3,
         font_size: heading_size || "m",
         padding: true,
       } %>
-    </div>
-
-    <% if time_hint %>
-      <%= render "govuk_publishing_components/components/hint", {
-        text: time_hint,
-        id: time_hint_id,
-      } %>
     <% end %>
 
-    <div class="app-c-datetime-fields__date-time-wrapper">
-      <div class="app-c-datetime-fields__date-time">
-        <%= render "govuk_publishing_components/components/label", {
-          text: "Hour",
-          html_for: hour_select_id,
-          id: hour_label_id,
-        } %>
+    <%= render "govuk_publishing_components/components/date_input", {
+      id: date_id,
+      hint: date_hint,
+      error_items: error_items,
+      items: date_input_items,
+    } %>
 
-        <%= select_hour hour_value,
-                        {
-                          include_blank: true,
-                          prefix: prefix,
-                          field_name: "#{field_name}(4i)",
-                        },
-                        {
-                          id: hour_select_id,
-                          class: "govuk-select app-c-datetime-fields__date-time-input",
-                          "aria-describedby": "#{hour_label_id} #{time_hint_id if time_hint.present?}".strip,
-                        } %>
+    <% unless date_only %>
+      <div class="govuk-!-margin-top-3">
+        <%= render "govuk_publishing_components/components/heading", {
+          text: "Time",
+          heading_level: heading_level || 3,
+          font_size: heading_size || "m",
+          padding: true,
+        } %>
       </div>
 
-      <p class="govuk-body app-c-datetime-fields__time-separator">:</p>
-
-      <div class="app-c-datetime-fields__date-time">
-        <%= render "govuk_publishing_components/components/label", {
-          text: "Minute",
-          html_for: minute_select_id,
-          id: minute_label_id,
+      <% if time_hint %>
+        <%= render "govuk_publishing_components/components/hint", {
+          text: time_hint,
+          id: time_hint_id,
         } %>
+      <% end %>
 
-        <%= select_minute minute_value,
+      <div class="app-c-datetime-fields__date-time-wrapper">
+        <div class="app-c-datetime-fields__date-time">
+          <%= render "govuk_publishing_components/components/label", {
+            text: "Hour",
+            html_for: hour_select_id,
+            id: hour_label_id,
+          } %>
+
+          <%= select_hour hour_value,
                           {
                             include_blank: true,
                             prefix: prefix,
-                            field_name: "#{field_name}(5i)",
+                            field_name: "#{field_name}(4i)",
                           },
                           {
-                            id: minute_select_id,
+                            id: hour_select_id,
                             class: "govuk-select app-c-datetime-fields__date-time-input",
-                            "aria-describedby": "#{minute_label_id} #{time_hint_id if time_hint.present?}".strip,
+                            "aria-describedby": "#{hour_label_id} #{time_hint_id if time_hint.present?}".strip,
                           } %>
+        </div>
+
+        <p class="govuk-body app-c-datetime-fields__time-separator">:</p>
+
+        <div class="app-c-datetime-fields__date-time">
+          <%= render "govuk_publishing_components/components/label", {
+            text: "Minute",
+            html_for: minute_select_id,
+            id: minute_label_id,
+          } %>
+
+          <%= select_minute minute_value,
+                            {
+                              include_blank: true,
+                              prefix: prefix,
+                              field_name: "#{field_name}(5i)",
+                            },
+                            {
+                              id: minute_select_id,
+                              class: "govuk-select app-c-datetime-fields__date-time-input",
+                              "aria-describedby": "#{minute_label_id} #{time_hint_id if time_hint.present?}".strip,
+                            } %>
+        </div>
       </div>
-    </div>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/components/_govspeak_editor.html.erb
+++ b/app/views/components/_govspeak_editor.html.erb
@@ -18,12 +18,12 @@
   data_attributes ||= {}
   data_attributes[:module] ||= ""
   data_attributes[:module] << " govspeak-editor"
-  data_attributes[:module] = data_attributes[:module].strip!
+  data_attributes[:module] = data_attributes[:module].strip
 
   textarea_data_attributes ||= {}
   textarea_data_attributes[:module] ||= ""
   textarea_data_attributes[:module] << " paste-html-to-govspeak"
-  textarea_data_attributes[:module] = textarea_data_attributes[:module].strip!
+  textarea_data_attributes[:module] = textarea_data_attributes[:module].strip
 
   preview_button_data_attributes ||= {}
   preview_button_data_attributes["content-target"] = "##{id}"

--- a/app/views/components/_inset_prompt.html.erb
+++ b/app/views/components/_inset_prompt.html.erb
@@ -8,24 +8,25 @@
   root_classes = %w[app-c-inset-prompt]
   root_classes << "app-c-inset-prompt--error" if error
 %>
+<% if title || description %>
+  <%= tag.div class: root_classes, id: id, data: data_attributes do %>
+    <% if title %>
+      <%= tag.h3 title, class: "app-c-inset-prompt__title" %>
+    <% end %>
 
-<%= tag.div class: root_classes, id: id, data: data_attributes do %>
-  <% if title %>
-    <%= tag.h3 title, class: "app-c-inset-prompt__title" %>
-  <% end %>
+    <%= tag.div class: "app-c-inset-prompt__body" do %>
+      <%= description if description %>
 
-  <%= tag.div class: "app-c-inset-prompt__body" do %>
-    <%= description if description %>
-
-    <% if items.any? %>
-      <%= tag.ul class: "govuk-list app-c-inset-prompt__list" do %>
-        <% items.each_with_index do |item, index| %>
-          <%= tag.li do %>
-            <% if item[:href] %>
-              <%= link_to(item[:text], item[:href], data: item[:data_attributes], class: "govuk-link govuk-link--no-visited-state") %>
-            <% else %>
-              <%= tag.span data: item[:data_attributes] do %>
-                <%= item[:text] %>
+      <% if items.any? %>
+        <%= tag.ul class: "govuk-list app-c-inset-prompt__list" do %>
+          <% items.each_with_index do |item, index| %>
+            <%= tag.li do %>
+              <% if item[:href] %>
+                <%= link_to(item[:text], item[:href], data: item[:data_attributes], class: "govuk-link govuk-link--no-visited-state") %>
+              <% else %>
+                <%= tag.span data: item[:data_attributes] do %>
+                  <%= item[:text] %>
+                <% end %>
               <% end %>
             <% end %>
           <% end %>

--- a/app/views/components/docs/autocomplete.yml
+++ b/app/views/components/docs/autocomplete.yml
@@ -90,21 +90,28 @@ examples:
             - fr
             - de
 
-  autocomplete_narrow_width:
+  with_data_attributes:
     data:
-      id: autocomplete-narrow
-      name: autocomplete-narrow
+      id: autocomplete
+      name: autocomplete
+      data_attributes:
+        module: not-a-module
+        loose: moose
       label:
-        text: Status
-      width: narrow
+        text: Select your country
       select:
         options:
           -
-            - Draft
+            -
           -
-            - Published
+            - France
+            - fr
           -
-            - Removed
+            - Germany
+            - de
+          -
+            - United Kingdom
+            - uk
 
   autocomplete_with_configuration_options:
     data:

--- a/app/views/components/docs/datetime_fields.yml
+++ b/app/views/components/docs/datetime_fields.yml
@@ -42,10 +42,16 @@ examples:
       field_name: first_published_at
       year:
         id: edition_first_published_year
+        name: Year
+        width: 4
       month:
         id: edition_first_published_month
+        name: Month
+        width: 2
       day:
         id: edition_first_published_day
+        name: Day
+        width: 2
       hour:
         id: edition_first_published_hour
       minute:
@@ -55,22 +61,21 @@ examples:
       prefix: edition
       field_name: first_published_at
       year:
+        name: Year
         value: 2022
+        width: 4
       month:
+        name: Month
         value: 1
+        width: 2
       day:
+        name: Day
         value: 1
+        width: 2
       hour:
         value: 9
       minute:
         value: 30
-  with_start_and_end_year:
-    data:
-      prefix: edition
-      field_name: first_published_at
-      year:
-        start_year: 2000
-        end_year: 2025
   with_error_items:
     data:
       prefix: edition

--- a/app/views/components/docs/datetime_fields.yml
+++ b/app/views/components/docs/datetime_fields.yml
@@ -77,6 +77,16 @@ examples:
         value: 9
       minute:
         value: 30
+  with_a_prepopulated_time:
+    data:
+      prefix: edition
+      field_name: first_published_at
+      hour:
+        value: 10
+        id: myhour
+      minute:
+        value: 51
+        id: myminute
   with_error_items:
     data:
       prefix: edition

--- a/app/views/components/docs/datetime_fields.yml
+++ b/app/views/components/docs/datetime_fields.yml
@@ -34,6 +34,7 @@ examples:
   with_hint_text:
     data:
       prefix: edition
+      field_name: first_published_at
       date_hint: For example, 01 August 2022
       time_hint: For example, 09:30 or 19:30
   with_custom_ids:

--- a/app/views/components/docs/govspeak_editor.yml
+++ b/app/views/components/docs/govspeak_editor.yml
@@ -24,6 +24,14 @@ examples:
         text: "Document content body"
         bold: true
       name: "default"
+  with_hint:
+    data:
+      label:
+        text: "Document content body"
+        bold: true
+      name: "default"
+      hint: Explain any acronyms
+      hint_id: this_is_optional
   with_tracking:
     data:
       label:
@@ -55,7 +63,33 @@ examples:
         ## What is Lorem Ipsum?
 
         Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.
-
+  with_textarea_rows:
+    description: Allows the number of rows in the textarea to be adjusted.
+    data:
+      label:
+        text: "Document content body"
+        bold: true
+      name: "name"
+      rows: 2
+  right_to_left:
+    data:
+      label:
+        text: "Document content body"
+        bold: true
+      name: "name"
+      right_to_left: true
+      value: This is right to left
+  with_errors:
+    data:
+      label:
+        text: "Document content body"
+        bold: true
+      name: default
+      error_items:
+        - text: there's nothing here
+          href: error1
+        - text: no really, there's nothing here
+          href: error2
   with_attachments_and_alternative_format_provider_id:
     data:
       label:

--- a/app/views/components/docs/image_cropper.yml
+++ b/app/views/components/docs/image_cropper.yml
@@ -3,6 +3,10 @@ description: Displays an image with resizable crop function
 body: |
  This component uses Cropper.js - a JavaScript library for cropping image.
  Users can select an specific area of an image the image will then be cropped on browser-side and appended to the parent form on submission.
+accessibility_criteria: |
+  The component must:
+
+  - be usable with a keyboard
 examples:
   default:
     data:

--- a/app/views/components/docs/inset_prompt.yml
+++ b/app/views/components/docs/inset_prompt.yml
@@ -39,3 +39,8 @@ examples:
         tracking: GTM-123AB
       items:
       - text: Descriptive link to the question with an error 1
+  with_id_attribute:
+    data:
+      title: If you want an id on the component for some reason
+      id: myid
+

--- a/test/component_test_helper.rb
+++ b/test/component_test_helper.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class ComponentTestCase < ActionView::TestCase
+  helper Rails.application.helpers
+
+  def component_name
+    raise NotImplementedError, "Override this method in your test class"
+  end
+
+  def render_component(locals)
+    render partial: "components/#{component_name}", locals:
+  end
+end

--- a/test/components/autocomplete_test.rb
+++ b/test/components/autocomplete_test.rb
@@ -1,0 +1,86 @@
+require "component_test_helper"
+
+class AutocompleteComponentTest < ComponentTestCase
+  def component_name
+    "autocomplete"
+  end
+
+  def component_data
+    {
+      id: "id",
+      name: "name",
+      label: {
+        text: "text",
+      },
+      select: {
+        options: [
+          [""],
+          ["France", "fr"],
+          ["Germany", "de"],
+          ["United Kingdom", "uk"],
+        ],
+      },
+    }
+  end
+
+  test "fails to render when no parameters given" do
+    assert_raise do
+      render_component({})
+    end
+  end
+
+  test "renders the basic component" do
+    render_component(component_data)
+    assert_select ".app-c-autocomplete"
+    assert_select ".govuk-select[id='id'][name='name']"
+    assert_select ".govuk-label", text: "text"
+  end
+
+  test "renders with a selected option" do
+    data = component_data
+    data[:select][:selected] = "de"
+    render_component(data)
+    assert_select ".app-c-autocomplete .govuk-select option[value='de'][selected='selected']"
+  end
+
+  test "renders with an error" do
+    data = component_data
+    data[:error_items] = [
+      {
+        text: "whoa something bad happened",
+      },
+    ]
+    render_component(data)
+    assert_select ".app-c-autocomplete.govuk-form-group--error .gem-c-error-message", text: "Error: whoa something bad happened"
+  end
+
+  test "renders in multiple mode" do
+    data = component_data
+    data[:select][:multiple] = true
+    data[:select][:selected] = %w[fr de]
+    render_component(data)
+    assert_select ".app-c-autocomplete .govuk-select[multiple='multiple']"
+    assert_select ".app-c-autocomplete .govuk-select option[value='fr'][selected='selected']"
+    assert_select ".app-c-autocomplete .govuk-select option[value='de'][selected='selected']"
+    assert_select ".app-c-autocomplete .govuk-select option[value='uk'][selected='selected']", false
+  end
+
+  test "accepts data attribures" do
+    data = component_data
+    data[:data_attributes] = {
+      module: "not-a-module",
+      isaac: "asimov",
+    }
+    render_component(data)
+    assert_select ".app-c-autocomplete[data-module='not-a-module autocomplete'][data-isaac='asimov']"
+  end
+
+  test "accepts configuration options" do
+    data = component_data
+    data[:autocomplete_configuration_options] = {
+      showAllValues: false,
+    }
+    render_component(data)
+    assert_select ".app-c-autocomplete[data-autocomplete-configuration-options='#{data[:autocomplete_configuration_options].to_json}']"
+  end
+end

--- a/test/components/datetime_fields_test.rb
+++ b/test/components/datetime_fields_test.rb
@@ -1,0 +1,174 @@
+require "component_test_helper"
+
+class DatetimefieldsComponentTest < ComponentTestCase
+  def component_name
+    "datetime_fields"
+  end
+
+  test "renders nothing when no parameters given" do
+    assert_empty render_component({})
+  end
+
+  test "renders the basic component" do
+    render_component({
+      prefix: "prefix",
+      field_name: "field_name",
+    })
+
+    assert_select ".app-c-datetime-fields"
+    assert_select "h3.govuk-heading-m", text: "Date (required)"
+    assert_select ".govuk-input[name='day']"
+    assert_select ".govuk-input[name='month']"
+    assert_select ".govuk-input[name='year']"
+    assert_select "h3.govuk-heading-m", text: "Time"
+    assert_select ".govuk-label", text: "Hour"
+    assert_select ".govuk-label", text: "Minute"
+  end
+
+  test "accepts an id" do
+    render_component({
+      prefix: "prefix",
+      field_name: "field_name",
+      id: "kevin",
+    })
+
+    assert_select ".app-c-datetime-fields[id='kevin']"
+    assert_select ".govuk-date-input[id='kevin_date']"
+  end
+
+  test "allows a different date heading, heading level and size" do
+    render_component({
+      prefix: "prefix",
+      field_name: "field_name",
+      date_heading: "i am heading",
+      heading_level: 1,
+      heading_size: "l",
+    })
+
+    assert_select "h1.govuk-heading-l", text: "i am heading"
+    assert_select "h1.govuk-heading-l", text: "Time"
+  end
+
+  test "shows hint text" do
+    render_component({
+      prefix: "prefix",
+      field_name: "field_name",
+      date_hint: "For example, 01 August 2022",
+      time_hint: "For example, 09:30 or 19:30",
+    })
+
+    assert_select ".govuk-hint", text: "For example, 01 August 2022"
+    assert_select ".govuk-hint", text: "For example, 09:30 or 19:30"
+  end
+
+  test "renders custom date fields" do
+    render_component({
+      prefix: "prefix",
+      field_name: "field_name",
+      year: {
+        id: "year_id",
+        name: "year_name",
+        width: 4,
+        value: "2024",
+      },
+      month: {
+        id: "month_id",
+        name: "month_name",
+        width: 3,
+        value: "1",
+      },
+      day: {
+        id: "day_id",
+        name: "day_name",
+        width: 2,
+        value: "14",
+      },
+    })
+
+    assert_select ".govuk-input.govuk-input--width-4[id='year_id'][name='year_name'][value='2024']"
+    assert_select ".govuk-input.govuk-input--width-3[id='month_id'][name='month_name'][value='1']"
+    assert_select ".govuk-input.govuk-input--width-2[id='day_id'][name='day_name'][value='14']"
+  end
+
+  test "accepts values and ids for hour and minute elements" do
+    render_component({
+      prefix: "prefix",
+      field_name: "field_name",
+      hour: {
+        value: 2,
+        id: "my-hour-id",
+      },
+      minute: {
+        value: 3,
+        id: "my-minute-id",
+      },
+    })
+
+    assert_select "select[id='my-hour-id'] option[value='02'][selected='selected']"
+    assert_select "select[id='my-minute-id'] option[value='03'][selected='selected']"
+  end
+
+  test "errors if hour data is incorrect" do
+    assert_raises do
+      render_component({
+        prefix: "prefix",
+        field_name: "field_name",
+        hour: "oops",
+      })
+    end
+  end
+
+  test "errors if minute data is incorrect" do
+    assert_raises do
+      render_component({
+        prefix: "prefix",
+        field_name: "field_name",
+        minute: "sorry",
+      })
+    end
+  end
+
+  test "renders error fields" do
+    render_component({
+      prefix: "prefix",
+      field_name: "field_name",
+      error_items: [
+        {
+          text: "Descriptive error 1",
+        },
+        {
+          text: "Descriptive error 2",
+        },
+      ],
+    })
+
+    assert_select ".app-c-datetime-fields.govuk-form-group--error"
+    assert_select ".govuk-form-group--error .govuk-error-message", text: "Error: Descriptive error 1Descriptive error 2"
+  end
+
+  test "accepts data attributes" do
+    render_component({
+      prefix: "prefix",
+      field_name: "field_name",
+      data_attributes: {
+        module: "not-a-real-module",
+        something_else: "i-just-thought-of",
+      },
+    })
+
+    assert_select ".app-c-datetime-fields[data-module='not-a-real-module'][data-something-else='i-just-thought-of']"
+  end
+
+  test "with date only option" do
+    render_component({
+      prefix: "prefix",
+      field_name: "field_name",
+      date_only: true,
+    })
+
+    assert_select ".govuk-input[name='day']"
+    assert_select ".govuk-input[name='month']"
+    assert_select ".govuk-input[name='year']"
+    assert_select ".app-c-datetime-fields__date-time-wrapper", false
+  end
+end

--- a/test/components/govspeak_editor_test.rb
+++ b/test/components/govspeak_editor_test.rb
@@ -1,0 +1,165 @@
+require "component_test_helper"
+
+class GovspeakeditorComponentTest < ComponentTestCase
+  def component_name
+    "govspeak_editor"
+  end
+
+  test "errors when no parameters given" do
+    assert_raises do
+      render_component({})
+    end
+  end
+
+  test "renders the basic component" do
+    render_component({
+      name: "my-name",
+      label: {
+        text: "my-label",
+      },
+    })
+
+    assert_select ".app-c-govspeak-editor[data-module='govspeak-editor']"
+    assert_select ".govuk-label.govuk-label--s", false
+  end
+
+  test "sets label to bold" do
+    render_component({
+      name: "my-name",
+      label: {
+        text: "my-label",
+        bold: true,
+      },
+    })
+
+    assert_select ".govuk-label.govuk-label--s"
+  end
+
+  test "includes hint" do
+    render_component({
+      name: "my-name",
+      label: {
+        text: "my-label",
+      },
+      hint: "look out",
+      hint_id: "optional",
+    })
+
+    assert_select ".govuk-hint[id='optional']", text: "look out"
+  end
+
+  test "can display errors" do
+    render_component({
+      name: "my-name",
+      label: {
+        text: "my-label",
+      },
+      error_items: [
+        {
+          text: "there's nothing here",
+          href: "error1",
+        },
+        {
+          text: "no really, there's nothing here",
+          href: "error2",
+        },
+      ],
+    })
+
+    assert_select ".app-c-govspeak-editor.govuk-form-group--error"
+    assert_select ".govuk-error-message", text: "Error: there's nothing hereno really, there's nothing here"
+  end
+
+  test "can set number of rows on the textarea" do
+    render_component({
+      name: "my-name",
+      label: {
+        text: "my-label",
+      },
+      rows: 2,
+    })
+
+    assert_select ".govuk-textarea[rows='2']"
+  end
+
+  test "can set the textarea to right to left" do
+    render_component({
+      name: "my-name",
+      label: {
+        text: "my-label",
+      },
+      right_to_left: true,
+    })
+
+    assert_select ".govuk-textarea[dir='rtl']"
+  end
+
+  test "allows tracking" do
+    render_component({
+      name: "my-name",
+      label: {
+        text: "my-label",
+      },
+      track_preview_toggle: true,
+      track_category: "category",
+      track_action: "action",
+    })
+
+    assert_select ".app-c-govspeak-editor .govuk-button[data-preview-toggle-track-category='category'][data-preview-toggle-track-action='action'][data-preview-toggle-tracking='true']"
+  end
+
+  test "accepts data attributes" do
+    render_component({
+      name: "my-name",
+      label: {
+        text: "my-label",
+      },
+      data_attributes: {
+        some_attribute: "This is for the main component",
+        module: "one-module",
+      },
+      textarea_data_attributes: {
+        some_attribute: "This is for the textarea",
+        module: "two-module",
+      },
+      preview_button_data_attributes: {
+        some_attribute: "This is for the toggle preview button",
+        module: "three-module",
+      },
+    })
+
+    assert_select ".app-c-govspeak-editor[data-some-attribute='This is for the main component'][data-module='one-module govspeak-editor']"
+    assert_select ".govuk-textarea[data-some-attribute='This is for the textarea'][data-module='two-module paste-html-to-govspeak']"
+    assert_select ".govuk-button[data-some-attribute='This is for the toggle preview button'][data-module='three-module']"
+  end
+
+  test "can have a value for the textarea" do
+    render_component({
+      name: "my-name",
+      label: {
+        text: "my-label",
+      },
+      value: "Here is some text I wrote",
+    })
+
+    assert_select ".govuk-textarea", text: "Here is some text I wrote"
+  end
+
+  test "can have attachments and alternative format provider id" do
+    render_component({
+      name: "my-name",
+      label: {
+        text: "my-label",
+      },
+      data_attributes: {
+        alternative_format_provider_id: "123",
+        image_ids: [1, 2, 3],
+        attachment_ids: [3, 4, 5],
+      },
+      value: "This is an attachment: !@1 This is an image: !!1",
+    })
+
+    assert_select ".app-c-govspeak-editor[data-alternative-format-provider-id='123'][data-image-ids='[1,2,3]'][data-attachment-ids='[3,4,5]']"
+    assert_select ".govuk-textarea", text: "This is an attachment: !@1 This is an image: !!1"
+  end
+end

--- a/test/components/image_cropper_test.rb
+++ b/test/components/image_cropper_test.rb
@@ -1,0 +1,24 @@
+require "component_test_helper"
+
+class ImagecropperComponentTest < ComponentTestCase
+  def component_name
+    "image_cropper"
+  end
+
+  test "errors when no parameters given" do
+    assert_raises do
+      render_component({})
+    end
+  end
+
+  test "renders the basic component" do
+    render_component({
+      name: "name",
+      src: "src",
+      filename: "filename",
+      type: "type",
+    })
+
+    assert_select ".app-c-image-cropper"
+  end
+end

--- a/test/components/inset_prompt_test.rb
+++ b/test/components/inset_prompt_test.rb
@@ -1,0 +1,84 @@
+require "component_test_helper"
+
+class InsetpromptComponentTest < ComponentTestCase
+  def component_name
+    "inset_prompt"
+  end
+
+  test "renders nothing when no parameters given" do
+    assert_empty render_component({})
+  end
+
+  test "shows a title" do
+    render_component({
+      title: "My title",
+    })
+
+    assert_select ".app-c-inset-prompt"
+    assert_select ".app-c-inset-prompt__title", text: "My title"
+  end
+
+  test "shows a description" do
+    render_component({
+      description: "My description",
+    })
+
+    assert_select ".app-c-inset-prompt"
+    assert_select ".app-c-inset-prompt__body", text: "My description"
+  end
+
+  test "accepts an id" do
+    render_component({
+      description: "My description",
+      id: "my-id",
+    })
+
+    assert_select ".app-c-inset-prompt[id='my-id']"
+  end
+
+  test "can show items" do
+    render_component({
+      description: "My description",
+      items: [
+        {
+          text: "item 1",
+          href: "#item1",
+          data_attributes: {
+            test: "item-1",
+          },
+        },
+        {
+          text: "item 2",
+          data_attributes: {
+            test: "item-2",
+          },
+        },
+      ],
+    })
+
+    assert_select ".app-c-inset-prompt__list"
+    assert_select ".govuk-link[href='#item1'][data-test='item-1']", text: "item 1"
+    assert_select ".app-c-inset-prompt__list li span[data-test='item-2']", text: "item 2"
+  end
+
+  test "can show an error" do
+    render_component({
+      description: "My description",
+      error: true,
+    })
+
+    assert_select ".app-c-inset-prompt.app-c-inset-prompt--error"
+  end
+
+  test "can accept data attributes" do
+    render_component({
+      description: "My description",
+      data_attributes: {
+        module: "not-a-module",
+        banoffee: "pie",
+      },
+    })
+
+    assert_select ".app-c-inset-prompt[data-module='not-a-module'][data-banoffee='pie']"
+  end
+end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Improve component testing, see individual commits for details. Broadly:

- adds tests for components where there were none
- fixes some bugs in components
- updates component documentation with undocumented features

The aim of this PR is to be eventually able to add a general test for component filename consistency, but this test requires all components to have tests and this is not yet the case, more work is required.

## Why
Relates to https://github.com/alphagov/govuk_publishing_components/issues/3369

## Visual changes
None.