### PR TITLE
Add a UI for republishing a role by slug

### DIFF
--- a/app/controllers/admin/republishing_controller.rb
+++ b/app/controllers/admin/republishing_controller.rb
@@ -88,6 +88,17 @@ class Admin::RepublishingController < Admin::BaseController
 
   def find_role; end
 
+  def search_role
+    role = Role.find_by(slug: params[:role_slug])
+
+    unless role
+      flash[:alert] = "Role with slug '#{params[:role_slug]}' not found"
+      return redirect_to(admin_republishing_role_find_path)
+    end
+
+    redirect_to("#")
+  end
+
 private
 
   def enforce_permissions!

--- a/app/controllers/admin/republishing_controller.rb
+++ b/app/controllers/admin/republishing_controller.rb
@@ -86,6 +86,8 @@ class Admin::RepublishingController < Admin::BaseController
     redirect_to(admin_republishing_index_path)
   end
 
+  def find_role; end
+
 private
 
   def enforce_permissions!

--- a/app/controllers/admin/republishing_controller.rb
+++ b/app/controllers/admin/republishing_controller.rb
@@ -89,14 +89,21 @@ class Admin::RepublishingController < Admin::BaseController
   def find_role; end
 
   def search_role
-    role = Role.find_by(slug: params[:role_slug])
+    @role = Role.find_by(slug: params[:role_slug])
 
-    unless role
+    unless @role
       flash[:alert] = "Role with slug '#{params[:role_slug]}' not found"
       return redirect_to(admin_republishing_role_find_path)
     end
 
-    redirect_to("#")
+    redirect_to(admin_republishing_role_confirm_path(params[:role_slug]))
+  end
+
+  def confirm_role
+    unless @role&.slug == params[:role_slug]
+      @role = Role.find_by(slug: params[:role_slug])
+      render "admin/errors/not_found", status: :not_found unless @role
+    end
   end
 
 private

--- a/app/controllers/admin/republishing_controller.rb
+++ b/app/controllers/admin/republishing_controller.rb
@@ -106,6 +106,17 @@ class Admin::RepublishingController < Admin::BaseController
     end
   end
 
+  def republish_role
+    unless @role&.slug == params[:role_slug]
+      @role = Role.find_by(slug: params[:role_slug])
+      return render "admin/errors/not_found", status: :not_found unless @role
+    end
+
+    @role.publish_to_publishing_api
+    flash[:notice] = "The '#{@role.name}' role has been scheduled for republishing"
+    redirect_to(admin_republishing_index_path)
+  end
+
 private
 
   def enforce_permissions!

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -183,11 +183,11 @@ class Role < ApplicationRecord
   end
 
   def public_path(options = {})
-    append_url_options(base_path, options)
+    append_url_options(base_path, options) if type == "MinisterialRole"
   end
 
   def public_url(options = {})
-    Plek.website_root + public_path(options)
+    Plek.website_root + public_path(options) if type == "MinisterialRole"
   end
 
   def publishing_api_presenter

--- a/app/views/admin/republishing/confirm_role.html.erb
+++ b/app/views/admin/republishing/confirm_role.html.erb
@@ -1,0 +1,22 @@
+<% content_for :page_title, "Republish '#{@role.name}'" %>
+<% content_for :title, "Are you sure you want to republish '#{@role.name}'?" %>
+<% content_for :title_margin_bottom, 6 %>
+
+<div class="govuk-grid-row">
+  <section class="govuk-grid-column-two-thirds">
+    <p class="govuk-body govuk-!-margin-bottom-7">
+      <% if @role.public_url %>
+        This will schedule the <%= link_to @role.name, @role.public_url, { class: "govuk-link" } %> role to be republished.
+      <% else %>
+        This will schedule the '<%= @role.name %>' role to be republished.
+      <% end %>
+    </p>
+    <%= form_with(url: "#", method: :post, data: {
+        module: "prevent-multiple-form-submissions",
+      }) do
+        render("govuk_publishing_components/components/button", {
+          text: "Confirm republishing",
+        })
+      end %>
+  </section>
+</div>

