### PR TITLE
Remove need for editionable worldwide orgs to be associated with a taxon

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -73,7 +73,11 @@ class Admin::EditionsController < Admin::BaseController
   def show
     fetch_version_and_remark_trails
 
-    @edition_taxons = EditionTaxonsFetcher.new(@edition.content_id).fetch
+    @edition_taxons = if @edition.requires_taxon?
+                        EditionTaxonsFetcher.new(@edition.content_id).fetch
+                      else
+                        []
+                      end
 
     if @edition.can_be_tagged_to_worldwide_taxonomy?
       @edition_world_taxons = EditionTaxonsFetcher.new(@edition.content_id).fetch_world_taxons
@@ -316,7 +320,7 @@ private
   end
 
   def saved_confirmation_notice
-    if params[:save].present? || @edition.has_been_tagged?
+    if params[:save].present? || @edition.has_been_tagged? || !@edition.requires_taxon?
       notice = "Your document has been saved"
       html_safe = false
     else

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -47,7 +47,7 @@ class Edition < ApplicationRecord
 
   validates_with SafeHtmlValidator
   validates_with NoFootnotesInGovspeakValidator, attribute: :body
-  validates_with TaxonValidator, on: :publish
+  validates_with TaxonValidator, on: :publish, if: :requires_taxon?
 
   validates :creator, presence: true
   validates :title, presence: true, if: :title_required?, length: { maximum: 255 }
@@ -621,6 +621,10 @@ EXISTS (
   end
 
   def body_required?
+    true
+  end
+
+  def requires_taxon?
     true
   end
 

--- a/app/models/editionable_worldwide_organisation.rb
+++ b/app/models/editionable_worldwide_organisation.rb
@@ -109,4 +109,8 @@ class EditionableWorldwideOrganisation < Edition
   def translatable?
     true
   end
+
+  def requires_taxon?
+    false
+  end
 end

--- a/app/views/admin/editions/show/_main.html.erb
+++ b/app/views/admin/editions/show/_main.html.erb
@@ -51,83 +51,87 @@
     </section>
   <% end %>
 
-  <section class="app-view-summary__section app-view-summary__taxonomy-topics">
-    <%= render "govuk_publishing_components/components/heading", {
-      text: "Topic taxonomy tags",
-      heading_level: 2,
-      font_size: "l",
-      margin_bottom: 3,
-    } %>
-
-    <p class="govuk-body">
-      <%= link_to(@edition_taxons.any? ? "Change tags" : "Add tags",
-                  edit_admin_edition_tags_path(@edition.id), class: "govuk-link") %>
-    </p>
-
-    <% @edition_taxons.map(&:full_path).each do | tag_path | %>
-      <div class="govuk-breadcrumbs">
-        <ol class="govuk-breadcrumbs__list app-view-summary__topic-tag-list">
-          <% tag_path.each do | path | %>
-            <li class="govuk-breadcrumbs__list-item app-view-summary__topic-tag-list-item"><%= path[:title] %></li>
-          <% end %>
-        </ol>
-      </div>
-    <% end %>
-    <% unless @edition_taxons.any? %>
-      <%= render "govuk_publishing_components/components/warning_text", {
-        text: "You need to add topic tags before you can publish this document.",
+  <% if @edition.requires_taxon? %>
+    <section class="app-view-summary__section app-view-summary__taxonomy-topics">
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "Topic taxonomy tags",
+        heading_level: 2,
+        font_size: "l",
+        margin_bottom: 3,
       } %>
-    <% end %>
-  </section>
 
-  <section class="app-view-summary__section">
-    <%= render "govuk_publishing_components/components/heading", {
-      text: "Specialist topic tags",
-      heading_level: 2,
-      font_size: "l",
-      margin_bottom: 3,
-    } %>
-
-    <% if @edition.editable? %>
       <p class="govuk-body">
-        <%= link_to(@edition.has_legacy_tags? ? "Change specialist topic tags" : "Add specialist topic tags",
-                    edit_admin_edition_legacy_associations_path(@edition.id), class: "govuk-link") %>
+        <%= link_to(@edition_taxons.any? ? "Change tags" : "Add tags",
+                    edit_admin_edition_tags_path(@edition.id), class: "govuk-link") %>
       </p>
-    <% end %>
 
-    <% if @edition.has_legacy_tags? %>
-      <% if @edition.has_primary_sector? %>
-        <%= render "govuk_publishing_components/components/heading", {
-          text: "Primary specialist topics",
-          font_size: "m",
-          heading_level: 3,
-          margin_bottom: 3,
-        } %>
-        <div class="app-view-summary__primary-specialist-sector">
-          <%= render "govuk_publishing_components/components/list", {
-            visible_counters: true,
-            items: [specialist_sector_name(@edition.primary_specialist_sector_tag)],
-          } %>
+      <% @edition_taxons.map(&:full_path).each do | tag_path | %>
+        <div class="govuk-breadcrumbs">
+          <ol class="govuk-breadcrumbs__list app-view-summary__topic-tag-list">
+            <% tag_path.each do | path | %>
+              <li class="govuk-breadcrumbs__list-item app-view-summary__topic-tag-list-item"><%= path[:title] %></li>
+            <% end %>
+          </ol>
         </div>
       <% end %>
-      <% if @edition.has_secondary_sectors? %>
-        <%= render "govuk_publishing_components/components/heading", {
-          text: "Secondary specialist topics",
-          font_size: "m",
-          heading_level: 3,
-          margin_bottom: 3,
+      <% unless @edition_taxons.any? %>
+        <%= render "govuk_publishing_components/components/warning_text", {
+          text: "You need to add topic tags before you can publish this document.",
         } %>
-        <div class="app-view-summary__secondary-specialist-sectors">
-          <%= render "govuk_publishing_components/components/list", {
-            visible_counters: true,
-            items: specialist_sector_names(@edition.secondary_specialist_sector_tags),
-          } %>
-        </div>
       <% end %>
-    <% else %>
-      <p class="govuk-body">No specialist topic tags for this document</p>
-    <% end %>
-  </section>
+    </section>
+  <% end %>
+
+  <% if @edition.requires_taxon? %>
+    <section class="app-view-summary__section">
+      <%= render "govuk_publishing_components/components/heading", {
+        text: "Specialist topic tags",
+        heading_level: 2,
+        font_size: "l",
+        margin_bottom: 3,
+      } %>
+
+      <% if @edition.editable? %>
+        <p class="govuk-body">
+          <%= link_to(@edition.has_legacy_tags? ? "Change specialist topic tags" : "Add specialist topic tags",
+                      edit_admin_edition_legacy_associations_path(@edition.id), class: "govuk-link") %>
+        </p>
+      <% end %>
+
+      <% if @edition.has_legacy_tags? %>
+        <% if @edition.has_primary_sector? %>
+          <%= render "govuk_publishing_components/components/heading", {
+            text: "Primary specialist topics",
+            font_size: "m",
+            heading_level: 3,
+            margin_bottom: 3,
+          } %>
+          <div class="app-view-summary__primary-specialist-sector">
+            <%= render "govuk_publishing_components/components/list", {
+              visible_counters: true,
+              items: [specialist_sector_name(@edition.primary_specialist_sector_tag)],
+            } %>
+          </div>
+        <% end %>
+        <% if @edition.has_secondary_sectors? %>
+          <%= render "govuk_publishing_components/components/heading", {
+            text: "Secondary specialist topics",
+            font_size: "m",
+            heading_level: 3,
+            margin_bottom: 3,
+          } %>
+          <div class="app-view-summary__secondary-specialist-sectors">
+            <%= render "govuk_publishing_components/components/list", {
+              visible_counters: true,
+              items: specialist_sector_names(@edition.secondary_specialist_sector_tags),
+            } %>
+          </div>
+        <% end %>
+      <% else %>
+        <p class="govuk-body">No specialist topic tags for this document</p>
+      <% end %>
+    </section>
+  <% end %>
 
   <% if @edition.can_be_tagged_to_worldwide_taxonomy? %>
     <section class="app-view-summary__section app-view-summary__world-taxonomy">

--- a/features/step_definitions/editionable_worldwide_organisation_steps.rb
+++ b/features/step_definitions/editionable_worldwide_organisation_steps.rb
@@ -179,6 +179,7 @@ Then(/^the worldwide organisation "([^"]*)" should have been created$/) do |titl
 
   expect(@worldwide_organisation).to be_present
   expect(@worldwide_organisation.logo_formatted_name).to eq("Logo\r\nformatted\r\nname\r\n")
+  expect(page).not_to have_text("Topic taxonomy tags")
 end
 
 Then(/^I should see the Welsh translated title "([^"]*)" for the "([^"]*)" worldwide organisation$/) do |translated_title, title|

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -101,7 +101,11 @@ module AdminEditionControllerTestHelpers
 
         edition = edition_class.last
         assert_redirected_to @controller.admin_edition_path(edition)
-        expected_message = "Your document has been saved. You need to <a class=\"govuk-link\" href=\"/government/admin/editions/#{edition.id}/tags/edit\">add topic tags</a> before you can publish this document."
+        expected_message = if edition.requires_taxon?
+                             "Your document has been saved. You need to <a class=\"govuk-link\" href=\"/government/admin/editions/#{edition.id}/tags/edit\">add topic tags</a> before you can publish this document."
+                           else
+                             "Your document has been saved"
+                           end
         assert_equal expected_message, flash[:notice]
       end
 
@@ -237,7 +241,11 @@ module AdminEditionControllerTestHelpers
             }
 
         assert_redirected_to @controller.admin_edition_path(edition)
