### PR TITLE
Worldwide organisation page translations

### DIFF
--- a/app/components/admin/worldwide_organisation_pages/index/summary_card_component.html.erb
+++ b/app/components/admin/worldwide_organisation_pages/index/summary_card_component.html.erb
@@ -1,6 +1,6 @@
 <div class="app-vc-worldwide-pages-index-page-summary-card-component">
   <%= render "components/summary_card", {
-    title: page.title,
+    title: title,
     rows: rows,
     summary_card_actions: summary_card_actions,
   } %>

--- a/app/components/admin/worldwide_organisation_pages/index/summary_card_component.rb
+++ b/app/components/admin/worldwide_organisation_pages/index/summary_card_component.rb
@@ -1,13 +1,18 @@
 # frozen_string_literal: true
 
 class Admin::WorldwideOrganisationPages::Index::SummaryCardComponent < ViewComponent::Base
-  attr_reader :page
+  attr_reader :page, :worldwide_organisation
 
-  def initialize(page:)
+  def initialize(page:, worldwide_organisation:)
     @page = page
+    @worldwide_organisation = worldwide_organisation
   end
 
 private
+
+  def title
+    non_english_translation? ? "#{page.default_locale_title} - #{page.translation_locale.native_and_english_language_name}" : page.title
+  end
 
   def rows
     [
@@ -37,22 +42,48 @@ private
   def summary_card_actions
     [
       edit_action,
+      add_translation_action,
       confirm_destroy_action,
     ].compact
   end
 
   def edit_action
+    href = if non_english_translation?
+             edit_admin_editionable_worldwide_organisation_page_translation_path(worldwide_organisation, page, page.translation_locale)
+           else
+             edit_admin_editionable_worldwide_organisation_page_path(page.edition, page)
+           end
+
     {
       label: "Edit",
-      href: edit_admin_editionable_worldwide_organisation_page_path(page.edition, page),
+      href:,
+    }
+  end
+
+  def add_translation_action
+    return if page.missing_translations.blank? || non_english_translation?
+
+    {
+      label: "Add translation",
+      href: admin_editionable_worldwide_organisation_page_translations_path(worldwide_organisation, page, page.translation_locale),
     }
   end
 
   def confirm_destroy_action
+    href = if non_english_translation?
+             confirm_destroy_admin_editionable_worldwide_organisation_page_translation_path(worldwide_organisation, page, page.translation_locale)
+           else
+             confirm_destroy_admin_editionable_worldwide_organisation_page_path(worldwide_organisation, page)
+           end
+
     {
       label: "Delete",
-      href: confirm_destroy_admin_editionable_worldwide_organisation_page_path(page.edition, page),
+      href:,
       destructive: true,
     }
+  end
+
+  def non_english_translation?
+    page.translation_locale.code != :en
   end
 end

--- a/app/controllers/admin/worldwide_organisation_page_translations_controller.rb
+++ b/app/controllers/admin/worldwide_organisation_page_translations_controller.rb
@@ -1,0 +1,46 @@
+class Admin::WorldwideOrganisationPageTranslationsController < Admin::BaseController
+  include TranslationControllerConcern
+
+  def index; end
+
+  def edit; end
+
+private
+
+  def create_redirect_path
+    edit_admin_editionable_worldwide_organisation_page_translation_path(@worldwide_organisation, @worldwide_page, id: translation_locale)
+  end
+
+  def destroy_redirect_path
+    admin_editionable_worldwide_organisation_pages_path(@worldwide_organisation)
+  end
+
+  def update_redirect_path
+    admin_editionable_worldwide_organisation_pages_path(@worldwide_organisation)
+  end
+
+  def load_translatable_item
+    @worldwide_organisation = Edition.find(params[:editionable_worldwide_organisation_id])
+    @worldwide_page = @worldwide_organisation.pages.find(params[:page_id])
+  end
+
+  def load_translated_models
+    @translated_page = LocalisedModel.new(@worldwide_page, translation_locale.code)
+    @english_page = LocalisedModel.new(@worldwide_page, :en)
+  end
+
+  def translatable_item
+    @translated_page
+  end
+
+  def translated_item_name
+    @translated_page.title
+  end
+
+  def translation_params
+    params.require(:page)
+          .permit(:title,
+                  :summary,
+                  :body)
+  end
+end

--- a/app/models/corporate_information_page_type.rb
+++ b/app/models/corporate_information_page_type.rb
@@ -21,6 +21,12 @@ class CorporateInformationPageType
     I18n.t("corporate_information_page.type.title.#{translation_key}", organisation_name: organisation_name(organisation))
   end
 
+  def default_locale_title(organisation)
+    I18n.with_locale(:en) do
+      title(organisation)
+    end
+  end
+
   def title_lang(organisation)
     translation_key = slug.tr("-", "_")
     t_lang("corporate_information_page.type.title.#{translation_key}", organisation_name: organisation_name(organisation))

--- a/app/models/editionable_worldwide_organisation.rb
+++ b/app/models/editionable_worldwide_organisation.rb
@@ -77,8 +77,8 @@ class EditionableWorldwideOrganisation < Edition
   end
 
   def destroy_associated(locale)
-    offices.each do |office|
-      office.contact.remove_translations_for(locale)
+    [offices.map(&:contact), pages].flatten.each do |association|
+      association.remove_translations_for(locale)
     end
   end
 

--- a/app/models/worldwide_organisation_page.rb
+++ b/app/models/worldwide_organisation_page.rb
@@ -23,6 +23,10 @@ class WorldwideOrganisationPage < ApplicationRecord
     corporate_information_page_type.title(edition)
   end
 
+  def default_locale_title
+    corporate_information_page_type.default_locale_title(edition)
+  end
+
   def corporate_information_page_type
     CorporateInformationPageType.find_by_id(corporate_information_page_type_id)
   end

--- a/app/models/worldwide_organisation_page.rb
+++ b/app/models/worldwide_organisation_page.rb
@@ -16,6 +16,9 @@ class WorldwideOrganisationPage < ApplicationRecord
   include HasContentId
   include Attachable
 
+  include TranslatableModel
+  translates :title, :summary, :body
+
   def title(_locale = :en)
     corporate_information_page_type.title(edition)
   end
@@ -43,6 +46,10 @@ class WorldwideOrganisationPage < ApplicationRecord
     if (type = CorporateInformationPageType.find(slug))
       find_by!(corporate_information_page_type_id: type.id)
     end
+  end
+
+  def missing_translations
+    super & edition.non_english_translated_locales
   end
 
   def publicly_visible?

--- a/app/views/admin/worldwide_organisation_page_translations/confirm_destroy.html.erb
+++ b/app/views/admin/worldwide_organisation_page_translations/confirm_destroy.html.erb
@@ -1,0 +1,29 @@
+<% content_for :context, @worldwide_page.title %>
+<% content_for :page_title, "Delete #{@translation_locale.native_and_english_language_name} translation" %>
+<% content_for :title, "Delete translation" %>
+<% content_for :title_margin_bottom, 6 %>
+
+<div class="govuk-grid-row">
+  <section class="govuk-grid-column-two-thirds">
+    <%= form_with url: admin_editionable_worldwide_organisation_page_translation_path(@worldwide_organisation, @worldwide_page, @translation_locale), method: :delete do %>
+      <p class="govuk-body govuk-!-margin-bottom-7">
+        Are you sure you want to delete the "<%= @translation_locale.native_and_english_language_name %>" translation for "<%= @worldwide_page.title %>"?
+      </p>
+
+      <div class="govuk-button-group">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Delete",
+          destructive: true,
+          data_attributes: {
+            module: "gem-track-click",
+            "track-category": "form-button",
+            "track-action": "worldwide-page-translations-button",
+            "track-label": "Delete",
+          },
+        } %>
+
+        <%= link_to("Cancel", admin_editionable_worldwide_organisation_pages_path(@worldwide_organisation), class: "govuk-link govuk-link--no-visited-state") %>
+      </div>
+    <% end %>
+  </section>
+</div>

