### PR TITLE
Remove duplicated code in `CallForEvidencePresenter` and `ConsultationPresenter`

### DIFF
--- a/app/presenters/publishing_api/call_for_evidence_presenter.rb
+++ b/app/presenters/publishing_api/call_for_evidence_presenter.rb
@@ -72,7 +72,7 @@ module PublishingApi
     def details
       base_details
         .merge(PayloadBuilder::ChangeHistory.for(call_for_evidence))
-        .merge(Documents.for(call_for_evidence))
+        .merge(PayloadBuilder::Documents.for(call_for_evidence))
         .merge(PayloadBuilder::ExternalUrl.for(call_for_evidence))
         .merge(Outcome.for(call_for_evidence))
         .merge(PayloadBuilder::NationalApplicability.for(call_for_evidence))
@@ -86,41 +86,6 @@ module PublishingApi
     def public_updated_at
       public_updated_at = call_for_evidence.public_timestamp || call_for_evidence.updated_at
       public_updated_at.rfc3339
-    end
-
-    class Documents
-      def self.for(call_for_evidence)
-        new(call_for_evidence).call
-      end
-
-      def initialize(call_for_evidence, renderer: Whitehall::GovspeakRenderer.new)
-        self.call_for_evidence = call_for_evidence
-        self.renderer = renderer
-      end
-
-      def call
-        return {} if call_for_evidence.attachments.blank?
-
-        {
-          documents:,
-          featured_attachments:,
-        }
-      end
-
-    private
-
-      attr_accessor :call_for_evidence, :renderer
-
-      def documents
-        renderer.block_attachments(
-          call_for_evidence.attachments,
-          call_for_evidence.alternative_format_contact_email,
-        )
-      end
-
-      def featured_attachments
-        call_for_evidence.attachments_ready_for_publishing.map { |a| a.publishing_api_details[:id] }
-      end
     end
 
     class Outcome

--- a/app/presenters/publishing_api/call_for_evidence_presenter.rb
+++ b/app/presenters/publishing_api/call_for_evidence_presenter.rb
@@ -73,7 +73,7 @@ module PublishingApi
       base_details
         .merge(ChangeHistory.for(call_for_evidence))
         .merge(Documents.for(call_for_evidence))
-        .merge(ExternalURL.for(call_for_evidence))
+        .merge(PayloadBuilder::ExternalUrl.for(call_for_evidence))
         .merge(Outcome.for(call_for_evidence))
         .merge(NationalApplicability.for(call_for_evidence))
         .merge(WaysToRespond.for(call_for_evidence))
@@ -141,26 +141,6 @@ module PublishingApi
       def featured_attachments
         call_for_evidence.attachments_ready_for_publishing.map { |a| a.publishing_api_details[:id] }
       end
-    end
-
-    class ExternalURL
-      def self.for(call_for_evidence)
-        new(call_for_evidence).call
-      end
-
-      def initialize(call_for_evidence)
-        self.call_for_evidence = call_for_evidence
-      end
-
-      def call
-        return {} unless call_for_evidence.external?
-
-        { held_on_another_website_url: call_for_evidence.external_url }
-      end
-
-    private
-
-      attr_accessor :call_for_evidence
     end
 
     class Outcome

--- a/app/presenters/publishing_api/call_for_evidence_presenter.rb
+++ b/app/presenters/publishing_api/call_for_evidence_presenter.rb
@@ -75,7 +75,7 @@ module PublishingApi
         .merge(Documents.for(call_for_evidence))
         .merge(PayloadBuilder::ExternalUrl.for(call_for_evidence))
         .merge(Outcome.for(call_for_evidence))
-        .merge(NationalApplicability.for(call_for_evidence))
+        .merge(PayloadBuilder::NationalApplicability.for(call_for_evidence))
         .merge(WaysToRespond.for(call_for_evidence))
         .merge(PayloadBuilder::FirstPublicAt.for(call_for_evidence))
         .merge(PayloadBuilder::PoliticalDetails.for(call_for_evidence))
@@ -185,26 +185,6 @@ module PublishingApi
       def outcome_attachments
         outcome.attachments_ready_for_publishing.map { |a| a.publishing_api_details[:id] }
       end
-    end
-
-    class NationalApplicability
-      def self.for(call_for_evidence)
-        new(call_for_evidence).call
-      end
-
-      def initialize(call_for_evidence)
-        self.call_for_evidence = call_for_evidence
-      end
-
-      def call
-        return {} if call_for_evidence.nation_inapplicabilities.blank?
-
-        { national_applicability: call_for_evidence.national_applicability }
-      end
-
-    private
-
-      attr_accessor :call_for_evidence
     end
 
     class WaysToRespond

