### PR TITLE
Add alternative format contact for Worldwide Organisation Pages

### DIFF
--- a/app/models/worldwide_organisation_page.rb
+++ b/app/models/worldwide_organisation_page.rb
@@ -18,6 +18,11 @@ class WorldwideOrganisationPage < ApplicationRecord
   include TranslatableModel
   translates :title, :summary, :body
 
+  delegate :alternative_format_contact_email, to: :sponsoring_organisation, allow_nil: true
+  def sponsoring_organisation
+    edition.lead_organisations.first
+  end
+
   def title(_locale = :en)
     corporate_information_page_type.title(edition)
   end

--- a/app/presenters/publishing_api/worldwide_organisation_page_presenter.rb
+++ b/app/presenters/publishing_api/worldwide_organisation_page_presenter.rb
@@ -18,7 +18,7 @@ module PublishingApi
 
       content.merge!(
         details: {
-          body: Whitehall::GovspeakRenderer.new.govspeak_with_attachments_to_html(item.body, item.attachments),
+          body: Whitehall::GovspeakRenderer.new.govspeak_with_attachments_to_html(item.body, item.attachments, item.alternative_format_contact_email),
         },
         description: item.summary,
         public_updated_at: item.updated_at.rfc3339,


### PR DESCRIPTION
We need to include an alternative format contact for Worldwide Organisation Pages to allow attachments to be displayed correctly.

This matches the same behaviour as the existing Worldwide Corporate Information Pages that will be migrated to Worldwide Organisation Pages.

[Trello card](https://trello.com/c/NFYppyyg)