### PR TITLE
Worldwide organisation pages

### DIFF
--- a/app/components/admin/worldwide_organisation_pages/index/summary_card_component.html.erb
+++ b/app/components/admin/worldwide_organisation_pages/index/summary_card_component.html.erb
@@ -1,0 +1,7 @@
+<div class="app-vc-worldwide-pages-index-page-summary-card-component">
+  <%= render "components/summary_card", {
+    title: page.title,
+    rows: rows,
+    summary_card_actions: summary_card_actions,
+  } %>
+</div>

--- a/app/components/admin/worldwide_organisation_pages/index/summary_card_component.rb
+++ b/app/components/admin/worldwide_organisation_pages/index/summary_card_component.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+class Admin::WorldwideOrganisationPages::Index::SummaryCardComponent < ViewComponent::Base
+  attr_reader :page
+
+  def initialize(page:)
+    @page = page
+  end
+
+private
+
+  def rows
+    [
+      summary_row,
+      body_row,
+    ].flatten.compact
+  end
+
+  def summary_row
+    return if page.summary.nil?
+
+    {
+      key: "Summary",
+      value: simple_format(truncate(page.summary, length: 500), class: "govuk-!-margin-top-0"),
+    }
+  end
+
+  def body_row
+    return if page.body.nil?
+
+    {
+      key: "Body",
+      value: simple_format(truncate(page.body, length: 500), class: "govuk-!-margin-top-0"),
+    }
+  end
+
+  def summary_card_actions
+    [
+      edit_action,
+    ].compact
+  end
+
+  def edit_action
+    {
+      label: "Edit",
+      href: edit_admin_editionable_worldwide_organisation_page_path(page.edition, page),
+    }
+  end
+end

--- a/app/components/admin/worldwide_organisation_pages/index/summary_card_component.rb
+++ b/app/components/admin/worldwide_organisation_pages/index/summary_card_component.rb
@@ -37,6 +37,7 @@ private
   def summary_card_actions
     [
       edit_action,
+      confirm_destroy_action,
     ].compact
   end
 
@@ -44,6 +45,14 @@ private
     {
       label: "Edit",
       href: edit_admin_editionable_worldwide_organisation_page_path(page.edition, page),
+    }
+  end
+
+  def confirm_destroy_action
+    {
+      label: "Delete",
+      href: confirm_destroy_admin_editionable_worldwide_organisation_page_path(page.edition, page),
+      destructive: true,
     }
   end
 end

--- a/app/controllers/admin/worldwide_organisation_pages_controller.rb
+++ b/app/controllers/admin/worldwide_organisation_pages_controller.rb
@@ -1,0 +1,11 @@
+class Admin::WorldwideOrganisationPagesController < Admin::BaseController
+  before_action :find_worldwide_organisation
+
+  def index; end
+
+private
+
+  def find_worldwide_organisation
+    @worldwide_organisation = Edition.find(params[:editionable_worldwide_organisation_id])
+  end
+end

--- a/app/controllers/admin/worldwide_organisation_pages_controller.rb
+++ b/app/controllers/admin/worldwide_organisation_pages_controller.rb
@@ -1,5 +1,6 @@
 class Admin::WorldwideOrganisationPagesController < Admin::BaseController
   before_action :find_worldwide_organisation
+  before_action :find_worldwide_organisation_page, only: %i[edit update]
 
   def index; end
 
@@ -17,10 +18,26 @@ class Admin::WorldwideOrganisationPagesController < Admin::BaseController
     end
   end
 
+  def edit; end
+
+  def update
+    @worldwide_organisation_page.assign_attributes(worldwide_organisation_page_params)
+
+    if @worldwide_organisation_page.save
+      redirect_to admin_editionable_worldwide_organisation_pages_path(@worldwide_organisation), notice: "#{@worldwide_organisation_page.title} has been updated"
+    else
+      render :edit
+    end
+  end
+
 private
 
   def find_worldwide_organisation
     @worldwide_organisation = Edition.find(params[:editionable_worldwide_organisation_id])
+  end
+
+  def find_worldwide_organisation_page
+    @worldwide_organisation_page = @worldwide_organisation.pages.find(params[:id])
   end
 
   def worldwide_organisation_page_params

--- a/app/controllers/admin/worldwide_organisation_pages_controller.rb
+++ b/app/controllers/admin/worldwide_organisation_pages_controller.rb
@@ -1,6 +1,6 @@
 class Admin::WorldwideOrganisationPagesController < Admin::BaseController
   before_action :find_worldwide_organisation
-  before_action :find_worldwide_organisation_page, only: %i[edit update]
+  before_action :find_worldwide_organisation_page, only: %i[edit update confirm_destroy destroy]
 
   def index; end
 
@@ -25,6 +25,18 @@ class Admin::WorldwideOrganisationPagesController < Admin::BaseController
 
     if @worldwide_organisation_page.save
       redirect_to admin_editionable_worldwide_organisation_pages_path(@worldwide_organisation), notice: "#{@worldwide_organisation_page.title} has been updated"
+    else
+      render :edit
+    end
+  end
+
+  def confirm_destroy; end
+
+  def destroy
+    title = @worldwide_organisation_page.title
+
+    if @worldwide_organisation_page.destroy
+      redirect_to admin_editionable_worldwide_organisation_pages_path(@worldwide_organisation), notice: "#{title} has been deleted"
     else
       render :edit
     end

--- a/app/controllers/admin/worldwide_organisation_pages_controller.rb
+++ b/app/controllers/admin/worldwide_organisation_pages_controller.rb
@@ -3,9 +3,30 @@ class Admin::WorldwideOrganisationPagesController < Admin::BaseController
 
   def index; end
 
