### PR TITLE
Add a UI for republishing a person by slug

### DIFF
--- a/app/controllers/admin/republishing_controller.rb
+++ b/app/controllers/admin/republishing_controller.rb
@@ -57,6 +57,17 @@ class Admin::RepublishingController < Admin::BaseController
 
   def find_person; end
 
+  def search_person
+    person = Person.find_by(slug: params[:person_slug])
+
+    unless person
+      flash[:alert] = "Person with slug '#{params[:person_slug]}' not found"
+      return redirect_to(admin_republishing_person_find_path)
+    end
+
+    redirect_to("#")
+  end
+
 private
 
   def enforce_permissions!

--- a/app/controllers/admin/republishing_controller.rb
+++ b/app/controllers/admin/republishing_controller.rb
@@ -58,14 +58,21 @@ class Admin::RepublishingController < Admin::BaseController
   def find_person; end
 
   def search_person
-    person = Person.find_by(slug: params[:person_slug])
+    @person = Person.find_by(slug: params[:person_slug])
 
-    unless person
+    unless @person
       flash[:alert] = "Person with slug '#{params[:person_slug]}' not found"
       return redirect_to(admin_republishing_person_find_path)
     end
 
-    redirect_to("#")
+    redirect_to(admin_republishing_person_confirm_path(params[:person_slug]))
+  end
+
+  def confirm_person
+    unless @person&.slug == params[:person_slug]
+      @person = Person.find_by(slug: params[:person_slug])
+      render "admin/errors/not_found", status: :not_found unless @person
+    end
   end
 
 private

--- a/app/controllers/admin/republishing_controller.rb
+++ b/app/controllers/admin/republishing_controller.rb
@@ -75,6 +75,17 @@ class Admin::RepublishingController < Admin::BaseController
     end
   end
 
+  def republish_person
+    unless @person&.slug == params[:person_slug]
+      @person = Person.find_by(slug: params[:person_slug])
+      return render "admin/errors/not_found", status: :not_found unless @person
+    end
+
+    @person.publish_to_publishing_api
+    flash[:notice] = "The '#{@person.name}' person has been scheduled for republishing"
+    redirect_to(admin_republishing_index_path)
+  end
+
 private
 
   def enforce_permissions!

--- a/app/controllers/admin/republishing_controller.rb
+++ b/app/controllers/admin/republishing_controller.rb
@@ -55,6 +55,8 @@ class Admin::RepublishingController < Admin::BaseController
     redirect_to(admin_republishing_index_path)
   end
 
+  def find_person; end
+
 private
 
   def enforce_permissions!

--- a/app/views/admin/republishing/confirm_person.html.erb
+++ b/app/views/admin/republishing/confirm_person.html.erb
@@ -1,0 +1,18 @@
+<% content_for :page_title, "Republish '#{@person.name}'" %>
+<% content_for :title, "Are you sure you want to republish '#{@person.name}'?" %>
+<% content_for :title_margin_bottom, 6 %>
+
+<div class="govuk-grid-row">
+  <section class="govuk-grid-column-two-thirds">
+    <p class="govuk-body govuk-!-margin-bottom-7">
+      This will schedule the <%= link_to @person.name, @person.public_url, { class: "govuk-link" } %> person to be republished.
+    </p>
+    <%= form_with(url: "#", method: :post, data: {
+        module: "prevent-multiple-form-submissions",
+      }) do
+        render("govuk_publishing_components/components/button", {
+          text: "Confirm republishing",
+        })
+      end %>
+  </section>
+</div>

--- a/app/views/admin/republishing/confirm_person.html.erb
+++ b/app/views/admin/republishing/confirm_person.html.erb
@@ -7,7 +7,7 @@
     <p class="govuk-body govuk-!-margin-bottom-7">
       This will schedule the <%= link_to @person.name, @person.public_url, { class: "govuk-link" } %> person to be republished.
     </p>
