### PR TITLE
Present `public_updated_at` in RFC-3339 format

### DIFF
--- a/app/presenters/publishing_api/worldwide_organisation_page_presenter.rb
+++ b/app/presenters/publishing_api/worldwide_organisation_page_presenter.rb
@@ -21,7 +21,7 @@ module PublishingApi
           body: Whitehall::GovspeakRenderer.new.govspeak_with_attachments_to_html(item.body, item.attachments),
         },
         description: item.summary,
-        public_updated_at: item.updated_at,
+        public_updated_at: item.updated_at.rfc3339,
         rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
         schema_name: "worldwide_corporate_information_page",
         document_type:,

--- a/test/unit/app/presenters/publishing_api/worldwide_organisation_page_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/worldwide_organisation_page_presenter_test.rb
@@ -25,7 +25,7 @@ module PublishingApi::WorldwideOrganisationPagePresenterTest
           locale: "en",
           publishing_app: Whitehall::PublishingApp::WHITEHALL,
           rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
-          public_updated_at: page.updated_at,
+          public_updated_at: page.updated_at.rfc3339,
           routes: [{ path: public_path, type: "exact" }],
           redirects: [],
           description: "Some summary",


### PR DESCRIPTION
This makes the `WorldwideOrganisationPage` presenter consistent with the format in the `WorldwideCorporateInformationPage` presenter.

[Trello card](https://trello.com/c/NFYppyyg)