### PR TITLE
Change publishing of offices associated with editionable worldwide organisations

### DIFF
--- a/app/controllers/admin/worldwide_offices_controller.rb
+++ b/app/controllers/admin/worldwide_offices_controller.rb
@@ -20,6 +20,7 @@ class Admin::WorldwideOfficesController < Admin::BaseController
     worldwide_office_params[:service_ids] ||= []
     if @worldwide_office.update(worldwide_office_params)
       handle_show_on_home_page_param
+      republish_draft_worldwide_organisation
       redirect_to admin_worldwide_organisation_worldwide_offices_path(@worldwide_organisation), notice: "#{@worldwide_office.title} has been edited"
     else
       @worldwide_office.contact.contact_numbers.build if @worldwide_office.contact.contact_numbers.blank?
@@ -31,6 +32,7 @@ class Admin::WorldwideOfficesController < Admin::BaseController
     @worldwide_office = @worldwide_organisation.offices.build(worldwide_office_params)
     if @worldwide_office.save
       handle_show_on_home_page_param
+      republish_draft_worldwide_organisation
       redirect_to admin_worldwide_organisation_worldwide_offices_path(@worldwide_organisation), notice: "#{@worldwide_office.title} has been added"
     else
       @worldwide_office.contact.contact_numbers.build if @worldwide_office.contact.contact_numbers.blank?
@@ -48,6 +50,7 @@ class Admin::WorldwideOfficesController < Admin::BaseController
     title = @worldwide_office.title
 
     if @worldwide_office.destroy
+      republish_draft_worldwide_organisation
       redirect_to admin_worldwide_organisation_worldwide_offices_path(@worldwide_organisation), notice: "#{title} has been deleted"
     else
       render :edit
@@ -125,5 +128,9 @@ private
                     :contact_form_url,
                     { contact_numbers_attributes: %i[id label number _destroy] },
                   ])
+  end
+
+  def republish_draft_worldwide_organisation
+    Whitehall.edition_services.draft_updater(@worldwide_office.edition).perform! if @worldwide_office.edition
   end
 end

--- a/app/controllers/admin/worldwide_offices_controller.rb
+++ b/app/controllers/admin/worldwide_offices_controller.rb
@@ -50,6 +50,11 @@ class Admin::WorldwideOfficesController < Admin::BaseController
     title = @worldwide_office.title
 
     if @worldwide_office.destroy
+      if @worldwide_office.edition
+        PublishingApiDiscardDraftWorker.perform_async(@worldwide_office.content_id, I18n.default_locale.to_s)
+        PublishingApiDiscardDraftWorker.perform_async(@worldwide_office.contact.content_id, I18n.default_locale.to_s)
+      end
+
       republish_draft_worldwide_organisation
       redirect_to admin_worldwide_organisation_worldwide_offices_path(@worldwide_organisation), notice: "#{title} has been deleted"
     else

--- a/app/models/call_for_evidence.rb
+++ b/app/models/call_for_evidence.rb
@@ -127,6 +127,14 @@ class CallForEvidence < Publicationesque
     true
   end
 
+  def associated_documents
+    attachables.flat_map(&:html_attachments)
+  end
+
+  def deleted_associated_documents
+    attachables.flat_map(&:deleted_html_attachments)
+  end
+
   def previously_published
     false
   end

--- a/app/models/call_for_evidence_response.rb
+++ b/app/models/call_for_evidence_response.rb
@@ -38,6 +38,14 @@ class CallForEvidenceResponse < ApplicationRecord
     true
   end
 
+  def associated_documents
+    attachables.flat_map(&:html_attachments)
+  end
+
+  def deleted_associated_documents
+    attachables.flat_map(&:deleted_html_attachments)
+  end
+
   def path_name
     to_model.class.name.underscore
   end

--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -141,6 +141,14 @@ class Consultation < Publicationesque
     true
   end
 
+  def associated_documents
+    attachables.flat_map(&:html_attachments)
+  end
+
+  def deleted_associated_documents
+    attachables.flat_map(&:deleted_html_attachments)
+  end
+
   def previously_published
     false
   end

--- a/app/models/consultation_response.rb
+++ b/app/models/consultation_response.rb
@@ -38,6 +38,14 @@ class ConsultationResponse < ApplicationRecord
     true
   end
 
+  def associated_documents
+    attachables.flat_map(&:html_attachments)
+  end
+
+  def deleted_associated_documents
+    attachables.flat_map(&:deleted_html_attachments)
+  end
+
   def path_name
     to_model.class.name.underscore
   end

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -40,7 +40,7 @@ class Contact < ApplicationRecord
   end
 
   def republish_worldwide_office_to_publishing_api
