### PR TITLE
Fix reference to visual editor JS

### DIFF
--- a/app/views/components/_govspeak_editor.html.erb
+++ b/app/views/components/_govspeak_editor.html.erb
@@ -101,5 +101,5 @@
     <p class="govuk-error-message" dir="ltr">There is an error in your Markdown. Select Back to edit and review your markdown.</p>
   <% end %>
 
-  <%= javascript_include_tag "components/govspeak-visual-editor", :type => "module" if show_visual_editor %>
+  <%= javascript_include_tag "components/visual-editor", :type => "module" if show_visual_editor %>
 <% end %>

--- a/test/components/govspeak_editor_test.rb
+++ b/test/components/govspeak_editor_test.rb
@@ -162,4 +162,16 @@ class GovspeakeditorComponentTest < ComponentTestCase
     assert_select ".app-c-govspeak-editor[data-alternative-format-provider-id='123'][data-image-ids='[1,2,3]'][data-attachment-ids='[3,4,5]']"
     assert_select ".govuk-textarea", text: "This is an attachment: !@1 This is an image: !!1"
   end
+
+  test "includes visual editor button" do
+    render_component({
+      name: "my-name",
+      label: {
+        text: "my-label",
+      },
+      show_visual_editor: true,
+    })
+
+    assert_select ".js-app-c-govspeak-editor__visual-editor-button", text: "Visual Editor Alpha"
+  end
 end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

# What
- Fix reference to visual editor JS
- Add test to ensure that the visual editor button renders

# Why
- The name of this file was update, but the reference was not