--- a/app/views/admin/worldwide_organisation_page_translations/edit.html.erb
+++ b/app/views/admin/worldwide_organisation_page_translations/edit.html.erb
@@ -1,0 +1,66 @@
+<% content_for :page_title, "#{@translated_page.translation.persisted? ? "Edit" : "New"} translation for #{@worldwide_page.title}" %>
+<% content_for :title, "#{@translated_page.translation.persisted? ? "Edit" : "New"} translation" %>
+<% content_for :context, @worldwide_page.title %>
+<% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @translated_page)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with model: @worldwide_page, as: :contact, url: admin_editionable_worldwide_organisation_page_translation_path(@worldwide_organisation, @worldwide_page, translation_locale), method: :put do |form| %>
+      <%= render "components/translated_textarea", {
+        textarea: {
+          label: {
+            heading_size: "l",
+            text: "Translated summary",
+          },
+          name: "page[summary]",
+          id: "page_summary",
+          value: @translated_page.summary,
+          rows: 2,
+          error_items: errors_for(form.object.errors, :summary),
+          right_to_left: @translated_page.translation_locale.rtl?,
+          right_to_left_help: false,
+        },
+        details: {
+          text: @worldwide_page.summary,
+        },
+      } %>
+
+      <%= render "components/translated_textarea", {
+        textarea: {
+          label: {
+            heading_size: "l",
+            text: "Translated body (required)",
+          },
+          name: "page[body]",
+          id: "page_body",
+          value: @translated_page.body,
+          rows: 20,
+          error_items: errors_for(form.object.errors, :body),
+          right_to_left: @translated_page.translation_locale.rtl?,
+          right_to_left_help: false,
+        },
+        details: {
+          text: @worldwide_page.body,
+        },
+      } %>
+
+      <div class="govuk-button-group govuk-!-margin-top-8">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Save",
+          data_attributes: {
+            module: "gem-track-click",
+            "track-category": "form-button",
+            "track-action": "worldwide-office-translation-button",
+            "track-label": "Save",
+          },
+        } %>
+
+        <% if @translated_page.translation.persisted? %>
+          <%= link_to("Cancel", admin_editionable_worldwide_organisation_pages_path(@worldwide_organisation), class: "govuk-link govuk-link--no-visited-state") %>
+        <% else %>
+          <%= link_to("Cancel", admin_editionable_worldwide_organisation_page_translations_path(@worldwide_organisation, @worldwide_page), class: "govuk-link govuk-link--no-visited-state") %>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/worldwide_organisation_page_translations/index.html.erb
+++ b/app/views/admin/worldwide_organisation_page_translations/index.html.erb
@@ -1,0 +1,38 @@
+<% content_for :page_title, "New translation for #{@worldwide_page.title}" %>
+<% content_for :title, "New translation" %>
+<% content_for :context, @worldwide_page.title %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with url: admin_editionable_worldwide_organisation_page_translations_path(@worldwide_organisation, @worldwide_page) do %>
+      <%= render "govuk_publishing_components/components/select", {
+        id: "translation_locale",
+        name: "translation_locale",
+        label: "Select language",
+        hint: "This is the first step before creating a translated version of this content",
+        heading_size: "l",
+        full_width: true,
+        options: @worldwide_page.missing_translations.map do |locale|
+          {
+            value: locale.code,
+            text: Locale.coerce(locale).native_and_english_language_name,
+          }
+        end,
+      } %>
+
+      <div class="govuk-button-group govuk-!-margin-top-8">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Next",
+          data_attributes: {
+            module: "gem-track-click",
+            "track-category": "form-button",
+            "track-action": "worldwide-office-translation-button",
+            "track-label": "Next",
+          },
+        } %>
+
+        <%= link_to("Cancel", admin_editionable_worldwide_organisation_pages_path(@worldwide_organisation), class: "govuk-link govuk-link--no-visited-state") %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/admin/worldwide_organisation_pages/index.html.erb
+++ b/app/views/admin/worldwide_organisation_pages/index.html.erb
@@ -49,7 +49,7 @@
   <div class="govuk-grid-column-two-thirds">
     <% if @worldwide_organisation.pages.any? %>
       <% @worldwide_organisation.pages.each do |page| %>
