### PR TITLE
Add ww orgs to filter

### DIFF
--- a/app/helpers/admin/edition_actions_helper.rb
+++ b/app/helpers/admin/edition_actions_helper.rb
@@ -173,7 +173,7 @@ private
   def type_options_container(user)
     Whitehall.edition_classes.map do |edition_type|
       unless edition_type == FatalityNotice && !user.can_handle_fatalities?
-        [edition_type.model_name.human.pluralize, edition_type.model_name.singular]
+        [edition_type.format_name.humanize.pluralize, edition_type.model_name.singular]
       end
     end
   end

--- a/features/editionable-worldwide-organisations.feature
+++ b/features/editionable-worldwide-organisations.feature
@@ -8,7 +8,8 @@ Feature: Editionable worldwide organisations
     When I draft a new worldwide organisation "Test Worldwide Organisation" assigned to world location "United Kingdom"
     Then the worldwide organisation "Test Worldwide Organisation" should have been created
     And I should see it has been assigned to the "United Kingdom" world location
-    And I should see the editionable worldwide organisation "Test Worldwide Organisation" in the list of draft documents
+    When I select the "Worldwide organisations" edition filter
+    Then I should see the editionable worldwide organisation "Test Worldwide Organisation" in the list of draft documents
 
   Scenario: Unpublishing a published worldwide organisation
     Given a published editionable worldwide organisation "Test Worldwide Organisation"

--- a/lib/whitehall.rb
+++ b/lib/whitehall.rb
@@ -166,11 +166,12 @@ module Whitehall
       Publication,
       Speech,
       StatisticalDataSet,
+      *(EditionableWorldwideOrganisation if Flipflop.editionable_worldwide_organisations?),
     ]
   end
 
   def self.edition_route_path_segments
-    %w[news speeches policies publications consultations priority detailed-guides case-studies statistical-data-sets fatalities collections supporting-pages calls-for-evidence]
+    %w[news speeches policies publications consultations priority detailed-guides case-studies statistical-data-sets fatalities collections supporting-pages calls-for-evidence editionable-worldwide-organisations]
   end
 
   def self.analytics_format(format)

--- a/test/factories/editionable_worldwide_organisations.rb
+++ b/test/factories/editionable_worldwide_organisations.rb
@@ -31,4 +31,10 @@ FactoryBot.define do
   end
 
   factory :draft_editionable_worldwide_organisation, parent: :editionable_worldwide_organisation, traits: [:draft]
+  factory :submitted_editionable_worldwide_organisation, parent: :editionable_worldwide_organisation, traits: [:submitted]
+  factory :rejected_editionable_worldwide_organisation, parent: :editionable_worldwide_organisation, traits: [:rejected]
+  factory :published_editionable_worldwide_organisation, parent: :editionable_worldwide_organisation, traits: [:published]
+  factory :deleted_editionable_worldwide_organisation, parent: :editionable_worldwide_organisation, traits: [:deleted]
+  factory :superseded_editionable_worldwide_organisation, parent: :editionable_worldwide_organisation, traits: [:superseded]
+  factory :scheduled_editionable_worldwide_organisation, parent: :editionable_worldwide_organisation, traits: [:scheduled]
 end


### PR DESCRIPTION
https://trello.com/c/am4j97F6

### Add missing factories for all editionable worldwide organisation states
All of the factories for editionable models have these factories which are used
by various helper tests.

### Include worldwide organisations in the filter list
When the editionable worldwide organisation feature flag is enabled, we want to
display the option to filter documents by the worldwide organisation type.

Because the model name is EditionableWorldwideOrganisation, this uses the
`format_name` method as in #8706.

|Before|After|
|-|-|
|<img width="323" alt="image" src="https://github.com/alphagov/whitehall/assets/47089130/33b15b6b-853f-4737-a2d6-c6b19302b7c6"><img width="305" alt="image" src="https://github.com/alphagov/whitehall/assets/47089130/0c438ad5-b144-49c7-af4f-5eb9c72285d6">|<img width="330" alt="image" src="https://github.com/alphagov/whitehall/assets/47089130/9f43284b-2d70-426d-a229-4ac07227632c"><img width="316" alt="image" src="https://github.com/alphagov/whitehall/assets/47089130/3dd1a72d-f062-4759-a7ae-e53036cd2cea">|


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
