### PR TITLE
Fix unpublishing of editionable worldwide organisations

### DIFF
--- a/app/presenters/publishing_api/editionable_worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/editionable_worldwide_organisation_presenter.rb
@@ -32,7 +32,7 @@ module PublishingApi
           social_media_links:,
           world_location_names:,
         },
-        document_type: "worldwide_organisation",
+        document_type:,
         public_updated_at: item.updated_at,
         rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
         schema_name: "worldwide_organisation",
@@ -52,6 +52,10 @@ module PublishingApi
         sponsoring_organisations: item.organisations.map(&:content_id),
         world_locations: item.world_locations.map(&:content_id),
       }
+    end
+
+    def document_type
+      "worldwide_organisation"
     end
 
   private

--- a/features/editionable-worldwide-organisations.feature
+++ b/features/editionable-worldwide-organisations.feature
@@ -10,6 +10,17 @@ Feature: Editionable worldwide organisations
     And I should see it has been assigned to the "United Kingdom" world location
     And I should see the editionable worldwide organisation "Test Worldwide Organisation" in the list of draft documents
 
+  Scenario: Unpublishing a published worldwide organisation
+    Given a published editionable worldwide organisation "Test Worldwide Organisation"
+    When I unpublish the document and ask for a redirect to "https://www.test.gov.uk/example"
+    Then the unpublishing should redirect to "https://www.test.gov.uk/example"
+
+  Scenario: Withdrawing a published worldwide organisation
+    Given a published editionable worldwide organisation "Test Worldwide Organisation"
+    When I withdraw the worldwide organisation "Test Worldwide Organisation" with the explanation "Closed for business"
+    Then there should be an unpublishing explanation of "Closed for business" and a reason of "No longer current government policy/activity"
+    And the withdrawal date should be today
+
   Scenario: Adding a translation to an existing worldwide organisation
     When I draft a new worldwide organisation "Test Worldwide Organisation" assigned to world location "United Kingdom"
     And I add a Welsh translation of the worldwide organisation "Test Worldwide Organisation" named "Translated Name"

--- a/features/editionable-worldwide-organisations.feature
+++ b/features/editionable-worldwide-organisations.feature
@@ -4,37 +4,37 @@ Feature: Editionable worldwide organisations
     And The editionable worldwide organisations feature flag is enabled
     And a world location "United Kingdom" exists
 
-  Scenario Outline: Creating a new draft worldwide organisation
+  Scenario: Creating a new draft worldwide organisation
     When I draft a new worldwide organisation "Test Worldwide Organisation" assigned to world location "United Kingdom"
     Then the worldwide organisation "Test Worldwide Organisation" should have been created
     And I should see it has been assigned to the "United Kingdom" world location
     And I should see the editionable worldwide organisation "Test Worldwide Organisation" in the list of draft documents
 
-  Scenario Outline: Adding a translation to an existing worldwide organisation
+  Scenario: Adding a translation to an existing worldwide organisation
     When I draft a new worldwide organisation "Test Worldwide Organisation" assigned to world location "United Kingdom"
     And I add a Welsh translation of the worldwide organisation "Test Worldwide Organisation" named "Translated Name"
     Then I should see the Welsh translated title "Translated Name" for the "Test Worldwide Organisation" worldwide organisation
 
-  Scenario Outline: Assigning a role to a worldwide organisation
+  Scenario: Assigning a role to a worldwide organisation
     Given a role "Prime Minister" exists
     When I draft a new worldwide organisation "Test Worldwide Organisation" assigned to world location "United Kingdom"
     And I edit the worldwide organisation "Test Worldwide Organisation" adding the role of "Prime Minister"
     Then I should see the "Prime Minister" role has been assigned to the worldwide organisation "Test Worldwide Organisation"
 
-  Scenario Outline: Adding a social media account to a worldwide organisation
+  Scenario: Adding a social media account to a worldwide organisation
     Given a social media service "Facebook" exists
     When I draft a new worldwide organisation "Test Worldwide Organisation" assigned to world location "United Kingdom"
     And I edit the worldwide organisation "Test Worldwide Organisation" adding the social media service of "Facebook" with title "Our Facebook page" at URL "https://www.social.gov.uk"
     Then I should see the "Our Facebook page" social media site has been assigned to the worldwide organisation "Test Worldwide Organisation"
 