-        <%= render Admin::WorldwideOrganisationPages::Index::SummaryCardComponent.new(page:) %>
+        <%= render Admin::WorldwideOrganisationPages::Index::SummaryCardComponent.new(page:, worldwide_organisation: @worldwide_organisation) %>
       <% end %>
     <% else %>
       <%= render "govuk_publishing_components/components/inset_text", {

--- a/app/views/admin/worldwide_organisation_pages/index.html.erb
+++ b/app/views/admin/worldwide_organisation_pages/index.html.erb
@@ -51,6 +51,21 @@
       <% @worldwide_organisation.pages.each do |page| %>
         <%= render Admin::WorldwideOrganisationPages::Index::SummaryCardComponent.new(page:, worldwide_organisation: @worldwide_organisation) %>
       <% end %>
+
+      <% if @worldwide_organisation.pages.any? { |page| page.non_english_localised_models.present? } %>
+        <%= render "govuk_publishing_components/components/heading", {
+          text: "Translated",
+          font_size: "m",
+          margin_bottom: 6,
+        } %>
+
+        <% @worldwide_organisation.pages.each do |page| %>
+          <% page.non_english_localised_models.each do |translation| %>
+            <%= render Admin::WorldwideOrganisationPages::Index::SummaryCardComponent.new(page: translation, worldwide_organisation: @worldwide_organisation) %>
+          <% end %>
+        <% end %>
+      <% end %>
+
     <% else %>
       <%= render "govuk_publishing_components/components/inset_text", {
         text: "No pages.",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -298,6 +298,10 @@ Whitehall::Application.routes.draw do
       resources :editionable_worldwide_organisations, path: "editionable-worldwide-organisations", except: [:index] do
         resources :pages, controller: "worldwide_organisation_pages" do
           get :confirm_destroy, on: :member
+
+          resources :translations, controller: "worldwide_organisation_page_translations", only: %i[create edit update destroy index] do
+            get :confirm_destroy, on: :member
+          end
         end
       end
       resources :worldwide_organisation_pages, only: [] do

--- a/db/migrate/20240412103303_add_worldwide_organisation_page_translations_table.rb
+++ b/db/migrate/20240412103303_add_worldwide_organisation_page_translations_table.rb
@@ -1,0 +1,9 @@
+class AddWorldwideOrganisationPageTranslationsTable < ActiveRecord::Migration[7.1]
+  def up
+    WorldwideOrganisationPage.create_translation_table! title: :string, summary: :text, body: :text
+  end
+
+  def down
+    WorldwideOrganisationPage.drop_translation_table!
+  end
+end

--- a/db/migrate/20240422091946_remove_worldwide_organisation_page_fields.rb
+++ b/db/migrate/20240422091946_remove_worldwide_organisation_page_fields.rb
@@ -1,0 +1,5 @@
+class RemoveWorldwideOrganisationPageFields < ActiveRecord::Migration[7.1]
+  def change
+    remove_columns(:worldwide_organisation_pages, :body, :summary, type: "text")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_10_133547) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_12_103303) do
   create_table "assets", charset: "utf8mb3", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.string "variant", null: false