-    <%= form_with(url: "#", method: :post, data: {
+    <%= form_with(url: admin_republishing_person_republish_path(@person.slug), method: :post, data: {
         module: "prevent-multiple-form-submissions",
       }) do
         render("govuk_publishing_components/components/button", {

--- a/app/views/admin/republishing/find_person.html.erb
+++ b/app/views/admin/republishing/find_person.html.erb
@@ -1,0 +1,24 @@
+<% content_for :page_title, "Republish a person" %>
+<% content_for :title, "Which person would you like to republish?" %>
+<% content_for :title_margin_bottom, 6 %>
+
+<div class="govuk-grid-row">
+  <section class="govuk-grid-column-two-thirds">
+    <%= form_with(url: "#", method: :post, data: {
+        module: "prevent-multiple-form-submissions",
+      }) do %>
+
+      <%= render "govuk_publishing_components/components/input", {
+          label: {
+            text: "Enter the slug for the person",
+          },
+          hint: "You can get the slug from the last part of the public URL - everything after '/government/people/'.",
+          name: "person_slug",
+      } %>
+
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Continue",
+      } %>
+    <% end %>
+  </section>
+</div>

--- a/app/views/admin/republishing/find_person.html.erb
+++ b/app/views/admin/republishing/find_person.html.erb
@@ -4,7 +4,7 @@
 
 <div class="govuk-grid-row">
   <section class="govuk-grid-column-two-thirds">
-    <%= form_with(url: "#", method: :post, data: {
+    <%= form_with(url: admin_republishing_person_search_path, method: :post, data: {
         module: "prevent-multiple-form-submissions",
       }) do %>
 

--- a/app/views/admin/republishing/index.html.erb
+++ b/app/views/admin/republishing/index.html.erb
@@ -90,6 +90,18 @@
               ),
           },
         ],
+        [
+          {
+            text: "Person",
+          },
+          {
+            text: link_to(sanitize("Republish #{tag.span('a person', class: 'govuk-visually-hidden')}"),
+                "#",
+                id: "republish-person",
+                class: "govuk-link",
+              ),
+          },
+        ],
       ],
     } %>
   </section>

