### PR TITLE
Add home page offices to worldwide organisation presenter tests

### DIFF
--- a/test/factories/editionable_worldwide_organisations.rb
+++ b/test/factories/editionable_worldwide_organisations.rb
@@ -17,9 +17,16 @@ FactoryBot.define do
       end
     end
 
-    trait(:with_office) do
+    trait(:with_main_office) do
       after :create do |organisation, _evaluator|
         FactoryBot.create(:worldwide_office, worldwide_organisation: nil, edition: organisation)
+      end
+    end
+
+    trait(:with_home_page_offices) do
+      after :create do |organisation, _evaluator|
+        worldwide_office = create(:worldwide_office, worldwide_organisation: nil, edition: organisation)
+        organisation.add_office_to_home_page!(worldwide_office)
       end
     end
 

--- a/test/factories/worldwide_organisations.rb
+++ b/test/factories/worldwide_organisations.rb
@@ -14,9 +14,16 @@ FactoryBot.define do
       end
     end
 
-    trait(:with_office) do
+    trait(:with_main_office) do
       after :create do |organisation, _evaluator|
         FactoryBot.create(:worldwide_office, worldwide_organisation: organisation)
+      end
+    end
+
+    trait(:with_home_page_offices) do
+      after :create do |organisation, _evaluator|
+        worldwide_office = create(:worldwide_office, worldwide_organisation: organisation)
+        organisation.add_office_to_home_page!(worldwide_office)
       end
     end
 

--- a/test/unit/app/models/worldwide_organisation_test.rb
+++ b/test/unit/app/models/worldwide_organisation_test.rb
@@ -367,7 +367,7 @@ class WorldwideOrganisationTest < ActiveSupport::TestCase
   end
 
   test "republishes related offices on change" do
-    organisation = create(:worldwide_organisation, :with_office)
+    organisation = create(:worldwide_organisation, :with_main_office)
     organisation.reload
 
     Whitehall::PublishingApi.expects(:republish_async).with(organisation.offices.first).once

--- a/test/unit/app/presenters/publishing_api/editionable_worldwide_organisation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/editionable_worldwide_organisation_presenter_test.rb
@@ -9,7 +9,8 @@ class PublishingApi::EditionableWorldwideOrganisationPresenterTest < ActiveSuppo
     worldwide_org = create(:editionable_worldwide_organisation,
                            :with_role,
                            :with_social_media_account,
-                           :with_office,
+                           :with_main_office,
+                           :with_home_page_offices,
                            analytics_identifier: "WO123")
 
     primary_role = create(:ambassador_role)
@@ -44,8 +45,12 @@ class PublishingApi::EditionableWorldwideOrganisationPresenterTest < ActiveSuppo
         },
         office_contact_associations: [
           {
-            office_content_id: worldwide_org.reload.offices.first.content_id,
-            contact_content_id: worldwide_org.reload.offices.first.contact.content_id,
+            office_content_id: worldwide_org.reload.main_office.content_id,
+            contact_content_id: worldwide_org.reload.main_office.contact.content_id,
+          },
+          {
+            office_content_id: worldwide_org.reload.home_page_offices.first.content_id,
+            contact_content_id: worldwide_org.reload.home_page_offices.first.contact.content_id,
           },
         ],
         people_role_associations: [
@@ -84,12 +89,15 @@ class PublishingApi::EditionableWorldwideOrganisationPresenterTest < ActiveSuppo
       },
       links: {
         contacts: [
-          worldwide_org.reload.offices.first.contact.content_id,
+          worldwide_org.reload.main_office.contact.content_id,
+          worldwide_org.reload.home_page_offices.first.contact.content_id,
         ],
         main_office: [
-          worldwide_org.reload.offices.first.content_id,
+          worldwide_org.reload.main_office.content_id,
         ],
-        home_page_offices: [],
+        home_page_offices: [
+          worldwide_org.reload.home_page_offices.first.content_id,
+        ],
         office_staff: worldwide_org.office_staff_roles.map(&:current_person).map(&:content_id),
         primary_role_person: [
           ambassador.content_id,

--- a/test/unit/app/presenters/publishing_api/worldwide_organisation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/worldwide_organisation_presenter_test.rb
@@ -8,7 +8,8 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
   test "presents a Worldwide Organisation ready for adding to the publishing API" do
     worldwide_org = create(:worldwide_organisation,
                            :with_corporate_information_pages,
-                           :with_office,
+                           :with_main_office,
+                           :with_home_page_offices,
                            :with_social_media_accounts,
                            :with_sponsorships,
                            :with_world_location,
@@ -52,8 +53,12 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
         },
         office_contact_associations: [
           {
-            office_content_id: worldwide_org.reload.offices.first.content_id,
-            contact_content_id: worldwide_org.reload.offices.first.contact.content_id,
+            office_content_id: worldwide_org.reload.main_office.content_id,
+            contact_content_id: worldwide_org.reload.main_office.contact.content_id,
+          },
+          {
+            office_content_id: worldwide_org.reload.home_page_offices.first.content_id,
+            contact_content_id: worldwide_org.reload.home_page_offices.first.contact.content_id,
           },
         ],
         ordered_corporate_information_pages: [
@@ -103,7 +108,8 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
       },
       links: {
         contacts: [
-          worldwide_org.reload.offices.first.contact.content_id,
+          worldwide_org.reload.main_office.contact.content_id,
+          worldwide_org.reload.home_page_offices.first.contact.content_id,
         ],
         corporate_information_pages: [
           worldwide_org.corporate_information_pages[0].content_id,
@@ -114,9 +120,11 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
           worldwide_org.corporate_information_pages[5].content_id,
         ],
         main_office: [
-          worldwide_org.reload.offices.first.content_id,
+          worldwide_org.reload.main_office.content_id,
         ],
-        home_page_offices: [],
+        home_page_offices: [
+          worldwide_org.reload.home_page_offices.first.content_id,
+        ],
         primary_role_person: [
           ambassador.content_id,
         ],


### PR DESCRIPTION
We were not including home page offices in the worldwide organisation presenter tests, therefore meaning the code for these was untested.

This adds a factory that allows us to have home page offices on worldwide organisations and tests they are currently included in the presented content.