### PR TITLE
Separate attachment asset creation worker

### DIFF
--- a/app/services/asset_manager/create_asset_response.rb
+++ b/app/services/asset_manager/create_asset_response.rb
@@ -1,0 +1,13 @@
+class AssetManager::CreateAssetResponse
+  def initialize(gds_api_response)
+    @response_attributes = gds_api_response.to_h
+  end
+
+  def asset_manager_id
+    @response_attributes["id"][/\/assets\/(.*)/, 1]
+  end
+
+  def filename
+    @response_attributes["name"]
+  end
+end

--- a/app/services/asset_manager/service_helper.rb
+++ b/app/services/asset_manager/service_helper.rb
@@ -11,6 +11,10 @@ private
     Services.asset_manager
   end
 
+  def create_asset(asset_options)
+    AssetManager::CreateAssetResponse.new(asset_manager.create_asset(asset_options))
+  end
+
   def find_asset_by_id(asset_manager_id)
     asset_manager.asset(asset_manager_id).to_hash
   rescue GdsApi::HTTPNotFound

--- a/app/uploaders/storage/attachment_storage.rb
+++ b/app/uploaders/storage/attachment_storage.rb
@@ -5,7 +5,7 @@ class Storage::AttachmentStorage < CarrierWave::Storage::Abstract
 
     logger.info("Saving to Asset Manager for model AttachmentData with ID #{uploader.model&.id || 'nil'}")
 
-    AssetManagerCreateAssetWorker.perform_async(temporary_location, uploader.asset_params, true, uploader.model.attachable.class.to_s, uploader.model.attachable.id, uploader.model.auth_bypass_ids || [])
+    AssetManagerCreateAttachmentAssetWorker.perform_async(temporary_location, uploader.asset_params, uploader.model.attachable.class.to_s, uploader.model.attachable.id, true, uploader.model.auth_bypass_ids || [])
 
     Whitehall::AssetManagerStorage::File.new(uploader.store_path(::File.basename(original_file)), uploader.model, uploader.version_name)
   end

--- a/app/uploaders/storage/previewable_storage.rb
+++ b/app/uploaders/storage/previewable_storage.rb
@@ -5,7 +5,7 @@ class Storage::PreviewableStorage < CarrierWave::Storage::Abstract
 
     logger.info("Saving to Asset Manager for model #{uploader.model.class} with ID #{uploader.model.id}")
 
-    AssetManagerCreateAssetWorker.perform_async(temporary_location, uploader.asset_params, false, nil, nil, uploader.model.auth_bypass_ids)
+    AssetManagerCreateAssetWorker.perform_async(temporary_location, uploader.asset_params, uploader.model.auth_bypass_ids)
 
     Whitehall::AssetManagerStorage::File.new(uploader.store_path(::File.basename(original_file)), uploader.model, uploader.version_name)
   end

--- a/app/workers/asset_manager_create_asset_worker.rb
+++ b/app/workers/asset_manager_create_asset_worker.rb
@@ -9,44 +9,22 @@ class AssetManagerCreateAssetWorker < WorkerBase
   def perform(temporary_location, asset_params, auth_bypass_ids = [])
     return unless File.exist?(temporary_location)
 
-    file = File.open(temporary_location)
-
     assetable_id, assetable_type, asset_variant = asset_params.values_at("assetable_id", "assetable_type", "asset_variant")
+    assetable = assetable_type.constantize.where(id: assetable_id).first
 
-    return logger.info("Assetable #{assetable_type} of id #{assetable_id} does not exist") unless assetable_type.constantize.where(id: assetable_id).exists?
+    return logger.info("Assetable #{assetable_type} of id #{assetable_id} does not exist") if assetable.nil?
 
-    asset_options = { file:, auth_bypass_ids:, draft: false }
-
-    response = create_asset(asset_options)
-    save_asset(assetable_id, assetable_type, asset_variant, response.asset_manager_id, response.filename)
-
-    enqueue_downstream_service_updates(assetable_id, assetable_type)
-
+    file = File.open(temporary_location)
+    response = create_asset({ file:, auth_bypass_ids:, draft: false })
     file.close
     FileUtils.rm(file)
     FileUtils.rmdir(File.dirname(file))
-  end
 
