### PR TITLE
Build on republishing work

### DIFF
--- a/app/controllers/admin/republishing_controller.rb
+++ b/app/controllers/admin/republishing_controller.rb
@@ -2,7 +2,7 @@ class Admin::RepublishingController < Admin::BaseController
   before_action :enforce_permissions!
 
   def index
-    @republishable_documents = republishable_documents
+    @republishable_pages = republishable_pages
   end
 
   def republish_past_prime_ministers_index
@@ -11,13 +11,13 @@ class Admin::RepublishingController < Admin::BaseController
     redirect_to(admin_republishing_index_path)
   end
 
-  def confirm
-    republishable_document = republishable_documents.find { |document| document[:slug] == params[:document_slug] }
+  def confirm_page
+    page_to_republish = republishable_pages.find { |page| page[:slug] == params[:page_slug] }
 
-    return render "admin/errors/not_found", status: :not_found unless republishable_document
+    return render "admin/errors/not_found", status: :not_found unless page_to_republish
 
-    @document_title = republishable_document[:title]
-    @republishing_path = republishable_document[:republishing_path]
+    @title = page_to_republish[:title]
+    @republishing_path = page_to_republish[:republishing_path]
   end
 
 private
@@ -26,7 +26,7 @@ private
     enforce_permission!(:administer, :republish_documents)
   end
 