+  def new
+    @worldwide_organisation_page = @worldwide_organisation.pages.build
+  end
+
+  def create
+    @worldwide_organisation_page = @worldwide_organisation.pages.build(worldwide_organisation_page_params)
+
+    if @worldwide_organisation_page.save
+      redirect_to admin_editionable_worldwide_organisation_pages_path(@worldwide_organisation), notice: "#{@worldwide_organisation_page.title} has been added"
+    else
+      render :new
+    end
+  end
+
 private
 
   def find_worldwide_organisation
     @worldwide_organisation = Edition.find(params[:editionable_worldwide_organisation_id])
+  end
+
+  def worldwide_organisation_page_params
+    params.require(:worldwide_organisation_page)
+          .permit(:corporate_information_page_type_id,
+                  :summary,
+                  :body)
   end
 end

--- a/app/helpers/admin/tabbed_nav_helper.rb
+++ b/app/helpers/admin/tabbed_nav_helper.rb
@@ -164,6 +164,11 @@ module Admin::TabbedNavHelper
         href: admin_worldwide_organisation_worldwide_offices_path(worldwide_organisation),
         current: current_path == admin_worldwide_organisation_worldwide_offices_path(worldwide_organisation),
       },
+      {
+        label: "Pages",
+        href: admin_editionable_worldwide_organisation_pages_path(worldwide_organisation),
+        current: current_path == admin_editionable_worldwide_organisation_pages_path(worldwide_organisation),
+      },
     ]
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -95,7 +95,7 @@ module ApplicationHelper
   end
 
   def corporate_information_page_types(organisation)
-    CorporateInformationPageType.all.map { |c| [c.title(organisation), c.id] }
+    organisation.corporate_information_page_types.map { |c| [c.title(organisation), c.id] }
   end
 
   def is_external?(href)

--- a/app/models/concerns/has_corporate_information_pages.rb
+++ b/app/models/concerns/has_corporate_information_pages.rb
@@ -16,8 +16,12 @@ module HasCorporateInformationPages
     about_us.body if about_us.present?
   end
 
+  def corporate_information_page_types
+    CorporateInformationPageType.all
+  end
+
   def unused_corporate_information_page_types
-    CorporateInformationPageType.all - corporate_information_pages.map(&:corporate_information_page_type)
+    corporate_information_page_types - corporate_information_pages.map(&:corporate_information_page_type)
   end
 
   def build_corporate_information_page(params)

--- a/app/models/editionable_worldwide_organisation.rb
+++ b/app/models/editionable_worldwide_organisation.rb
@@ -8,6 +8,8 @@ class EditionableWorldwideOrganisation < Edition
   include Edition::Roles
   include Edition::WorldLocations
 
+  has_many :pages, class_name: "WorldwideOrganisationPage", foreign_key: :edition_id, dependent: :destroy, autosave: true
+
   has_many :offices, class_name: "WorldwideOffice", foreign_key: :edition_id, dependent: :destroy, autosave: true
   belongs_to :main_office, class_name: "WorldwideOffice"
 

--- a/app/models/editionable_worldwide_organisation.rb
+++ b/app/models/editionable_worldwide_organisation.rb
@@ -18,6 +18,8 @@ class EditionableWorldwideOrganisation < Edition
 
   after_commit :republish_dependent_documents
 
+  alias_method :name, :title
+
   class CloneOfficesTrait < Edition::Traits::Trait
     def process_associations_before_save(new_edition)
       @edition.offices.each do |office|

--- a/app/models/editionable_worldwide_organisation.rb
+++ b/app/models/editionable_worldwide_organisation.rb
@@ -119,6 +119,10 @@ class EditionableWorldwideOrganisation < Edition
     roles.occupied.find_by(type: SECONDARY_ROLES.map(&:name))
   end
 
+  def corporate_information_page_types
+    CorporateInformationPageType.all.reject { |page| page.slug == "about" }
+  end
+
   def previously_published
     false
   end

--- a/app/models/worldwide_organisation_page.rb
+++ b/app/models/worldwide_organisation_page.rb
@@ -1,0 +1,19 @@
+class WorldwideOrganisationPage < ApplicationRecord
+  belongs_to :edition
+
+  validates :body, presence: true
+  validates :edition, presence: true
+  validates :corporate_information_page_type_id, presence: true
+
+  def title(_locale = :en)
+    corporate_information_page_type.title(edition)
+  end
+
+  def corporate_information_page_type
+    CorporateInformationPageType.find_by_id(corporate_information_page_type_id)
+  end
+
+  def corporate_information_page_type=(type)
+    self.corporate_information_page_type_id = type && type.id
+  end
+end

--- a/app/models/worldwide_organisation_page.rb
+++ b/app/models/worldwide_organisation_page.rb
@@ -3,7 +3,9 @@ class WorldwideOrganisationPage < ApplicationRecord
 
   validates :body, presence: true
   validates :edition, presence: true
-  validates :corporate_information_page_type_id, presence: true
+  validates :corporate_information_page_type_id,
+            presence: true,
+            exclusion: { in: [CorporateInformationPageType::AboutUs.id], message: "Type cannot be `About us`" }
 
   def title(_locale = :en)
     corporate_information_page_type.title(edition)

