### PR TITLE
Rename `WorkingGroupPresenter`

### DIFF
--- a/app/models/policy_group.rb
+++ b/app/models/policy_group.rb
@@ -81,6 +81,6 @@ class PolicyGroup < ApplicationRecord
              description: :summary
 
   def publishing_api_presenter
-    PublishingApi::WorkingGroupPresenter
+    PublishingApi::PolicyGroupPresenter
   end
 end

--- a/app/presenters/publishing_api/policy_group_presenter.rb
+++ b/app/presenters/publishing_api/policy_group_presenter.rb
@@ -1,5 +1,5 @@
 module PublishingApi
-  class WorkingGroupPresenter
+  class PolicyGroupPresenter
     attr_accessor :item, :update_type
 
     def initialize(item, update_type: nil)

--- a/test/unit/app/presenters/publishing_api/policy_group_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/policy_group_presenter_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class PublishingApi::WorkingGroupPresenterTest < ActiveSupport::TestCase
+class PublishingApi::PolicyGroupPresenterTest < ActiveSupport::TestCase
   test 'presents a valid "working_group" content item' do
     group = create(
       :policy_group,
@@ -37,7 +37,7 @@ class PublishingApi::WorkingGroupPresenterTest < ActiveSupport::TestCase
       },
     }
 
-    presenter = PublishingApi::WorkingGroupPresenter.new(group)
+    presenter = PublishingApi::PolicyGroupPresenter.new(group)
 
     assert_equal expected_hash, presenter.content
     assert_valid_against_publisher_schema(presenter.content, "working_group")
@@ -47,7 +47,7 @@ class PublishingApi::WorkingGroupPresenterTest < ActiveSupport::TestCase
   test "renders attachments in the body" do
     group = create(:policy_group, :with_file_attachment, description: "#Heading\n\n!@1\n\n##Subheading")
 
-    presenter = PublishingApi::WorkingGroupPresenter.new(group)
+    presenter = PublishingApi::PolicyGroupPresenter.new(group)
 
     body = Nokogiri::HTML.parse(presenter.content[:details][:body])
     assert_not_nil body.at_css("section.gem-c-attachment")
@@ -57,7 +57,7 @@ class PublishingApi::WorkingGroupPresenterTest < ActiveSupport::TestCase
   test "handles empty description" do
     group = create(:policy_group, :with_file_attachment, description: nil)
     assert_nothing_raised do
-      PublishingApi::WorkingGroupPresenter.new(group).content
+      PublishingApi::PolicyGroupPresenter.new(group).content
     end
   end
 end

--- a/test/unit/app/presenters/publishing_api_presenters_test.rb
+++ b/test/unit/app/presenters/publishing_api_presenters_test.rb
@@ -85,7 +85,7 @@ class PublishingApiPresentersTest < ActiveSupport::TestCase
     policy_group = PolicyGroup.new
     presenter = PublishingApiPresenters.presenter_for(policy_group)
 
-    assert_equal PublishingApi::WorkingGroupPresenter, presenter.class
+    assert_equal PublishingApi::PolicyGroupPresenter, presenter.class
   end
 
   test ".presenter_for returns TopicalEvent placeholder for a TopicalEvent" do


### PR DESCRIPTION
Renaming the `WorkingGroupPresenter` to be more consistently named compared to the other Publishing API presenters.