### PR TITLE
Add migration to unpublish unpublished documents from Publishing API

### DIFF
--- a/db/data_migration/20240312153326_unpublish_unpublished_documents.rb
+++ b/db/data_migration/20240312153326_unpublish_unpublished_documents.rb
@@ -1,0 +1,16 @@
+# These translations were unpublished but the translation was never marked as 'gone' in Publishing API or Content Store
+WorldLocation.find_by(slug: "afghanistan").world_location_news.publish_gone_translation_to_publishing_api(:dr)
+WorldLocation.find_by(slug: "azerbaijan").world_location_news.publish_gone_translation_to_publishing_api(:az)
+WorldLocation.find_by(slug: "portugal").world_location_news.publish_gone_translation_to_publishing_api(:pt)
+
+# These documents were unpublished but there is no associated unpublishing record in the Whitehall database, nor did the unpublishing request make it through to Publishing API or Content Store
+slugs = %w[
+  cumbre-de-las-ninas-2014
+  department-of-healths-staff-survey-results-2013
+  local-authority-carbon-dioxide-emissions-methodology-notes
+  national-curriculum-review
+  uk-greenhouse-gas-emissions
+]
+Document.where(slug: slugs).pluck(:content_id).each do |content_id|
+  PublishingApiGoneWorker.new.perform(content_id, nil, nil, :en)
+end


### PR DESCRIPTION
A small number of documents were previously unpublished but the 'gone' request was never sent to Publishing API.

There appear to be two reasons for this:
- translations of World Location News pages weren't unpublished when the translation was deleted (this was fixed in https://github.com/alphagov/whitehall/commit/7faf776275d8d51e4b70c304fad26bd55cc9387d, but there were still three documents where the unpublishing request hadn't been sent to Publishing API).
- five documents were somehow reverted back to draft state, but with the previously published edition also having been deleted; this means there is no 'unpublishing' record for the previously published edition.

In both cases, it means a bulk republishing results in the wrong data (with a placeholder schema and render app of `whitehall_admin`) that is held in the Publishing API database being republished to Content Store.

Therefore sending a request to Publishing API that these should be deleted properly.

[Trello card](https://trello.com/c/UdAr5zOb)