### PR TITLE
Empty office links for worldwide organisations

### DIFF
--- a/app/presenters/publishing_api/editionable_worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/editionable_worldwide_organisation_presenter.rb
@@ -51,8 +51,8 @@ module PublishingApi
       {
         contacts:,
         office_staff:,
-        main_office:,
-        home_page_offices:,
+        main_office: [],
+        home_page_offices: [],
         primary_role_person:,
         role_appointments: item.roles.map(&:current_role_appointment)&.compact&.map(&:content_id),
         roles: item.roles.map(&:content_id),
@@ -78,18 +78,6 @@ module PublishingApi
 
     def office_staff
       item.office_staff_roles.map(&:current_person).map(&:content_id)
-    end
-
-    def main_office
-      return [] unless item.main_office
-
-      [item.main_office.content_id]
-    end
-
-    def home_page_offices
-      return [] unless item.home_page_offices.any?
-
-      item.home_page_offices.map(&:content_id)
     end
 
     def contacts

--- a/app/presenters/publishing_api/worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/worldwide_organisation_presenter.rb
@@ -41,8 +41,8 @@ module PublishingApi
       {
         contacts:,
         corporate_information_pages:,
-        main_office:,
-        home_page_offices:,
+        main_office: [],
+        home_page_offices: [],
         primary_role_person:,
         roles:,
         role_appointments:,
@@ -79,18 +79,6 @@ module PublishingApi
       return [] unless item.main_office_contact || item.home_page_office_contacts&.any?
 
       [item.main_office_contact&.content_id] + item.home_page_office_contacts&.map(&:content_id)
-    end
-
-    def main_office
-      return [] unless item.main_office
-
-      [item.main_office.content_id]
-    end
-
-    def home_page_offices
-      return [] unless item.home_page_offices.any?
-
-      item.home_page_offices.map(&:content_id)
     end
 
     def office_contact_associations

--- a/test/unit/app/presenters/publishing_api/editionable_worldwide_organisation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/editionable_worldwide_organisation_presenter_test.rb
@@ -119,12 +119,8 @@ class PublishingApi::EditionableWorldwideOrganisationPresenterTest < ActiveSuppo
           worldwide_org.reload.main_office.contact.content_id,
           worldwide_org.reload.home_page_offices.first.contact.content_id,
         ],
-        main_office: [
-          worldwide_org.reload.main_office.content_id,
-        ],
-        home_page_offices: [
-          worldwide_org.reload.home_page_offices.first.content_id,
-        ],
+        main_office: [],
+        home_page_offices: [],
         office_staff: worldwide_org.office_staff_roles.map(&:current_person).map(&:content_id),
         primary_role_person: [
           ambassador.content_id,

--- a/test/unit/app/presenters/publishing_api/worldwide_organisation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/worldwide_organisation_presenter_test.rb
@@ -146,12 +146,8 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
           worldwide_org.corporate_information_pages[4].content_id,
           worldwide_org.corporate_information_pages[5].content_id,
         ],
-        main_office: [
-          worldwide_org.reload.main_office.content_id,
-        ],
-        home_page_offices: [
-          worldwide_org.reload.home_page_offices.first.content_id,
-        ],
+        main_office: [],
+        home_page_offices: [],
         primary_role_person: [
           ambassador.content_id,
         ],


### PR DESCRIPTION
Offices are now being included in the main details of the content item, to allow us to use the same content item to render all pages.

We therefore don't need these pages to be included in links, so need to empty them.

In a later PR (once all worldwide organisations are republished), we will remove these links entirely.

Depends on: https://github.com/alphagov/whitehall/pull/8853, https://github.com/alphagov/content-store/pull/1238 and https://github.com/alphagov/publishing-api/pull/2644.

[Trello card](https://trello.com/c/9ivR4TGQ)