### PR TITLE
Disable support for Services and Information links

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -489,7 +489,7 @@ class Organisation < ApplicationRecord
   end
 
   def has_services_and_information_link?
-    organisations_with_services_and_information_link.include?(slug)
+    false
   end
 
   def has_scoped_search?
@@ -522,13 +522,6 @@ class Organisation < ApplicationRecord
 
   def visible_featured_links
     featured_links.limit(visible_featured_links_count)
-  end
-
-  def organisations_with_services_and_information_link
-    %w[
-      charity-commission
-      hm-revenue-customs
-    ]
   end
 
   def base_path

--- a/test/unit/app/models/organisation_test.rb
+++ b/test/unit/app/models/organisation_test.rb
@@ -942,27 +942,6 @@ class OrganisationTest < ActiveSupport::TestCase
     assert_equal [org_with_announcement], Organisation.with_statistics_announcements
   end
 
-  test "#has_services_and_information_link? returns true if slug is in the whitelist" do
-    org = create(:organisation)
-
-    list = [
-      org.slug,
-    ]
-    org.stubs(:organisations_with_services_and_information_link).returns(list)
-
-    assert org.has_services_and_information_link?
-  end
-
-  test "#has_services_and_information_link? returns false if slug is not in the whitelist" do
-    list = %w[
-      a-slug
-    ]
-    org = create(:organisation)
-    org.stubs(:organisations_with_services_and_information_link).returns(list)
-
-    assert_not org.has_services_and_information_link?
-  end
-
   test "#jobs_url defaults to the default jobs url" do
     organisation = build(:organisation)
     assert_equal Organisation::DEFAULT_JOBS_URL, organisation.jobs_url


### PR DESCRIPTION
These pages have been removed and redirected site-wide, so support for them are being removed from Whitehall in a future commit. This commit disabled the functionality to prevent accidental republishing of future pages.

https://trello.com/c/glTY32Db/2354-archive-and-redirect-the-hmrc-services-and-info-page-s
https://trello.com/c/sEFJFiMn/2376-remove-services-and-information-code-from-whitehall-s-m

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
