### PR TITLE
Provide a rake task to allow developers to reinstate a deleted document

### DIFF
--- a/lib/data_hygiene/deleted_document_restorer.rb
+++ b/lib/data_hygiene/deleted_document_restorer.rb
@@ -1,0 +1,32 @@
+class DataHygiene::DeletedDocumentRestorer
+  def initialize(document_id, user_email)
+    @document_id = document_id
+    @user_email = user_email
+  end
+
+  def run!
+    latest_edition = Edition.unscoped.where(document_id: @document_id).last
+
+    unless latest_edition.deleted?
+      raise RestoreDocumentError.latest_edition_not_deleted
+    end
+
+    user = User.where(email: @user_email).first
+
+    if user.nil?
+      raise RestoreDocumentError.user_not_found(@user_email)
+    end
+
+    latest_edition.create_draft(user, allow_creating_draft_from_deleted_edition: true)
+  end
+
+  class RestoreDocumentError < StandardError
+    def self.latest_edition_not_deleted
+      new("This document's latest edition is not deleted")
+    end
+
+    def self.user_not_found(user_email)
+      new("This document doesn't exist for user with email #{user_email}")
+    end
+  end
+end

--- a/lib/tasks/data_hygiene.rake
+++ b/lib/tasks/data_hygiene.rake
@@ -32,4 +32,16 @@ namespace :data_hygiene do
       speech.save!(validate: false)
     end
   end
+
+  desc "Restore a deleted document by creating a new edition from its latest deleted draft"
+  task :restore_deleted_document, %i[document_id user_email] => :environment do |_, args|
+    deleted_document_restorer = DataHygiene::DeletedDocumentRestorer.new(args[:document_id], args[:user_email])
+
+    begin
+      deleted_document_restorer.run!
+      puts "Created a new draft for document with ID #{args[:document_id]}"
+    rescue DataHygiene::DeletedDocumentRestorer::RestoreDocumentError => e
+      puts e.message
+    end
+  end
 end

--- a/test/unit/lib/data_hygiene/deleted_document_restorer_test.rb
+++ b/test/unit/lib/data_hygiene/deleted_document_restorer_test.rb
@@ -1,0 +1,39 @@
+require "test_helper"
+
+class DataHygiene::DeletedDocumentRestorerTest < ActiveSupport::TestCase
+  test "it raises a document state error when the document's latest edition is not deleted" do
+    published_edition = create(:published_edition)
+    user = create(:user)
+    restorer = DataHygiene::DeletedDocumentRestorer.new(published_edition.document.id, user.email)
+
+    error = assert_raises DataHygiene::DeletedDocumentRestorer::RestoreDocumentError do
+      restorer.run!
+    end
+    assert_equal error.message, "This document's latest edition is not deleted"
+  end
+
+  test "it raises a user not found error when there is no user found for the provided email address" do
+    deleted_edition = create(:deleted_edition)
+    email = "missing-user@example.com"
+
+    restorer = DataHygiene::DeletedDocumentRestorer.new(deleted_edition.document.id, email)
+
+    error = assert_raises DataHygiene::DeletedDocumentRestorer::RestoreDocumentError do
+      restorer.run!
+    end
+    assert_equal error.message, "This document doesn't exist for user with email #{email}"
+  end
+
+  test "it creates a new draft of the deleted document with the provided user as the author" do
+    deleted_edition = create(:deleted_edition)
+    user = create(:user)
+
+    restorer = DataHygiene::DeletedDocumentRestorer.new(deleted_edition.document.id, user.email)
+
+    restorer.run!
+
+    document = deleted_edition.document.reload
+    assert document.latest_edition.draft?
+    assert_equal document.latest_edition.creator, user
+  end
+end


### PR DESCRIPTION
Sometimes a document gets into a state where its live edition is deleted. We don't currently understand how this happens, but Publishing API and Content Store are not updated to reflect the fact that the edition has been deleted.

It is not possible to recover from this situation via the Whitehall user interface, but the Edition model does expose a method for creating a new draft edition from a deleted edition. This commit provides a rake task to call the method safely so that we can allow users to recover the deleted document.

Trello: https://trello.com/c/mIxPZUew

Original Zendesk ticket: https://govuk.zendesk.com/agent/tickets/5799605
