### PR TITLE
Put the corporate information pages into a consistent order

### DIFF
--- a/app/presenters/publishing_api/editionable_worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/editionable_worldwide_organisation_presenter.rb
@@ -162,7 +162,7 @@ module PublishingApi
     def pages
       return [] unless item.pages.any?
 
-      item.pages.map(&:content_id)
+      item.pages.map(&:content_id).sort
     end
 
     def ordered_corporate_information_pages

--- a/app/presenters/publishing_api/worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/worldwide_organisation_presenter.rb
@@ -145,7 +145,7 @@ module PublishingApi
     def corporate_information_pages
       return [] unless item.corporate_information_pages.any?
 
-      item.corporate_information_pages.published.where.not(corporate_information_page_type_id: CorporateInformationPageType::AboutUs.id).map(&:content_id)
+      item.corporate_information_pages.published.where.not(corporate_information_page_type_id: CorporateInformationPageType::AboutUs.id).map(&:content_id).sort
     end
 
     def ordered_corporate_information_pages

--- a/test/unit/app/presenters/publishing_api/editionable_worldwide_organisation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/editionable_worldwide_organisation_presenter_test.rb
@@ -127,7 +127,7 @@ class PublishingApi::EditionableWorldwideOrganisationPresenterTest < ActiveSuppo
         ],
         sponsoring_organisations: worldwide_org.organisations.map(&:content_id),
         world_locations: worldwide_org.world_locations.map(&:content_id),
-        corporate_information_pages: worldwide_org.pages.map(&:content_id),
+        corporate_information_pages: worldwide_org.pages.map(&:content_id).sort,
       },
       analytics_identifier: "WO123",
       update_type: "major",

--- a/test/unit/app/presenters/publishing_api/worldwide_organisation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/worldwide_organisation_presenter_test.rb
@@ -121,7 +121,7 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
           worldwide_org.corporate_information_pages[3].content_id,
           worldwide_org.corporate_information_pages[4].content_id,
           worldwide_org.corporate_information_pages[5].content_id,
-        ],
+        ].sort,
         main_office: [
           worldwide_org.reload.main_office.content_id,
         ],


### PR DESCRIPTION
Links are ordered lists, however we don't care about the ordering of corporate information pages, as there is additional information in the `details` hash that shows how the pages should be ordered.

They are currently being included in database order, which means there is a variation each time a new edition of an Editionable Worldwide Organisation is created, plus a difference when doing the integrity check for the migration of these to be editionable.

Therefore always including these in alphabetical order (by content ID) to ensure the order is consistent between editions and the two presenters.

[Trello card](https://trello.com/c/NFYppyyg)