-    Whitehall::PublishingApi.republish_async(contactable) if contactable.is_a?(WorldwideOffice)
+    Whitehall::PublishingApi.republish_async(contactable) if contactable.is_a?(WorldwideOffice) && !contactable.edition
   end
 
   def contactable_name

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -35,6 +35,12 @@ class Contact < ApplicationRecord
   extend HomePageList::ContentItem
   is_stored_on_home_page_lists
 
+  def can_publish_to_publishing_api?
+    return false if contactable.is_a?(WorldwideOffice) && contactable.edition
+
+    super
+  end
+
   def republish_organisation_to_publishing_api
     Whitehall::PublishingApi.republish_async(contactable) if contactable.is_a?(Organisation)
   end

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -41,6 +41,12 @@ class Contact < ApplicationRecord
     super
   end
 
+  def can_publish_gone_to_publishing_api?
+    return false if contactable.is_a?(WorldwideOffice) && contactable.edition
+
+    super
+  end
+
   def republish_organisation_to_publishing_api
     Whitehall::PublishingApi.republish_async(contactable) if contactable.is_a?(Organisation)
   end

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -742,6 +742,14 @@ EXISTS (
     names.uniq.length == names.length
   end
 
+  def associated_documents
+    []
+  end
+
+  def deleted_associated_documents
+    []
+  end
+
 private
 
   def date_for_government

--- a/app/models/editionable_worldwide_organisation.rb
+++ b/app/models/editionable_worldwide_organisation.rb
@@ -158,4 +158,8 @@ class EditionableWorldwideOrganisation < Edition
 
     documents.each { |d| Whitehall::PublishingApi.republish_document_async(d) }
   end
+
+  def associated_documents
+    (offices + offices.map(&:contact)).compact.flatten
+  end
 end

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -151,6 +151,14 @@ class Publication < Publicationesque
     true
   end
 
+  def associated_documents
+    attachables.flat_map(&:html_attachments)
+  end
+
+  def deleted_associated_documents
+    attachables.flat_map(&:deleted_html_attachments)
+  end
+
   def assign_statistics_announcement
     if statistics_announcement_id.present?
       self.statistics_announcement = StatisticsAnnouncement.find(statistics_announcement_id)

--- a/app/models/worldwide_office.rb
+++ b/app/models/worldwide_office.rb
@@ -35,6 +35,12 @@ class WorldwideOffice < ApplicationRecord
     super
   end
 
+  def can_publish_gone_to_publishing_api?
+    return false if edition
+
+    super
+  end
+
   def worldwide_organisation
     super || edition
   end

--- a/app/models/worldwide_office.rb
+++ b/app/models/worldwide_office.rb
@@ -29,6 +29,12 @@ class WorldwideOffice < ApplicationRecord
   delegate(:non_english_translated_locales, to: :worldwide_organisation)
   delegate(:embassy_office?, to: :worldwide_office_type)
 
+  def can_publish_to_publishing_api?
+    return false if edition
+
+    super
+  end
+
   def worldwide_organisation
     super || edition
   end

--- a/app/services/service_listeners/publishing_api_associated_documents.rb
+++ b/app/services/service_listeners/publishing_api_associated_documents.rb
@@ -103,13 +103,13 @@ module ServiceListeners
     end
 
     def current_associated_documents
-      edition.attachables.flat_map(&:html_attachments)
+      edition.associated_documents
     end
 
     def previous_associated_documents
       return [] unless previous_edition
 
-      previous_edition.attachables.flat_map(&:html_attachments)
+      previous_edition.associated_documents
     end
 
     def content_ids_to_remove
@@ -123,7 +123,7 @@ module ServiceListeners
     end
 
     def deleted_associated_documents
-      edition.attachables.flat_map(&:deleted_html_attachments)
+      edition.deleted_associated_documents
     end
 
     def do_publish(update_type)

--- a/app/services/service_listeners/publishing_api_associated_documents.rb
+++ b/app/services/service_listeners/publishing_api_associated_documents.rb
@@ -38,7 +38,7 @@ module ServiceListeners
       current_associated_documents.each do |associated_document|
         Whitehall::PublishingApi.save_draft_translation(
           associated_document,
-          associated_document.locale || I18n.default_locale.to_s,
+          locale_for_document(associated_document),
           update_type || (edition.minor_change? ? "minor" : "major"),
         )
       end
@@ -59,7 +59,7 @@ module ServiceListeners
         PublishingApiRedirectWorker.new.perform(
           associated_document.content_id,
           destination,
-          associated_document.locale || I18n.default_locale.to_s,
+          locale_for_document(associated_document),
           allow_draft,
         )
       end
@@ -70,7 +70,7 @@ module ServiceListeners
         PublishingApiWithdrawalWorker.new.perform(
           associated_document.content_id,
           edition.unpublishing.explanation,
-          associated_document.locale || I18n.default_locale.to_s,
+          locale_for_document(associated_document),
           false,
           edition.unpublishing.unpublished_at.to_s,
         )
@@ -82,6 +82,14 @@ module ServiceListeners
     end
 
   private
+
+    def locale_for_document(document)
+      if document.respond_to?(:locale) && document.locale
+        document.locale
+      else
+        I18n.default_locale.to_s
+      end
+    end
 
     def discard_drafts(associated_documents)
       associated_documents.each do |associated_document|
@@ -140,7 +148,7 @@ module ServiceListeners
           associated_document.class.name,
           associated_document.id,
           update_type,
-          associated_document.locale || I18n.default_locale.to_s,
+          locale_for_document(associated_document),
         )
       end
     end

