### PR TITLE
Make worldwide organisation body content consistent

### DIFF
--- a/app/presenters/publishing_api/editionable_worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/editionable_worldwide_organisation_presenter.rb
@@ -62,7 +62,11 @@ module PublishingApi
   private
 
     def body
-      Whitehall::GovspeakRenderer.new.govspeak_edition_to_html(item)
+      if item.body.present?
+        Whitehall::GovspeakRenderer.new.govspeak_edition_to_html(item)
+      else
+        ""
+      end
     end
 
     def details

--- a/test/unit/app/presenters/publishing_api/editionable_worldwide_organisation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/editionable_worldwide_organisation_presenter_test.rb
@@ -212,4 +212,28 @@ class PublishingApi::EditionableWorldwideOrganisationPresenterTest < ActiveSuppo
 
     assert_not presented_item.content[:details].key? :default_news_image
   end
+
+  test "does not convert an absent body to govspeak" do
+    worldwide_org = create(:editionable_worldwide_organisation)
+
+    # rubocop:disable Rails/SkipsModelValidations
+    worldwide_org.update_attribute(:body, nil)
+    # rubocop:enable Rails/SkipsModelValidations
+
+    presented_item = present(worldwide_org.reload)
+
+    assert_equal "", presented_item.content.dig(:details, :body)
+  end
+
+  test "does not convert an empty body to govspeak" do
+    worldwide_org = create(:editionable_worldwide_organisation)
+
+    # rubocop:disable Rails/SkipsModelValidations
+    worldwide_org.update_attribute(:body, "")
+    # rubocop:enable Rails/SkipsModelValidations
+
+    presented_item = present(worldwide_org.reload)
+
+    assert_equal "", presented_item.content.dig(:details, :body)
+  end
 end


### PR DESCRIPTION
The body of an editionable worldwide organisation without any content was different to that of a non-editionable worldwide organisation (i.e. we were including an empty div as govspeak conversion was taking place).

Updating the edtionable presenter to ensure both types are consistent.

[Trello card](https://trello.com/c/NFYppyyg)