-private
-
-  def enqueue_downstream_service_updates(assetable_id, assetable_type)
-    assetable = assetable_type.constantize.find(assetable_id)
-    assetable.republish_on_assets_ready if assetable.respond_to? :republish_on_assets_ready
-  end
-
-  def get_authorised_organisation_ids(attachable_model_class, attachable_model_id)
-    if attachable_model_class && attachable_model_id
-      attachable_model = attachable_model_class.constantize.find(attachable_model_id)
-      if attachable_model.respond_to?(:access_limited?) && attachable_model.access_limited?
-        AssetManagerAccessLimitation.for(attachable_model)
-      end
-    end
-  end
-
-  def save_asset(assetable_id, assetable_type, variant, asset_manager_id, filename)
-    asset = Asset.where(assetable_id:, assetable_type:, variant:).first_or_initialize
-    asset.asset_manager_id = asset_manager_id
-    asset.filename = filename
+    asset = assetable.assets.where(variant: asset_variant).first_or_initialize
+    asset.asset_manager_id = response.asset_manager_id
+    asset.filename = response.filename
     asset.save!
+
+    assetable.republish_on_assets_ready if assetable.respond_to? :republish_on_assets_ready
   end
 end

--- a/app/workers/asset_manager_create_attachment_asset_worker.rb
+++ b/app/workers/asset_manager_create_attachment_asset_worker.rb
@@ -9,51 +9,37 @@ class AssetManagerCreateAttachmentAssetWorker < WorkerBase
   def perform(temporary_location, asset_params, attachable_model_class, attachable_model_id, draft = false, auth_bypass_ids = [])
     return unless File.exist?(temporary_location)
 
-    file = File.open(temporary_location)
+    attachment_data = AttachmentData.where(id: asset_params["assetable_id"]).first
 
-    assetable_id, assetable_type, asset_variant = asset_params.values_at("assetable_id", "assetable_type", "asset_variant")
+    return logger.info("Assetable AttachmentData of id #{asset_params['assetable_id']} does not exist") if attachment_data.nil?
 
-    return logger.info("Assetable #{assetable_type} of id #{assetable_id} does not exist") unless assetable_type.constantize.where(id: assetable_id).exists?
-
-    if !attachable_model_class.constantize.where(id: attachable_model_id).exists?
+    attachable = attachable_model_class.constantize.where(id: attachable_model_id).first
+    if attachable.nil?
       return logger.info("Attachable #{attachable_model_class} of id #{attachable_model_id} does not exist")
     end
 
+    file = File.open(temporary_location)
+
     asset_options = { file:, auth_bypass_ids:, draft: }
-    authorised_organisation_uids = get_authorised_organisation_ids(attachable_model_class, attachable_model_id)
-    asset_options[:access_limited_organisation_ids] = authorised_organisation_uids if authorised_organisation_uids
+    if attachable.respond_to?(:access_limited?) && attachable.access_limited?
+      asset_options[:access_limited_organisation_ids] = AssetManagerAccessLimitation.for(attachable)
+    end
 
     response = create_asset(asset_options)
-    save_asset(assetable_id, assetable_type, asset_variant, response.asset_manager_id, response.filename)
-
-    enqueue_downstream_service_updates(assetable_id, attachable_model_class, attachable_model_id)
 
     file.close
     FileUtils.rm(file)
     FileUtils.rmdir(File.dirname(file))
-  end
 
-  private
-
-  def enqueue_downstream_service_updates(assetable_id, attachable_model_class, attachable_model_id)
-    if attachable_model_class.constantize.ancestors.include?(Edition)
-      PublishingApiDraftUpdateWorker.perform_async(attachable_model_class, attachable_model_id)
-    else
-      AssetManagerAttachmentMetadataWorker.perform_async(assetable_id)
-    end
-  end
-
-  def get_authorised_organisation_ids(attachable_model_class, attachable_model_id)
-    attachable_model = attachable_model_class.constantize.find(attachable_model_id)
-    if attachable_model.respond_to?(:access_limited?) && attachable_model.access_limited?
-      AssetManagerAccessLimitation.for(attachable_model)
-    end
-  end
-
-  def save_asset(assetable_id, assetable_type, variant, asset_manager_id, filename)
-    asset = Asset.where(assetable_id:, assetable_type:, variant:).first_or_initialize
-    asset.asset_manager_id = asset_manager_id
-    asset.filename = filename
+    asset = attachment_data.assets.where(variant: asset_params["asset_variant"]).first_or_initialize
+    asset.asset_manager_id = response.asset_manager_id
+    asset.filename = response.filename
     asset.save!
+
+    if attachable.is_a?(Edition)
+      PublishingApiDraftUpdateWorker.perform_async(attachable.class.to_s, attachable.id)
+    else
+      AssetManagerAttachmentMetadataWorker.perform_async(attachment_data.id)
+    end
   end
 end

