### PR TITLE
Ensure Republishing worker can re-unpublish HTML attachments for unpublished editions successfully

### DIFF
--- a/app/services/service_listeners/publishing_api_html_attachments.rb
+++ b/app/services/service_listeners/publishing_api_html_attachments.rb
@@ -95,7 +95,7 @@ module ServiceListeners
         if edition.withdrawn?
           withdraw
         else
-          unpublish(allow_draft: true)
+          unpublish(allow_draft: false)
         end
       end
     end

--- a/test/unit/app/services/service_listeners/publishing_api_html_attachments_test.rb
+++ b/test/unit/app/services/service_listeners/publishing_api_html_attachments_test.rb
@@ -462,7 +462,7 @@ module ServiceListeners
           attachment.content_id,
           "/government/another/page",
           "en",
-          true,
+          false,
         )
         call(publication)
       end
@@ -474,7 +474,7 @@ module ServiceListeners
           attachment.content_id,
           "/government/another/page",
           "en",
-          true,
+          false,
         )
         call(publication)
       end
@@ -486,7 +486,7 @@ module ServiceListeners
           attachment.content_id,
           publication.search_link,
           "en",
-          true,
+          false,
         )
         call(publication)
       end


### PR DESCRIPTION
When the republishing worker is passed an unpublished document, it has to republish the document in case there have been code changes that would affect the display of the unpublishing message (e.g. govspeak changes), and then unpublish it again. It also has to do this for the unpublished document's HTML attachments.

It might be that we can remove this behaviour, because the route for an unpublished document should either redirect or show a generic "gone" message, but I'm not confident enough to risk it yet.

In any case, currently the unpublishing of the HTML attachments fails. Publishing API returns a 404 response. This is because if the "allow_draft" parameter is used, which we were using, Publishing API tries to find a document from the draft stack to unpublish. However, there isn't one there, because the republishing worker has just published the attachment (to potentially update the Govspeak etc.).

We have therefore fixed this issue by switching the "allow_draft" parameter to false for the unpublishing request. We have worked through the code as thoroughly as we can and we are fairly confident the only time that code is called is in the case where we are republishing an HTML attachment. 

We had to test the behaviour of republishing worker for unpublished document with draft using Webmock. We need to use Webmock because mocking the republishing worker dependencies is obscuring an issue which causes HTML attachments to published inadvertently whilst republishing an unpublished document. I intend to rewrite all of the tests for the republishing worker using WebMock, and also to look into doing the same for PublishingAPIPusher.
