### PR TITLE
Uncouple visual editor from govspeak editor and begin initialising library

### DIFF
--- a/app/assets/javascripts/components/govspeak-editor.js
+++ b/app/assets/javascripts/components/govspeak-editor.js
@@ -9,9 +9,6 @@ window.GOVUK.Modules = window.GOVUK.Modules || {}
     this.previewButton = this.module.querySelector(
       '.js-app-c-govspeak-editor__preview-button'
     )
-    this.visualEditorButton = this.module.querySelector(
-      '.js-app-c-govspeak-editor__visual-editor-button'
-    )
     this.backButton = this.module.querySelector(
       '.js-app-c-govspeak-editor__back-button'
     )
@@ -29,15 +26,8 @@ window.GOVUK.Modules = window.GOVUK.Modules || {}
     this.previewButton.classList.add(
       'app-c-govspeak-editor__preview-button--show'
     )
-    this.visualEditorButton?.classList.add(
-      'app-c-govspeak-editor__visual-editor-button--show'
-    )
 
     this.previewButton.addEventListener('click', this.showPreview.bind(this))
-    this.visualEditorButton?.addEventListener(
-      'click',
-      this.showVisualEditor.bind(this)
-    )
     this.backButton.addEventListener('click', this.hidePreview.bind(this))
   }
 
@@ -96,9 +86,6 @@ window.GOVUK.Modules = window.GOVUK.Modules || {}
     this.previewButton.classList.remove(
       'app-c-govspeak-editor__preview-button--show'
     )
-    this.visualEditorButton?.classList.remove(
-      'app-c-govspeak-editor__visual-editor-button--show'
-    )
 
     this.preview.classList.add('app-c-govspeak-editor__preview--show')
     this.textareaWrapper.classList.add(
@@ -127,35 +114,12 @@ window.GOVUK.Modules = window.GOVUK.Modules || {}
     this.maybeTrackEvent('preview')
   }
 
