### PR TITLE
Fix docs link with newline in the middle

### DIFF
--- a/config/locales/en/admin/training.yml
+++ b/config/locales/en/admin/training.yml
@@ -86,8 +86,7 @@ en:
 
             You can filter documents, for example by using the title, organisation or author associated with the document.
 
-            Read more [guidance about filtering documents](https://www.gov.uk/guidance/how-to-publish-on-gov-uk/
-            introduction-and-access-to-whitehall-publisher#filter-documents).
+            Read more [guidance about filtering documents](https://www.gov.uk/guidance/how-to-publish-on-gov-uk/introduction-and-access-to-whitehall-publisher#filter-documents).
           video_heading: "Video: finding and filtering documents"
           video_transcript: |
             When you select 'Documents' from the main menu bar, it will take you to the documents page, where it will show all the content from your organisation. You can use the filters to find the content you need easily.


### PR DESCRIPTION
This is rendering as a link to:

https://www.gov.uk/guidance/how-to-publish-on-gov-uk/%0Aintroduction-and-access-to-whitehall-publisher#filter-documents

Note the %0A - hex code for a newline

Removing that fixes the link.
