### PR TITLE
Make `WorldwideOrganisationPresenter` properly support drafts

### DIFF
--- a/test/unit/app/presenters/publishing_api/worldwide_organisation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/worldwide_organisation_presenter_test.rb
@@ -20,16 +20,16 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
     primary_role = create(:ambassador_role)
     ambassador = create(:person)
     create(:ambassador_role_appointment, role: primary_role, person: ambassador)
-    FactoryBot.create(:worldwide_organisation_role, worldwide_organisation: worldwide_org, role: primary_role)
+    create(:worldwide_organisation_role, worldwide_organisation: worldwide_org, role: primary_role)
 
     secondary_role = create(:deputy_head_of_mission_role)
     deputy_head_of_mission = create(:person)
     create(:deputy_head_of_mission_role_appointment, role: secondary_role, person: deputy_head_of_mission)
-    FactoryBot.create(:worldwide_organisation_role, worldwide_organisation: worldwide_org, role: secondary_role)
+    create(:worldwide_organisation_role, worldwide_organisation: worldwide_org, role: secondary_role)
 
     former_role = create(:ambassador_role)
     create(:ambassador_role_appointment, :ended, role: former_role, person: deputy_head_of_mission)
-    FactoryBot.create(:worldwide_organisation_role, worldwide_organisation: worldwide_org, role: secondary_role)
+    create(:worldwide_organisation_role, worldwide_organisation: worldwide_org, role: secondary_role)
 
     public_path = worldwide_org.public_path
 
@@ -273,8 +273,8 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
 
   test "includes the draft corporate information pages when state is set to draft" do
     worldwide_organisation = build(:worldwide_organisation)
-    published_cip = FactoryBot.create(:complaints_procedure_corporate_information_page, organisation: nil, worldwide_organisation:)
-    draft_cip = FactoryBot.create(:personal_information_charter_corporate_information_page, :draft, organisation: nil, worldwide_organisation:)
+    published_cip = create(:complaints_procedure_corporate_information_page, organisation: nil, worldwide_organisation:)
+    draft_cip = create(:personal_information_charter_corporate_information_page, :draft, organisation: nil, worldwide_organisation:)
 
     presented_item = present(worldwide_organisation, state: "draft")
 
@@ -283,8 +283,8 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
 
   test "does not include the draft corporate information pages when state is not set to draft" do
     worldwide_organisation = build(:worldwide_organisation)
-    published_cip = FactoryBot.create(:complaints_procedure_corporate_information_page, organisation: nil, worldwide_organisation:)
-    FactoryBot.create(:personal_information_charter_corporate_information_page, :draft, organisation: nil, worldwide_organisation:)
+    published_cip = create(:complaints_procedure_corporate_information_page, organisation: nil, worldwide_organisation:)
+    create(:personal_information_charter_corporate_information_page, :draft, organisation: nil, worldwide_organisation:)
 
     presented_item = present(worldwide_organisation)
 
@@ -293,8 +293,8 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
 
   test "uses the updated_at date for a draft corporate information page and the CIP was updated most recently when state is set to draft" do
     worldwide_organisation = build(:worldwide_organisation, updated_at: 3.days.ago)
-    FactoryBot.create(:complaints_procedure_corporate_information_page, organisation: nil, worldwide_organisation:, updated_at: 2.days.ago)
-    draft_cip = FactoryBot.create(:personal_information_charter_corporate_information_page, :draft, organisation: nil, worldwide_organisation:, updated_at: 1.day.ago)
+    create(:complaints_procedure_corporate_information_page, organisation: nil, worldwide_organisation:, updated_at: 2.days.ago)
+    draft_cip = create(:personal_information_charter_corporate_information_page, :draft, organisation: nil, worldwide_organisation:, updated_at: 1.day.ago)
 
     presented_item = present(worldwide_organisation, state: "draft")
 
@@ -303,8 +303,8 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
 
   test "uses the updated_at date for the worldwide organisation when a CIP has a draft state and the worldwide organsation was updated most recently when state is set to draft" do
     worldwide_organisation = build(:worldwide_organisation, updated_at: 1.day.ago)
