### PR TITLE
Featured image for editionable worldwide orgs

### DIFF
--- a/app/controllers/admin/editionable_worldwide_organisations_controller.rb
+++ b/app/controllers/admin/editionable_worldwide_organisations_controller.rb
@@ -4,4 +4,9 @@ private
   def edition_class
     EditionableWorldwideOrganisation
   end
+
+  def build_edition_dependencies
+    super
+    @edition.default_news_image || @edition.build_default_news_image
+  end
 end

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -286,6 +286,7 @@ private
             ],
           },
         ],
+        default_news_image_attributes: %i[file file_cache id],
         nation_inapplicabilities_attributes: %i[id nation_id alternative_url excluded],
         fatality_notice_casualties_attributes: %i[id personal_details _destroy],
         document_attributes: [

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -254,6 +254,7 @@ private
         related_detailed_guide_ids: [],
         role_appointment_ids: [],
         statistical_data_set_document_ids: [],
+        editionable_worldwide_organisation_document_ids: [],
         policy_group_ids: [],
         document_collection_group_ids: [],
         consultation_participation_attributes: [

--- a/app/helpers/admin/taggable_content_helper.rb
+++ b/app/helpers/admin/taggable_content_helper.rb
@@ -132,6 +132,15 @@ module Admin::TaggableContentHelper
     end
   end
 
+  # Returns an Array that represents the taggable worldwide organisations.
+  # Each element of the array consists of two values: the name of the worldwide
+  # organisation and its ID.
+  def taggable_editionable_worldwide_organisations_container
+    Rails.cache.fetch(taggable_editionable_worldwide_organisations_cache_digest, expires_in: 1.day) do
+      EditionableWorldwideOrganisation.with_translations.latest_edition.map { |wo| [wo.title, wo.document.id] }
+    end
+  end
+
   # Returns an MD5 digest representing the current set of taggable topical
   # events. This will change if any of the Topics should change or if a new
   # topic event is added.
@@ -215,6 +224,12 @@ module Admin::TaggableContentHelper
   # This will change if any worldwide organisations are added or updated.
   def taggable_worldwide_organisations_cache_digest
     @taggable_worldwide_organisations_cache_digest ||= calculate_digest(WorldwideOrganisation.order(:id), "worldwide-organisations")
+  end
+
+  # Returns an MD5 digest representing the taggable editionable worldwide organisations. This
+  # will change if any editionable worldwide organisation is added or updated.
+  def taggable_editionable_worldwide_organisations_cache_digest
+    @taggable_editionable_worldwide_organisations_cache_digest ||= calculate_digest(Document.where(document_type: "EditionableWorldwideOrganisation").order(:id), "editionable-worldwide-organisations")
   end
 
 private

--- a/app/models/concerns/edition/editionable_worldwide_organisations.rb
+++ b/app/models/concerns/edition/editionable_worldwide_organisations.rb
@@ -1,0 +1,22 @@
+module Edition::EditionableWorldwideOrganisations
+  extend ActiveSupport::Concern
+
+  class Trait < Edition::Traits::Trait
+    def process_associations_before_save(edition)
+      edition.editionable_worldwide_organisation_documents = @edition.editionable_worldwide_organisation_documents
+    end
+  end
+
+  included do
+    has_many :edition_editionable_worldwide_organisations, foreign_key: :edition_id, dependent: :destroy
+    has_many :editionable_worldwide_organisation_documents, through: :edition_editionable_worldwide_organisations, source: :document
+    has_many :editionable_worldwide_organisations, through: :editionable_worldwide_organisation_documents, source: :latest_edition
+    has_many :published_editionable_worldwide_organisations, through: :editionable_worldwide_organisation_documents, source: :live_edition, class_name: "EditionableWorldwideOrganisation"
+
+    add_trait Trait
+  end
+
+  def editionable_worldwide_organisations=(editionable_worldwide_organisations)
+    self.editionable_worldwide_organisation_documents = editionable_worldwide_organisations.map(&:document)
+  end
+end

--- a/app/models/concerns/edition/editionable_worldwide_organisations.rb
+++ b/app/models/concerns/edition/editionable_worldwide_organisations.rb
@@ -14,9 +14,25 @@ module Edition::EditionableWorldwideOrganisations
     has_many :published_editionable_worldwide_organisations, through: :editionable_worldwide_organisation_documents, source: :live_edition, class_name: "EditionableWorldwideOrganisation"
 
     add_trait Trait
+
+    validate :at_least_one_editionable_worldwide_organisations
   end
 
   def editionable_worldwide_organisations=(editionable_worldwide_organisations)
     self.editionable_worldwide_organisation_documents = editionable_worldwide_organisations.map(&:document)
+  end
+
+  def can_be_associated_with_worldwide_organisations?
+    true
+  end
+
+  def skip_worldwide_organisations_validation?
+    true
+  end
+
+  def at_least_one_editionable_worldwide_organisations
+    return unless Flipflop.editionable_worldwide_organisations? && !skip_worldwide_organisations_validation?
+
+    errors.add(:editionable_worldwide_organisations, "at least one required") if editionable_worldwide_organisation_document_ids.empty?
   end
 end

--- a/app/models/concerns/edition/lead_image.rb
+++ b/app/models/concerns/edition/lead_image.rb
@@ -64,6 +64,8 @@ private
       organisations.first.default_news_image
     elsif respond_to?(:worldwide_organisations) && worldwide_organisations.any? && worldwide_organisations.first.default_news_image
       worldwide_organisations.first.default_news_image
+    elsif respond_to?(:editionable_worldwide_organisations) && published_editionable_worldwide_organisations.any? && published_editionable_worldwide_organisations.first.default_news_image
+      published_editionable_worldwide_organisations.first.default_news_image
     end
   end
 

--- a/app/models/concerns/edition/worldwide_organisations.rb
+++ b/app/models/concerns/edition/worldwide_organisations.rb
@@ -27,8 +27,8 @@ module Edition::WorldwideOrganisations
   end
 
   def at_least_one_worldwide_organisations
-    if !skip_worldwide_organisations_validation? && worldwide_organisations.empty?
-      errors.add(:worldwide_organisations, "at least one required")
-    end
+    return if Flipflop.editionable_worldwide_organisations? || skip_worldwide_organisations_validation?
+
+    errors.add(:worldwide_organisations, "at least one required") if worldwide_organisations.empty?
   end
 end

--- a/app/models/edition_editionable_worldwide_organisation.rb
+++ b/app/models/edition_editionable_worldwide_organisation.rb
@@ -1,0 +1,4 @@
+class EditionEditionableWorldwideOrganisation < ApplicationRecord
+  belongs_to :edition
+  belongs_to :document
+end

--- a/app/models/editionable_worldwide_organisation.rb
+++ b/app/models/editionable_worldwide_organisation.rb
@@ -10,6 +10,7 @@ class EditionableWorldwideOrganisation < Edition
 
   has_many :offices, class_name: "WorldwideOffice", foreign_key: :edition_id, dependent: :destroy, autosave: true
   belongs_to :main_office, class_name: "WorldwideOffice"
+  has_one :default_news_image, class_name: "FeaturedImageData", as: :featured_imageable, inverse_of: :featured_imageable
 
   class CloneOfficesTrait < Edition::Traits::Trait
     def process_associations_before_save(new_edition)

--- a/app/models/editionable_worldwide_organisation.rb
+++ b/app/models/editionable_worldwide_organisation.rb
@@ -10,7 +10,9 @@ class EditionableWorldwideOrganisation < Edition
 
   has_many :offices, class_name: "WorldwideOffice", foreign_key: :edition_id, dependent: :destroy, autosave: true
   belongs_to :main_office, class_name: "WorldwideOffice"
+
   has_one :default_news_image, class_name: "FeaturedImageData", as: :featured_imageable, inverse_of: :featured_imageable
+  accepts_nested_attributes_for :default_news_image, reject_if: :all_blank
 
   class CloneOfficesTrait < Edition::Traits::Trait
     def process_associations_before_save(new_edition)

--- a/app/models/editionable_worldwide_organisation.rb
+++ b/app/models/editionable_worldwide_organisation.rb
@@ -14,6 +14,8 @@ class EditionableWorldwideOrganisation < Edition
   has_one :default_news_image, class_name: "FeaturedImageData", as: :featured_imageable, inverse_of: :featured_imageable
   accepts_nested_attributes_for :default_news_image, reject_if: :all_blank
 
+  after_commit :republish_dependent_documents
+
   class CloneOfficesTrait < Edition::Traits::Trait
     def process_associations_before_save(new_edition)
       @edition.offices.each do |office|

--- a/app/models/editionable_worldwide_organisation.rb
+++ b/app/models/editionable_worldwide_organisation.rb
@@ -28,6 +28,20 @@ class EditionableWorldwideOrganisation < Edition
 
   add_trait CloneOfficesTrait
 
+  class CloneDefaultImageTrait < Edition::Traits::Trait
+    def process_associations_before_save(new_edition)
+      return if @edition.default_news_image.blank?
+
+      new_edition.build_default_news_image(@edition.default_news_image.attributes.except("id"))
+
+      @edition.default_news_image.assets.each do |asset|
+        new_edition.default_news_image.assets << asset.dup
+      end
+    end
+  end
+
+  add_trait CloneDefaultImageTrait
+
   include AnalyticsIdentifierPopulator
   self.analytics_prefix = "WO"
 

--- a/app/models/editionable_worldwide_organisation.rb
+++ b/app/models/editionable_worldwide_organisation.rb
@@ -124,4 +124,16 @@ class EditionableWorldwideOrganisation < Edition
   def requires_taxon?
     false
   end
+
+  def republish_dependent_documents
+    documents = NewsArticle
+      .joins(:edition_editionable_worldwide_organisations)
+      .where(edition_editionable_worldwide_organisations: { document: })
+      .includes(:images)
+      .where(images: { id: nil })
+      .map(&:document)
+      .uniq(&:id)
+
+    documents.each { |d| Whitehall::PublishingApi.republish_document_async(d) }
+  end
 end

--- a/app/models/featured_image_data.rb
+++ b/app/models/featured_image_data.rb
@@ -31,6 +31,7 @@ class FeaturedImageData < ApplicationRecord
     if all_asset_variants_uploaded?
       logger.info("FeaturedImageData #{id} (#{featured_imageable_type}:#{featured_imageable_id}) republishing after all asset variants are uploaded")
       featured_imageable.republish_to_publishing_api_async if featured_imageable.respond_to? :republish_to_publishing_api_async
+      Whitehall::PublishingApi.republish_document_async(featured_imageable.document) if featured_imageable.is_a?(Edition)
       featured_imageable.republish_dependent_documents if featured_imageable.respond_to? :republish_dependent_documents
     end
   end

--- a/app/models/news_article.rb
+++ b/app/models/news_article.rb
@@ -5,6 +5,7 @@ class NewsArticle < Announcement
   include Edition::AlternativeFormatProvider
   include Edition::CanApplyToLocalGovernmentThroughRelatedPolicies
   include Edition::WorldwideOrganisations
+  include Edition::EditionableWorldwideOrganisations
   include Edition::FactCheckable
   include Edition::CustomLeadImage
   include Edition::LeadImage

--- a/app/views/admin/editionable_worldwide_organisations/_form.html.erb
+++ b/app/views/admin/editionable_worldwide_organisations/_form.html.erb
@@ -11,6 +11,24 @@
     rows: 4,
   } %>
 
+  <%= form.fields_for :default_news_image do |_image_fields| %>
+    <%= render "components/single_image_upload", {
+      title: "Default news image",
+      name: "edition[default_news_image_attributes]",
+      id: "edition_default_news_image",
+      image_id: "edition_default_news_image_file",
+      image_name: "edition[default_news_image_attributes][file]",
+      remove_alt_text_field: true,
+      filename: edition.default_news_image.file.identifier,
+      page_errors: edition.errors.any?,
+      error_items: errors_for(edition.errors, :"default_news_image.file"),
+      image_src: edition.default_news_image.url,
+      image_cache_name: "edition[default_news_image_attributes][file_cache]",
+      image_cache: edition.default_news_image.file_cache.presence,
+      image_uploaded: edition.default_news_image.all_asset_variants_uploaded?,
+    } %>
+  <% end %>
+
   <%= render "govuk_publishing_components/components/fieldset", {
     legend_text: "Associations",
     heading_level: 2,

--- a/app/views/admin/editions/_editionable_worldwide_organisation_fields.html.erb
+++ b/app/views/admin/editions/_editionable_worldwide_organisation_fields.html.erb
@@ -1,0 +1,23 @@
+<% required = false unless defined?(required) %>
+
+<% cache_if edition.editionable_worldwide_organisation_document_ids.empty?, "#{taggable_editionable_worldwide_organisations_cache_digest}-design-system" do %>
+  <%= render "components/autocomplete", {
+    id: "edition_editionable_worldwide_organisation_document_ids",
+    name: "edition[editionable_worldwide_organisation_document_ids][]",
+    error_items: errors_for(edition.errors, :editionable_worldwide_organisations),
+    label: {
+      text:  "Worldwide organisations" + "#{' (required)' if required}",
+      heading_size: "m",
+    },
+    select: {
+      options: [""] + taggable_editionable_worldwide_organisations_container,
+      multiple: true,
+      selected: edition.editionable_worldwide_organisation_document_ids,
+    },
+    data: {
+      module: "track-select-click",
+      track_category: "worldwideOrganisationSelection",
+      track_label: request.path,
+    },
+  } %>
+<% end %>

--- a/app/views/admin/news_articles/_form.html.erb
+++ b/app/views/admin/news_articles/_form.html.erb
@@ -18,9 +18,15 @@
 
       <%= render "topical_event_fields", form: form, edition: edition %>
 
-      <div class="app-view-edit-edition__world-organisation-fields govuk-!-margin-bottom-4">
-        <%= render "worldwide_organisation_fields", form: form, edition: edition %>
-      </div>
+      <% if Flipflop.editionable_worldwide_organisations? %>
+        <div class="app-view-edit-edition__editionable-world-organisation-fields govuk-!-margin-bottom-4">
+          <%= render "editionable_worldwide_organisation_fields", form: form, edition: edition, required: true %>
+        </div>
+      <% else %>
+        <div class="app-view-edit-edition__world-organisation-fields govuk-!-margin-bottom-4">
+          <%= render "worldwide_organisation_fields", form: form, edition: edition %>
+        </div>
+      <% end %>
 
       <%= render "world_location_fields", form: form, edition: edition %>
 

--- a/db/migrate/20240229163850_create_edition_editionable_worldwide_organisations.rb
+++ b/db/migrate/20240229163850_create_edition_editionable_worldwide_organisations.rb
@@ -1,0 +1,13 @@
+class CreateEditionEditionableWorldwideOrganisations < ActiveRecord::Migration[7.1]
+  def change
+    create_table :edition_editionable_worldwide_organisations do |t|
+      t.integer "edition_id"
+      t.integer "document_id"
+
+      t.timestamps
+
+      t.index %w[edition_id], name: "index_edition_editionable_worldwide_organisations_on_edition_id"
+      t.index %w[document_id], name: "index_edition_editionable_worldwide_organisations_on_document_id"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_03_112519) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_29_163850) do
   create_table "assets", charset: "utf8mb3", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.string "variant", null: false
