### PR TITLE
Add audit history for worldwide organisation pages

### DIFF
--- a/app/views/admin/editionable_worldwide_organisations/_pages_diff.html.erb
+++ b/app/views/admin/editionable_worldwide_organisations/_pages_diff.html.erb
@@ -1,0 +1,47 @@
+<% if @edition.pages.any? %>
+  <div class="govuk-!-margin-bottom-5">
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "Pages",
+      margin_bottom: 3,
+      font_size: "xl",
+    } %>
+  </div>
+
+  <% @edition.pages.each do |page| %>
+    <% previous_page = @audit_trail_entry.pages.find_by(corporate_information_page_type_id: page.corporate_information_page_type_id) %>
+
+    <div class="app-view-audit-trail__page-comparison">
+      <div class="govuk-!-margin-bottom-5">
+        <%= render "govuk_publishing_components/components/heading", {
+          text: page.corporate_information_page_type&.title(@edition),
+          margin_bottom: 3,
+          font_size: "l",
+        } %>
+      </div>
+
+      <div class="govuk-!-margin-bottom-5">
+        <%= render "govuk_publishing_components/components/heading", {
+          text: "Summary",
+          margin_bottom: 3,
+          font_size: "m",
+        } %>
+      </div>
+
+      <div class="govuk-body app-view-audit-trail__history-comparison">
+        <%= diff_html(previous_page.try(:summary), page.summary) %>
+      </div>
+
+      <div class="govuk-!-margin-bottom-5">
+        <%= render "govuk_publishing_components/components/heading", {
+          text: "Body",
+          margin_bottom: 3,
+          font_size: "m",
+        } %>
+      </div>
+
+      <div class="govuk-body app-view-audit-trail__history-comparison">
+        <%= diff_html(previous_page.try(:body), page.body) %>
+      </div>
+    </div>
+  <% end %>
+<% end %>

--- a/app/views/admin/editions/diff.html.erb
+++ b/app/views/admin/editions/diff.html.erb
@@ -11,7 +11,11 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
 
-    <p class="govuk-body">This page shows changes to the title, summary and body in this edition. It does not show changes to attachments or associations.</p>
+    <% if @edition.is_a?(EditionableWorldwideOrganisation) %>
+      <p class="govuk-body">This page shows changes to the title, summary, body, and pages in this edition. It does not show changes to attachments.</p>
+    <% else %>
+      <p class="govuk-body">This page shows changes to the title, summary and body in this edition. It does not show changes to attachments or associations.</p>
+    <% end %>
 
     <div class="govuk-!-margin-bottom-5">
       <%= render "govuk_publishing_components/components/heading", {
@@ -45,5 +49,9 @@
         <%= diff_html(@audit_trail_entry.body, @edition.body) %>
       </div>
     </div>
+
+    <% if @edition.is_a?(EditionableWorldwideOrganisation) %>
+      <%= render "admin/editionable_worldwide_organisations/pages_diff" %>
+    <% end %>
   </div>
 </div>

--- a/features/editionable-worldwide-organisations.feature
+++ b/features/editionable-worldwide-organisations.feature
@@ -145,6 +145,22 @@ Feature: Editionable worldwide organisations
     And I visit the "Pages" tab
     Then I should see that the translated page with body "French Body" is gone
 
+  Scenario: Viewing audit history for the worldwide organisation and associated pages
+    Given a published editionable worldwide organisation "Test Worldwide Organisation" with a "Personal information charter" page
+    When I create a new edition of the "Test Worldwide Organisation" worldwide organisation
+    And I visit the pages tab for the worldwide organisation
+    And I click the "Edit" link for the "Personal information charter" page
+    And I correctly fill out the worldwide organisation page fields for a "Personal information charter" with:
+      | Summary | Some updated summary |
+      | Body (required) | Some updated body |
+    And I click the link to create a new page
+    And I correctly fill out the worldwide organisation page fields for a "Complaints procedure" with:
+      | Summary | An interesting summary |
+      | Body (required) | An interesting body |
+    Then The audit history for the pages should be displayed on the document history page with:
+      | Personal information charter | Some summary | Some updated summary | Some body | Some updated body |
+      | Complaints procedure | | An interesting summary | | An interesting body |
+
   @javascript
   Scenario: Reordering home page offices for a worldwide organisation
     Given An editionable worldwide organisation "Test Worldwide Organisation" with home page offices "Home page office 1" and "Home page office 2"


### PR DESCRIPTION
https://trello.com/c/2VqUBhuS

Worldwide organisation pages are intended to replace corporate information pages for the new editionable worldwide organisation model.

Whereas corporate information pages are editionable, worldwide organisation pages are not, and are more similar to worldwide offices.

The upside of this is that they can be published in sync with the editionable worldwide organisation. One of the downsides is that they won't have their own audit history.

In order to address this, this adds the pages to the audit history of the editionable worldwide organisation. 

Currently, this simply add conditions to the existing `diff` view. If in future we want more models to display the audit history of their associated models, we may want to add the `diff` route to the models themselves and make this more polymorphic.

![image](https://github.com/alphagov/whitehall/assets/47089130/669f2fa8-a3bc-4b2c-9589-10aa459e7806)

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
