### PR TITLE
Remove references to mapped_specialist_topic_content_id

### DIFF
--- a/app/models/document_collection.rb
+++ b/app/models/document_collection.rb
@@ -56,10 +56,6 @@ class DocumentCollection < Edition
     "/government/collections/#{slug}"
   end
 
-  def specialist_topic_conversion?
-    mapped_specialist_topic_content_id.present?
-  end
-
   def publishing_api_presenter
     PublishingApi::DocumentCollectionPresenter
   end

--- a/app/presenters/publishing_api/document_collection_presenter.rb
+++ b/app/presenters/publishing_api/document_collection_presenter.rb
@@ -64,7 +64,6 @@ module PublishingApi
       }.tap do |details_hash|
         details_hash.merge!(PayloadBuilder::PoliticalDetails.for(item))
         details_hash.merge!(PayloadBuilder::FirstPublicAt.for(item))
-        details_hash.merge!({ mapped_specialist_topic_content_id: item.mapped_specialist_topic_content_id }) if item.mapped_specialist_topic_content_id
       end
     end
 

--- a/test/unit/app/models/document_collection_test.rb
+++ b/test/unit/app/models/document_collection_test.rb
@@ -149,11 +149,6 @@ class DocumentCollectionTest < ActiveSupport::TestCase
     assert_equal doc_collection.content_ids, [doc.content_id, non_whitehall_link.content_id]
   end
 
-  test "#specialist_topic_conversion? returns true if mapped_specialist_topic_content_id is present" do
-    doc = create(:document_collection, mapped_specialist_topic_content_id: "123")
-    assert doc.specialist_topic_conversion?
-  end
-
   test "#has_topic_level_notifications? returns true if taxonomy topic email override is present" do
     doc = create(:document_collection, taxonomy_topic_email_override: "some_content_id")
     assert doc.has_topic_level_notifications?

--- a/test/unit/app/presenters/publishing_api/document_collection_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/document_collection_presenter_test.rb
@@ -410,31 +410,6 @@ class PublishingApi::DocumentCollectionAccessLimitedTest < ActiveSupport::TestCa
   end
 end
 
-class PublishingApi::DocumentCollectionWithMappedSpecialistTopicTest < ActiveSupport::TestCase
-  setup do
-    create(:current_government)
-  end
-
-  test "presents the mapped specialist topic when one exists" do
-    mapped_specialist_topic_content_id = "fc33fada-fe47-4451-b4d3-89fea99bf796"
-    document_collection = create(:document_collection, mapped_specialist_topic_content_id:)
-    presented_document_collection = PublishingApi::DocumentCollectionPresenter.new(document_collection)
-
-    assert_equal mapped_specialist_topic_content_id, presented_document_collection.content[:details][:mapped_specialist_topic_content_id]
-
-    assert_valid_against_publisher_schema presented_document_collection.content, "document_collection"
-  end
-
-  test "does not present the mapped specialist topic if it is nil" do
-    document_collection = create(:document_collection)
-    presented_document_collection = PublishingApi::DocumentCollectionPresenter.new(document_collection)
-
-    assert_not presented_document_collection.content[:details].key?(:mapped_specialist_topic_content_id)
-
-    assert_valid_against_publisher_schema presented_document_collection.content, "document_collection"
-  end
-end
-
 class PublishingApi::DocumentCollectionWithTaxonomyTopicEmailOverrideTest < ActiveSupport::TestCase
   setup do
     create(:current_government)


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

# What

As part of work to retire specialist topics, we temporarily stored a mapping between the archived specialist topic and its document collection conversion. We should remove this once we’re done.

This PR is the first one and it prepares for the database column removal.

# Why

To keep the system clean and avoid unnecessary data.

[Trello card](https://trello.com/c/T6GgX4Vj/2503-remove-mappedspecialisttopiccontentid-from-document-collections-m-l)