### PR TITLE
Start importing the visual editor style

### DIFF
--- a/app/assets/stylesheets/components/_govspeak-editor.scss
+++ b/app/assets/stylesheets/components/_govspeak-editor.scss
@@ -1,3 +1,5 @@
+@import "govspeak-visual-editor/dist/style";
+
 .app-c-govspeak-editor {
   margin-bottom: govuk-spacing(6);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1514,8 +1514,8 @@ gopd@^1.0.1:
     get-intrinsic "^1.1.3"
 
 govspeak-visual-editor@alphagov/govspeak-visual-editor:
-  version "0.0.0"
-  resolved "https://codeload.github.com/alphagov/govspeak-visual-editor/tar.gz/9076c2d36c9d8f03c670c91f153ec8daf9abdff2"
+  version "0.0.1"
+  resolved "https://codeload.github.com/alphagov/govspeak-visual-editor/tar.gz/d04ce9f713457d1591472da855f2f7d92426e897"
   dependencies:
     govuk-frontend "^4.7.0"
     prosemirror-example-setup "^1.2.2"


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

# What
- Add and import for the visual editor styles to the govspeak editor css

# Why
- It's needed to render the visual edit
- This could not be done previously as the visual editor css included the govuk fonts