--- a/app/views/admin/worldwide_organisation_pages/_form.html.erb
+++ b/app/views/admin/worldwide_organisation_pages/_form.html.erb
@@ -1,4 +1,7 @@
-<%= form_for worldwide_organisation_page, url: admin_editionable_worldwide_organisation_pages_path(@worldwide_organisation) do |form| %>
+<%= form_for worldwide_organisation_page, url:
+  @worldwide_organisation_page.persisted? ?
+    admin_editionable_worldwide_organisation_page_path(@worldwide_organisation, @worldwide_organisation_page) :
+    admin_editionable_worldwide_organisation_pages_path(@worldwide_organisation) do |form| %>
 
   <% unless form.object.persisted? %>
     <%= render "components/select_with_search", {

--- a/app/views/admin/worldwide_organisation_pages/_form.html.erb
+++ b/app/views/admin/worldwide_organisation_pages/_form.html.erb
@@ -1,0 +1,69 @@
+<%= form_for worldwide_organisation_page, url: admin_editionable_worldwide_organisation_pages_path(@worldwide_organisation) do |form| %>
+
+  <% unless form.object.persisted? %>
+    <%= render "components/select_with_search", {
+      id: "worldwide_organisation_page_corporate_information_page_type_id",
+      name: "worldwide_organisation_page[corporate_information_page_type_id]",
+      label: "Type",
+      heading_size: "l",
+      error_message: errors_for_input(worldwide_organisation_page.errors, :corporate_information_page_type_id),
+      include_blank: true,
+      options: corporate_information_page_types(@worldwide_organisation).map do |type, value|
+        {
+          text: type,
+          value: value,
+        }
+      end,
+    } %>
+  <% end %>
+
+  <%= render "govuk_publishing_components/components/textarea", {
+      label: {
+        text: "Summary",
+        heading_size: "l",
+      },
+      name: "worldwide_organisation_page[summary]",
+      id: "worldwide_organisation_page_summary",
+      value: form.object.summary,
+      rows: 4,
+      error_items: errors_for(form.object.errors, :summary),
+  } %>
+
+  <% if Flipflop.govspeak_visual_editor? %>
+    <%= render "components/visual_editor", {
+      label: {
+        text: "Body (required)",
+        heading_size: "l",
+      },
+      name: "worldwide_organisation_page[body]",
+      value: form.object.body,
+      error_items: errors_for(form.object.errors, :body),
+    } %>
+  <% else %>
+    <%= render "components/govspeak_editor", {
+      label: {
+        text: "Body (required)",
+        heading_size: "l",
+      },
+      name: "worldwide_organisation_page[body]",
+      id: "worldwide_organisation_page_body",
+      value: form.object.body,
+      rows: 20,
+      error_items: errors_for(form.object.errors, :body),
+    } %>
+  <% end %>
+
+  <div class="govuk-button-group">
+    <%= render "govuk_publishing_components/components/button", {
+      text: "Save",
+      data_attributes: {
+        module: "gem-track-click",
+        "track-category": "form-button",
+        "track-action": "worldwide-organisation-page-button",
+        "track-label": "Save",
+      },
+    } %>
+
+    <%= link_to "Cancel", admin_editionable_worldwide_organisation_pages_path(@worldwide_organisation), class: "govuk-link govuk-link--no-visited-state" %>
+  </div>
+<% end %>

--- a/app/views/admin/worldwide_organisation_pages/confirm_destroy.html.erb
+++ b/app/views/admin/worldwide_organisation_pages/confirm_destroy.html.erb
@@ -1,0 +1,29 @@
+<% content_for :context, @worldwide_organisation.title %>
+<% content_for :page_title, "Delete page for #{@worldwide_organisation.title}" %>
+<% content_for :title, "Delete page" %>
+<% content_for :title_margin_bottom, 6 %>
+
+<div class="govuk-grid-row">
+  <section class="govuk-grid-column-two-thirds">
+    <%= form_with url: admin_editionable_worldwide_organisation_page_path(@worldwide_organisation, @worldwide_organisation_page), method: :delete do %>
+      <p class="govuk-body">
+        Are you sure you want to delete "<%= @worldwide_organisation_page.title %>"?
+      </p>
+
+      <div class="govuk-button-group govuk-!-margin-bottom-6">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Delete",
+          destructive: true,
+          data_attributes: {
+            module: "gem-track-click",
+            "track-category": "form-button",
+            "track-action": "worldwide-organisation-page-button",
+            "track-label": "Delete",
+          },
+        } %>
+
+        <%= link_to "Cancel", admin_editionable_worldwide_organisation_pages_path(@worldwide_organisation), class: "govuk-link govuk-link--no-visited-state" %>
+      </div>
+    <% end %>
+  </section>
+</div>

--- a/app/views/admin/worldwide_organisation_pages/edit.html.erb
+++ b/app/views/admin/worldwide_organisation_pages/edit.html.erb
@@ -1,0 +1,14 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <% content_for :page_title, "Edit page details" %>
+    <% content_for :title, "Edit page details" %>
+    <% content_for :context, @worldwide_organisation.title %>
+    <% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @worldwide_organisation_page)) %>
+
+    <%= render partial: "form", locals: {worldwide_organisation_page: @worldwide_organisation_page} %>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <%= simple_formatting_sidebar %>
+  </div>
+</div>