@@ -257,6 +257,15 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_03_112519) do
     t.integer "dependable_id"
     t.string "dependable_type"
     t.index ["dependable_id", "dependable_type", "edition_id"], name: "index_edition_dependencies_on_dependable_and_edition", unique: true
+  end
+
+  create_table "edition_editionable_worldwide_organisations", charset: "utf8mb3", force: :cascade do |t|
+    t.integer "edition_id"
+    t.integer "document_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["document_id"], name: "index_edition_editionable_worldwide_organisations_on_document_id"
+    t.index ["edition_id"], name: "index_edition_editionable_worldwide_organisations_on_edition_id"
   end
 
   create_table "edition_lead_images", charset: "utf8mb3", force: :cascade do |t|

--- a/features/news-article.feature
+++ b/features/news-article.feature
@@ -1,6 +1,7 @@
 Feature: News articles
   Background:
     Given I am an GDS editor
+    And The editionable worldwide organisations feature flag is disabled
 
   Scenario: Create a news article of type 'News story'
     When I draft a valid news article of type "News story" with title "You will never guess"
@@ -16,6 +17,11 @@ Feature: News articles
 
   Scenario: Create a news article of type 'World news story'
     When I draft a valid news article of type "World news story" with title "A thing happened in X"
+    Then the news article "A thing happened in X" should have been created
+
+  Scenario: Create a news article of type 'World news story' with an editionable worldwide organisation
+    When The editionable worldwide organisations feature flag is enabled
+    And I draft a valid news article of type "World news story" with title "A thing happened in X" associated with an editionable worldwide organisation
     Then the news article "A thing happened in X" should have been created
 
   Scenario: Create a news article of type 'World news story', then changing its locale from en

