### PR TITLE
Enable adding mainstream guide sub-pages to document collections

### DIFF
--- a/app/validators/gov_uk_url_validator.rb
+++ b/app/validators/gov_uk_url_validator.rb
@@ -2,10 +2,8 @@ class GovUkUrlValidator < ActiveModel::Validator
   def validate(record)
     return if record.url.blank?
 
-    url = parse_url(record.url)
-
-    validate_must_be_valid_govuk_host(url.host)
-    validate_must_reference_govuk_page(url.path)
+    validate_must_be_valid_govuk_host(record)
+    validate_must_reference_govuk_page(record)
   rescue URI::InvalidURIError
     record.errors.add(:url, "must be a valid GOV.UK URL")
   rescue GdsApi::HTTPNotFound
@@ -14,71 +12,19 @@ class GovUkUrlValidator < ActiveModel::Validator
     record.errors.add(:base, "Link lookup failed, please try again later")
   end
 
-  def validate_must_be_valid_govuk_host(host)
-    if host.present? && !valid_govuk_host?(host)
+  def validate_must_be_valid_govuk_host(record)
+    if record.parsed_url.host.present? && !govuk_url_regex.match?(record.parsed_url.host)
       raise URI::InvalidURIError
     end
   end
 
-  def validate_must_reference_govuk_page(path)
-    if content_item_found?(path)
-      validate_link_lookup(content_id(path))
-    else
-      validate_must_reference_guide_subpage(path)
-    end
-  end
-
-  def validate_must_reference_guide_subpage(path)
-    _separator, toplevel_path_segment, *_subpaths = path.split("/")
-    content_id = content_id("/#{toplevel_path_segment}")
-
-    if content_id.blank?
-      raise GdsApi::HTTPNotFound, 404
-    else
-      content_item = get_content_item(content_id)
-
-      unless guide?(content_item)
-        raise GdsApi::HTTPNotFound, 404
-      end
-    end
+  def validate_must_reference_govuk_page(record)
+    record.content_item.present?
   end
 
 private
 
-  def validate_link_lookup(content_id)
-    get_content_item(content_id)
-  end
-
-  def guide?(content_item)
-    content_item["document_type"] == "guide"
-  end
-
-  def valid_govuk_host?(host)
-    govuk_url_regex.match?(host)
-  end
-
-  def content_item_found?(path)
-    content_id(path).present?
-  end
-
-  def content_id(path)
-    Services.publishing_api.lookup_content_id(
-      base_path: path,
-      with_drafts: true,
-    )
-  end
-
-  def get_content_item(content_id)
-    Services.publishing_api.get_content(content_id).to_h
-  end
-
   def govuk_url_regex
     /(publishing.service|www).gov.uk\Z/
-  end
-
-  def parse_url(url)
-    return URI.parse("https://#{url}") if url.start_with?("www.")
-
-    URI.parse(url)
   end
 end

--- a/test/unit/app/models/document_collection_non_whitehall_link/govuk_url_test.rb
+++ b/test/unit/app/models/document_collection_non_whitehall_link/govuk_url_test.rb
@@ -30,6 +30,23 @@ class DocumentCollectionNonWhitehallLink::GovukUrlTest < ActiveSupport::TestCase
     assert url.valid?
   end
 
+  test "should be valid when a mainstream guide sub-page url is used" do
+    content_id = SecureRandom.uuid
+    stub_publishing_api_has_lookups("/foo" => content_id)
+    stub_publishing_api_has_item(content_id:,
+                                 title: "Foo Bar",
+                                 base_path: "/foo",
+                                 document_type: "guide",
+                                 publishing_app: "content-publisher")
+
+    url = DocumentCollectionNonWhitehallLink::GovukUrl.new(
+      url: "https://www.gov.uk/foo/subpage",
+      document_collection_group: build(:document_collection_group),
+    )
+
+    assert url.valid?
+  end
+
   test "should be invalid without a url" do
     url = DocumentCollectionNonWhitehallLink::GovukUrl.new(
       url: nil,
@@ -88,6 +105,23 @@ class DocumentCollectionNonWhitehallLink::GovukUrlTest < ActiveSupport::TestCase
 
     assert_not url.valid?
     assert url.errors.full_messages.include?("Url must reference a GOV.UK page")
+  end
+
+  test "should be valid when a non-mainstream guide sub-page url is used" do
+    content_id = SecureRandom.uuid
+    stub_publishing_api_has_lookups("/foo" => content_id)
+    stub_publishing_api_has_item(content_id:,
+                                 title: "Foo Bar",
+                                 base_path: "/foo",
+                                 document_type: "other",
+                                 publishing_app: "content-publisher")
+
+    url = DocumentCollectionNonWhitehallLink::GovukUrl.new(
+      url: "https://www.gov.uk/foo/subpage",
+      document_collection_group: build(:document_collection_group),
+    )
+
+    assert_not url.valid?
   end
 
   test "should be invalid when Publishing API is down" do


### PR DESCRIPTION
This fixes an error that users would see when trying to add a mainstream guide sub-page to a document collection. The GovukUrl class, unlike the GovukUrlValidator class, did not allow for sub-page paths when verifying that a content item existed at the path provided. We refactor the validator to check the record can access a content item rather than fetching the content item inside the validator so that we can avoid duplicating the behaviour.

Trello: https://trello.com/c/aP2ZQQ9b
