### PR TITLE
Worldwide organisation pages features

### DIFF
--- a/app/helpers/admin/tabbed_nav_helper.rb
+++ b/app/helpers/admin/tabbed_nav_helper.rb
@@ -171,4 +171,19 @@ module Admin::TabbedNavHelper
       },
     ]
   end
+
+  def worldwide_organisation_page_nav_items(page, current_path)
+    [
+      {
+        label: "Page",
+        href: edit_admin_editionable_worldwide_organisation_page_path(page.edition, page),
+        current: current_path == edit_admin_editionable_worldwide_organisation_page_path(page.edition, page),
+      },
+      {
+        label: sanitize("Attachments #{tag.span(page.attachments.count, class: 'govuk-tag govuk-tag--grey') if page.attachments.count.positive?}"),
+        href: admin_worldwide_organisation_page_attachments_path(page),
+        current: current_path == admin_worldwide_organisation_page_attachments_path(page),
+      },
+    ]
+  end
 end

--- a/app/models/editionable_worldwide_organisation.rb
+++ b/app/models/editionable_worldwide_organisation.rb
@@ -49,7 +49,12 @@ class EditionableWorldwideOrganisation < Edition
   class ClonePagesTrait < Edition::Traits::Trait
     def process_associations_before_save(new_edition)
       @edition.pages.each do |page|
-        new_edition.pages << page.dup
+        new_page = page.dup
+
+        page.attachments.each do |attachment|
+          new_page.attachments << attachment.deep_clone
+        end
+        new_edition.pages << new_page
       end
     end
   end

--- a/app/models/editionable_worldwide_organisation.rb
+++ b/app/models/editionable_worldwide_organisation.rb
@@ -46,6 +46,16 @@ class EditionableWorldwideOrganisation < Edition
 
   add_trait CloneDefaultImageTrait
 
+  class ClonePagesTrait < Edition::Traits::Trait
+    def process_associations_before_save(new_edition)
+      @edition.pages.each do |page|
+        new_edition.pages << page.dup
+      end
+    end
+  end
+
+  add_trait ClonePagesTrait
+
   include AnalyticsIdentifierPopulator
   self.analytics_prefix = "WO"
 

--- a/app/models/worldwide_organisation_page.rb
+++ b/app/models/worldwide_organisation_page.rb
@@ -10,6 +10,8 @@ class WorldwideOrganisationPage < ApplicationRecord
 
   delegate :display_type_key, to: :corporate_information_page_type
 
+  include Attachable
+
   def title(_locale = :en)
     corporate_information_page_type.title(edition)
   end
@@ -20,6 +22,14 @@ class WorldwideOrganisationPage < ApplicationRecord
 
   def corporate_information_page_type=(type)
     self.corporate_information_page_type_id = type && type.id
+  end
+
+  def publicly_visible?
+    true
+  end
+
+  def access_limited?
+    false
   end
 
 private

--- a/app/models/worldwide_organisation_page.rb
+++ b/app/models/worldwide_organisation_page.rb
@@ -6,6 +6,9 @@ class WorldwideOrganisationPage < ApplicationRecord
   validates :corporate_information_page_type_id,
             presence: true,
             exclusion: { in: [CorporateInformationPageType::AboutUs.id], message: "Type cannot be `About us`" }
+  validate :unique_worldwide_organisation_and_page_type, on: :create, if: :edition
+
+  delegate :display_type_key, to: :corporate_information_page_type
 
   def title(_locale = :en)
     corporate_information_page_type.title(edition)
@@ -17,5 +20,16 @@ class WorldwideOrganisationPage < ApplicationRecord
 
   def corporate_information_page_type=(type)
     self.corporate_information_page_type_id = type && type.id
+  end
+
+private
+
+  def unique_worldwide_organisation_and_page_type
+    current_page_types = edition.pages.map(&:corporate_information_page_type_id).flatten
+    duplicate_page = current_page_types.include?(corporate_information_page_type_id)
+
+    if duplicate_page
+      errors.add(:base, "Another '#{display_type_key.humanize}' page already exists for this worldwide organisation")
+    end
   end
 end