--- a/features/step_definitions/news_article_steps.rb
+++ b/features/step_definitions/news_article_steps.rb
@@ -24,6 +24,17 @@ When(/^I draft a valid news article of type "([^"]*)" with title "([^"]*)"$/) do
   click_button "Save"
 end
 
+When(/^I draft a valid news article of type "([^"]*)" with title "([^"]*)" associated with an editionable worldwide organisation$/) do |news_type, title|
+  create(:published_editionable_worldwide_organisation, title: "Afghanistan embassy")
+  create(:world_location, name: "Afghanistan", active: true)
+  begin_drafting_news_article(title:, first_published: Time.zone.today.to_s, announcement_type: news_type)
+  select "Afghanistan embassy", from: "Worldwide organisations"
+  select "Afghanistan", from: "World locations"
+  select "", from: "edition_lead_organisation_ids_1"
+
+  click_button "Save"
+end
+
 Then(/^the news article "([^"]*)" should have been created$/) do |title|
   @news_article = NewsArticle.find_by(title:)
   expect(@news_article).to be_present

--- a/test/components/admin/edition_images/lead_image_component_test.rb
+++ b/test/components/admin/edition_images/lead_image_component_test.rb
@@ -170,6 +170,21 @@ class Admin::EditionImages::LeadImageComponentTest < ViewComponent::TestCase
     assert_selector ".app-c-edition-images-lead-image-component__default_lead_image .govuk-hint", text: "Default image for your organisation"
   end
 
