### PR TITLE
Editionable worldwide organisation corporate information pages

### DIFF
--- a/app/controllers/admin/corporate_information_pages_controller.rb
+++ b/app/controllers/admin/corporate_information_pages_controller.rb
@@ -38,8 +38,13 @@ private
     @organisation =
       if params.key?(:organisation_id)
         Organisation.friendly.find(params[:organisation_id])
-      elsif params.key?(:worldwide_organisation_id)
-        WorldwideOrganisation.friendly.find(params[:worldwide_organisation_id])
+      elsif params.key?(:worldwide_organisation_id) || params.key?(:editionable_worldwide_organisation_id)
+        id = params[:worldwide_organisation_id] || params[:editionable_worldwide_organisation_id]
+        if Flipflop.editionable_worldwide_organisations?
+          EditionableWorldwideOrganisation.find(id)
+        else
+          WorldwideOrganisation.friendly.find(params[:worldwide_organisation_id])
+        end
       else
         raise ActiveRecord::RecordNotFound
       end

--- a/app/controllers/admin/corporate_information_pages_controller.rb
+++ b/app/controllers/admin/corporate_information_pages_controller.rb
@@ -16,9 +16,14 @@ class Admin::CorporateInformationPagesController < Admin::EditionsController
     # stash it before the page is destroyed, as the join model between the page
     # and the organisation will no longer exist afterwards.
     title = @edition.title
+    redirect = if @organisation.is_a?(EditionableWorldwideOrganisation)
+                 admin_editionable_worldwide_organisation_path(@organisation)
+               else
+                 [:admin, @organisation, CorporateInformationPage]
+               end
     edition_deleter = Whitehall.edition_services.deleter(@edition)
     if edition_deleter.perform!
-      redirect_to [:admin, @organisation, CorporateInformationPage], notice: "The document '#{title}' has been deleted"
+      redirect_to redirect, notice: "The document '#{title}' has been deleted"
     else
       redirect_to admin_edition_path(@edition), alert: edition_deleter.failure_reason
     end

--- a/app/controllers/admin/editionable_worldwide_organisations_controller.rb
+++ b/app/controllers/admin/editionable_worldwide_organisations_controller.rb
@@ -1,4 +1,14 @@
 class Admin::EditionableWorldwideOrganisationsController < Admin::EditionsController
+  FakeEditionFilter = Struct.new(:editions, :page_title, :show_stats, :hide_type)
+
+  def show
+    super
+
+    params[:state] = "active" # Ensure that state column is displayed.
+    @paginator = @edition.corporate_information_pages.where("state != ?", "superseded").order("corporate_information_page_type_id").page(params["page"].to_i || 1).per(100)
+    @filter = FakeEditionFilter.new @paginator, "Corporate information pages", false, true
+  end
+
 private
 
   def edition_class

--- a/app/controllers/admin/editionable_worldwide_organisations_controller.rb
+++ b/app/controllers/admin/editionable_worldwide_organisations_controller.rb
@@ -1,12 +1,11 @@
 class Admin::EditionableWorldwideOrganisationsController < Admin::EditionsController
-  FakeEditionFilter = Struct.new(:editions, :page_title, :show_stats, :hide_type)
+  FakeEditionFilter = Struct.new(:editions)
 
   def show
     super
 
-    params[:state] = "active" # Ensure that state column is displayed.
-    @paginator = @edition.corporate_information_pages.where("state != ?", "superseded").order("corporate_information_page_type_id").page(params["page"].to_i || 1).per(100)
-    @filter = FakeEditionFilter.new @paginator, "Corporate information pages", false, true
+    editions = @edition.corporate_information_pages.where("state != ?", "superseded").order("corporate_information_page_type_id")
+    @filter = FakeEditionFilter.new editions
   end
 
 private

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -95,7 +95,7 @@ module ApplicationHelper
   end
 
   def corporate_information_page_types(organisation)
-    CorporateInformationPageType.all.map { |c| [c.title(organisation), c.id] }
+    CorporateInformationPageType.for(organisation).map { |c| [c.title(organisation), c.id] }
   end
 
   def is_external?(href)

--- a/app/models/concerns/attachable.rb
+++ b/app/models/concerns/attachable.rb
@@ -176,7 +176,7 @@ module Attachable
     max ? max + 1 : 0
   end
 
-  def delete_all_attachments
+  def finalise_delete
     attachments.each(&:destroy)
   end
 

--- a/app/models/corporate_information_page.rb
+++ b/app/models/corporate_information_page.rb
@@ -149,7 +149,7 @@ class CorporateInformationPage < Edition
   end
 
   def title_prefix_organisation_name
-    [owning_organisation.name, title].join(" \u2013 ")
+    [owning_organisation.title, title].join(" \u2013 ")
   end
 
   def title(_locale = :en)

--- a/app/models/corporate_information_page.rb
+++ b/app/models/corporate_information_page.rb
@@ -17,6 +17,7 @@ class CorporateInformationPage < Edition
   validate :unique_organisation_and_page_type, on: :create, if: :organisation
   validate :unique_worldwide_organisation_and_page_type, on: :create, if: :worldwide_organisation
   validate :unique_editionable_worldwide_organisation_and_page_type, on: :create, if: :editionable_worldwide_organisation
+  validate :owning_organisation_has_published_edition, on: :publish, if: :editionable_worldwide_organisation
 
   add_trait do
     def process_associations_before_save(new_edition)
