### PR TITLE
Revert "Switch worldwide offices to be included in worldwide organisation content items"

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -20,7 +20,7 @@ class Contact < ApplicationRecord
   after_create :republish_organisation_to_publishing_api
   after_destroy :republish_organisation_to_publishing_api
 
-  after_commit :republish_embassies_index_page_to_publishing_api, :republish_worldwide_organisation_to_publishing_api
+  after_commit :republish_embassies_index_page_to_publishing_api, :republish_worldwide_office_to_publishing_api
 
   include TranslatableModel
   translates :title,
@@ -39,11 +39,8 @@ class Contact < ApplicationRecord
     Whitehall::PublishingApi.republish_async(contactable) if contactable.is_a?(Organisation)
   end
 
-  def republish_worldwide_organisation_to_publishing_api
-    if contactable.is_a?(WorldwideOffice)
-      Whitehall::PublishingApi.republish_async(contactable.worldwide_organisation) if contactable.worldwide_organisation.is_a?(WorldwideOrganisation)
-      PublishingApiDocumentRepublishingWorker.perform_async(contactable.edition.document_id) if contactable.edition && contactable.edition.is_a?(EditionableWorldwideOrganisation)
-    end
+  def republish_worldwide_office_to_publishing_api
+    Whitehall::PublishingApi.republish_async(contactable) if contactable.is_a?(WorldwideOffice)
   end
 
   def contactable_name

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -728,10 +728,6 @@ EXISTS (
     website_root + public_path(options)
   end
 
-  def multipart_content_paths
-    []
-  end
-
   def force_scheduled?
     force_published? && state == "scheduled"
   end

--- a/app/models/editionable_worldwide_organisation.rb
+++ b/app/models/editionable_worldwide_organisation.rb
@@ -38,13 +38,6 @@ class EditionableWorldwideOrganisation < Edition
     "worldwide organisation"
   end
 
-  def multipart_content_paths
-    ([main_office] + home_page_offices)
-      .compact
-      .select { |office| office.contact.available_in_locale?(I18n.locale) }
-      .map { |office| office.public_path(locale: I18n.locale) }
-  end
-
   alias_method :original_main_office, :main_office
 
   extend HomePageList::Container

--- a/app/models/worldwide_office.rb
+++ b/app/models/worldwide_office.rb
@@ -11,6 +11,8 @@ class WorldwideOffice < ApplicationRecord
 
   accepts_nested_attributes_for :contact
 
+  include PublishesToPublishingApi
+
   extend FriendlyId
   friendly_id :title, use: :scoped, scope: :worldwide_organisation
 
@@ -61,6 +63,10 @@ class WorldwideOffice < ApplicationRecord
 
   def public_url(options = {})
     Plek.website_root + public_path(options)
+  end
+
+  def publishing_api_presenter
+    PublishingApi::WorldwideOfficePresenter
   end
 
 private

--- a/app/presenters/publishing_api/organisation_presenter.rb
+++ b/app/presenters/publishing_api/organisation_presenter.rb
@@ -33,7 +33,7 @@ module PublishingApi
         schema_name:,
       )
       content.merge!(
-        PayloadBuilder::PolymorphicPath.for(item, prefix: use_prefix_route?, suffixes:),
+        PayloadBuilder::PolymorphicPath.for(item, prefix: use_prefix_route?, additional_routes:),
       )
       content.merge!(PayloadBuilder::AnalyticsIdentifier.for(item))
     end
@@ -67,7 +67,7 @@ module PublishingApi
       !court_or_tribunal?
     end
 
-    def suffixes
+    def additional_routes
       return [] if court_or_tribunal?
 
       %w[atom]

--- a/app/presenters/publishing_api/payload_builder/polymorphic_path.rb
+++ b/app/presenters/publishing_api/payload_builder/polymorphic_path.rb
@@ -1,21 +1,21 @@
 module PublishingApi
   module PayloadBuilder
     class PolymorphicPath
-      attr_reader :item, :prefix, :suffixes
+      attr_reader :item, :prefix, :additional_routes
 
-      def self.for(item, prefix: false, suffixes: [])
-        new(item, prefix:, suffixes:).call
+      def self.for(item, prefix: false, additional_routes: [])
+        new(item, prefix:, additional_routes:).call
       end
 
