### PR TITLE
Switch Worldwide Corporate Information Pages to use edition links

### DIFF
--- a/app/presenters/publishing_api/worldwide_corporate_information_page_presenter.rb
+++ b/app/presenters/publishing_api/worldwide_corporate_information_page_presenter.rb
@@ -24,13 +24,17 @@ module PublishingApi
       content.merge!(
         document_type:,
         schema_name: "worldwide_corporate_information_page",
+        links: {
+          parent: [item.worldwide_organisation.content_id],
+          worldwide_organisation: [item.worldwide_organisation.content_id],
+        },
       )
     end
 
     def links
       {
-        parent: [item.worldwide_organisation.content_id],
-        worldwide_organisation: [item.worldwide_organisation.content_id],
+        parent: [],
+        worldwide_organisation: [],
       }
     end
 

--- a/test/unit/app/presenters/publishing_api/worldwide_corporate_information_page_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/worldwide_corporate_information_page_presenter_test.rb
@@ -36,15 +36,19 @@ module PublishingApi::WorldwideCorporateInformationPagePresenterTest
             body: "<div class=\"govspeak\"><p>Some stuff</p>\n</div>",
           },
           update_type: "major",
+          links: {
+            parent: [
+              corporate_information_page.owning_organisation.content_id,
+            ],
+            worldwide_organisation: [
+              corporate_information_page.owning_organisation.content_id,
+            ],
+          },
         }
 
         expected_links = {
-          parent: [
-            corporate_information_page.owning_organisation.content_id,
-          ],
-          worldwide_organisation: [
-            corporate_information_page.owning_organisation.content_id,
-          ],
+          parent: [],
+          worldwide_organisation: [],
         }
 
         presented_item = presented_corporate_information_page


### PR DESCRIPTION
In https://github.com/alphagov/publishing-api/pull/2708, we allowed Worldwide Corporate Information Pages to use edition links. This change switches those pages to use edition links, allowing us to move towards having Worldwide Organisation editionable.

This will empty the non-edition links. Once all these pages are republished, another PR will remove the non-edition links method.

[Trello card](https://trello.com/c/2VqUBhuS)