### PR TITLE
Republish roles when role appointments are changed

### DIFF
--- a/app/models/role_appointment.rb
+++ b/app/models/role_appointment.rb
@@ -73,8 +73,8 @@ class RoleAppointment < ApplicationRecord
   after_create :make_other_current_appointments_non_current
   before_destroy :prevent_destruction_unless_destroyable
 
-  after_save :republish_organisation_to_publishing_api, :republish_worldwide_organisations_to_publishing_api, :republish_prime_ministers_index_page_to_publishing_api, :republish_ministerial_pages_to_publishing_api
-  after_destroy :republish_organisation_to_publishing_api, :republish_worldwide_organisations_to_publishing_api, :republish_prime_ministers_index_page_to_publishing_api
+  after_save :republish_organisation_to_publishing_api, :republish_worldwide_organisations_to_publishing_api, :republish_prime_ministers_index_page_to_publishing_api, :republish_ministerial_pages_to_publishing_api, :republish_role_to_publishing_api
+  after_destroy :republish_organisation_to_publishing_api, :republish_worldwide_organisations_to_publishing_api, :republish_prime_ministers_index_page_to_publishing_api, :republish_role_to_publishing_api
 
   def republish_organisation_to_publishing_api
     organisations.each do |organisation|
@@ -97,6 +97,10 @@ class RoleAppointment < ApplicationRecord
 
   def republish_prime_ministers_index_page_to_publishing_api
     PresentPageToPublishingApiWorker.perform_async("PublishingApi::HistoricalAccountsIndexPresenter") unless current? || role.slug != "prime-minister" || has_historical_account?
+  end
+
+  def republish_role_to_publishing_api
+    Whitehall::PublishingApi.republish_async(role)
   end
 
   def self.between(start_time, end_time)

--- a/test/factories/roles.rb
+++ b/test/factories/roles.rb
@@ -10,9 +10,9 @@ FactoryBot.define do
     role_type { "minister" }
   end
 
-  factory :non_ministerial_role_without_organisations, class: Role, traits: [:translated] do
+  factory :non_ministerial_role_without_organisations, class: BoardMemberRole, traits: [:translated] do
     sequence(:name) { |index| "role-name-#{index}" }
-    type { "permanent_secretary" }
+    role_type { "permanent_secretary" }
   end
 
   trait :occupied do

--- a/test/functional/admin/people_controller_test.rb
+++ b/test/functional/admin/people_controller_test.rb
@@ -349,6 +349,10 @@ class Admin::PeopleControllerTest < ActionController::TestCase
     Whitehall::PublishingApi.expects(:republish_async).with(role_appointment2.organisations.first)
     Whitehall::PublishingApi.expects(:republish_async).with(role_appointment4.organisations.first)
     Whitehall::PublishingApi.expects(:republish_async).with(role_appointment5.organisations.first)
+    Whitehall::PublishingApi.expects(:republish_async).with(role_appointment1.role)
+    Whitehall::PublishingApi.expects(:republish_async).with(role_appointment2.role)
+    Whitehall::PublishingApi.expects(:republish_async).with(role_appointment4.role)
+    Whitehall::PublishingApi.expects(:republish_async).with(role_appointment5.role)
 
     put :update_order_role_appointments, params: {
       id: person.id,

--- a/test/unit/app/models/role_appointment_test.rb
+++ b/test/unit/app/models/role_appointment_test.rb
@@ -532,6 +532,7 @@ class RoleAppointmentTest < ActiveSupport::TestCase
     create(:worldwide_organisation_role, role:, worldwide_organisation:)
 
     Whitehall::PublishingApi.expects(:republish_async).with(worldwide_organisation)
+    Whitehall::PublishingApi.expects(:republish_async).with(role)
 
     create(:role_appointment, role:)
   end
@@ -543,6 +544,7 @@ class RoleAppointmentTest < ActiveSupport::TestCase
     role_appointment = create(:role_appointment, role:)
 
     Whitehall::PublishingApi.expects(:republish_async).with(worldwide_organisation)
+    Whitehall::PublishingApi.expects(:republish_async).with(role)
 
     role_appointment.update!(ended_at: Time.zone.now)
   end
@@ -554,7 +556,28 @@ class RoleAppointmentTest < ActiveSupport::TestCase
     role_appointment = create(:role_appointment, role:)
 
     Whitehall::PublishingApi.expects(:republish_async).with(worldwide_organisation)
+    Whitehall::PublishingApi.expects(:republish_async).with(role)
 
+    role_appointment.destroy!
+  end
+
+  test "republishes a role when a role appointment is created" do
+    role = create(:role_without_organisations)
+    Whitehall::PublishingApi.expects(:republish_async).with(role)
+    create(:role_appointment, role:)
+  end
+
+  test "republishes a role when a role appointment is updated" do
+    role = create(:role_without_organisations)
+    role_appointment = create(:role_appointment, role:)
+    Whitehall::PublishingApi.expects(:republish_async).with(role)
+    role_appointment.update!(ended_at: Time.zone.now)
+  end
+
+  test "republishes a role when a role appointment is destroyed" do
+    role = create(:role_without_organisations)
+    role_appointment = create(:role_appointment, role:)
+    Whitehall::PublishingApi.expects(:republish_async).with(role)
     role_appointment.destroy!
   end
 end


### PR DESCRIPTION
When creating new roles, appointing a new Role Appointment without first clicking save on the Role resulted in the person appearing on the Organisation page without their Role Title. We are making this change so it will automatically save the Role when new Role Appointments are created or edited.
Additionally uncovered a small issue in Role factory where data wasn't correctly setup, which was previously never called upon.

[Trello card](https://trello.com/c/eC3PwJJa/2292-issue-with-titles-on-organisation-page)

(⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.)
