### PR TITLE
Enable featuring topical events on world location news pages

### DIFF
--- a/app/views/admin/world_location_news/features.html.erb
+++ b/app/views/admin/world_location_news/features.html.erb
@@ -61,6 +61,20 @@
       ),
     },
     {
+      id: "topical_events_tab",
+      label: "Topical events",
+      tab_data_attributes: {
+        module: "gem-track-click",
+        "track-category": "tab",
+        "track-action": "world-location-news-features-tab",
+        "track-label": "Topical events",
+      },
+      content: render("admin/feature_lists/featureable_topical_events",
+                      feature_list: @feature_list,
+                      featurable_topical_events: featurable_topical_events_for_feature_list(@featurable_topical_events, @feature_list),
+                      ),
+    },
+    {
       id: "non_govuk_government_links_tab",
       label: "Non-GOV.UK government links",
       tab_data_attributes: {

--- a/features/step_definitions/world_location_news_steps.rb
+++ b/features/step_definitions/world_location_news_steps.rb
@@ -71,6 +71,10 @@ Given(/^there is a published document with the tile "([^"]*)"$/) do |title|
   create(:edition, :published, title:)
 end
 
+Given(/^there is an active topical event with the name "([^"]*)"$/) do |name|
+  create(:topical_event, :active, name:)
+end
+
 And(/^filter documents by all organisations$/) do
   select "All locations"
   click_button "Search"

--- a/features/world-location-news.feature
+++ b/features/world-location-news.feature
@@ -35,6 +35,12 @@ Feature: Administering world location news information
       And I feature "Featured document"
       Then I see that "Featured document" has been featured
 
+    Scenario: Featuring a topical event
+      Given there is an active topical event with the name "Featured topical event"
+      When I visit the world location news page
+      And I feature "Featured topical event"
+      Then I see that "Featured topical event" has been featured
+
     Scenario: Featuring a non-GOV.UK link
       Given the world location has an offsite link with the title "Featured link"
       When I visit the world location news page


### PR DESCRIPTION
This feature existed prior to transitioning to the design system but was missed.

Trello: https://trello.com/c/GmwWTvEV
