### PR TITLE
Raise an error if we do not have a content ID for an existing GOV.UK URL when adding a document to a collection

### DIFF
--- a/app/models/document_collection_non_whitehall_link/govuk_url.rb
+++ b/app/models/document_collection_non_whitehall_link/govuk_url.rb
@@ -39,6 +39,8 @@ class DocumentCollectionNonWhitehallLink::GovukUrl
 private
 
   def content_item
+    raise "No content ID found for URL #{@url}" if @content_item.nil? && content_id.nil?
+
     @content_item ||= Services.publishing_api.get_content(content_id).to_h
   end
 


### PR DESCRIPTION
This should never happen, but we have seen several error reports suggesting that it does. This will log the actual URL, which we don't currently have access to.

We must also check that the content item is not set before raising the exception, just in case another function has set the content item without first loading the content ID

Trello: https://trello.com/c/tehMQ7i2