@@ -273,6 +274,12 @@ private
 
     if duplicate_scope.exists?
       errors.add(:base, "Another '#{display_type_key.humanize}' page was already published for this worldwide organisation")
+    end
+  end
+
+  def owning_organisation_has_published_edition
+    if owning_organisation.document.live_edition.blank?
+      errors.add(:base, "The owning organisation must be published before the corporate information page can be published")
     end
   end
 end

--- a/app/models/corporate_information_page.rb
+++ b/app/models/corporate_information_page.rb
@@ -10,6 +10,8 @@ class CorporateInformationPage < Edition
   has_one :organisation, -> { includes(:translations) }, through: :edition_organisation, autosave: false
   has_one :edition_worldwide_organisation, foreign_key: :edition_id, inverse_of: :edition, dependent: :destroy
   has_one :worldwide_organisation, through: :edition_worldwide_organisation, autosave: false
+  has_one :document_corporate_information_page, foreign_key: :edition_id, inverse_of: :corporate_information_page, dependent: :destroy
+  has_one :owning_organisation_document, through: :document_corporate_information_page, autosave: false
 
   delegate :slug, :display_type_key, to: :corporate_information_page_type
   validate :unique_organisation_and_page_type, on: :create, if: :organisation

--- a/app/models/corporate_information_page_type.rb
+++ b/app/models/corporate_information_page_type.rb
@@ -8,6 +8,12 @@ class CorporateInformationPageType
     all.detect { |type| type.slug == slug } || raise(ActiveRecord::RecordNotFound)
   end
 
+  def self.for(organisation)
+    return all.reject { |page| page.slug == "about" } if organisation.is_a?(EditionableWorldwideOrganisation)
+
+    all
+  end
+
   def key
     # RegisterableEdition expects model_name_type instances to have a `key`
     # attribute: Publication and WorldLocation for example define this to have

--- a/app/models/corporate_information_page_type.rb
+++ b/app/models/corporate_information_page_type.rb
@@ -107,7 +107,7 @@ private
     if organisation.respond_to?(:acronym) && organisation.acronym.present?
       organisation.acronym
     else
-      organisation.try(:name).to_s
+      organisation.try(:title).to_s
     end
   end
 end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -33,6 +33,8 @@ class Document < ApplicationRecord
   has_many :document_collection_groups, through: :document_collection_group_memberships
   has_many :document_collections, through: :document_collection_groups
   has_many :features, inverse_of: :document, dependent: :destroy
+  has_many :document_corporate_information_pages, foreign_key: :owning_document_id
+  has_many :corporate_information_pages, through: :document_corporate_information_pages, class_name: "CorporateInformationPage"
 
   has_many :edition_versions, through: :editions, source: :versions
   has_many :editorial_remarks, through: :editions

