### PR TITLE
Add translations to Offices associated with editionable WWOrgs

### DIFF
--- a/app/controllers/admin/worldwide_office_translations_controller.rb
+++ b/app/controllers/admin/worldwide_office_translations_controller.rb
@@ -20,7 +20,11 @@ private
   end
 
   def load_translatable_item
-    @worldwide_organisation = WorldwideOrganisation.friendly.find(params[:worldwide_organisation_id])
+    @worldwide_organisation = if Flipflop.editionable_worldwide_organisations?
+                                Edition.find(params[:worldwide_organisation_id])
+                              else
+                                WorldwideOrganisation.find(params[:worldwide_organisation_id])
+                              end
     @worldwide_office = @worldwide_organisation.offices.find(params[:worldwide_office_id])
     @contact = @worldwide_office.contact
   end

--- a/app/models/worldwide_office.rb
+++ b/app/models/worldwide_office.rb
@@ -33,6 +33,10 @@ class WorldwideOffice < ApplicationRecord
     super || edition
   end
 
+  def translatable?
+    true
+  end
+
   def worldwide_office_type
     WorldwideOfficeType.find_by_id(worldwide_office_type_id)
   end

--- a/features/editionable-worldwide-organisations.feature
+++ b/features/editionable-worldwide-organisations.feature
@@ -26,6 +26,12 @@ Feature: Editionable worldwide organisations
     And I add a Welsh translation of the worldwide organisation "Test Worldwide Organisation" named "Translated Name"
     Then I should see the Welsh translated title "Translated Name" for the "Test Worldwide Organisation" worldwide organisation
 
+  Scenario: Adding a translation to an existing worldwide office
+    Given an editionable worldwide organisation in draft with a translation in French
+    When I visit the Offices tab
+    And I add a new translation with a title of "French Title"
+    Then I should see the "Translated" subheading in the "Offices" tab with my new translation
+
   Scenario: Assigning a role to a worldwide organisation
     Given a role "Prime Minister" exists
     When I draft a new worldwide organisation "Test Worldwide Organisation" assigned to world location "United Kingdom"

--- a/features/step_definitions/editionable_worldwide_organisation_steps.rb
+++ b/features/step_definitions/editionable_worldwide_organisation_steps.rb
@@ -26,6 +26,11 @@ Given(/^An editionable worldwide organisation "([^"]*)" with home page offices "
   worldwide_organisation.add_office_to_home_page!(create(:worldwide_office, worldwide_organisation: nil, edition: worldwide_organisation, contact: create(:contact, title: office_2_title)))
 end
 
+Given(/^an editionable worldwide organisation in draft with a translation in French$/) do
+  worldwide_organisation = create(:editionable_worldwide_organisation, translated_into: :fr)
+  worldwide_organisation.add_office_to_home_page!(create(:worldwide_office, worldwide_organisation: nil, edition: worldwide_organisation, contact: create(:contact, title: "Main office")))
+end
+
 When(/^I choose "([^"]*)" to be the main office for the editionable worldwide organisation$/) do |contact_title|
   WorldwideOffice.joins(contact: :translations).where(contact_translations: { title: contact_title }).first
   visit admin_editionable_worldwide_organisation_path(EditionableWorldwideOrganisation.last)
@@ -53,6 +58,11 @@ end
 When(/^I visit the reorder offices page/) do
   visit admin_worldwide_organisation_worldwide_offices_path(EditionableWorldwideOrganisation.last)
   click_link "Reorder"
+end
+
+When(/^I visit the Offices tab/) do
+  visit admin_worldwide_organisation_worldwide_offices_path(EditionableWorldwideOrganisation.last)
+  click_link "Offices"
 end
 
 When(/^I reorder the offices/) do
@@ -131,6 +141,17 @@ Then(/^I should see the Welsh translated title "([^"]*)" for the "([^"]*)" world
   I18n.with_locale(:cy) do
     expect(@worldwide_organisation.title).to eq(translated_title)
   end
+end
+
+And(/^I add a new translation with a title of "([^"]*)"$/) do |title|
+  click_link "Add translation"
+  click_button "Next"
+  fill_in "Title (required)", with: title
+  click_button "Save"
+end
+
+Then(/^I should see the "Translated" subheading in the "Offices" tab with my new translation$/) do
+  expect(page).to have_text("Translated")
 end
 
 Given(/^a role "([^"]*)" exists$/) do |name|

--- a/test/factories/editionable_worldwide_organisations.rb
+++ b/test/factories/editionable_worldwide_organisations.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :editionable_worldwide_organisation, class: EditionableWorldwideOrganisation, parent: :edition_with_organisations do
+  factory :editionable_worldwide_organisation, class: EditionableWorldwideOrganisation, parent: :edition_with_organisations, traits: [:translated] do
     title { "Editionable worldwide organisation title" }
     logo_formatted_name { title.to_s.split.join("\n") }
     summary { "Basic information about the organisation." }


### PR DESCRIPTION
This adds the translation feature to offices associated with editionable worldwide orgs. This is part of ongoing work to make worldwide organisations fully editionable

Trello - https://trello.com/c/H6na4tQf/992-add-office-contact-translations-for-editionable-worldwide-organisaitons

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
