### PR TITLE
Only set html_safe for the filter errors

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -48,12 +48,10 @@ class Admin::EditionsController < Admin::BaseController
       session[:document_filters] = params_filters
       render :index
     elsif session_filters.any?
-      flash[:html_safe] = true
-      flash[:alert] = filter.errors.join("<br>") if filter&.errors&.any?
+      display_filter_error_message
       redirect_to session_filters
     else
-      flash[:html_safe] = true
-      flash[:alert] = filter.errors.join("<br>") if filter&.errors&.any?
+      display_filter_error_message
       redirect_to default_filters
     end
   end
@@ -182,6 +180,13 @@ class Admin::EditionsController < Admin::BaseController
   end
 
 private
+
+  def display_filter_error_message
+    if filter&.errors&.any?
+      flash["html_safe"] = true
+      flash[:alert] = filter.errors.join("<br>")
+    end
+  end
 
   def fetch_version_and_remark_trails
     @document_history = Document::PaginatedTimeline.new(document: @edition.document, page: params[:page] || 1, only: params[:only])

--- a/test/functional/admin/editions_controller_test.rb
+++ b/test/functional/admin/editions_controller_test.rb
@@ -151,6 +151,7 @@ class Admin::EditionsControllerTest < ActionController::TestCase
     get :index, params: { author: "invalid" }
     assert_redirected_to admin_editions_path(state: :submitted, author: current_user, organisation:)
     assert_equal "Author not found", flash[:alert]
+    assert flash["html_safe"]
   end
 
   test "index should redirect to department if logged in with no remembered filters" do
@@ -167,6 +168,7 @@ class Admin::EditionsControllerTest < ActionController::TestCase
     assert_redirected_to admin_editions_path(organisation: organisation.id, state: :active)
     assert_includes flash[:alert], "The 'From date' is incorrect. It should be dd/mm/yyyy"
     assert_includes flash[:alert], "The 'To date' is incorrect. It should be dd/mm/yyyy"
+    assert flash["html_safe"]
   end
 
   view_test "should not show published editions as force published" do
@@ -299,6 +301,7 @@ class Admin::EditionsControllerTest < ActionController::TestCase
            state: "active",
          }
     assert_equal "The document list is too large for export", flash[:alert]
+    assert_not flash["html_safe"]
   end
 
 private


### PR DESCRIPTION
The html_safe flag was being set for all alerts and notices, making certain notices not render.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