-        expected_message = "Your document has been saved. You need to <a class=\"govuk-link\" href=\"/government/admin/editions/#{edition.id}/tags/edit\">add topic tags</a> before you can publish this document."
+        expected_message = if edition.requires_taxon?
+                             "Your document has been saved. You need to <a class=\"govuk-link\" href=\"/government/admin/editions/#{edition.id}/tags/edit\">add topic tags</a> before you can publish this document."
+                           else
+                             "Your document has been saved"
+                           end
         assert_equal expected_message, flash[:notice]
       end
 

--- a/test/unit/app/models/editionable_worldwide_organisation_test.rb
+++ b/test/unit/app/models/editionable_worldwide_organisation_test.rb
@@ -18,6 +18,11 @@ class EditionableWorldwideOrganisationTest < ActiveSupport::TestCase
     assert_equal 0, worldwide_organisation.offices.count
   end
 
+  test "should be be valid without taxons" do
+    worldwide_organisation = build(:draft_editionable_worldwide_organisation)
+    assert worldwide_organisation.valid?
+  end
+
   test "should set an analytics identifier on create" do
     worldwide_organisation = create(:editionable_worldwide_organisation)
     assert_equal "WO#{worldwide_organisation.id}", worldwide_organisation.analytics_identifier


### PR DESCRIPTION
Editionable worldwide orgs are not associated with taxons, so requiring a user to do this is unnecessary.

Trello: https://trello.com/c/knyAKE82/1023-dont-require-editionable-worldwide-organisations-to-be-associated-with-a-taxon

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
