### PR TITLE
Add editionable worldwide organisation links to world news stories

### DIFF
--- a/app/presenters/publishing_api/links_presenter.rb
+++ b/app/presenters/publishing_api/links_presenter.rb
@@ -65,6 +65,8 @@ module PublishingApi
     end
 
     def worldwide_organisation_ids
+      return (item.try(:editionable_worldwide_organisations) || []).map(&:content_id) if item.try(:editionable_worldwide_organisations)&.any?
+
       (item.try(:worldwide_organisations) || []).map(&:content_id)
     end
 

--- a/app/views/admin/news_articles/_form.html.erb
+++ b/app/views/admin/news_articles/_form.html.erb
@@ -18,15 +18,13 @@
 
       <%= render "topical_event_fields", form: form, edition: edition %>
 
-      <% if Flipflop.editionable_worldwide_organisations? %>
-        <div class="app-view-edit-edition__editionable-world-organisation-fields govuk-!-margin-bottom-4">
+      <div class="app-view-edit-edition__world-organisation-fields govuk-!-margin-bottom-4">
+        <% if Flipflop.editionable_worldwide_organisations? %>
           <%= render "editionable_worldwide_organisation_fields", form: form, edition: edition, required: true %>
-        </div>
-      <% else %>
-        <div class="app-view-edit-edition__world-organisation-fields govuk-!-margin-bottom-4">
+        <% else %>
           <%= render "worldwide_organisation_fields", form: form, edition: edition %>
-        </div>
-      <% end %>
+        <% end %>
+      </div>
 
       <%= render "world_location_fields", form: form, edition: edition %>
 

--- a/test/unit/app/presenters/publishing_api/news_article_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/news_article_presenter_test.rb
@@ -181,6 +181,22 @@ module PublishingApi::NewsArticlePresenterTest
     end
   end
 
+  class WorldNewsStory < TestCase
+    def setup
+      self.news_article = create(:news_article_world_news_story)
+    end
+
+    test "includes worldwide organisation links" do
+      assert_equal news_article.worldwide_organisations.first.content_id, presented_news_article.links[:worldwide_organisations].first
+    end
+
+    test "includes editionable worldwide organisations as worldwide organisation links when the editionable_worldwide_organisations is enabled" do
+      news_article.editionable_worldwide_organisations = [create(:editionable_worldwide_organisation)]
+
+      assert_equal news_article.editionable_worldwide_organisations.first.content_id, presented_news_article.links[:worldwide_organisations].first
+    end
+  end
+
   class GovernmentResponseTest < TestCase
     def setup
       self.news_article = create(:news_article_government_response)


### PR DESCRIPTION
https://trello.com/c/5nBCpGZr

### Link to editionable worldwide organisations for news articles
We are currently migrating worldwide organisations to "editionable worldwide
organisations".

We must include the new editionable worldwide organisations where the old
worldwide organisations were, this inlcludes where other content items have
links to worldwide organisations.

### Fix worldwide organisations select element JavaScript
There is JavaScript on this page which shows/hides the worldwide organisation
select element depending on the news article type.

The JavaScript depends on the
`app-view-edit-edition__world-organisation-fields` class.

Wrap both editionable worldwide organisations and worldwide organisations in
this class so that the JavaScript works for either.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
