### PR TITLE
Add offices to home page lists on new edition creation

### DIFF
--- a/app/models/editionable_worldwide_organisation.rb
+++ b/app/models/editionable_worldwide_organisation.rb
@@ -22,11 +22,15 @@ class EditionableWorldwideOrganisation < Edition
   alias_method :name, :title
 
   class CloneOfficesTrait < Edition::Traits::Trait
-    def process_associations_before_save(new_edition)
+    def process_associations_after_save(new_edition)
       @edition.offices.each do |office|
         new_office = new_edition.offices.build(office.attributes.except("id", "edition_id"))
 
         new_office.contact = office.contact.dup
+
+        if @edition.office_shown_on_home_page?(office)
+          new_edition.add_office_to_home_page!(new_office)
+        end
       end
     end
   end

--- a/test/unit/app/models/editionable_worldwide_organisation_test.rb
+++ b/test/unit/app/models/editionable_worldwide_organisation_test.rb
@@ -168,6 +168,16 @@ class EditionableWorldwideOrganisationTest < ActiveSupport::TestCase
                  draft_worldwide_organisation.offices.first.contact.translations.find_by(locale: :en).attributes.except("id", "contact_id")
   end
 
+  test "should retain home page lists for offices when new draft of published edition is created" do
+    published_worldwide_organisation = create(:editionable_worldwide_organisation, :published, :with_main_office, :with_home_page_offices)
+
+    draft_worldwide_organisation = published_worldwide_organisation.create_draft(create(:writer))
+    published_worldwide_organisation.reload
+
+    assert_equal published_worldwide_organisation.home_page_offices.first.attributes.except("id", "edition_id"),
+                 draft_worldwide_organisation.home_page_offices.first.attributes.except("id", "edition_id")
+  end
+
   test "should clone default news image when new draft of published edition is created" do
     published_worldwide_organisation = create(
       :editionable_worldwide_organisation,


### PR DESCRIPTION
When a new edition is created, we need to assign the home page offices to the "home page list" for the new edition.

This must be done after save, as otherwise the record can't be associated correctly with the new edition.

[Trello card](https://trello.com/c/NFYppyyg)