### PR TITLE
Remove duplicated configuration

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -53,8 +53,6 @@ Whitehall::Application.configure do
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 
-  # Raise an error on page load if there are pending migrations.
-  config.active_record.migration_error = :page_load
   # Raise exceptions for disallowed deprecations.
   config.active_support.disallowed_deprecation = :raise
 


### PR DESCRIPTION
The value for `config.active_record.migration_error` has been specified twice in this config file.

Therefore removing one of them.