### PR TITLE
Analyse component usage in some subset of document types

### DIFF
--- a/lib/tasks/analyse_component_usage.rake
+++ b/lib/tasks/analyse_component_usage.rake
@@ -1,0 +1,65 @@
+desc "Analyse component usage"
+task :analyse_component_usage, %i[document_class number_of_docs type_field_name type_field_value] => :environment do |_, args|
+  document_class = args[:document_class]
+  number_of_docs = args[:number_of_docs]
+  type_field_name = args[:type_field_name]
+  type_field_value = args[:type_field_value]
+
+  @patterns = {
+    heading: /##+ /,
+    underline_heading: /(--+)|(==+)/,
+    blockquote: /> /,
+    bullet: /^- /,
+    list: /1\./,
+    code_block: /`/,
+    links: /[^x]\[.+\]\(.+\)/,
+    email_link: /<.+\..+>/,
+    markdown_images: /!\[.+\]\(.+\)/,
+    information_callouts: /[^\[]\^.+/,
+    warning_callouts: /%.+/,
+    example_callout: /\$E /,
+    statistic_headline: /{stat-headline}/,
+    contact_block: /\$C[ |\n\r]/,
+    address: /\$A[ |\n\r]/,
+    downloads: /\$D[ |\n\r]/,
+    place: /\$P[ |\n\r]/,
+    information: /\$I[ |\n\r]/,
+    additional_information: /\$AI[ |\n\r]/,
+    call_to_action: /\$CTA[ |\n\r]/,
+    external_link: /x\[.+\]\(.+\)x/,
+    step: /s1./,
+    legislative_list: /\* 1./,
+    devolved_content: /:((england)|(scotland)|(london)|(wales)|(northern-ireland)|(england-wales)|):/,
+    table: /\|.*\|.*\|/,
+    barchart: /{barchart}/,
+    attachment: /(\[Attachment:)|(!@\d)/,
+    attachment_link: /(\[AttachmentLink:)|(\[InlineAttachment:)/,
+    image: /(\[Image:)|(!!\d)/,
+    embeded_link: /\[embed:link:/,
+    embeded_contact: /\[Contact:/,
+    button: /{button}/,
+    acronym: /\*\[\w+\]:/,
+    supersubscript: /<(sup)|(sub)>/,
+    video: /youtube.com/,
+    footnote: /\[\^\d+\]/,
+  }
+  @results = @patterns.keys.index_with { |_x| 0 }
+
+  documents = if type_field_name
+                document_class.constantize.where("#{type_field_name}": type_field_value).last(number_of_docs)
+              else
+                document_class.constantize.last(number_of_docs)
+              end
+
+  documents.map { |item| count_documents_using_the_components(item.body) }
+
+  @results.each do |key, value|
+    Sidekiq.logger.info("#{key.capitalize}: is used (at least once) by #{value} documents")
+  end
+end
+
+def count_documents_using_the_components(text)
+  @patterns.each do |component, pattern|
+    @results[component] = @results[component] + 1 if text =~ pattern
+  end
+end


### PR DESCRIPTION
Add a rake task to aid analysis of govspeak component usage across document types.

Analysis results [here](https://docs.google.com/spreadsheets/d/1ps58qqD0zgbWR-H0K6jmWJM-KhYBl6JApi5ZawOxmeU/edit?pli=1#gid=1797747077)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
