### PR TITLE
Worldwide organisation pages publishing

### DIFF
--- a/app/models/editionable_worldwide_organisation.rb
+++ b/app/models/editionable_worldwide_organisation.rb
@@ -183,6 +183,6 @@ class EditionableWorldwideOrganisation < Edition
   end
 
   def associated_documents
-    (offices + offices.map(&:contact)).compact.flatten
+    [offices, offices.map(&:contact), pages].compact.flatten
   end
 end

--- a/app/models/worldwide_organisation_page.rb
+++ b/app/models/worldwide_organisation_page.rb
@@ -10,6 +10,8 @@ class WorldwideOrganisationPage < ApplicationRecord
 
   delegate :slug, :display_type_key, to: :corporate_information_page_type
 
+  after_commit :republish_worldwide_organisation_draft
+
   include HasContentId
   include Attachable
 
@@ -67,6 +69,10 @@ class WorldwideOrganisationPage < ApplicationRecord
   end
 
 private
+
+  def republish_worldwide_organisation_draft
+    Whitehall.edition_services.draft_updater(edition).perform! if edition.present?
+  end
 
   def unique_worldwide_organisation_and_page_type
     current_page_types = edition.pages.map(&:corporate_information_page_type_id).flatten

--- a/app/models/worldwide_organisation_page.rb
+++ b/app/models/worldwide_organisation_page.rb
@@ -10,6 +10,7 @@ class WorldwideOrganisationPage < ApplicationRecord
 
   delegate :slug, :display_type_key, to: :corporate_information_page_type
 
+  include HasContentId
   include Attachable
 
   def title(_locale = :en)

--- a/app/models/worldwide_organisation_page.rb
+++ b/app/models/worldwide_organisation_page.rb
@@ -8,7 +8,7 @@ class WorldwideOrganisationPage < ApplicationRecord
             exclusion: { in: [CorporateInformationPageType::AboutUs.id], message: "Type cannot be `About us`" }
   validate :unique_worldwide_organisation_and_page_type, on: :create, if: :edition
 
-  delegate :display_type_key, to: :corporate_information_page_type
+  delegate :slug, :display_type_key, to: :corporate_information_page_type
 
   include Attachable
 
@@ -24,12 +24,33 @@ class WorldwideOrganisationPage < ApplicationRecord
     self.corporate_information_page_type_id = type && type.id
   end
 
+  def self.by_menu_heading(menu_heading)
+    type_ids = CorporateInformationPageType.by_menu_heading(menu_heading).map(&:id)
+    where(corporate_information_page_type_id: type_ids)
+  end
+
   def publicly_visible?
     true
   end
 
   def access_limited?
     false
+  end
+
+  def publishing_api_presenter
+    PublishingApi::WorldwideOrganisationPagePresenter
+  end
+
+  def base_path
+    "#{edition.base_path}/about/#{slug}"
+  end
+
+  def public_path(options = {})
+    append_url_options(base_path, options)
+  end
+
+  def public_url(options = {})
+    Plek.website_root + public_path(options)
   end
 
 private

--- a/app/models/worldwide_organisation_page.rb
+++ b/app/models/worldwide_organisation_page.rb
@@ -11,6 +11,7 @@ class WorldwideOrganisationPage < ApplicationRecord
   delegate :slug, :display_type_key, to: :corporate_information_page_type
 
   after_commit :republish_worldwide_organisation_draft
+  after_destroy :discard_draft
 
   include HasContentId
   include Attachable
@@ -72,6 +73,10 @@ private
 
   def republish_worldwide_organisation_draft
     Whitehall.edition_services.draft_updater(edition).perform! if edition.present?
+  end
+
+  def discard_draft
+    PublishingApiDiscardDraftWorker.perform_async(content_id, I18n.default_locale.to_s)
   end
 
   def unique_worldwide_organisation_and_page_type