-  GovspeakEditor.prototype.showVisualEditor = function (event) {
-    event.preventDefault()
-
-    this.backButton.classList.add('app-c-govspeak-editor__back-button--show')
-    this.previewButton.classList.remove(
-      'app-c-govspeak-editor__preview-button--show'
-    )
-    this.visualEditorButton?.classList.remove(
-      'app-c-govspeak-editor__visual-editor-button--show'
-    )
-
-    this.textareaWrapper.classList.add(
-      'app-c-govspeak-editor__textarea--hidden'
-    )
-
-    this.backButton.focus()
-
-    this.maybeTrackEvent('visual')
-  }
-
   GovspeakEditor.prototype.hidePreview = function (event) {
     event.preventDefault()
 
     this.backButton.classList.remove('app-c-govspeak-editor__back-button--show')
     this.previewButton.classList.add(
       'app-c-govspeak-editor__preview-button--show'
-    )
-    this.visualEditorButton?.classList.add(
-      'app-c-govspeak-editor__visual-editor-button--show'
     )
 
     this.preview.classList.remove('app-c-govspeak-editor__preview--show')

--- a/app/assets/javascripts/components/visual-editor.js
+++ b/app/assets/javascripts/components/visual-editor.js
@@ -1,1 +1,24 @@
 //= require govspeak-visual-editor/dist/govspeak-visual-editor.js
+import GovspeakVisualEditor from './visual-editor.js'
+
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {}
+;(function (Modules) {
+  function VisualEditor(module) {
+    this.module = module
+
+    this.content = module.querySelector('.app-c-visual-editor__content')
+    this.container = module.querySelector('.app-c-visual-editor__container')
+    this.textarea = module.querySelector(
+      '.app-c-visual-editor__textarea-wrapper textarea'
+    )
+  }
+
+  VisualEditor.prototype.init = function () {
+    this.textarea.classList.add('app-c-visual-editor__textarea--hidden')
+
+    new GovspeakVisualEditor(this.content, this.container, this.textarea) // eslint-disable-line no-new
+  }
+
+  Modules.VisualEditor = VisualEditor
+})(window.GOVUK.Modules)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,6 +13,7 @@ $govuk-page-width: 1140px;
 @import "./components/single-image-upload";
 @import "./components/sub-navigation";
 @import "./components/summary-card";
+@import "./components/visual-editor";
 
 @import "./admin/overrides";
 

--- a/app/assets/stylesheets/components/_govspeak-editor.scss
+++ b/app/assets/stylesheets/components/_govspeak-editor.scss
@@ -1,5 +1,3 @@
-@import "govspeak-visual-editor/dist/style";
-
 .app-c-govspeak-editor {
   margin-bottom: govuk-spacing(6);
 }
@@ -22,7 +20,6 @@
 
 .app-c-govspeak-editor__preview,
 .app-c-govspeak-editor__error,
-.js-app-c-govspeak-editor__visual-editor-button,
 .js-app-c-govspeak-editor__preview-button,
 .js-app-c-govspeak-editor__back-button {
   display: none;
@@ -30,7 +27,6 @@
 
 .app-c-govspeak-editor__preview--show,
 .app-c-govspeak-editor__error--show,
-.app-c-govspeak-editor__visual-editor-button--show,
 .app-c-govspeak-editor__preview-button--show,
 .app-c-govspeak-editor__back-button--show {
   display: block;

--- a/app/assets/stylesheets/components/_visual-editor.scss
+++ b/app/assets/stylesheets/components/_visual-editor.scss
@@ -1,0 +1,6 @@
+@import "govspeak-visual-editor/dist/style";
+
+.app-c-visual-editor__content,
+.app-c-visual-editor__textarea--hidden {
+  display: none;
+}

--- a/app/views/admin/corporate_information_pages/_standard_fields.html.erb
+++ b/app/views/admin/corporate_information_pages/_standard_fields.html.erb
@@ -34,22 +34,34 @@
     maxlength: 160,
   } %>
 
-  <%= render "components/govspeak_editor", {
-    label: {
-      text: "Body (required)",
-      heading_size: "l",
-    },
-    name: "edition[body]",
-    id: "edition_body",
-    value: edition.body,
-    rows: 20,
-    error_items: errors_for(form.object.errors, :body),
-    data_attributes: {
-      image_ids: edition.images.map { |img| img[:id] }.to_json,
-      attachment_ids: edition.allows_attachments? ? edition.attachments.map(&:id) : [],
-      alternative_format_provider_id: (edition.alternative_format_provider_id || current_user.organisation.try(:id)),
-    },
-  } %>
+  <% if Flipflop.govspeak_visual_editor? %>
+    <%= render "components/visual_editor", {
+      label: {
+        text: "Body (required)",
+        heading_size: "l",
+      },
+      name: "edition[body]",
+      value: edition.body,
+      error_items: errors_for(form.object.errors, :body),
+    } %>
+  <% else %>
+    <%= render "components/govspeak_editor", {
+      label: {
+        text: "Body (required)",
+        heading_size: "l",
+      },
+      name: "edition[body]",
+      id: "edition_body",
+      value: edition.body,
+      rows: 20,
+      error_items: errors_for(form.object.errors, :body),
+      data_attributes: {
+        image_ids: edition.images.map { |img| img[:id] }.to_json,
+        attachment_ids: edition.allows_attachments? ? edition.attachments.map(&:id) : [],
+        alternative_format_provider_id: (edition.alternative_format_provider_id || current_user.organisation.try(:id)),
+      },
+    } %>
+  <% end %>
 
   <%= render "additional_significant_fields", form: form, edition: form.object %>
 </div>

--- a/app/views/admin/editions/_standard_fields.html.erb
+++ b/app/views/admin/editions/_standard_fields.html.erb
@@ -64,23 +64,36 @@
   </div>
 
   <div class="govuk-!-margin-bottom-8 js-locale-switcher-field">
-    <%= render "components/govspeak_editor", {
-      label: {
-        text: "Body" + "#{' (required)' if form.object.body_required?}",
-        heading_size: "m",
-      },
-      name: "edition[body]",
-      id: "edition_body",
-      value: edition.body,
-      rows: 20,
-      error_items: errors_for(edition.errors, :body),
-      right_to_left: form.object.translation_rtl?,
-      data_attributes: {
-        image_ids: edition.images.map { |img| img[:id] }.to_json,
-        attachment_ids: edition.allows_inline_attachments? ? edition.attachments.map(&:id) : [],
-        alternative_format_provider_id: (edition.alternative_format_provider_id || current_user.organisation.try(:id)),
-      },
-    } %>
+    <% if Flipflop.govspeak_visual_editor? %>
+      <%= render "components/visual_editor", {
+        label: {
+          text: "Body" + "#{' (required)' if form.object.body_required?}",
+          heading_size: "m",
+        },
+        name: "edition[body]",
+        value: edition.body,
+        error_items: errors_for(edition.errors, :body),
+        right_to_left: form.object.translation_rtl?,
+      } %>
+    <% else %>
+      <%= render "components/govspeak_editor", {
+        label: {
+          text: "Body" + "#{' (required)' if form.object.body_required?}",
+          heading_size: "m",
+        },
+        name: "edition[body]",
+        id: "edition_body",
+        value: edition.body,
+        rows: 20,
+        error_items: errors_for(edition.errors, :body),
+        right_to_left: form.object.translation_rtl?,
+        data_attributes: {
+          image_ids: edition.images.map { |img| img[:id] }.to_json,
+          attachment_ids: edition.allows_inline_attachments? ? edition.attachments.map(&:id) : [],
+          alternative_format_provider_id: (edition.alternative_format_provider_id || current_user.organisation.try(:id)),
+        },
+      } %>
+    <% end %>
   </div>
 
   <% if !edition.new_record? && @edition.versioning_completed? %>

--- a/app/views/admin/editions/_standard_fields.html.erb
+++ b/app/views/admin/editions/_standard_fields.html.erb
@@ -65,7 +65,6 @@
 
   <div class="govuk-!-margin-bottom-8 js-locale-switcher-field">
     <%= render "components/govspeak_editor", {
-      show_visual_editor: Flipflop.govspeak_visual_editor?,
       label: {
         text: "Body" + "#{' (required)' if form.object.body_required?}",
         heading_size: "m",

--- a/app/views/components/_govspeak_editor.html.erb
+++ b/app/views/components/_govspeak_editor.html.erb
@@ -1,6 +1,4 @@
 <%
-  show_visual_editor ||= false
-
   id ||= "#{name}-#{SecureRandom.hex(4)}"
   preview_id = "#{id}-preview"
   error_id = "#{id}-error"
@@ -51,13 +49,6 @@
     </div>
     <div class="govuk-grid-column-one-half app-c-govspeak-editor__preview-button-wrapper">
       <%= render "govuk_publishing_components/components/button", {
-        text: sanitize("Visual Editor #{tag.span("Alpha", class: 'govuk-tag app-view-summary__tag')}"),
-        secondary_quiet: true,
-        margin_bottom: hint ? 5 : 2,
-        classes: "js-app-c-govspeak-editor__visual-editor-button",
-        type: "button",
-      } if show_visual_editor %>
-      <%= render "govuk_publishing_components/components/button", {
         text: "Preview",
         secondary_quiet: true,
         margin_bottom: hint ? 5 : 2,
@@ -100,6 +91,4 @@
   <%= tag.div class: "app-c-govspeak-editor__error js-locale-switcher-custom", 'aria-live': "polite", id: error_id, dir: dir do %>
     <p class="govuk-error-message" dir="ltr">There is an error in your Markdown. Select Back to edit and review your markdown.</p>
   <% end %>
-
-  <%= javascript_include_tag "components/visual-editor", :type => "module" if show_visual_editor %>
 <% end %>

--- a/app/views/components/_visual_editor.html.erb
+++ b/app/views/components/_visual_editor.html.erb
@@ -1,0 +1,29 @@
+<%
+  error_items ||= nil
+  right_to_left ||= false
+  rows ||= 20
+  value ||= nil
+%>
+
+<div data-module="visual-editor">
+  <div class="app-c-visual-editor__textarea-wrapper">
+    <%= render "govuk_publishing_components/components/textarea", {
+      label: label,
+      name: name,
+      rows: rows,
+      value: value,
+      error_items: error_items,
+      margin_bottom: 0,
+      right_to_left: right_to_left,
+      right_to_left_help: false,
+    } %>
+  </div>
+
+  <div class="app-c-visual-editor__content">
+    <%= govspeak_to_admin_html value, [], [], nil %>
+  </div>
+
+  <div class="app-c-visual-editor__container"></div>
+</div>
+
+<%= javascript_include_tag "components/visual-editor", :type => "module" %>

--- a/app/views/components/docs/govspeak_editor.yml
+++ b/app/views/components/docs/govspeak_editor.yml
@@ -114,12 +114,3 @@ examples:
         This is an attachment: !@1
 
         This is an image: !!1
-
-
-  with_visual_editor:
-    data:
-      label:
-        text: "Document content body"
-        bold: true
-      name: "with_visual_editor"
-      show_visual_editor: true

--- a/spec/javascripts/components/govspeak-editor-spec.js
+++ b/spec/javascripts/components/govspeak-editor-spec.js
@@ -59,385 +59,321 @@ describe('GOVUK.Modules.GovspeakEditor', function () {
     component.appendChild(textareaSection)
     component.appendChild(previewSection)
     component.appendChild(errorSection)
+
+    module = new GOVUK.Modules.GovspeakEditor(component)
+    module.init()
+
+    spyOn(module, 'getCsrfToken').and.returnValue('a-csrf-token')
+
+    jasmine.Ajax.install()
   })
 
-  describe('without visual editor', function () {
-    beforeEach(function () {
-      module = new GOVUK.Modules.GovspeakEditor(component)
-      module.init()
-
-      spyOn(module, 'getCsrfToken').and.returnValue('a-csrf-token')
-
-      jasmine.Ajax.install()
-    })
-
-    afterEach(function () {
-      jasmine.Ajax.uninstall()
-    })
-
-    it('renders component correctly', function () {
-      expect(
-        component.querySelectorAll('.js-app-c-govspeak-editor__preview-button')
-          .length
-      ).toEqual(1)
-      expect(
-        component
-          .querySelector('.js-app-c-govspeak-editor__preview-button')
-          .getAttribute('data-preview-toggle-tracking')
-      ).toEqual('true')
-
-      expect(
-        component.querySelectorAll('.app-c-govspeak-editor__textarea').length
-      ).toEqual(1)
-      expect(
-        component.querySelectorAll('.app-c-govspeak-editor__textarea textarea')
-          .length
-      ).toEqual(1)
-      expect(
-        component.querySelector('.app-c-govspeak-editor__textarea')
-      ).not.toHaveClass('app-c-govspeak-editor__textarea--hidden')
-
-      expect(
-        component.querySelectorAll('.app-c-govspeak-editor__preview').length
-      ).toEqual(1)
-      expect(
-        component.querySelector('.app-c-govspeak-editor__preview')
-      ).not.toHaveClass('app-c-govspeak-editor__preview--show')
-
-      expect(
-        component.querySelectorAll('.app-c-govspeak-editor__error').length
-      ).toEqual(1)
-      expect(
-        component.querySelector('.app-c-govspeak-editor__error')
-      ).not.toHaveClass('app-c-govspeak-editor__error--show')
-    })
-
-    it('shows preview section when button clicked', function () {
-      const previewButton = component.querySelector(
-        '.js-app-c-govspeak-editor__preview-button'
-      )
-      const backButton = component.querySelector(
-        '.js-app-c-govspeak-editor__back-button'
-      )
-      const textareaSection = component.querySelector(
-        '.app-c-govspeak-editor__textarea'
-      )
-      const previewSection = component.querySelector(
-        '.app-c-govspeak-editor__preview'
-      )
-
-      expect(textareaSection).not.toHaveClass(
-        'app-c-govspeak-editor__textarea--hidden'
-      )
-      expect(previewSection).not.toHaveClass(
-        'app-c-govspeak-editor__preview--show'
-      )
-
-      previewButton.dispatchEvent(new Event('click'))
-
-      expect(textareaSection).toHaveClass(
-        'app-c-govspeak-editor__textarea--hidden'
-      )
-      expect(previewSection).toHaveClass('app-c-govspeak-editor__preview--show')
-      expect(previewButton).not.toHaveClass(
-        'app-c-govspeak-editor__preview-button--show'
-      )
-      expect(backButton).toHaveClass('app-c-govspeak-editor__back-button--show')
-    })
-
-    it('shows textarea section when you toggle back to edit', function () {
-      const previewButton = component.querySelector(
-        '.js-app-c-govspeak-editor__preview-button'
-      )
-      const backButton = component.querySelector(
-        '.js-app-c-govspeak-editor__back-button'
-      )
-      const textareaSection = component.querySelector(
-        '.app-c-govspeak-editor__textarea'
-      )
-      const previewSection = component.querySelector(
-        '.app-c-govspeak-editor__preview'
-      )
-
-      expect(textareaSection).not.toHaveClass(
-        'app-c-govspeak-editor__textarea--hidden'
-      )
-      expect(previewSection).not.toHaveClass(
-        'app-c-govspeak-editor__preview--show'
-      )
-      expect(previewButton.innerText).toEqual('Preview')
-
-      previewButton.dispatchEvent(new Event('click'))
-
-      expect(textareaSection).toHaveClass(
-        'app-c-govspeak-editor__textarea--hidden'
-      )
-      expect(previewSection).toHaveClass('app-c-govspeak-editor__preview--show')
-      expect(previewButton).not.toHaveClass(
-        'app-c-govspeak-editor__preview-button--show'
-      )
-      expect(backButton).toHaveClass('app-c-govspeak-editor__back-button--show')
-
-      backButton.dispatchEvent(new Event('click'))
-
-      expect(textareaSection).not.toHaveClass(
-        'app-c-govspeak-editor__textarea--hidden'
-      )
-      expect(previewSection).not.toHaveClass(
-        'app-c-govspeak-editor__preview--show'
-      )
-      expect(previewButton.innerText).toEqual('Preview')
-    })
-
-    it('renders govspeak correctly on preview', function () {
-      const previewButton = component.querySelector(
-        '.js-app-c-govspeak-editor__preview-button'
-      )
-      const previewSection = component.querySelector(
-        '.app-c-govspeak-editor__preview'
-      )
-      const html = [
-        '<section class="document_page">',
-        '<article class="document">',
-        '<div class="body">',
-        '<div class="govspeak">',
-        '<h2>Hello</h2>',
-        '</div>',
-        '</div>',
-        '</article>',
-        '</section>'
-      ].join('')
-
-      jasmine.Ajax.stubRequest(
-        '/government/admin/preview',
-        null,
-        'POST'
-      ).andReturn({
-        status: 200,
-        contentType: 'text/html',
-        responseText: html
-      })
-
-      previewButton.dispatchEvent(new Event('click'))
-
-      expect(previewSection.innerHTML).toEqual(html)
-    })
-
-    it('renders an error message when the govspeak service returns a 403 "forbidden" response', function () {
-      const previewButton = component.querySelector(
-        '.js-app-c-govspeak-editor__preview-button'
-      )
-      const previewSection = component.querySelector(
-        '.app-c-govspeak-editor__preview'
-      )
-      const errorSection = component.querySelector(
-        '.app-c-govspeak-editor__error'
-      )
-
-      jasmine.Ajax.stubRequest(
-        '/government/admin/preview',
-        null,
-        'POST'
-      ).andReturn({
-        status: 403,
-        contentType: 'text/html'
-      })
-
-      previewButton.dispatchEvent(new Event('click'))
-
-      expect(errorSection.classList).toContain(
-        'app-c-govspeak-editor__error--show'
-      )
-      expect(previewSection.classList).not.toContain(
-        'app-c-govspeak-editor__preview--show'
-      )
-    })
-
-    it('hides the error message when the user returns to the editor view', function () {
-      const backButton = component.querySelector(
-        '.js-app-c-govspeak-editor__back-button'
-      )
-      const errorSection = component.querySelector(
-        '.app-c-govspeak-editor__error'
-      )
-
-      errorSection.classList.add('app-c-govspeak-editor__error--show')
-
-      backButton.dispatchEvent(new Event('click'))
-
-      expect(errorSection.classList).not.toContain(
-        'app-c-govspeak-editor__error--show'
-      )
-    })
-
-    it('renders govspeak correctly with changing content', function () {
-      const previewButton = component.querySelector(
-        '.js-app-c-govspeak-editor__preview-button'
-      )
-      const textarea = component.querySelector('#textarea_id')
-      const previewSection = component.querySelector(
-        '.app-c-govspeak-editor__preview'
-      )
-      const html = [
-        '<section class="document_page">',
-        '<article class="document">',
-        '<div class="body">',
-        '<div class="govspeak">',
-        '<h2>Hello</h2>',
-        '</div>',
-        '</div>',
-        '</article>',
-        '</section>'
-      ].join('')
-
-      jasmine.Ajax.stubRequest(
-        '/government/admin/preview',
-        null,
-        'POST'
-      ).andReturn({
-        status: 200,
-        contentType: 'text/html',
-        responseText: html
-      })
-
-      previewButton.dispatchEvent(new Event('click'))
-
-      expect(previewSection.innerHTML).toEqual(html)
-
-      // back to edit
-      previewButton.dispatchEvent(new Event('click'))
-
-      textarea.innerText = '## Hello this is a heading'
-      const newHtml = [
-        '<section class="document_page">',
-        '<article class="document">',
-        '<div class="body">',
-        '<div class="govspeak">',
-        '<h2>Hello this is a heading</h2>',
-        '</div>',
-        '</div>',
-        '</article>',
-        '</section>'
-      ].join('')
-
-      jasmine.Ajax.stubRequest(
-        '/government/admin/preview',
-        null,
-        'POST'
-      ).andReturn({
-        status: 200,
-        contentType: 'text/html',
-        responseText: newHtml
-      })
-
-      previewButton.dispatchEvent(new Event('click'))
-
-      expect(previewSection.innerHTML).toEqual(newHtml)
-    })
-
-    it('sends tracking events correctly', function () {
-      spyOn(GOVUK.analytics, 'trackEvent')
-      const previewButton = component.querySelector(
-        '.js-app-c-govspeak-editor__preview-button'
-      )
-
-      previewButton.dispatchEvent(new Event('click'))
-
-      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
-        'govspeak-editor',
-        'pressed-preview-button',
-        { label: 'preview' }
-      )
-
-      const backButton = component.querySelector(
-        '.js-app-c-govspeak-editor__back-button'
-      )
-
-      backButton.dispatchEvent(new Event('click'))
-
-      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
-        'govspeak-editor',
-        'pressed-preview-button',
-        { label: 'edit' }
-      )
-    })
-
-    it('generates form data correctly', function () {
-      const formData = module.generateFormData('some text')
-
-      expect(Array.from(formData.entries())).toEqual([
-        ['body', 'some text'],
-        ['authenticity_token', 'a-csrf-token'],
-        ['alternative_format_provider_id', '11'],
-        ['image_ids[]', '1'],
-        ['image_ids[]', '2'],
-        ['image_ids[]', '3'],
-        ['image_ids[]', '4'],
-        ['attachment_ids[]', '5'],
-        ['attachment_ids[]', '6'],
-        ['attachment_ids[]', '7'],
-        ['attachment_ids[]', '8']
-      ])
-    })
+  afterEach(function () {
+    jasmine.Ajax.uninstall()
   })
 
-  describe('with visual editor', function () {
-    beforeEach(function () {
-      const visualEditorButton = document.createElement('button')
-      visualEditorButton.classList.add(
-        'js-app-c-govspeak-editor__visual-editor-button'
-      )
-      visualEditorButton.innerText = 'Visual editor'
-      component.appendChild(visualEditorButton)
+  it('renders component correctly', function () {
+    expect(
+      component.querySelectorAll('.js-app-c-govspeak-editor__preview-button')
+        .length
+    ).toEqual(1)
+    expect(
+      component
+        .querySelector('.js-app-c-govspeak-editor__preview-button')
+        .getAttribute('data-preview-toggle-tracking')
+    ).toEqual('true')
 
-      module = new GOVUK.Modules.GovspeakEditor(component)
-      module.init()
+    expect(
+      component.querySelectorAll('.app-c-govspeak-editor__textarea').length
+    ).toEqual(1)
+    expect(
+      component.querySelectorAll('.app-c-govspeak-editor__textarea textarea')
+        .length
+    ).toEqual(1)
+    expect(
+      component.querySelector('.app-c-govspeak-editor__textarea')
+    ).not.toHaveClass('app-c-govspeak-editor__textarea--hidden')
 
-      spyOn(module, 'getCsrfToken').and.returnValue('a-csrf-token')
+    expect(
+      component.querySelectorAll('.app-c-govspeak-editor__preview').length
+    ).toEqual(1)
+    expect(
+      component.querySelector('.app-c-govspeak-editor__preview')
+    ).not.toHaveClass('app-c-govspeak-editor__preview--show')
 
-      jasmine.Ajax.install()
+    expect(
+      component.querySelectorAll('.app-c-govspeak-editor__error').length
+    ).toEqual(1)
+    expect(
+      component.querySelector('.app-c-govspeak-editor__error')
+    ).not.toHaveClass('app-c-govspeak-editor__error--show')
+  })
+
+  it('shows preview section when button clicked', function () {
+    const previewButton = component.querySelector(
+      '.js-app-c-govspeak-editor__preview-button'
+    )
+    const backButton = component.querySelector(
+      '.js-app-c-govspeak-editor__back-button'
+    )
+    const textareaSection = component.querySelector(
+      '.app-c-govspeak-editor__textarea'
+    )
+    const previewSection = component.querySelector(
+      '.app-c-govspeak-editor__preview'
+    )
+
+    expect(textareaSection).not.toHaveClass(
+      'app-c-govspeak-editor__textarea--hidden'
+    )
+    expect(previewSection).not.toHaveClass(
+      'app-c-govspeak-editor__preview--show'
+    )
+
+    previewButton.dispatchEvent(new Event('click'))
+
+    expect(textareaSection).toHaveClass(
+      'app-c-govspeak-editor__textarea--hidden'
+    )
+    expect(previewSection).toHaveClass('app-c-govspeak-editor__preview--show')
+    expect(previewButton).not.toHaveClass(
+      'app-c-govspeak-editor__preview-button--show'
+    )
+    expect(backButton).toHaveClass('app-c-govspeak-editor__back-button--show')
+  })
+
+  it('shows textarea section when you toggle back to edit', function () {
+    const previewButton = component.querySelector(
+      '.js-app-c-govspeak-editor__preview-button'
+    )
+    const backButton = component.querySelector(
+      '.js-app-c-govspeak-editor__back-button'
+    )
+    const textareaSection = component.querySelector(
+      '.app-c-govspeak-editor__textarea'
+    )
+    const previewSection = component.querySelector(
+      '.app-c-govspeak-editor__preview'
+    )
+
+    expect(textareaSection).not.toHaveClass(
+      'app-c-govspeak-editor__textarea--hidden'
+    )
+    expect(previewSection).not.toHaveClass(
+      'app-c-govspeak-editor__preview--show'
+    )
+    expect(previewButton.innerText).toEqual('Preview')
+
+    previewButton.dispatchEvent(new Event('click'))
+
+    expect(textareaSection).toHaveClass(
+      'app-c-govspeak-editor__textarea--hidden'
+    )
+    expect(previewSection).toHaveClass('app-c-govspeak-editor__preview--show')
+    expect(previewButton).not.toHaveClass(
+      'app-c-govspeak-editor__preview-button--show'
+    )
+    expect(backButton).toHaveClass('app-c-govspeak-editor__back-button--show')
+
+    backButton.dispatchEvent(new Event('click'))
+
+    expect(textareaSection).not.toHaveClass(
+      'app-c-govspeak-editor__textarea--hidden'
+    )
+    expect(previewSection).not.toHaveClass(
+      'app-c-govspeak-editor__preview--show'
+    )
+    expect(previewButton.innerText).toEqual('Preview')
+  })
+
+  it('renders govspeak correctly on preview', function () {
+    const previewButton = component.querySelector(
+      '.js-app-c-govspeak-editor__preview-button'
+    )
+    const previewSection = component.querySelector(
+      '.app-c-govspeak-editor__preview'
+    )
+    const html = [
+      '<section class="document_page">',
+      '<article class="document">',
+      '<div class="body">',
+      '<div class="govspeak">',
+      '<h2>Hello</h2>',
+      '</div>',
+      '</div>',
+      '</article>',
+      '</section>'
+    ].join('')
+
+    jasmine.Ajax.stubRequest(
+      '/government/admin/preview',
+      null,
+      'POST'
+    ).andReturn({
+      status: 200,
+      contentType: 'text/html',
+      responseText: html
     })
 
-    afterEach(function () {
-      jasmine.Ajax.uninstall()
+    previewButton.dispatchEvent(new Event('click'))
+
+    expect(previewSection.innerHTML).toEqual(html)
+  })
+
+  it('renders an error message when the govspeak service returns a 403 "forbidden" response', function () {
+    const previewButton = component.querySelector(
+      '.js-app-c-govspeak-editor__preview-button'
+    )
+    const previewSection = component.querySelector(
+      '.app-c-govspeak-editor__preview'
+    )
+    const errorSection = component.querySelector(
+      '.app-c-govspeak-editor__error'
+    )
+
+    jasmine.Ajax.stubRequest(
+      '/government/admin/preview',
+      null,
+      'POST'
+    ).andReturn({
+      status: 403,
+      contentType: 'text/html'
     })
 
-    it('renders component correctly', function () {
-      expect(
-        component.querySelector('.js-app-c-govspeak-editor__preview-button')
-      ).toHaveClass('app-c-govspeak-editor__preview-button--show')
+    previewButton.dispatchEvent(new Event('click'))
 
-      expect(
-        component.querySelector(
-          '.js-app-c-govspeak-editor__visual-editor-button'
-        )
-      ).toHaveClass('app-c-govspeak-editor__visual-editor-button--show')
+    expect(errorSection.classList).toContain(
+      'app-c-govspeak-editor__error--show'
+    )
+    expect(previewSection.classList).not.toContain(
+      'app-c-govspeak-editor__preview--show'
+    )
+  })
+
+  it('hides the error message when the user returns to the editor view', function () {
+    const backButton = component.querySelector(
+      '.js-app-c-govspeak-editor__back-button'
+    )
+    const errorSection = component.querySelector(
+      '.app-c-govspeak-editor__error'
+    )
+
+    errorSection.classList.add('app-c-govspeak-editor__error--show')
+
+    backButton.dispatchEvent(new Event('click'))
+
+    expect(errorSection.classList).not.toContain(
+      'app-c-govspeak-editor__error--show'
+    )
+  })
+
+  it('renders govspeak correctly with changing content', function () {
+    const previewButton = component.querySelector(
+      '.js-app-c-govspeak-editor__preview-button'
+    )
+    const textarea = component.querySelector('#textarea_id')
+    const previewSection = component.querySelector(
+      '.app-c-govspeak-editor__preview'
+    )
+    const html = [
+      '<section class="document_page">',
+      '<article class="document">',
+      '<div class="body">',
+      '<div class="govspeak">',
+      '<h2>Hello</h2>',
+      '</div>',
+      '</div>',
+      '</article>',
+      '</section>'
+    ].join('')
+
+    jasmine.Ajax.stubRequest(
+      '/government/admin/preview',
+      null,
+      'POST'
+    ).andReturn({
+      status: 200,
+      contentType: 'text/html',
+      responseText: html
     })
 
-    it('hides textarea when visual editor button clicked', function () {
-      const visualEditorButton = component.querySelector(
-        '.js-app-c-govspeak-editor__visual-editor-button'
-      )
-      const backButton = component.querySelector(
-        '.js-app-c-govspeak-editor__back-button'
-      )
-      const textareaSection = component.querySelector(
-        '.app-c-govspeak-editor__textarea'
-      )
+    previewButton.dispatchEvent(new Event('click'))
 
-      expect(textareaSection).not.toHaveClass(
-        'app-c-govspeak-editor__textarea--hidden'
-      )
+    expect(previewSection.innerHTML).toEqual(html)
 
-      visualEditorButton.dispatchEvent(new Event('click'))
+    // back to edit
+    previewButton.dispatchEvent(new Event('click'))
 
-      expect(textareaSection).toHaveClass(
-        'app-c-govspeak-editor__textarea--hidden'
-      )
-      expect(visualEditorButton).not.toHaveClass(
-        'app-c-govspeak-editor__visual-editor--show'
-      )
-      expect(backButton).toHaveClass('app-c-govspeak-editor__back-button--show')
+    textarea.innerText = '## Hello this is a heading'
+    const newHtml = [
+      '<section class="document_page">',
+      '<article class="document">',
+      '<div class="body">',
+      '<div class="govspeak">',
+      '<h2>Hello this is a heading</h2>',
+      '</div>',
+      '</div>',
+      '</article>',
+      '</section>'
+    ].join('')
+
+    jasmine.Ajax.stubRequest(
+      '/government/admin/preview',
+      null,
+      'POST'
+    ).andReturn({
+      status: 200,
+      contentType: 'text/html',
+      responseText: newHtml
     })
+
+    previewButton.dispatchEvent(new Event('click'))
+
+    expect(previewSection.innerHTML).toEqual(newHtml)
+  })
+
+  it('sends tracking events correctly', function () {
+    spyOn(GOVUK.analytics, 'trackEvent')
+    const previewButton = component.querySelector(
+      '.js-app-c-govspeak-editor__preview-button'
+    )
+
+    previewButton.dispatchEvent(new Event('click'))
+
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+      'govspeak-editor',
+      'pressed-preview-button',
+      { label: 'preview' }
+    )
+
+    const backButton = component.querySelector(
+      '.js-app-c-govspeak-editor__back-button'
+    )
+
+    backButton.dispatchEvent(new Event('click'))
+
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+      'govspeak-editor',
+      'pressed-preview-button',
+      { label: 'edit' }
+    )
+  })
+
+  it('generates form data correctly', function () {
+    const formData = module.generateFormData('some text')
+
+    expect(Array.from(formData.entries())).toEqual([
+      ['body', 'some text'],
+      ['authenticity_token', 'a-csrf-token'],
+      ['alternative_format_provider_id', '11'],
+      ['image_ids[]', '1'],
+      ['image_ids[]', '2'],
+      ['image_ids[]', '3'],
+      ['image_ids[]', '4'],
+      ['attachment_ids[]', '5'],
+      ['attachment_ids[]', '6'],
+      ['attachment_ids[]', '7'],
+      ['attachment_ids[]', '8']
+    ])
   })
 })

--- a/test/components/govspeak_editor_test.rb
+++ b/test/components/govspeak_editor_test.rb
@@ -162,16 +162,4 @@ class GovspeakeditorComponentTest < ComponentTestCase
     assert_select ".app-c-govspeak-editor[data-alternative-format-provider-id='123'][data-image-ids='[1,2,3]'][data-attachment-ids='[3,4,5]']"
     assert_select ".govuk-textarea", text: "This is an attachment: !@1 This is an image: !!1"
   end
-
-  test "includes visual editor button" do
-    render_component({
-      name: "my-name",
-      label: {
-        text: "my-label",
-      },
-      show_visual_editor: true,
-    })
-
-    assert_select ".js-app-c-govspeak-editor__visual-editor-button", text: "Visual Editor Alpha"
-  end
 end

--- a/test/components/visual_editor_test.rb
+++ b/test/components/visual_editor_test.rb
@@ -1,0 +1,24 @@
+require "component_test_helper"
+
+class VisualeditorComponentTest < ComponentTestCase
+  def component_name
+    "visual_editor"
+  end
+
+  test "errors when no parameters given" do
+    assert_raises do
+      render_component({})
+    end
+  end
+
+  test "renders the basic component" do
+    render_component({
+      name: "my-name",
+      label: {
+        text: "my-label",
+      },
+    })
+
+    assert_select "div[data-module='visual-editor']"
+  end
+end

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -60,6 +60,14 @@ module AdminEditionControllerTestHelpers
         assert_select(".js-app-c-govspeak-editor__preview-button")
       end
 
+      view_test "new form has visual editor when enabled" do
+        feature_flags.switch!(:govspeak_visual_editor, true)
+
+        get :new
+
+        assert_select(".app-c-visual-editor__container")
+      end
+
       view_test "new form has cancel link which takes the user to the list of drafts" do
         get :new
         assert_select "a[href=?]", admin_editions_path, text: /cancel/i
@@ -177,6 +185,16 @@ module AdminEditionControllerTestHelpers
         get :edit, params: { id: edition }
 
         assert_select(".js-app-c-govspeak-editor__preview-button")
+      end
+
+      view_test "edit form has visual editor when enabled" do
+        feature_flags.switch!(:govspeak_visual_editor, true)
+
+        edition = create(edition_type) # rubocop:disable Rails/SaveBang
+
+        get :edit, params: { id: edition }
+
+        assert_select(".app-c-visual-editor__container")
       end
 
       view_test "edit form has cancel link which takes the user back to edition" do


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

# What
- Removed visual editor toggle button from the govspeak component
- Introduced a new visual editor component
- Us JS to initialise the visual editor library in the visual editor component
- Render the visual editor component instead of the govspeak component when the feature flag is enabled
- Introduce a test for the new behaviour

# Why
- Make it more clear what is the responsibility of the visual editor and the govspeak editor
- We want to test the visual editor in context so it is important to embed it into Whitehall as soon as possible
- https://trello.com/c/g5zGbaIy/2351-uncouple-visual-editor-from-govspeak-editor
- https://trello.com/c/7NTcQi1M/2340-display-document-content-in-visual-editor

# Screenshot
![whitehall-admin dev gov uk_government_admin_news_1374132_edit(iPad Pro)](https://github.com/alphagov/whitehall/assets/9594455/d1c231c0-d694-4f32-b4a2-85bcd74b0f15)
