### PR TITLE
Editionable ww org case studies

### DIFF
--- a/app/models/case_study.rb
+++ b/app/models/case_study.rb
@@ -7,6 +7,7 @@ class CaseStudy < Edition
   include Edition::TaggableOrganisations
   include Edition::WorldLocations
   include Edition::WorldwideOrganisations
+  include Edition::EditionableWorldwideOrganisations
   include Edition::LeadImage
 
   def rendering_app

--- a/app/views/admin/case_studies/_form.html.erb
+++ b/app/views/admin/case_studies/_form.html.erb
@@ -10,7 +10,12 @@
     id: "associations",
   } do %>
     <div class="govuk-!-margin-bottom-4">
-      <%= render "worldwide_organisation_fields", form: form, edition: edition %>
+      <% if Flipflop.editionable_worldwide_organisations? %>
+        <%= render "editionable_worldwide_organisation_fields", form: form, edition: edition %>
+      <% else %>
+        <%= render "worldwide_organisation_fields", form: form, edition: edition %>
+      <% end %>
+
       <%= render "world_location_fields", form: form, edition: edition %>
       <%= render "organisation_fields", form: form, edition: edition %>
     </div>

--- a/test/functional/admin/case_studies_controller_test.rb
+++ b/test/functional/admin/case_studies_controller_test.rb
@@ -14,6 +14,7 @@ class Admin::CaseStudiesControllerTest < ActionController::TestCase
   should_have_summary :case_study
   should_allow_scheduled_publication_of :case_study
   should_allow_association_with_worldwide_organisations :case_study
+  should_allow_association_with_editionable_worldwide_organisations :case_study
   should_allow_association_between_world_locations_and :case_study
   should_send_drafts_to_content_preview_environment_for :case_study
   should_render_govspeak_history_and_fact_checking_tabs_for :case_study

--- a/test/functional/admin/news_articles_controller_test.rb
+++ b/test/functional/admin/news_articles_controller_test.rb
@@ -13,6 +13,7 @@ class Admin::NewsArticlesControllerTest < ActionController::TestCase
   should_allow_lead_and_supporting_organisations_for :news_article
   should_allow_role_appointments_for :news_article
   should_allow_association_between_world_locations_and :news_article
+  should_allow_association_with_editionable_worldwide_organisations :news_article, required: true
   should_prevent_modification_of_unmodifiable :news_article
   should_allow_overriding_of_first_published_at_for :news_article
   should_have_summary :news_article

--- a/test/unit/app/presenters/publishing_api/case_study_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/case_study_presenter_test.rb
@@ -190,6 +190,19 @@ class PublishingApi::CaseStudyPresenterTest < ActiveSupport::TestCase
     assert_equal [wworg.content_id], presented_item.links[:worldwide_organisations]
   end
 
+  test "includes editionable worldwide organisations as worldwide organisation links when the editionable_worldwide_organisations is enabled" do
+    worldwide_organisation = create(:editionable_worldwide_organisation)
+    case_study = create(
+      :published_case_study,
+      editionable_worldwide_organisations: [worldwide_organisation],
+    )
+
+    presented_item = present(case_study)
+
+    assert_valid_against_links_schema({ links: presented_item.links }, "case_study")
+    assert_equal [worldwide_organisation.content_id], presented_item.links[:worldwide_organisations]
+  end
+
   test "an unpublished document has a first_public_at of the document creation time" do
     case_study = create(:draft_case_study)
     presented_item = present(case_study)


### PR DESCRIPTION
> [!WARNING]  
> Do not merge. Depends on #8912

https://trello.com/c/Bf9HazKR

### Associate case studies with editionable worldwide organisations
Allows users to select an editionable worldwide organisation when creating or
updating a world news story.

As editionable worldwide organisations are set to replace worldwide
organisations, this is behind a feature flag ready for the eventual switch.

### Add editionable worldwide organisation controller test for news articles
News articles were assoicated with editionable worldwide organisations in
#8877.

This adds controller tests for the association that were missed as they are
also covered by feature tests.

### Test that case studies publish editionable worldwide organisations
We are currently migrating worldwide organisations to "editionable worldwide
organisations".

We must include the new editionable worldwide organisations where the old
worldwide organisations were, this includes where other content items have
links to worldwide organisations.

The LinkPresenter was updated in #8912 so the functionality is already there.
This adds test coverage.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