--- a/app/models/worldwide_organisation_page.rb
+++ b/app/models/worldwide_organisation_page.rb
@@ -29,6 +29,18 @@ class WorldwideOrganisationPage < ApplicationRecord
     where(corporate_information_page_type_id: type_ids)
   end
 
+  def self.for_slug(slug)
+    if (type = CorporateInformationPageType.find(slug))
+      find_by(corporate_information_page_type_id: type.id)
+    end
+  end
+
+  def self.for_slug!(slug)
+    if (type = CorporateInformationPageType.find(slug))
+      find_by!(corporate_information_page_type_id: type.id)
+    end
+  end
+
   def publicly_visible?
     true
   end

--- a/app/presenters/publishing_api/worldwide_organisation_page_presenter.rb
+++ b/app/presenters/publishing_api/worldwide_organisation_page_presenter.rb
@@ -1,0 +1,49 @@
+module PublishingApi
+  class WorldwideOrganisationPagePresenter
+    attr_accessor :item, :update_type
+
+    def initialize(item, update_type: nil)
+      self.item = item
+      self.update_type = update_type || "major"
+    end
+
+    delegate :content_id, to: :item
+
+    def content
+      content = BaseItemPresenter.new(
+        item,
+        title: item.title,
+        update_type:,
+      ).base_attributes
+
+      content.merge!(
+        details: {
+          body: Whitehall::GovspeakRenderer.new.govspeak_with_attachments_to_html(item.body, item.attachments),
+        },
+        description: item.summary,
+        public_updated_at: item.updated_at,
+        rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
+        schema_name: "worldwide_corporate_information_page",
+        document_type:,
+        links: edition_links,
+      )
+
+      content.merge!(PayloadBuilder::PolymorphicPath.for(item))
+    end
+
+    def edition_links
+      {
+        parent: [item.edition.content_id],
+        worldwide_organisation: [item.edition.content_id],
+      }
+    end
+
+    def links
+      {}
+    end
+
+    def document_type
+      item.display_type_key
+    end
+  end
+end

--- a/test/factories/editionable_worldwide_organisations.rb
+++ b/test/factories/editionable_worldwide_organisations.rb
@@ -42,9 +42,21 @@ FactoryBot.define do
       end
     end
 
+    trait(:with_page) do
+      after :create do |organisation, _evaluator|
+        organisation.pages = [build(:worldwide_organisation_page)]
+      end
+    end
+
     trait(:with_pages) do
-      after :create do |organisation|
-        create(:worldwide_organisation_page, edition: organisation)
+      after :create do |organisation, _evaluator|
+        organisation.pages = [
+          build(:worldwide_organisation_page, corporate_information_page_type: CorporateInformationPageType::ComplaintsProcedure, edition: organisation),
+          build(:worldwide_organisation_page, corporate_information_page_type: CorporateInformationPageType::PersonalInformationCharter, edition: organisation),
+          build(:worldwide_organisation_page, corporate_information_page_type: CorporateInformationPageType::PublicationScheme, edition: organisation),
+          build(:worldwide_organisation_page, corporate_information_page_type: CorporateInformationPageType::Recruitment, edition: organisation),
+          build(:worldwide_organisation_page, corporate_information_page_type: CorporateInformationPageType::WelshLanguageScheme, edition: organisation),
+        ]
       end
     end
   end

--- a/test/factories/worldwide_organisation_pages.rb
+++ b/test/factories/worldwide_organisation_pages.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :worldwide_organisation_page do
+    content_id { SecureRandom.uuid }
     summary { "Some summary" }
     body { "Some body" }
     corporate_information_page_type_id { CorporateInformationPageType::PublicationScheme.id }

--- a/test/unit/app/models/editionable_worldwide_organisation_test.rb
+++ b/test/unit/app/models/editionable_worldwide_organisation_test.rb
@@ -187,7 +187,7 @@ class EditionableWorldwideOrganisationTest < ActiveSupport::TestCase
     published_worldwide_organisation = create(
       :editionable_worldwide_organisation,
       :published,
-      :with_pages,
+      :with_page,
     )
 
     draft_worldwide_organisation = published_worldwide_organisation.create_draft(create(:writer))

