### PR TITLE
Add new link to footer for the GOVUK Status page

### DIFF
--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -92,6 +92,10 @@
             href: "https://www.gov.uk/government/content-publishing",
             text: "How to write, publish, and improve content",
           },
+          {
+            href: "https://status.publishing.service.gov.uk/",
+            text: "Check if publishing apps are working or if there’s any maintenance planned",
+          },
         ],
       },
     ],


### PR DESCRIPTION
As part of some associated work during GIFT week we would like to add a new link to the footer in Whitehall. This is to give users a link to the GOVUK Status Page so that they can see if there are any incidents or scheduled maintenance on the publishing apps that might effect them. We have discussed the change with Darren and Ruth in the Publishing Experience Team. 

|Current|Updated|
|-|-|
|![Screenshot 2024-01-11 at 12 22 12](https://github.com/alphagov/whitehall/assets/6080548/e691dcfc-ba64-4a65-8ee5-c0cbf45b40c7)|![Screenshot 2024-01-11 at 12 31 01](https://github.com/alphagov/whitehall/assets/6080548/798be5ee-ed59-454f-bc19-a7561d410af5)|
