### PR TITLE
Strip spaces from the end of the slug

### DIFF
--- a/lib/data_hygiene/document_reslugger.rb
+++ b/lib/data_hygiene/document_reslugger.rb
@@ -14,7 +14,7 @@ module DataHygiene
       @document = document
       @published_edition = published_edition
       @current_user = current_user
-      @new_slug = new_slug
+      @new_slug = new_slug.strip
     end
 
     def run!

--- a/test/unit/lib/data_hygiene/document_reslugger_test.rb
+++ b/test/unit/lib/data_hygiene/document_reslugger_test.rb
@@ -47,6 +47,15 @@ class DocumentResluggerTest < ActiveSupport::TestCase
     assert_equal "new-slug", @document.slug
   end
 
+  test "updates the slug when the new slug has trailing spaces" do
+    create(:document, slug: "new-slug", document_type: "publication")
+
+    reslugger = DataHygiene::DocumentReslugger.new(@document, @published_edition, @user, "new-slug   ")
+    reslugger.run!
+
+    assert_equal "new-slug", @document.slug
+  end
+
   test "returns false and the adds an error to the document when new_slug starts with a slash" do
     reslugger = DataHygiene::DocumentReslugger.new(@document, @published_edition, @user, "/invalid slug")
     assert_equal false, reslugger.run!


### PR DESCRIPTION
Slugs can't have trailing spaces. If a user puts trailing spaces in by accident, they'll get a Server error telling them to contact support.

Specifically, the error is:

```
GdsApi::HTTPUnprocessableEntity (URL: http://publishing-api/v2/content/5f4ff56a-7631-11e4-a3cb-005056011aef
Response body:
[{"schema":{"scheme":null,"user":null,"password":null,"host":null,"port":null,"path":"518d3a74-1d42-5ac2-8593-06c64010d807","query":null,"fragment":""},"fragment":"#/base_path","message":"The property '#/base_path' value \"/guidance/lorem-ipsum-dolor-sit-amet-elit-231554       \" did not match the regex '^/(([a-zA-Z0-9._~!$\u0026'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$\u0026'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$' in schema 518d3a74-1d42-5ac2-8593-06c64010d807#","failed_attribute":"Pattern"}]):

lib/whitehall/publishing_api.rb:74:in `block in save_draft_translation'
lib/whitehall/publishing_api.rb:69:in `save_draft_translation'
lib/whitehall/publishing_api.rb:54:in `block in save_draft'
lib/whitehall/publishing_api.rb:53:in `each'
lib/whitehall/publishing_api.rb:53:in `save_draft'
lib/whitehall/publishing_api.rb:25:in `publish'
app/workers/publishing_api_document_republishing_worker.rb:96:in `send_live_edition'
app/workers/publishing_api_document_republishing_worker.rb:47:in `block in perform'
app/workers/publishing_api_document_republishing_worker.rb:31:in `perform'
lib/data_hygiene/document_reslugger.rb:56:in `republish_document'
lib/data_hygiene/document_reslugger.rb:26:in `run!'
app/controllers/admin/edition_slug_controller.rb:10:in `update_slug'
```

Fixes #8762