--- a/test/unit/app/models/worldwide_organisation_page_test.rb
+++ b/test/unit/app/models/worldwide_organisation_page_test.rb
@@ -1,6 +1,27 @@
 require "test_helper"
 
 class WorldwideOrganisationPageTest < ActiveSupport::TestCase
+  test "creating a new page republishes the associated worldwide organisation" do
+    worldwide_organisation = create(:editionable_worldwide_organisation)
+    Whitehall::PublishingApi.expects(:save_draft).with(worldwide_organisation).once
+    create(:worldwide_organisation_page, edition: worldwide_organisation)
+  end
+
+  test "updating an existing page republishes the associated worldwide organisation" do
+    worldwide_organisation = create(:editionable_worldwide_organisation)
+    page = create(:worldwide_organisation_page, edition: worldwide_organisation)
+    page.body = "updated"
+    Whitehall::PublishingApi.expects(:save_draft).with(worldwide_organisation).once
+    page.save!
+  end
+
+  test "deleting a page republishes the associated worldwide organisation" do
+    worldwide_organisation = create(:editionable_worldwide_organisation)
+    page = create(:worldwide_organisation_page, edition: worldwide_organisation)
+    Whitehall::PublishingApi.expects(:save_draft).with(worldwide_organisation).once
+    page.destroy!
+  end
+
   %w[body corporate_information_page_type_id].each do |param|
     test "should not be valid without a #{param}" do
       assert_not build(:worldwide_organisation_page, param.to_sym => nil).valid?

--- a/test/unit/app/models/worldwide_organisation_page_test.rb
+++ b/test/unit/app/models/worldwide_organisation_page_test.rb
@@ -22,6 +22,13 @@ class WorldwideOrganisationPageTest < ActiveSupport::TestCase
     page.destroy!
   end
 
+  test "deleting a page discards the draft page" do
+    worldwide_organisation = create(:editionable_worldwide_organisation)
+    page = create(:worldwide_organisation_page, edition: worldwide_organisation)
+    PublishingApiDiscardDraftWorker.expects(:perform_async).with(page.content_id, "en").once
+    page.destroy!
+  end
+
   %w[body corporate_information_page_type_id].each do |param|
     test "should not be valid without a #{param}" do
       assert_not build(:worldwide_organisation_page, param.to_sym => nil).valid?

--- a/test/unit/app/presenters/publishing_api/editionable_worldwide_organisation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/editionable_worldwide_organisation_presenter_test.rb
@@ -11,6 +11,7 @@ class PublishingApi::EditionableWorldwideOrganisationPresenterTest < ActiveSuppo
                            :with_social_media_account,
                            :with_main_office,
                            :with_home_page_offices,
+                           :with_pages,
                            analytics_identifier: "WO123")
 
     primary_role = create(:ambassador_role)
@@ -47,6 +48,17 @@ class PublishingApi::EditionableWorldwideOrganisationPresenterTest < ActiveSuppo
           crest: "single-identity",
           formatted_title: "Editionable<br/>worldwide<br/>organisation<br/>title",
         },
