### PR TITLE
Republish ministerial index pages when ministerial people or roles are updated

### DIFF
--- a/app/controllers/admin/people_controller.rb
+++ b/app/controllers/admin/people_controller.rb
@@ -30,11 +30,6 @@ class Admin::PeopleController < Admin::BaseController
 
   def update
     if @person.update(person_params)
-      if @person.current_or_previous_prime_minister?
-        @person.historical_account.republish_to_publishing_api_async if @person.historical_account.present?
-        PresentPageToPublishingApiWorker.perform_async("PublishingApi::HistoricalAccountsIndexPresenter")
-      end
-
       redirect_to [:admin, @person], notice: %("#{@person.name}" saved.)
     else
       render :edit

--- a/app/models/ministerial_role.rb
+++ b/app/models/ministerial_role.rb
@@ -6,6 +6,8 @@ class MinisterialRole < Role
   has_many :news_articles, -> { where("editions.type" => "NewsArticle").distinct }, through: :role_appointments
   has_many :speeches, through: :role_appointments
 
+  after_save :republish_ministerial_pages_to_publishing_api
+
   def published_speeches(options = {})
     speeches
       .live_edition.published
@@ -36,5 +38,10 @@ private
 
   def default_person_name
     name
+  end
+
+  def republish_ministerial_pages_to_publishing_api
+    PresentPageToPublishingApiWorker.perform_async("PublishingApi::HowGovernmentWorksPresenter")
+    PresentPageToPublishingApiWorker.perform_async("PublishingApi::MinistersIndexPresenter")
   end
 end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -161,5 +161,10 @@ private
       PresentPageToPublishingApiWorker.perform_async("PublishingApi::HowGovernmentWorksPresenter")
       PresentPageToPublishingApiWorker.perform_async("PublishingApi::MinistersIndexPresenter")
     end
+
+    if current_or_previous_prime_minister?
+      historical_account.republish_to_publishing_api_async if historical_account.present?
+      PresentPageToPublishingApiWorker.perform_async("PublishingApi::HistoricalAccountsIndexPresenter")
+    end
   end
 end

--- a/test/functional/admin/people_controller_test.rb
+++ b/test/functional/admin/people_controller_test.rb
@@ -188,36 +188,6 @@ class Admin::PeopleControllerTest < ActionController::TestCase
     end
   end
 
-  test "PUT :update republishes the past prime ministers page & the persons historical account if the person is or has been the prime minister" do
-    login_as :gds_admin
-    historical_account = build(:historical_account)
-    person = create(:pm, historical_account:)
-
-    service = mock
-
-    PresentPageToPublishingApi
-    .expects(:new)
-    .once
-    .returns(service)
-
-    service
-    .expects(:publish)
-    .once
-    .with(PublishingApi::HistoricalAccountsIndexPresenter)
-
-    HistoricalAccount
-    .any_instance
-    .expects(:republish_to_publishing_api_async)
-    .once
-
-    Sidekiq::Testing.inline! do
-      put :update, params: {
-        id: person.id,
-        person: attributes_for(:person),
-      }
-    end
-  end
-
   test "should be able to destroy a destroyable person" do
     person = create(:person, forename: "Dave")
     delete :destroy, params: { id: person.id }

--- a/test/unit/lib/data_hygiene/role_reslugger_test.rb
+++ b/test/unit/lib/data_hygiene/role_reslugger_test.rb
@@ -38,6 +38,12 @@ class MinisterialRoleResluggerTest < ActiveSupport::TestCase
       stub_publishing_api_put_content(organisation_content_item.content_id, organisation_content_item.content),
       stub_publishing_api_patch_links(organisation_content_item.content_id, links: organisation_content_item.links),
       stub_publishing_api_publish(organisation_content_item.content_id, locale: "en", update_type: nil),
+      stub_publishing_api_put_content(PublishingApi::HowGovernmentWorksPresenter.new.content_id, PublishingApi::HowGovernmentWorksPresenter.new.content),
+      stub_publishing_api_patch_links(PublishingApi::HowGovernmentWorksPresenter.new.content_id, links: PublishingApi::HowGovernmentWorksPresenter.new.links),
+      stub_publishing_api_publish(PublishingApi::HowGovernmentWorksPresenter.new.content_id, locale: "en", update_type: nil),
+      stub_publishing_api_put_content(PublishingApi::MinistersIndexPresenter.new.content_id, PublishingApi::MinistersIndexPresenter.new.content),
+      stub_publishing_api_patch_links(PublishingApi::MinistersIndexPresenter.new.content_id, links: PublishingApi::MinistersIndexPresenter.new.links),
+      stub_publishing_api_publish(PublishingApi::MinistersIndexPresenter.new.content_id, locale: "en", update_type: nil),
     ]
 
     Sidekiq::Testing.inline! do


### PR DESCRIPTION
We are missing callbacks on the `Person` and `MinisterialRole` models which means the ministers index page isn't updated when either of these are changed.

This adds that callback, so the page will be updated if something on the model (e.g. a person's role or name changes).

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
