### PR TITLE
Do not present non-edition links for Worldwide Offices

### DIFF
--- a/app/presenters/publishing_api/worldwide_office_presenter.rb
+++ b/app/presenters/publishing_api/worldwide_office_presenter.rb
@@ -41,11 +41,7 @@ module PublishingApi
     end
 
     def links
-      {
-        contact: [],
-        parent: [],
-        worldwide_organisation: [],
-      }
+      {}
     end
 
   private

--- a/test/unit/app/presenters/publishing_api/worldwide_office_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/worldwide_office_presenter_test.rb
@@ -46,11 +46,7 @@ class PublishingApi::WorldwideOfficePresenterTest < ActiveSupport::TestCase
       },
     }
 
-    expected_links = {
-      contact: [],
-      parent: [],
-      worldwide_organisation: [],
-    }
+    expected_links = {}
 
     presented_item = present(worldwide_office)
 


### PR DESCRIPTION
In https://github.com/alphagov/whitehall/pull/8908, we switched Worldwide Offices to use edition links, so the draft version of the document can have different links to the parent.

Once all Worldwide Offices have been republished with edition links, we can remove the code to publish the non-edition links.

Depends on: https://github.com/alphagov/whitehall/pull/8908

[Trello card](https://trello.com/c/5Nr1NieG)