### PR TITLE
Expose default news image on WorldwideOrganisation

### DIFF
--- a/app/presenters/publishing_api/default_news_image_helper.rb
+++ b/app/presenters/publishing_api/default_news_image_helper.rb
@@ -1,0 +1,14 @@
+module PublishingApi::DefaultNewsImageHelper
+  def default_news_image
+    return unless item.default_news_image && item.default_news_image.all_asset_variants_uploaded?
+
+    {
+      url: default_news_image_url(:s300),
+      high_resolution_url: default_news_image_url(:s960),
+    }
+  end
+
+  def default_news_image_url(size = nil)
+    size ? item.default_news_image.url(size) : item.default_news_image.url
+  end
+end

--- a/app/presenters/publishing_api/organisation_presenter.rb
+++ b/app/presenters/publishing_api/organisation_presenter.rb
@@ -7,6 +7,7 @@ module PublishingApi
     # This is a hack to get the OrganisationHelper to work in this context
     include ActionView::Helpers::UrlHelper
     include FeaturedDocumentsPresenter
+    include DefaultNewsImageHelper
 
     attr_accessor :item, :update_type
 
@@ -409,19 +410,6 @@ module PublishingApi
 
     def roles_links
       item.roles.distinct.pluck(:content_id)
-    end
-
-    def default_news_image
-      return unless item.default_news_image && item.default_news_image.all_asset_variants_uploaded?
-
-      {
-        url: default_news_image_url(:s300),
-        high_resolution_url: default_news_image_url(:s960),
-      }
-    end
-
-    def default_news_image_url(size = nil)
-      size ? item.default_news_image.url(size) : item.default_news_image.url
     end
   end
 end

--- a/app/presenters/publishing_api/worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/worldwide_organisation_presenter.rb
@@ -4,6 +4,7 @@ module PublishingApi
     include ActionView::Helpers::UrlHelper
     include ApplicationHelper
     include OrganisationHelper
+    include DefaultNewsImageHelper
 
     attr_accessor :item, :update_type, :state
 
@@ -30,6 +31,7 @@ module PublishingApi
             crest: "single-identity",
             formatted_title: worldwide_organisation_logo_name(item),
           },
+          default_news_image:,
           office_contact_associations:,
           ordered_corporate_information_pages:,
           people_role_associations:,

--- a/test/unit/app/presenters/publishing_api/worldwide_organisation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/worldwide_organisation_presenter_test.rb
@@ -13,7 +13,8 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
                            :with_sponsorships,
                            :with_world_location,
                            name: "Locationia Embassy",
-                           analytics_identifier: "WO123")
+                           analytics_identifier: "WO123",
+                           default_news_image: create(:featured_image_data))
 
     primary_role = create(:ambassador_role)
     ambassador = create(:person)
@@ -44,6 +45,10 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
         logo: {
           crest: "single-identity",
           formatted_title: "Locationia<br/>Embassy",
+        },
+        default_news_image: {
+          url: worldwide_org.default_news_image.file.url(:s300),
+          high_resolution_url: worldwide_org.default_news_image.file.url(:s960),
         },
         office_contact_associations: [
           {
@@ -217,5 +222,14 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
     presented_item = present(worldwide_org)
 
     assert_equal [], presented_item.content.dig(:links, :contacts)
+  end
+
+  test "should ignore the default news image if all variants are not uploaded" do
+    featured_image = build(:featured_image_data)
+    featured_image.assets.destroy_all
+    worldwide_organisation = build(:worldwide_organisation, default_news_image: featured_image)
+    presenter = PublishingApi::WorldwideOrganisationPresenter.new(worldwide_organisation)
+
+    assert_nil presenter.content.dig(:details, :default_news_image)
   end
 end


### PR DESCRIPTION
The concept of a default news image is used across different content
types, however the impementation vairies.

We want to make it consistent, here we expose the default news image in
the WorldwideOrganisationPresenter which in turn will allow the
PublishingAPI to treat it as a link, this is how the same attribute is
handled for Organisation.

We first exptract the helper methods to a module and then make the
necessary changes the schema has already been updated to reflect this
change.

Part of: https://trello.com/c/k4iXUPJU

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
