### PR TITLE
Allow Editionable Worldwide Organisations to have attachments

### DIFF
--- a/app/models/editionable_worldwide_organisation.rb
+++ b/app/models/editionable_worldwide_organisation.rb
@@ -7,6 +7,7 @@ class EditionableWorldwideOrganisation < Edition
   include Edition::Organisations
   include Edition::Roles
   include Edition::WorldLocations
+  include Attachable
 
   has_many :pages, class_name: "WorldwideOrganisationPage", foreign_key: :edition_id, dependent: :destroy, autosave: true
 
@@ -63,6 +64,11 @@ class EditionableWorldwideOrganisation < Edition
 
   include AnalyticsIdentifierPopulator
   self.analytics_prefix = "WO"
+
+  delegate :alternative_format_contact_email, to: :sponsoring_organisation, allow_nil: true
+  def sponsoring_organisation
+    lead_organisations.first
+  end
 
   def base_path
     "/editionable-world/organisations/#{slug}"

--- a/test/unit/app/helpers/admin/tabbed_nav_helper_test.rb
+++ b/test/unit/app/helpers/admin/tabbed_nav_helper_test.rb
@@ -380,6 +380,11 @@ class Admin::TabbedNavHelperTest < ActionView::TestCase
         current: true,
       },
       {
+        label: "Attachments ",
+        href: admin_edition_attachments_path(edition),
+        current: false,
+      },
+      {
         label: "Offices",
         href: admin_worldwide_organisation_worldwide_offices_path(edition),
         current: false,

--- a/test/unit/app/models/editionable_worldwide_organisation_test.rb
+++ b/test/unit/app/models/editionable_worldwide_organisation_test.rb
@@ -332,4 +332,9 @@ class EditionableWorldwideOrganisationTest < ActiveSupport::TestCase
     assert_not_includes organisation.corporate_information_page_types.map(&:slug), "about"
     assert_not_includes organisation.corporate_information_page_types.map(&:id), 20
   end
+
+  test "should support attachments" do
+    organisation = build(:editionable_worldwide_organisation)
+    organisation.attachments << build(:file_attachment)
+  end
 end


### PR DESCRIPTION
Corporate Information Pages (CIPs) attached to non-editionable Worldwide Organisations currently support attachments.

As we are embedding the "About Us" CIP into the main Editionable Worldwide Organisation, we need them to support attachments too, so these can be migrated across.

[Trello card](https://trello.com/c/V3UmyopH)