--- a/app/services/service_listeners/publishing_api_pusher.rb
+++ b/app/services/service_listeners/publishing_api_pusher.rb
@@ -46,7 +46,7 @@ module ServiceListeners
   private
 
     def handle_associated_documents(event)
-      if edition.respond_to?(:html_attachments)
+      if edition.respond_to?(:associated_documents) || edition.respond_to?(:deleted_associated_documents)
         PublishingApiAssociatedDocuments.process(edition, event)
       end
     end

--- a/app/services/service_listeners/publishing_api_pusher.rb
+++ b/app/services/service_listeners/publishing_api_pusher.rb
@@ -40,14 +40,14 @@ module ServiceListeners
         api.discard_draft_async(edition)
       end
 
-      handle_html_attachments(event)
+      handle_associated_documents(event)
     end
 
   private
 
-    def handle_html_attachments(event)
+    def handle_associated_documents(event)
       if edition.respond_to?(:html_attachments)
-        PublishingApiHtmlAttachments.process(edition, event)
+        PublishingApiAssociatedDocuments.process(edition, event)
       end
     end
 

--- a/app/workers/publishing_api_document_republishing_worker.rb
+++ b/app/workers/publishing_api_document_republishing_worker.rb
@@ -120,7 +120,7 @@ private
   end
 
   def handle_attachments_for(edition)
