### PR TITLE
Fix .govuk_dependabot_merger.yml

### DIFF
--- a/.govuk_dependabot_merger.yml
+++ b/.govuk_dependabot_merger.yml
@@ -12,7 +12,7 @@ auto_merge:
     allowed_semver_bumps:
       - patch
       - minor
- - dependency: govuk_ab_testing
+  - dependency: govuk_ab_testing
     allowed_semver_bumps:
       - patch
       - minor


### PR DESCRIPTION
This invalid YAML was causing build failures in govuk-dependabot-merger (now fixed in https://github.com/alphagov/govuk-dependabot-merger/pull/41).

This PR fixes the configuration so that Whitehall dependency PRs  can be auto-merged again.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
