### PR TITLE
Return CIPs in a consistent order

### DIFF
--- a/app/models/concerns/has_corporate_information_page_type.rb
+++ b/app/models/concerns/has_corporate_information_page_type.rb
@@ -14,7 +14,7 @@ module HasCorporateInformationPageType
 
     def self.by_menu_heading(menu_heading)
       type_ids = CorporateInformationPageType.by_menu_heading(menu_heading).map(&:id)
-      where(corporate_information_page_type_id: type_ids)
+      where(corporate_information_page_type_id: type_ids).sort_by(&:title)
     end
 
     def self.for_slug(slug)


### PR DESCRIPTION
At the moment, Corporate Information Pages (CIPs) are grouped by "menu heading". However, within each group, the CIPs are presented in database order.

This means they are inconsistently ordered between different organisations, and between different editions of the same organisation.

Therefore updating this method to return the CIPs in alphabetical order within the group, to ensure they are always the same.

This will allow us to compare presenter outputs when migrating worldwide organisations to be editionable.

[Trello card](https://trello.com/c/NFYppyyg)