### PR TITLE
Load and configure Google Analytics 4

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,4 +1,5 @@
 //= link_tree ../images
 //= link_tree ../builds
 //= link application.js
+//= link admin/domain-config.js
 //= link components/visual-editor.js

--- a/app/assets/javascripts/admin/domain-config.js
+++ b/app/assets/javascripts/admin/domain-config.js
@@ -1,0 +1,19 @@
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.vars = window.GOVUK.vars || {}
+window.GOVUK.vars.extraDomains = [
+  {
+    name: 'production',
+    domains: ['whitehall-admin.publishing.service.gov.uk'],
+    initialiseGA4: true,
+    id: 'GTM-P93SHJ4Z',
+    gaProperty: 'UA-26179049-6'
+  },
+  {
+    name: 'integration',
+    domains: ['whitehall-admin.integration.publishing.service.gov.uk'],
+    initialiseGA4: true,
+    id: 'GTM-P93SHJ4Z',
+    auth: '8jHx-VNEguw67iX9TBC6_g',
+    preview: 'env-50'
+  }
+]

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -3,6 +3,7 @@
 //= require govuk_publishing_components/dependencies
 //= require govuk_publishing_components/all_components
 //= require govuk_publishing_components/analytics
+//= require govuk_publishing_components/analytics-ga4
 
 //= require components/autocomplete
 //= require components/govspeak-editor
@@ -26,3 +27,6 @@
 //= require admin/views/track-selected-taxons
 //= require admin/views/unpublish-display-conditions
 //= require admin/views/unpublish-tracking
+
+window.GOVUK.approveAllCookieTypes()
+window.GOVUK.cookie('cookies_preferences_set', 'true', { days: 365 })

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -1,17 +1,10 @@
 <% environment = GovukPublishingComponents::AppHelpers::Environment.current_acceptance_environment %>
 
-<% if ENV["GOOGLE_TAG_MANAGER_ID"] %>
-  <% content_for :head do %>
-    <%= render "govuk_publishing_components/components/google_tag_manager_script", {
-      gtm_id: ENV["GOOGLE_TAG_MANAGER_ID"],
-      gtm_auth: ENV["GOOGLE_TAG_MANAGER_AUTH"],
-      gtm_preview: ENV["GOOGLE_TAG_MANAGER_PREVIEW"],
-    } %>
-  <% end %>
-<% end %>
-
 <% if user_signed_in? %>
   <% content_for :head do %>
+    <meta name="govuk:components_gem_version" content="<%= GovukPublishingComponents::VERSION %>">
+    <%= javascript_include_tag "admin/domain-config" %>
+    <%= javascript_include_tag "govuk_publishing_components/load-analytics" %>
     <meta name="custom-dimension:8" content="<%= current_user.organisation_slug.presence || "(not set)" %>">
   <% end %>
 <% end %>
@@ -21,7 +14,7 @@
            environment: environment,
            browser_title: ("Error: " if yield(:error_summary).present?).to_s + sanitize((yield(:page_title).presence || yield(:title))) do %>
 
-  <!-- This element exists to initialise the JS module that configures custom Analytics behaviour -->
+  <!-- This element exists to initialise the JS module that configures custom Universal Analytics behaviour -->
   <div data-module="app-analytics"></div>
 
   <%= render "govuk_publishing_components/components/skip_link" %>


### PR DESCRIPTION
We will run both GA4 and Universal Analytics in tandem while we migrate event tracking to GA4.

Note that we have to accept the default cookie settings on the user's behalf to enable GA4 tracking. This is considered reasonable given that all publishers are part of government.

I have removed the rendering of the Google Tag Manager script component as the GTM script is loaded when initialising GA4

Trello: https://trello.com/c/yauxjItY
