### PR TITLE
Fix weak URL validation regex and make it const.

### DIFF
--- a/app/validators/gov_uk_url_validator.rb
+++ b/app/validators/gov_uk_url_validator.rb
@@ -13,7 +13,7 @@ class GovUkUrlValidator < ActiveModel::Validator
   end
 
   def validate_must_be_valid_govuk_host(record)
-    if record.parsed_url.host.present? && !govuk_url_regex.match?(record.parsed_url.host)
+    if record.parsed_url.host.present? && !GOVUK_URL_REGEX.match?(record.parsed_url.host)
       raise URI::InvalidURIError
     end
   end
@@ -22,9 +22,6 @@ class GovUkUrlValidator < ActiveModel::Validator
     record.content_item.present?
   end
 
-private
-
-  def govuk_url_regex
-    /(publishing\.service|www)\.gov\.uk\z/
-  end
+  GOVUK_URL_REGEX = /(publishing\.service|www)\.gov\.uk\z/
+  private_constant :GOVUK_URL_REGEX
 end

--- a/app/validators/gov_uk_url_validator.rb
+++ b/app/validators/gov_uk_url_validator.rb
@@ -25,6 +25,6 @@ class GovUkUrlValidator < ActiveModel::Validator
 private
 
   def govuk_url_regex
-    /(publishing.service|www).gov.uk\Z/
+    /(publishing\.service|www)\.gov\.uk\z/
   end
 end


### PR DESCRIPTION
- Match dots correctly when validating that a URL has a GOV.UK domain.
- Make the (private) validation regex a class constant instead of constructing it every time via an unnecessary private method.

Fixes https://github.com/alphagov/whitehall/security/code-scanning/11.