--- a/app/views/admin/republishing/confirm_role.html.erb
+++ b/app/views/admin/republishing/confirm_role.html.erb
@@ -11,7 +11,7 @@
         This will schedule the '<%= @role.name %>' role to be republished.
       <% end %>
     </p>
-    <%= form_with(url: "#", method: :post, data: {
+    <%= form_with(url: admin_republishing_role_republish_path(@role.slug), method: :post, data: {
         module: "prevent-multiple-form-submissions",
       }) do
         render("govuk_publishing_components/components/button", {

--- a/app/views/admin/republishing/find_role.html.erb
+++ b/app/views/admin/republishing/find_role.html.erb
@@ -1,0 +1,38 @@
+<% content_for :page_title, "Republish a role" %>
+<% content_for :title, "Which role would you like to republish?" %>
+<% content_for :title_margin_bottom, 6 %>
+
+<div class="govuk-grid-row">
+  <section class="govuk-grid-column-two-thirds">
+    <details class="govuk-details">
+      <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text">
+          Guidance on finding the slug for a role
+        </span>
+      </summary>
+      <div class="govuk-details__text">
+        <ol class="govuk-list govuk-list--number">
+          <li>Visit the <a href="<%= admin_roles_path %>" class="govuk-link">roles</a> page.</li>
+          <li>Find the role you'd like to republish.</li>
+          <li>Click on either the 'Manage' link under 'Translations' or the 'Edit' link.</li>
+          <li>The role slug is the penultimate part of the URL - everything between '/government/admin/roles/' and the next '/'.</li>
+        </ol>
+      </div>
+    </details>
+
+    <%= form_with(url: "#", method: :post, data: {
+        module: "prevent-multiple-form-submissions",
+      }) do %>
+      <%= render "govuk_publishing_components/components/input", {
+          label: {
+            text: "Enter the slug for the role",
+          },
+          hint: "Guidance on how to find the slug is provided above.",
+          name: "role_slug",
+      } %>
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Continue",
+      } %>
+    <% end %>
+  </section>
+</div>

--- a/app/views/admin/republishing/find_role.html.erb
+++ b/app/views/admin/republishing/find_role.html.erb
@@ -20,7 +20,7 @@
       </div>
     </details>
 
-    <%= form_with(url: "#", method: :post, data: {
+    <%= form_with(url: admin_republishing_role_search_path, method: :post, data: {
         module: "prevent-multiple-form-submissions",
       }) do %>
       <%= render "govuk_publishing_components/components/input", {

--- a/app/views/admin/republishing/index.html.erb
+++ b/app/views/admin/republishing/index.html.erb
@@ -108,7 +108,7 @@
           },
           {
             text: link_to(sanitize("Republish #{tag.span('a role', class: 'govuk-visually-hidden')}"),
-                "#",
+                admin_republishing_role_find_path,
                 id: "republish-role",
                 class: "govuk-link",
               ),

--- a/app/views/admin/republishing/index.html.erb
+++ b/app/views/admin/republishing/index.html.erb
@@ -102,6 +102,18 @@
               ),
           },
         ],
+        [
+          {
+            text: "Role",
+          },
+          {
+            text: link_to(sanitize("Republish #{tag.span('a role', class: 'govuk-visually-hidden')}"),
+                "#",
+                id: "republish-role",
+                class: "govuk-link",
+              ),
+          },
+        ],
       ],
     } %>
   </section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,6 +43,7 @@ Whitehall::Application.routes.draw do
         scope :role do
           get "/find" => "republishing#find_role", as: :republishing_role_find
           post "/search" => "republishing#search_role", as: :republishing_role_search
+          get "/:role_slug/confirm" => "republishing#confirm_role", as: :republishing_role_confirm
         end
       end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,6 +42,7 @@ Whitehall::Application.routes.draw do
         end
         scope :role do
           get "/find" => "republishing#find_role", as: :republishing_role_find
+          post "/search" => "republishing#search_role", as: :republishing_role_search
         end
       end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,9 @@ Whitehall::Application.routes.draw do
           get "/:person_slug/confirm" => "republishing#confirm_person", as: :republishing_person_confirm
           post "/:person_slug/republish" => "republishing#republish_person", as: :republishing_person_republish
         end
+        scope :role do
+          get "/find" => "republishing#find_role", as: :republishing_role_find
+        end
       end
 
       resources :documents, only: [] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,6 +44,7 @@ Whitehall::Application.routes.draw do
           get "/find" => "republishing#find_role", as: :republishing_role_find
           post "/search" => "republishing#search_role", as: :republishing_role_search
           get "/:role_slug/confirm" => "republishing#confirm_role", as: :republishing_role_confirm
+          post "/:role_slug/republish" => "republishing#republish_role", as: :republishing_role_republish
         end
       end
 

--- a/features/republishing-content.feature
+++ b/features/republishing-content.feature
@@ -59,3 +59,9 @@ Feature: Republishing published documents
     And the "Existing Person" person can be republished
     When I request a republish of the "Existing Person" person
     Then I can see the "Existing Person" person has been scheduled for republishing
+
+  Scenario: Republish a role
+    Given a published role "An Existing Role" exists
+    And the "An Existing Role" role can be republished
+    When I request a republish of the "An Existing Role" role
+    Then I can see the "An Existing Role" role has been scheduled for republishing

--- a/features/step_definitions/republishing_content_steps.rb.rb
+++ b/features/step_definitions/republishing_content_steps.rb.rb
@@ -52,6 +52,26 @@ Then(/^I can see the "Existing Person" person has been scheduled for republishin
   expect(page).to have_selector(".gem-c-success-alert", text: "The 'Existing Person' person has been scheduled for republishing")
 end
 
+Given(/^a published role "An Existing Role" exists$/) do
+  create(:role, name: "An Existing Role", slug: "an-existing-role")
+end
+
+Given(/^the "An Existing Role" role can be republished$/) do
+  create(:ministerial_role, name: "Prime Minister", cabinet_member: true)
+end
+
+When(/^I request a republish of the "An Existing Role" role$/) do
+  visit admin_republishing_index_path
+  find("#republish-role").click
+  fill_in "Enter the slug for the role", with: "an-existing-role"
+  click_button("Continue")
+  click_button("Confirm republishing")
+end
+
+Then(/^I can see the "An Existing Role" role has been scheduled for republishing/) do
+  expect(page).to have_selector(".gem-c-success-alert", text: "The 'An Existing Role' role has been scheduled for republishing")
+end
+
 def republishing_link_id_from_page_title(page_title)
   link_id = "#republish-"
 

--- a/test/functional/admin/republishing_controller_test.rb
+++ b/test/functional/admin/republishing_controller_test.rb
@@ -16,7 +16,7 @@ class Admin::RepublishingControllerTest < ActionController::TestCase
 
     assert_select ".govuk-table:nth-of-type(2) .govuk-table__body .govuk-table__row:nth-child(1) .govuk-table__cell:nth-child(2) a[href='/government/admin/republishing/organisation/find']", text: "Republish an organisation"
     assert_select ".govuk-table:nth-of-type(2) .govuk-table__body .govuk-table__row:nth-child(2) .govuk-table__cell:nth-child(2) a[href='/government/admin/republishing/person/find']", text: "Republish a person"
-    assert_select ".govuk-table:nth-of-type(2) .govuk-table__body .govuk-table__row:nth-child(3) .govuk-table__cell:nth-child(2) a[href='#']", text: "Republish a role"
+    assert_select ".govuk-table:nth-of-type(2) .govuk-table__body .govuk-table__row:nth-child(3) .govuk-table__cell:nth-child(2) a[href='/government/admin/republishing/role/find']", text: "Republish a role"
 
     assert_response :ok
   end
@@ -241,6 +241,19 @@ class Admin::RepublishingControllerTest < ActionController::TestCase
     login_as :writer
 
     post :republish_person, params: { person_slug: "existing-person" }
+    assert_response :forbidden
+  end
+
+  view_test "GDS Admin users should be able to GET :find_role" do
+    get :find_role
+
+    assert_response :ok
+  end
+
+  test "Non-GDS Admin users should not be able to GET :find_role" do
+    login_as :writer
+
+    get :find_role
     assert_response :forbidden
   end
 end

--- a/test/functional/admin/republishing_controller_test.rb
+++ b/test/functional/admin/republishing_controller_test.rb
@@ -16,6 +16,7 @@ class Admin::RepublishingControllerTest < ActionController::TestCase
 
     assert_select ".govuk-table:nth-of-type(2) .govuk-table__body .govuk-table__row:nth-child(1) .govuk-table__cell:nth-child(2) a[href='/government/admin/republishing/organisation/find']", text: "Republish an organisation"
     assert_select ".govuk-table:nth-of-type(2) .govuk-table__body .govuk-table__row:nth-child(2) .govuk-table__cell:nth-child(2) a[href='/government/admin/republishing/person/find']", text: "Republish a person"
+    assert_select ".govuk-table:nth-of-type(2) .govuk-table__body .govuk-table__row:nth-child(3) .govuk-table__cell:nth-child(2) a[href='#']", text: "Republish a role"
 
     assert_response :ok
   end

--- a/test/functional/admin/republishing_controller_test.rb
+++ b/test/functional/admin/republishing_controller_test.rb
@@ -256,4 +256,28 @@ class Admin::RepublishingControllerTest < ActionController::TestCase
     get :find_role
     assert_response :forbidden
   end
+
+  test "GDS Admin users should be able to POST :search_role with an existing role slug" do
+    create(:role, slug: "an-existing-role")
+
+    post :search_role, params: { role_slug: "an-existing-role" }
+
+    assert_redirected_to "#"
+  end
+
+  test "GDS Admin users should be redirected back to :find_role when trying to POST :search_role with a nonexistent role slug" do
+    get :search_role, params: { role_slug: "not-an-existing-role" }
+
+    assert_redirected_to admin_republishing_role_find_path
+    assert_equal "Role with slug 'not-an-existing-role' not found", flash[:alert]
+  end
+
+  test "Non-GDS Admin users should not be able to POST :search_role" do
+    create(:role, slug: "an-existing-role")
+
+    login_as :writer
+
+    post :search_role, params: { role_slug: "an-existing-role" }
+    assert_response :forbidden
+  end
 end

--- a/test/functional/admin/republishing_controller_test.rb
+++ b/test/functional/admin/republishing_controller_test.rb
@@ -262,7 +262,7 @@ class Admin::RepublishingControllerTest < ActionController::TestCase
 
     post :search_role, params: { role_slug: "an-existing-role" }
 
-    assert_redirected_to "#"
+    assert_redirected_to admin_republishing_role_confirm_path("an-existing-role")
   end
 
   test "GDS Admin users should be redirected back to :find_role when trying to POST :search_role with a nonexistent role slug" do
@@ -278,6 +278,27 @@ class Admin::RepublishingControllerTest < ActionController::TestCase
     login_as :writer
 
     post :search_role, params: { role_slug: "an-existing-role" }
+    assert_response :forbidden
+  end
+
+  test "GDS Admin users should be able to GET :confirm_role with an existing role slug" do
+    create(:role, slug: "an-existing-role")
+
+    get :confirm_role, params: { role_slug: "an-existing-role" }
+    assert_response :ok
+  end
+
+  test "GDS Admin users should see a 404 page when trying to GET :confirm_role with a nonexistent role slug" do
+    get :confirm_role, params: { role_slug: "not-an-existing-role" }
+    assert_response :not_found
+  end
+
+  test "Non-GDS Admin users should not be able to GET :confirm_role" do
+    create(:role, slug: "an-existing-role")
+
+    login_as :writer
+
+    get :confirm_role, params: { role_slug: "an-existing-role" }
     assert_response :forbidden
   end
 end

--- a/test/unit/app/models/historical_account_test.rb
+++ b/test/unit/app/models/historical_account_test.rb
@@ -72,46 +72,44 @@ class HistoricalAccountTest < ActiveSupport::TestCase
   should_not_accept_footnotes_in(:body)
 
   context "for a previous prime minister" do
-    let(:object) do
+    let(:role) { create(:prime_minister_role) }
+    let(:person) { create(:person, slug: "foo") }
+    let(:historical_account) do
       build(:historical_account,
-            role: create(:prime_minister_role),
-            person: create(:person, slug: "foo"))
+            role:,
+            person:)
+    end
+
+    setup do
+      create(:historic_role_appointment, person:, role:)
     end
 
     test "public_path returns the correct path" do
-      assert_equal "/government/history/past-prime-ministers/foo", object.public_path
+      assert_equal "/government/history/past-prime-ministers/foo", historical_account.public_path
     end
 
     test "public_path returns the correct path with options" do
-      assert_equal "/government/history/past-prime-ministers/foo?cachebust=123", object.public_path(cachebust: "123")
+      assert_equal "/government/history/past-prime-ministers/foo?cachebust=123", historical_account.public_path(cachebust: "123")
     end
 
     test "public_url returns the correct path" do
-      assert_equal "https://www.test.gov.uk/government/history/past-prime-ministers/foo", object.public_url
+      assert_equal "https://www.test.gov.uk/government/history/past-prime-ministers/foo", historical_account.public_url
     end
 
     test "public_url returns the correct path with options" do
-      assert_equal "https://www.test.gov.uk/government/history/past-prime-ministers/foo?cachebust=123", object.public_url(cachebust: "123")
-    end
-  end
-
-  context "for a person who was a prime minister" do
-    setup do
-      @pm_role = create(:prime_minister_role)
-      @person = create(:person)
-      create(:historic_role_appointment, person: @person, role: @pm_role)
+      assert_equal "https://www.test.gov.uk/government/history/past-prime-ministers/foo?cachebust=123", historical_account.public_url(cachebust: "123")
     end
 
     test "republishes the past prime ministers page on create" do
       PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::HistoricalAccountsIndexPresenter)
 
       Sidekiq::Testing.inline! do
