### PR TITLE
Save visual editor content html attachments

### DIFF
--- a/app/views/admin/attachments/_form.html.erb
+++ b/app/views/admin/attachments/_form.html.erb
@@ -52,6 +52,7 @@
             value: form.object.govspeak_content.body,
             error_items: errors_for(attachment.errors, :"govspeak_content.body"),
             right_to_left:  form.object.rtl_locale?,
+            id: "attachment_govspeak_content_body",
           } %>
         <% else %>
         <%= render "components/govspeak_editor", {

--- a/features/renders_govspeak_editor_no_js.feature
+++ b/features/renders_govspeak_editor_no_js.feature
@@ -7,3 +7,7 @@ Feature: Renders govspeak editor if JS is disabled
   Scenario: I create a new publication
     When I start creating a new publication
     Then I should see the textarea instead of the visual editor
+
+  Scenario: I create a new HTML attachment
+    When I start creating a new HTML attachment for publication "Publication with HTML attachments and visual editor"
+    Then I should see the textarea instead of the visual editor

--- a/features/renders_govspeak_editor_no_permission.feature
+++ b/features/renders_govspeak_editor_no_permission.feature
@@ -7,3 +7,8 @@ Feature: Renders govspeak editor if no visual editor permission is given
   Scenario: I create a new publication
     When I start creating a new publication
     Then I should see the govspeak editor instead of the visual editor
+
+  @javascript
+  Scenario: I create a new HTML attachment
+    When I start creating a new HTML attachment for publication "Publication with HTML attachments and visual editor"
+    Then I should see the govspeak editor instead of the visual editor

--- a/features/step_definitions/visual_editor_steps.rb
+++ b/features/step_definitions/visual_editor_steps.rb
@@ -38,17 +38,24 @@ Then(/^I see the visual editor on subsequent edits of the publication$/) do
   expect(page).to have_content("Any old iron")
 end
 
-When(/^I start creating a new HTML attachment for a publication$/) do
-  publication = create(:publication)
-  visit new_admin_edition_attachment_path(publication, type: "html")
+When(/^I start creating a new HTML attachment for publication "(.*?)"$/) do |title|
+  @publication = create(:publication, title:, attachments: [])
+  visit new_admin_edition_attachment_path(@publication, type: "html")
 end
 
-Given(/^a draft publication with an HTML attachment "(.*?)" exists$/) do |title|
-  html_attachment = create(:html_attachment, title:)
-  @publication = create(:publication, attachments: [html_attachment])
+When(/^I fill in the required fields for HTML attachment "(.*?)"$/) do |title|
+  fill_in "Title", with: title
+  find(".ProseMirror").base.send_keys("Any old iron")
+  check "Use manually numbered headings"
 end
 
-When(/^I edit the HTML attachment "(.*?)"$/) do |title|
-  html_attachment = Attachment.find_by(title:)
-  visit edit_admin_edition_attachment_path(@publication, html_attachment)
+And(/^I save the HTML attachment$/) do
+  click_on "Save"
+end
+
+Then(/^I see the visual editor on subsequent edits of the HTML attachment$/) do
+  click_link "Edit attachment"
+  expect(page).to have_selector(".app-c-visual-editor__container")
+  expect(page).not_to have_selector(".app-c-govspeak-editor")
+  expect(page).to have_content("Any old iron")
 end

--- a/features/visual-editor.feature
+++ b/features/visual-editor.feature
@@ -15,11 +15,10 @@ Feature: Save edition content with visual editor
     
   @javascript
   Scenario: I create a new HTML attachment
-    When I start creating a new HTML attachment for a publication
+    When I start creating a new HTML attachment for publication "Publication with HTML attachments and visual editor"
     Then I should see the visual editor instead of the govspeak editor
+    When I fill in the required fields for HTML attachment "HTML Attachment with visual editor"
+    And I save the HTML attachment
+    Then I see the visual editor on subsequent edits of the HTML attachment
+    And I force publish the publication "Publication with HTML attachments and visual editor"
 
-  @javascript
-  Scenario: I edit an existing HTML attachment
-    Given a draft publication with an HTML attachment "HTML Attachment with visual editor" exists
-    When I edit the HTML attachment "HTML Attachment with visual editor"
-    Then I should see the visual editor instead of the govspeak editor


### PR DESCRIPTION
Introduced feature tests to cover flow of saving content with visual editor for HTML attachments.

[Trello card](https://trello.com/c/4iDwXa2d/2533-save-visual-editor-content-to-document-html-attachments)