--- a/app/presenters/publishing_api/call_for_evidence_presenter.rb
+++ b/app/presenters/publishing_api/call_for_evidence_presenter.rb
@@ -71,7 +71,7 @@ module PublishingApi
 
     def details
       base_details
-        .merge(ChangeHistory.for(call_for_evidence))
+        .merge(PayloadBuilder::ChangeHistory.for(call_for_evidence))
         .merge(Documents.for(call_for_evidence))
         .merge(PayloadBuilder::ExternalUrl.for(call_for_evidence))
         .merge(Outcome.for(call_for_evidence))
@@ -86,26 +86,6 @@ module PublishingApi
     def public_updated_at
       public_updated_at = call_for_evidence.public_timestamp || call_for_evidence.updated_at
       public_updated_at.rfc3339
-    end
-
-    class ChangeHistory
-      def self.for(call_for_evidence)
-        new(call_for_evidence).call
-      end
-
-      def initialize(call_for_evidence)
-        self.call_for_evidence = call_for_evidence
-      end
-
-      def call
-        return {} if call_for_evidence.change_history.blank?
-
-        { change_history: call_for_evidence.change_history.as_json }
-      end
-
-    private
-
-      attr_accessor :call_for_evidence
     end
 
     class Documents

--- a/app/presenters/publishing_api/consultation_presenter.rb
+++ b/app/presenters/publishing_api/consultation_presenter.rb
@@ -71,7 +71,7 @@ module PublishingApi
 
     def details
       base_details
-        .merge(ChangeHistory.for(consultation))
+        .merge(PayloadBuilder::ChangeHistory.for(consultation))
         .merge(Documents.for(consultation))
         .merge(PayloadBuilder::ExternalUrl.for(consultation))
         .merge(FinalOutcome.for(consultation))
@@ -87,26 +87,6 @@ module PublishingApi
     def public_updated_at
       public_updated_at = consultation.public_timestamp || consultation.updated_at
       public_updated_at.rfc3339
-    end
-
-    class ChangeHistory
-      def self.for(consultation)
-        new(consultation).call
-      end
-
-      def initialize(consultation)
-        self.consultation = consultation
-      end
-
-      def call
-        return {} if consultation.change_history.blank?
-
-        { change_history: consultation.change_history.as_json }
-      end
-
-    private
-
-      attr_accessor :consultation
     end
 
     class Documents

--- a/app/presenters/publishing_api/consultation_presenter.rb
+++ b/app/presenters/publishing_api/consultation_presenter.rb
@@ -75,7 +75,7 @@ module PublishingApi
         .merge(Documents.for(consultation))
         .merge(PayloadBuilder::ExternalUrl.for(consultation))
         .merge(FinalOutcome.for(consultation))
-        .merge(NationalApplicability.for(consultation))
+        .merge(PayloadBuilder::NationalApplicability.for(consultation))
         .merge(PublicFeedback.for(consultation))
         .merge(WaysToRespond.for(consultation))
         .merge(PayloadBuilder::FirstPublicAt.for(consultation))
@@ -186,26 +186,6 @@ module PublishingApi
       def final_outcome_attachments
         outcome.attachments_ready_for_publishing.map { |a| a.publishing_api_details[:id] }
       end
-    end
-
-    class NationalApplicability
-      def self.for(consultation)
-        new(consultation).call
-      end
-
-      def initialize(consultation)
-        self.consultation = consultation
-      end
-
-      def call
-        return {} if consultation.nation_inapplicabilities.blank?
-
-        { national_applicability: consultation.national_applicability }
-      end
-
-    private
-
-      attr_accessor :consultation
     end
 
     class PublicFeedback

--- a/app/presenters/publishing_api/consultation_presenter.rb
+++ b/app/presenters/publishing_api/consultation_presenter.rb
@@ -73,7 +73,7 @@ module PublishingApi
       base_details
         .merge(ChangeHistory.for(consultation))
         .merge(Documents.for(consultation))
-        .merge(ExternalURL.for(consultation))
+        .merge(PayloadBuilder::ExternalUrl.for(consultation))
         .merge(FinalOutcome.for(consultation))
         .merge(NationalApplicability.for(consultation))
         .merge(PublicFeedback.for(consultation))
@@ -142,26 +142,6 @@ module PublishingApi
       def featured_attachments
         consultation.attachments_ready_for_publishing.map { |a| a.publishing_api_details[:id] }
       end
-    end
-
-    class ExternalURL
-      def self.for(consultation)
-        new(consultation).call
-      end
-
-      def initialize(consultation)
-        self.consultation = consultation
-      end
-
-      def call
-        return {} unless consultation.external?
-
-        { held_on_another_website_url: consultation.external_url }
-      end
-
-    private
-
-      attr_accessor :consultation
     end
 
     class FinalOutcome

