### PR TITLE
Spike: Load visual govspeak editor in parallel with main application JS bundle

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,3 +1,4 @@
 //= link_tree ../images
 //= link_directory ../stylesheets .css
 //= link application.js
+//= link components/govspeak-editor.js

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -5,7 +5,6 @@
 //= require govuk_publishing_components/analytics
 
 //= require components/autocomplete
-//= require components/govspeak-editor
 //= require components/image-cropper
 //= require components/miller-columns
 //= require components/select-with-search

--- a/app/assets/javascripts/components/govspeak-editor.js
+++ b/app/assets/javascripts/components/govspeak-editor.js
@@ -1,3 +1,4 @@
+// TODO, but something like this: //= require govspeak-visual-editor/dist/editor.js
 window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {}
 ;(function (Modules) {

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -100,4 +100,5 @@
       },
     ],
   } %>
+  <%= javascript_include_tag "components/govspeak-editor" %>
 <% end %>


### PR DESCRIPTION
Not sure if this will bundle the underlying editor library separately or not and what the performance impacts would be, but it does prove we can load a separate JS bundle using sprockets fairly easily.
