### PR TITLE
Make the `reporting:matching_docs` rake task more useful

### DIFF
--- a/lib/tasks/reporting.rake
+++ b/lib/tasks/reporting.rake
@@ -20,33 +20,33 @@ namespace :reporting do
     Document.where.not(live_edition_id: nil).find_each do |object|
       next unless object.editions.published.any?
 
-      document_includes_regex(regex, object.content_id, object.class.name, object.editions.published.last.body)
+      document_includes_regex(regex, object.editions.published.last, object.editions.published.last.body)
     end
 
     HtmlAttachment.find_each do |object|
       next unless object.govspeak_content
 
-      document_includes_regex(regex, object.content_id, object.class.name, object.govspeak_content.body)
+      document_includes_regex(regex, object, object.govspeak_content.body)
     end
 
     Person.find_each do |object|
-      document_includes_regex(regex, object.content_id, object.class.name, object.biography)
+      document_includes_regex(regex, object, object.biography)
     end
 
     PolicyGroup.find_each do |object|
-      document_includes_regex(regex, object.content_id, object.class.name, object.description)
+      document_includes_regex(regex, object, object.description)
     end
 
     WorldLocationNews.find_each do |object|
-      document_includes_regex(regex, object.content_id, object.class.name, object.mission_statement)
+      document_includes_regex(regex, object, object.mission_statement)
     end
 
     WorldwideOffice.find_each do |object|
-      document_includes_regex(regex, object.content_id, object.class.name, object.access_and_opening_times)
+      document_includes_regex(regex, object, object.access_and_opening_times)
     end
   end
 end
 
-def document_includes_regex(regex, content_id, class_name, text)
-  puts "#{class_name}: #{content_id}" if text && text.match?(regex)
+def document_includes_regex(regex, object, text)
+  puts "#{object.class.name},#{object.content_id},#{object.base_path}" if text && text.match?(regex)
 end

--- a/test/unit/lib/tasks/reporting_test.rb
+++ b/test/unit/lib/tasks/reporting_test.rb
@@ -16,15 +16,15 @@ class ReportingRake < ActiveSupport::TestCase
     end
 
     test "it prints the content IDs of the matching documents from published editions" do
-      assert_output(/#{@document_1.document.content_id}/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
+      assert_output(/#{@document_1.document.content_id},#{@document_1.base_path}/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
     end
 
     test "it does not print the content IDs of the matching documents from draft editions" do
-      assert_output(/^(?!.*#{@document_2.document.content_id}).*$/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
+      assert_output(/^(?!.*#{@document_2.document.content_id},#{@document_2.base_path}).*$/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
     end
 
     test "it does not print the content IDs of the non-matching documents from published editions" do
-      assert_output(/^(?!.*#{@document_3.document.content_id}).*$/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
+      assert_output(/^(?!.*#{@document_3.document.content_id},#{@document_3.base_path}).*$/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
     end
   end
 
@@ -50,11 +50,11 @@ class ReportingRake < ActiveSupport::TestCase
     end
 
     test "it prints the content IDs of the matching documents from people" do
-      assert_output(/#{@person_1.content_id}/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
+      assert_output(/#{@person_1.content_id},#{@person_1.base_path}/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
     end
 
     test "it does not print the content IDs of the non-matching documents from people" do
-      assert_output(/^(?!.*#{@person_2.content_id}).*$/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
+      assert_output(/^(?!.*#{@person_2.content_id},#{@person_2.base_path}).*$/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
     end
   end
 
@@ -65,11 +65,11 @@ class ReportingRake < ActiveSupport::TestCase
     end
 
     test "it prints the content IDs of the matching documents from policy groups" do
-      assert_output(/#{@policy_group_1.content_id}/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
+      assert_output(/#{@policy_group_1.content_id},#{@policy_group_1.base_path}/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
     end
 
     test "it does not print the content IDs of the non-matching documents from policy groups" do
-      assert_output(/^(?!.*#{@policy_group_2.content_id}).*$/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
+      assert_output(/^(?!.*#{@policy_group_2.content_id},#{@policy_group_2.base_path}).*$/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
     end
   end
 
@@ -80,11 +80,11 @@ class ReportingRake < ActiveSupport::TestCase
     end
 
     test "it prints the content IDs of the matching documents from world location news" do
-      assert_output(/#{@world_location_news_1.content_id}/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
+      assert_output(/#{@world_location_news_1.content_id},#{@world_location_news_1.base_path}/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
     end
 
     test "it does not print the content IDs of the non-matching documents from world location news" do
-      assert_output(/^(?!.*#{@world_location_news_2.content_id}).*$/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
+      assert_output(/^(?!.*#{@world_location_news_2.content_id},#{@world_location_news_2.base_path}).*$/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
     end
   end
 
@@ -95,11 +95,11 @@ class ReportingRake < ActiveSupport::TestCase
     end
 
     test "it prints the content IDs of the matching documents from worldwide offices" do
-      assert_output(/#{@worldwide_office_1.content_id}/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
+      assert_output(/#{@worldwide_office_1.content_id},#{@worldwide_office_1.base_path}/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
     end
 
     test "it does not print the content IDs of the non-matching documents from worldwide offices" do
-      assert_output(/^(?!.*#{@worldwide_office_2.content_id}).*$/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
+      assert_output(/^(?!.*#{@worldwide_office_2.content_id},#{@worldwide_office_2.base_path}).*$/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
     end
   end
 end


### PR DESCRIPTION
At the moment, the task prints only the Content ID for the matching documents.

Adding the base path, as this will make the output more useful for users.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