-    ServiceListeners::PublishingApiHtmlAttachments.process(
+    ServiceListeners::PublishingApiAssociatedDocuments.process(
       edition,
       "republish",
     )

--- a/lib/publishes_to_publishing_api.rb
+++ b/lib/publishes_to_publishing_api.rb
@@ -4,12 +4,16 @@ module PublishesToPublishingApi
 
   included do
     after_commit :publish_to_publishing_api, if: :can_publish_to_publishing_api?
-    after_commit :publish_gone_to_publishing_api, on: :destroy
+    after_commit :publish_gone_to_publishing_api, on: :destroy, if: :can_publish_gone_to_publishing_api?
     define_callbacks :published, :published_gone
   end
 
   def can_publish_to_publishing_api?
     persisted?
+  end
+
+  def can_publish_gone_to_publishing_api?
+    true
   end
 
   def republish_to_publishing_api_async

--- a/test/factories/editionable_worldwide_organisations.rb
+++ b/test/factories/editionable_worldwide_organisations.rb
@@ -50,4 +50,9 @@ FactoryBot.define do
   factory :deleted_editionable_worldwide_organisation, parent: :editionable_worldwide_organisation, traits: [:deleted]
   factory :superseded_editionable_worldwide_organisation, parent: :editionable_worldwide_organisation, traits: [:superseded]
   factory :scheduled_editionable_worldwide_organisation, parent: :editionable_worldwide_organisation, traits: [:scheduled]
+  factory :unpublished_editionable_worldwide_organisation, parent: :editionable_worldwide_organisation, traits: [:unpublished]
+  factory :unpublished_editionable_worldwide_organisation_consolidated, parent: :editionable_worldwide_organisation, traits: [:consolidated_redirect]
+  factory :unpublished_editionable_worldwide_organisation_in_error_redirect, parent: :editionable_worldwide_organisation, traits: [:published_in_error_redirect]
+  factory :unpublished_editionable_worldwide_organisation_in_error_no_redirect, parent: :editionable_worldwide_organisation, traits: [:published_in_error_no_redirect]
+  factory :withdrawn_editionable_worldwide_organisation, parent: :editionable_worldwide_organisation, traits: [:withdrawn]
 end

--- a/test/functional/admin/worldwide_offices_controller_test.rb
+++ b/test/functional/admin/worldwide_offices_controller_test.rb
@@ -389,6 +389,57 @@ class Admin::WorldwideOfficesControllerTest < ActionController::TestCase
     assert_equal [office1, office2], assigns(:reorderable_offices)
   end
 
+  test "POST :create for an office attached to an editionable worldwide organisation republishes the draft of the editionable worldwide organisation" do
+    feature_flags.switch! :editionable_worldwide_organisations, true
+
+    worldwide_organisation = create(:draft_editionable_worldwide_organisation)
+
+    Whitehall::PublishingApi.expects(:save_draft).with(worldwide_organisation)
+
+    post :create,
+         params: {
+           worldwide_office: {
+             worldwide_office_type_id: WorldwideOfficeType::Other.id,
+             contact_attributes: {
+               title: "Main office",
+               contact_type_id: ContactType::General.id,
+             },
+           },
+           worldwide_organisation_id: worldwide_organisation,
+         }
+  end
+
+  test "PUT :update for an office attached to an editionable worldwide organisation republishes the draft of the editionable worldwide organisation" do
+    feature_flags.switch! :editionable_worldwide_organisations, true
+
+    office = create(:worldwide_office, edition: create(:draft_editionable_worldwide_organisation), worldwide_organisation: nil)
+
+    Whitehall::PublishingApi.expects(:save_draft).with(office.edition)
+
+    put :update,
+        params: {
+          worldwide_office: {
+            access_and_opening_times: "New times",
+          },
+          id: office,
+          worldwide_organisation_id: office.edition,
+        }
+  end
+
+  test "DELETE :destroy for an office attached to an editionable worldwide organisation republishes the draft of the editionable worldwide organisation" do
+    feature_flags.switch! :editionable_worldwide_organisations, true
+
+    office = create(:worldwide_office, edition: create(:draft_editionable_worldwide_organisation), worldwide_organisation: nil)
+
+    Whitehall::PublishingApi.expects(:save_draft).with(office.edition)
+
+    delete :destroy,
+           params: {
+             id: office,
+             worldwide_organisation_id: office.edition,
+           }
+  end
+
 private
 
   def create_worldwide_organisation_and_office

--- a/test/unit/app/models/publishes_to_publishing_api_test.rb
+++ b/test/unit/app/models/publishes_to_publishing_api_test.rb
@@ -31,6 +31,7 @@ class PublishesToPublishingApiTest < ActiveSupport::TestCase
     TestObject.stubs(:after_commit).with(
       :publish_gone_to_publishing_api,
       on: :destroy,
+      if: :can_publish_gone_to_publishing_api?,
     )
   end
 
@@ -46,6 +47,7 @@ class PublishesToPublishingApiTest < ActiveSupport::TestCase
     TestObject.expects(:after_commit).with(
       :publish_gone_to_publishing_api,
       on: :destroy,
+      if: :can_publish_gone_to_publishing_api?,
     )
     include_module(TestObject.new)
   end

--- a/test/unit/app/models/worldwide_office_test.rb
+++ b/test/unit/app/models/worldwide_office_test.rb
@@ -138,4 +138,26 @@ class WorldwideOfficeTest < ActiveSupport::TestCase
       office.contact.update!(title: "New title")
     end
   end
+
+  test "is deleted from Publishing API on destroy when associated with a non-editionable worldwide organisation" do
+    office = create(:worldwide_office)
+
+    Whitehall::PublishingApi.expects(:publish_gone_async).with(office.content_id, nil, nil)
+    Whitehall::PublishingApi.expects(:publish_gone_async).with(office.contact.content_id, nil, nil)
+
+    Sidekiq::Testing.inline! do
+      office.destroy!
+    end
+  end
+
+  test "is not deleted from Publishing API on destroy when associated with an editionable worldwide organisation" do
+    office = create(:worldwide_office, edition: create(:editionable_worldwide_organisation), worldwide_organisation: nil)
+
+    Whitehall::PublishingApi.expects(:publish_gone_async).with(office.content_id, nil, nil).never
+    Whitehall::PublishingApi.expects(:publish_gone_async).with(office.contact.content_id, nil, nil).never
+
+    Sidekiq::Testing.inline! do
+      office.destroy!
+    end
+  end
 end

--- a/test/unit/app/services/service_listeners/publishing_api_associated_documents_test.rb
+++ b/test/unit/app/services/service_listeners/publishing_api_associated_documents_test.rb
@@ -1,13 +1,13 @@
 require "test_helper"
 
 module ServiceListeners
-  class PublishingApiHtmlAttachmentsTest < ActiveSupport::TestCase
+  class PublishingApiAssociatedDocumentsTest < ActiveSupport::TestCase
     def call(edition)
       event = self.class.name.demodulize.underscore
-      PublishingApiHtmlAttachments.process(edition, event)
+      PublishingApiAssociatedDocuments.process(edition, event)
     end
 
-    class Publish < PublishingApiHtmlAttachmentsTest
+    class Publish < PublishingApiAssociatedDocumentsTest
       test "for something that can't have html attachments doesn't publish" do
         call(create(:published_news_article))
       end
@@ -204,7 +204,7 @@ module ServiceListeners
       end
     end
 
-    class UpdateDraft < PublishingApiHtmlAttachmentsTest
+    class UpdateDraft < PublishingApiAssociatedDocumentsTest
       test "for something that can't have html attachments doesn't save draft" do
         call(create(:published_news_article))
       end
@@ -280,7 +280,7 @@ module ServiceListeners
       end
     end
 
-    class Unpublish < PublishingApiHtmlAttachmentsTest
+    class Unpublish < PublishingApiAssociatedDocumentsTest
       test "for something that can't have html attachments doesn't publish a redirect" do
         edition = create(:unpublished_edition)
         assert_equal edition.attachments.count, 0
@@ -336,7 +336,7 @@ module ServiceListeners
         call(publication)
       end
 
-      class Withdraw < PublishingApiHtmlAttachmentsTest
+      class Withdraw < PublishingApiAssociatedDocumentsTest
         test "for something that can't have html attachments doesn't publish a withdrawal" do
           call(create(:published_news_article))
         end
@@ -378,7 +378,7 @@ module ServiceListeners
         end
       end
 
-      class Delete < PublishingApiHtmlAttachmentsTest
+      class Delete < PublishingApiAssociatedDocumentsTest
         test "for something that can't have html attachments doesn't discard any drafts" do
           call(create(:published_news_article))
         end
@@ -412,7 +412,7 @@ module ServiceListeners
       end
     end
 
-    class Republish < PublishingApiHtmlAttachmentsTest
+    class Republish < PublishingApiAssociatedDocumentsTest
       test "for a draft publication with an attachment saves the draft" do
         publication = create(:draft_publication)
         attachment = publication.html_attachments.first
@@ -511,7 +511,7 @@ module ServiceListeners
       end
     end
 
-    class Unwithdraw < PublishingApiHtmlAttachmentsTest
+    class Unwithdraw < PublishingApiAssociatedDocumentsTest
       test "with an html attachment on a new document publishes the attachment" do
         publication = create(:published_publication)
         attachment = publication.html_attachments.first

--- a/test/unit/app/services/service_listeners/publishing_api_associated_documents_test.rb
+++ b/test/unit/app/services/service_listeners/publishing_api_associated_documents_test.rb
@@ -202,6 +202,52 @@ module ServiceListeners
 
         call(new_edition)
       end
+
+      test "with an office on a new editionable worldwide organisation publishes the office and it's contact" do
+        worldwide_organisation = create(:editionable_worldwide_organisation, :with_main_office)
+
+        PublishingApiWorker.any_instance.expects(:perform).with(
+          "WorldwideOffice",
+          worldwide_organisation.main_office.id,
+          "major",
+          "en",
+        )
+
+        PublishingApiWorker.any_instance.expects(:perform).with(
+          "Contact",
+          worldwide_organisation.main_office.contact.id,
+          "major",
+          "en",
+        )
+
+        call(worldwide_organisation)
+      end
+
+      test "with an office on the old version of an editionable worldwide organisation redirects the office" do
+        worldwide_organisation = create(:published_editionable_worldwide_organisation, :with_main_office)
+
+        new_edition = worldwide_organisation.create_draft(create(:writer))
+        new_edition.main_office.destroy!
+        new_edition.minor_change = true
+        new_edition.submit!
+        new_edition.publish!
+
+        old_office = worldwide_organisation.main_office
+
+        PublishingApiRedirectWorker.any_instance.expects(:perform).with(
+          old_office.content_id,
+          new_edition.search_link,
+          "en",
+        )
+
+        PublishingApiRedirectWorker.any_instance.expects(:perform).with(
+          old_office.contact.content_id,
+          new_edition.search_link,
+          "en",
+        )
+
+        call(new_edition)
+      end
     end
 
     class UpdateDraft < PublishingApiAssociatedDocumentsTest
@@ -278,6 +324,24 @@ module ServiceListeners
           call(publication)
         end
       end
+
+      test "with an office on a new editionable worldwide organisation saves the office as draft" do
+        worldwide_organisation = create(:editionable_worldwide_organisation, :with_main_office)
+
+        Whitehall::PublishingApi.expects(:save_draft_translation).with(
+          worldwide_organisation.main_office,
+          "en",
+          "major",
+        )
+
+        Whitehall::PublishingApi.expects(:save_draft_translation).with(
+          worldwide_organisation.main_office.contact,
+          "en",
+          "major",
+        )
+
+        call(worldwide_organisation)
+      end
     end
 
     class Unpublish < PublishingApiAssociatedDocumentsTest
@@ -299,6 +363,27 @@ module ServiceListeners
         call(publication)
       end
 
+      test "for an editionable worldwide organisation that has been consolidated publishes a redirect to the alternative url" do
+        worldwide_organisation = create(:unpublished_editionable_worldwide_organisation_consolidated, :with_main_office)
+        office = worldwide_organisation.main_office
+
+        PublishingApiRedirectWorker.any_instance.expects(:perform).with(
+          office.content_id,
+          "/government/another/page",
+          "en",
+          false,
+        )
+
+        PublishingApiRedirectWorker.any_instance.expects(:perform).with(
+          office.contact.content_id,
+          "/government/another/page",
+          "en",
+          false,
+        )
+
+        call(worldwide_organisation)
+      end
+
       test "for a publication that has been unpublished with a redirect publishes a redirect to the alternative url" do
         publication = create(:unpublished_publication_in_error_redirect)
         attachment = publication.html_attachments.first
@@ -309,6 +394,27 @@ module ServiceListeners
           false,
         )
         call(publication)
