### PR TITLE
Remove raising behaviour from PersonPresenter

### DIFF
--- a/app/models/featured_image_data.rb
+++ b/app/models/featured_image_data.rb
@@ -38,6 +38,8 @@ class FeaturedImageData < ApplicationRecord
 private
 
   def assets_match_updated_image_filename
+    return false unless carrierwave_image
+
     assets.all? { |asset| asset.filename.include?(carrierwave_image) }
   end
 end

--- a/app/presenters/publishing_api/person_presenter.rb
+++ b/app/presenters/publishing_api/person_presenter.rb
@@ -35,8 +35,7 @@ module PublishingApi
       details_hash = {}
 
       if item.image&.all_asset_variants_uploaded? && item.image&.url(:s465)
-        raise "person image path should not use carrierwave path" if item.image.url(:s465).include?("carrierwave-tmp")
-
+        logger.error("PersonPresenter: Person of ID##{item.id} has image with url '#{item.image&.url(:s465)}'") if item.image.url(:s465).include?("carrierwave-tmp")
         details_hash[:image] = { url: item.image.url(:s465), alt_text: item.name }
       end
 

--- a/test/unit/app/presenters/publishing_api/person_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/person_presenter_test.rb
@@ -118,16 +118,4 @@ class PublishingApi::PersonPresenterTest < ActiveSupport::TestCase
 
     assert_nil presented_item.content.dig(:details, :image)
   end
-
-  test "it raises if a carrierwave path is used for the image path" do
-    person = build(:person)
-
-    image = build(:featured_image_data)
-    image.expects(:url).twice.with(:s465).returns("/uploads/carrierwave-tmp/1704204355-973510646575090-0009-0387/s465_test-img.jpg")
-    person.image = image
-
-    assert_raises do
-      present(person).content
-    end
-  end
 end


### PR DESCRIPTION
The raising behaviour was previously introduced to get a stack trace to help debug broken Person urls reported in prod. 

Narrowed down the error to the filename check with an action point to reconsider that logic and make it
not rely on filename.

Adding a log to track this in the future.

[Trello card](https://trello.com/c/COWkIRaH/2312-investigate-cause-of-carrierwave-path-in-person-image)