-      def initialize(item, prefix: false, suffixes: [])
+      def initialize(item, prefix: false, additional_routes: [])
         @item = item
         @prefix = prefix
-        @suffixes = suffixes
+        @additional_routes = additional_routes
       end
 
       def call
         { base_path: }.merge(
-          PayloadBuilder::Routes.for(base_path, prefix:, suffixes:, additional_routes:),
+          PayloadBuilder::Routes.for(base_path, prefix:, additional_routes:),
         )
       end
 
@@ -23,12 +23,6 @@ module PublishingApi
 
       def base_path
         @base_path ||= item.public_path(locale: I18n.locale)
-      end
-
-      def additional_routes
-        return [] unless item.respond_to?(:multipart_content_paths)
-
-        item.multipart_content_paths
       end
     end
   end

--- a/app/presenters/publishing_api/payload_builder/routes.rb
+++ b/app/presenters/publishing_api/payload_builder/routes.rb
@@ -1,27 +1,23 @@
 module PublishingApi
   module PayloadBuilder
     class Routes
-      attr_reader :base_path, :suffixes, :additional_routes
+      attr_reader :base_path, :additional_routes
 
-      def self.for(base_path, prefix: false, suffixes: [], additional_routes: [])
-        new(base_path, prefix:, suffixes:, additional_routes:).call
+      def self.for(base_path, prefix: false, additional_routes: [])
+        new(base_path, prefix:, additional_routes:).call
       end
 
-      def initialize(base_path, prefix: false, suffixes: [], additional_routes: [])
+      def initialize(base_path, prefix: false, additional_routes: [])
         @base_path = base_path
         @prefix = prefix
-        @suffixes = suffixes
         @additional_routes = additional_routes
       end
 
       def call
         routes = []
         routes << { path: base_path, type: }
-        suffixes.each do |suffix|
-          routes << { path: "#{base_path}.#{suffix}", type: "exact" }
-        end
         additional_routes.each do |additional_route|
-          routes << { path: additional_route, type: "exact" }
+          routes << { path: "#{base_path}.#{additional_route}", type: "exact" }
         end
         { routes: }
       end

--- a/app/presenters/publishing_api/topical_event_presenter.rb
+++ b/app/presenters/publishing_api/topical_event_presenter.rb
@@ -24,7 +24,7 @@ module PublishingApi
         rendering_app: Whitehall::RenderingApp::COLLECTIONS_FRONTEND,
         schema_name: "topical_event",
       )
-      content.merge!(PayloadBuilder::PolymorphicPath.for(item, suffixes: %w[atom]))
+      content.merge!(PayloadBuilder::PolymorphicPath.for(item, additional_routes: %w[atom]))
     end
 
     def links

--- a/app/presenters/publishing_api/worldwide_office_presenter.rb
+++ b/app/presenters/publishing_api/worldwide_office_presenter.rb
@@ -1,0 +1,48 @@
+module PublishingApi
+  class WorldwideOfficePresenter
+    include Presenters::PublishingApi::WorldwideOfficeHelper
+
+    attr_accessor :item, :update_type
+
+    def initialize(item, update_type: nil)
+      self.item = item
+      self.update_type = update_type || "major"
+    end
+
+    delegate :content_id, to: :item
+
+    def content
+      content = BaseItemPresenter.new(
+        item,
+        title: item.worldwide_organisation.title,
+        update_type:,
+      ).base_attributes
+
+      content.merge!(
+        details: worldwide_office_details(item),
+        document_type: item.class.name.underscore,
+        public_updated_at: item.updated_at,
+        rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
+        schema_name: "worldwide_office",
+      )
+
+      content.merge!(PayloadBuilder::PolymorphicPath.for(item))
+    end
+
+    def links
+      {
+        contact:,
+        parent: [item.worldwide_organisation.content_id],
+        worldwide_organisation: [item.worldwide_organisation.content_id],
+      }
+    end
+
+  private
+
+    def contact
+      return [] if item.contact.blank?
+
+      [item.contact.content_id]
+    end
+  end
+end

--- a/test/unit/app/models/contact_test.rb
+++ b/test/unit/app/models/contact_test.rb
@@ -188,57 +188,28 @@ class ContactTest < ActiveSupport::TestCase
     end
   end
 