--- a/app/presenters/publishing_api/consultation_presenter.rb
+++ b/app/presenters/publishing_api/consultation_presenter.rb
@@ -72,7 +72,7 @@ module PublishingApi
     def details
       base_details
         .merge(PayloadBuilder::ChangeHistory.for(consultation))
-        .merge(Documents.for(consultation))
+        .merge(PayloadBuilder::Documents.for(consultation))
         .merge(PayloadBuilder::ExternalUrl.for(consultation))
         .merge(FinalOutcome.for(consultation))
         .merge(PayloadBuilder::NationalApplicability.for(consultation))
@@ -87,41 +87,6 @@ module PublishingApi
     def public_updated_at
       public_updated_at = consultation.public_timestamp || consultation.updated_at
       public_updated_at.rfc3339
-    end
-
-    class Documents
-      def self.for(consultation)
-        new(consultation).call
-      end
-
-      def initialize(consultation, renderer: Whitehall::GovspeakRenderer.new)
-        self.consultation = consultation
-        self.renderer = renderer
-      end
-
-      def call
-        return {} if consultation.attachments.blank?
-
-        {
-          documents:,
-          featured_attachments:,
-        }
-      end
-
-    private
-
-      attr_accessor :consultation, :renderer
-
-      def documents
-        renderer.block_attachments(
-          consultation.attachments,
-          consultation.alternative_format_contact_email,
-        )
-      end
-
-      def featured_attachments
-        consultation.attachments_ready_for_publishing.map { |a| a.publishing_api_details[:id] }
-      end
     end
 
     class FinalOutcome

--- a/app/presenters/publishing_api/payload_builder/change_history.rb
+++ b/app/presenters/publishing_api/payload_builder/change_history.rb
@@ -1,0 +1,23 @@
+module PublishingApi
+  module PayloadBuilder
+    class ChangeHistory
+      def self.for(document)
+        new(document).call
+      end
+
+      def initialize(document)
+        self.document = document
+      end
+
+      def call
+        return {} if document.change_history.blank?
+
+        { change_history: document.change_history.as_json }
+      end
+
+    private
+
+      attr_accessor :document
+    end
+  end
+end

--- a/app/presenters/publishing_api/payload_builder/documents.rb
+++ b/app/presenters/publishing_api/payload_builder/documents.rb
@@ -1,0 +1,38 @@
+module PublishingApi
+  module PayloadBuilder
+    class Documents
+      def self.for(document)
+        new(document).call
+      end
+
+      def initialize(document, renderer: Whitehall::GovspeakRenderer.new)
+        self.document = document
+        self.renderer = renderer
+      end
+
+      def call
+        return {} if document.attachments.blank?
+
+        {
+          documents:,
+          featured_attachments:,
+        }
+      end
+
+    private
+
+      attr_accessor :document, :renderer
+
+      def documents
+        renderer.block_attachments(
+          document.attachments,
+          document.alternative_format_contact_email,
+        )
+      end
+
+      def featured_attachments
+        document.attachments_ready_for_publishing.map { |a| a.publishing_api_details[:id] }
+      end
+    end
+  end
+end

--- a/app/presenters/publishing_api/payload_builder/external_url.rb
+++ b/app/presenters/publishing_api/payload_builder/external_url.rb
@@ -1,0 +1,23 @@
+module PublishingApi
+  module PayloadBuilder
+    class ExternalUrl
+      def self.for(document)
+        new(document).call
+      end
+
+      def initialize(document)
+        self.document = document
+      end
+
+      def call
+        return {} unless document.external?
+
+        { held_on_another_website_url: document.external_url }
+      end
+
+    private
+
+      attr_accessor :document
+    end
+  end
+end

--- a/app/presenters/publishing_api/payload_builder/national_applicability.rb
+++ b/app/presenters/publishing_api/payload_builder/national_applicability.rb
@@ -1,0 +1,23 @@
+module PublishingApi
+  module PayloadBuilder
+    class NationalApplicability
+      def self.for(document)
+        new(document).call
+      end
+
+      def initialize(document)
+        self.document = document
+      end
+
+      def call
+        return {} if document.nation_inapplicabilities.blank?
+
+        { national_applicability: document.national_applicability }
+      end
+
+    private
+
+      attr_accessor :document
+    end
+  end
+end

--- a/test/unit/app/presenters/publishing_api/call_for_evidence_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/call_for_evidence_presenter_test.rb
@@ -126,7 +126,7 @@ module PublishingApi::CallForEvidencePresenterTest
 
       Whitehall::GovspeakRenderer.expects(:new).returns(govspeak_renderer)
 
