### PR TITLE
Enable automatic recompiling of stylesheets

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,2 @@
+web: bin/rails server -p 3000 --restart
+css: bin/rails dartsass:watch

--- a/bin/dev
+++ b/bin/dev
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+if !(gem list foreman -i --silent); then
+  echo "Installing foreman..."
+  gem install foreman
+fi
+exec foreman start -f Procfile.dev "$@"

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -58,9 +58,6 @@ Whitehall::Application.configure do
   # Raise exceptions for disallowed deprecations.
   config.active_support.disallowed_deprecation = :raise
 
-  # Suppress logger output for asset requests.
-  config.assets.quiet = true
-
   config.active_record.verbose_query_logs = true
 
   # Tell Active Support which deprecation messages to disallow.
@@ -88,10 +85,13 @@ Whitehall::Application.configure do
 
   # Asset digests allow you to set far-future HTTP expiration dates on all assets,
   # yet still be able to expire them through the digest params.
-  config.assets.digest = true
+  config.assets.digest = false
 
   # Suppress logger output for asset requests.
   config.assets.quiet = true
+
+  # Dartsass' default watch doesn't work with GOVUK Docker, so poll for changes instead
+  config.dartsass.build_options << " --poll"
 
   # Adds additional error checking when serving assets at runtime.
   # Checks for improperly declared sprockets dependencies.


### PR DESCRIPTION
Follows guidance from https://docs.publishing.service.gov.uk/manual/migrate-to-dart-sass-from-libsass.html

One thing to note is that the basic watch command doesn't seem to work inside govuk docker. I had to add the option to poll for changes to the development configuration.

Trello: https://trello.com/c/n9bObkAU
