### PR TITLE
Do not require body for Editionable Worldwide Organisations

### DIFF
--- a/app/models/editionable_worldwide_organisation.rb
+++ b/app/models/editionable_worldwide_organisation.rb
@@ -162,6 +162,10 @@ class EditionableWorldwideOrganisation < Edition
     false
   end
 
+  def body_required?
+    false
+  end
+
   def translatable?
     true
   end


### PR DESCRIPTION
Non-editionable worldwide organisations do not always have body content, so matching that behaviour for the editionable versions.

[Trello card](https://trello.com/c/NFYppyyg)
