### PR TITLE
Only include current roles for worldwide organisations

### DIFF
--- a/app/presenters/publishing_api/editionable_worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/editionable_worldwide_organisation_presenter.rb
@@ -114,7 +114,7 @@ module PublishingApi
       people.compact.map do |person|
         {
           person_content_id: person.content_id,
-          role_appointments: person.role_appointments&.map do |role_appointment|
+          role_appointments: person.current_role_appointments&.map do |role_appointment|
             {
               role_appointment_content_id: role_appointment.content_id,
               role_content_id: role_appointment.role.content_id,

--- a/app/presenters/publishing_api/worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/worldwide_organisation_presenter.rb
@@ -133,7 +133,7 @@ module PublishingApi
       people.compact.map do |person|
         {
           person_content_id: person.content_id,
-          role_appointments: person.role_appointments&.map do |role_appointment|
+          role_appointments: person.current_role_appointments&.map do |role_appointment|
             {
               role_appointment_content_id: role_appointment.content_id,
               role_content_id: role_appointment.role.content_id,

--- a/test/unit/app/presenters/publishing_api/editionable_worldwide_organisation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/editionable_worldwide_organisation_presenter_test.rb
@@ -25,6 +25,10 @@ class PublishingApi::EditionableWorldwideOrganisationPresenterTest < ActiveSuppo
     create(:deputy_head_of_mission_role_appointment, role: secondary_role, person: deputy_head_of_mission)
     worldwide_org.roles << secondary_role
 
+    former_role = create(:ambassador_role)
+    create(:ambassador_role_appointment, :ended, role: former_role, person: deputy_head_of_mission)
+    worldwide_org.roles << former_role
+
     public_path = worldwide_org.public_path
 
     expected_hash = {

--- a/test/unit/app/presenters/publishing_api/worldwide_organisation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/worldwide_organisation_presenter_test.rb
@@ -29,6 +29,10 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
     create(:deputy_head_of_mission_role_appointment, role: secondary_role, person: deputy_head_of_mission)
     FactoryBot.create(:worldwide_organisation_role, worldwide_organisation: worldwide_org, role: secondary_role)
 
+    former_role = create(:ambassador_role)
+    create(:ambassador_role_appointment, :ended, role: former_role, person: deputy_head_of_mission)
+    FactoryBot.create(:worldwide_organisation_role, worldwide_organisation: worldwide_org, role: secondary_role)
+
     public_path = worldwide_org.public_path
 
     expected_hash = {


### PR DESCRIPTION
We are currently including all roles that a person has held at a Worldwide Organisation, when we only need to include their current roles.

This has led to a situation where a person's former role incorrectly appears on the Worldwide Organisation page.

After deployment: all worldwide organisations will need republishing.

[Trello card](https://trello.com/c/V79CVWB3)