--- a/app/views/admin/worldwide_organisation_pages/_form.html.erb
+++ b/app/views/admin/worldwide_organisation_pages/_form.html.erb
@@ -21,16 +21,19 @@
     } %>
   <% end %>
 
-  <%= render "govuk_publishing_components/components/textarea", {
+  <%= render "govuk_publishing_components/components/character_count", {
+    textarea: {
       label: {
         text: "Summary",
         heading_size: "l",
       },
       name: "worldwide_organisation_page[summary]",
-      id: "worldwide_organisation_page_summary",
       value: form.object.summary,
       rows: 4,
       error_items: errors_for(form.object.errors, :summary),
+    },
+    id: "worldwide_organisation_page_summary",
+    maxlength: 160,
   } %>
 
   <% if Flipflop.govspeak_visual_editor? %>

--- a/app/views/admin/worldwide_organisation_pages/_form.html.erb
+++ b/app/views/admin/worldwide_organisation_pages/_form.html.erb
@@ -15,6 +15,7 @@
         {
           text: type,
           value: value,
+          selected: form.object.corporate_information_page_type_id == value,
         }
       end,
     } %>

--- a/app/views/admin/worldwide_organisation_pages/edit.html.erb
+++ b/app/views/admin/worldwide_organisation_pages/edit.html.erb
@@ -5,6 +5,11 @@
     <% content_for :context, @worldwide_organisation.title %>
     <% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @worldwide_organisation_page)) %>
 
+    <%= render "components/secondary_navigation", {
+      aria_label: "Worldwide organisation page navigation",
+      items: secondary_navigation_tabs_items(@worldwide_organisation_page, request.path),
+    } %>
+
     <%= render partial: "form", locals: {worldwide_organisation_page: @worldwide_organisation_page} %>
   </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -292,6 +292,12 @@ Whitehall::Application.routes.draw do
           get :confirm_destroy, on: :member
         end
       end
+      resources :worldwide_organisation_pages, only: [] do
+        resources :attachments, except: [:show] do
+          get :confirm_destroy, on: :member
+        end
+      end
+
       resources :detailed_guides, path: "detailed-guides", except: [:index]
       resources :people do
         resources :translations, controller: "person_translations" do

--- a/db/migrate/20240410133547_add_content_id_to_worldwide_organisation_pages.rb
+++ b/db/migrate/20240410133547_add_content_id_to_worldwide_organisation_pages.rb
@@ -1,0 +1,5 @@
+class AddContentIdToWorldwideOrganisationPages < ActiveRecord::Migration[7.1]
+  def change
+    add_column :worldwide_organisation_pages, :content_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_03_25_104416) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_10_133547) do
   create_table "assets", charset: "utf8mb3", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.string "variant", null: false
@@ -1217,6 +1217,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_03_25_104416) do
     t.text "body"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "content_id"
     t.index ["edition_id"], name: "index_worldwide_organisation_pages_on_edition_id"
   end
 

--- a/features/editionable-worldwide-organisations.feature
+++ b/features/editionable-worldwide-organisations.feature
@@ -122,6 +122,14 @@ Feature: Editionable worldwide organisations
     And I visit the pages tab for the worldwide organisation
     Then I should see that the list of pages for the worldwide organisation is empty
 
+  Scenario: Managing attachments for a worldwide organisation page
+    Given an editionable worldwide organisation "Test Worldwide Organisation" with a "Personal information charter" page
+    When I visit the pages tab for the worldwide organisation
+    And I click the "Edit" link for the "Personal information charter" page
+    And I click the Attachments tab
+    And I upload a file attachment with the title "Beard Length Statistics 2014" and the file "dft_statistical_data_set_sample.csv"
+    Then The "Beard Length Statistics 2014" attachment should have uploaded successfully
+
   @javascript
   Scenario: Reordering home page offices for a worldwide organisation
     Given An editionable worldwide organisation "Test Worldwide Organisation" with home page offices "Home page office 1" and "Home page office 2"