-  test "republishes worldwide organisation on creation of related contact through a worldwide office" do
+  test "republishes worldwide office on creation of related contact" do
     worldwide_office = create(:worldwide_office)
 
-    Whitehall::PublishingApi.expects(:republish_async).with(worldwide_office.worldwide_organisation).once
+    Whitehall::PublishingApi.expects(:republish_async).with(worldwide_office).once
 
     Sidekiq::Testing.inline! do
       create(:contact, contactable: worldwide_office)
     end
   end
 
-  test "republishes worldwide organsation on update of related contact through a worldwide office" do
+  test "republishes worldwide office on update of related contact" do
     worldwide_office = create(:worldwide_office)
 
-    Whitehall::PublishingApi.expects(:republish_async).with(worldwide_office.worldwide_organisation).once
+    Whitehall::PublishingApi.expects(:republish_async).with(worldwide_office).once
 
     worldwide_office.contact.update!(locality: "new-locality")
   end
 
-  test "republishes worldwide organisation on deletion of related contact through a worldwide office" do
+  test "republishes worldwide office on deletion of related contact" do
     worldwide_office = create(:worldwide_office)
 
-    Whitehall::PublishingApi.expects(:republish_async).with(worldwide_office.worldwide_organisation).once
-
-    worldwide_office.contact.destroy!
-  end
-
-  test "republishes editionable worldwide organisation on creation of related contact through a worldwide office" do
-    worldwide_organisation = create(:editionable_worldwide_organisation)
-    worldwide_office = create(:worldwide_office, edition: worldwide_organisation, worldwide_organisation: nil)
-
-    PublishingApiDocumentRepublishingWorker.expects(:perform_async).with(worldwide_organisation.document_id).once
-
-    Sidekiq::Testing.inline! do
-      create(:contact, contactable: worldwide_office)
-    end
-  end
-
-  test "republishes editionable worldwide organsation on update of related contact through a worldwide office" do
-    worldwide_organisation = create(:editionable_worldwide_organisation)
-    worldwide_office = create(:worldwide_office, edition: worldwide_organisation, worldwide_organisation: nil)
-
-    PublishingApiDocumentRepublishingWorker.expects(:perform_async).with(worldwide_organisation.document_id).once
-
-    worldwide_office.contact.update!(locality: "new-locality")
-  end
-
-  test "republishes editionable worldwide organisation on deletion of related contact through a worldwide office" do
-    worldwide_organisation = create(:editionable_worldwide_organisation)
-    worldwide_office = create(:worldwide_office, edition: worldwide_organisation, worldwide_organisation: nil)
-
-    PublishingApiDocumentRepublishingWorker.expects(:perform_async).with(worldwide_organisation.document_id).once
+    Whitehall::PublishingApi.expects(:republish_async).with(worldwide_office).once
 
     worldwide_office.contact.destroy!
   end

--- a/test/unit/app/models/worldwide_organisation_test.rb
+++ b/test/unit/app/models/worldwide_organisation_test.rb
@@ -366,6 +366,23 @@ class WorldwideOrganisationTest < ActiveSupport::TestCase
     end
   end
 
+  test "republishes related offices on change" do
+    organisation = create(:worldwide_organisation, :with_main_office)
+    organisation.reload
+
+    Whitehall::PublishingApi.expects(:republish_async).with(organisation.offices.first).once
+
+    organisation.update!(name: "new name")
+  end
+
+  test "does not try to republish offices when there are none" do
+    organisation = create(:worldwide_organisation)
+
+    Whitehall::PublishingApi.expects(:republish_async).never
+
+    organisation.update!(name: "new name")
+  end
+
   test "#title returns the name of the organisation" do
     organisation = create(:worldwide_organisation)
 

--- a/test/unit/app/presenters/publishing_api/editionable_worldwide_organisation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/editionable_worldwide_organisation_presenter_test.rb
@@ -36,11 +36,7 @@ class PublishingApi::EditionableWorldwideOrganisationPresenterTest < ActiveSuppo
       publishing_app: Whitehall::PublishingApp::WHITEHALL,
       rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
       public_updated_at: worldwide_org.updated_at,
