### PR TITLE
Don't render previously published component for worldwide organisations

### DIFF
--- a/app/components/admin/editions/first_published_at_component.rb
+++ b/app/components/admin/editions/first_published_at_component.rb
@@ -12,7 +12,7 @@ class Admin::Editions::FirstPublishedAtComponent < ViewComponent::Base
   end
 
   def render?
-    !edition.is_a?(Consultation)
+    edition.can_set_previously_published?
   end
 
 private

--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -92,6 +92,10 @@ class Consultation < Publicationesque
     true
   end
 
+  def can_set_previously_published?
+    false
+  end
+
   def has_consultation_participation?
     consultation_participation.present?
   end

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -639,6 +639,10 @@ EXISTS (
     @previously_published
   end
 
+  def can_set_previously_published?
+    true
+  end
+
   def government
     @government ||= Government.on_date(date_for_government) unless date_for_government.nil?
   end

--- a/app/models/editionable_worldwide_organisation.rb
+++ b/app/models/editionable_worldwide_organisation.rb
@@ -90,6 +90,14 @@ class EditionableWorldwideOrganisation < Edition
     roles.occupied.find_by(type: SECONDARY_ROLES.map(&:name))
   end
 
+  def previously_published
+    false
+  end
+
+  def can_set_previously_published?
+    false
+  end
+
   def skip_world_location_validation?
     false
   end

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -103,7 +103,7 @@ module DocumentHelper
   end
 
   def begin_drafting_worldwide_organisation(options)
-    begin_drafting_document options.merge(type: "editionable_worldwide_organisation", previously_published: false)
+    begin_drafting_document options.merge(type: "editionable_worldwide_organisation")
 
     fill_in_worldwide_organisation_fields(**options.slice(:world_location))
   end

--- a/test/components/admin/editions/first_published_at_component_test.rb
+++ b/test/components/admin/editions/first_published_at_component_test.rb
@@ -3,7 +3,7 @@
 require "test_helper"
 
 class Admin::Editions::FirstPublishedAtComponentTest < ViewComponent::TestCase
-  test "doesn't render when the edition is a consultation" do
+  test "doesn't render when the edition can't set previously published" do
     edition = build(:consultation)
 
     render_inline(Admin::Editions::FirstPublishedAtComponent.new(edition:, previously_published: true))


### PR DESCRIPTION
https://trello.com/c/SeyqAoOu

When editing an editionable worldwide organisation, there is an option to choose a “First published date”.

This is used for things that may have been published in print before appearing on GOV.UK (or even pre-date GOV.UK).

This isn’t the case for editionable worldwide organisations, so we should remove the item from the editing form.

|Before|After|
|-|-|
|![image](https://github.com/alphagov/whitehall/assets/47089130/8256dcd6-406c-417b-8b84-407e5c96a95c)|![image](https://github.com/alphagov/whitehall/assets/47089130/3f3481cc-7f7d-4ce8-90fb-bfbd17157e1e)|

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
