### PR TITLE
Remove non-edition worldwide organisation links

### DIFF
--- a/app/presenters/publishing_api/editionable_worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/editionable_worldwide_organisation_presenter.rb
@@ -64,16 +64,7 @@ module PublishingApi
     end
 
     def links
-      {
-        home_page_offices: [],
-        main_office: [],
-        office_staff: [],
-        primary_role_person: [],
-        roles: [],
-        secondary_role_person: [],
-        sponsoring_organisations: [],
-        world_locations: [],
-      }
+      {}
     end
 
   private

--- a/app/presenters/publishing_api/worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/worldwide_organisation_presenter.rb
@@ -64,17 +64,7 @@ module PublishingApi
     end
 
     def links
-      {
-        corporate_information_pages: [],
-        main_office: [],
-        home_page_offices: [],
-        primary_role_person: [],
-        secondary_role_person: [],
-        office_staff: [],
-        sponsoring_organisations: [],
-        world_locations: [],
-        roles: [],
-      }
+      {}
     end
 
     def description

--- a/test/unit/app/presenters/publishing_api/editionable_worldwide_organisation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/editionable_worldwide_organisation_presenter_test.rb
@@ -108,16 +108,7 @@ class PublishingApi::EditionableWorldwideOrganisationPresenterTest < ActiveSuppo
       update_type: "major",
     }
 
-    expected_links = {
-      main_office: [],
-      home_page_offices: [],
-      primary_role_person: [],
-      secondary_role_person: [],
-      office_staff: [],
-      sponsoring_organisations: [],
-      world_locations: [],
-      roles: [],
-    }
+    expected_links = {}
 
     presented_item = present(worldwide_org)
 

--- a/test/unit/app/presenters/publishing_api/worldwide_organisation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/worldwide_organisation_presenter_test.rb
@@ -136,17 +136,7 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
       update_type: "major",
     }
 
-    expected_links = {
-      corporate_information_pages: [],
-      main_office: [],
-      home_page_offices: [],
-      primary_role_person: [],
-      secondary_role_person: [],
-      office_staff: [],
-      sponsoring_organisations: [],
-      world_locations: [],
-      roles: [],
-    }
+    expected_links = {}
 
     presented_item = present(worldwide_org)
 


### PR DESCRIPTION
We have previously emptied these links to switch from non-edition links to edition links for worldwide organisations.

Now that those links have been emptied, we can stop presenting non-edition links to Publishing API for these documents.

[Trello card](https://trello.com/c/yNJwHw4K)