--- a/app/views/admin/worldwide_organisation_pages/index.html.erb
+++ b/app/views/admin/worldwide_organisation_pages/index.html.erb
@@ -1,0 +1,60 @@
+<% content_for :back_link do %>
+  <%= render "govuk_publishing_components/components/back_link", {
+    href: admin_worldwide_organisations_path,
+  } %>
+<% end %>
+<% content_for :page_title, "#{@worldwide_organisation.title} offices" %>
+<% content_for :title, @worldwide_organisation.title %>
+<% content_for :context, "Worldwide organisation" %>
+<% content_for :title_margin_bottom, 4 %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <p class="govuk-body govuk-!-margin-bottom-4">
+      <%= view_on_website_link_for @worldwide_organisation, class: "govuk-link" %>
+    </p>
+
+    <%= render "components/secondary_navigation", {
+      aria_label: "Worldwide organisation navigation",
+      items: secondary_navigation_tabs_items(@worldwide_organisation, request.path),
+    } %>
+  </div>
+
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "Pages",
+      font_size: "l",
+      margin_bottom: 6,
+    } %>
+
+    <%= render "govuk_publishing_components/components/button", {
+      text: "Create new page",
+      href: new_admin_editionable_worldwide_organisation_page_path(@worldwide_organisation),
+      margin_bottom: 6,
+    } %>
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <div class="govuk-grid-column-two-thirds">
+        <%= render "govuk_publishing_components/components/heading", {
+          text: "Pages within this organisation",
+          font_size: "m",
+          margin_bottom: 6,
+        } %>
+      </div>
+    </div>
+  </div>
+
+  <div class="govuk-grid-column-two-thirds">
+    <% if @worldwide_organisation.pages.any? %>
+      <% @worldwide_organisation.pages.each do |page| %>
+        <%= render Admin::WorldwideOrganisationPages::Index::SummaryCardComponent.new(page:) %>
+      <% end %>
+    <% else %>
+      <%= render "govuk_publishing_components/components/inset_text", {
+        text: "No pages.",
+      } %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/worldwide_organisation_pages/new.html.erb
+++ b/app/views/admin/worldwide_organisation_pages/new.html.erb
@@ -1,0 +1,14 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <% content_for :page_title, "New page details" %>
+    <% content_for :title, "New page details" %>
+    <% content_for :context, @worldwide_organisation.title %>
+    <% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @worldwide_organisation_page)) %>
+
+    <%= render partial: "form", locals: {worldwide_organisation_page: @worldwide_organisation_page} %>
+  </div>
+
+  <div class="govuk-grid-column-one-third">
+    <%= simple_formatting_sidebar %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -287,7 +287,9 @@ Whitehall::Application.routes.draw do
 
       resources :speeches, except: [:index]
       resources :statistical_data_sets, path: "statistical-data-sets", except: [:index]
-      resources :editionable_worldwide_organisations, path: "editionable-worldwide-organisations", except: [:index]
+      resources :editionable_worldwide_organisations, path: "editionable-worldwide-organisations", except: [:index] do
+        resources :pages, controller: "worldwide_organisation_pages"
+      end
       resources :detailed_guides, path: "detailed-guides", except: [:index]
       resources :people do
         resources :translations, controller: "person_translations" do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -288,7 +288,9 @@ Whitehall::Application.routes.draw do
       resources :speeches, except: [:index]
       resources :statistical_data_sets, path: "statistical-data-sets", except: [:index]
       resources :editionable_worldwide_organisations, path: "editionable-worldwide-organisations", except: [:index] do
-        resources :pages, controller: "worldwide_organisation_pages"
+        resources :pages, controller: "worldwide_organisation_pages" do
+          get :confirm_destroy, on: :member
+        end
       end
       resources :detailed_guides, path: "detailed-guides", except: [:index]
       resources :people do

--- a/db/migrate/20240325104416_create_worldwide_organisation_pages.rb
+++ b/db/migrate/20240325104416_create_worldwide_organisation_pages.rb
@@ -1,0 +1,14 @@
+class CreateWorldwideOrganisationPages < ActiveRecord::Migration[7.1]
+  def change
+    create_table :worldwide_organisation_pages do |t|
+      t.integer "corporate_information_page_type_id", null: false
+      t.integer "edition_id", null: false
+      t.text "summary"
+      t.text "body"
+
+      t.timestamps
+
+      t.index %w[edition_id], name: "index_worldwide_organisation_pages_on_edition_id"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_07_145552) do
+ActiveRecord::Schema[7.1].define(version: 2024_03_25_104416) do
   create_table "assets", charset: "utf8mb3", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.string "variant", null: false
@@ -1208,6 +1208,16 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_07_145552) do
     t.index ["edition_id"], name: "index_worldwide_offices_on_edition_id"
     t.index ["slug"], name: "index_worldwide_offices_on_slug"
     t.index ["worldwide_organisation_id"], name: "index_worldwide_offices_on_worldwide_organisation_id"
+  end
+
+  create_table "worldwide_organisation_pages", charset: "utf8mb3", force: :cascade do |t|
+    t.integer "corporate_information_page_type_id", null: false
+    t.integer "edition_id", null: false
+    t.text "summary"
+    t.text "body"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["edition_id"], name: "index_worldwide_organisation_pages_on_edition_id"
   end
 
   create_table "worldwide_organisation_roles", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -190,5 +190,14 @@ if WorldLocation.where(name: "Test International Delegation").blank?
         content_id: SecureRandom.uuid,
       )
     end
+
+    if WorldwideOrganisationPage.where(edition: EditionableWorldwideOrganisation.find_by(title: "Test Editionable Worldwide Organisation"), corporate_information_page_type_id: 1).blank?
+      WorldwideOrganisationPage.create!(
+        summary: "Some summary",
+        body: "Some body",
+        edition: EditionableWorldwideOrganisation.find_by(title: "Test Editionable Worldwide Organisation"),
+        corporate_information_page_type_id: 1,
+      )
+    end
   end
 end

--- a/features/editionable-worldwide-organisations.feature
+++ b/features/editionable-worldwide-organisations.feature
@@ -85,6 +85,18 @@ Feature: Editionable worldwide organisations
     Then I should see that the list of offices for the worldwide organisation is empty
     And The "Test Worldwide Organisation" worldwide organisation should have no offices
 