+        ordered_corporate_information_pages: [
+          {
+            content_id: worldwide_org.pages[0].content_id,
+            title: "Complaints procedure",
+          },
+          {
+            content_id: worldwide_org.pages[3].content_id,
+            title: "Working for Editionable worldwide organisation title",
+          },
+        ],
+        secondary_corporate_information_pages: "Read about the types of information we routinely publish in our <a class=\"govuk-link\" href=\"/editionable-world/organisations/editionable-worldwide-organisation-title/about/publication-scheme\">Publication scheme</a>. Find out about our commitment to <a class=\"govuk-link\" href=\"/editionable-world/organisations/editionable-worldwide-organisation-title/about/welsh-language-scheme\">publishing in Welsh</a>. Our <a class=\"govuk-link\" href=\"/editionable-world/organisations/editionable-worldwide-organisation-title/about/personal-information-charter\">Personal information charter</a> explains how we treat your personal information.",
         office_contact_associations: [
           {
             office_content_id: worldwide_org.reload.main_office.content_id,
@@ -115,6 +127,7 @@ class PublishingApi::EditionableWorldwideOrganisationPresenterTest < ActiveSuppo
         ],
         sponsoring_organisations: worldwide_org.organisations.map(&:content_id),
         world_locations: worldwide_org.world_locations.map(&:content_id),
+        corporate_information_pages: worldwide_org.pages.map(&:content_id),
       },
       analytics_identifier: "WO123",
       update_type: "major",

--- a/test/unit/app/presenters/publishing_api/worldwide_organisation_page_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/worldwide_organisation_page_presenter_test.rb
@@ -1,0 +1,65 @@
+require "test_helper"
+
+module PublishingApi::WorldwideOrganisationPagePresenterTest
+  class TestCase < ActiveSupport::TestCase
+    attr_accessor :page, :update_type
+
+    def presented_page
+      PublishingApi::WorldwideOrganisationPagePresenter.new(
+        page,
+        update_type:,
+      )
+    end
+
+    class BasicWorldwideOrganisationPageTest < TestCase
+      setup do
+        self.page = create(:worldwide_organisation_page)
+      end
+
+      test "presents a Worldwide Organisation Page ready for adding to the publishing API" do
+        public_path = page.public_path
+
+        expected_hash = {
+          base_path: public_path,
+          title: page.title,
+          schema_name: "worldwide_corporate_information_page",
+          document_type: page.display_type_key,
+          locale: "en",
+          publishing_app: Whitehall::PublishingApp::WHITEHALL,
+          rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
+          public_updated_at: page.updated_at,
+          routes: [{ path: public_path, type: "exact" }],
+          redirects: [],
+          description: "Some summary",
+          details: {
+            body: "<div class=\"govspeak\"><p>Some body</p>\n</div>",
+          },
+          update_type: "major",
+          links: {
+            parent: [page.edition.content_id],
+            worldwide_organisation: [page.edition.content_id],
+          },
+        }
+
+        expected_links = {
+          parent: [
+            page.edition.content_id,
+          ],
+          worldwide_organisation: [
+            page.edition.content_id,
+          ],
+        }
+
+        presented_item = presented_page
+
+        assert_equal expected_hash, presented_item.content
+        assert_hash_includes presented_item.edition_links, expected_links
+        assert_equal "major", presented_item.update_type
+        assert_equal page.content_id, presented_item.content_id
+
+        assert_valid_against_publisher_schema(presented_item.content, "worldwide_corporate_information_page")
+        assert_valid_against_links_schema({ links: presented_item.edition_links }, "worldwide_corporate_information_page")
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/2VqUBhuS

### Add worldwide organisation page presenter
The new worldwide organisation page model is to replace corporate information
pages for editionable worldwide organisations.  

Add a new presenter for it.

### Add multiple page types to worldwide organisation factory
This is required to sufficiently test the editionable worldwide organisation
presenter.

### Publish worldwide organisation pages associated with organisation
The associated pages of an editionable worldwide organisation must be
published.

### Publish worldwide organisation pages with organisation
We want to present pages to Publishing API in sync with their editionable
worldwide organisation.

This copies the approach taken in #8904 to present offices along with
organisations.

### Republish draft when worldwide organisation page changes
The pages of an editionabel worldwide organisation are surfaced in the content
item in `details`. We must republish the draft worldwide organisation when there
are any changes to the pages so that the draft correctly displays the pages.

This copies the approach taken in #8904.

### Discard worldwide organisation page draft when destroyed
We must discard the draft of an editionable worldwide organisation page when its
model is destroyed so that the draft app is in sync with the model state.

This copies the approach taken in #8904.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
