### PR TITLE
Bump visual editor to 0.0.3

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1514,8 +1514,8 @@ gopd@^1.0.1:
     get-intrinsic "^1.1.3"
 
 govspeak-visual-editor@alphagov/govspeak-visual-editor:
-  version "0.0.2"
-  resolved "https://codeload.github.com/alphagov/govspeak-visual-editor/tar.gz/9b6ea682d7c26b1969bf74c41bac44d62a697d4b"
+  version "0.0.3"
+  resolved "https://codeload.github.com/alphagov/govspeak-visual-editor/tar.gz/e731de71df929473c1702defff70f450c120a705"
   dependencies:
     govuk-frontend "^4.7.0"
     prosemirror-example-setup "^1.2.2"


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This new version of the visual editor removes the italic button