+  Scenario: Adding a page to a worldwide organisation
+    Given an editionable worldwide organisation "Test Worldwide Organisation"
+    When I visit the pages tab for the worldwide organisation
+    Then I should see that the list of pages for the worldwide organisation is empty
+    When I click the link to create a new page
+    And I correctly fill out the worldwide organisation page fields for a "Personal information charter" with:
+      | Summary | Some summary |
+      | Body (required) | Some body |
+    Then I should see the "Personal information charter" page on the list of pages with the details:
+      | Summary | Some summary |
+      | Body | Some body |
+
   @javascript
   Scenario: Reordering home page offices for a worldwide organisation
     Given An editionable worldwide organisation "Test Worldwide Organisation" with home page offices "Home page office 1" and "Home page office 2"

--- a/features/editionable-worldwide-organisations.feature
+++ b/features/editionable-worldwide-organisations.feature
@@ -97,6 +97,20 @@ Feature: Editionable worldwide organisations
       | Summary | Some summary |
       | Body | Some body |
 
+  Scenario: Editing an existing worldwide organisation page
+    Given an editionable worldwide organisation "Test Worldwide Organisation" with a "Personal information charter" page
+    When I visit the pages tab for the worldwide organisation
+    Then I should see the "Personal information charter" page on the list of pages with the details:
+      | Summary | Some summary |
+      | Body | Some body |
+    When I click the "Edit" link for the "Personal information charter" page
+    And I correctly fill out the worldwide organisation page fields for a "Personal information charter" with:
+      | Summary | Some updated summary |
+      | Body (required) | Some updated body |
+    Then I should see the "Personal information charter" page on the list of pages with the details:
+      | Summary | Some updated summary |
+      | Body | Some updated body |
+
   @javascript
   Scenario: Reordering home page offices for a worldwide organisation
     Given An editionable worldwide organisation "Test Worldwide Organisation" with home page offices "Home page office 1" and "Home page office 2"

--- a/features/editionable-worldwide-organisations.feature
+++ b/features/editionable-worldwide-organisations.feature
@@ -111,6 +111,17 @@ Feature: Editionable worldwide organisations
       | Summary | Some updated summary |
       | Body | Some updated body |
 
+  Scenario: Deleting a worldwide organisation page
+    Given an editionable worldwide organisation "Test Worldwide Organisation" with a "Personal information charter" page
+    When I visit the pages tab for the worldwide organisation
+    Then I should see the "Personal information charter" page on the list of pages with the details:
+      | Summary | Some summary |
+      | Body | Some body |
+    When I click the "Delete" link for the "Personal information charter" page
+    And I submit the confirmation form to delete the "Personal information charter" page
+    And I visit the pages tab for the worldwide organisation
+    Then I should see that the list of pages for the worldwide organisation is empty
+
   @javascript
   Scenario: Reordering home page offices for a worldwide organisation
     Given An editionable worldwide organisation "Test Worldwide Organisation" with home page offices "Home page office 1" and "Home page office 2"

--- a/features/step_definitions/editionable_worldwide_organisation_steps.rb
+++ b/features/step_definitions/editionable_worldwide_organisation_steps.rb
@@ -111,10 +111,30 @@ When(/^I delete the "([^"]*)" office for the worldwide organisation$/) do |_offi
   click_button "Delete"
 end
 
+When(/^I visit the pages tab for the worldwide organisation$/) do
+  visit admin_editionable_worldwide_organisation_path(EditionableWorldwideOrganisation.last)
+  click_link "Edit draft"
+  click_link "Pages"
+end
+
 When(/^I remove the French translation from the main document$/) do
   visit admin_editionable_worldwide_organisation_path(EditionableWorldwideOrganisation.last)
   click_link "Delete"
   click_button "Delete translation"
+end
+
+When(/^I click the link to create a new page$/) do
+  visit admin_editionable_worldwide_organisation_pages_path(EditionableWorldwideOrganisation.last)
+  click_link "Create new page"
+end
+
+When(/^I correctly fill out the worldwide organisation page fields for a "([^"]*)" with:$/) do |type, table|
+  select type, from: "Type"
+  table.rows_hash.each do |field, value|
+    fill_in field, with: value
+  end
+
+  click_on "Save"
 end
 
 And(/^I navigate to the Offices tab/) do
@@ -254,6 +274,24 @@ end
 Then(/^I should see that the list of offices for the worldwide organisation is empty$/) do
   expect(page).to have_current_path(admin_worldwide_organisation_worldwide_offices_path(EditionableWorldwideOrganisation.last))
   expect(page).to have_text("No offices.")
+end
+
+Then(/^I should see that the list of pages for the worldwide organisation is empty$/) do
+  expect(page).to have_current_path(admin_editionable_worldwide_organisation_pages_path(EditionableWorldwideOrganisation.last))
+  expect(page).to have_text("No pages.")
+end
+
+Then(/^I should see the "([^"]*)" page on the list of pages with the details:$/) do |type, table|
+  expect(page).to have_current_path(admin_editionable_worldwide_organisation_pages_path(EditionableWorldwideOrganisation.last))
+  expect(page).to_not have_text("No pages.")
+
+  page_component = find("h2", text: type).ancestor(".govuk-summary-card")
+  within page_component do
+    table.rows_hash.each do |field, value|
+      description = find("dt", text: field).sibling("dd")
+      expect(description).to have_text(value)
+    end
+  end
 end
 
 Then(/^I should see that the list of offices are ordered "([^"]*)" then "([^"]*)"$/) do |first_office, second_office|

--- a/features/step_definitions/editionable_worldwide_organisation_steps.rb
+++ b/features/step_definitions/editionable_worldwide_organisation_steps.rb
@@ -141,6 +141,14 @@ When(/^I click the "([^"]*)" link for the "([^"]*)" page$/) do |link, type|
   end
 end
 
+When(/^I submit the confirmation form to delete the "([^"]*)" page$/) do |type|
+  worldwide_organisation_page = WorldwideOrganisationPage.last
+  expect(page).to have_current_path(confirm_destroy_admin_editionable_worldwide_organisation_page_path(worldwide_organisation_page.edition, worldwide_organisation_page))
+  expect(page).to have_content "Are you sure you want to delete \"#{type}\"?"
+
+  click_button "Delete"
+end
+
 When(/^I correctly fill out the worldwide organisation page fields for a "([^"]*)" with:$/) do |type, table|
   select type, from: "Type" if has_select?("Type")
   table.rows_hash.each do |field, value|