--- a/app/models/document_corporate_information_page.rb
+++ b/app/models/document_corporate_information_page.rb
@@ -1,0 +1,6 @@
+class DocumentCorporateInformationPage < ApplicationRecord
+  belongs_to :corporate_information_page, foreign_key: :edition_id, class_name: "Edition"
+  belongs_to :owning_organisation_document, inverse_of: :document_corporate_information_pages, foreign_key: :owning_document_id, class_name: "Document"
+
+  validates :corporate_information_page, :owning_organisation_document, presence: true
+end

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -451,6 +451,10 @@ EXISTS (
     false
   end
 
+  def has_corporate_information_pages?
+    false
+  end
+
   def is_associated_with_a_minister?
     false
   end
@@ -557,6 +561,10 @@ EXISTS (
 
   def is_latest_edition?
     document.latest_edition == self
+  end
+
+  def is_live_edition?
+    document.live_edition == self
   end
 
   def all_nation_applicability_selected?

--- a/app/models/edition/corporate_information_pages.rb
+++ b/app/models/edition/corporate_information_pages.rb
@@ -5,6 +5,10 @@ module Edition::CorporateInformationPages
     delegate :corporate_information_pages, to: :document
   end
 
+  def finalise_delete
+    corporate_information_pages.each { |e| Whitehall.edition_services.deleter(e).perform! } if other_editions.empty?
+  end
+
   def build_corporate_information_page(params)
     CorporateInformationPage.new(params.merge("owning_organisation_document" => document))
   end

--- a/app/models/edition/corporate_information_pages.rb
+++ b/app/models/edition/corporate_information_pages.rb
@@ -1,0 +1,15 @@
+module Edition::CorporateInformationPages
+  extend ActiveSupport::Concern
+
+  included do
+    delegate :corporate_information_pages, to: :document
+  end
+
+  def build_corporate_information_page(params)
+    CorporateInformationPage.new(params.merge("owning_organisation_document" => document))
+  end
+
+  def unused_corporate_information_page_types
+    CorporateInformationPageType.for(self) - corporate_information_pages.map(&:corporate_information_page_type)
+  end
+end

--- a/app/models/editionable_worldwide_organisation.rb
+++ b/app/models/editionable_worldwide_organisation.rb
@@ -7,6 +7,7 @@ class EditionableWorldwideOrganisation < Edition
   include Edition::Organisations
   include Edition::Roles
   include Edition::WorldLocations
+  include Edition::CorporateInformationPages
 
   has_many :offices, class_name: "WorldwideOffice", foreign_key: :edition_id, dependent: :destroy
   belongs_to :main_office, class_name: "WorldwideOffice"

--- a/app/models/editionable_worldwide_organisation.rb
+++ b/app/models/editionable_worldwide_organisation.rb
@@ -63,6 +63,10 @@ class EditionableWorldwideOrganisation < Edition
     roles.occupied.find_by(type: PRIMARY_ROLES.map(&:name))
   end
 
+  def has_corporate_information_pages?
+    true
+  end
+
   def publishing_api_presenter
     PublishingApi::EditionableWorldwideOrganisationPresenter
   end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -225,6 +225,8 @@ class Organisation < ApplicationRecord
     end
   end
 
+  alias_method :title, :name
+
   def republish_how_government_works_page_to_publishing_api
     PresentPageToPublishingApiWorker.perform_async("PublishingApi::HowGovernmentWorksPresenter")
   end

--- a/app/presenters/publishing_api/worldwide_corporate_information_page_presenter.rb
+++ b/app/presenters/publishing_api/worldwide_corporate_information_page_presenter.rb
@@ -29,8 +29,8 @@ module PublishingApi
 
     def links
       {
-        parent: [item.worldwide_organisation.content_id],
-        worldwide_organisation: [item.worldwide_organisation.content_id],
+        parent: [item.owning_organisation.content_id],
+        worldwide_organisation: [item.owning_organisation.content_id],
       }
     end
   end

--- a/app/services/edition_deleter.rb
+++ b/app/services/edition_deleter.rb
@@ -26,6 +26,6 @@ private
     edition.public_send(verb)
     edition.save!(validate: false)
     edition.clear_slug
-    edition.delete_all_attachments if edition.respond_to?(:delete_all_attachments)
+    edition.finalise_delete if edition.respond_to?(:finalise_delete)
   end
 end

--- a/app/views/admin/corporate_information_pages/index.html.erb
+++ b/app/views/admin/corporate_information_pages/index.html.erb
@@ -3,9 +3,9 @@
     href: [:admin, @organisation.class],
   } %>
 <% end %>
-<% content_for :page_title, @organisation.name %>
+<% content_for :page_title, @organisation.title %>
 <% content_for :context, organisation_context_block(current_user, @organisation) %>
-<% content_for :title, @organisation.name %>
+<% content_for :title, @organisation.title %>
 <% content_for :title_margin_bottom, 4 %>
 
 <p class="govuk-body"><%= view_on_website_link_for @organisation, class: "govuk-link" %></p>

--- a/app/views/admin/corporate_information_pages/new.html.erb
+++ b/app/views/admin/corporate_information_pages/new.html.erb
@@ -1,5 +1,5 @@
-<% content_for :page_title, "New corporate information page for #{@organisation.name}" %>
-<% content_for :title, sanitize("Add new corporate information page to #{link_to(@organisation.name, [:admin, @organisation], class: 'govuk-link')}") %>
+<% content_for :page_title, "New corporate information page for #{@organisation.title}" %>
+<% content_for :title, sanitize("Add new corporate information page to #{link_to(@organisation.title, [:admin, @organisation], class: 'govuk-link')}") %>
 <% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @edition, parent_class: "edition")) %>
 
 <div class="govuk-grid-row">

--- a/app/views/admin/editions/_search_results.html.erb
+++ b/app/views/admin/editions/_search_results.html.erb
@@ -9,44 +9,7 @@
 <% if filter.editions.blank? %>
   <p class="govuk-body app-view-edition-search-results__no_documents">No documents found</p>
 <% else %>
-  <div class="govuk-table--with-actions">
-    <%= render "govuk_publishing_components/components/table", {
-      head: [
-        {
-          text: "Title",
-        },
-        {
-          text: "Updated by",
-        },
-        {
-          text: "State",
-        },
-        {
-          text: tag.span("View", class: "govuk-visually-hidden"),
-        },
-      ],
-      rows:
-        filter.editions.map do |edition|
-          [
-            {
-              text: tag.span(index_table_title_row(edition), class: "govuk-!-font-weight-bold"),
-            },
-            {
-              text: tag.p("#{time_ago_in_words edition.updated_at} ago", class: "govuk-!-margin-0") +
-                "by " +
-                linked_author(edition.last_author, class: "govuk-link"),
-            },
-            {
-              text: render(Admin::Editions::TagsComponent.new(edition)),
-            },
-            {
-              text: search_results_table_actions(edition),
-            },
-          ]
-        end,
-      first_cell_is_header: true,
-    } %>
-  </div>
+  <%= render "admin/editions/search_results_table", filter: @filter %>
 
   <% if paginate(paginator, theme: "govuk_paginator").present? && show_export && can?(:export, Edition) %>
     <div class="govuk-grid-row">

--- a/app/views/admin/editions/_search_results_table.html.erb
+++ b/app/views/admin/editions/_search_results_table.html.erb
@@ -1,0 +1,38 @@
+<div class="govuk-table--with-actions">
+  <%= render "govuk_publishing_components/components/table", {
+    head: [
+      {
+        text: "Title",
+      },
+      {
+        text: "Updated by",
+      },
+      {
+        text: "State",
+      },
+      {
+        text: tag.span("View", class: "govuk-visually-hidden"),
+      },
+    ],
+    rows:
+      filter.editions.map do |edition|
+        [
+          {
+            text: tag.span(index_table_title_row(edition), class: "govuk-!-font-weight-bold"),
+          },
+          {
+            text: tag.p("#{time_ago_in_words edition.updated_at} ago", class: "govuk-!-margin-0") +
+              "by " +
+              linked_author(edition.last_author, class: "govuk-link"),
+          },
+          {
+            text: render(Admin::Editions::TagsComponent.new(edition)),
+          },
+          {
+            text: search_results_table_actions(edition),
+          },
+        ]
+      end,
+    first_cell_is_header: true,
+  } %>
+</div>

