### PR TITLE
Make social media seed valid against Publishing API

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -160,9 +160,9 @@ if WorldLocation.where(name: "Test International Delegation").blank?
       world_locations: [WorldLocation.first],
     )
 
-    if SocialMediaService.where(name: "Some social media service").blank?
+    if SocialMediaService.where(name: "Blog").blank?
       SocialMediaService.create!(
-        name: "Some social media service",
+        name: "Blog",
       )
     end
 


### PR DESCRIPTION
Currently, this creates a content item which is invalid against Publishing API as the social media service is restricted to a [fixed set of values](https://github.com/alphagov/publishing-api/blob/f91dd24e568c453ebcefcddb2fb05ed9c0d6c015/content_schemas/formats/shared/definitions/_social_media_links.jsonnet#L14).

This updates the type to `blog` (which seems generic enough) so that the content type is valid.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
