### PR TITLE
Update descriptions for people, groups and ministers

### DIFF
--- a/app/presenters/publishing_api/ministers_index_presenter.rb
+++ b/app/presenters/publishing_api/ministers_index_presenter.rb
@@ -21,6 +21,7 @@ module PublishingApi
 
       content.merge!(
         base_path:,
+        description: "Read biographies and responsibilities of Cabinet ministers and all ministers by department, as well as the whips who help co-ordinate parliamentary business.",
         details:,
         document_type: "ministers_index",
         rendering_app: Whitehall::RenderingApp::COLLECTIONS_FRONTEND,

--- a/lib/finders/groups.json
+++ b/lib/finders/groups.json
@@ -1,7 +1,7 @@
 {
   "base_path": "/government/groups",
   "title": "Groups",
-  "description": "",
+  "description": "Find information about a public sector group.",
   "locale": "en",
   "document_type": "finder",
   "schema_name": "finder",

--- a/lib/finders/people.json
+++ b/lib/finders/people.json
@@ -1,7 +1,7 @@
 {
   "base_path": "/government/people",
   "title": "All ministers and senior officials on GOV.UK",
-  "description": "",
+  "description": "Find information about a minister or senior official.",
   "locale": "en",
   "document_type": "finder",
   "schema_name": "finder",

--- a/test/unit/app/presenters/publishing_api/ministers_index_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/ministers_index_presenter_test.rb
@@ -39,6 +39,7 @@ class PublishingApi::MinistersIndexPresenterTest < ActionView::TestCase
         redirects: [],
         update_type: "major",
         base_path: "/government/ministers",
+        description: "Read biographies and responsibilities of Cabinet ministers and all ministers by department, as well as the whips who help co-ordinate parliamentary business.",
         details: {
           body: "Read biographies and responsibilities of <a href=\"#cabinet-ministers\" class=\"govuk-link\">Cabinet ministers</a> and all <a href=\"#ministers-by-department\" class=\"govuk-link\">ministers by department</a>, as well as the <a href=\"#whips\" class=\"govuk-link\">whips</a> who help co-ordinate parliamentary business.",
         },

--- a/test/unit/app/presenters/publishing_api/payload_builder/links_test.rb
+++ b/test/unit/app/presenters/publishing_api/payload_builder/links_test.rb
@@ -7,7 +7,7 @@ class PublishingApi::PayloadBuilder::LinksTest < ActionView::TestCase
     PublishingApi::PayloadBuilder::Links.for(item).extract(filter_links)
   end
 
-  test "extracts content_ids from a detailed guide" do
+  test "extracts content_i'ds from a detailed guide" do
     document = create(:detailed_guide)
     links = links_for(document)
 


### PR DESCRIPTION
Update descriptions for
- groups
- people
- ministers

The description being nil meant that there was no summary shown on the search page under the result title.

Requested via Zendesk.

Tested in integration for all changes ✅

👀 There is a bit of an odd behaviour around the description for ministers, as it will be used as expected on the search page, but remains null in the content. It does nonetheless get updated fine in `publishing-api`. Suspecting some integration env foul play. Will keep an eye in production. 

[Trello card](https://trello.com/c/Qj3TDebj/2387-update-description-for-specialist-finders)