+      end
+
+      test "for an editionable worldwide organisation that has been unpublished with a redirect publishes a redirect to the alternative url" do
+        worldwide_organisation = create(:unpublished_editionable_worldwide_organisation_in_error_redirect, :with_main_office)
+        office = worldwide_organisation.main_office
+
+        PublishingApiRedirectWorker.any_instance.expects(:perform).with(
+          office.content_id,
+          "/government/another/page",
+          "en",
+          false,
+        )
+
+        PublishingApiRedirectWorker.any_instance.expects(:perform).with(
+          office.contact.content_id,
+          "/government/another/page",
+          "en",
+          false,
+        )
+
+        call(worldwide_organisation)
       end
 
       test "for a publication that has been unpublished with an external redirect publishes a redirect to the alternative url" do
@@ -324,6 +430,28 @@ module ServiceListeners
         call(publication)
       end
 
+      test "for an editionable worldwide organisation that has been unpublished with an external redirect publishes a redirect to the alternative url" do
+        external_url = "https://test.ukri.org/some-page"
+        worldwide_organisation = create(:unpublished_editionable_worldwide_organisation_in_error_redirect, :with_main_office, { unpublishing: build(:unpublishing, { redirect: true, alternative_url: external_url }) })
+        office = worldwide_organisation.main_office
+
+        PublishingApiRedirectWorker.any_instance.expects(:perform).with(
+          office.content_id,
+          external_url,
+          "en",
+          false,
+        )
+
+        PublishingApiRedirectWorker.any_instance.expects(:perform).with(
+          office.contact.content_id,
+          external_url,
+          "en",
+          false,
+        )
+
+        call(worldwide_organisation)
+      end
+
       test "for a publication that has been unpublished without a redirect publishes a redirect to the parent document" do
         publication = create(:unpublished_publication_in_error_no_redirect)
         attachment = publication.html_attachments.first
