### PR TITLE
Add missing tests for Editionable Worldwide Organisations

### DIFF
--- a/test/functional/admin/editionable_worldwide_organisations_controller_test.rb
+++ b/test/functional/admin/editionable_worldwide_organisations_controller_test.rb
@@ -7,10 +7,12 @@ class Admin::EditionableWorldwideOrganisationsControllerTest < ActionController:
   end
 
   should_be_an_admin_controller
-
   should_allow_creating_of :editionable_worldwide_organisation
   should_allow_editing_of :editionable_worldwide_organisation
-
+  should_allow_organisations_for :editionable_worldwide_organisation
+  should_prevent_modification_of_unmodifiable :editionable_worldwide_organisation
+  should_allow_scheduled_publication_of :editionable_worldwide_organisation
+  should_allow_access_limiting_of :editionable_worldwide_organisation
   should_allow_association_between_roles_and :editionable_worldwide_organisation
   should_allow_association_between_world_locations_and :editionable_worldwide_organisation
 


### PR DESCRIPTION
The editions workflow include some standard tests for editionable content, which were not added when we set up worldwide organisations to be editionable.

Therefore adding these tests now.