### PR TITLE
Speed up `reporting:matching_docs` rake task

### DIFF
--- a/test/unit/lib/tasks/reporting_test.rb
+++ b/test/unit/lib/tasks/reporting_test.rb
@@ -30,16 +30,21 @@ class ReportingRake < ActiveSupport::TestCase
 
   context "for HTML attachments" do
     setup do
-      @html_attachment_1 = create(:html_attachment, body: "Some text")
-      @html_attachment_2 = create(:html_attachment, body: "Some other text")
+      @html_attachment_1 = create(:html_attachment, body: "Some text on a published edition", attachable: create(:published_edition))
+      @html_attachment_2 = create(:html_attachment, body: "Some other text on a published edition", attachable: create(:published_edition))
+      @html_attachment_3 = create(:html_attachment, body: "Some text on a draft edition", attachable: create(:draft_edition))
     end
 
-    test "it prints the content IDs of the matching documents from HTML attachments" do
-      assert_output(/#{@html_attachment_1.content_id}/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
+    test "it prints the content IDs of the matching documents from published HTML attachments" do
+      assert_output(/#{@html_attachment_1.content_id},#{@html_attachment_1.base_path}/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
     end
 
-    test "it does not print the content IDs of the non-matching documents from HTML attachments" do
-      assert_output(/^(?!.*#{@html_attachment_2.content_id}).*$/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
+    test "it does not print the content IDs of the non-matching documents from published HTML attachments" do
+      assert_output(/^(?!.*#{@html_attachment_2.content_id},#{@html_attachment_2.base_path}).*$/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
+    end
+
+    test "it does not print the content IDs of the matching documents from draft HTML attachments" do
+      assert_output(/^(?!.*#{@html_attachment_3.content_id},#{@html_attachment_3.base_path}).*$/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
     end
   end
 


### PR DESCRIPTION
This was previously retrieving all published editions and other documents (in batches of 1,000) into memory then looping through each to check the regex.

As of MySQL 8, there is support for `REGEXP` where queries. Therefore we can switch to use these, which speeds up the task from taking around one hour to 10 minutes.

This also fixes an issue where some runs of the rake task abort with an error as the pod runs out of memory.

[Trello card](https://trello.com/c/K3jNNRgX)