-  Scenario Outline: Editing a social media account to a worldwide organisation
+  Scenario: Editing a social media account to a worldwide organisation
     Given a social media service "Facebook" exists
     When I draft a new worldwide organisation "Test Worldwide Organisation" assigned to world location "United Kingdom"
     And I edit the worldwide organisation "Test Worldwide Organisation" adding the social media service of "Facebook" with title "Our Facebook page" at URL "https://www.social.gov.uk"
     And I edit the worldwide organisation "Test Worldwide Organisation" changing the social media account with title "Our Facebook page" to "Our new Facebook page"
     Then I should see the "Our new Facebook page" social media site has been assigned to the worldwide organisation "Test Worldwide Organisation"
 
-  Scenario Outline: Deleting a social media account assigned to a worldwide organisation
+  Scenario: Deleting a social media account assigned to a worldwide organisation
     Given a social media service "Facebook" exists
     When I draft a new worldwide organisation "Test Worldwide Organisation" assigned to world location "United Kingdom"
     And I edit the worldwide organisation "Test Worldwide Organisation" adding the social media service of "Facebook" with title "Our Facebook page" at URL "https://www.social.gov.uk"

--- a/features/step_definitions/editionable_worldwide_organisation_steps.rb
+++ b/features/step_definitions/editionable_worldwide_organisation_steps.rb
@@ -8,6 +8,11 @@ Given(/^an editionable worldwide organisation "([^"]*)"$/) do |title|
   worldwide_organisation.main_office = create(:worldwide_office, worldwide_organisation: nil, edition: worldwide_organisation, title: "Main office for #{title}")
 end
 
+Given(/^a published editionable worldwide organisation "([^"]*)"$/) do |title|
+  worldwide_organisation = create(:editionable_worldwide_organisation, :published, title:)
+  worldwide_organisation.main_office = create(:worldwide_office, worldwide_organisation: nil, edition: worldwide_organisation, title: "Main office for #{title}")
+end
+
 Given(/^an editionable worldwide organisation "([^"]*)" with offices "([^"]*)" and "([^"]*)"$/) do |title, contact_1_title, contact_2_title|
   worldwide_organisation = create(:editionable_worldwide_organisation, title:)
   worldwide_organisation.add_office_to_home_page!(create(:worldwide_office, worldwide_organisation: nil, edition: worldwide_organisation, contact: create(:contact, title: contact_1_title)))
@@ -30,6 +35,19 @@ When(/^I choose "([^"]*)" to be the main office for the editionable worldwide or
   click_link "Set main office"
   choose contact_title
   click_button "Save"
+end
+
+When(/^I withdraw the worldwide organisation "([^"]*)" with the explanation "([^"]*)"$/) do |org_name, explanation|
+  organisation = EditionableWorldwideOrganisation.find_by(title: org_name)
+  visit admin_editionable_worldwide_organisation_path(organisation)
+  click_on "Withdraw or unpublish"
+  choose "Withdraw: no longer current government policy/activity"
+  within ".js-app-view-unpublish-withdraw-form__withdrawal" do
+    fill_in "Public explanation", with: explanation
+    click_button "Withdraw"
+  end
+
+  expect(:withdrawn).to eq(organisation.reload.current_state)
 end
 
 When(/^I visit the reorder offices page/) do


### PR DESCRIPTION
https://trello.com/c/wgY1dwSH

### Use `Scenario` instead of `Scenario Outline`
Scenario outline is designed to be used with multiple examples.
https://cucumber.io/docs/gherkin/reference/#scenario-outline

### Fix unpublishing of editionable worldwide organisations
Currently, when trying to unpublish editionable worldwide organisations we see
a `NoMethodError` from `Admin::EditionWorkflowController#unpublish` where the
`EditionableWorldwideOrganisationPresenter` is expected to define a method
`document_type`.

This fixes the issue and also adds some coverage for withdrawing an editionable
worldwide organisation.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