-      routes: [
-        { path: public_path, type: "exact" },
-        { path: worldwide_org.reload.main_office.base_path, type: "exact" },
-        { path: worldwide_org.reload.home_page_offices.first.base_path, type: "exact" },
-      ],
+      routes: [{ path: public_path, type: "exact" }],
       redirects: [],
       description: worldwide_org.summary,
       details: {
@@ -196,56 +192,5 @@ class PublishingApi::EditionableWorldwideOrganisationPresenterTest < ActiveSuppo
     presented_item = present(worldwide_org)
 
     assert_equal [lead_organisation_2.content_id, lead_organisation_1.content_id], presented_item.content.dig(:links, :sponsoring_organisations)
-  end
-
-  test "presents correct routes when the worldwide organisation and its office are translated" do
-    worldwide_organisation = create(
-      :editionable_worldwide_organisation,
-      translated_into: %i[fr es],
-    )
-
-    contact = create(:contact, translated_into: [:fr])
-    main_office = create(:worldwide_office, contact:, edition: worldwide_organisation, worldwide_organisation: nil)
-
-    I18n.with_locale(:en) do
-      presented_item = present(worldwide_organisation)
-      expected_routes = [
-        {
-          path: worldwide_organisation.reload.base_path,
-          type: "exact",
-        },
-        {
-          path: main_office.base_path,
-          type: "exact",
-        },
-      ]
-      assert_equal expected_routes, presented_item.content[:routes]
-    end
-
-    I18n.with_locale(:fr) do
-      presented_item = present(worldwide_organisation)
-      expected_routes = [
-        {
-          path: "#{worldwide_organisation.base_path}.fr",
-          type: "exact",
-        },
-        {
-          path: "#{worldwide_organisation.main_office.base_path}.fr",
-          type: "exact",
-        },
-      ]
-      assert_equal expected_routes, presented_item.content[:routes]
-    end
-
-    I18n.with_locale(:es) do
-      presented_item = present(worldwide_organisation)
-      expected_routes = [
-        {
-          path: "#{worldwide_organisation.base_path}.es",
-          type: "exact",
-        },
-      ]
-      assert_equal expected_routes, presented_item.content[:routes]
-    end
   end
 end

--- a/test/unit/app/presenters/publishing_api/payload_builder/routes_test.rb
+++ b/test/unit/app/presenters/publishing_api/payload_builder/routes_test.rb
@@ -17,14 +17,14 @@ module PublishingApi
 
       test "returns a routes payload with additional routes" do
         base_path = "some/base/path"
-        suffixes = %w[atom rss]
+        additional_routes = %w[atom rss]
         expected_routes = [
           { path: base_path, type: "exact" },
           { path: "#{base_path}.atom", type: "exact" },
           { path: "#{base_path}.rss", type: "exact" },
         ]
 
-        assert_equal({ routes: expected_routes }, Routes.for(base_path, suffixes:))
+        assert_equal({ routes: expected_routes }, Routes.for(base_path, additional_routes:))
       end
     end
   end

--- a/test/unit/app/presenters/publishing_api/worldwide_office_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/worldwide_office_presenter_test.rb
@@ -1,0 +1,68 @@
+require "test_helper"
+
+class PublishingApi::WorldwideOfficePresenterTest < ActiveSupport::TestCase
+  def present(...)
+    PublishingApi::WorldwideOfficePresenter.new(...)
+  end
+
+  test "presents a Worldwide Office ready for adding to the publishing API" do
+    access_and_opening_times = "## About us\r\n\r\nVisit our [profile page](https://www.gov.uk/government/world/organisations/british-consulate-general-atlanta)"
+    worldwide_office = build(:worldwide_office, access_and_opening_times:)
+    worldwide_office_service = create(:worldwide_office_worldwide_service, worldwide_office:)
+    public_path = worldwide_office.public_path
+
+    expected_hash = {
+      base_path: public_path,
+      title: worldwide_office.worldwide_organisation.name,
+      schema_name: "worldwide_office",
+      document_type: "worldwide_office",
+      locale: "en",
+      publishing_app: Whitehall::PublishingApp::WHITEHALL,
+      rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
+      public_updated_at: worldwide_office.updated_at,
+      routes: [{ path: public_path, type: "exact" }],
+      redirects: [],
+      details: {
+        access_and_opening_times: Whitehall::GovspeakRenderer.new.govspeak_to_html(worldwide_office.access_and_opening_times),
+        services: [
+          {
+            title: worldwide_office_service.worldwide_service.name,
+            type: worldwide_office_service.worldwide_service.service_type.name,
+          },
+        ],
+        type: worldwide_office.worldwide_office_type.name,
+      },
+      update_type: "major",
+    }
+
+    expected_links = {
+      contact: [
+        worldwide_office.contact.content_id,
+      ],
+      parent: [
+        worldwide_office.worldwide_organisation.content_id,
+      ],
+      worldwide_organisation: [
+        worldwide_office.worldwide_organisation.content_id,
+      ],
+    }
+
+    presented_item = present(worldwide_office)
+
+    assert_equal expected_hash, presented_item.content
+    assert_hash_includes presented_item.links, expected_links
+    assert_equal "major", presented_item.update_type
+    assert_equal worldwide_office.content_id, presented_item.content_id
+
+    assert_valid_against_publisher_schema(presented_item.content, "worldwide_office")
+    assert_valid_against_links_schema({ links: presented_item.links }, "worldwide_office")
+  end
+
+  test "sets access_and_opening_times as nil when they are blank" do
+    worldwide_office = create(:worldwide_office)
+
+    presented_item = present(worldwide_office)
+
+    assert_nil presented_item.content.dig(:details, :access_and_opening_times)
+  end
+end

--- a/test/unit/app/presenters/publishing_api/worldwide_organisation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/worldwide_organisation_presenter_test.rb
@@ -29,8 +29,6 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
     create(:deputy_head_of_mission_role_appointment, role: secondary_role, person: deputy_head_of_mission)
     FactoryBot.create(:worldwide_organisation_role, worldwide_organisation: worldwide_org, role: secondary_role)
 
-    worldwide_org.reload
-
     public_path = worldwide_org.public_path
 
     expected_hash = {
@@ -43,11 +41,7 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
       publishing_app: Whitehall::PublishingApp::WHITEHALL,
       rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
       public_updated_at: worldwide_org.updated_at,
-      routes: [
-        { path: public_path, type: "exact" },
-        { path: worldwide_org.reload.main_office.base_path, type: "exact" },
-        { path: worldwide_org.reload.home_page_offices.first.base_path, type: "exact" },
-      ],
+      routes: [{ path: public_path, type: "exact" }],
       redirects: [],
       details: {
         body: "<div class=\"govspeak\"><p>Some stuff</p>\n</div>",
@@ -299,56 +293,5 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
     presenter = PublishingApi::WorldwideOrganisationPresenter.new(worldwide_organisation)
 
     assert_not presenter.content[:details].key? :default_news_image
-  end
-
-  test "presents correct routes when the worldwide organisation and its office are translated" do
-    worldwide_organisation = create(
-      :worldwide_organisation,
-      translated_into: %i[fr es],
-    )
-
-    contact = create(:contact, translated_into: [:fr])
-    main_office = create(:worldwide_office, contact:, worldwide_organisation:)
-
-    I18n.with_locale(:en) do
-      presented_item = present(worldwide_organisation)
-      expected_routes = [
-        {
-          path: worldwide_organisation.reload.base_path,
-          type: "exact",
-        },
-        {
-          path: main_office.base_path,
-          type: "exact",
-        },
-      ]
-      assert_equal expected_routes, presented_item.content[:routes]
-    end
-
-    I18n.with_locale(:fr) do
-      presented_item = present(worldwide_organisation)
-      expected_routes = [
-        {
-          path: "#{worldwide_organisation.base_path}.fr",
-          type: "exact",
-        },
-        {
-          path: "#{worldwide_organisation.main_office.base_path}.fr",
-          type: "exact",
-        },
-      ]
-      assert_equal expected_routes, presented_item.content[:routes]
-    end
-
-    I18n.with_locale(:es) do
-      presented_item = present(worldwide_organisation)
-      expected_routes = [
-        {
-          path: "#{worldwide_organisation.base_path}.es",
-          type: "exact",
-        },
-      ]
-      assert_equal expected_routes, presented_item.content[:routes]
-    end
   end
 end


### PR DESCRIPTION
Reverting this PR as there are a number of issues on translated worldwide organisations that need to be corrected.

Reverts alphagov/whitehall#8853

[Trello card](https://trello.com/c/9ivR4TGQ)