### PR TITLE
Remove non-edition links from presenter

### DIFF
--- a/app/presenters/publishing_api/worldwide_corporate_information_page_presenter.rb
+++ b/app/presenters/publishing_api/worldwide_corporate_information_page_presenter.rb
@@ -32,10 +32,7 @@ module PublishingApi
     end
 
     def links
-      {
-        parent: [],
-        worldwide_organisation: [],
-      }
+      {}
     end
 
     def document_type

--- a/test/unit/app/presenters/publishing_api/worldwide_corporate_information_page_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/worldwide_corporate_information_page_presenter_test.rb
@@ -46,10 +46,7 @@ module PublishingApi::WorldwideCorporateInformationPagePresenterTest
           },
         }
 
-        expected_links = {
-          parent: [],
-          worldwide_organisation: [],
-        }
+        expected_links = {}
 
         presented_item = presented_corporate_information_page
 


### PR DESCRIPTION
Now that all Worldwide Corporate Information Pages have been republished without non-edition links, the method can be emptied so none are included in the requests to Publishing API.

[Trello card](https://trello.com/c/RGhXIPME)