@@ -334,6 +462,27 @@ module ServiceListeners
           false,
         )
         call(publication)
+      end
+
+      test "for an editionable worldwide organisation that has been unpublished without a redirect publishes a redirect to the parent docuemnt" do
+        worldwide_organisation = create(:unpublished_editionable_worldwide_organisation_in_error_no_redirect, :with_main_office)
+        office = worldwide_organisation.main_office
+
+        PublishingApiRedirectWorker.any_instance.expects(:perform).with(
+          office.content_id,
+          worldwide_organisation.search_link,
+          "en",
+          false,
+        )
+
+        PublishingApiRedirectWorker.any_instance.expects(:perform).with(
+          office.contact.content_id,
+          worldwide_organisation.search_link,
+          "en",
+          false,
+        )
+
+        call(worldwide_organisation)
       end
 
       class Withdraw < PublishingApiAssociatedDocumentsTest
@@ -357,6 +506,28 @@ module ServiceListeners
             publication.unpublishing.unpublished_at.to_s,
           )
           call(publication)
+        end
+
+        test "for an editionable worldwide organisation that has been withdrawn publishes a withdrawal for the office" do
+          worldwide_organisation = create(:withdrawn_editionable_worldwide_organisation, :with_main_office)
+
+          PublishingApiWithdrawalWorker.any_instance.expects(:perform).with(
+            worldwide_organisation.main_office.content_id,
+            "content was withdrawn",
+            "en",
+            false,
+            worldwide_organisation.unpublishing.unpublished_at.to_s,
+          )
+
+          PublishingApiWithdrawalWorker.any_instance.expects(:perform).with(
+            worldwide_organisation.main_office.contact.content_id,
+            "content was withdrawn",
+            "en",
+            false,
+            worldwide_organisation.unpublishing.unpublished_at.to_s,
+          )
+
+          call(worldwide_organisation)
         end
 
         test "for a publication with a translated HTML attachment publishes a withdrawal with the expected locale for each attachment" do
