### PR TITLE
Remove office links for worldwide organisations

### DIFF
--- a/app/presenters/publishing_api/editionable_worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/editionable_worldwide_organisation_presenter.rb
@@ -51,8 +51,6 @@ module PublishingApi
       {
         contacts:,
         office_staff:,
-        main_office: [],
-        home_page_offices: [],
         primary_role_person:,
         role_appointments: item.roles.map(&:current_role_appointment)&.compact&.map(&:content_id),
         roles: item.roles.map(&:content_id),

--- a/app/presenters/publishing_api/worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/worldwide_organisation_presenter.rb
@@ -41,8 +41,6 @@ module PublishingApi
       {
         contacts:,
         corporate_information_pages:,
-        main_office: [],
-        home_page_offices: [],
         primary_role_person:,
         roles:,
         role_appointments:,

--- a/test/unit/app/presenters/publishing_api/editionable_worldwide_organisation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/editionable_worldwide_organisation_presenter_test.rb
@@ -119,8 +119,6 @@ class PublishingApi::EditionableWorldwideOrganisationPresenterTest < ActiveSuppo
           worldwide_org.reload.main_office.contact.content_id,
           worldwide_org.reload.home_page_offices.first.contact.content_id,
         ],
-        main_office: [],
-        home_page_offices: [],
         office_staff: worldwide_org.office_staff_roles.map(&:current_person).map(&:content_id),
         primary_role_person: [
           ambassador.content_id,

--- a/test/unit/app/presenters/publishing_api/worldwide_organisation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/worldwide_organisation_presenter_test.rb
@@ -146,8 +146,6 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
           worldwide_org.corporate_information_pages[4].content_id,
           worldwide_org.corporate_information_pages[5].content_id,
         ],
-        main_office: [],
-        home_page_offices: [],
         primary_role_person: [
           ambassador.content_id,
         ],


### PR DESCRIPTION
In https://github.com/alphagov/whitehall/pull/8857, we emptied the office links from Worldwide Organisations, as offices are now being included in the main details of the content item, to allow us to use the same content item to render all pages.

After these have been republished, we no longer need the office links to be present in the presenter, so can remove them.

Depends on: https://github.com/alphagov/whitehall/pull/8857

[Trello card](https://trello.com/c/9ivR4TGQ)