@@ -1208,6 +1208,18 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_10_133547) do
     t.index ["edition_id"], name: "index_worldwide_offices_on_edition_id"
     t.index ["slug"], name: "index_worldwide_offices_on_slug"
     t.index ["worldwide_organisation_id"], name: "index_worldwide_offices_on_worldwide_organisation_id"
+  end
+
+  create_table "worldwide_organisation_page_translations", charset: "utf8mb3", force: :cascade do |t|
+    t.bigint "worldwide_organisation_page_id", null: false
+    t.string "locale", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "title"
+    t.text "summary"
+    t.text "body"
+    t.index ["locale"], name: "index_worldwide_organisation_page_translations_on_locale"
+    t.index ["worldwide_organisation_page_id"], name: "index_bbd0fc4436b2d97c8b36796e9089468751fc0f2e"
   end
 
   create_table "worldwide_organisation_pages", charset: "utf8mb3", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_12_103303) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_22_091946) do
   create_table "assets", charset: "utf8mb3", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.string "variant", null: false
@@ -1225,8 +1225,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_12_103303) do
   create_table "worldwide_organisation_pages", charset: "utf8mb3", force: :cascade do |t|
     t.integer "corporate_information_page_type_id", null: false
     t.integer "edition_id", null: false
-    t.text "summary"
-    t.text "body"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "content_id"

--- a/features/editionable-worldwide-organisations.feature
+++ b/features/editionable-worldwide-organisations.feature
@@ -32,12 +32,12 @@ Feature: Editionable worldwide organisations
     And I add an associated office, also with a translation in French
     When I remove the French translation from the main document
     Then I should see the main document translation is gone
-    And I navigate to the Offices tab
+    And I visit the "Offices" tab
     Then I should see that the translated office is gone
 
   Scenario: Adding a translation to an existing worldwide office
     Given an editionable worldwide organisation in draft with a translation in French
-    When I visit the Offices tab
+    When I visit the "Offices" tab
     And I add a new translation with a title of "French Title"
     Then I should see the "Translated" subheading in the "Offices" tab with my new translation
 
@@ -129,6 +129,12 @@ Feature: Editionable worldwide organisations
     And I click the Attachments tab
     And I upload a file attachment with the title "Beard Length Statistics 2014" and the file "dft_statistical_data_set_sample.csv"
     Then The "Beard Length Statistics 2014" attachment should have uploaded successfully
+
+  Scenario: Adding a translation to an existing worldwide organisation page
+    Given an editionable worldwide organisation "Test Worldwide Organisation" with a "Personal information charter" page and a translation in French
+    When I visit the "Pages" tab
+    And I add a new page translation with a body of "French Body"
+    Then I should see the "Translated" subheading in the "Offices" tab with my new translation
 
   @javascript
   Scenario: Reordering home page offices for a worldwide organisation