--- a/app/views/admin/editions/show/_main.html.erb
+++ b/app/views/admin/editions/show/_main.html.erb
@@ -158,6 +158,27 @@
     </section>
   <% end %>
 
+  <% if @edition.has_corporate_information_pages? %>
+    <section class="app-view-summary__section app-view-summary__section--corporate-information-pages">
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "Corporate information pages",
+        heading_level: 2,
+        font_size: "l",
+        margin_bottom: 3,
+      } %>
+
+      <% if @edition.unused_corporate_information_page_types.any? %>
+        <p class="govuk-body">
+          <%= link_to("Add corporate information page",
+                      new_admin_editionable_worldwide_organisation_corporate_information_page_path(@edition.id),
+                      class: "govuk-link") %>
+        </p>
+      <% end %>
+
+      <%= render "admin/editions/search_results", filter: @filter, paginator: @paginator, show_export: false %>
+    </section>
+  <% end %>
+
   <% if @edition.allows_image_attachments? %>
     <section class="app-view-summary__section app-view-summary__section--attachments">
       <%= render "govuk_publishing_components/components/heading", {

--- a/app/views/admin/editions/show/_main.html.erb
+++ b/app/views/admin/editions/show/_main.html.erb
@@ -174,8 +174,11 @@
                       class: "govuk-link") %>
         </p>
       <% end %>
-
-      <%= render "admin/editions/search_results", filter: @filter, paginator: @paginator, show_export: false %>
+      <% if @edition.corporate_information_pages.any? %>
+        <%= render "admin/editions/search_results_table", filter: @filter %>
+      <% else %>
+        <p class="govuk-body">No corporate information pages for this document</p>
+      <% end %>
     </section>
   <% end %>
 

--- a/app/views/admin/editions/show/_main.html.erb
+++ b/app/views/admin/editions/show/_main.html.erb
@@ -10,7 +10,7 @@
           { field: "Type of document", value: edition_type(@edition) },
           { field: "Status", value: status_text(@edition) },
           { field: "Change type", value: @edition.minor_change? ? "Minor" : "Major" },
-          *([{ field: "Organisations", value: joined_list(@edition.organisations.map { |o| o.name }) }] if @edition.respond_to?(:organisations)),
+          *([{ field: "Organisations", value: joined_list(@edition.organisations.map { |o| o.title }) }] if @edition.respond_to?(:organisations)),
           {
             field: "Review date",
             value: @edition.document.review_reminder.present? ? @edition.document.review_reminder.review_at.strftime("%-d %B %Y") : "Not set",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -287,7 +287,9 @@ Whitehall::Application.routes.draw do
 
       resources :speeches, except: [:index]
       resources :statistical_data_sets, path: "statistical-data-sets", except: [:index]
-      resources :editionable_worldwide_organisations, path: "editionable-worldwide-organisations", except: [:index]
+      resources :editionable_worldwide_organisations, path: "editionable-worldwide-organisations", except: [:index] do
+        resources :corporate_information_pages, controller: "corporate_information_pages", except: [:index]
+      end
       resources :detailed_guides, path: "detailed-guides", except: [:index]
       resources :people do
         resources :translations, controller: "person_translations" do

--- a/db/migrate/20240104165452_add_document_corporate_information_pages.rb
+++ b/db/migrate/20240104165452_add_document_corporate_information_pages.rb
@@ -1,0 +1,12 @@
+class AddDocumentCorporateInformationPages < ActiveRecord::Migration[7.1]
+  def change
+    create_table :document_corporate_information_pages do |t|
+      t.integer :owning_document_id
+      t.integer :edition_id
+      t.timestamps
+
+      t.index :owning_document_id, name: "index_document_corporate_information_pages_on_owning_document_id"
+      t.index :edition_id, name: "index_document_corporate_information_pages_on_edition_id"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_03_112519) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_04_165452) do
   create_table "assets", charset: "utf8mb3", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.string "variant", null: false
@@ -226,6 +226,15 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_03_112519) do
     t.string "publishing_app", null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
+  end
+
+  create_table "document_corporate_information_pages", charset: "utf8mb3", force: :cascade do |t|
+    t.integer "owning_document_id"
+    t.integer "edition_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["edition_id"], name: "index_document_corporate_information_pages_on_edition_id"
+    t.index ["owning_document_id"], name: "idx_on_owning_document_id_cdb159144b"
   end
 
   create_table "documents", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|

--- a/features/editionable-worldwide-organisations.feature
+++ b/features/editionable-worldwide-organisations.feature
@@ -1,6 +1,6 @@
 Feature: Editionable worldwide organisations
   Background:
-    Given I am a writer
+    Given I am a GDS editor
     And The editionable worldwide organisations feature flag is enabled
     And a world location "United Kingdom" exists
 
@@ -67,3 +67,35 @@ Feature: Editionable worldwide organisations
     When I reorder the offices
     And I visit the reorder offices page
     Then I should see that the list of offices are ordered "Home page office 2" then "Home page office 1"
