### PR TITLE
Use new version of visual editor library

### DIFF
--- a/app/assets/javascripts/components/visual-editor.js
+++ b/app/assets/javascripts/components/visual-editor.js
@@ -1,5 +1,4 @@
 //= require govspeak-visual-editor/dist/govspeak-visual-editor.js
-import GovspeakVisualEditor from './visual-editor.js'
 
 window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {}
@@ -17,7 +16,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {}
   VisualEditor.prototype.init = function () {
     this.textarea.classList.add('app-c-visual-editor__textarea--hidden')
 
-    new GovspeakVisualEditor(this.content, this.container, this.textarea) // eslint-disable-line no-new
+    new window.GovspeakVisualEditor(this.content, this.container, this.textarea) // eslint-disable-line no-new
   }
 
   Modules.VisualEditor = VisualEditor

--- a/yarn.lock
+++ b/yarn.lock
@@ -1514,8 +1514,8 @@ gopd@^1.0.1:
     get-intrinsic "^1.1.3"
 
 govspeak-visual-editor@alphagov/govspeak-visual-editor:
-  version "0.0.1"
-  resolved "https://codeload.github.com/alphagov/govspeak-visual-editor/tar.gz/d04ce9f713457d1591472da855f2f7d92426e897"
+  version "0.0.2"
+  resolved "https://codeload.github.com/alphagov/govspeak-visual-editor/tar.gz/9b6ea682d7c26b1969bf74c41bac44d62a697d4b"
   dependencies:
     govuk-frontend "^4.7.0"
     prosemirror-example-setup "^1.2.2"


### PR DESCRIPTION

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


# What
- Use the new version of the visual editor library
- Instantiate it without importing it as an ES6 module

# Why
- The previous approach was causing problems in production environments