--- a/features/editionable-worldwide-organisations.feature
+++ b/features/editionable-worldwide-organisations.feature
@@ -136,6 +136,15 @@ Feature: Editionable worldwide organisations
     And I add a new page translation with a body of "French Body"
     Then I should see the "Translated" subheading in the "Offices" tab with my new translation
 
+  Scenario: Removing a translation to an existing worldwide organisation with pages
+    Given an editionable worldwide organisation "Test Worldwide Organisation" with a "Personal information charter" page and a translation in French
+    When I visit the "Pages" tab
+    And I add a new page translation with a body of "French Body"
+    When I remove the French translation from the main document
+    Then I should see the main document translation is gone
+    And I visit the "Pages" tab
+    Then I should see that the translated page with body "French Body" is gone
+
   @javascript
   Scenario: Reordering home page offices for a worldwide organisation
     Given An editionable worldwide organisation "Test Worldwide Organisation" with home page offices "Home page office 1" and "Home page office 2"

--- a/features/step_definitions/editionable_worldwide_organisation_steps.rb
+++ b/features/step_definitions/editionable_worldwide_organisation_steps.rb
@@ -36,6 +36,11 @@ Given(/^an editionable worldwide organisation "([^"]*)" with a "([^"]*)" page$/)
   create(:worldwide_organisation_page, edition: worldwide_organisation, corporate_information_page_type: CorporateInformationPageType.find(type.parameterize))
 end
 
+Given(/^an editionable worldwide organisation "([^"]*)" with a "([^"]*)" page and a translation in French$/) do |title, type|
+  worldwide_organisation = create(:editionable_worldwide_organisation, title:, translated_into: :fr)
+  create(:worldwide_organisation_page, edition: worldwide_organisation, corporate_information_page_type: CorporateInformationPageType.find(type.parameterize))
+end
+
 Given(/^a role "([^"]*)" exists$/) do |name|
   create(:role, name:)
 end
@@ -73,9 +78,9 @@ When(/^I visit the reorder offices page/) do
   click_link "Reorder"
 end
 
-When(/^I visit the Offices tab/) do
+When(/^I visit the "([^"]*)" tab/) do |tab|
   visit admin_worldwide_organisation_worldwide_offices_path(EditionableWorldwideOrganisation.last)
-  click_link "Offices"
+  click_link tab
 end
 
 When(/^I reorder the offices/) do
@@ -162,9 +167,11 @@ When(/^I correctly fill out the worldwide organisation page fields for a "([^"]*
   click_on "Save"
 end
 
-And(/^I navigate to the Offices tab/) do
-  visit admin_worldwide_organisation_worldwide_offices_path(EditionableWorldwideOrganisation.last)
-  click_link "Offices"
+When(/^I add a new page translation with a body of "([^"]*)"$/) do |body|
+  click_link "Add translation"
+  click_button "Next"
+  fill_in "Translated body (required)", with: body
+  click_button "Save"
 end
 
 And(/^I add an associated office, also with a translation in French$/) do

--- a/features/step_definitions/editionable_worldwide_organisation_steps.rb
+++ b/features/step_definitions/editionable_worldwide_organisation_steps.rb
@@ -241,6 +241,11 @@ Then(/^I should see that the translated office is gone$/) do
   expect(page).not_to have_text("Translated")
 end
 
+Then(/^I should see that the translated page with body "([^"]*)" is gone$/) do |body|
+  expect(page).not_to have_text("Translated")
+  expect(page).not_to have_text(body)
+end
+
 Then(/^I should be able to remove all services from the editionable worldwide organisation "(.*?)" office$/) do |description|
   worldwide_office = WorldwideOffice.joins(contact: :translations).where(contact_translations: { title: description }).first
   visit edit_admin_worldwide_organisation_worldwide_office_path(worldwide_organisation_id: EditionableWorldwideOrganisation.last.id, id: worldwide_office.id)

--- a/test/components/admin/worldwide_organisation_pages/index/summary_card_component_test.rb
+++ b/test/components/admin/worldwide_organisation_pages/index/summary_card_component_test.rb
@@ -8,7 +8,7 @@ class Admin::WorldwideOrganisationPages::Index::SummaryCardComponentTest < ViewC
   test "renders a worldwide organisation page summary card" do
     page = create(:worldwide_organisation_page, summary: "a" * 501, body: "b" * 501)
 
