### PR TITLE
Use edition links for worldwide organisations

### DIFF
--- a/app/presenters/publishing_api/editionable_worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/editionable_worldwide_organisation_presenter.rb
@@ -33,6 +33,7 @@ module PublishingApi
           world_location_names:,
         },
         document_type:,
+        links: edition_links,
         public_updated_at: item.updated_at,
         rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
         schema_name: "worldwide_organisation",
@@ -41,7 +42,7 @@ module PublishingApi
       content.merge!(PayloadBuilder::AnalyticsIdentifier.for(item))
     end
 
-    def links
+    def edition_links
       {
         office_staff:,
         main_office:,
@@ -56,6 +57,19 @@ module PublishingApi
 
     def document_type
       "worldwide_organisation"
+    end
+
+    def links
+      {
+        home_page_offices: [],
+        main_office: [],
+        office_staff: [],
+        primary_role_person: [],
+        roles: [],
+        secondary_role_person: [],
+        sponsoring_organisations: [],
+        world_locations: [],
+      }
     end
 
   private

--- a/app/presenters/publishing_api/worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/worldwide_organisation_presenter.rb
@@ -126,7 +126,7 @@ module PublishingApi
     def corporate_information_pages
       return [] unless item.corporate_information_pages.any?
 
-      item.corporate_information_pages.map(&:content_id)
+      item.corporate_information_pages.published.map(&:content_id)
     end
 
     def ordered_corporate_information_pages

--- a/app/presenters/publishing_api/worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/worldwide_organisation_presenter.rb
@@ -30,7 +30,9 @@ module PublishingApi
             crest: "single-identity",
             formatted_title: worldwide_organisation_logo_name(item),
           },
+          office_contact_associations:,
           ordered_corporate_information_pages:,
+          people_role_associations:,
           secondary_corporate_information_pages:,
           social_media_links:,
           world_location_names:,
@@ -47,15 +49,17 @@ module PublishingApi
 
     def edition_links
       {
+        contacts:,
         corporate_information_pages:,
         main_office:,
         home_page_offices:,
         primary_role_person:,
+        roles:,
+        role_appointments:,
         secondary_role_person:,
         office_staff:,
         sponsoring_organisations:,
         world_locations:,
-        roles:,
       }
     end
 
@@ -91,6 +95,10 @@ module PublishingApi
       end
     end
 
+    def contacts
+      [item.main_office&.contact&.content_id] + item.home_page_offices&.map(&:contact)&.map(&:content_id)
+    end
+
     def main_office
       return [] unless item.main_office
 
@@ -101,6 +109,17 @@ module PublishingApi
       return [] unless item.home_page_offices.any?
 
       item.home_page_offices.map(&:content_id)
+    end
+
+    def office_contact_associations
+      offices = [item.main_office] + item.home_page_offices
+
+      offices.compact.map do |office|
+        {
+          office_content_id: office.content_id,
+          contact_content_id: office.contact.content_id,
+        }
+      end
     end
 
     def primary_role_person
@@ -119,8 +138,27 @@ module PublishingApi
       item.office_staff_roles.map(&:current_person).map(&:content_id)
     end
 
+    def role_appointments
+      item.roles&.distinct&.map(&:current_role_appointment)&.compact&.map(&:content_id)
+    end
+
     def roles
       item.roles.distinct.pluck(:content_id)
+    end
+
+    def people_role_associations
+      people = [item.primary_role&.current_person] + [item.secondary_role&.current_person] + item.office_staff_roles.map(&:current_person)
+      people.compact.map do |person|
+        {
+          person_content_id: person.content_id,
+          role_appointments: person.role_appointments&.map do |role_appointment|
+            {
+              role_appointment_content_id: role_appointment.content_id,
+              role_content_id: role_appointment.role.content_id,
+            }
+          end,
+        }
+      end
     end
 
     def corporate_information_pages

--- a/app/presenters/publishing_api/worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/worldwide_organisation_presenter.rb
@@ -36,6 +36,7 @@ module PublishingApi
           world_location_names:,
         },
         document_type: item.class.name.underscore,
+        links: edition_links,
         public_updated_at: item.updated_at,
         rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
         schema_name: "worldwide_organisation",
@@ -44,7 +45,7 @@ module PublishingApi
       content.merge!(PayloadBuilder::AnalyticsIdentifier.for(item))
     end
 
-    def links
+    def edition_links
       {
         corporate_information_pages:,
         main_office:,
@@ -55,6 +56,20 @@ module PublishingApi
         sponsoring_organisations:,
         world_locations:,
         roles:,
+      }
+    end
+
+    def links
+      {
+        corporate_information_pages: [],
+        main_office: [],
+        home_page_offices: [],
+        primary_role_person: [],
+        secondary_role_person: [],
+        office_staff: [],
+        sponsoring_organisations: [],
+        world_locations: [],
+        roles: [],
       }
     end
 