--- a/app/views/admin/republishing/index.html.erb
+++ b/app/views/admin/republishing/index.html.erb
@@ -96,7 +96,7 @@
           },
           {
             text: link_to(sanitize("Republish #{tag.span('a person', class: 'govuk-visually-hidden')}"),
-                "#",
+                admin_republishing_person_find_path,
                 id: "republish-person",
                 class: "govuk-link",
               ),

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,9 @@ Whitehall::Application.routes.draw do
           get "/:organisation_slug/confirm" => "republishing#confirm_organisation", as: :republishing_organisation_confirm
           post "/:organisation_slug/republish" => "republishing#republish_organisation", as: :republishing_organisation_republish
         end
+        scope :person do
+          get "/find" => "republishing#find_person", as: :republishing_person_find
+        end
       end
 
       resources :documents, only: [] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,7 @@ Whitehall::Application.routes.draw do
         end
         scope :person do
           get "/find" => "republishing#find_person", as: :republishing_person_find
+          post "/search" => "republishing#search_person", as: :republishing_person_search
         end
       end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,7 @@ Whitehall::Application.routes.draw do
           get "/find" => "republishing#find_person", as: :republishing_person_find
           post "/search" => "republishing#search_person", as: :republishing_person_search
           get "/:person_slug/confirm" => "republishing#confirm_person", as: :republishing_person_confirm
+          post "/:person_slug/republish" => "republishing#republish_person", as: :republishing_person_republish
         end
       end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,6 +37,7 @@ Whitehall::Application.routes.draw do
         scope :person do
           get "/find" => "republishing#find_person", as: :republishing_person_find
           post "/search" => "republishing#search_person", as: :republishing_person_search
+          get "/:person_slug/confirm" => "republishing#confirm_person", as: :republishing_person_confirm
         end
       end
 

--- a/features/republishing-content.feature
+++ b/features/republishing-content.feature
@@ -53,3 +53,9 @@ Feature: Republishing published documents
     And the "An Existing Organisation" organisation can be republished
     When I request a republish of the "An Existing Organisation" organisation
     Then I can see the "An Existing Organisation" organisation has been scheduled for republishing
+
+  Scenario: Republish a person
+    Given a published person "Existing Person" exists
+    And the "Existing Person" person can be republished
+    When I request a republish of the "Existing Person" person
+    Then I can see the "Existing Person" person has been scheduled for republishing

--- a/features/step_definitions/republishing_content_steps.rb.rb
+++ b/features/step_definitions/republishing_content_steps.rb.rb
@@ -32,6 +32,26 @@ Then(/^I can see the "An Existing Organisation" organisation has been scheduled 
   expect(page).to have_selector(".gem-c-success-alert", text: "The 'An Existing Organisation' organisation has been scheduled for republishing")
 end
 
+Given(/^a published person "Existing Person" exists$/) do
+  create(:person, forename: "Existing", surname: "Person", slug: "existing-person")
+end
+
+Given(/^the "Existing Person" person can be republished$/) do
+  create(:ministerial_role, name: "Prime Minister", cabinet_member: true)
+end
+
+When(/^I request a republish of the "Existing Person" person$/) do
+  visit admin_republishing_index_path
+  find("#republish-person").click
+  fill_in "Enter the slug for the person", with: "existing-person"
+  click_button("Continue")
+  click_button("Confirm republishing")
+end
+
+Then(/^I can see the "Existing Person" person has been scheduled for republishing/) do
+  expect(page).to have_selector(".gem-c-success-alert", text: "The 'Existing Person' person has been scheduled for republishing")
+end
+
 def republishing_link_id_from_page_title(page_title)
   link_id = "#republish-"
 

--- a/test/functional/admin/republishing_controller_test.rb
+++ b/test/functional/admin/republishing_controller_test.rb
@@ -15,7 +15,7 @@ class Admin::RepublishingControllerTest < ActionController::TestCase
     assert_select ".govuk-table:nth-of-type(1) .govuk-table__cell:nth-child(2) a[href='/government/admin/republishing/page/past-prime-ministers/confirm']", text: "Republish the 'Past Prime Ministers' page"
 
     assert_select ".govuk-table:nth-of-type(2) .govuk-table__body .govuk-table__row:nth-child(1) .govuk-table__cell:nth-child(2) a[href='/government/admin/republishing/organisation/find']", text: "Republish an organisation"
-    assert_select ".govuk-table:nth-of-type(2) .govuk-table__body .govuk-table__row:nth-child(2) .govuk-table__cell:nth-child(2) a[href='#']", text: "Republish a person"
+    assert_select ".govuk-table:nth-of-type(2) .govuk-table__body .govuk-table__row:nth-child(2) .govuk-table__cell:nth-child(2) a[href='/government/admin/republishing/person/find']", text: "Republish a person"
 
     assert_response :ok
   end
@@ -153,6 +153,19 @@ class Admin::RepublishingControllerTest < ActionController::TestCase
     login_as :writer
 
     post :republish_organisation, params: { organisation_slug: "an-existing-organisation" }
+    assert_response :forbidden
+  end
+
+  view_test "GDS Admin users should be able to GET :find_person" do
+    get :find_person
+
+    assert_response :ok
+  end
+
+  test "Non-GDS Admin users should not be able to GET :find_person" do
+    login_as :writer
+
+    get :find_person
     assert_response :forbidden
   end
 end

--- a/test/functional/admin/republishing_controller_test.rb
+++ b/test/functional/admin/republishing_controller_test.rb
@@ -14,7 +14,8 @@ class Admin::RepublishingControllerTest < ActionController::TestCase
     assert_select ".govuk-table:nth-of-type(1) .govuk-table__cell:nth-child(1) a[href='https://www.test.gov.uk/government/history/past-prime-ministers']", text: "Past Prime Ministers"
     assert_select ".govuk-table:nth-of-type(1) .govuk-table__cell:nth-child(2) a[href='/government/admin/republishing/page/past-prime-ministers/confirm']", text: "Republish the 'Past Prime Ministers' page"
 
-    assert_select ".govuk-table:nth-of-type(2) .govuk-table__cell:nth-child(2) a[href='/government/admin/republishing/organisation/find']", text: "Republish an organisation"
+    assert_select ".govuk-table:nth-of-type(2) .govuk-table__body .govuk-table__row:nth-child(1) .govuk-table__cell:nth-child(2) a[href='/government/admin/republishing/organisation/find']", text: "Republish an organisation"
+    assert_select ".govuk-table:nth-of-type(2) .govuk-table__body .govuk-table__row:nth-child(2) .govuk-table__cell:nth-child(2) a[href='#']", text: "Republish a person"
 
     assert_response :ok
   end

--- a/test/functional/admin/republishing_controller_test.rb
+++ b/test/functional/admin/republishing_controller_test.rb
@@ -168,4 +168,28 @@ class Admin::RepublishingControllerTest < ActionController::TestCase
     get :find_person
     assert_response :forbidden
   end
+
+  test "GDS Admin users should be able to POST :search_person with an existing person slug" do
+    create(:person, slug: "existing-person")
+
+    post :search_person, params: { person_slug: "existing-person" }
+
+    assert_redirected_to "#"
+  end
+
+  test "GDS Admin users should be redirected back to :find_person when trying to POST :search_person with a nonexistent person slug" do
+    get :search_person, params: { person_slug: "nonexistent-person" }
+
+    assert_redirected_to admin_republishing_person_find_path
+    assert_equal "Person with slug 'nonexistent-person' not found", flash[:alert]
+  end
+
+  test "Non-GDS Admin users should not be able to POST :search_person" do
+    create(:person, slug: "existing-person")
+
+    login_as :writer
+
+    post :search_person, params: { person_slug: "existing-person" }
+    assert_response :forbidden
+  end
 end

--- a/test/functional/admin/republishing_controller_test.rb
+++ b/test/functional/admin/republishing_controller_test.rb
@@ -146,7 +146,7 @@ class Admin::RepublishingControllerTest < ActionController::TestCase
   end
 
   test "Non-GDS Admin users should not be able to POST :republish_organisation" do
-    create(:organisation, slug: "an-existing-organisation", name: "An Existing Organisation")
+    create(:organisation, slug: "an-existing-organisation")
 
     Organisation.any_instance.expects(:publish_to_publishing_api).never
 

--- a/test/functional/admin/republishing_controller_test.rb
+++ b/test/functional/admin/republishing_controller_test.rb
@@ -174,7 +174,7 @@ class Admin::RepublishingControllerTest < ActionController::TestCase
 
     post :search_person, params: { person_slug: "existing-person" }
 
-    assert_redirected_to "#"
+    assert_redirected_to admin_republishing_person_confirm_path("existing-person")
   end
 
   test "GDS Admin users should be redirected back to :find_person when trying to POST :search_person with a nonexistent person slug" do
@@ -190,6 +190,27 @@ class Admin::RepublishingControllerTest < ActionController::TestCase
     login_as :writer
 
     post :search_person, params: { person_slug: "existing-person" }
+    assert_response :forbidden
+  end
+
+  test "GDS Admin users should be able to GET :confirm_person with an existing person slug" do
+    create(:person, slug: "existing-person")
+
+    get :confirm_person, params: { person_slug: "existing-person" }
+    assert_response :ok
+  end
+
+  test "GDS Admin users should see a 404 page when trying to GET :confirm_person with a nonexistent person slug" do
+    get :confirm_person, params: { person_slug: "nonexistent-person" }
+    assert_response :not_found
+  end
+
+  test "Non-GDS Admin users should not be able to GET :confirm_person" do
+    create(:person, slug: "existing-person")
+
+    login_as :writer
+
+    get :confirm_person, params: { person_slug: "existing-person" }
     assert_response :forbidden
   end
 end


### PR DESCRIPTION
[Trello](https://trello.com/c/zaKO0SSu)

This adds a flow for republishing a person by their slug, following the pattern established by the organisation by slug flow

## Screenshots

### Before

<img width="790" alt="image" src="https://github.com/alphagov/whitehall/assets/40244233/a4892c02-b74d-4c49-8f02-46399376f178">

### After

<img width="778" alt="image" src="https://github.com/alphagov/whitehall/assets/40244233/691e5290-a40f-4981-9f27-291530849350">

<img width="782" alt="image" src="https://github.com/alphagov/whitehall/assets/40244233/bc6249a6-5afe-4c40-bd81-e3ca75f345ce">

<img width="782" alt="image" src="https://github.com/alphagov/whitehall/assets/40244233/7805f2e9-99e6-4a6e-947f-57f46b6e5865">

<img width="1176" alt="image" src="https://github.com/alphagov/whitehall/assets/40244233/1b357a64-6124-4ebf-ac4c-38a11753e243">

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