--- a/app/workers/asset_manager_create_attachment_asset_worker.rb
+++ b/app/workers/asset_manager_create_attachment_asset_worker.rb
@@ -1,4 +1,4 @@
-class AssetManagerCreateAssetWorker < WorkerBase
+class AssetManagerCreateAttachmentAssetWorker < WorkerBase
   include AssetManager::ServiceHelper
 
   # Carrierwave runs on an after_save hook and the transaction that inserts Assetable into the database
@@ -6,7 +6,7 @@ class AssetManagerCreateAssetWorker < WorkerBase
   # Use TransactionAwareClient for this worker to ensure that the commit is finished before the worker is executed.
   sidekiq_options queue: "asset_manager", client_class: Sidekiq::TransactionAwareClient
 
-  def perform(temporary_location, asset_params, auth_bypass_ids = [])
+  def perform(temporary_location, asset_params, attachable_model_class, attachable_model_id, draft = false, auth_bypass_ids = [])
     return unless File.exist?(temporary_location)
 
     file = File.open(temporary_location)
@@ -15,31 +15,38 @@ class AssetManagerCreateAssetWorker < WorkerBase
 
     return logger.info("Assetable #{assetable_type} of id #{assetable_id} does not exist") unless assetable_type.constantize.where(id: assetable_id).exists?
 
-    asset_options = { file:, auth_bypass_ids:, draft: false }
+    if !attachable_model_class.constantize.where(id: attachable_model_id).exists?
+      return logger.info("Attachable #{attachable_model_class} of id #{attachable_model_id} does not exist")
+    end
+
+    asset_options = { file:, auth_bypass_ids:, draft: }
+    authorised_organisation_uids = get_authorised_organisation_ids(attachable_model_class, attachable_model_id)
+    asset_options[:access_limited_organisation_ids] = authorised_organisation_uids if authorised_organisation_uids
 
     response = create_asset(asset_options)
     save_asset(assetable_id, assetable_type, asset_variant, response.asset_manager_id, response.filename)
 
-    enqueue_downstream_service_updates(assetable_id, assetable_type)
+    enqueue_downstream_service_updates(assetable_id, attachable_model_class, attachable_model_id)
 
     file.close
     FileUtils.rm(file)
     FileUtils.rmdir(File.dirname(file))
   end
 
-private
+  private
 
-  def enqueue_downstream_service_updates(assetable_id, assetable_type)
-    assetable = assetable_type.constantize.find(assetable_id)
-    assetable.republish_on_assets_ready if assetable.respond_to? :republish_on_assets_ready
+  def enqueue_downstream_service_updates(assetable_id, attachable_model_class, attachable_model_id)
+    if attachable_model_class.constantize.ancestors.include?(Edition)
+      PublishingApiDraftUpdateWorker.perform_async(attachable_model_class, attachable_model_id)
+    else
+      AssetManagerAttachmentMetadataWorker.perform_async(assetable_id)
+    end
   end
 
   def get_authorised_organisation_ids(attachable_model_class, attachable_model_id)
-    if attachable_model_class && attachable_model_id
-      attachable_model = attachable_model_class.constantize.find(attachable_model_id)
-      if attachable_model.respond_to?(:access_limited?) && attachable_model.access_limited?
-        AssetManagerAccessLimitation.for(attachable_model)
-      end
+    attachable_model = attachable_model_class.constantize.find(attachable_model_id)
+    if attachable_model.respond_to?(:access_limited?) && attachable_model.access_limited?
+      AssetManagerAccessLimitation.for(attachable_model)
     end
   end
 

--- a/test/functional/admin/attachments_controller_test.rb
+++ b/test/functional/admin/attachments_controller_test.rb
@@ -172,8 +172,8 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
     attachment = valid_file_attachment_params
     model_type = AttachmentData.to_s
 
