### PR TITLE
change order of date

### DIFF
--- a/app/views/components/_datetime_fields.html.erb
+++ b/app/views/components/_datetime_fields.html.erb
@@ -20,9 +20,9 @@
   month ||= nil
   day ||= nil
   date_input_items = []
-  date_input_items << year if year
-  date_input_items << month if month
   date_input_items << day if day
+  date_input_items << month if month
+  date_input_items << year if year
   date_input_items = nil unless date_input_items.any?
 
   hour ||= {}


### PR DESCRIPTION
Small PR to adjust the layout of date input in Whitehall. A change in this PR (https://github.com/alphagov/whitehall/pull/8726) saw the input set as YYYY-MM-DD, which is not the format we want. The hint above the input boxes demonstrates we desire DD-MM-YYYY instead. 

Zendesk ticket: https://govuk.zendesk.com/agent/tickets/5614114

**BEFORE**

![Screenshot 2024-03-04 at 18 24 59](https://github.com/alphagov/whitehall/assets/41922771/cc41baff-b800-4140-8271-78127abe91ac)


**AFTER**

![Screenshot 2024-03-04 at 18 20 21](https://github.com/alphagov/whitehall/assets/41922771/59e01b38-21ce-4ce6-8c89-027a4245e46a)

[Trello](https://trello.com/c/XJS35nY7/2412-fix-incorrect-date-input-ordering)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