--- a/features/step_definitions/editionable_worldwide_organisation_steps.rb
+++ b/features/step_definitions/editionable_worldwide_organisation_steps.rb
@@ -141,6 +141,10 @@ When(/^I click the "([^"]*)" link for the "([^"]*)" page$/) do |link, type|
   end
 end
 
+When(/^I click the Attachments tab$/) do
+  click_link "Attachments"
+end
+
 When(/^I submit the confirmation form to delete the "([^"]*)" page$/) do |type|
   worldwide_organisation_page = WorldwideOrganisationPage.last
   expect(page).to have_current_path(confirm_destroy_admin_editionable_worldwide_organisation_page_path(worldwide_organisation_page.edition, worldwide_organisation_page))
@@ -331,4 +335,8 @@ Then(/^I should see that the list of offices are ordered "([^"]*)" then "([^"]*)
   expect(last_item).to have_text(second_office)
   expect(last_item).to have_button("Up")
   expect(last_item).not_to have_button("Down")
+end
+
+Then(/^The "(.*?)" attachment should have uploaded successfully$/) do |attachment_title|
+  expect(page).to have_content("Attachment '#{attachment_title}' uploaded")
 end

--- a/test/factories/editionable_worldwide_organisations.rb
+++ b/test/factories/editionable_worldwide_organisations.rb
@@ -41,6 +41,12 @@ FactoryBot.define do
         organisation.default_news_image = build(:featured_image_data)
       end
     end
+
+    trait(:with_pages) do
+      after :create do |organisation|
+        create(:worldwide_organisation_page, edition: organisation)
+      end
+    end
   end
 
   factory :draft_editionable_worldwide_organisation, parent: :editionable_worldwide_organisation, traits: [:draft]

--- a/test/unit/app/helpers/admin/tabbed_nav_helper_test.rb
+++ b/test/unit/app/helpers/admin/tabbed_nav_helper_test.rb
@@ -398,4 +398,23 @@ class Admin::TabbedNavHelperTest < ActionView::TestCase
 
     assert_equal expected_output, secondary_navigation_tabs_items(edition, edit_admin_editionable_worldwide_organisation_path(edition))
   end
+
+  test "#secondary_navigation_tabs_items for worldwide organisation pages" do
+    page = build_stubbed(:worldwide_organisation_page)
+
+    expected_output = [
+      {
+        label: "Page",
+        href: edit_admin_editionable_worldwide_organisation_page_path(page.edition, page),
+        current: true,
+      },
+      {
+        label: "Attachments ",
+        href: admin_worldwide_organisation_page_attachments_path(page),
+        current: false,
+      },
+    ]
+
+    assert_equal expected_output, secondary_navigation_tabs_items(page, edit_admin_editionable_worldwide_organisation_page_path(page.edition, page))
+  end
 end

--- a/test/unit/app/models/editionable_worldwide_organisation_test.rb
+++ b/test/unit/app/models/editionable_worldwide_organisation_test.rb
@@ -183,6 +183,18 @@ class EditionableWorldwideOrganisationTest < ActiveSupport::TestCase
     end
   end
 
+  test "should clone pages when a new draft of published edition is created" do
+    published_worldwide_organisation = create(
+      :editionable_worldwide_organisation,
+      :published,
+      :with_pages,
+    )
+
+    draft_worldwide_organisation = published_worldwide_organisation.create_draft(create(:writer))
+
+    assert_equal published_worldwide_organisation.pages.first.attributes.except("id", "edition_id"), draft_worldwide_organisation.pages.first.attributes.except("id", "edition_id")
+  end
+
   test "when destroyed, will remove its home page list for storing offices" do
     world_organisation = create(:editionable_worldwide_organisation)
     h = world_organisation.__send__(:home_page_offices_list)

--- a/test/unit/app/models/editionable_worldwide_organisation_test.rb
+++ b/test/unit/app/models/editionable_worldwide_organisation_test.rb
@@ -195,6 +195,18 @@ class EditionableWorldwideOrganisationTest < ActiveSupport::TestCase
     assert_equal published_worldwide_organisation.pages.first.attributes.except("id", "edition_id"), draft_worldwide_organisation.pages.first.attributes.except("id", "edition_id")
   end
 
+  test "should clone page attachments when a new draft of published edition is created" do
+    page = create(:worldwide_organisation_page)
+    attachment = build(:file_attachment)
+    page.attachments << attachment
+    published_worldwide_organisation = create(:editionable_worldwide_organisation, :published, pages: [page])
+
+    draft_worldwide_organisation = published_worldwide_organisation.create_draft(create(:writer))
+
+    cloned_attachment = draft_worldwide_organisation.pages.first.attachments.first
+    assert_equal cloned_attachment.attributes.except("id", "attachable_id", "safely_resluggable"), attachment.attributes.except("id", "attachable_id", "safely_resluggable")
+  end
+
   test "when destroyed, will remove its home page list for storing offices" do
     world_organisation = create(:editionable_worldwide_organisation)
     h = world_organisation.__send__(:home_page_offices_list)

--- a/test/unit/app/models/worldwide_organisation_page_test.rb
+++ b/test/unit/app/models/worldwide_organisation_page_test.rb
@@ -21,6 +21,16 @@ class WorldwideOrganisationPageTest < ActiveSupport::TestCase
     assert page.errors[:corporate_information_page_type_id].include?("Type cannot be `About us`")
   end
 
+  test "should not be valid when a worldwide organisation page of that type already exists for the worldwide organisation" do
+    organisation = create(:editionable_worldwide_organisation)
+    create(:worldwide_organisation_page, corporate_information_page_type: CorporateInformationPageType::TermsOfReference, edition: organisation)
+
+    page = build(:worldwide_organisation_page, corporate_information_page_type: CorporateInformationPageType::TermsOfReference, edition: organisation.reload)
+
+    assert_not page.valid?
+    assert page.errors[:base].include?("Another 'Terms of reference' page already exists for this worldwide organisation")
+  end
+
   test "should derive title from type" do
     page = build(:worldwide_organisation_page, corporate_information_page_type: CorporateInformationPageType::TermsOfReference)
     assert_equal "Terms of reference", page.title


### PR DESCRIPTION
https://trello.com/c/2VqUBhuS

### Validate that worldwide organisation page types are unique
An editionable worldwide organisation must only have one of each worldwide page
type.

### Re-render worldwide organisation page type when invalid
We want the previously selected page type to persist when the form is
re-rendered after an invalid submission.

### Add character count to worldwide organisation page summary
This reflects the form of the existing corporate information pages. The count
isn't validated, it's just there to encourage users to write short summaries.

### Clone pages when new edition is created
Follow the existing patterns for offices and other associations to ensure that
new editions have cloned pages.

### Add content ID to worldwide organisation pages
Worldwide organisation pages must be presented to Publishing API and therefore
require a content ID.

### Add attachments functionality to worldwide organisation page
As worldwide organisation pages are replacing corporate information pages for
editionable worldwide organisations they must be able to have associated
attachments.

Note: Attachments can't be uploaded on the `new` form. This is consistent with
the other models of Whitehall such as corporate information pages and policy
groups.

Note 2: The attachments URL path isn't appended to the full worldwide
organisation pages path. Again, this is consistent with corporate information
pages. We might want to consider making some of the editionable worldwide
organisation paths shallow as a further refinement.

### Clone attachments when pages are cloned
Attachments assoiciated with a worldwide organisation page must also be cloned
when a new edition of an editionable worldwide organisation is created.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
