### PR TITLE
Fix code injection warning

### DIFF
--- a/app/controllers/admin/attachments_controller.rb
+++ b/app/controllers/admin/attachments_controller.rb
@@ -136,13 +136,28 @@ private
   end
 
   def attachable_class
-    if attachable_param
-      attachable_param.sub(/_id$/, "").classify.constantize
+    # Note - this case statement needs to include a clause for every resource
+    # in the routes.rb file which has resources :attachments nested under it.
+    # For example, if we have the following in routes.rb:
+    #
+    #  resources :consultation_responses do
+    #    resources :attachments
+    #  end
+    #
+    # We need to add a clause like:
+    #
+    #   when "consultation_response_id" then ConsultationResponse
+    #
+    case attachable_param
+    when "edition_id" then Edition
+    when "consultation_response_id" then ConsultationResponse
+    when "call_for_evidence_response_id" then CallForEvidenceResponse
+    when "worldwide_organisation_page_id" then WorldwideOrganisationPage
+    when "corporate_information_page_id" then CorporateInformationPage
+    when "policy_group_id" then PolicyGroup
     else
       raise ActiveRecord::RecordNotFound
     end
-  rescue NameError
-    raise ActiveRecord::RecordNotFound
   end
 
   def attachable_id


### PR DESCRIPTION
For those with access to GitHub code scanning alerts, this is https://github.com/alphagov/whitehall/security/code-scanning/51

I'm happy discussing this in a public issue because I'm confident it isn't exploitable.

attachable_param is effectively user input - any param the user provides ending with _id could be treated as the attachable param.

Calling constantize on this is a possible code injection vulnerability - if the user provides a param like:

  my_really_malicious_class_id

Then we'll end up using MyReallyMaliciousClass as the attachable_class, and any methods we call on it will be executed on the malicious class.

In practice, this is unlikely to be an exploitable issue since there are only so many classes available in our application (and the user can't create them arbitrarily), and the methods we call  on attachable_class are very limited (I think just `#friendly` and `#find`).

At the very least though, it requires careful thought to be confident that this code is _not_ causing an exploitable vulnerability, and generally the less careful thought we need to do the better.

This commit replaces transforming the id into a class and then constantizing it with a simple lookup from every legitimately possible attachable_param to every legitimately possible class.

There is a drawback to this new approach, which is that the mapping will need to be updated any time we nest `resources :attachments` under a new resource. I can't think of a better way of doing it though, and it feels better than the approach with a potential code injection issue.
