### PR TITLE
Fix issue where `[nil]` is presented when no contacts

### DIFF
--- a/app/models/editionable_worldwide_organisation.rb
+++ b/app/models/editionable_worldwide_organisation.rb
@@ -34,12 +34,20 @@ class EditionableWorldwideOrganisation < Edition
     super - [main_office]
   end
 
+  def home_page_office_contacts
+    home_page_offices&.map(&:contact)
+  end
+
   def office_shown_on_home_page?(office)
     super || is_main_office?(office)
   end
 
   def main_office
     original_main_office || offices.first
+  end
+
+  def main_office_contact
+    main_office&.contact
   end
 
   def other_offices

--- a/app/models/worldwide_organisation.rb
+++ b/app/models/worldwide_organisation.rb
@@ -57,6 +57,10 @@ class WorldwideOrganisation < ApplicationRecord
     super - [main_office]
   end
 
+  def home_page_office_contacts
+    home_page_offices&.map(&:contact)
+  end
+
   def office_shown_on_home_page?(office)
     super || is_main_office?(office)
   end
@@ -83,6 +87,10 @@ class WorldwideOrganisation < ApplicationRecord
 
   def main_office
     original_main_office || offices.first
+  end
+
+  def main_office_contact
+    main_office&.contact
   end
 
   def other_offices

--- a/app/presenters/publishing_api/editionable_worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/editionable_worldwide_organisation_presenter.rb
@@ -90,9 +90,9 @@ module PublishingApi
     end
 
     def contacts
-      return [] unless item.main_office&.contact || item.home_page_offices&.map(&:contact)&.any?
+      return [] unless item.main_office_contact || item.home_page_office_contacts&.any?
 
-      [item.main_office&.contact&.content_id] + item.home_page_offices&.map(&:contact)&.map(&:content_id)
+      [item.main_office_contact&.content_id] + item.home_page_office_contacts&.map(&:content_id)
     end
 
     def office_contact_associations

--- a/app/presenters/publishing_api/editionable_worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/editionable_worldwide_organisation_presenter.rb
@@ -90,6 +90,8 @@ module PublishingApi
     end
 
     def contacts
+      return [] unless item.main_office&.contact || item.home_page_offices&.map(&:contact)&.any?
+
       [item.main_office&.contact&.content_id] + item.home_page_offices&.map(&:contact)&.map(&:content_id)
     end
 

--- a/app/presenters/publishing_api/worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/worldwide_organisation_presenter.rb
@@ -86,9 +86,9 @@ module PublishingApi
     end
 
     def contacts
-      return [] unless item.main_office&.contact || item.home_page_offices&.map(&:contact)&.any?
+      return [] unless item.main_office_contact || item.home_page_office_contacts&.any?
 
-      [item.main_office&.contact&.content_id] + item.home_page_offices&.map(&:contact)&.map(&:content_id)
+      [item.main_office_contact&.content_id] + item.home_page_office_contacts&.map(&:content_id)
     end
 
     def main_office

--- a/app/presenters/publishing_api/worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/worldwide_organisation_presenter.rb
@@ -86,6 +86,8 @@ module PublishingApi
     end
 
     def contacts
+      return [] unless item.main_office&.contact || item.home_page_offices&.map(&:contact)&.any?
+
       [item.main_office&.contact&.content_id] + item.home_page_offices&.map(&:contact)&.map(&:content_id)
     end
 

--- a/test/unit/app/presenters/publishing_api/editionable_worldwide_organisation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/editionable_worldwide_organisation_presenter_test.rb
@@ -139,4 +139,12 @@ class PublishingApi::EditionableWorldwideOrganisationPresenterTest < ActiveSuppo
 
     assert_equal "Editionable worldwide organisation title", presented_item.content.dig(:details, :logo, :formatted_title)
   end
+
+  test "includes an empty array when there are no contacts" do
+    worldwide_org = create(:editionable_worldwide_organisation)
+
+    presented_item = present(worldwide_org)
+
+    assert_equal [], presented_item.content.dig(:links, :contacts)
+  end
 end

--- a/test/unit/app/presenters/publishing_api/worldwide_organisation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/worldwide_organisation_presenter_test.rb
@@ -210,4 +210,12 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
 
     assert_equal worldwide_org.name, presented_item.content.dig(:details, :logo, :formatted_title)
   end
+
+  test "includes an empty array when there are no contacts" do
+    worldwide_org = create(:worldwide_organisation)
+
+    presented_item = present(worldwide_org)
+
+    assert_equal [], presented_item.content.dig(:links, :contacts)
+  end
 end


### PR DESCRIPTION
We were including an array containing a single value of `nil`, if a worldwide organisation had no contacts.

This is not valid against the schema. Therefore updating to publish an empty array instead.

[Trello card](https://trello.com/c/yNJwHw4K)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
