### PR TITLE
Add missing callbacks for Editionable Worldwide Organisations

### DIFF
--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -54,7 +54,7 @@ class Role < ApplicationRecord
 
   before_destroy :prevent_destruction_unless_destroyable
   after_update :touch_role_appointments
-  after_save :republish_organisations_to_publishing_api, :republish_worldwide_organisations_to_publishing_api
+  after_save :republish_associated_editions_to_publishing_api, :republish_organisations_to_publishing_api, :republish_worldwide_organisations_to_publishing_api
 
   accepts_nested_attributes_for :edition_roles
 
@@ -66,6 +66,12 @@ class Role < ApplicationRecord
 
   def self.prime_minister_role
     find_by(slug: "prime-minister")
+  end
+
+  def republish_associated_editions_to_publishing_api
+    edition_roles.each do |edition_role|
+      PublishingApiDocumentRepublishingWorker.perform_async(edition_role.edition.document_id)
+    end
   end
 
   def republish_organisations_to_publishing_api

--- a/app/models/role_appointment.rb
+++ b/app/models/role_appointment.rb
@@ -73,8 +73,14 @@ class RoleAppointment < ApplicationRecord
   after_create :make_other_current_appointments_non_current
   before_destroy :prevent_destruction_unless_destroyable
 
-  after_save :republish_organisation_to_publishing_api, :republish_worldwide_organisations_to_publishing_api, :republish_prime_ministers_index_page_to_publishing_api, :republish_ministerial_pages_to_publishing_api, :republish_role_to_publishing_api
-  after_destroy :republish_organisation_to_publishing_api, :republish_worldwide_organisations_to_publishing_api, :republish_prime_ministers_index_page_to_publishing_api, :republish_role_to_publishing_api
+  after_save :republish_associated_editions_to_publishing_api, :republish_organisation_to_publishing_api, :republish_worldwide_organisations_to_publishing_api, :republish_prime_ministers_index_page_to_publishing_api, :republish_ministerial_pages_to_publishing_api, :republish_role_to_publishing_api
+  after_destroy :republish_associated_editions_to_publishing_api, :republish_organisation_to_publishing_api, :republish_worldwide_organisations_to_publishing_api, :republish_prime_ministers_index_page_to_publishing_api, :republish_role_to_publishing_api
+
+  def republish_associated_editions_to_publishing_api
+    role.edition_roles.each do |edition_role|
+      PublishingApiDocumentRepublishingWorker.perform_async(edition_role.edition.document_id)
+    end
+  end
 
   def republish_organisation_to_publishing_api
     organisations.each do |organisation|

--- a/test/unit/app/models/role_appointment_test.rb
+++ b/test/unit/app/models/role_appointment_test.rb
@@ -561,6 +561,41 @@ class RoleAppointmentTest < ActiveSupport::TestCase
     role_appointment.destroy!
   end
 
+  test "republishes an editionable worldwide organisation when a role appointment is created" do
+    worldwide_organisation = create(:editionable_worldwide_organisation)
+    role = create(:role_without_organisations)
+    create(:edition_role, role:, edition: worldwide_organisation)
+    role.reload
+
+    PublishingApiDocumentRepublishingWorker.expects(:perform_async).with(worldwide_organisation.document_id)
+
+    create(:role_appointment, role:)
+  end
+
+  test "republishes an editionable worldwide organisation when a role appointment is updated" do
+    worldwide_organisation = create(:editionable_worldwide_organisation)
+    role = create(:role_without_organisations)
+    create(:edition_role, role:, edition: worldwide_organisation)
+    role_appointment = create(:role_appointment, role:)
+    role.reload
+
+    PublishingApiDocumentRepublishingWorker.expects(:perform_async).with(worldwide_organisation.document_id)
+
+    role_appointment.update!(ended_at: Time.zone.now)
+  end
+
+  test "republishes an editionable worldwide organisation when a role appointment is destroyed" do
+    worldwide_organisation = create(:editionable_worldwide_organisation)
+    role = create(:role_without_organisations)
+    create(:edition_role, role:, edition: worldwide_organisation)
+    role_appointment = create(:role_appointment, role:)
+    role.reload
+
+    PublishingApiDocumentRepublishingWorker.expects(:perform_async).with(worldwide_organisation.document_id)
+
+    role_appointment.destroy!
+  end
+
   test "republishes a role when a role appointment is created" do
     role = create(:role_without_organisations)
     Whitehall::PublishingApi.expects(:republish_async).with(role)

--- a/test/unit/app/models/role_test.rb
+++ b/test/unit/app/models/role_test.rb
@@ -266,4 +266,15 @@ class RoleTest < ActiveSupport::TestCase
 
     role.update!(name: "New role name")
   end
+
+  test "republishes an editionable worldwide organisation when a role is updated" do
+    worldwide_organisation = create(:editionable_worldwide_organisation)
+    role = create(:role_without_organisations)
+    create(:edition_role, role:, edition: worldwide_organisation)
+    role.reload
+
+    PublishingApiDocumentRepublishingWorker.expects(:perform_async).with(worldwide_organisation.document_id)
+
+    role.update!(name: "New role name")
+  end
 end


### PR DESCRIPTION
This adds missing callbacks for republishing associated editions (at the moment only Editionable Worldwide Organisations) when roles and role appointments are changed.

This has all been made generic, so any editionable content types added in the future will automatically be republished when their associated roles or people are updated.

We don't need a callback on `Person`, as these will be updated through link expansion because it is not possible to associate a person with a worldwide organisation, only indirectly through the role appointment.

Full explanation in the commit messages.

[Trello card](https://trello.com/c/cHHrOnAj)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
