### PR TITLE
Add ARM Builds for Whitehall

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
   build-and-publish-image:
     if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'v')
     name: Build and publish image
-    uses: alphagov/govuk-infrastructure/.github/workflows/build-and-push-image.yml@main
+    uses: alphagov/govuk-infrastructure/.github/workflows/build-and-push-multiarch-image.yml@main
     with:
       gitRef: ${{ inputs.gitRef || github.event.release.tag_name }}
     permissions:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-ARG ruby_version=3.2.2
+ARG ruby_version=3.2.3
 ARG base_image=ghcr.io/alphagov/govuk-ruby-base:$ruby_version
 ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:$ruby_version
 
 
-FROM $builder_image AS builder
+FROM --platform=$TARGETPLATFORM $builder_image AS builder
 
 ENV JWT_AUTH_SECRET=unused_yet_required
 
@@ -17,7 +17,7 @@ RUN bootsnap precompile --gemfile .
 RUN SECRET_KEY_BASE_DUMMY=1 rails assets:precompile && rm -fr log
 
 
-FROM $base_image
+FROM --platform=$TARGETPLATFORM $base_image
 RUN install_packages ghostscript imagemagick unzip
 
 ENV GOVUK_APP_NAME=whitehall


### PR DESCRIPTION
## What?
This switches Whitehall to use the multi-arch workflow so we can start getting ARM builds ready. Also bumping this to Ruby 3.2.3 (since we don't have ARM base images for 3.2.2).