### PR TITLE
Preserve external domains in HTML attachment unpublishing redirect URLs

### DIFF
--- a/app/services/service_listeners/publishing_api_html_attachments.rb
+++ b/app/services/service_listeners/publishing_api_html_attachments.rb
@@ -50,7 +50,7 @@ module ServiceListeners
 
     def unpublish(allow_draft: false)
       destination = if edition.unpublishing.redirect?
-                      Addressable::URI.parse(edition.unpublishing.alternative_url).path
+                      edition.unpublishing.alternative_path
                     else
                       edition.public_path
                     end

--- a/test/unit/app/services/service_listeners/publishing_api_html_attachments_test.rb
+++ b/test/unit/app/services/service_listeners/publishing_api_html_attachments_test.rb
@@ -311,6 +311,19 @@ module ServiceListeners
         call(publication)
       end
 
+      test "for a publication that has been unpublished with an external redirect publishes a redirect to the alternative url" do
+        external_url = "https://test.ukri.org/some-page"
+        publication = create(:unpublished_publication, { unpublishing: build(:unpublishing, { redirect: true, alternative_url: external_url }) })
+        attachment = publication.html_attachments.first
+        PublishingApiRedirectWorker.any_instance.expects(:perform).with(
+          attachment.content_id,
+          external_url,
+          "en",
+          false,
+        )
+        call(publication)
+      end
+
       test "for a publication that has been unpublished without a redirect publishes a redirect to the parent document" do
         publication = create(:unpublished_publication_in_error_no_redirect)
         attachment = publication.html_attachments.first


### PR DESCRIPTION
This fixes a bug which prevented Whitehall users from redirecting unpublished documents to non gov.uk domains. Conveniently, there was already an `alternative_path` method available on the unpublishing model that will use the path for GOV.UK URLs but allow the full url for other hosts.

Trello: https://trello.com/c/A9ViialC