--- a/test/unit/app/presenters/publishing_api/editionable_worldwide_organisation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/editionable_worldwide_organisation_presenter_test.rb
@@ -42,6 +42,32 @@ class PublishingApi::EditionableWorldwideOrganisationPresenterTest < ActiveSuppo
           crest: "single-identity",
           formatted_title: "Editionable<br/>worldwide<br/>organisation<br/>title",
         },
+        office_contact_associations: [
+          {
+            office_content_id: worldwide_org.reload.offices.first.content_id,
+            contact_content_id: worldwide_org.reload.offices.first.contact.content_id,
+          },
+        ],
+        people_role_associations: [
+          {
+            person_content_id: ambassador.content_id,
+            role_appointments: [
+              {
+                role_appointment_content_id: ambassador.roles.first.current_role_appointment.content_id,
+                role_content_id: ambassador.roles.first.current_role_appointment.role.content_id,
+              },
+            ],
+          },
+          {
+            person_content_id: deputy_head_of_mission.content_id,
+            role_appointments: [
+              {
+                role_appointment_content_id: deputy_head_of_mission.roles.first.current_role_appointment.content_id,
+                role_content_id: deputy_head_of_mission.roles.first.current_role_appointment.role.content_id,
+              },
+            ],
+          },
+        ],
         social_media_links: [
           {
             href: worldwide_org.social_media_accounts.first.url,
@@ -57,6 +83,9 @@ class PublishingApi::EditionableWorldwideOrganisationPresenterTest < ActiveSuppo
         ],
       },
       links: {
+        contacts: [
+          worldwide_org.reload.offices.first.contact.content_id,
+        ],
         main_office: [
           worldwide_org.reload.offices.first.content_id,
         ],
@@ -64,6 +93,9 @@ class PublishingApi::EditionableWorldwideOrganisationPresenterTest < ActiveSuppo
         office_staff: worldwide_org.office_staff_roles.map(&:current_person).map(&:content_id),
         primary_role_person: [
           ambassador.content_id,
+        ],
+        role_appointments: [
+          ambassador.roles.first.current_role_appointment.content_id, deputy_head_of_mission.roles.first.current_role_appointment.content_id
         ],
         roles: worldwide_org.roles.map(&:content_id),
         secondary_role_person: [

--- a/test/unit/app/presenters/publishing_api/editionable_worldwide_organisation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/editionable_worldwide_organisation_presenter_test.rb
@@ -56,25 +56,35 @@ class PublishingApi::EditionableWorldwideOrganisationPresenterTest < ActiveSuppo
           },
         ],
       },
+      links: {
+        main_office: [
+          worldwide_org.reload.offices.first.content_id,
+        ],
+        home_page_offices: [],
+        office_staff: worldwide_org.office_staff_roles.map(&:current_person).map(&:content_id),
+        primary_role_person: [
+          ambassador.content_id,
+        ],
+        roles: worldwide_org.roles.map(&:content_id),
+        secondary_role_person: [
+          deputy_head_of_mission.content_id,
+        ],
+        sponsoring_organisations: worldwide_org.organisations.map(&:content_id),
+        world_locations: worldwide_org.world_locations.map(&:content_id),
+      },
       analytics_identifier: "WO123",
       update_type: "major",
     }
 
     expected_links = {
-      main_office: [
-        worldwide_org.reload.offices.first.content_id,
-      ],
+      main_office: [],
       home_page_offices: [],
-      office_staff: worldwide_org.office_staff_roles.map(&:current_person).map(&:content_id),
-      primary_role_person: [
-        ambassador.content_id,
-      ],
-      roles: worldwide_org.roles.map(&:content_id),
-      secondary_role_person: [
-        deputy_head_of_mission.content_id,
-      ],
-      sponsoring_organisations: worldwide_org.organisations.map(&:content_id),
-      world_locations: worldwide_org.world_locations.map(&:content_id),
+      primary_role_person: [],
+      secondary_role_person: [],
+      office_staff: [],
+      sponsoring_organisations: [],
+      world_locations: [],
+      roles: [],
     }
 
     presented_item = present(worldwide_org)

--- a/test/unit/app/presenters/publishing_api/worldwide_organisation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/worldwide_organisation_presenter_test.rb
@@ -45,6 +45,12 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
           crest: "single-identity",
           formatted_title: "Locationia<br/>Embassy",
         },