-        create(:historical_account, person: @person, role: @pm_role)
+        create(:historical_account, person:, role:)
       end
     end
 
     test "republishes the past prime ministers page on update" do
-      account = create(:historical_account, person: @person, role: @pm_role)
+      account = create(:historical_account, person:, role:)
 
       PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::HistoricalAccountsIndexPresenter)
 
@@ -121,7 +119,7 @@ class HistoricalAccountTest < ActiveSupport::TestCase
     end
 
     test "republishes the past prime ministers page on destroy" do
-      account = create(:historical_account, person: @person, role: @pm_role)
+      account = create(:historical_account, person:, role:)
 
       PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::HistoricalAccountsIndexPresenter)
 

--- a/test/unit/app/models/historical_account_test.rb
+++ b/test/unit/app/models/historical_account_test.rb
@@ -128,4 +128,20 @@ class HistoricalAccountTest < ActiveSupport::TestCase
       end
     end
   end
+
+  context "for a historical account for a non-prime ministerial role" do
+    let(:historical_account) do
+      build(:historical_account,
+            role: create(:non_ministerial_role_without_organisations),
+            person: create(:person))
+    end
+
+    test "public_path returns `nil``" do
+      assert_nil historical_account.public_path
+    end
+
+    test "public_url returns `nil`" do
+      assert_nil historical_account.public_url
+    end
+  end
 end

