### PR TITLE
Change HTML Attachment public updated at to reflect parent edition last updated at

### DIFF
--- a/app/presenters/publishing_api/html_attachment_presenter.rb
+++ b/app/presenters/publishing_api/html_attachment_presenter.rb
@@ -19,7 +19,7 @@ module PublishingApi
           description: nil,
           details:,
           document_type: schema_name,
-          public_updated_at: item.updated_at,
+          public_updated_at: public_timestamp,
           rendering_app: item.rendering_app,
           schema_name:,
           links: edition_links,

--- a/test/unit/app/presenters/publishing_api/html_attachment_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/html_attachment_presenter_test.rb
@@ -27,7 +27,7 @@ class PublishingApi::HtmlAttachmentPresenterTest < ActiveSupport::TestCase
       schema_name: "html_publication",
       document_type: "html_publication",
       locale: "en",
-      public_updated_at: html_attachment.updated_at,
+      public_updated_at: edition.public_timestamp,
       publishing_app: Whitehall::PublishingApp::WHITEHALL,
       rendering_app: "government-frontend",
       routes: [


### PR DESCRIPTION

Minor and major version updates previously did not affect HTML attachments. This led to issues where the HTML attachments would appear in latest document search even when the edition was a minor change. With this change, it should reflect the same date that parent edition has for public updated at timestamp.

https://trello.com/c/7m8BSPAw/2416-latest-organisation-documents-should-not-reflect-minor-updates

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