+        office_contact_associations: [
+          {
+            office_content_id: worldwide_org.reload.offices.first.content_id,
+            contact_content_id: worldwide_org.reload.offices.first.contact.content_id,
+          },
+        ],
         ordered_corporate_information_pages: [
           {
             content_id: worldwide_org.corporate_information_pages[1].content_id,
@@ -53,6 +59,26 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
           {
             content_id: worldwide_org.corporate_information_pages[4].content_id,
             title: "Working for Locationia Embassy",
+          },
+        ],
+        people_role_associations: [
+          {
+            person_content_id: ambassador.content_id,
+            role_appointments: [
+              {
+                role_appointment_content_id: ambassador.roles.first.current_role_appointment.content_id,
+                role_content_id: ambassador.roles.first.current_role_appointment.role.content_id,
+              },
+            ],
+          },
+          {
+            person_content_id: deputy_head_of_mission.content_id,
+            role_appointments: [
+              {
+                role_appointment_content_id: deputy_head_of_mission.roles.first.current_role_appointment.content_id,
+                role_content_id: deputy_head_of_mission.roles.first.current_role_appointment.role.content_id,
+              },
+            ],
           },
         ],
         secondary_corporate_information_pages: "Read about the types of information we routinely publish in our <a class=\"govuk-link\" href=\"/world/organisations/locationia-embassy/about/publication-scheme\">Publication scheme</a>. Find out about our commitment to <a class=\"govuk-link\" href=\"/world/organisations/locationia-embassy/about/welsh-language-scheme\">publishing in Welsh</a>. Our <a class=\"govuk-link\" href=\"/world/organisations/locationia-embassy/about/personal-information-charter\">Personal information charter</a> explains how we treat your personal information.",
@@ -71,6 +97,9 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
         ],
       },
       links: {
+        contacts: [
+          worldwide_org.reload.offices.first.contact.content_id,
+        ],
         corporate_information_pages: [
           worldwide_org.corporate_information_pages[0].content_id,
           worldwide_org.corporate_information_pages[1].content_id,
@@ -98,6 +127,9 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
         ],
         roles: [
           ambassador.roles.first.content_id, deputy_head_of_mission.roles.first.content_id
+        ],
+        role_appointments: [
+          ambassador.roles.first.current_role_appointment.content_id, deputy_head_of_mission.roles.first.current_role_appointment.content_id
         ],
       },
       analytics_identifier: "WO123",

--- a/test/unit/app/presenters/publishing_api/worldwide_organisation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/worldwide_organisation_presenter_test.rb
@@ -70,39 +70,50 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
           },
         ],
       },
+      links: {
+        corporate_information_pages: [
+          worldwide_org.corporate_information_pages[0].content_id,
+          worldwide_org.corporate_information_pages[1].content_id,
+          worldwide_org.corporate_information_pages[2].content_id,
+          worldwide_org.corporate_information_pages[3].content_id,
+          worldwide_org.corporate_information_pages[4].content_id,
+          worldwide_org.corporate_information_pages[5].content_id,
+        ],
+        main_office: [
+          worldwide_org.reload.offices.first.content_id,
+        ],
+        home_page_offices: [],
+        primary_role_person: [
+          ambassador.content_id,
+        ],
+        secondary_role_person: [
+          deputy_head_of_mission.content_id,
+        ],
+        office_staff: worldwide_org.reload.office_staff_roles.map(&:current_person).map(&:content_id),
+        sponsoring_organisations: [
+          worldwide_org.sponsoring_organisations.first.content_id,
+        ],
+        world_locations: [
+          worldwide_org.world_locations.first.content_id,
+        ],
+        roles: [
+          ambassador.roles.first.content_id, deputy_head_of_mission.roles.first.content_id
+        ],
+      },
       analytics_identifier: "WO123",
       update_type: "major",
     }
 
     expected_links = {
-      corporate_information_pages: [
-        worldwide_org.corporate_information_pages[0].content_id,
-        worldwide_org.corporate_information_pages[1].content_id,
-        worldwide_org.corporate_information_pages[2].content_id,
-        worldwide_org.corporate_information_pages[3].content_id,
-        worldwide_org.corporate_information_pages[4].content_id,
-        worldwide_org.corporate_information_pages[5].content_id,
-      ],
-      main_office: [
-        worldwide_org.reload.offices.first.content_id,
-      ],
+      corporate_information_pages: [],
+      main_office: [],
       home_page_offices: [],
-      primary_role_person: [
-        ambassador.content_id,
-      ],
-      secondary_role_person: [
-        deputy_head_of_mission.content_id,
-      ],
-      office_staff: worldwide_org.reload.office_staff_roles.map(&:current_person).map(&:content_id),
-      sponsoring_organisations: [
-        worldwide_org.sponsoring_organisations.first.content_id,
-      ],
-      world_locations: [
-        worldwide_org.world_locations.first.content_id,
-      ],
-      roles: [
-        ambassador.roles.first.content_id, deputy_head_of_mission.roles.first.content_id
-      ],
+      primary_role_person: [],
+      secondary_role_person: [],
+      office_staff: [],
+      sponsoring_organisations: [],
+      world_locations: [],
+      roles: [],
     }
 
     presented_item = present(worldwide_org)


### PR DESCRIPTION
We are working to make Worldwide Organisation editionable.

Therefore we need to be able to link the links to editions, rather than documents, to prevent draft updates becoming live before publication.

There are multiple steps to deploying the switch to edition links:
1. merge https://github.com/alphagov/government-frontend/pull/3055
2. merge https://github.com/alphagov/publishing-api/pull/2601
3. merge this PR
4. republish all existing non-editionable worldwide organisations (this will introduce the edition links into the content items, and remove all the non-edtion links)
5. merge https://github.com/alphagov/government-frontend/pull/3057
6. raise a PR in Whitehall to remove the non-edition links from the presenter

Depends on https://github.com/alphagov/publishing-api/pull/2601.

[Trello card](https://trello.com/c/yNJwHw4K)