### PR TITLE
Add custom error messages for operational fields

### DIFF
--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -11,3 +11,9 @@ en:
               invalid_date: First published date is not in the correct format
               blank: Enter a first published date
               inclusion: First published date must be between 1/1/1900 and the present
+        operational_field:
+          attributes:
+            name:
+              format: "%{message}"
+              blank: Enter a name
+              taken: Name has already been taken


### PR DESCRIPTION
## Description

We’ve added the ability to add custom error messages in this PR https://github.com/alphagov/whitehall/pull/8361

There’s a lot of guidance on error messages in the [GOV.UK](http://gov.uk/) Design System documentation https://design-system.service.gov.uk/components/error-message/

This updates the operation fields section to use custom error messages

## Screenshot of change

<img width="559" alt="image" src="https://github.com/alphagov/whitehall/assets/42515961/dcae7310-5622-43ee-9880-20e5792e6fb9">

## Spreadsheet tracking changes 

https://docs.google.com/spreadsheets/d/14ddw64VusBCWlP54BqWpukAqUkBnRWktAwjff4RKKRQ/edit#gid=0

## Trello card

https://trello.com/c/vBwGvHCa/2318-custom-error-messages

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