--- a/features/step_definitions/editionable_worldwide_organisation_steps.rb
+++ b/features/step_definitions/editionable_worldwide_organisation_steps.rb
@@ -31,6 +31,11 @@ Given(/^an editionable worldwide organisation in draft with a translation in Fre
   worldwide_organisation.add_office_to_home_page!(create(:worldwide_office, worldwide_organisation: nil, edition: worldwide_organisation, contact: create(:contact, title: "Main office")))
 end
 
+Given(/^an editionable worldwide organisation "([^"]*)" with a "([^"]*)" page$/) do |title, type|
+  worldwide_organisation = create(:editionable_worldwide_organisation, title:)
+  create(:worldwide_organisation_page, edition: worldwide_organisation, corporate_information_page_type: CorporateInformationPageType.find(type.parameterize))
+end
+
 Given(/^a role "([^"]*)" exists$/) do |name|
   create(:role, name:)
 end
@@ -128,8 +133,16 @@ When(/^I click the link to create a new page$/) do
   click_link "Create new page"
 end
 
+When(/^I click the "([^"]*)" link for the "([^"]*)" page$/) do |link, type|
+  visit admin_editionable_worldwide_organisation_pages_path(EditionableWorldwideOrganisation.last)
+  page_component = find("h2", text: type).ancestor(".govuk-summary-card__title-wrapper")
+  within page_component do
+    click_link link
+  end
+end
+
 When(/^I correctly fill out the worldwide organisation page fields for a "([^"]*)" with:$/) do |type, table|
-  select type, from: "Type"
+  select type, from: "Type" if has_select?("Type")
   table.rows_hash.each do |field, value|
     fill_in field, with: value
   end

--- a/test/components/admin/worldwide_organisation_pages/index/summary_card_component_test.rb
+++ b/test/components/admin/worldwide_organisation_pages/index/summary_card_component_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class Admin::WorldwideOrganisationPages::Index::SummaryCardComponentTest < ViewComponent::TestCase
+  include Rails.application.routes.url_helpers
+
+  test "renders a worldwide organisation page summary card" do
+    page = create(:worldwide_organisation_page, summary: "a" * 501, body: "b" * 501)
+
+    render_inline(Admin::WorldwideOrganisationPages::Index::SummaryCardComponent.new(page:))
+
+    assert_selector ".govuk-summary-card__title", text: "Publication scheme"
+    assert_selector ".govuk-summary-card__actions .govuk-summary-card__action:nth-child(1) a[href='#{edit_admin_editionable_worldwide_organisation_page_path(page.edition, page)}']"
+
+    assert_selector ".govuk-summary-list__row", count: 2
+    assert_selector ".govuk-summary-list__row:nth-child(1) .govuk-summary-list__key", text: "Summary"
+    assert_selector ".govuk-summary-list__row:nth-child(1) .govuk-summary-list__value", text: "#{'a' * 497}..."
+    assert_selector ".govuk-summary-list__row:nth-child(2) .govuk-summary-list__key", text: "Body"
+    assert_selector ".govuk-summary-list__row:nth-child(2) .govuk-summary-list__value", text: "#{'b' * 497}..."
+  end
+end

--- a/test/components/admin/worldwide_organisation_pages/index/summary_card_component_test.rb
+++ b/test/components/admin/worldwide_organisation_pages/index/summary_card_component_test.rb
@@ -12,6 +12,7 @@ class Admin::WorldwideOrganisationPages::Index::SummaryCardComponentTest < ViewC
 
     assert_selector ".govuk-summary-card__title", text: "Publication scheme"
     assert_selector ".govuk-summary-card__actions .govuk-summary-card__action:nth-child(1) a[href='#{edit_admin_editionable_worldwide_organisation_page_path(page.edition, page)}']"
+    assert_selector ".govuk-summary-card__actions .govuk-summary-card__action:nth-child(2) a[href='#{confirm_destroy_admin_editionable_worldwide_organisation_page_path(page.edition, page)}']"
 
     assert_selector ".govuk-summary-list__row", count: 2
     assert_selector ".govuk-summary-list__row:nth-child(1) .govuk-summary-list__key", text: "Summary"

--- a/test/factories/worldwide_organisation_pages.rb
+++ b/test/factories/worldwide_organisation_pages.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :worldwide_organisation_page do
+    summary { "Some summary" }
+    body { "Some body" }
+    corporate_information_page_type_id { CorporateInformationPageType::PublicationScheme.id }
+
+    edition factory: :editionable_worldwide_organisation
+  end
+end

--- a/test/functional/admin/worldwide_organisation_pages_controller_test.rb
+++ b/test/functional/admin/worldwide_organisation_pages_controller_test.rb
@@ -54,4 +54,38 @@ class Admin::WorldwideOrganisationPagesControllerTest < ActionController::TestCa
     assert_equal "Some summary", worldwide_organisation.pages.first.summary
     assert_equal "Some body", worldwide_organisation.pages.first.body
   end