-    AssetManagerCreateAssetWorker.expects(:perform_async).with(anything, has_entries("assetable_id" => kind_of(Integer), "asset_variant" => Asset.variants[:original], "assetable_type" => model_type), anything, @edition.class.to_s, @edition.id, [@edition.auth_bypass_id]).once
-    AssetManagerCreateAssetWorker.expects(:perform_async).with(anything, has_entries("assetable_id" => kind_of(Integer), "asset_variant" => Asset.variants[:thumbnail], "assetable_type" => model_type), anything, @edition.class.to_s, @edition.id, [@edition.auth_bypass_id])
+    AssetManagerCreateAttachmentAssetWorker.expects(:perform_async).with(anything, has_entries("assetable_id" => kind_of(Integer), "asset_variant" => Asset.variants[:original], "assetable_type" => model_type), @edition.class.to_s, @edition.id, anything, [@edition.auth_bypass_id]).once
+    AssetManagerCreateAttachmentAssetWorker.expects(:perform_async).with(anything, has_entries("assetable_id" => kind_of(Integer), "asset_variant" => Asset.variants[:thumbnail], "assetable_type" => model_type), @edition.class.to_s, @edition.id, anything, [@edition.auth_bypass_id])
 
     post :create, params: { edition_id: @edition.id, type: "file", attachment: }
   end
@@ -349,8 +349,8 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
     attachment = create(:file_attachment, attachable: @edition)
     model_type = attachment.attachment_data.class.to_s
 
-    AssetManagerCreateAssetWorker.expects(:perform_async).with(anything, has_entries("assetable_id" => kind_of(Integer), "asset_variant" => Asset.variants[:original], "assetable_type" => model_type), anything, @edition.class.to_s, @edition.id, [@edition.auth_bypass_id])
-    AssetManagerCreateAssetWorker.expects(:perform_async).with(anything, has_entries("assetable_id" => kind_of(Integer), "asset_variant" => Asset.variants[:thumbnail], "assetable_type" => model_type), anything, @edition.class.to_s, @edition.id, [@edition.auth_bypass_id])
+    AssetManagerCreateAttachmentAssetWorker.expects(:perform_async).with(anything, has_entries("assetable_id" => kind_of(Integer), "asset_variant" => Asset.variants[:original], "assetable_type" => model_type), @edition.class.to_s, @edition.id, anything, [@edition.auth_bypass_id])
+    AssetManagerCreateAttachmentAssetWorker.expects(:perform_async).with(anything, has_entries("assetable_id" => kind_of(Integer), "asset_variant" => Asset.variants[:thumbnail], "assetable_type" => model_type), @edition.class.to_s, @edition.id, anything, [@edition.auth_bypass_id])
 
     put :update,
         params: {
@@ -421,8 +421,8 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
     whitepaper_pdf = upload_fixture("whitepaper.pdf", "application/pdf")
     whitepaper_attachment_data = build(:attachment_data, file: whitepaper_pdf, attachable: @edition)
 
-    AssetManagerCreateAssetWorker.expects(:perform_async).with(regexp_matches(/whitepaper/), anything, anything, anything, anything, anything).never
-    AssetManagerCreateAssetWorker.expects(:perform_async).with(regexp_matches(/greenpaper/), anything, anything, anything, anything, anything).times(2)
+    AssetManagerCreateAttachmentAssetWorker.expects(:perform_async).with(regexp_matches(/whitepaper/), anything, anything, anything, anything, anything).never
+    AssetManagerCreateAttachmentAssetWorker.expects(:perform_async).with(regexp_matches(/greenpaper/), anything, anything, anything, anything, anything).times(2)
 
     post :create,
          params: {
@@ -442,8 +442,8 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
     whitepaper_pdf = upload_fixture("whitepaper.pdf", "application/pdf")
     whitepaper_attachment_data = build(:attachment_data, file: whitepaper_pdf)
 
-    AssetManagerCreateAssetWorker.expects(:perform_async).with(regexp_matches(/whitepaper/), anything, anything, anything, anything, anything).never
-    AssetManagerCreateAssetWorker.expects(:perform_async).with(regexp_matches(/greenpaper/), anything, anything, anything, anything, anything).times(2)
+    AssetManagerCreateAttachmentAssetWorker.expects(:perform_async).with(regexp_matches(/whitepaper/), anything, anything, anything, anything, anything).never
+    AssetManagerCreateAttachmentAssetWorker.expects(:perform_async).with(regexp_matches(/greenpaper/), anything, anything, anything, anything, anything).times(2)
 
     put :update,
         params: {

--- a/test/integration/asset_access_options_integration_test.rb
+++ b/test/integration/asset_access_options_integration_test.rb
@@ -91,7 +91,7 @@ class AssetAccessOptionsIntegrationTest < ActionDispatch::IntegrationTest
             ),
           ).returns(asset_manager_response)
 
-          AssetManagerCreateAssetWorker.drain
+          AssetManagerCreateAttachmentAssetWorker.drain
         end
       end
 
@@ -148,7 +148,7 @@ class AssetAccessOptionsIntegrationTest < ActionDispatch::IntegrationTest
             ),
           ).returns(asset_manager_response)
 
