### PR TITLE
Bump govspeak-visual-editor from 0.0.3 to 0.0.4

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1514,8 +1514,8 @@ gopd@^1.0.1:
     get-intrinsic "^1.1.3"
 
 govspeak-visual-editor@alphagov/govspeak-visual-editor:
-  version "0.0.3"
-  resolved "https://codeload.github.com/alphagov/govspeak-visual-editor/tar.gz/e731de71df929473c1702defff70f450c120a705"
+  version "0.0.4"
+  resolved "https://codeload.github.com/alphagov/govspeak-visual-editor/tar.gz/ede7749e501b9b4e1b5b83e7d53ee40c0a8a3ce8"
   dependencies:
     govuk-frontend "^4.7.0"
     prosemirror-example-setup "^1.2.2"


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
