### PR TITLE
Implement Worldwide Organisation offices as multi-part content

### DIFF
--- a/app/helpers/presenters/publishing_api/worldwide_office_helper.rb
+++ b/app/helpers/presenters/publishing_api/worldwide_office_helper.rb
@@ -1,0 +1,26 @@
+module Presenters::PublishingApi::WorldwideOfficeHelper
+  def worldwide_office_details(worldwide_office)
+    {
+      access_and_opening_times: access_and_opening_times(worldwide_office),
+      services: services(worldwide_office),
+      type: worldwide_office.worldwide_office_type.name,
+    }
+  end
+
+private
+
+  def access_and_opening_times(worldwide_office)
+    return if worldwide_office.access_and_opening_times.blank?
+
+    Whitehall::GovspeakRenderer.new.govspeak_to_html(worldwide_office.access_and_opening_times)
+  end
+
+  def services(worldwide_office)
+    worldwide_office.services.map do |service|
+      {
+        title: service.name,
+        type: service.service_type.name,
+      }
+    end
+  end
+end

--- a/app/helpers/presenters/publishing_api/worldwide_office_helper.rb
+++ b/app/helpers/presenters/publishing_api/worldwide_office_helper.rb
@@ -7,6 +7,16 @@ module Presenters::PublishingApi::WorldwideOfficeHelper
     }
   end
 
+  def worldwide_office_parts(worldwide_offices)
+    worldwide_offices.map do |worldwide_office|
+      worldwide_office_details(worldwide_office).merge(
+        contact_content_id: worldwide_office.contact.content_id,
+        slug: worldwide_office.base_path.gsub("#{worldwide_office.worldwide_organisation.base_path}/", ""),
+        title: worldwide_office.title,
+      )
+    end
+  end
+
 private
 
   def access_and_opening_times(worldwide_office)

--- a/app/models/worldwide_office.rb
+++ b/app/models/worldwide_office.rb
@@ -54,7 +54,7 @@ class WorldwideOffice < ApplicationRecord
   end
 
   def base_path
-    "/world/organisations/#{worldwide_organisation.slug}/office/#{slug}"
+    "#{worldwide_organisation.base_path}/office/#{slug}"
   end
 
   def public_path(options = {})

--- a/app/presenters/publishing_api/editionable_worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/editionable_worldwide_organisation_presenter.rb
@@ -4,6 +4,7 @@ module PublishingApi
     include ActionView::Helpers::UrlHelper
     include ApplicationHelper
     include OrganisationHelper
+    include Presenters::PublishingApi::WorldwideOfficeHelper
 
     attr_accessor :item, :update_type, :state
 
@@ -25,10 +26,12 @@ module PublishingApi
         description: item.summary,
         details: {
           body:,
+          home_page_office_parts:,
           logo: {
             crest: "single-identity",
             formatted_title: worldwide_organisation_logo_name(item),
           },
+          main_office_parts:,
           office_contact_associations:,
           people_role_associations:,
           social_media_links:,
@@ -154,6 +157,18 @@ module PublishingApi
           name: world_location.name,
         }
       end
+    end
+
+    def home_page_office_parts
+      return [] unless item.home_page_offices.any?
+
+      worldwide_office_parts(item.home_page_offices)
+    end
+
+    def main_office_parts
+      return [] unless item.main_office
+
+      worldwide_office_parts([item.main_office])
     end
   end
 end

--- a/app/presenters/publishing_api/worldwide_office_presenter.rb
+++ b/app/presenters/publishing_api/worldwide_office_presenter.rb
@@ -1,5 +1,7 @@
 module PublishingApi
   class WorldwideOfficePresenter
+    include Presenters::PublishingApi::WorldwideOfficeHelper
+
     attr_accessor :item, :update_type
 
     def initialize(item, update_type: nil)
