### PR TITLE
Do not require world locations for editionable worldwide organisations

### DIFF
--- a/app/models/editionable_worldwide_organisation.rb
+++ b/app/models/editionable_worldwide_organisation.rb
@@ -164,10 +164,6 @@ class EditionableWorldwideOrganisation < Edition
     false
   end
 
-  def skip_world_location_validation?
-    false
-  end
-
   def summary_required?
     false
   end

--- a/test/unit/app/models/editionable_worldwide_organisation_test.rb
+++ b/test/unit/app/models/editionable_worldwide_organisation_test.rb
@@ -360,4 +360,11 @@ class EditionableWorldwideOrganisationTest < ActiveSupport::TestCase
     organisation = build(:editionable_worldwide_organisation)
     organisation.attachments << build(:file_attachment)
   end
+
+  test "does not require a world location" do
+    organisation = build(:editionable_worldwide_organisation)
+    organisation.world_locations = []
+
+    assert_valid organisation
+  end
 end


### PR DESCRIPTION
Non-editionable worldwide organisations do not require any world locations.

Therefore updating the editionable worldwide organisations to match.

[Trello card](https://trello.com/c/NFYppyyg)