+  test "world news stories render the published editionable worldwide organisations default_lead_image when no lead image has been selected" do
+    image = build(:featured_image_data, file: upload_fixture("big-cheese.960x640.jpg", "image/jpg"))
+    draft_organisation = create(:draft_editionable_worldwide_organisation, default_news_image: image)
+    published_organisation = create(:published_editionable_worldwide_organisation, :with_default_news_image)
+    edition = create(:news_article_world_news_story, :draft, editionable_worldwide_organisations: [draft_organisation, published_organisation])
+
+    render_inline(Admin::EditionImages::LeadImageComponent.new(edition:))
+
+    lead_image = page.find ".app-c-edition-images-lead-image-component__default_lead_image"
+    img = lead_image.find "img"
+    assert_equal "Default organisation image", img[:alt]
+    assert_match "s300_minister-of-funk.960x640.jpg", img[:src]
+    assert_equal "Default image for your organisation", lead_image.find(".govuk-hint").text
+  end
+
   test "news articles doesn't render the organisations default_lead_image when one is not present" do
     organisation = build(:organisation, default_news_image: nil)
     edition = create(:draft_news_article, lead_organisations: [organisation])

--- a/test/components/admin/edition_images/lead_image_component_test.rb
+++ b/test/components/admin/edition_images/lead_image_component_test.rb
@@ -161,6 +161,15 @@ class Admin::EditionImages::LeadImageComponentTest < ViewComponent::TestCase
     assert_selector ".app-c-edition-images-lead-image-component__default_lead_image .govuk-hint", text: "Default image for your organisation"
   end
 