-    render_inline(Admin::WorldwideOrganisationPages::Index::SummaryCardComponent.new(page:))
+    render_inline(Admin::WorldwideOrganisationPages::Index::SummaryCardComponent.new(page:, worldwide_organisation: page.edition))
 
     assert_selector ".govuk-summary-card__title", text: "Publication scheme"
     assert_selector ".govuk-summary-card__actions .govuk-summary-card__action:nth-child(1) a[href='#{edit_admin_editionable_worldwide_organisation_page_path(page.edition, page)}']"
@@ -19,5 +19,33 @@ class Admin::WorldwideOrganisationPages::Index::SummaryCardComponentTest < ViewC
     assert_selector ".govuk-summary-list__row:nth-child(1) .govuk-summary-list__value", text: "#{'a' * 497}..."
     assert_selector ".govuk-summary-list__row:nth-child(2) .govuk-summary-list__key", text: "Body"
     assert_selector ".govuk-summary-list__row:nth-child(2) .govuk-summary-list__value", text: "#{'b' * 497}..."
+  end
+
+  test "renders the add translation action when there are missing translations for a page" do
+    worldwide_organisation = create(:editionable_worldwide_organisation, translated_into: [:fr])
+    page = create(:worldwide_organisation_page, edition: worldwide_organisation)
+
+    render_inline(Admin::WorldwideOrganisationPages::Index::SummaryCardComponent.new(page:, worldwide_organisation:))
+
+    assert_selector ".govuk-summary-card__actions .govuk-summary-card__action:nth-child(2) a[href='#{admin_editionable_worldwide_organisation_page_translations_path(worldwide_organisation, page, page.translation_locale)}']", text: "Add translation"
+  end
+
+  test "renders the correct values when contact is a translation" do
+    page = create(:worldwide_organisation_page,
+                  translated_into: [:fr])
+    french_translation = page.non_english_localised_models.first
+
+    render_inline(Admin::WorldwideOrganisationPages::Index::SummaryCardComponent.new(page: french_translation, worldwide_organisation: page.edition))
+
+    assert_selector ".govuk-summary-card__title", text: "Publication scheme - Français (French)"
+    assert_selector ".govuk-summary-card__actions .govuk-summary-card__action:nth-child(1) a[href='#{edit_admin_editionable_worldwide_organisation_page_translation_path(page.edition, page, french_translation.translation_locale)}']"
+    assert_selector ".govuk-summary-card__actions .govuk-summary-card__action:nth-child(2) a[href='#{confirm_destroy_admin_editionable_worldwide_organisation_page_translation_path(page.edition, page, french_translation.translation_locale)}']"
+
+    assert_selector ".govuk-summary-list__row", count: 2
+
+    assert_selector ".govuk-summary-list__row:nth-child(1) .govuk-summary-list__key", text: "Summary"
+    assert_selector ".govuk-summary-list__row:nth-child(1) .govuk-summary-list__value", text: "fr-Some summary"
+    assert_selector ".govuk-summary-list__row:nth-child(2) .govuk-summary-list__key", text: "Body"
+    assert_selector ".govuk-summary-list__row:nth-child(2) .govuk-summary-list__value", text: "fr-Some body"
   end
 end

--- a/test/factories/worldwide_organisation_pages.rb
+++ b/test/factories/worldwide_organisation_pages.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :worldwide_organisation_page do
+  factory :worldwide_organisation_page, traits: [:translated] do
     content_id { SecureRandom.uuid }
     summary { "Some summary" }
     body { "Some body" }

