### PR TITLE
Present corporate information pages as parts

### DIFF
--- a/app/presenters/publishing_api/worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/worldwide_organisation_presenter.rb
@@ -272,6 +272,7 @@ module PublishingApi
         world_location_names:,
       }
       details[:default_news_image] = present_default_news_image(item) if present_default_news_image(item).present?
+      details[:page_parts] = page_parts if page_parts.present?
       details
     end
 
@@ -285,6 +286,21 @@ module PublishingApi
       return [] unless item.main_office
 
       worldwide_office_parts([item.main_office])
+    end
+
+    def page_parts
+      return unless item.corporate_information_pages.any?
+
+      item.corporate_information_pages.published.reject(&:about_page?).map do |page|
+        {
+          title: page.title,
+          slug: page.base_path.gsub("#{page.worldwide_organisation.base_path}/", ""),
+          summary: page.summary,
+          body: [
+            { "content_type" => "text/govspeak", "content" => page.body },
+          ],
+        }
+      end
     end
   end
 end

--- a/app/presenters/publishing_api/worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/worldwide_organisation_presenter.rb
@@ -160,6 +160,7 @@ module PublishingApi
           links << {
             content_id: corporate_information_page.content_id,
             title: corporate_information_page.title,
+            path: corporate_information_page.base_path.gsub("#{corporate_information_page.worldwide_organisation.base_path}/", ""),
           }
         end
       end

--- a/test/unit/app/presenters/publishing_api/worldwide_organisation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/worldwide_organisation_presenter_test.rb
@@ -99,10 +99,12 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
           {
             content_id: worldwide_org.corporate_information_pages[1].content_id,
             title: "Complaints procedure",
+            path: "about/complaints-procedure",
           },
           {
             content_id: worldwide_org.corporate_information_pages[4].content_id,
             title: "Working for Locationia Embassy",
+            path: "about/recruitment",
           },
         ],
         people_role_associations: [

--- a/test/unit/app/presenters/publishing_api/worldwide_organisation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/worldwide_organisation_presenter_test.rb
@@ -78,6 +78,13 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
             type: worldwide_org.reload.main_office.worldwide_office_type.name,
           },
         ],
+        page_parts: [
+          { title: "Complaints procedure", slug: "about/complaints-procedure", summary: "edition-summary", body: [{ "content_type" => "text/govspeak", "content" => "Some stuff" }] },
+          { title: "Personal information charter", slug: "about/personal-information-charter", summary: "edition-summary", body: [{ "content_type" => "text/govspeak", "content" => "Some stuff" }] },
+          { title: "Publication scheme", slug: "about/publication-scheme", summary: "edition-summary", body: [{ "content_type" => "text/govspeak", "content" => "Some stuff" }] },
+          { title: "Working for Locationia Embassy", slug: "about/recruitment", summary: "edition-summary", body: [{ "content_type" => "text/govspeak", "content" => "Some stuff" }] },
+          { title: "Welsh language scheme", slug: "about/welsh-language-scheme", summary: "edition-summary", body: [{ "content_type" => "text/govspeak", "content" => "Some stuff" }] },
+        ],
         office_contact_associations: [
           {
             office_content_id: worldwide_org.reload.main_office.content_id,


### PR DESCRIPTION
⚠️ DO NOT MERGE ⚠️ Depends on https://github.com/alphagov/publishing-api/pull/2637

https://trello.com/c/npYpoK31

### Present corporate information pages as parts
As part of the larger piece of work to make worldwide organisations editionable,
we want to implement a type of "multi-part" content for worldwide organisation
corporate information pages.

This means that corporate information pages associated with worldwide
organisations will no longer have their own content items, they will instead be
part of the worldwide organisation itself.

This benefits us as we will not have to keep the state of worldwide
organisations and corporate information pages in sync, allowing us to simplify
worldwide organisations in Whitehall.

As part of our migration plan from worldwide organisations to editionable
worldwide organisations, we intend to compare content items to ensure parity.
Therefore, this updates the legacy worldwide organisation to add the required
pages array.

### Include paths for pages
Some corporate information pages are shown as a list.

Currently, we link to these by retrieving the path from the corporate
information page links.

Now that we are removing links, we need another way to associate the ordered
corporate information pages with each page.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
