### PR TITLE
Add default ordering for World Location associations

### DIFF
--- a/app/models/edition_world_location.rb
+++ b/app/models/edition_world_location.rb
@@ -4,5 +4,7 @@ class EditionWorldLocation < ApplicationRecord
 
   validates :edition, :world_location, presence: true
 
+  default_scope -> { order(:id) }
+
   scope :with_translations, ->(*locales) { joins(edition: :translations).merge(Edition.with_locales(*locales)) }
 end

--- a/app/models/worldwide_organisation_world_location.rb
+++ b/app/models/worldwide_organisation_world_location.rb
@@ -1,4 +1,6 @@
 class WorldwideOrganisationWorldLocation < ApplicationRecord
   belongs_to :worldwide_organisation
   belongs_to :world_location
+
+  default_scope -> { order(:id) }
 end


### PR DESCRIPTION
MySQL does not guarantee the order in which results are returned, instead returning results in the order of the record structure on disk.

Normally this is done by ID, but sometimes (e.g. after deletions or optimisations), records can be in the wrong order.

We want world locations to retain the order that the user added them, so need to add a default scope that ensures these are always returned in that order.  A similar default scope is already in use on the `Image` model.

[This Stack Overflow answer](https://stackoverflow.com/questions/8746519/sql-what-is-the-default-order-by-of-queries#:~:text=MySQL%20by%20default%20seems%20to,which%20is%20not%20the%20case!) explains the issue in more detail.

The issue has caused a bug in production, where the British High Commission Bridgetown has the world locations in the wrong order.  This will fix that bug for this world location and also for world locations associated with editionable worldwide organisations.

| In Whitehall (with explicit ordering through the `each_with_index` method | After publishing (without any explicit ordering) |
| -- | -- |
| ![Screenshot with countries in the order Barbados, Dominica, St Lucia, and St Kitts and Nevis](https://github.com/alphagov/whitehall/assets/6329861/01a9765f-fc61-44d0-b26f-a96ef87bc629) | ![Screenshot with countries in the order Barbados, Dominica, St Kitts and Nevis, and St Lucia](https://github.com/alphagov/whitehall/assets/6329861/3799237d-af0f-4166-989d-9dd6ef2605c5)  |

This can also be seen in the Rails console output, where the IDs are out of order (note 172798 is returned prior to 172797):
```ruby
$ worldwide_organisation.edition_world_locations.inspect
#<ActiveRecord::Associations::CollectionProxy [#<EditionWorldLocation id: 172794, edition_id: 1491746, world_location_id: 13, created_at: "2024-04-25 14:18:02.000000000 +0100", updated_at: "2024-04-25 14:18:02.000000000 +0100">, #<EditionWorldLocation id: 172795, edition_id: 1491746, world_location_id: 175, created_at: "2024-04-25 14:18:02.000000000 +0100", updated_at: "2024-04-25 14:18:02.000000000 +0100">, #<EditionWorldLocation id: 172796, edition_id: 1491746, world_location_id: 195, created_at: "2024-04-25 14:18:02.000000000 +0100", updated_at: "2024-04-25 14:18:02.000000000 +0100">, #<EditionWorldLocation id: 172798, edition_id: 1491746, world_location_id: 196, created_at: "2024-04-25 14:18:02.000000000 +0100", updated_at: "2024-04-25 14:18:02.000000000 +0100">, #<EditionWorldLocation id: 172797, edition_id: 1491746, world_location_id: 217, created_at: "2024-04-25 14:18:02.000000000 +0100", updated_at: "2024-04-25 14:18:02.000000000 +0100">]>
```

[Trello card](https://trello.com/c/NFYppyyg)