-          AssetManagerCreateAssetWorker.drain
+          AssetManagerCreateAttachmentAssetWorker.drain
         end
       end
     end
@@ -195,7 +195,7 @@ class AssetAccessOptionsIntegrationTest < ActionDispatch::IntegrationTest
               params[:auth_bypass_ids] == [edition.auth_bypass_id]
           }.returns(asset_manager_response)
 
-          AssetManagerCreateAssetWorker.drain
+          AssetManagerCreateAttachmentAssetWorker.drain
         end
       end
     end
@@ -225,7 +225,7 @@ class AssetAccessOptionsIntegrationTest < ActionDispatch::IntegrationTest
               auth_bypass_ids: [edition.auth_bypass_id],
             ),
           ).returns(asset_manager_response)
-          AssetManagerCreateAssetWorker.drain
+          AssetManagerCreateAttachmentAssetWorker.drain
         end
       end
 

--- a/test/integration/asset_manager_test.rb
+++ b/test/integration/asset_manager_test.rb
@@ -31,7 +31,7 @@ class AssetManagerIntegrationTest
       end
     end
 
-    test "sends the user ids of authorised users to Asset Manager" do
+    test "sends the user ids of authorised organisations to Asset Manager for attachment assets" do
       organisation = FactoryBot.create(:organisation)
       consultation = FactoryBot.create(:consultation, access_limited: true, organisations: [organisation])
       @attachment.attachable = consultation
@@ -41,7 +41,7 @@ class AssetManagerIntegrationTest
       Services.asset_manager.expects(:create_asset).with(has_entry(access_limited_organisation_ids: [organisation.content_id]))
               .returns(@asset_manager_response)
 
-      AssetManagerCreateAssetWorker.drain
+      AssetManagerCreateAttachmentAssetWorker.drain
     end
   end
 

--- a/test/integration/attachment_draft_status_integration_test.rb
+++ b/test/integration/attachment_draft_status_integration_test.rb
@@ -101,7 +101,7 @@ class AttachmentDraftStatusIntegrationTest < ActionDispatch::IntegrationTest
         visit admin_policy_group_attachments_path(policy_group)
         add_attachment(filename)
 
-        AssetManagerCreateAssetWorker.drain
+        AssetManagerCreateAttachmentAssetWorker.drain
 
         assert_sets_draft_status_in_asset_manager_to false
       end

--- a/test/integration/attachment_replacement_integration_test.rb
+++ b/test/integration/attachment_replacement_integration_test.rb
@@ -54,7 +54,7 @@ class AttachmentReplacementIntegrationTest < ActionDispatch::IntegrationTest
                   .at_least_once
                   .with(asset_manager_id, { "replacement_id" => replacement_asset_manager_id })
 
-          AssetManagerCreateAssetWorker.drain
+          AssetManagerCreateAttachmentAssetWorker.drain
           PublishingApiDraftUpdateWorker.drain
           AssetManagerAttachmentMetadataWorker.drain
         end
@@ -83,7 +83,7 @@ class AttachmentReplacementIntegrationTest < ActionDispatch::IntegrationTest
         # asset is marked as replaced, because the replacement is not yet
         # visible to the user.
         it "updates replacement_id for attachment in Asset Manager" do
-          AssetManagerCreateAssetWorker.drain
+          AssetManagerCreateAttachmentAssetWorker.drain
 
           Services.asset_manager.expects(:update_asset)
                   .at_least_once

--- a/test/unit/app/models/attachment_data_test.rb
+++ b/test/unit/app/models/attachment_data_test.rb
@@ -163,7 +163,7 @@ class AttachmentDataTest < ActiveSupport::TestCase
 
     assert second_attempt_attachment.save
 
-    AssetManagerCreateAssetWorker.drain
+    AssetManagerCreateAttachmentAssetWorker.drain
   end
 
   test "should return nil file extension when no uploader present" do

--- a/test/unit/app/uploaders/attachment_uploader_test.rb
+++ b/test/unit/app/uploaders/attachment_uploader_test.rb
@@ -224,7 +224,7 @@ class AttachmentUploaderPDFTest < ActiveSupport::TestCase
 
     expect_thumbnail_sent_to_asset_manager_to_be_an_actual_png
 
-    AssetManagerCreateAssetWorker.drain
+    AssetManagerCreateAttachmentAssetWorker.drain
   end
 
   test "should scale the thumbnail down proportionally to A4" do
