### PR TITLE
Fix back link

### DIFF
--- a/app/views/admin/corporate_information_pages/index.html.erb
+++ b/app/views/admin/corporate_information_pages/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for :back_link do %>
   <%= render "govuk_publishing_components/components/back_link", {
-    href: [:admin, @organisation.class],
+    href: admin_worldwide_organisations_path,
   } %>
 <% end %>
 <% content_for :page_title, @organisation.name %>

--- a/app/views/admin/social_media_accounts/index.html.erb
+++ b/app/views/admin/social_media_accounts/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for :back_link do %>
   <%= render "govuk_publishing_components/components/back_link", {
-    href: [:admin, @socialable.class],
+    href: admin_worldwide_organisations_path,
   } %>
 <% end %>
 <% content_for :page_title, @socialable.name %>


### PR DESCRIPTION
The back link on the on the Worldwide Organisation "social media accounts" page and the Worldwide Organisation “Pages” page now correctly links back to the Worldwide Organisation index page.

**BEFORE**


https://github.com/alphagov/whitehall/assets/41922771/2b66992d-8fac-4811-b655-1c2486fadc85




**AFTER**

https://github.com/alphagov/whitehall/assets/41922771/f01d7e07-bd6d-43d2-a737-397a1d49d549

[Trello](https://trello.com/c/i2p604YZ/2409-back-links-are-broken-on-worldwide-organisation-social-media-account-and-corporate-information-pages-lists)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
