### PR TITLE
EMERGENCY: Add mapped_specialist_topic_content_id again

### DIFF
--- a/db/migrate/20240429113105_add_mapped_specialist_topic_content_id_to_editions.rb
+++ b/db/migrate/20240429113105_add_mapped_specialist_topic_content_id_to_editions.rb
@@ -1,0 +1,5 @@
+class AddMappedSpecialistTopicContentIdToEditions < ActiveRecord::Migration[7.1]
+  def change
+    add_column :editions, :mapped_specialist_topic_content_id, :string, null: true, default: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_22_091946) do
+ActiveRecord::Schema[7.1].define(version: 2024_04_29_113105) do
   create_table "assets", charset: "utf8mb3", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.string "variant", null: false
@@ -407,6 +407,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_22_091946) do
     t.integer "main_office_id"
     t.string "logo_formatted_name"
     t.string "analytics_identifier"
+    t.string "mapped_specialist_topic_content_id"
     t.index ["alternative_format_provider_id"], name: "index_editions_on_alternative_format_provider_id"
     t.index ["closing_at"], name: "index_editions_on_closing_at"
     t.index ["document_id"], name: "index_editions_on_document_id"


### PR DESCRIPTION
Reverses f06dc91b60f62ba2b4694e4a5bfcc7ac86518d1a

There were some errors in Sentry related to that commit, so I've prepared this commit just in case the issues are persisten and the previous one needs to be reverted.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