@@ -17,11 +19,7 @@ module PublishingApi
       ).base_attributes
 
       content.merge!(
-        details: {
-          access_and_opening_times:,
-          services:,
-          type: item.worldwide_office_type.name,
-        },
+        details: worldwide_office_details(item),
         document_type: item.class.name.underscore,
         public_updated_at: item.updated_at,
         rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
@@ -45,21 +43,6 @@ module PublishingApi
       return [] if item.contact.blank?
 
       [item.contact.content_id]
-    end
-
-    def access_and_opening_times
-      return if item.access_and_opening_times.blank?
-
-      Whitehall::GovspeakRenderer.new.govspeak_to_html(item.access_and_opening_times)
-    end
-
-    def services
-      item.services.map do |service|
-        {
-          title: service.name,
-          type: service.service_type.name,
-        }
-      end
     end
   end
 end

--- a/app/presenters/publishing_api/worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/worldwide_organisation_presenter.rb
@@ -5,6 +5,7 @@ module PublishingApi
     include ApplicationHelper
     include OrganisationHelper
     include Presenters::PublishingApi::DefaultNewsImageHelper
+    include Presenters::PublishingApi::WorldwideOfficeHelper
 
     attr_accessor :item, :update_type, :state
 
@@ -257,10 +258,12 @@ module PublishingApi
     def details
       details = {
         body:,
+        home_page_office_parts:,
         logo: {
           crest: "single-identity",
           formatted_title: worldwide_organisation_logo_name(item),
         },
+        main_office_parts:,
         office_contact_associations:,
         ordered_corporate_information_pages:,
         people_role_associations:,
@@ -270,6 +273,18 @@ module PublishingApi
       }
       details[:default_news_image] = present_default_news_image(item) if present_default_news_image(item).present?
       details
+    end
+
+    def home_page_office_parts
+      return [] unless item.home_page_offices.any?
+
+      worldwide_office_parts(item.home_page_offices)
+    end
+
+    def main_office_parts
+      return [] unless item.main_office
+
+      worldwide_office_parts([item.main_office])
     end
   end
 end

--- a/test/factories/editionable_worldwide_organisations.rb
+++ b/test/factories/editionable_worldwide_organisations.rb
@@ -19,13 +19,23 @@ FactoryBot.define do
 
     trait(:with_main_office) do
       after :create do |organisation, _evaluator|
-        FactoryBot.create(:worldwide_office, worldwide_organisation: nil, edition: organisation)
+        FactoryBot.create(
+          :worldwide_office,
+          worldwide_organisation: nil,
+          edition: organisation,
+          access_and_opening_times: "our main office opening times",
+        )
       end
     end
 
     trait(:with_home_page_offices) do
       after :create do |organisation, _evaluator|
-        worldwide_office = create(:worldwide_office, worldwide_organisation: nil, edition: organisation)
+        worldwide_office = create(
+          :worldwide_office,
+          worldwide_organisation: nil,
+          edition: organisation,
+          access_and_opening_times: "our office opening times",
+        )
         organisation.add_office_to_home_page!(worldwide_office)
       end
     end

--- a/test/factories/worldwide_organisations.rb
+++ b/test/factories/worldwide_organisations.rb
@@ -16,13 +16,21 @@ FactoryBot.define do
 
     trait(:with_main_office) do
       after :create do |organisation, _evaluator|
-        FactoryBot.create(:worldwide_office, worldwide_organisation: organisation)
+        FactoryBot.create(
+          :worldwide_office,
+          worldwide_organisation: organisation,
+          access_and_opening_times: "our main office opening times",
+        )
       end
     end
 
     trait(:with_home_page_offices) do
       after :create do |organisation, _evaluator|
-        worldwide_office = create(:worldwide_office, worldwide_organisation: organisation)
+        worldwide_office = create(
+          :worldwide_office,
+          worldwide_organisation: organisation,
+          access_and_opening_times: "our office opening times",
+        )
         organisation.add_office_to_home_page!(worldwide_office)
       end
     end

--- a/test/unit/app/presenters/publishing_api/editionable_worldwide_organisation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/editionable_worldwide_organisation_presenter_test.rb
@@ -13,6 +13,8 @@ class PublishingApi::EditionableWorldwideOrganisationPresenterTest < ActiveSuppo
                            :with_home_page_offices,
                            analytics_identifier: "WO123")
 
+    main_office_service = create(:worldwide_office_worldwide_service, worldwide_office: worldwide_org.reload.main_office)
+
     primary_role = create(:ambassador_role)
     ambassador = create(:person)
     create(:ambassador_role_appointment, role: primary_role, person: ambassador)