+  test "world news stories render the worldwide organisations default_lead_image no lead image has been selected" do
+    organisation = build(:worldwide_organisation, :with_default_news_image)
+    edition = create(:news_article_world_news_story, :draft, worldwide_organisations: [organisation])
+    render_inline(Admin::EditionImages::LeadImageComponent.new(edition:))
+
+    assert_selector ".app-c-edition-images-lead-image-component__default_lead_image img[alt='Default organisation image']"
+    assert_selector ".app-c-edition-images-lead-image-component__default_lead_image .govuk-hint", text: "Default image for your organisation"
+  end
+
   test "news articles doesn't render the organisations default_lead_image when one is not present" do
     organisation = build(:organisation, default_news_image: nil)
     edition = create(:draft_news_article, lead_organisations: [organisation])

--- a/test/factories/editionable_worldwide_organisations.rb
+++ b/test/factories/editionable_worldwide_organisations.rb
@@ -45,6 +45,12 @@ FactoryBot.define do
         create(:social_media_account, socialable: organisation, social_media_service: create(:social_media_service, name: "Blog"))
       end
     end
+
+    trait(:with_default_news_image) do
+      after :build do |organisation|
+        organisation.default_news_image = build(:featured_image_data)
+      end
+    end
   end
 
   factory :draft_editionable_worldwide_organisation, parent: :editionable_worldwide_organisation, traits: [:draft]

--- a/test/functional/admin/editionable_worldwide_organisations_controller_test.rb
+++ b/test/functional/admin/editionable_worldwide_organisations_controller_test.rb
@@ -25,6 +25,45 @@ class Admin::EditionableWorldwideOrganisationsControllerTest < ActionController:
     assert_response :forbidden
   end
 