--- a/test/unit/app/models/role_test.rb
+++ b/test/unit/app/models/role_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class RoleTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
   should_protect_against_xss_and_content_attacks_on :role, :responsibilities
 
   %w[name responsibilities].each do |column_name|
@@ -196,24 +198,36 @@ class RoleTest < ActiveSupport::TestCase
     assert_not_includes Role.occupied, vacant
   end
 
-  test "public_path returns the correct path for ministerial role" do
-    role = create(:ministerial_role, name: "Prime Minister, Cabinet Office")
-    assert_equal "/government/ministers/prime-minister-cabinet-office", role.public_path
+  context "for a ministerial role" do
+    let(:role) { create(:ministerial_role, name: "Prime Minister, Cabinet Office") }
+
+    test "public_path returns the correct path for ministerial role" do
+      assert_equal "/government/ministers/prime-minister-cabinet-office", role.public_path
+    end
+
+    test "public_path returns the correct path with options" do
+      assert_equal "/government/ministers/prime-minister-cabinet-office?cachebust=123", role.public_path(cachebust: "123")
+    end
+
+    test "public_url returns the correct path for a Ministerial role" do
+      assert_equal "https://www.test.gov.uk/government/ministers/prime-minister-cabinet-office", role.public_url
+    end
+
+    test "public_url returns the correct path for a Ministerial Role with options" do
+      assert_equal "https://www.test.gov.uk/government/ministers/prime-minister-cabinet-office?cachebust=123", role.public_url(cachebust: "123")
+    end
   end
 