+
+  Scenario: Adding a corporate information page to a worldwide organisation
+    Given an editionable worldwide organisation "Test Worldwide Organisation"
+    When I add a "Terms of reference" corporate information page to the editionable worldwide organisation
+    Then I should see the corporate information on the editionable worldwide organisation document page
+    And I should see the corporate information page "Terms of reference" in the list of "draft" documents
+    When I force-publish the "Terms of reference" corporate information page for the editionable worldwide organisation "Test Worldwide Organisation"
+    Then I should see the corporate information on the editionable worldwide organisation document page
+    And I should see the corporate information page "Terms of reference" in the list of "published" documents
+    When I create a new draft of the "Terms of reference" corporate information page for the worldwide organisation "Test Worldwide Organisation"
+    Then I should see the corporate information page "Terms of reference" in the list of "draft" documents
+
+  Scenario: Deleting a corporate information page from a worldwide organisation
+    Given an editionable worldwide organisation "Test Worldwide Organisation"
+    When I add a "Terms of reference" corporate information page to the editionable worldwide organisation
+    And I delete the draft "Terms of reference" corporate information page for the editionable worldwide organisation "Test Worldwide Organisation"
+    Then I should not see the corporate information page "Terms of reference" in the list of "draft" documents
+
+  Scenario: Deleting a draft worldwide organisation that has not been published
+    Given an editionable worldwide organisation "Test Worldwide Organisation"
+    When I add a "Terms of reference" corporate information page to the editionable worldwide organisation
+    And I delete the draft "Test Worldwide Organisation" worldwide organisation
+    Then I should not see the editionable worldwide organisation "Test Worldwide Organisation" in the list of "draft" documents
+    And I should not see the corporate information page "Terms of reference" in the list of "draft" documents
+
+  Scenario: Deleting a draft worldwide organisation that was previously published
+    Given a published editionable worldwide organisation "Test Worldwide Organisation"
+    When I create a new draft for the "Test Worldwide Organisation" editionable worldwide organisation
+    When I add a "Terms of reference" corporate information page to the editionable worldwide organisation
+    And I delete the draft "Test Worldwide Organisation" worldwide organisation
+    And I visit the list of draft documents
+    And I should see the corporate information page "Terms of reference" in the list of "draft" documents

--- a/features/editionable-worldwide-organisations.feature
+++ b/features/editionable-worldwide-organisations.feature
@@ -69,7 +69,7 @@ Feature: Editionable worldwide organisations
     Then I should see that the list of offices are ordered "Home page office 2" then "Home page office 1"
 
   Scenario: Adding a corporate information page to a worldwide organisation
-    Given an editionable worldwide organisation "Test Worldwide Organisation"
+    Given a published editionable worldwide organisation "Test Worldwide Organisation"
     When I add a "Terms of reference" corporate information page to the editionable worldwide organisation
     Then I should see the corporate information on the editionable worldwide organisation document page
     And I should see the corporate information page "Terms of reference" in the list of "draft" documents

--- a/features/step_definitions/corporate_information_page_steps.rb
+++ b/features/step_definitions/corporate_information_page_steps.rb
@@ -66,7 +66,7 @@ When(/^I delete the draft "([^"]*)" corporate information page for the editionab
   click_link "Delete draft"
   click_button "Delete"
 
-  expect(page).to have_current_path(admin_editionable_worldwide_organisation_corporate_information_pages_path(organisation))
+  expect(page).to have_current_path(admin_editionable_worldwide_organisation_path(organisation))
   expect(page).to have_content("The document '#{page_type}' has been deleted")
 end
 

--- a/features/step_definitions/corporate_information_page_steps.rb
+++ b/features/step_definitions/corporate_information_page_steps.rb
@@ -30,6 +30,7 @@ end
 When(/^I add a "([^"]*)" corporate information page to the editionable worldwide organisation$/) do |page_type|
   worldwide_organisation = EditionableWorldwideOrganisation.last
   visit admin_editionable_worldwide_organisation_path(worldwide_organisation)
+  expect(page).to have_content("No corporate information pages for this document")
   click_link "Add corporate information page"
   fill_in "Body", with: "This is a new #{page_type} page"
   select page_type, from: "Type"
@@ -105,6 +106,7 @@ Then(/^I should see the corporate information on the editionable worldwide organ
   visit admin_editionable_worldwide_organisation_path(worldwide_organisation)
 
   corporate_information_page = worldwide_organisation.corporate_information_pages.last
+  expect(page).to_not have_content("No corporate information pages for this document")
   expect(page).to have_content(corporate_information_page.title)
 
   click_link corporate_information_page.title

--- a/features/step_definitions/document_steps.rb
+++ b/features/step_definitions/document_steps.rb
@@ -65,6 +65,10 @@ When(/^I visit the list of documents awaiting review$/) do
   visit admin_editions_path(state: :submitted)
 end
 
+When(/^I visit the list of published documents$/) do
+  visit admin_editions_path(state: :published)
+end
+
 When(/^I select the "([^"]*)" edition filter$/) do |edition_type|
   filter_editions_by :type, edition_type
 end

--- a/features/step_definitions/editionable_worldwide_organisation_steps.rb
+++ b/features/step_definitions/editionable_worldwide_organisation_steps.rb
@@ -8,6 +8,11 @@ Given(/^an editionable worldwide organisation "([^"]*)"$/) do |title|
   worldwide_organisation.main_office = create(:worldwide_office, worldwide_organisation: nil, edition: worldwide_organisation, title: "Main office for #{title}")
 end
 