@@ -398,6 +569,22 @@ module ServiceListeners
           call(publication)
         end
 
+        test "for a draft editionable worldwide organisation with offices discards the draft" do
+          worldwide_organisation = create(:draft_editionable_worldwide_organisation, :with_main_office)
+
+          PublishingApiDiscardDraftWorker.expects(:perform_async).with(
+            worldwide_organisation.main_office.content_id,
+            "en",
+          )
+
+          PublishingApiDiscardDraftWorker.expects(:perform_async).with(
+            worldwide_organisation.main_office.contact.content_id,
+            "en",
+          )
+
+          call(worldwide_organisation)
+        end
+
         test "for a draft publication with deleted html attachments discards the deleted attachment drafts" do
           publication = create(:draft_publication)
           attachment = publication.html_attachments.first
@@ -424,6 +611,24 @@ module ServiceListeners
         call(publication)
       end
 
+      test "for a draft editionable worldwide organisation with an office publishes the draft office" do
+        worldwide_organisation = create(:draft_editionable_worldwide_organisation, :with_main_office)
+
+        Whitehall::PublishingApi.expects(:save_draft_translation).with(
+          worldwide_organisation.main_office,
+          "en",
+          "republish",
+        )
+
+        Whitehall::PublishingApi.expects(:save_draft_translation).with(
+          worldwide_organisation.main_office.contact,
+          "en",
+          "republish",
+        )
+
+        call(worldwide_organisation)
+      end
+
       test "for a published publication with an attachment publishes the attachment" do
         publication = create(:published_publication)
         attachment = publication.html_attachments.first
@@ -434,6 +639,26 @@ module ServiceListeners
           "en",
         )
         call(publication)
+      end
+
+      test "for a published editionable worldwide organisation with an office publishes the office" do
+        worldwide_organisation = create(:published_editionable_worldwide_organisation, :with_main_office)
+
+        PublishingApiWorker.any_instance.expects(:perform).with(
+          "WorldwideOffice",
+          worldwide_organisation.main_office.id,
+          "republish",
+          "en",
+        )
+
+        PublishingApiWorker.any_instance.expects(:perform).with(
+          "Contact",
+          worldwide_organisation.main_office.contact.id,
+          "republish",
+          "en",
+        )
+
+        call(worldwide_organisation)
       end
 
       test "for a published publication with a deleted attachment discards the attachment draft" do

--- a/test/unit/app/services/service_listeners/publishing_api_pusher_test.rb
+++ b/test/unit/app/services/service_listeners/publishing_api_pusher_test.rb
@@ -2,8 +2,8 @@ require "test_helper"
 
 module ServiceListeners
   class PublishingApiPusherTest < ActiveSupport::TestCase
-    def stub_html_attachment_pusher(edition, event)
-      PublishingApiHtmlAttachments
+    def stub_associated_document_pusher(edition, event)
+      PublishingApiAssociatedDocuments
         .expects(:process)
         .with(edition, event)
     end
@@ -11,7 +11,7 @@ module ServiceListeners
     test "saves draft async for update_draft" do
       edition = build(:draft_publication, document: build(:document))
       Whitehall::PublishingApi.expects(:save_draft).with(edition)
-      stub_html_attachment_pusher(edition, "update_draft")
+      stub_associated_document_pusher(edition, "update_draft")
       Sidekiq::Testing.inline! do
         PublishingApiPusher.new(edition).push(event: "update_draft")
       end
@@ -24,7 +24,7 @@ module ServiceListeners
         document: build(:document),
       )
       Whitehall::PublishingApi.expects(:save_draft).with(edition)
-      stub_html_attachment_pusher(edition, "update_draft")
+      stub_associated_document_pusher(edition, "update_draft")
       Sidekiq::Testing.inline! do
         PublishingApiPusher.new(edition).push(event: "update_draft")
       end
@@ -33,7 +33,7 @@ module ServiceListeners
     test "publish publishes" do
       edition = build(:publication, document: build(:document))
       Whitehall::PublishingApi.expects(:publish).with(edition)
-      stub_html_attachment_pusher(edition, "publish")
+      stub_associated_document_pusher(edition, "publish")
       Sidekiq::Testing.inline! do
         PublishingApiPusher.new(edition).push(event: "publish")
       end
@@ -42,7 +42,7 @@ module ServiceListeners
     test "force_publish publishes" do
       edition = build(:publication, document: build(:document))
       Whitehall::PublishingApi.expects(:publish).with(edition)