@@ -232,7 +232,7 @@ class AttachmentUploaderPDFTest < ActiveSupport::TestCase
 
     expect_thumbnail_sent_to_asset_manager_to_be_scaled_proportionally
 
-    AssetManagerCreateAssetWorker.drain
+    AssetManagerCreateAttachmentAssetWorker.drain
   end
 
   test "should use a generic thumbnail if conversion fails" do
@@ -241,7 +241,7 @@ class AttachmentUploaderPDFTest < ActiveSupport::TestCase
 
     expect_fallback_thumbnail_to_be_uploaded_to_asset_manager
 
-    AssetManagerCreateAssetWorker.drain
+    AssetManagerCreateAttachmentAssetWorker.drain
   end
 
   test "should use a generic thumbnail if conversion takes longer than 10 seconds to complete" do
@@ -250,7 +250,7 @@ class AttachmentUploaderPDFTest < ActiveSupport::TestCase
 
     expect_fallback_thumbnail_to_be_uploaded_to_asset_manager
 
-    AssetManagerCreateAssetWorker.drain
+    AssetManagerCreateAttachmentAssetWorker.drain
   end
 
   def expect_fallback_thumbnail_to_be_uploaded_to_asset_manager

--- a/test/unit/app/uploaders/storage/attachment_storage_test.rb
+++ b/test/unit/app/uploaders/storage/attachment_storage_test.rb
@@ -21,7 +21,7 @@ class AttachmentStorageTest < ActiveSupport::TestCase
     storage = Storage::AttachmentStorage.new(uploader)
     file = CarrierWave::SanitizedFile.new(@file)
 
