### PR TITLE
Remove references to Jenkins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,6 @@ on:
     branches:
       - main
     paths-ignore:
-      - "Jenkinsfile"
       - ".git**"
   pull_request:
 

--- a/db/data_migration/README.md
+++ b/db/data_migration/README.md
@@ -60,5 +60,4 @@ or up to a specific version:
 
 ### At deploy time
 
-We have a Jenkins job for convenience to save you having to ssh onto a box to
-run the rake task. Here's the job on deploy.integration: [Run_Whitehall_Data_Migrations](https://deploy.integration.publishing.service.gov.uk/job/Run_Whitehall_Data_Migrations/)
+Follow the instructions [for running a rake task](https://docs.publishing.service.gov.uk/manual/running-rake-tasks.html).

--- a/script/codebase_metrics
+++ b/script/codebase_metrics
@@ -5,7 +5,7 @@ set -e
 REPO_DIR=${REPO_DIR:="/tmp/codebase-metrics"}/$(date +%s)
 REPO_URL=${REPO_URL:="https://github.com/alphagov/whitehall.git"}
 REVISION=${REVISION:="main"}
-LAST_BUILD_URL=${LAST_BUILD_URL:="https://ci.integration.publishing.service.gov.uk/job/whitehall/job/${REVISION}/lastSuccessfulBuild/console"}
+LAST_BUILD_URL=${LAST_BUILD_URL:="https://github.com/alphagov/whitehall/actions/workflows/ci.yml?query=branch%3A${REVISION}"}
 
 
 get_total_size() {
@@ -64,7 +64,7 @@ report() {
     echo "Number of routes:           ${ROUTES}"
     echo 
     echo "You can retrieve 'Test coverage %' and 'Time to build (s)' from the latest"
-    echo "build against 'main' in Jenkins, at:"
+    echo "build against 'main' in CI, at:"
     echo "  ${LAST_BUILD_URL}"
   else
     echo 'To get "Number of routes", run this line in a Rails console against this revision:'
@@ -77,7 +77,7 @@ report() {
     echo "  git checkout ${CURRENT_COMMIT_SHA}"
     echo "  git push -u origin (some unique branch name)"
     echo
-    echo 'You can then retrieve those figures from the console output of that build in Jenkins, at:'
+    echo 'You can then retrieve those figures from the console output of that build in CI, at:'
     echo "  $LAST_BUILD_URL" | sed 's/\/main\//\/(your branch name)\//' 
   fi
   echo


### PR DESCRIPTION
We don't use Jenkins anymore and the old deployments of Jenkins have been switched off.

Updating all references with their replacements.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
