### PR TITLE
Add UI for remaining page republishing tasks

### DIFF
--- a/app/controllers/admin/republishing_controller.rb
+++ b/app/controllers/admin/republishing_controller.rb
@@ -62,13 +62,23 @@ private
   end
 
   def republishable_pages
-    historical_accounts_index_presenter = PublishingApi::HistoricalAccountsIndexPresenter.new
+    [
+      "PublishingApi::HistoricalAccountsIndexPresenter",
+      "PublishingApi::HowGovernmentWorksPresenter",
+      "PublishingApi::OperationalFieldsIndexPresenter",
+      "PublishingApi::MinistersIndexPresenter",
+      "PublishingApi::EmbassiesIndexPresenter",
+      "PublishingApi::WorldIndexPresenter",
+      "PublishingApi::OrganisationsIndexPresenter",
+    ].map do |presenter_class_string|
+      presenter_instance = presenter_class_string.constantize.new
 
-    [{
-      title: historical_accounts_index_presenter.content[:title],
-      public_path: historical_accounts_index_presenter.base_path,
-      slug: historical_accounts_index_presenter.base_path.split("/").last,
-      presenter: "PublishingApi::HistoricalAccountsIndexPresenter",
-    }]
+      {
+        title: presenter_instance.content[:title],
+        public_path: presenter_instance.base_path,
+        slug: presenter_instance.base_path.split("/").last,
+        presenter: presenter_class_string,
+      }
+    end
   end
 end

--- a/app/presenters/publishing_api/embassies_index_presenter.rb
+++ b/app/presenters/publishing_api/embassies_index_presenter.rb
@@ -29,11 +29,11 @@ module PublishingApi
       { parent: [WORLD_INDEX_CONTENT_ID] }
     end
 
-  private
-
     def base_path
       "/world/embassies"
     end
+
+  private
 
     def details
       {

--- a/app/presenters/publishing_api/ministers_index_presenter.rb
+++ b/app/presenters/publishing_api/ministers_index_presenter.rb
@@ -46,6 +46,10 @@ module PublishingApi
       }
     end
 
+    def base_path
+      "/government/ministers"
+    end
+
   private
 
     def details
@@ -58,10 +62,6 @@ module PublishingApi
           body: "Read biographies and responsibilities of <a href=\"#cabinet-ministers\" class=\"govuk-link\">Cabinet ministers</a> and all <a href=\"#ministers-by-department\" class=\"govuk-link\">ministers by department</a>, as well as the <a href=\"#whips\" class=\"govuk-link\">whips</a> who help co-ordinate parliamentary business.",
         }
       end
-    end
-
-    def base_path
-      "/government/ministers"
     end
 
     def reshuffle_in_progress?

