### PR TITLE
Fix unpublishing of Worldwide Organisation Corporate Information Pages

### DIFF
--- a/app/presenters/publishing_api/worldwide_corporate_information_page_presenter.rb
+++ b/app/presenters/publishing_api/worldwide_corporate_information_page_presenter.rb
@@ -22,7 +22,7 @@ module PublishingApi
       content.merge!(PayloadBuilder::PolymorphicPath.for(item))
 
       content.merge!(
-        document_type: item.display_type_key,
+        document_type:,
         schema_name: "worldwide_corporate_information_page",
       )
     end
@@ -32,6 +32,10 @@ module PublishingApi
         parent: [item.worldwide_organisation.content_id],
         worldwide_organisation: [item.worldwide_organisation.content_id],
       }
+    end
+
+    def document_type
+      item.display_type_key
     end
   end
 end

--- a/db/data_migration/20240201110922_populate_missing_worldwide_organisation_unpublishing.rb
+++ b/db/data_migration/20240201110922_populate_missing_worldwide_organisation_unpublishing.rb
@@ -1,0 +1,16 @@
+unpublished_cips = CorporateInformationPage.where(state: "unpublished").select { |o| o.unpublishing.nil? }
+
+unpublished_cips.each do |cip|
+  Unpublishing.create!(
+    edition: cip,
+    unpublishing_reason: UnpublishingReason::Consolidated,
+    alternative_url: cip.worldwide_organisation.public_url,
+    document_type: cip.document.document_type,
+    slug: cip.slug,
+    redirect: true,
+    content_id: cip.document.content_id,
+    unpublished_at: cip.versions.where(state: "unpublished").last.created_at,
+  )
+
+  PublishingApiDocumentRepublishingWorker.perform_async(cip.document_id)
+end

--- a/features/step_definitions/corporate_information_page_steps.rb
+++ b/features/step_definitions/corporate_information_page_steps.rb
@@ -28,6 +28,14 @@ When(/^I force-publish the "([^"]*)" corporate information page for the worldwid
   publish(force: true)
 end
 
+When(/^I unpublish the "([^"]*)" corporate information page for the worldwide organisation "([^"]*)"$/) do |cip_title, org_name|
+  edition = WorldwideOrganisation.find_by(name: org_name).corporate_information_pages.find_by(title: cip_title)
+  unpublish_edition(edition) do
+    fill_in "published_in_error_alternative_url", with: "https://www.gov.uk/somewhere-else"
+    check "Redirect to URL automatically?"
+  end
+end
+
 Then(/^I should see the corporate information on the worldwide organisation corporate information pages page/) do
   worldwide_organisation = WorldwideOrganisation.last
   visit admin_worldwide_organisation_corporate_information_pages_path(worldwide_organisation)
@@ -38,6 +46,13 @@ Then(/^I should see the corporate information on the worldwide organisation corp
 
   click_link corporate_information_page.title
   expect(page).to have_content(corporate_information_page.title)
+end
+
+Then(/^I should not see the corporate information page "([^"]*)" on the worldwide organisation corporate information pages page/) do |cip_title|
+  worldwide_organisation = WorldwideOrganisation.last
+  visit admin_worldwide_organisation_corporate_information_pages_path(worldwide_organisation)
+
+  expect(page).to_not have_content(cip_title)
 end
 
 When(/^I translate the "([^"]*)" corporate information page for the worldwide organisation "([^"]*)"$/) do |corp_page, worldwide_org|

--- a/features/step_definitions/worldwide_organisation_steps.rb
+++ b/features/step_definitions/worldwide_organisation_steps.rb
@@ -50,6 +50,11 @@ Given(/^a worldwide organisation "([^"]*)" exists for the world location "([^"]*
   create(:worldwide_organisation, name:, world_locations: [country])
 end
 
+Given(/^a worldwide organisation "([^"]*)" with a published "([^"]*)" corporate information page$/) do |worldwide_organisation_name, cip_title|
+  worldwide_organisation = create(:worldwide_organisation, name: worldwide_organisation_name)
+  create(:published_worldwide_organisation_corporate_information_page, worldwide_organisation:, title: cip_title)
+end
+
 When(/^I add an "([^"]*)" office for the home page with address, phone number, and some services$/) do |description|
   service1 = create(:worldwide_service, name: "Dance lessons")
   _service2 = create(:worldwide_service, name: "Courses in advanced sword fighting")

--- a/features/worldwide-organisations.feature
+++ b/features/worldwide-organisations.feature
@@ -59,6 +59,12 @@ Feature: Administering worldwide organisation
     And I force-publish the "Terms of reference" corporate information page for the worldwide organisation "Department of Beards in France"
     Then I should see the corporate information on the worldwide organisation corporate information pages page
 
+  Scenario: Unpublishing a corporate information page from a worldwide organisation
+    Given I am a managing editor
+    Given a worldwide organisation "Department of Beards in France" with a published "Personal information charter" corporate information page
+    When I unpublish the "Personal information charter" corporate information page for the worldwide organisation "Department of Beards in France"
+    Then I should not see the corporate information page "Personal information charter" on the worldwide organisation corporate information pages page
+
   Scenario: Adding a new translation
     Given a worldwide organisation "Department of Beards in France" exists for the world location "France" with translations into "Français"
     When I add a new translation to the worldwide organisation "Department of Beards in France" with:


### PR DESCRIPTION
Unpublishing an editionable piece of content requires a `document_type` method in the Publishing API presenter.

Therefore adding the method and a test for the scenario.

Also unpublishes the affected Worldwide Organisation Corporate Information Pages and adds the missing database record for this, as they were not unpublished due to this error.

[Trello card](https://trello.com/c/xSMLrrf1)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