-  test "public_path returns the correct path with options" do
-    role = create(:ministerial_role, name: "Prime Minister, Cabinet Office")
-    assert_equal "/government/ministers/prime-minister-cabinet-office?cachebust=123", role.public_path(cachebust: "123")
-  end
+  context "for a non-ministerial role" do
+    let(:role) { create(:board_member_role) }
 
-  test "public_url returns the correct path for a Ministerial role" do
-    role = create(:ministerial_role, name: "Prime Minister, Cabinet Office")
-    assert_equal "https://www.test.gov.uk/government/ministers/prime-minister-cabinet-office", role.public_url
-  end
+    test "public_path returns `nil``" do
+      assert_nil role.public_path
+    end
 
-  test "public_url returns the correct path for a Ministerial Role with options" do
-    role = create(:ministerial_role, name: "Prime Minister, Cabinet Office")
-    assert_equal "https://www.test.gov.uk/government/ministers/prime-minister-cabinet-office?cachebust=123", role.public_url(cachebust: "123")
+    test "public_url returns `nil`" do
+      assert_nil role.public_url
+    end
   end
 
   test "has removeable translations" do


### PR DESCRIPTION
[Trello](https://trello.com/c/BrFoc5p6)

This adds a flow for republishing a role by its slug, following the pattern established by the organisation by slug flow

There's a short diversion into `HistoricalAccount`s in the middle here, but it establishes a pattern that will then be used to test `Role`s (for which a small fix is included)

## Screenshots

### Before

<img width="778" alt="image" src="https://github.com/alphagov/whitehall/assets/40244233/691e5290-a40f-4981-9f27-291530849350">

### After

<img width="802" alt="image" src="https://github.com/alphagov/whitehall/assets/40244233/ba9c7452-0c0e-40b8-ba46-b7025315920a">

<img width="788" alt="image" src="https://github.com/alphagov/whitehall/assets/40244233/5d556b22-93ba-48fb-be1d-8fd955c04a57">

<img width="792" alt="image" src="https://github.com/alphagov/whitehall/assets/40244233/bd05c034-8056-4949-9141-87b825f251ee">

<img width="1177" alt="image" src="https://github.com/alphagov/whitehall/assets/40244233/06931438-d325-4215-912c-ca61dae391bd">

<img width="767" alt="image" src="https://github.com/alphagov/whitehall/assets/40244233/1c2e7b9b-d74e-4b7b-b078-0f77516231da">

<img width="1182" alt="image" src="https://github.com/alphagov/whitehall/assets/40244233/3054ff08-5cd9-4a8e-832e-016821ab41a3">

<img width="778" alt="image" src="https://github.com/alphagov/whitehall/assets/40244233/aee0bc7a-3c61-4833-853e-bc5c28a006bc">

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