@@ -39,10 +41,35 @@ class PublishingApi::EditionableWorldwideOrganisationPresenterTest < ActiveSuppo
       description: worldwide_org.summary,
       details: {
         body: "<div class=\"govspeak\"><p>Information about the organisation with <em>italics</em>.</p>\n</div>",
+        home_page_office_parts: [
+          {
+            access_and_opening_times: Whitehall::GovspeakRenderer.new.govspeak_to_html(worldwide_org.reload.home_page_offices.first.access_and_opening_times),
+            contact_content_id: worldwide_org.reload.home_page_offices.first.contact.content_id,
+            services: [],
+            slug: "office/#{worldwide_org.reload.home_page_offices.first.slug}",
+            title: worldwide_org.reload.home_page_offices.first.title,
+            type: worldwide_org.reload.home_page_offices.first.worldwide_office_type.name,
+          },
+        ],
         logo: {
           crest: "single-identity",
           formatted_title: "Editionable<br/>worldwide<br/>organisation<br/>title",
         },
+        main_office_parts: [
+          {
+            access_and_opening_times: Whitehall::GovspeakRenderer.new.govspeak_to_html(worldwide_org.reload.main_office.access_and_opening_times),
+            contact_content_id: worldwide_org.reload.main_office.contact.content_id,
+            services: [
+              {
+                title: main_office_service.worldwide_service.name,
+                type: main_office_service.worldwide_service.service_type.name,
+              },
+            ],
+            slug: "office/#{worldwide_org.reload.main_office.slug}",
+            title: worldwide_org.reload.main_office.title,
+            type: worldwide_org.reload.main_office.worldwide_office_type.name,
+          },
+        ],
         office_contact_associations: [
           {
             office_content_id: worldwide_org.reload.main_office.content_id,

--- a/test/unit/app/presenters/publishing_api/worldwide_organisation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/worldwide_organisation_presenter_test.rb
@@ -17,6 +17,8 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
                            analytics_identifier: "WO123",
                            default_news_image: create(:featured_image_data))
 
+    main_office_service = create(:worldwide_office_worldwide_service, worldwide_office: worldwide_org.reload.main_office)
+
     primary_role = create(:ambassador_role)
     ambassador = create(:person)
     create(:ambassador_role_appointment, role: primary_role, person: ambassador)
@@ -51,6 +53,31 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
           url: worldwide_org.default_news_image.file.url(:s300),
           high_resolution_url: worldwide_org.default_news_image.file.url(:s960),
         },
+        home_page_office_parts: [
+          {
+            access_and_opening_times: Whitehall::GovspeakRenderer.new.govspeak_to_html(worldwide_org.reload.home_page_offices.first.access_and_opening_times),
+            contact_content_id: worldwide_org.reload.home_page_offices.first.contact.content_id,
+            services: [],
+            slug: "office/#{worldwide_org.reload.home_page_offices.first.slug}",
+            title: worldwide_org.reload.home_page_offices.first.title,
+            type: worldwide_org.reload.home_page_offices.first.worldwide_office_type.name,
+          },
+        ],
+        main_office_parts: [
+          {
+            access_and_opening_times: Whitehall::GovspeakRenderer.new.govspeak_to_html(worldwide_org.reload.main_office.access_and_opening_times),
+            contact_content_id: worldwide_org.reload.main_office.contact.content_id,
+            services: [
+              {
+                title: main_office_service.worldwide_service.name,
+                type: main_office_service.worldwide_service.service_type.name,
+              },
+            ],
+            slug: "office/#{worldwide_org.reload.main_office.slug}",
+            title: worldwide_org.reload.main_office.title,
+            type: worldwide_org.reload.main_office.worldwide_office_type.name,
+          },
+        ],
         office_contact_associations: [
           {
             office_content_id: worldwide_org.reload.main_office.content_id,


### PR DESCRIPTION
We are switching Worldwide Organisations to include the content of their offices in the main content item for the organisation.  This adds that into the presenters for these content types.

In a later PR, we will remove the links and update routes once the rendering code (https://github.com/alphagov/government-frontend/pull/3095) has been updated.

Depends on https://github.com/alphagov/publishing-api/pull/2638.

[Trello card](https://trello.com/c/9ivR4TGQ)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