+
+  view_test "GET :edit displays the populated worldwide organisation page fields" do
+    worldwide_organisation_page = create(:worldwide_organisation_page)
+
+    get :edit, params: { editionable_worldwide_organisation_id: worldwide_organisation_page.edition, id: worldwide_organisation_page }
+
+    assert_response :success
+    assert_template :edit
+
+    assert_select "form#edit_worldwide_organisation_page_#{worldwide_organisation_page.id}" do
+      assert_select "textarea[name='worldwide_organisation_page[summary]']", "Some summary"
+      assert_select "textarea[name='worldwide_organisation_page[body]']", "Some body"
+    end
+  end
+
+  test "PUT :updated should update an existing worldwide organisation page" do
+    worldwide_organisation_page = create(:worldwide_organisation_page)
+
+    put :update,
+        params: {
+          worldwide_organisation_page: {
+            summary: "Some updated summary",
+            body: "Some updated body",
+          },
+          editionable_worldwide_organisation_id: worldwide_organisation_page.edition.id,
+          id: worldwide_organisation_page.id,
+        }
+
+    assert_redirected_to admin_editionable_worldwide_organisation_pages_path(worldwide_organisation_page.edition)
+    assert_equal 1, worldwide_organisation_page.reload.edition.pages.count
+    assert_equal 2, worldwide_organisation_page.corporate_information_page_type_id
+    assert_equal "Some updated summary", worldwide_organisation_page.summary
+    assert_equal "Some updated body", worldwide_organisation_page.body
+  end
 end

--- a/test/functional/admin/worldwide_organisation_pages_controller_test.rb
+++ b/test/functional/admin/worldwide_organisation_pages_controller_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+
+class Admin::WorldwideOrganisationPagesControllerTest < ActionController::TestCase
+  setup { login_as :user }
+
+  should_be_an_admin_controller
+
+  view_test "GET :index returns a list of worldwide organisation pages" do
+    worldwide_organisation = create(:editionable_worldwide_organisation, title: "British Antarctic Territory")
+    create(:worldwide_organisation_page, edition: worldwide_organisation)
+    create(:worldwide_organisation_page, edition: worldwide_organisation, corporate_information_page_type: CorporateInformationPageType::Recruitment)
+
+    get :index, params: { editionable_worldwide_organisation_id: worldwide_organisation }
+
+    assert_response :success
+    assert_template :index
+    assert_select "h1", "British Antarctic Territory"
+    assert_select "h2", "Pages within this organisation"
+    assert_select "h2", "Publication scheme"
+    assert_select "h2", "Working for British Antarctic Territory"
+  end
+end

--- a/test/functional/admin/worldwide_organisation_pages_controller_test.rb
+++ b/test/functional/admin/worldwide_organisation_pages_controller_test.rb
@@ -88,4 +88,28 @@ class Admin::WorldwideOrganisationPagesControllerTest < ActionController::TestCa
     assert_equal "Some updated summary", worldwide_organisation_page.summary
     assert_equal "Some updated body", worldwide_organisation_page.body
   end
+
+  view_test "GET :confirm_destroy requests confirmation" do
+    worldwide_organisation_page = create(:worldwide_organisation_page)
+
+    get :confirm_destroy, params: { editionable_worldwide_organisation_id: worldwide_organisation_page.edition, id: worldwide_organisation_page }
+
+    assert_response :success
+    assert_template :confirm_destroy
+
+    assert_select "p.govuk-body", text: "Are you sure you want to delete \"Publication scheme\"?"
+  end
+
+  test "DELETE :destroy removes the worldwide organisation page" do
+    worldwide_organisation_page = create(:worldwide_organisation_page)
+    worldwide_organisation = worldwide_organisation_page.edition
+
+    delete :destroy, params: {
+      editionable_worldwide_organisation_id: worldwide_organisation_page.edition.id,
+      id: worldwide_organisation_page.id,
+    }
+
+    assert_redirected_to admin_editionable_worldwide_organisation_pages_path(worldwide_organisation_page.edition)
+    assert_equal 0, worldwide_organisation.pages.count
+  end
 end

--- a/test/functional/admin/worldwide_organisation_pages_controller_test.rb
+++ b/test/functional/admin/worldwide_organisation_pages_controller_test.rb
@@ -19,4 +19,39 @@ class Admin::WorldwideOrganisationPagesControllerTest < ActionController::TestCa
     assert_select "h2", "Publication scheme"
     assert_select "h2", "Working for British Antarctic Territory"
   end
+
+  view_test "GET :new displays the worldwide organisation page fields" do
+    worldwide_organisation = create(:editionable_worldwide_organisation, title: "British Antarctic Territory")
+
+    get :new, params: { editionable_worldwide_organisation_id: worldwide_organisation }
+
+    assert_response :success
+    assert_template :new
+
+    assert_select "form#new_worldwide_organisation_page" do
+      assert_select "select[name='worldwide_organisation_page[corporate_information_page_type_id]']"
+      assert_select "textarea[name='worldwide_organisation_page[summary]']"
+      assert_select "textarea[name='worldwide_organisation_page[body]']"
+    end
+  end
+
+  test "POST :create should create a new worldwide organisation page" do
+    worldwide_organisation = create(:editionable_worldwide_organisation)
+
+    post :create,
+         params: {
+           worldwide_organisation_page: {
+             corporate_information_page_type_id: CorporateInformationPageType::PublicationScheme.id,
+             summary: "Some summary",
+             body: "Some body",
+           },
+           editionable_worldwide_organisation_id: worldwide_organisation.id,
+         }
+
+    assert_redirected_to admin_editionable_worldwide_organisation_pages_path(worldwide_organisation)
+    assert_equal 1, worldwide_organisation.reload.pages.count
+    assert_equal 2, worldwide_organisation.pages.first.corporate_information_page_type_id
+    assert_equal "Some summary", worldwide_organisation.pages.first.summary
+    assert_equal "Some body", worldwide_organisation.pages.first.body
+  end
 end

