### PR TITLE
Show errors editionable socials

### DIFF
--- a/app/controllers/admin/editionable_social_media_accounts_controller.rb
+++ b/app/controllers/admin/editionable_social_media_accounts_controller.rb
@@ -5,10 +5,10 @@ class Admin::EditionableSocialMediaAccountsController < Admin::BaseController
   def confirm_destroy; end
 
   def create
-    social_media_account = SocialMediaAccount.create(social_media_account_params)
+    @social_media_account = SocialMediaAccount.new(social_media_account_params)
 
-    if social_media_account.persisted?
-      redirect_to admin_edition_social_media_accounts_path(@edition), notice: "Social media account '#{social_media_account.title}' created"
+    if @social_media_account.save
+      redirect_to admin_edition_social_media_accounts_path(@edition), notice: "Social media account '#{@social_media_account.title}' created"
     else
       render :new
     end
@@ -32,7 +32,9 @@ class Admin::EditionableSocialMediaAccountsController < Admin::BaseController
     @editionable_social_media_accounts_index_presenter = EditionableSocialMediaAccountsIndexPresenter.new(@edition)
   end
 
-  def new; end
+  def new
+    @social_media_account = SocialMediaAccount.new
+  end
 
   def update
     @social_media_account.attributes = social_media_account_params

--- a/app/views/admin/editionable_social_media_accounts/edit.html.erb
+++ b/app/views/admin/editionable_social_media_accounts/edit.html.erb
@@ -3,6 +3,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @social_media_account)) %>
+
     <%= render("form", edition: @edition, social_media_account: @social_media_account, destination: admin_edition_social_media_account_path(@edition, @social_media_account)) %>
   </div>
 </div>

--- a/app/views/admin/editionable_social_media_accounts/new.erb
+++ b/app/views/admin/editionable_social_media_accounts/new.erb
@@ -3,6 +3,8 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render("form", edition: @edition, social_media_account: SocialMediaAccount.new, destination: admin_edition_social_media_accounts_path(@edition)) %>
+    <% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @social_media_account)) %>
+
+    <%= render("form", edition: @edition, social_media_account: @social_media_account, destination: admin_edition_social_media_accounts_path(@edition)) %>
   </div>
 </div>

--- a/test/functional/admin/editionable_social_media_accounts_controller_test.rb
+++ b/test/functional/admin/editionable_social_media_accounts_controller_test.rb
@@ -101,6 +101,19 @@ class Admin::EditionableSocialMediaAccountsControllerTest < ActionController::Te
     assert_equal "https://www.social.gov.uk", @edition.social_media_accounts.last.url
   end
 
+  view_test "POST :create with invalid data shows errors" do
+    post :create, params: {
+      edition_id: @edition,
+      social_media_account: {
+        social_media_service_id: SocialMediaService.first,
+        title: "Account title",
+        url: "www.invalid.gov.uk",
+      },
+    }
+
+    assert_select ".govuk-error-summary"
+  end
+
   view_test "GET :confirm_destroy shows a confirmation before deletion" do
     get :confirm_destroy, params: {
       edition_id: @edition,

--- a/test/functional/admin/editionable_social_media_accounts_controller_test.rb
+++ b/test/functional/admin/editionable_social_media_accounts_controller_test.rb
@@ -86,6 +86,19 @@ class Admin::EditionableSocialMediaAccountsControllerTest < ActionController::Te
     end
   end
 
+  view_test "PATCH :update with invalid data shows errors" do
+    patch :update, params: {
+      edition_id: @edition,
+      id: @edition.social_media_accounts.first,
+      social_media_account: {
+        title: "New title",
+        url: "www.invalid.gov.uk",
+      },
+    }
+
+    assert_select ".govuk-error-summary"
+  end
+
   test "POST :create creates a social media account" do
     post :create, params: {
       edition_id: @edition,


### PR DESCRIPTION
https://trello.com/c/hqhOzDj1

### Show errors and error summary on new editionable social media page form
Currently, the new social media page form doesn't show field errors or the
error summary.

### Show error summary on the edit editionable social media pages form
Currently, the edit social media page form doesn't show the error summary.

![image](https://github.com/alphagov/whitehall/assets/47089130/e3bcf6fb-016d-4f57-8863-76277ef69617)

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
