### PR TITLE
Rake task to set a taxonomy topic email override

### DIFF
--- a/lib/tasks/set_taxonomy_topic_email_override.rake
+++ b/lib/tasks/set_taxonomy_topic_email_override.rake
@@ -1,0 +1,25 @@
+desc "override email notifications for a document collection to a given taxonomy topic, can only be run on against a document that has never been published."
+task :set_taxonomy_topic_email_override, %i[document_collection_id taxon_content_id confirmation_string] => :environment do |_, args|
+  document_collection_id = args[:document_collection_id]
+  taxon_content_id = args[:taxon_content_id]
+  confirmation_string = args[:confirmation_string]
+
+  if document_collection_id.blank? || taxon_content_id.blank?
+    raise "Document collection ID and taxon content ID are required arguments"
+  end
+
+  document_collection = DocumentCollection.find_by(id: document_collection_id)
+  raise "Cannot find document collection with ID: #{document_collection_id}" unless document_collection
+
+  raise "Cannot set a taxonomy topic email override on previously published documents" if document_collection.document.live?
+
+  taxon_content_item = Services.publishing_api.get_content(taxon_content_id)
+  sub_message = "#{taxon_content_item.to_h['title']} for document collection #{document_collection.id}, #{document_collection.title}."
+
+  if confirmation_string == "run_for_real"
+    document_collection.update!(taxonomy_topic_email_override: taxon_content_id)
+    puts "Taxonomy topic email override set to #{sub_message}"
+  else
+    puts "This was a dry run. Taxonomy topic email override would have been set to #{sub_message}"
+  end
+end

--- a/test/unit/lib/tasks/set_taxonomy_topic_email_override_test.rb
+++ b/test/unit/lib/tasks/set_taxonomy_topic_email_override_test.rb
@@ -1,0 +1,74 @@
+require "test_helper"
+require "rake"
+
+class SetTaxonomyTopicEmailOverrideRake < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
+  teardown { task.reenable }
+
+  describe "#set_taxonomy_topic_email_override" do
+    let(:task) { Rake::Task["set_taxonomy_topic_email_override"] }
+
+    it "raises an error unless document collection ID and taxon content ID are both provided" do
+      e = assert_raises(StandardError) { task.invoke }
+      assert_equal e.message, "Document collection ID and taxon content ID are required arguments"
+    end
+
+    it "raises an error if document collection does not exist" do
+      e = assert_raises(StandardError) { task.invoke("nothing-at-this-id", "taxon-content-id") }
+      assert_equal e.message, "Cannot find document collection with ID: nothing-at-this-id"
+    end
+
+    it "raises an error if document collection has previously been published" do
+      document_collection = create(:document_collection, :published)
+      e = assert_raises(StandardError) { task.invoke(document_collection.id.to_s, "taxon-content-id") }
+      assert_equal e.message, "Cannot set a taxonomy topic email override on previously published documents"
+    end
+
+    it "raises an error if no content item is returned for the given taxon content ID" do
+      document_collection = create(:document_collection, :draft)
+      bad_taxon_content_id = "123abc"
+      stub_publishing_api_does_not_have_item(bad_taxon_content_id)
+      assert_raises(GdsApi::HTTPNotFound) do
+        task.invoke(document_collection.id.to_s, bad_taxon_content_id.to_s)
+      end
+    end
+
+    describe "default dry run feature" do
+      let(:document_collection) { create(:document_collection, :draft) }
+      let(:taxon_content_id) { "123abc" }
+      let(:taxon_title) { "Taxonomy topic" }
+      let(:dry_run_output) do
+        "This was a dry run. Taxonomy topic email override would have been set to #{taxon_title} for document collection #{document_collection.id}, #{document_collection.title}."
+      end
+      let(:confirmation_output) do
+        "Taxonomy topic email override set to #{taxon_title} for document collection #{document_collection.id}, #{document_collection.title}."
+      end
+
+      before do
+        stub_publishing_api_has_item(content_id: taxon_content_id, title: taxon_title)
+      end
+
+      context "when no confirmation_string argument is provided" do
+        it "it defaults to running as dry run and does not update the document collection" do
+          assert_output(/#{dry_run_output}/) { task.invoke(document_collection.id.to_s, taxon_content_id.to_s) }
+          assert document_collection.taxonomy_topic_email_override.nil?
+        end
+      end
+
+      context "when anything other than run_for_real is provided" do
+        it "it defaults to running as dry run and does not update the document collection" do
+          assert_output(/#{dry_run_output}/) { task.invoke(document_collection.id.to_s, taxon_content_id.to_s, "dry_runnish") }
+          assert document_collection.taxonomy_topic_email_override.nil?
+        end
+      end
+
+      context "run_for_real is provided" do
+        it "updates the taxonomy topic email override field of a document collection" do
+          assert_output(/#{confirmation_output}/) { task.invoke(document_collection.id.to_s, taxon_content_id.to_s, "run_for_real") }
+          assert_equal DocumentCollection.find(document_collection.id).taxonomy_topic_email_override, taxon_content_id
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
When a document collection has a taxonomy topic email override field set, government frontend will show an email signup link for the taxonomy topic stored in the field. See code [here](https://github.com/alphagov/government-frontend/blob/main/app/views/shared/_document_collections_email_signup.html.erb#L1-L21)

This less than ideal complexity in the email sign up journey from some document collection pages was a necessary compromise to unblock the retirement of specialist topics. 

There will be documentation added to the developer docs to describe when this task should be run.

Trello card:
https://trello.com/c/OSr529Am/2080-workflow-to-manage-future-requests-from-hmrc-to-set-topic-level-email-notifications-on-new-not-yet-published-document-collection