--- a/test/functional/admin/worldwide_organisation_page_translations_controller_test.rb
+++ b/test/functional/admin/worldwide_organisation_page_translations_controller_test.rb
@@ -1,0 +1,118 @@
+require "test_helper"
+
+class Admin::WorldwideOrganisationPageTranslationsControllerTest < ActionController::TestCase
+  setup do
+    login_as(:writer)
+    @worldwide_organisation = create(:editionable_worldwide_organisation, translated_into: %i[fr es])
+  end
+
+  should_be_an_admin_controller
+
+  view_test "index shows a form to create missing translations" do
+    page = create(:worldwide_organisation_page, edition: @worldwide_organisation)
+
+    get :index, params: { editionable_worldwide_organisation_id: @worldwide_organisation, page_id: page }
+
+    translations_path = admin_editionable_worldwide_organisation_page_translations_path(@worldwide_organisation, page)
+    assert_select "form[action=?]", translations_path do
+      assert_select "select[name=translation_locale]" do
+        assert_select "option", count: 2
+        assert_select "option[value=fr]", text: "Français (French)"
+        assert_select "option[value=es]", text: "Español (Spanish)"
+      end
+
+      assert_select ".govuk-button-group .govuk-button", text: "Next"
+      assert_select ".govuk-button-group .govuk-link[href='#{admin_editionable_worldwide_organisation_pages_path(@worldwide_organisation)}']"
+    end
+  end
+
+  view_test "edit presents a form to update an existing translation" do
+    page = create(:worldwide_organisation_page,
+                  edition: @worldwide_organisation,
+                  translated_into: [:fr])
+    french_translation = page.translations.find_by(locale: :fr)
+
+    get :edit, params: { editionable_worldwide_organisation_id: @worldwide_organisation, page_id: page, id: "fr" }
+
+    translation_path = admin_editionable_worldwide_organisation_page_translation_path(@worldwide_organisation, page, "fr")
+    assert_select "form[action=?]", translation_path do
+      assert_select "textarea[name='page[summary]']", text: french_translation.summary
+      assert_select "textarea[name='page[body]']", text: french_translation.body
+
+      assert_select ".govuk-button-group .govuk-button", text: "Save"
+    end
+  end
+
+  view_test "edit presents a form respecting the RTL value of the language" do
+    page = create(:worldwide_organisation_page,
+                  edition: @worldwide_organisation,
+                  translated_into: [:ar])
+
+    get :edit, params: { editionable_worldwide_organisation_id: @worldwide_organisation, page_id: page, id: "ar" }
+
+    assert_select "form" do
+      assert_select "textarea[name='page[summary]'][dir='rtl']"
+      assert_select "textarea[name='page[body]'][dir='rtl']"
+    end
+  end
+
+  view_test "update updates translation and redirects back to the index" do
+    page = create(:worldwide_organisation_page, edition: @worldwide_organisation)
+
+    put :update, params: { editionable_worldwide_organisation_id: @worldwide_organisation,
+                           page_id: page,
+                           id: "fr",
+                           page: {
+                             summary: "translated-summary",
+                             body: "translated-body",
+                           } }
+
+    with_locale :fr do
+      assert_equal "translated-summary", page.reload.summary
+      assert_equal "translated-body", page.body
+    end
+
+    assert_redirected_to admin_editionable_worldwide_organisation_pages_path(@worldwide_organisation)
+  end
+
+  test "update re-renders form if translation is invalid" do
+    page = create(:worldwide_organisation_page, edition: @worldwide_organisation)
+
+    put :update, params: { editionable_worldwide_organisation_id: @worldwide_organisation,
+                           page_id: page,
+                           id: "fr",
+                           page: {
+                             summary: "translated-summary",
+                             body: "",
+                           } }
+
+    assert_not page.reload.available_in_locale?("fr")
+    assert_template :edit
+  end
+
+  test "destroy removes translation and redirects to admin edition page" do
+    page = create(:worldwide_organisation_page,
+                  edition: @worldwide_organisation,
+                  translated_into: [:fr])
+
+    delete :destroy, params: { editionable_worldwide_organisation_id: @worldwide_organisation,
+                               page_id: page,
+                               id: "fr" }
+    assert_not page.reload.translated_locales.include?(:fr)
+    assert_redirected_to admin_editionable_worldwide_organisation_pages_path(@worldwide_organisation)
+  end
+
+  test "#destroy deletes the translation from the publishing API" do
+    Sidekiq::Testing.inline! do
+      page = create(:worldwide_organisation_page,
+                    edition: @worldwide_organisation,
+                    translated_into: [:fr])
+
+      delete :destroy, params: { editionable_worldwide_organisation_id: @worldwide_organisation,
+                                 page_id: page,
+                                 id: "fr" }
+
+      assert_publishing_api_discard_draft(page.content_id, locale: "fr")
+    end
+  end
+end

--- a/test/unit/app/models/editionable_worldwide_organisation_test.rb
+++ b/test/unit/app/models/editionable_worldwide_organisation_test.rb
@@ -184,15 +184,16 @@ class EditionableWorldwideOrganisationTest < ActiveSupport::TestCase
   end
 
   test "should clone pages when a new draft of published edition is created" do
-    published_worldwide_organisation = create(
-      :editionable_worldwide_organisation,
-      :published,
-      :with_page,
-    )
+    published_worldwide_organisation = create(:editionable_worldwide_organisation, :published, translated_into: [:fr])
+    create(:worldwide_organisation_page, edition: published_worldwide_organisation, translated_into: [:fr])
 
     draft_worldwide_organisation = published_worldwide_organisation.create_draft(create(:writer))
 
