### PR TITLE
Include `default_news_image` for editionable worldwide organisation

### DIFF
--- a/app/presenters/publishing_api/editionable_worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/editionable_worldwide_organisation_presenter.rb
@@ -4,6 +4,7 @@ module PublishingApi
     include ActionView::Helpers::UrlHelper
     include ApplicationHelper
     include OrganisationHelper
+    include Presenters::PublishingApi::DefaultNewsImageHelper
 
     attr_accessor :item, :update_type, :state
 
@@ -23,19 +24,7 @@ module PublishingApi
 
       content.merge!(
         description: item.summary,
-        details: {
-          body:,
-          logo: {
-            crest: "single-identity",
-            formatted_title: worldwide_organisation_logo_name(item),
-          },
-          ordered_corporate_information_pages:,
-          secondary_corporate_information_pages:,
-          office_contact_associations:,
-          people_role_associations:,
-          social_media_links:,
-          world_location_names:,
-        },
+        details:,
         document_type:,
         links: edition_links,
         public_updated_at: item.updated_at,
@@ -74,6 +63,24 @@ module PublishingApi
 
     def body
       Whitehall::GovspeakRenderer.new.govspeak_edition_to_html(item)
+    end
+
+    def details
+      details = {
+        body:,
+        logo: {
+          crest: "single-identity",
+          formatted_title: worldwide_organisation_logo_name(item),
+        },
+        ordered_corporate_information_pages:,
+        secondary_corporate_information_pages:,
+        office_contact_associations:,
+        people_role_associations:,
+        social_media_links:,
+        world_location_names:,
+      }
+      details[:default_news_image] = present_default_news_image(item) if present_default_news_image(item).present?
+      details
     end
 
     def office_staff


### PR DESCRIPTION
This attribute is [included in the presenter](https://github.com/alphagov/whitehall/blob/607d5d19cf94d5b2681e1eb6c712d3ff4f80a81f/app/presenters/publishing_api/worldwide_organisation_presenter.rb#L299) for non-editionable worldwide organisations, but not the editionable worldwide organisation.

Therefore adding it to the presenter and copying the tests that are included for the non-editionable presenter.

[Trello card](https://trello.com/c/NFYppyyg)