-  def republishable_documents
+  def republishable_pages
     historical_accounts_index_presenter = PublishingApi::HistoricalAccountsIndexPresenter.new
 
     [{

--- a/app/controllers/admin/republishing_controller.rb
+++ b/app/controllers/admin/republishing_controller.rb
@@ -23,7 +23,7 @@ class Admin::RepublishingController < Admin::BaseController
 private
 
   def enforce_permissions!
-    enforce_permission!(:administer, :republish_documents)
+    enforce_permission!(:administer, :republish_content)
   end
 
   def republishable_pages

--- a/app/controllers/admin/republishing_controller.rb
+++ b/app/controllers/admin/republishing_controller.rb
@@ -21,7 +21,7 @@ class Admin::RepublishingController < Admin::BaseController
     return render "admin/errors/not_found", status: :not_found unless page_to_republish
 
     @title = page_to_republish[:title]
-    @republishing_path = admin_republish_page_path(page_to_republish[:slug])
+    @republishing_path = admin_republishing_page_republish_path(page_to_republish[:slug])
   end
 
 private

--- a/app/controllers/admin/republishing_controller.rb
+++ b/app/controllers/admin/republishing_controller.rb
@@ -5,6 +5,15 @@ class Admin::RepublishingController < Admin::BaseController
     @republishable_pages = republishable_pages
   end
 
+  def confirm_page
+    page_to_republish = republishable_pages.find { |page| page[:slug] == params[:page_slug] }
+
+    return render "admin/errors/not_found", status: :not_found unless page_to_republish
+
+    @title = page_to_republish[:title]
+    @republishing_path = admin_republishing_page_republish_path(page_to_republish[:slug])
+  end
+
   def republish_page
     page_to_republish = republishable_pages.find { |page| page[:slug] == params[:page_slug] }
 
@@ -13,15 +22,6 @@ class Admin::RepublishingController < Admin::BaseController
     PresentPageToPublishingApiWorker.perform_async(page_to_republish[:presenter])
     flash[:notice] = "'#{page_to_republish[:title]}' page has been scheduled for republishing"
     redirect_to(admin_republishing_index_path)
-  end
-
-  def confirm_page
-    page_to_republish = republishable_pages.find { |page| page[:slug] == params[:page_slug] }
-
-    return render "admin/errors/not_found", status: :not_found unless page_to_republish
-
-    @title = page_to_republish[:title]
-    @republishing_path = admin_republishing_page_republish_path(page_to_republish[:slug])
   end
 
 private

--- a/app/views/admin/republishing/confirm_page.html.erb
+++ b/app/views/admin/republishing/confirm_page.html.erb
@@ -1,5 +1,5 @@
-<% content_for :page_title, "Republish '#{@document_title}'" %>
-<% content_for :title, "Are you sure you want to republish '#{@document_title}'?" %>
+<% content_for :page_title, "Republish '#{@title}'" %>
+<% content_for :title, "Are you sure you want to republish '#{@title}'?" %>
 <% content_for :title_margin_bottom, 6 %>
 
 <div class="govuk-grid-row">

--- a/app/views/admin/republishing/index.html.erb
+++ b/app/views/admin/republishing/index.html.erb
@@ -21,20 +21,20 @@
     <%= render "govuk_publishing_components/components/table", {
       head: [
         {
-          text: "Document",
+          text: "Page",
         },
         {
           text: "Action",
         },
       ],
-      rows: @republishable_documents.map do |document|
+      rows: @republishable_pages.map do |page|
       [
         {
-          text: link_to(document[:title], Plek.website_root + document[:public_path], class:"govuk-link"),
+          text: link_to(page[:title], Plek.website_root + page[:public_path], class:"govuk-link"),
         },
         {
-          text: link_to(sanitize("Republish #{tag.span('\'' + document[:title] + '\' page', class: 'govuk-visually-hidden')}"),
-              admin_confirm_republishing_path(document[:slug]),
+          text: link_to(sanitize("Republish #{tag.span('\'' + page[:title] + '\' page', class: 'govuk-visually-hidden')}"),
+              admin_confirm_page_republishing_path(page[:slug]),
               id: "republish-past-prime-ministers-index",
               class: "govuk-link",
             ),

--- a/app/views/admin/republishing/index.html.erb
+++ b/app/views/admin/republishing/index.html.erb
@@ -34,7 +34,7 @@
         },
         {
           text: link_to(sanitize("Republish #{tag.span('\'' + page[:title] + '\' page', class: 'govuk-visually-hidden')}"),
-              admin_confirm_page_republishing_path(page[:slug]),
+              admin_republishing_page_confirm_path(page[:slug]),
               id: "republish-" + page[:slug],
               class: "govuk-link",
             ),

--- a/app/views/admin/republishing/index.html.erb
+++ b/app/views/admin/republishing/index.html.erb
@@ -35,7 +35,7 @@
         {
           text: link_to(sanitize("Republish #{tag.span('\'' + page[:title] + '\' page', class: 'govuk-visually-hidden')}"),
               admin_confirm_page_republishing_path(page[:slug]),
-              id: "republish-past-prime-ministers-index",
+              id: "republish-" + page[:slug],
               class: "govuk-link",
             ),
         },

--- a/app/views/admin/republishing/index.html.erb
+++ b/app/views/admin/republishing/index.html.erb
@@ -1,5 +1,5 @@
-<% content_for :page_title, "Republish documents" %>
-<% content_for :title, "Republish documents" %>
+<% content_for :page_title, "Republish content" %>
+<% content_for :title, "Republish content" %>
 <% content_for :title_margin_bottom, 6 %>
 
 <div class="govuk-grid-row">
@@ -15,7 +15,7 @@
     <p class="govuk-body">
       The following actions will allow you to schedule the republishing of content that was originally published in this application.
       Any linked editions will also be republished through dependency resolution.
-      Try to pick the document type most focused to the scope of what you need to republish to avoid unnecessary server load.
+      Try to pick the republishing task most focused to the scope of what you need to republish to avoid unnecessary server load.
     </p>
 
     <%= render "govuk_publishing_components/components/table", {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,9 +22,13 @@ Whitehall::Application.routes.draw do
 
       resources :users, only: %i[index show edit update]
 
-      get "republishing" => "republishing#index", as: :republishing_index
-      get "republishing/:page_slug/confirm" => "republishing#confirm_page", as: :confirm_page_republishing
-      post "republishing/:page_slug/republish" => "republishing#republish_page", as: :republish_page
+      scope :republishing do
+        root to: "republishing#index", as: :republishing_index, via: :get
+        scope :page do
+          get "/:page_slug/confirm" => "republishing#confirm_page", as: :republishing_page_confirm
+          post "/:page_slug/republish" => "republishing#republish_page", as: :republishing_page_republish
+        end
+      end
 
       resources :documents, only: [] do
         resources :review_reminders, only: %i[new create edit update]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,7 +23,7 @@ Whitehall::Application.routes.draw do
       resources :users, only: %i[index show edit update]
 
       get "republishing" => "republishing#index", as: :republishing_index
-      get "republishing/:document_slug/confirm" => "republishing#confirm", as: :confirm_republishing
+      get "republishing/:page_slug/confirm" => "republishing#confirm_page", as: :confirm_page_republishing
       post "republishing/republish-past-prime-ministers" => "republishing#republish_past_prime_ministers_index"
 
       resources :documents, only: [] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,7 @@ Whitehall::Application.routes.draw do
 
       get "republishing" => "republishing#index", as: :republishing_index
       get "republishing/:page_slug/confirm" => "republishing#confirm_page", as: :confirm_page_republishing
-      post "republishing/republish-past-prime-ministers" => "republishing#republish_past_prime_ministers_index"
+      post "republishing/:page_slug/republish" => "republishing#republish_page", as: :republish_page
 
       resources :documents, only: [] do
         resources :review_reminders, only: %i[new create edit update]

--- a/features/step_definitions/republishing_published_documents_steps.rb.rb
+++ b/features/step_definitions/republishing_published_documents_steps.rb.rb
@@ -4,7 +4,7 @@ end
 
 When(/^I request a republish of the "Past prime ministers" page$/) do
   visit admin_republishing_index_path
-  find("#republish-past-prime-ministers-index").click
+  find("#republish-past-prime-ministers").click
   click_button("Confirm republishing")
 end
 

--- a/lib/whitehall/authority/rules/miscellaneous_rules.rb
+++ b/lib/whitehall/authority/rules/miscellaneous_rules.rb
@@ -8,7 +8,7 @@ module Whitehall::Authority::Rules
       end
     end
 
-    def can_for_republish_documents?(_action)
+    def can_for_republish_content?(_action)
       actor.gds_admin?
     end
 

--- a/test/functional/admin/republishing_controller_test.rb
+++ b/test/functional/admin/republishing_controller_test.rb
@@ -12,7 +12,7 @@ class Admin::RepublishingControllerTest < ActionController::TestCase
     get :index
 
     assert_select ".govuk-table__cell:nth-child(1) a[href='https://www.test.gov.uk/government/history/past-prime-ministers']", text: "Past Prime Ministers"
-    assert_select ".govuk-table__cell:nth-child(2) a[href='/government/admin/republishing/past-prime-ministers/confirm']", text: "Republish 'Past Prime Ministers' page"
+    assert_select ".govuk-table__cell:nth-child(2) a[href='/government/admin/republishing/page/past-prime-ministers/confirm']", text: "Republish 'Past Prime Ministers' page"
     assert_response :ok
   end
 

--- a/test/functional/admin/republishing_controller_test.rb
+++ b/test/functional/admin/republishing_controller_test.rb
@@ -8,7 +8,7 @@ class Admin::RepublishingControllerTest < ActionController::TestCase
 
   should_be_an_admin_controller
 
-  view_test "GDS Admin users should be able to acess the GET :index and see links to republishable documents" do
+  view_test "GDS Admin users should be able to acess the GET :index and see links to republishable pages" do
     get :index
 
     assert_select ".govuk-table__cell:nth-child(1) a[href='https://www.test.gov.uk/government/history/past-prime-ministers']", text: "Past Prime Ministers"
@@ -23,20 +23,20 @@ class Admin::RepublishingControllerTest < ActionController::TestCase
     assert_response :forbidden
   end
 
-  test "GDS Admin users should be able to access GET :confirm with a republishable document slug" do
-    get :confirm, params: { document_slug: "past-prime-ministers" }
+  test "GDS Admin users should be able to access GET :confirm_page with a republishable page slug" do
+    get :confirm_page, params: { page_slug: "past-prime-ministers" }
     assert_response :ok
   end
 
-  test "GDS Admin users should see a 404 page when trying to republish a document with an unregistered document slug" do
-    get :confirm, params: { document_slug: "not-republishable" }
+  test "GDS Admin users should see a 404 page when trying to GET :confirm_page with an unregistered page slug" do
+    get :confirm_page, params: { page_slug: "not-republishable" }
     assert_response :not_found
   end
 
-  test "Non-GDS Admin users should not be able to access GET :confirm" do
+  test "Non-GDS Admin users should not be able to access GET :confirm_page" do
     login_as :writer
 
-    get :confirm, params: { document_slug: "past-prime-ministers" }
+    get :confirm_page, params: { page_slug: "past-prime-ministers" }
     assert_response :forbidden
   end
 

--- a/test/functional/admin/republishing_controller_test.rb
+++ b/test/functional/admin/republishing_controller_test.rb
@@ -8,7 +8,7 @@ class Admin::RepublishingControllerTest < ActionController::TestCase
 
   should_be_an_admin_controller
 
-  view_test "GDS Admin users should be able to acess the GET :index and see links to republishable pages" do
+  view_test "GDS Admin users should be able to acess the GET :index and see links to republishable content" do
     get :index
 
     assert_select ".govuk-table__cell:nth-child(1) a[href='https://www.test.gov.uk/government/history/past-prime-ministers']", text: "Past Prime Ministers"


### PR DESCRIPTION
This builds on the republishing work in #8958, renaming and DRYing up various bits of functionality and content in order to prepare us to extend the republishing functionality to further documents, other content types, and bulk republishing

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
