### PR TITLE
Improve readability of asset filename matching method

### DIFF
--- a/app/models/featured_image_data.rb
+++ b/app/models/featured_image_data.rb
@@ -38,6 +38,6 @@ class FeaturedImageData < ApplicationRecord
 private
 
   def assets_match_updated_image_filename
-    assets.reject { |asset| asset.filename.include?(carrierwave_image) }.empty?
+    assets.all? { |asset| asset.filename.include?(carrierwave_image) }
   end
 end


### PR DESCRIPTION
We can use `all?` here instead of a double-negative of `reject` and `empty?`