+  test "POST :create - creates a default news image" do
+    post :create,
+         params: {
+           edition: controller_attributes_for(
+             :editionable_worldwide_organisation,
+             default_news_image_attributes: {
+               file: upload_fixture("minister-of-funk.960x640.jpg"),
+             },
+           ),
+         }
+    worldwide_organisation = EditionableWorldwideOrganisation.last
+    assert_equal "minister-of-funk.960x640.jpg", worldwide_organisation.default_news_image.file.file.filename
+    assert_equal "Your document has been saved", flash[:notice]
+    assert_redirected_to admin_editionable_worldwide_organisation_path(worldwide_organisation)
+  end
+
+  test "PUT :update - updates existing default new image when image file is replaced" do
+    worldwide_organisation = create(:draft_editionable_worldwide_organisation, :with_default_news_image)
+    default_news_image_id = worldwide_organisation.default_news_image.id
+
+    put :update,
+        params: {
+          id: worldwide_organisation.id,
+          edition: controller_attributes_for(
+            :editionable_worldwide_organisation,
+            default_news_image_attributes: {
+              id: default_news_image_id,
+              file: upload_fixture("big-cheese.960x640.jpg"),
+            },
+          ),
+        }
+    worldwide_organisation = EditionableWorldwideOrganisation.last
+    assert_equal "big-cheese.960x640.jpg", worldwide_organisation.default_news_image.file.file.filename
+    assert_equal "Your document has been saved", flash[:notice]
+    assert_redirected_to admin_editionable_worldwide_organisation_path(worldwide_organisation)
+  end
+
+private
+
   def controller_attributes_for(edition_type, attributes = {})
     super.merge(
       role_ids: [create(:role).id],

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -47,6 +47,8 @@ class ActiveSupport::TestCase
 
   parallelize(workers: :number_of_processors)
 
+  attr_reader :feature_flags
+
   # Fix the merging of coverage reports from parallel processes when using
   # Rails 6 parallelization rather than parallel_tests
   # from https://github.com/simplecov-ruby/simplecov/issues/718#issuecomment-538201587
@@ -61,6 +63,7 @@ class ActiveSupport::TestCase
   end
 
   setup do
+    @feature_flags = Flipflop::FeatureSet.current.test!
     Timecop.freeze(2011, 11, 11, 11, 11, 11)
     Sidekiq::Worker.clear_all
     stub_any_publishing_api_call

--- a/test/unit/app/models/edition/editionable_worldwide_organisation_test.rb
+++ b/test/unit/app/models/edition/editionable_worldwide_organisation_test.rb
@@ -1,0 +1,52 @@
+require "test_helper"
+
+class Edition::EditionableWorldwideOrganisationTest < ActiveSupport::TestCase
+  class EditionWithWorldwideOrganisations < Edition
+    include ::Edition::EditionableWorldwideOrganisations
+  end
+
+  include ActionDispatch::TestProcess
+
+  def valid_edition_attributes
+    {
+      title: "edition-title",
+      body: "edition-body",
+      summary: "edition-summary",
+      creator: create(:user),
+      previously_published: false,
+    }
+  end
+
+  def editionable_worldwide_organisations
+    @editionable_worldwide_organisations ||= [
+      create(:editionable_worldwide_organisation),
+      create(:editionable_worldwide_organisation),
+    ]
+  end
+
+  setup do
+    @edition = EditionWithWorldwideOrganisations.create!(valid_edition_attributes.merge(editionable_worldwide_organisations:))
+  end
+
+  test "edition can be created with editionable worldwide organisations" do
+    assert_equal editionable_worldwide_organisations, @edition.editionable_worldwide_organisations
+  end
+
+  test "edition does not require editionable worldwide organisations" do
+    assert EditionWithWorldwideOrganisations.create!(valid_edition_attributes).valid?
+  end
+
+  test "copies the data sets over to a create draft" do
+    published = create(:news_article_world_news_story, :published, editionable_worldwide_organisations:)
+    assert_equal editionable_worldwide_organisations, published.create_draft(create(:user)).editionable_worldwide_organisations
+  end
+
+  test "returns published editionable worldwide organisations" do
+    published = create(:published_editionable_worldwide_organisation)
+    draft = create(:draft_editionable_worldwide_organisation)
+
+    edition = EditionWithWorldwideOrganisations.create!(valid_edition_attributes.merge(editionable_worldwide_organisations: [published, draft]))
+
+    assert_equal [published], edition.published_editionable_worldwide_organisations
+  end
+end

--- a/test/unit/app/models/editionable_worldwide_organisation_test.rb
+++ b/test/unit/app/models/editionable_worldwide_organisation_test.rb
@@ -168,6 +168,21 @@ class EditionableWorldwideOrganisationTest < ActiveSupport::TestCase
                  draft_worldwide_organisation.offices.first.contact.translations.find_by(locale: :en).attributes.except("id", "contact_id")
   end
 
+  test "should clone default news image when new draft of published edition is created" do
+    published_worldwide_organisation = create(
+      :editionable_worldwide_organisation,
+      :published,
+      :with_default_news_image,
+    )
+
+    draft_worldwide_organisation = published_worldwide_organisation.create_draft(create(:writer))
+
+    assert_equal published_worldwide_organisation.default_news_image.attributes.except("id", "featured_imageable_id"), draft_worldwide_organisation.default_news_image.attributes.except("id", "featured_imageable_id")
+    published_worldwide_organisation.default_news_image.assets.each_with_index do |asset, index|
+      assert_equal asset.attributes.except("id", "assetable_id"), draft_worldwide_organisation.default_news_image.assets[index].attributes.except("id", "assetable_id")
+    end
+  end
+
   test "when destroyed, will remove its home page list for storing offices" do
     world_organisation = create(:editionable_worldwide_organisation)
     h = world_organisation.__send__(:home_page_offices_list)

--- a/test/unit/app/models/editionable_worldwide_organisation_test.rb
+++ b/test/unit/app/models/editionable_worldwide_organisation_test.rb
@@ -8,6 +8,12 @@ class EditionableWorldwideOrganisationTest < ActiveSupport::TestCase
     assert_equal [worldwide_office], worldwide_organisation.offices
   end
 
+  test "can have a default news article image" do
+    image = build(:featured_image_data)
+    worldwide_organisation = build(:editionable_worldwide_organisation, default_news_image: image)
+    assert_equal image, worldwide_organisation.default_news_image
+  end
+
   test "destroys associated worldwide offices" do
     worldwide_organisation = create(:editionable_worldwide_organisation)
     worldwide_office = create(:worldwide_office)

--- a/test/unit/app/models/featured_image_data_test.rb
+++ b/test/unit/app/models/featured_image_data_test.rb
@@ -125,6 +125,22 @@ class FeaturedImageDataTest < ActiveSupport::TestCase
     worldwide_organisation.default_news_image.republish_on_assets_ready
   end
 
+  test "#republish_on_assets_ready should republish editionable worldwide organisation and associations if assets are ready" do
+    worldwide_organisation = create(:published_editionable_worldwide_organisation, :with_default_news_image)
+    news_article = create(:news_article_world_news_story, :published, editionable_worldwide_organisations: [worldwide_organisation])
+    draft_news_article = create(:news_article_world_news_story, :draft, editionable_worldwide_organisations: [worldwide_organisation])
+    other_organisation_news_article = create(:news_article_world_news_story, :draft, editionable_worldwide_organisations: [create(:published_editionable_worldwide_organisation, :with_default_news_image)])
+    news_article_with_image = create(:news_article_world_news_story, images: [create(:image)], editionable_worldwide_organisations: [worldwide_organisation])
+
+    Whitehall::PublishingApi.expects(:republish_document_async).with(worldwide_organisation.document).once
+    Whitehall::PublishingApi.expects(:republish_document_async).with(news_article.document).once
+    Whitehall::PublishingApi.expects(:republish_document_async).with(draft_news_article.document).once
+    Whitehall::PublishingApi.expects(:republish_document_async).with(other_organisation_news_article.document).never
+    Whitehall::PublishingApi.expects(:republish_document_async).with(news_article_with_image.document).never
+
+    worldwide_organisation.default_news_image.republish_on_assets_ready
+  end
+
   test "#republish_on_assets_ready should republish topical event if assets are ready" do
     topical_event = create(:topical_event, :with_logo)
 

--- a/test/unit/app/models/news_article_test.rb
+++ b/test/unit/app/models/news_article_test.rb
@@ -110,8 +110,21 @@ class WorldNewsStoryTypeNewsArticleTest < ActiveSupport::TestCase
   test "is invalid when not associating a worldwide organisation" do
     news_article = build(:news_article_world_news_story)
     news_article.worldwide_organisations = []
+
     assert_not news_article.valid?
     assert news_article.errors[:worldwide_organisations].include?("at least one required")
+    assert_not news_article.errors[:editionable_worldwide_organisations].present?
+  end
+
+  test "is invalid when not associating an editionable worldwide organisation" do
+    feature_flags.switch! :editionable_worldwide_organisations, true
+    news_article = build(:news_article_world_news_story)
+
+    news_article.editionable_worldwide_organisations = []
+
+    assert_not news_article.valid?
+    assert news_article.errors[:editionable_worldwide_organisations].include?("at least one required")
+    assert_not news_article.errors[:worldwide_organisations].present?
   end
 
   test "are invalid if associated with a minister" do

--- a/test/unit/app/presenters/publishing_api/news_article_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/news_article_presenter_test.rb
@@ -270,6 +270,22 @@ module PublishingApi::NewsArticlePresenterTest
       self.news_article = create(:news_article_world_news_story, worldwide_organisations: [worldwide_organisation])
       assert presented_news_article.content[:details][:image].nil?
     end
+
+    test "should return lead image from editionable worldwide organisations when lead_image_has_all_assets?" do
+      worldwide_organisation = create(:published_editionable_worldwide_organisation, :with_default_news_image)
+      self.news_article = create(:news_article_world_news_story, editionable_worldwide_organisations: [worldwide_organisation])
+
+      assert presented_news_article.content[:details][:image][:url].include?("s300_minister-of-funk.960x640.jpg")
+    end
+
+    test "should not return lead image from editionable worldwide organisations when lead_image dont have assets?" do
+      image = build(:featured_image_data)
+      worldwide_organisation = create(:published_editionable_worldwide_organisation, default_news_image: image)
+      worldwide_organisation.default_news_image.assets = []
+
+      self.news_article = create(:news_article_world_news_story, editionable_worldwide_organisations: [worldwide_organisation])
+      assert presented_news_article.content[:details][:image].nil?
+    end
   end
 
   class NewsArticleWithMinisterialRoleAppointments < TestCase


### PR DESCRIPTION
https://trello.com/c/k4iXUPJU

> [!NOTE]  
> We considered including default news image as a link instead of relying on ActiveRecord callbacks. However:
> 1. That leaves us with inconsistency between the records in Whitehall, and the content item (unless we add additional fields to the content item)
> 2. There is already a [callback pattern](https://github.com/alphagov/whitehall/blob/cee99a9c6a7d59afc72cf6d262af5cd40c2006f2/app/models/featured_image_data.rb#L34) in place to deal with the delay in uploading assets. 

See https://github.com/alphagov/whitehall/pull/8873 and https://github.com/alphagov/government-frontend/pull/3096


https://github.com/alphagov/whitehall/assets/47089130/5f666310-035b-422d-931c-a4ac1a66e3b5

### Add default news image to editionable worldwide organisation
Editionable worldwide organisation are to replace worldwide organisations. Add
default news image to achieve parity.

### Add default news image to editionable worldwide organisation forms
Allow users to upload a default news image when creating or updating an
editionable worldwide organisation.

### Add edition editionable worldwide organisations table
Add database table for the association between editionable worldwide
organisations and other models (such as news stories).

The naming is unfortunate here, but follows existing convention.

### Add editionable worldwide organisations module
Add module for the association between editionable worldwide organisations and
other models (such as news stories).

This follows the same pattern defined in the statistical data sets module.

### Add missing test for worldwide organisations
There isn't any coverage for the featured image of world news stories where
their worldwide organisation has a default news image.

### Surface editionable worldwide organisation lead image
This will surface the default news image of an editionable worldwide
organisation when a model (such as a world news story) does not have its own
image.

This is displayed in Whitehall and also presented to the Publishing API.

### Republish world news stories when default news image is changed
All world news stories that use a default news image must be republished when
the editionable worldwide organisation default news image is updated.

This follows the existing pattern for organisations and worldwide organisations.

### Include the feature flags helper in model tests
This is included in controller tests but not model tests.

### Associate editionable worldwide organisations with world news stories
Allows users to select an editionable worldwide organisation when creating or
updating a world news story.

As editionable worldwide organisations are set to replace worldwide
organisations, this is behind a feature flag ready for the eventual switch.

### Republish world news stories after commit
An editionable worldwide organisation may have a change of state such as being
withdrawn. When this happens, any world news stories that are using the default
news image of the organisation must be republished.

### Clone default news image when creating a new draft
The default news image must be cloned when creating a new draft of an
editionable worldwide organisaiton.


---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