-    assert_equal published_worldwide_organisation.pages.first.attributes.except("id", "edition_id"), draft_worldwide_organisation.pages.first.attributes.except("id", "edition_id")
+    assert_equal published_worldwide_organisation.reload.pages.first.attributes.except("id", "edition_id"), draft_worldwide_organisation.pages.first.attributes.except("id", "edition_id")
+    assert_equal published_worldwide_organisation.pages.first.translations.find_by(locale: :fr).attributes.except("id", "worldwide_organisation_page_id"),
+                 draft_worldwide_organisation.pages.first.translations.find_by(locale: :fr).attributes.except("id", "worldwide_organisation_page_id")
+    assert_equal published_worldwide_organisation.pages.first.translations.find_by(locale: :en).attributes.except("id", "worldwide_organisation_page_id"),
+                 draft_worldwide_organisation.pages.first.translations.find_by(locale: :en).attributes.except("id", "worldwide_organisation_page_id")
   end
 
   test "should clone page attachments when a new draft of published edition is created" do

--- a/test/unit/app/models/worldwide_organisation_page_test.rb
+++ b/test/unit/app/models/worldwide_organisation_page_test.rb
@@ -77,4 +77,12 @@ class WorldwideOrganisationPageTest < ActiveSupport::TestCase
     page = build(:worldwide_organisation_page, edition: worldwide_organisation, corporate_information_page_type: CorporateInformationPageType::Recruitment)
     assert_equal "Working for British Antarctic Territory", page.title
   end
+
+  test "#missing_translations should only include worldwide organisation translations" do
+    worldwide_organisation = create(:editionable_worldwide_organisation, translated_into: %i[de es fr])
+    page = create(:worldwide_organisation_page, edition: worldwide_organisation, translated_into: [:es])
+
+    expected_locales = %i[de fr].map { |l| Locale.new(l) }
+    assert_equal expected_locales, page.missing_translations
+  end
 end

--- a/test/unit/app/presenters/publishing_api/worldwide_organisation_page_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/worldwide_organisation_page_presenter_test.rb
@@ -12,11 +12,9 @@ module PublishingApi::WorldwideOrganisationPagePresenterTest
     end
 
     class BasicWorldwideOrganisationPageTest < TestCase
-      setup do
-        self.page = create(:worldwide_organisation_page)
-      end
-
       test "presents a Worldwide Organisation Page ready for adding to the publishing API" do
+        self.page = create(:worldwide_organisation_page)
+
         public_path = page.public_path
 
         expected_hash = {
@@ -59,6 +57,30 @@ module PublishingApi::WorldwideOrganisationPagePresenterTest
 
         assert_valid_against_publisher_schema(presented_item.content, "worldwide_corporate_information_page")
         assert_valid_against_links_schema({ links: presented_item.edition_links }, "worldwide_corporate_information_page")
+      end
+
+      test "presents the correct routes for a Worldwide Organisation Page with a translation" do
+        self.page = create(:worldwide_organisation_page, translated_into: [:fr])
+
+        I18n.with_locale(:en) do
+          presented_item = PublishingApi::WorldwideOrganisationPagePresenter.new(page)
+
+          assert_equal page.base_path, presented_item.content[:base_path]
+
+          assert_equal [
+            { path: page.base_path, type: "exact" },
+          ], presented_item.content[:routes]
+        end
+
+        I18n.with_locale(:fr) do
+          presented_item = PublishingApi::WorldwideOrganisationPagePresenter.new(page)
+
+          assert_equal "#{page.base_path}.fr", presented_item.content[:base_path]
+
+          assert_equal [
+            { path: "#{page.base_path}.fr", type: "exact" },
+          ], presented_item.content[:routes]
+        end
       end
     end
   end


### PR DESCRIPTION
https://trello.com/c/2VqUBhuS

### Add translations table for worldwide organisation pages
Use the helpers provided by the Gloabalize Gem to create the translations table
for worldwide organisation pages.

### Make worldwide organisation page translatable
Add the modules to make the worldwide organisation page model translatable. 

Also add the required #missing_translations method for the translations feature.

### Test that worldwide organisation page translations get cloned correctly

### Add routes for worldwide organisation page translations

### Rework worldwide page summary component for translations
We want the worldwide page summary component to handle translations as well as
ordinary worldwide organsation pages.

### Test that the worldwide organisation page presenter handles translations

### Add the translation actions for worldwide organisation pages
Add the various actions required to trainslate worldwide organisation pages.

### Delete associated translations when worldwide organisation page deleted
Ensure that when the translation of an editionable worldwide organisation is
deleted, all of the translations of its pages are deleted too.

Follows the approach taken in #8913.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
