### PR TITLE
Inline the updating of asset redirects

### DIFF
--- a/app/services/asset_manager/attachment_updater.rb
+++ b/app/services/asset_manager/attachment_updater.rb
@@ -27,12 +27,4 @@ class AssetManager::AttachmentUpdater
       AssetManager::AssetUpdater.call(asset.asset_manager_id, { "replacement_id" => replacement_id })
     end
   end
-
-  def self.redirect(attachment_data)
-    return if attachment_data.deleted?
-
-    attachment_data.assets.each do |asset|
-      AssetManager::AssetUpdater.call(asset.asset_manager_id, { "redirect_url" => attachment_data.redirect_url })
-    end
-  end
 end

--- a/app/workers/asset_manager_attachment_redirect_url_update_worker.rb
+++ b/app/workers/asset_manager_attachment_redirect_url_update_worker.rb
@@ -3,8 +3,10 @@ class AssetManagerAttachmentRedirectUrlUpdateWorker < WorkerBase
 
   def perform(attachment_data_id)
     attachment_data = AttachmentData.find_by(id: attachment_data_id)
-    return if attachment_data.blank?
+    return if attachment_data.blank? || attachment_data.deleted?
 
-    AssetManager::AttachmentUpdater.redirect(attachment_data)
+    attachment_data.assets.each do |asset|
+      AssetManager::AssetUpdater.call(asset.asset_manager_id, { "redirect_url" => attachment_data.redirect_url })
+    end
   end
 end

--- a/test/unit/app/services/asset_manager/attachment_updater_test.rb
+++ b/test/unit/app/services/asset_manager/attachment_updater_test.rb
@@ -197,22 +197,5 @@ class AssetManager::AttachmentUpdaterTest < ActiveSupport::TestCase
         end
       end
     end
-
-    context "when the attachment's attachable is unpublished" do
-      it "updates redirect URL for all assets" do
-        edition = create(:unpublished_edition)
-        attachment = create(:file_attachment, attachable: edition)
-
-        expected_attribute_hash = {
-          "redirect_url" => edition.unpublishing.document_url,
-        }
-
-        attachment.attachment_data.assets.each do |asset|
-          AssetManager::AssetUpdater.expects(:call).with(asset.asset_manager_id, expected_attribute_hash)
-        end
-
-        AssetManager::AttachmentUpdater.redirect(attachment.attachment_data)
-      end
-    end
   end
 end


### PR DESCRIPTION
### What

This PR inlines the code for updating the redirect_url for each asset to make it easier to follow rather than having to read multiple files.

Previously the AttachmentUpdater was responsible for updating the redirect URL for each asset, but the abstraction wasn't providing much value.

### Why

I was trying to look into https://govuk.sentry.io/issues/4725413878/events/00f57c264fcf41b0ac7225047e56ef76/ and finding it difficult to follow the code. Reducing the depth of the stack by one level helps make it a bit easier to understand what it going on.