+Given(/^a published editionable worldwide organisation "([^"]*)"$/) do |title|
+  worldwide_organisation = create(:editionable_worldwide_organisation, :published, title:)
+  worldwide_organisation.main_office = create(:worldwide_office, worldwide_organisation: nil, edition: worldwide_organisation, title: "Main office for #{title}")
+end
+
 Given(/^an editionable worldwide organisation "([^"]*)" with offices "([^"]*)" and "([^"]*)"$/) do |title, contact_1_title, contact_2_title|
   worldwide_organisation = create(:editionable_worldwide_organisation, title:)
   worldwide_organisation.add_office_to_home_page!(create(:worldwide_office, worldwide_organisation: nil, edition: worldwide_organisation, contact: create(:contact, title: contact_1_title)))
@@ -30,6 +35,30 @@ When(/^I choose "([^"]*)" to be the main office for the editionable worldwide or
   click_link "Set main office"
   choose contact_title
   click_button "Save"
+end
+
+When(/^I create a new draft for the "([^"]*)" editionable worldwide organisation/) do |title|
+  worldwide_organisation = EditionableWorldwideOrganisation.find_by(title:)
+  visit admin_editionable_worldwide_organisation_path(worldwide_organisation)
+  click_button "Create new edition"
+end
+
+When(/^I create a new draft for the "([^"]*)" corporate information page/) do |_title|
+  corporate_information_page = CorporateInformationPage.last
+  worldwide_organisation = EditionableWorldwideOrganisation.last
+  visit admin_editionable_worldwide_organisation_corporate_information_page_path(worldwide_organisation, corporate_information_page)
+  click_button "Create new edition"
+end
+
+When(/^I delete the draft "([^"]*)" worldwide organisation$/) do |title|
+  worldwide_organisation = EditionableWorldwideOrganisation.last
+  visit admin_editionable_worldwide_organisation_path(worldwide_organisation)
+
+  click_link "Delete draft"
+  click_button "Delete"
+
+  expect(page).to have_current_path(admin_editions_path(state: :active))
+  expect(page).to have_content("The draft of '#{title}' has been deleted")
 end
 
 When(/^I visit the reorder offices page/) do

--- a/lib/whitehall/authority/enforcer.rb
+++ b/lib/whitehall/authority/enforcer.rb
@@ -48,5 +48,6 @@ module Whitehall::Authority
     "Government" => Rules::GovernmentRules,
     "StatisticsAnnouncement" => Rules::StatisticsAnnouncementRules,
     "EditionableWorldwideOrganisation" => Rules::EditionableWorldwideOrganisationRules,
+    "CorporateInformationPage" => Rules::CorporateInformationPageRules,
   }.freeze
 end

--- a/lib/whitehall/authority/rules/corporate_information_page_rules.rb
+++ b/lib/whitehall/authority/rules/corporate_information_page_rules.rb
@@ -1,0 +1,9 @@
+module Whitehall::Authority::Rules
+  CorporateInformationPageRules = Struct.new(:actor, :subject) do
+    def can?(_action)
+      return true unless !subject.is_a?(Class) && subject.editionable_worldwide_organisation.present?
+
+      Flipflop.editionable_worldwide_organisations?
+    end
+  end
+end

--- a/test/factories/editionable_worldwide_organisations.rb
+++ b/test/factories/editionable_worldwide_organisations.rb
@@ -11,6 +11,16 @@ FactoryBot.define do
       end
     end
 
+    trait(:with_corporate_information_pages) do
+      after :create do |organisation, _evaluator|
+        FactoryBot.create(:complaints_procedure_corporate_information_page, organisation: nil, worldwide_organisation: nil, owning_organisation_document: organisation.document)
+        FactoryBot.create(:personal_information_charter_corporate_information_page, organisation: nil, worldwide_organisation: nil, owning_organisation_document: organisation.document)
+        FactoryBot.create(:publication_scheme_corporate_information_page, organisation: nil, worldwide_organisation: nil, owning_organisation_document: organisation.document)
+        FactoryBot.create(:recruitment_corporate_information_page, organisation: nil, worldwide_organisation: nil, owning_organisation_document: organisation.document)
+        FactoryBot.create(:welsh_language_scheme_corporate_information_page, organisation: nil, worldwide_organisation: nil, owning_organisation_document: organisation.document)
+      end
+    end
+
     trait(:with_role) do
       after :create do |organisation, _evaluator|
         organisation.roles << create(:ambassador_role)

--- a/test/unit/app/models/attachable_test.rb
+++ b/test/unit/app/models/attachable_test.rb
@@ -284,13 +284,13 @@ class AttachableTest < ActiveSupport::TestCase
     assert draft.attachments[0].persisted?
   end
 
-  test "#delete_all_attachments soft-deletes any attachments that the edition has" do
+  test "#finalise_delete soft-deletes any attachments that the edition has" do
     publication = create(:draft_publication)
 
     publication.attachments << attachment1 = build(:file_attachment)
     publication.attachments << attachment2 = build(:html_attachment)
 
-    publication.delete_all_attachments
+    publication.finalise_delete
 
     assert Attachment.find(attachment1.id).deleted?
     assert Attachment.find(attachment2.id).deleted?
@@ -332,7 +332,7 @@ class AttachableTest < ActiveSupport::TestCase
       ],
     )
 
-    publication.delete_all_attachments
+    publication.finalise_delete
 
     assert_equal [attachment1, attachment2], publication.deleted_attachments
   end

--- a/test/unit/app/models/corporate_information_page_test.rb
+++ b/test/unit/app/models/corporate_information_page_test.rb
@@ -222,6 +222,30 @@ class CorporateInformationPageTest < ActiveSupport::TestCase
     assert corporate_information_page2.errors.full_messages.include?("Another 'About' page was already published for this worldwide organisation")
   end
 