--- a/test/unit/app/helpers/admin/tabbed_nav_helper_test.rb
+++ b/test/unit/app/helpers/admin/tabbed_nav_helper_test.rb
@@ -385,6 +385,11 @@ class Admin::TabbedNavHelperTest < ActionView::TestCase
         current: false,
       },
       {
+        label: "Pages",
+        href: admin_editionable_worldwide_organisation_pages_path(edition),
+        current: false,
+      },
+      {
         label: "Social media accounts",
         href: admin_edition_social_media_accounts_path(edition),
         current: false,

--- a/test/unit/app/models/editionable_worldwide_organisation_test.rb
+++ b/test/unit/app/models/editionable_worldwide_organisation_test.rb
@@ -300,4 +300,11 @@ class EditionableWorldwideOrganisationTest < ActiveSupport::TestCase
     HomePageList.expects(:get).with(has_entries(owned_by: world_organisation, called: "offices")).returns :a_home_page_list_of_offices
     assert_equal :a_home_page_list_of_offices, world_organisation.__send__(:home_page_offices_list)
   end
+
+  test "#corporate_information_page_types does not return `About Us` pages" do
+    organisation = build(:editionable_worldwide_organisation)
+
+    assert_not_includes organisation.corporate_information_page_types.map(&:slug), "about"
+    assert_not_includes organisation.corporate_information_page_types.map(&:id), 20
+  end
 end

--- a/test/unit/app/models/worldwide_organisation_page_test.rb
+++ b/test/unit/app/models/worldwide_organisation_page_test.rb
@@ -14,6 +14,13 @@ class WorldwideOrganisationPageTest < ActiveSupport::TestCase
     assert page.errors[:edition].include?("can't be blank")
   end
 
+  test "should not be valid when corporate information page type is `about us`" do
+    page = build(:worldwide_organisation_page, corporate_information_page_type: CorporateInformationPageType::AboutUs)
+
+    assert_not page.valid?
+    assert page.errors[:corporate_information_page_type_id].include?("Type cannot be `About us`")
+  end
+
   test "should derive title from type" do
     page = build(:worldwide_organisation_page, corporate_information_page_type: CorporateInformationPageType::TermsOfReference)
     assert_equal "Terms of reference", page.title

--- a/test/unit/app/models/worldwide_organisation_page_test.rb
+++ b/test/unit/app/models/worldwide_organisation_page_test.rb
@@ -1,0 +1,35 @@
+require "test_helper"
+
+class WorldwideOrganisationPageTest < ActiveSupport::TestCase
+  %w[body corporate_information_page_type_id].each do |param|
+    test "should not be valid without a #{param}" do
+      assert_not build(:worldwide_organisation_page, param.to_sym => nil).valid?
+    end
+  end
+
+  test "should not be valid without a worldwide organisation" do
+    page = build(:worldwide_organisation_page, edition: nil)
+
+    assert_not page.valid?
+    assert page.errors[:edition].include?("can't be blank")
+  end
+
+  test "should derive title from type" do
+    page = build(:worldwide_organisation_page, corporate_information_page_type: CorporateInformationPageType::TermsOfReference)
+    assert_equal "Terms of reference", page.title
+  end
+
+  test "should translate title" do
+    welsh_language_scheme_page = build(:worldwide_organisation_page, corporate_information_page_type: CorporateInformationPageType::WelshLanguageScheme)
+    assert_equal "Welsh language scheme", welsh_language_scheme_page.title
+    I18n.with_locale(:cy) do
+      assert_equal "Cynllun iaith Gymraeg", welsh_language_scheme_page.title
+    end
+  end
+
+  test "should derive title from type and interpolate organisation name" do
+    worldwide_organisation = build(:editionable_worldwide_organisation, title: "British Antarctic Territory")
+    page = build(:worldwide_organisation_page, edition: worldwide_organisation, corporate_information_page_type: CorporateInformationPageType::Recruitment)
+    assert_equal "Working for British Antarctic Territory", page.title
+  end
+end


### PR DESCRIPTION
https://trello.com/c/2VqUBhuS

https://github.com/alphagov/whitehall/assets/47089130/123011d9-f1f4-4a4e-917e-21bb8f8526ca

### Add worldwide organisation pages table
We want to model worldwide organisation pages like worldwide offices. These
will be a replacement for corporate information pages on the new editionable
worldwide organisation.

### Add worldwide organisation page model
Add the basic model and associations for a worldwide organisation page.

### Add worldwide organisation pages to the seed data

### Add name to editionable worldwide organisation
Classes like CorporateInformationPageType must be compatible with (currently)
worldwide organisations, editionable worldwide organisations, and
organisations.

This adds an alias of name to editionable worldwide organisation.

### Add a summary card component for worldwide organisation pages
We want to display worldwide organisation pages in the same way we display
worldwide offices.

### Add index action for worldwide organisation pages
This adds the basic index action journey for the new worldwide organisation
page model.

### Add create and new actions for worldwide organisation pages
This adds the basic create journey for the new worldwide organisation page
model.

### Add update and edit actions for worldwide organisation pages
This adds the basic update journey for the new worldwide organisation page
model.

### Add destroy and confirm destroy actions for worldwide organisation pages
This adds the basic destroy journey for the new worldwide organisation page
model.

### Remove about us page option for editionable worldwide organisations
Part of the move from using the legacy worldwide organisations to using the new
editionable worldwide organisations involves removing the "about us" corporate
information page.

Instead, this information will live on the editionable worldwide organisation
itself.

This adds methods to the various organisation types to retrieve the types for
that particular organisation.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
