### PR TITLE
Remove mapped_specialist_topic_content_id

### DIFF
--- a/db/migrate/20240418133820_remove_mapped_specialist_topic_content_id_from_editions.rb
+++ b/db/migrate/20240418133820_remove_mapped_specialist_topic_content_id_from_editions.rb
@@ -1,0 +1,5 @@
+class RemoveMappedSpecialistTopicContentIdFromEditions < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :editions, :mapped_specialist_topic_content_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -403,7 +403,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_22_091946) do
     t.boolean "all_nation_applicability", default: true
     t.string "image_display_option"
     t.string "auth_bypass_id", null: false
-    t.string "mapped_specialist_topic_content_id"
     t.string "taxonomy_topic_email_override"
     t.integer "main_office_id"
     t.string "logo_formatted_name"


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

# Warning

The following [PR](https://github.com/alphagov/whitehall/pull/8969) must be merged first.

# What

As part of work to retire specialist topics, we temporarily stored a mapping between the archived specialist topic and its document collection conversion. We should remove this once we’re done.

This PR is the second one and it removes the database column.

# Why

To keep the system clean and avoid unnecessary data.

[Trello card](https://trello.com/c/T6GgX4Vj/2503-remove-mappedspecialisttopiccontentid-from-document-collections-m-l)