### PR TITLE
Upgrade the validates_email_format_of gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -906,6 +906,8 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
+    simpleidn (0.2.1)
+      unf (~> 0.1.4)
     smart_properties (1.17.0)
     snaky_hash (2.0.1)
       hashie
@@ -940,10 +942,14 @@ GEM
     ttfunk (1.7.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.9.1)
     unicode-display_width (2.5.0)
     uri (0.13.0)
-    validates_email_format_of (1.7.2)
-      i18n
+    validates_email_format_of (1.8.0)
+      i18n (>= 0.8.0)
+      simpleidn
     version_gem (1.1.3)
     view_component (3.11.0)
       activesupport (>= 5.2.0, < 8.0)

--- a/test/functional/admin/fact_check_requests_controller_test.rb
+++ b/test/functional/admin/fact_check_requests_controller_test.rb
@@ -264,7 +264,7 @@ class Admin::CreatingFactCheckRequestsControllerTest < ActionController::TestCas
     @attributes[:email_address] = "not-an-email"
     post :create, params: { edition_id: @edition.id, fact_check_request: @attributes }
 
-    assert_match "There was a problem: Email address does not appear to be a valid e-mail address", flash[:alert]
+    assert_match "There was a problem: Email address does not appear to be a valid email address", flash[:alert]
   end
 
   view_test "should display an apology if requesting a fact check for an edition that has been deleted" do


### PR DESCRIPTION
Required updating a test to match error message returned by latest version of the gem

Trello: https://trello.com/c/106UiNtb