### PR TITLE
Do not include "About Us" CIP in links

### DIFF
--- a/app/presenters/publishing_api/worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/worldwide_organisation_presenter.rb
@@ -145,7 +145,7 @@ module PublishingApi
     def corporate_information_pages
       return [] unless item.corporate_information_pages.any?
 
-      item.corporate_information_pages.published.map(&:content_id)
+      item.corporate_information_pages.published.where.not(corporate_information_page_type_id: CorporateInformationPageType::AboutUs.id).map(&:content_id)
     end
 
     def ordered_corporate_information_pages

--- a/test/unit/app/presenters/publishing_api/worldwide_organisation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/worldwide_organisation_presenter_test.rb
@@ -116,7 +116,6 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
           worldwide_org.reload.home_page_offices.first.contact.content_id,
         ],
         corporate_information_pages: [
-          worldwide_org.corporate_information_pages[0].content_id,
           worldwide_org.corporate_information_pages[1].content_id,
           worldwide_org.corporate_information_pages[2].content_id,
           worldwide_org.corporate_information_pages[3].content_id,


### PR DESCRIPTION
The "About Us" page isn't actually published to Publishing API for Worldwide Organisations, so there's no point including it in the links.

This will allow us to compared the output of the editionable and non-editionable presenters when migrating content from one to the other.

[Trello card](https://trello.com/c/NFYppyyg)