-    FactoryBot.create(:complaints_procedure_corporate_information_page, organisation: nil, worldwide_organisation:, updated_at: 2.days.ago)
-    FactoryBot.create(:personal_information_charter_corporate_information_page, :draft, organisation: nil, worldwide_organisation:, updated_at: 3.days.ago)
+    create(:complaints_procedure_corporate_information_page, organisation: nil, worldwide_organisation:, updated_at: 2.days.ago)
+    create(:personal_information_charter_corporate_information_page, :draft, organisation: nil, worldwide_organisation:, updated_at: 3.days.ago)
 
     presented_item = present(worldwide_organisation, state: "draft")
 
@@ -313,8 +313,8 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
 
   test "uses the updated_at date for the worldwide organisation when state is not set to draft" do
     worldwide_organisation = build(:worldwide_organisation, updated_at: 3.days.ago)
-    FactoryBot.create(:complaints_procedure_corporate_information_page, organisation: nil, worldwide_organisation:, updated_at: 2.days.ago)
-    FactoryBot.create(:personal_information_charter_corporate_information_page, :draft, organisation: nil, worldwide_organisation:, updated_at: 1.day.ago)
+    create(:complaints_procedure_corporate_information_page, organisation: nil, worldwide_organisation:, updated_at: 2.days.ago)
+    create(:personal_information_charter_corporate_information_page, :draft, organisation: nil, worldwide_organisation:, updated_at: 1.day.ago)
 
     presented_item = present(worldwide_organisation)
 

--- a/test/unit/app/presenters/publishing_api/worldwide_organisation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/worldwide_organisation_presenter_test.rb
@@ -257,18 +257,18 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
 
   test "default_news_image is not present when there is no image" do
     worldwide_organisation = build(:worldwide_organisation, default_news_image: nil)
-    presenter = PublishingApi::WorldwideOrganisationPresenter.new(worldwide_organisation)
+    presented_item = present(worldwide_organisation)
 
-    assert_not presenter.content[:details].key? :default_news_image
+    assert_not presented_item.content[:details].key? :default_news_image
   end
 
   test "default_news_image is not present when variants are not uploaded" do
     featured_image = build(:featured_image_data)
     featured_image.assets.destroy_all
     worldwide_organisation = build(:worldwide_organisation, default_news_image: featured_image)
-    presenter = PublishingApi::WorldwideOrganisationPresenter.new(worldwide_organisation)
+    presented_item = present(worldwide_organisation)
 
-    assert_not presenter.content[:details].key? :default_news_image
+    assert_not presented_item.content[:details].key? :default_news_image
   end
 
   test "includes the draft corporate information pages when state is set to draft" do
@@ -291,7 +291,7 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
     assert_equal [published_cip.content_id], presented_item.content.dig(:links, :corporate_information_pages)
   end
 
-  test "uses the updated_at date for a draft corporate information pages when state is set to draft and the CIP was updated most recently when state is set to draft" do
+  test "uses the updated_at date for a draft corporate information page and the CIP was updated most recently when state is set to draft" do
     worldwide_organisation = build(:worldwide_organisation, updated_at: 3.days.ago)
     FactoryBot.create(:complaints_procedure_corporate_information_page, organisation: nil, worldwide_organisation:, updated_at: 2.days.ago)
     draft_cip = FactoryBot.create(:personal_information_charter_corporate_information_page, :draft, organisation: nil, worldwide_organisation:, updated_at: 1.day.ago)


### PR DESCRIPTION
The `WorldwideOrganisationPresenter` has a half implemented solution where a `state` parameter can be used to present a draft (or other state version) of the document. This currently doesn't work, as it always includes the published versions of the corporate information pages.

However, as Worldwide Organisation pages don't support drafts (but their Coprorate Information Pages do) we never actually use the `state` paremeter in production, so the broken code never mattered.

Now we want to use the draft version of the Worldwide Organisation's presented content when doing an integrity check whilst migrating from non-editionable to editionable Worldwide Organisations.

Therefore fixing the presenter to properly support the state provided as a parameter.

[Trello card](https://trello.com/c/NFYppyyg)