### PR TITLE
Use edition links for Worldwide Offices

### DIFF
--- a/app/presenters/publishing_api/worldwide_office_presenter.rb
+++ b/app/presenters/publishing_api/worldwide_office_presenter.rb
@@ -23,6 +23,7 @@ module PublishingApi
           type: item.worldwide_office_type.name,
         },
         document_type: item.class.name.underscore,
+        links: edition_links,
         public_updated_at: item.updated_at,
         rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
         schema_name: "worldwide_office",
@@ -31,11 +32,19 @@ module PublishingApi
       content.merge!(PayloadBuilder::PolymorphicPath.for(item))
     end
 
-    def links
+    def edition_links
       {
         contact:,
         parent: [item.worldwide_organisation.content_id],
         worldwide_organisation: [item.worldwide_organisation.content_id],
+      }
+    end
+
+    def links
+      {
+        contact: [],
+        parent: [],
+        worldwide_organisation: [],
       }
     end
 

--- a/test/unit/app/presenters/publishing_api/worldwide_office_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/worldwide_office_presenter_test.rb
@@ -33,18 +33,23 @@ class PublishingApi::WorldwideOfficePresenterTest < ActiveSupport::TestCase
         type: worldwide_office.worldwide_office_type.name,
       },
       update_type: "major",
+      links: {
+        contact: [
+          worldwide_office.contact.content_id,
+        ],
+        parent: [
+          worldwide_office.worldwide_organisation.content_id,
+        ],
+        worldwide_organisation: [
+          worldwide_office.worldwide_organisation.content_id,
+        ],
+      },
     }
 
     expected_links = {
-      contact: [
-        worldwide_office.contact.content_id,
-      ],
-      parent: [
-        worldwide_office.worldwide_organisation.content_id,
-      ],
-      worldwide_organisation: [
-        worldwide_office.worldwide_organisation.content_id,
-      ],
+      contact: [],
+      parent: [],
+      worldwide_organisation: [],
     }
 
     presented_item = present(worldwide_office)


### PR DESCRIPTION
We are working to make Worldwide Organisations and their offices editionable.

Therefore we need to be able to link the links to editions, rather than documents, to prevent draft updates becoming live before publication.

Depends on https://github.com/alphagov/publishing-api/pull/2686.  After this is merged, all Worldwide Offices will need republishing.  Then another PR can be raised to remove the non-edition links.

[Trello card](https://trello.com/c/5Nr1NieG)