+  test "should be invalid if a CIP of the same type already exists for the editionable worldwide organisation" do
+    editionable_worldwide_organisation = create(:editionable_worldwide_organisation)
+    corporate_information_page1 = build(
+      :corporate_information_page,
+      :published,
+      organisation: nil,
+      owning_organisation_document: editionable_worldwide_organisation.document,
+      corporate_information_page_type: CorporateInformationPageType::PersonalInformationCharter,
+      state: "published",
+      major_change_published_at: Time.zone.now,
+    )
+    corporate_information_page1.save!
+
+    corporate_information_page2 = build(
+      :corporate_information_page,
+      organisation: nil,
+      owning_organisation_document: editionable_worldwide_organisation.document,
+      corporate_information_page_type: CorporateInformationPageType::PersonalInformationCharter,
+    )
+    assert_not corporate_information_page2.valid?
+
+    assert corporate_information_page2.errors.full_messages.include?("Another 'Personal information charter' page was already published for this worldwide organisation")
+  end
+
   test "should be valid if it is a new draft of the same document" do
     organisation = create(:organisation)
     corporate_information_page1 = build(

--- a/test/unit/app/models/corporate_information_page_type_test.rb
+++ b/test/unit/app/models/corporate_information_page_type_test.rb
@@ -57,4 +57,18 @@ class CorporateInformationPageTypeTest < ActiveSupport::TestCase
 
     assert_equal "Procurement at Department of Alphabet", corporate_information_page.title
   end
+
+  test ".for returns all corporate information types for organisations" do
+    organisation = build(:organisation)
+
+    assert_includes CorporateInformationPageType.for(organisation).map(&:slug), "about"
+    assert_includes CorporateInformationPageType.for(organisation).map(&:id), 20
+  end
+
+  test ".for returns all corporate information types for editionable worldwide organisations" do
+    organisation = build(:editionable_worldwide_organisation)
+
+    assert_not_includes CorporateInformationPageType.for(organisation).map(&:slug), "about"
+    assert_not_includes CorporateInformationPageType.for(organisation).map(&:id), 20
+  end
 end

--- a/test/unit/app/models/edition/corporate_information_pages_test.rb
+++ b/test/unit/app/models/edition/corporate_information_pages_test.rb
@@ -1,0 +1,18 @@
+require "test_helper"
+
+class Edition::CorporateInformationPagesTest < ActiveSupport::TestCase
+  setup do
+    @edition = create(:editionable_worldwide_organisation, :with_document)
+    @corporate_information_page = create(:complaints_procedure_corporate_information_page, organisation: nil, worldwide_organisation: nil, owning_organisation_document: @edition.document)
+  end
+
+  test "#build_corporate_information_page assigns the edition document to the corporate information page" do
+    cip = @edition.build_corporate_information_page({})
+
+    assert_equal cip.owning_organisation_document, @edition.document
+  end
+
+  test "#unused_corporate_information_page_types returns the unused corporate information page type for the document" do
+    assert_not_includes @edition.unused_corporate_information_page_types, @corporate_information_page
+  end
+end

--- a/test/unit/app/models/edition/corporate_information_pages_test.rb
+++ b/test/unit/app/models/edition/corporate_information_pages_test.rb
@@ -15,4 +15,24 @@ class Edition::CorporateInformationPagesTest < ActiveSupport::TestCase
   test "#unused_corporate_information_page_types returns the unused corporate information page type for the document" do
     assert_not_includes @edition.unused_corporate_information_page_types, @corporate_information_page
   end
+
+  test "#finalise_delete deletes associated corporate information pages when it's the only edition" do
+    Whitehall.edition_services
+             .expects(:deleter)
+             .with(@corporate_information_page)
+             .returns(deleter = stub)
+
+    deleter.expects(:perform!)
+
+    @edition.finalise_delete
+  end
+
+  test "#finalise_delete does not delete associated corporate information pages when it's not the only edition" do
+    edition = create(:editionable_worldwide_organisation, :with_document, :published)
+    edition.create_draft(create(:user))
+
+    Whitehall.edition_services.expects(:deleter).never
+
+    edition.finalise_delete
+  end
 end

--- a/test/unit/app/models/organisation_test.rb
+++ b/test/unit/app/models/organisation_test.rb
@@ -1201,4 +1201,10 @@ class OrganisationTest < ActiveSupport::TestCase
 
     organisation.republish_on_assets_ready
   end
+
+  test "#title returns the name of the organisation" do
+    organisation = create(:organisation)
+
+    assert_equal organisation.name, organisation.title
+  end
 end

--- a/test/unit/app/presenters/publishing_api/editionable_worldwide_organisation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/editionable_worldwide_organisation_presenter_test.rb
@@ -7,6 +7,7 @@ class PublishingApi::EditionableWorldwideOrganisationPresenterTest < ActiveSuppo
 
   test "presents a Worldwide Organisation ready for adding to the publishing API" do
     worldwide_org = create(:editionable_worldwide_organisation,
+                           :with_corporate_information_pages,
                            :with_role,
                            :with_social_media_account,
                            :with_office,
@@ -42,6 +43,17 @@ class PublishingApi::EditionableWorldwideOrganisationPresenterTest < ActiveSuppo
           crest: "single-identity",
           formatted_title: "Editionable<br/>worldwide<br/>organisation<br/>title",
         },
+        ordered_corporate_information_pages: [
+          {
+            content_id: worldwide_org.corporate_information_pages[0].content_id,
+            title: "Complaints procedure",
+          },
+          {
+            content_id: worldwide_org.corporate_information_pages[3].content_id,
+            title: "Working for Editionable worldwide organisation title",
+          },
+        ],
+        secondary_corporate_information_pages: "Read about the types of information we routinely publish in our <a class=\"govuk-link\" href=\"/editionable-world/organisations/editionable-worldwide-organisation-title/about/publication-scheme\">Publication scheme</a>. Find out about our commitment to <a class=\"govuk-link\" href=\"/editionable-world/organisations/editionable-worldwide-organisation-title/about/welsh-language-scheme\">publishing in Welsh</a>. Our <a class=\"govuk-link\" href=\"/editionable-world/organisations/editionable-worldwide-organisation-title/about/personal-information-charter\">Personal information charter</a> explains how we treat your personal information.",
         social_media_links: [
           {
             href: worldwide_org.social_media_accounts.first.url,
@@ -61,6 +73,13 @@ class PublishingApi::EditionableWorldwideOrganisationPresenterTest < ActiveSuppo
     }
 
     expected_links = {
+      corporate_information_pages: [
+        worldwide_org.corporate_information_pages[0].content_id,
+        worldwide_org.corporate_information_pages[1].content_id,
+        worldwide_org.corporate_information_pages[2].content_id,
+        worldwide_org.corporate_information_pages[3].content_id,
+        worldwide_org.corporate_information_pages[4].content_id,
+      ],
       main_office: [
         worldwide_org.reload.offices.first.content_id,
       ],


### PR DESCRIPTION
https://trello.com/c/MUhuggob

**This is part of the work to make worldwide organsiations editionable**

## Screenshots

### Organisation document with CIPs

![image](https://github.com/alphagov/whitehall/assets/47089130/6da7905c-ef67-4ae2-ad3e-3e9f14487c95)

## Changes

### Add title method to organisation model
The new editionable worldwide organisation model uses the title method
instead of name.

This adds title to the organisation model so that views and helpers etc. can be
compatible with both model types.

### Use title for the corporate information page views
Now that we have a title method for the organisation model, we can make these
views compatible with the worldwide organisation model, the editionable
worldwide organisation model, and the organisation model.

### Use title for the corporate information page type
This class must be compatible with (currently) worldwide organisations,
editionable worldwide organisations, and organisations.

This uses `title` instead of `name` as all of the above classes now have a
`title` method.

### Use title method for the search title
This must be compatible with (currently) worldwide organisations,
editionable worldwide organisations, and organisations.

This uses `title` instead of `name` as all of the above classes now have a
`title` method.

### Add association between document and CIPs
For now, the simplest way of associating an edition (corporate information
page) with another edition (editionable worldwide organisation) is to
associate it with its document. This means that users can add and edit
corporate information pages no matter what state the owning worldwide
organisation is in.

This adds an association between corporate information pages and document,
using a join table to avoid adding more columns to the document or edition
tables

### Add `Edition::CorporateInformationPages` module
This adds a new module for editions which are related to corporate informaiton
pages.

It it derived from the `HasCorporateInformationPages` module, but does not
contain the "about" page functionality.

### Only one of each CIP can be created for an editionable worldwide org
An editionable worldwide organisation should only have (at most) one of each
corporate information page type.

### Remove option to create an about us page for editionable worldwide orgs
Part of the move from using the legacy worldwide organisations to using the new
editionable worldwide organisations involves removing the "about us" corporate
information page.

Instead, this information will live on the editionable worldwide organisation
itself.

This adds a class method to the corporate information types so we can return
everything except the about page. Organisations (non-worldwide) however, still
need the about page.

### Make `delete_all_attachments` method more generic
We want to hook into the end of a deletion so that we can remove all of the
corporate informaiton pages associated with an editionable worldwide
organisation when it is deleted.

This gives the `delete_all_attachments` a more generic name so that we can use
that.

### Make the CIP pages work for editionable worldwide organisations
This modifies the existing corporate information controller and model so that
they are compatible with editionable worldwide organisations as well as legacy
worldwide organisations.

The owning organisation of a CIP must be an editionable worldwide organisation
and is used for the base path of the CIP, we fetch the live edition if
available, or the most recent version otherwise.

Note: When the editionable worldwide organisations feature flag is enabled,
performing actions related to the corporate information pages of legacy
worldwide organisations will not function (and vice versa). This should be okay
as we don't want these features running side-by-side. The feature flag hides
the legacy worldwide organisations for an extra level of safety.

### Prevent users viewing worldwide org CIP pages when feature flag enabled

### Include CIPs in the editionable worldwide organisation presenter
We want to the result of this API presenter to equal the result of the (now
legacy) worldwide organisation API presenter.

Now that editionable worldwide organisations have associated corporate
information pages, this copies over the related links and details.

### Redirect to the edition page when editionable worldwide organisation
We want to redirect back to the edition page of the editionable worldwide
organisation when a corporate informaiton page is deleted as we aren't using
the index page for these.

### Use minimal table for document corporate information pages
We want a list of corporate information pages related to a document, but
without the pagination and extra detail.

This moves the table itself into a partial and uses this for document corporate
information pages.

### Validate owning organisation has published edition when publishing CIP
A published corporate information page shouldn't exist if it doesn't have a
pbulished worldwide organisation.



---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