-      PublishingApi::CallForEvidencePresenter::Documents.stubs(:for).returns({})
+      PublishingApi::PayloadBuilder::Documents.stubs(:for).returns({})
       PublishingApi::CallForEvidencePresenter::Outcome.stubs(:for).returns({})
 
       assert_details_attribute :body, body_double
@@ -354,7 +354,7 @@ module PublishingApi::CallForEvidencePresenterTest
       Whitehall::GovspeakRenderer.expects(:new).returns(govspeak_renderer)
 
       PublishingApi::CallForEvidencePresenter.any_instance.stubs(:body)
-      PublishingApi::CallForEvidencePresenter::Documents.stubs(:for).returns({})
+      PublishingApi::PayloadBuilder::Documents.stubs(:for).returns({})
 
       assert_details_attribute :outcome_detail,
                                outcome_detail_double
@@ -379,7 +379,7 @@ module PublishingApi::CallForEvidencePresenterTest
       Whitehall::GovspeakRenderer.expects(:new).returns(govspeak_renderer).at_least_once
 
       PublishingApi::CallForEvidencePresenter.any_instance.stubs(:body)
-      PublishingApi::CallForEvidencePresenter::Documents.stubs(:for).returns({})
+      PublishingApi::PayloadBuilder::Documents.stubs(:for).returns({})
 
       assert_details_attribute :outcome_documents, [attachments_double]
       assert_details_attribute :outcome_attachments,

--- a/test/unit/app/presenters/publishing_api/consultation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/consultation_presenter_test.rb
@@ -126,7 +126,7 @@ module PublishingApi::ConsultationPresenterTest
 
       Whitehall::GovspeakRenderer.expects(:new).returns(govspeak_renderer)
 
-      PublishingApi::ConsultationPresenter::Documents.stubs(:for).returns({})
+      PublishingApi::PayloadBuilder::Documents.stubs(:for).returns({})
       PublishingApi::ConsultationPresenter::FinalOutcome.stubs(:for).returns({})
       PublishingApi::ConsultationPresenter::PublicFeedback.stubs(:for).returns({})
 
@@ -360,7 +360,7 @@ module PublishingApi::ConsultationPresenterTest
       Whitehall::GovspeakRenderer.expects(:new).returns(govspeak_renderer)
 
       PublishingApi::ConsultationPresenter.any_instance.stubs(:body)
-      PublishingApi::ConsultationPresenter::Documents.stubs(:for).returns({})
+      PublishingApi::PayloadBuilder::Documents.stubs(:for).returns({})
       PublishingApi::ConsultationPresenter::FinalOutcome.stubs(:for).returns({})
 
       assert_details_attribute :public_feedback_detail,
@@ -386,7 +386,7 @@ module PublishingApi::ConsultationPresenterTest
       Whitehall::GovspeakRenderer.expects(:new).returns(govspeak_renderer).at_least_once
 
       PublishingApi::ConsultationPresenter.any_instance.stubs(:body)
-      PublishingApi::ConsultationPresenter::Documents.stubs(:for).returns({})
+      PublishingApi::PayloadBuilder::Documents.stubs(:for).returns({})
       PublishingApi::ConsultationPresenter::FinalOutcome.stubs(:for).returns({})
 
       assert_details_attribute :public_feedback_documents, [attachments_double]
@@ -429,7 +429,7 @@ module PublishingApi::ConsultationPresenterTest
       Whitehall::GovspeakRenderer.expects(:new).returns(govspeak_renderer)
 
       PublishingApi::ConsultationPresenter.any_instance.stubs(:body)
-      PublishingApi::ConsultationPresenter::Documents.stubs(:for).returns({})
+      PublishingApi::PayloadBuilder::Documents.stubs(:for).returns({})
       PublishingApi::ConsultationPresenter::PublicFeedback.stubs(:for).returns({})
 
       assert_details_attribute :final_outcome_detail,
@@ -455,7 +455,7 @@ module PublishingApi::ConsultationPresenterTest
       Whitehall::GovspeakRenderer.expects(:new).returns(govspeak_renderer).at_least_once
 
       PublishingApi::ConsultationPresenter.any_instance.stubs(:body)
-      PublishingApi::ConsultationPresenter::Documents.stubs(:for).returns({})
+      PublishingApi::PayloadBuilder::Documents.stubs(:for).returns({})
       PublishingApi::ConsultationPresenter::PublicFeedback.stubs(:for).returns({})
 
       assert_details_attribute :final_outcome_documents, [attachments_double]


### PR DESCRIPTION
There are a number of duplicated pieces of code between these presenters, therefore moving them into `PayloadBuilder` to make consistent with the other pieces of shared presenter code.