--- a/app/views/admin/republishing/index.html.erb
+++ b/app/views/admin/republishing/index.html.erb
@@ -48,7 +48,7 @@
           text: link_to(page[:title], Plek.website_root + page[:public_path], class:"govuk-link"),
         },
         {
-          text: link_to(sanitize("Republish #{tag.span('\'' + page[:title] + '\' page', class: 'govuk-visually-hidden')}"),
+          text: link_to(sanitize("Republish #{tag.span('the \'' + page[:title] + '\' page', class: 'govuk-visually-hidden')}"),
               admin_republishing_page_confirm_path(page[:slug]),
               id: "republish-" + page[:slug],
               class: "govuk-link",

--- a/features/republishing-content.feature
+++ b/features/republishing-content.feature
@@ -6,11 +6,47 @@ Feature: Republishing published documents
   Background:
     Given I am a GDS admin
 
-  Scenario: Republish the "Past prime ministers" page
-    Given a published publication "Past prime ministers" exists
-    And the "Past prime ministers" page can be republished
-    When I request a republish of the "Past prime ministers" page
-    Then I can see the "Past prime ministers" page has been scheduled for republishing
+  Scenario: Republish the "Past Prime Ministers" page
+    Given a published publication "Past Prime Ministers" exists
+    And the "Past Prime Ministers" page can be republished
+    When I request a republish of the "Past Prime Ministers" page
+    Then I can see the "Past Prime Ministers" page has been scheduled for republishing
+
+  Scenario: Republish the "How government works" page
+    Given a published publication "How government works" exists
+    And the "How government works" page can be republished
+    When I request a republish of the "How government works" page
+    Then I can see the "How government works" page has been scheduled for republishing
+
+  Scenario: Republish the "Fields of operation" page
+    Given a published publication "Fields of operation" exists
+    And the "Fields of operation" page can be republished
+    When I request a republish of the "Fields of operation" page
+    Then I can see the "Fields of operation" page has been scheduled for republishing
+
+  Scenario: Republish the "Ministers" page
+    Given a published publication "Ministers" exists
+    And the "Ministers" page can be republished
+    When I request a republish of the "Ministers" page
+    Then I can see the "Ministers" page has been scheduled for republishing
+
+  Scenario: Republish the "Find a British embassy, high commission or consulate" page
+    Given a published publication "Find a British embassy, high commission or consulate" exists
+    And the "Find a British embassy, high commission or consulate" page can be republished
+    When I request a republish of the "Find a British embassy, high commission or consulate" page
+    Then I can see the "Find a British embassy, high commission or consulate" page has been scheduled for republishing
+
+  Scenario: Republish the "Help and services around the world" page
+    Given a published publication "Help and services around the world" exists
+    And the "Help and services around the world" page can be republished
+    When I request a republish of the "Help and services around the world" page
+    Then I can see the "Help and services around the world" page has been scheduled for republishing
+
+  Scenario: Republish the "Departments, agencies and public bodies" page
+    Given a published publication "Departments, agencies and public bodies" exists
+    And the "Departments, agencies and public bodies" page can be republished
+    When I request a republish of the "Departments, agencies and public bodies" page
+    Then I can see the "Departments, agencies and public bodies" page has been scheduled for republishing
 
   Scenario: Republish an organisation
     Given a published organisation "An Existing Organisation" exists

--- a/features/step_definitions/republishing_content_steps.rb.rb
+++ b/features/step_definitions/republishing_content_steps.rb.rb
@@ -1,15 +1,15 @@
-Given(/^the "Past prime ministers" page can be republished$/) do
+Given(/^the "([^"]*)" page can be republished$/) do |_page_title|
   create(:ministerial_role, name: "Prime Minister", cabinet_member: true)
 end
 
-When(/^I request a republish of the "Past prime ministers" page$/) do
+When(/^I request a republish of the "([^"]*)" page$/) do |page_title|
   visit admin_republishing_index_path
-  find("#republish-past-prime-ministers").click
+  find(republishing_link_id_from_page_title(page_title)).click
   click_button("Confirm republishing")
 end
 
-Then(/^I can see the "Past prime ministers" page has been scheduled for republishing/) do
-  expect(page).to have_selector(".gem-c-success-alert", text: "The 'Past Prime Ministers' page has been scheduled for republishing")
+Then(/^I can see the "([^"]*)" page has been scheduled for republishing/) do |page_title|
+  expect(page).to have_selector(".gem-c-success-alert", text: "The '#{page_title}' page has been scheduled for republishing")
 end
 
 Given(/^a published organisation "An Existing Organisation" exists$/) do
@@ -30,4 +30,21 @@ end
 
 Then(/^I can see the "An Existing Organisation" organisation has been scheduled for republishing/) do
   expect(page).to have_selector(".gem-c-success-alert", text: "The 'An Existing Organisation' organisation has been scheduled for republishing")
+end
+
+def republishing_link_id_from_page_title(page_title)
+  link_id = "#republish-"
+
+  link_id += case page_title
+             when "Find a British embassy, high commission or consulate"
+               "embassies"
+             when "Help and services around the world"
+               "world"
+             when "Departments, agencies and public bodies"
+               "organisations"
+             else
+               page_title.downcase.gsub(" ", "-")
+             end
+
+  link_id
 end

--- a/test/functional/admin/republishing_controller_test.rb
+++ b/test/functional/admin/republishing_controller_test.rb
@@ -12,7 +12,7 @@ class Admin::RepublishingControllerTest < ActionController::TestCase
     get :index
 
     assert_select ".govuk-table:nth-of-type(1) .govuk-table__cell:nth-child(1) a[href='https://www.test.gov.uk/government/history/past-prime-ministers']", text: "Past Prime Ministers"
-    assert_select ".govuk-table:nth-of-type(1) .govuk-table__cell:nth-child(2) a[href='/government/admin/republishing/page/past-prime-ministers/confirm']", text: "Republish 'Past Prime Ministers' page"
+    assert_select ".govuk-table:nth-of-type(1) .govuk-table__cell:nth-child(2) a[href='/government/admin/republishing/page/past-prime-ministers/confirm']", text: "Republish the 'Past Prime Ministers' page"
 
     assert_select ".govuk-table:nth-of-type(2) .govuk-table__cell:nth-child(2) a[href='/government/admin/republishing/organisation/find']", text: "Republish an organisation"
 


### PR DESCRIPTION
[Trello](https://trello.com/c/pIcBDoQT)

This adds a UI flow for the remaining specific page republishing tasks

## Screenshots

###

<img width="797" alt="image" src="https://github.com/alphagov/whitehall/assets/40244233/856d03af-563d-41e0-822f-f32fa0156f2e">

### After

<img width="714" alt="image" src="https://github.com/alphagov/whitehall/assets/40244233/b99d7fe3-d95e-4f9d-8dd2-84883b53b4f2">

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