-    AssetManagerCreateAssetWorker.expects(:perform_async).with do |actual_path, asset_params, draft, attachable_model_class, attachable_id, auth_bypass_ids|
+    AssetManagerCreateAttachmentAssetWorker.expects(:perform_async).with do |actual_path, asset_params, attachable_model_class, attachable_id, draft, auth_bypass_ids|
       uploaded_file_name = File.basename(@file.path)
       expected_path = %r{#{Whitehall.asset_manager_tmp_dir}/[a-z0-9-]+/#{uploaded_file_name}}
 

--- a/test/unit/app/uploaders/storage/previewable_storage_test.rb
+++ b/test/unit/app/uploaders/storage/previewable_storage_test.rb
@@ -17,13 +17,13 @@ class PreviewableStorageTest < ActiveSupport::TestCase
     storage = Storage::PreviewableStorage.new(uploader)
     file = CarrierWave::SanitizedFile.new(@file)
 
-    AssetManagerCreateAssetWorker.expects(:perform_async).with do |actual_path, asset_params, draft, attachment_model_class, attachment_model_id, auth_bypass_ids|
+    AssetManagerCreateAssetWorker.expects(:perform_async).with do |actual_path, asset_params, auth_bypass_ids|
       uploaded_file_name = File.basename(@file.path)
       expected_path = %r{#{Whitehall.asset_manager_tmp_dir}/[a-z0-9-]+/#{uploaded_file_name}}
 
       expected_asset_params = { assetable_id: uploader.model.id, asset_variant: Asset.variants[:original], assetable_type: uploader.model.class.to_s }.deep_stringify_keys
 
-      actual_path =~ expected_path && asset_params == expected_asset_params && draft == false && attachment_model_class.nil? && attachment_model_id.nil? && auth_bypass_ids == image_data.auth_bypass_ids
+      actual_path =~ expected_path && asset_params == expected_asset_params && auth_bypass_ids == image_data.auth_bypass_ids
     end
 
     result = storage.store!(file)

--- a/test/unit/app/workers/asset_manager_create_attachment_asset_worker_test.rb
+++ b/test/unit/app/workers/asset_manager_create_attachment_asset_worker_test.rb
@@ -1,0 +1,190 @@
+require "test_helper"
+
+class AssetManagerCreateAttachmentAssetWorkerTest < ActiveSupport::TestCase
+  setup do
+    @file = Tempfile.new("asset", Dir.mktmpdir)
+    @worker = AssetManagerCreateAttachmentAssetWorker.new
+    @asset_manager_id = "asset_manager_id"
+    @organisation = create(:organisation)
+    @edition = create(:draft_publication)
+    @model_without_assets = create(:attachment_data_with_no_assets, attachable: @edition)
+    @asset_manager_response = {
+      "id" => "http://asset-manager/assets/#{@asset_manager_id}",
+      "name" => File.basename(@file),
+    }
+    @asset_params = {
+      assetable_id: @model_without_assets.id,
+      asset_variant: Asset.variants[:original],
+      assetable_type: @model_without_assets.class.to_s,
+    }.deep_stringify_keys
+  end
+
+  test "uploads an asset using a file object at the correct path" do
+    Services.asset_manager.expects(:create_asset).with { |args|
+      args[:file].path == @file.path
+    }.returns(@asset_manager_response)
+
+    @worker.perform(@file.path, @asset_params, @edition.class.to_s, @edition.id, false)
+  end
+
+  test "marks the asset as draft if instructed" do
+    Services.asset_manager.expects(:create_asset).with(has_entry(draft: true)).returns(@asset_manager_response)
+
+    @worker.perform(@file.path, @asset_params, @edition.class.to_s, @edition.id, true)
+  end
+
+  test "removes the local temp file after the file has been successfully uploaded" do
+    Services.asset_manager.stubs(:create_asset).returns(@asset_manager_response)
+
+    @worker.perform(@file.path, @asset_params, @edition.class.to_s, @edition.id, false)
+    assert_not File.exist?(@file.path)
+  end
+
+  test "removes the local temp directory after the file has been successfully uploaded" do
+    Services.asset_manager.stubs(:create_asset).returns(@asset_manager_response)
+
+    @worker.perform(@file.path, @asset_params, @edition.class.to_s, @edition.id, false)
+    assert_not Dir.exist?(File.dirname(@file))
+  end
+
+  test "marks attachments belonging to consultations as access limited" do
+    consultation = create(:consultation, organisations: [@organisation], access_limited: true)
+    attachment = create(:file_attachment, attachable: consultation)
+    attachment.attachment_data.attachable = consultation
+
+    Services.asset_manager.expects(:create_asset).with(has_entry(access_limited_organisation_ids: [@organisation.content_id])).returns(@asset_manager_response)
+
+    @worker.perform(@file.path, @asset_params, consultation.class.to_s, consultation.id, true)
+  end
+
+  test "marks attachments belonging to consultation responses as access limited" do
+    consultation = create(:consultation, organisations: [@organisation], access_limited: true)
+    response = create(:consultation_outcome, consultation:)
+    attachment = create(:file_attachment, attachable: response)
+    attachment.attachment_data.attachable = consultation
+
+    Services.asset_manager.expects(:create_asset).with(has_entry(access_limited_organisation_ids: [@organisation.content_id])).returns(@asset_manager_response)
+
+    @worker.perform(@file.path, @asset_params, consultation.class.to_s, consultation.id, true)
+  end
+
+  test "does not mark attachments belonging to policy groups as access limited" do
+    policy_group = create(:policy_group)
+    attachment = create(:file_attachment, attachable: policy_group)
+    attachment.attachment_data.attachable = policy_group
+
+    Services.asset_manager.expects(:create_asset).with(Not(has_key(:access_limited))).returns(@asset_manager_response)
+
+    @worker.perform(@file.path, @asset_params, policy_group.class.to_s, policy_group.id, true)
+  end
+
+  test "sends auth bypass ids to asset manager when these are passed through in the params" do
+    consultation = create(:consultation)
+    response = create(:consultation_outcome, consultation:)
+    attachment = create(:file_attachment, attachable: response)
+    attachment.attachment_data.attachable = consultation
+
+    Services.asset_manager.expects(:create_asset).with(has_entry(auth_bypass_ids: [consultation.auth_bypass_id])).returns(@asset_manager_response)
+
+    @worker.perform(@file.path, @asset_params, consultation.class.to_s, consultation.id, true, [consultation.auth_bypass_id])
+  end
+
+  test "doesn't run if the file is missing (e.g. job ran twice)" do
+    path = @file.path
+    FileUtils.rm(@file)
+
+    Services.asset_manager.expects(:create_asset).never
+
+    @worker.perform(path, @asset_params, @edition.class.to_s, @edition.id)
+  end
+
+  test "stores corresponding asset_manager_id and filename for current file attachment" do
+    Services.asset_manager.stubs(:create_asset).returns(@asset_manager_response)
+
+    @worker.perform(@file.path, @asset_params, @edition.class.to_s, @edition.id)
+
+    assert_equal 1, Asset.where(asset_manager_id: @asset_manager_id, variant: Asset.variants[:original], filename: File.basename(@file)).count
+  end
+
+  test "triggers an update to asset-manager for any edition based document-type" do
+    # This happens via the edition services coordinator,
+    # for the "update_draft" event triggered by the call to draft_updater.
+
+    consultation = create(:consultation)
+    Services.asset_manager.stubs(:create_asset).returns(@asset_manager_response)
+
+    ServiceListeners::AttachmentUpdater.expects(:call).with(attachable: consultation).once
+
+    @worker.perform(@file.path, @asset_params, consultation.class.to_s, consultation.id, true)
+
+    PublishingApiDraftUpdateWorker.drain
+  end
+
+  test "triggers an update to asset-manager for policy group" do
+    policy_group = create(:policy_group, :with_file_attachment, description: "Description")
+
+    Services.asset_manager.stubs(:create_asset).returns(@asset_manager_response)
+
+    AssetManagerAttachmentMetadataWorker.expects(:perform_async).with(@model_without_assets.id).once
+
+    @worker.perform(@file.path, @asset_params, policy_group.class.to_s, policy_group.id, true)
+  end
+
+  test "triggers an update to publishing api after asset has been saved" do
+    consultation = create(:consultation)
+    Services.asset_manager.stubs(:create_asset).returns(@asset_manager_response)
+
+    PublishingApiDraftUpdateWorker.expects(:perform_async).with(consultation.class.to_s, consultation.id)
+
+    @worker.perform(@file.path, @asset_params, consultation.class.to_s, consultation.id, true)
+  end
+
+  test "does not trigger an update to publishing api if attachable is not an edition" do
+    consultation_outcome = create(:consultation_outcome)
+    Services.asset_manager.stubs(:create_asset).returns(@asset_manager_response)
+
+    Services.publishing_api.stubs(:put_content).never
+
+    @worker.perform(@file.path, @asset_params, consultation_outcome.class.to_s, consultation_outcome.id, true)
+  end
+
+  test "updates existing asset of same variant if it already exists" do
+    # This behaviour applies to all models that have a mount_uploader
+    consultation = create(:consultation, organisations: [@organisation], access_limited: true)
+    attachment = create(:file_attachment, attachable: consultation)
+    attachment.attachment_data.attachable = consultation
+
+    new_asset_manager_id = "new_asset_manager_id"
+    asset_manager_response_with_new_id = { "id" => "http://asset-manager/assets/#{new_asset_manager_id}", "name" => File.basename(@file) }
+    Services.asset_manager.stubs(:create_asset).returns(asset_manager_response_with_new_id)
+
+    update_asset_args = { assetable_id: attachment.attachment_data.id, asset_variant: Asset.variants[:original], assetable_type: attachment.attachment_data.class.to_s }.deep_stringify_keys
+    @worker.perform(@file.path, update_asset_args, @edition.class.to_s, @edition.id, true)
+
+    assets = Asset.where(assetable_id: attachment.attachment_data.id, assetable_type: attachment.attachment_data.class.to_s, variant: Asset.variants[:original])
+    assert_equal 1, assets.count
+    assert_equal new_asset_manager_id, assets.first.asset_manager_id
+  end
+
+  test "does not run if assetable has been deleted" do
+    consultation = create(:consultation)
+    @model_without_assets.delete
+
+    Services.asset_manager.expects(:create_asset).never
+    Services.publishing_api.expects(:put_content).never
+    Sidekiq.logger.expects(:info).once
+
+    @worker.perform(@file.path, @asset_params, consultation.class.to_s, consultation.id, true)
+  end
+
+  test "should not process the file if the attachable has been deleted" do
+    consultation = create(:consultation, organisations: [@organisation], access_limited: true)
+    consultation.delete
+    consultation.save!(validate: false)
+
+    Sidekiq.logger.expects(:info).once
+    Services.asset_manager.expects(:create_asset).never
+
+    @worker.perform(@file.path, @asset_params, consultation.class.to_s, consultation.id, true)
+  end
+end


### PR DESCRIPTION
## What

Create a separate asset creation worker for creating attachment assets

## Why

Having a single asset creation worker which tried to handle all possible asset creation requirements, regardless of whether the asset belonged to an attachment, an image, or another kind of model, led to the worker being very difficult to understand.

Attachments in particular needed a lot of special case handling, so I have created a separate asset creation worker specifically for attachment assets.

I have not yet DRYed the two workers up even though they duplicate a lot of code, because I am not yet completely confident that I wouldn't need to pull some of that code back into the concrete classes. I think we may want to change the behaviour of the attachment worker further (see TODO comment about Policy Groups). Once I am confident that I fully understand what the correct behaviour of the attachment asset creation worker should be I will remove the duplication.

Trello: https://trello.com/c/N1My8EtT