-      stub_html_attachment_pusher(edition, "force_publish")
+      stub_associated_document_pusher(edition, "force_publish")
       Sidekiq::Testing.inline! do
         PublishingApiPusher.new(edition).push(event: "force_publish")
       end
@@ -51,7 +51,7 @@ module ServiceListeners
     test "update_draft_translation saves draft translation" do
       edition = build(:publication, document: build(:document))
       Whitehall::PublishingApi.expects(:save_draft_translation).with(edition, "en")
-      stub_html_attachment_pusher(edition, "update_draft_translation")
+      stub_associated_document_pusher(edition, "update_draft_translation")
       Sidekiq::Testing.inline! do
         PublishingApiPusher.new(edition).push(event: "update_draft_translation", options: { locale: "en" })
       end
@@ -74,7 +74,7 @@ module ServiceListeners
           .with(edition.document.content_id, edition.unpublishing.explanation, edition.unpublishing.unpublished_at, translation.to_s)
       end
 
-      stub_html_attachment_pusher(edition, "withdraw")
+      stub_associated_document_pusher(edition, "withdraw")
 
       Sidekiq::Testing.inline! do
         PublishingApiPusher.new(edition).push(event: "withdraw")
@@ -84,7 +84,7 @@ module ServiceListeners
     test "unpublish publishes the unpublishing" do
       edition = create(:unpublished_publication)
       Whitehall::PublishingApi.expects(:unpublish_async).with(edition.unpublishing)
-      stub_html_attachment_pusher(edition, "unpublish")
+      stub_associated_document_pusher(edition, "unpublish")
       Sidekiq::Testing.inline! do
         PublishingApiPusher.new(edition).push(event: "unpublish")
       end
@@ -93,7 +93,7 @@ module ServiceListeners
     test "force_schedule schedules the edition" do
       edition = build(:publication, document: build(:document))
       Whitehall::PublishingApi.expects(:schedule_async).with(edition)
-      stub_html_attachment_pusher(edition, "force_schedule")
+      stub_associated_document_pusher(edition, "force_schedule")
       Sidekiq::Testing.inline! do
         PublishingApiPusher.new(edition).push(event: "force_schedule")
       end
@@ -102,7 +102,7 @@ module ServiceListeners
     test "schedule schedules the edition" do
       edition = build(:publication, document: build(:document))
       Whitehall::PublishingApi.expects(:schedule_async).with(edition)
-      stub_html_attachment_pusher(edition, "schedule")
+      stub_associated_document_pusher(edition, "schedule")
       Sidekiq::Testing.inline! do
         PublishingApiPusher.new(edition).push(event: "schedule")
       end
@@ -111,7 +111,7 @@ module ServiceListeners
     test "unschedule unschedules the edition" do
       edition = build(:publication, document: build(:document))
       Whitehall::PublishingApi.expects(:unschedule_async).with(edition)
-      stub_html_attachment_pusher(edition, "unschedule")
+      stub_associated_document_pusher(edition, "unschedule")
       Sidekiq::Testing.inline! do
         PublishingApiPusher.new(edition).push(event: "unschedule")
       end
@@ -120,7 +120,7 @@ module ServiceListeners
     test "delete discards draft" do
       edition = build(:publication, document: build(:document))
       Whitehall::PublishingApi.expects(:discard_draft_async).with(edition)
-      stub_html_attachment_pusher(edition, "delete")
+      stub_associated_document_pusher(edition, "delete")
       Sidekiq::Testing.inline! do
         PublishingApiPusher.new(edition).push(event: "delete")
       end

--- a/test/unit/app/workers/publishing_api_document_republishing_worker_test.rb
+++ b/test/unit/app/workers/publishing_api_document_republishing_worker_test.rb
@@ -10,7 +10,7 @@ class PublishingApiDocumentRepublishingWorkerTest < ActiveSupport::TestCase
     Whitehall::PublishingApi.expects(:locales_for).never
     Whitehall::PublishingApi.expects(:patch_links).never
     PublishingApiUnpublishingWorker.any_instance.expects(:perform).never
-    ServiceListeners::PublishingApiHtmlAttachments.expects(:process).never
+    ServiceListeners::PublishingApiAssociatedDocuments.expects(:process).never
 
     PublishingApiDocumentRepublishingWorker.new.perform(document.id)
   end


### PR DESCRIPTION
When a Worldwide Office is associated with an Editionable Worldwide Organisation, we do not want it to be published immediately to the live website on create, update or delete, as it is part of the edition cycle.

Therefore updating the logic to ensure the Worldwide Office (and it's Contact) are only published to draft and live at the correct points in the edition lifecycle.

The same concept will be used in later work for Worldwide Corporate Information Pages.

[Trello card](https://trello.com/c/5Nr1NieG)