### PR TITLE
Do not allow worldwide organisations to be marked as political

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -463,6 +463,10 @@ EXISTS (
     false
   end
 
+  def can_be_marked_political?
+    true
+  end
+
   def path_name
     to_model.class.name.underscore
   end

--- a/app/models/editionable_worldwide_organisation.rb
+++ b/app/models/editionable_worldwide_organisation.rb
@@ -102,6 +102,10 @@ class EditionableWorldwideOrganisation < Edition
     false
   end
 
+  def can_be_marked_political?
+    false
+  end
+
   def skip_world_location_validation?
     false
   end

--- a/app/views/admin/editions/_standard_fields.html.erb
+++ b/app/views/admin/editions/_standard_fields.html.erb
@@ -120,7 +120,7 @@
 
   <%= render "additional_significant_fields", form: form, edition: form.object %>
 
-  <% if edition.document && edition.document.live? && can?(:mark_political, edition) %>
+  <% if edition.document&.live? && edition.can_be_marked_political? && can?(:mark_political, edition) %>
     <div class="govuk-!-margin-bottom-8">
       <%= form.hidden_field :political, value: "0" %>
 

--- a/test/functional/admin/generic_editions_controller_tests/political_document_test.rb
+++ b/test/functional/admin/generic_editions_controller_tests/political_document_test.rb
@@ -57,3 +57,14 @@ class Admin::GenericEditionsController::PolticalDocumentsTest < ActionController
     assert_response :success
   end
 end
+
+class Admin::GenericEditionsController::PolticalDocumentsTestWhenCannotBeMarkedPolitical < ActionController::TestCase
+  tests Admin::EditionableWorldwideOrganisationsController
+
+  view_test "does not display the political checkbox for editions which cannot be marked political" do
+    published_edition = create(:published_editionable_worldwide_organisation)
+    new_draft = create(:editionable_worldwide_organisation, document: published_edition.document)
+    get :edit, params: { id: new_draft }
+    assert_select "#edition_political", count: 0
+  end
+end


### PR DESCRIPTION
Associating with the government of the time is not applicable to worldwide organisations because the the existence of an organisation is not something that would change with a change of government.

|Before|After|
|-|-|
|![image](https://github.com/alphagov/whitehall/assets/47089130/dc1a300e-b805-4de4-9850-d11053636de9)|![image](https://github.com/alphagov/whitehall/assets/47089130/eba1beab-fb76-4e4b-9942-7054e5d8d34e)|

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
