### PR TITLE
Delete office translations when the org translation is deleted

### DIFF
--- a/app/controllers/concerns/translation_controller_concern.rb
+++ b/app/controllers/concerns/translation_controller_concern.rb
@@ -26,6 +26,7 @@ module TranslationControllerConcern
 
   def destroy
     translatable_item.remove_translations_for(translation_locale.code)
+    translatable_item.destroy_associated(translation_locale.code)
     redirect_to destroy_redirect_path, notice: notice_message("deleted")
   end
 

--- a/app/models/editionable_worldwide_organisation.rb
+++ b/app/models/editionable_worldwide_organisation.rb
@@ -57,6 +57,12 @@ class EditionableWorldwideOrganisation < Edition
     "worldwide organisation"
   end
 
+  def destroy_associated(locale)
+    offices.each do |office|
+      office.contact.remove_translations_for(locale)
+    end
+  end
+
   alias_method :original_main_office, :main_office
 
   extend HomePageList::Container

--- a/features/editionable-worldwide-organisations.feature
+++ b/features/editionable-worldwide-organisations.feature
@@ -27,6 +27,14 @@ Feature: Editionable worldwide organisations
     And I add a Welsh translation of the worldwide organisation "Test Worldwide Organisation" named "Translated Name"
     Then I should see the Welsh translated title "Translated Name" for the "Test Worldwide Organisation" worldwide organisation
 
+  Scenario: Removing a translation to an existing worldwide organisation
+    Given an editionable worldwide organisation in draft with a translation in French
+    And I add an associated office, also with a translation in French
+    When I remove the French translation from the main document
+    Then I should see the main document translation is gone
+    And I navigate to the Offices tab
+    Then I should see that the translated office is gone
+
   Scenario: Adding a translation to an existing worldwide office
     Given an editionable worldwide organisation in draft with a translation in French
     When I visit the Offices tab

--- a/features/step_definitions/editionable_worldwide_organisation_steps.rb
+++ b/features/step_definitions/editionable_worldwide_organisation_steps.rb
@@ -111,6 +111,25 @@ When(/^I delete the "([^"]*)" office for the worldwide organisation$/) do |_offi
   click_button "Delete"
 end
 
+When(/^I remove the French translation from the main document$/) do
+  visit admin_editionable_worldwide_organisation_path(EditionableWorldwideOrganisation.last)
+  click_link "Delete"
+  click_button "Delete translation"
+end
+
+And(/^I navigate to the Offices tab/) do
+  visit admin_worldwide_organisation_worldwide_offices_path(EditionableWorldwideOrganisation.last)
+  click_link "Offices"
+end
+
+And(/^I add an associated office, also with a translation in French$/) do
+  visit admin_worldwide_organisation_worldwide_offices_path(EditionableWorldwideOrganisation.last)
+  click_link "Add translation"
+  click_button "Next"
+  fill_in "Title (required)", with: "French title"
+  click_button "Save"
+end
+
 And(/^I should see it has been assigned to the "([^"]*)" world location$/) do |title|
   expect(@worldwide_organisation.world_locations.first.name).to eq(title)
 end
@@ -160,6 +179,14 @@ And(/^I edit the worldwide organisation "([^"]*)" deleting the social media acco
   click_link "Social media accounts"
   click_link "Delete"
   click_button "Delete"
+end
+
+Then(/^I should see the main document translation is gone$/) do
+  expect(page).to have_text("No translations for this document")
+end
+
+Then(/^I should see that the translated office is gone$/) do
+  expect(page).not_to have_text("Translated")
 end
 
 Then(/^I should be able to remove all services from the editionable worldwide organisation "(.*?)" office$/) do |description|

--- a/lib/translatable_model.rb
+++ b/lib/translatable_model.rb
@@ -48,6 +48,8 @@ module TranslatableModel
     Locale.new(translation.locale)
   end
 
+  def destroy_associated(locale); end
+
 private
 
   def non_english_translated_locale_codes


### PR DESCRIPTION
This makes sure that when the translation on an editionable worldwide org is deleted
that all of the translations of offices are deleted too

This stops users from being able to translate offices into languages that the original
org isn't translated into

Trello - https://trello.com/c/BzQdhTx6/1045-delete-associated-translated-offices-when-a-translation-is-deleted

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
