### PR TITLE
Allow external redirects to victimandwitnessinformation.org.uk

### DIFF
--- a/app/models/offsite_link.rb
+++ b/app/models/offsite_link.rb
@@ -105,6 +105,7 @@ private
       "beisgovuk.citizenspace.com",
       "nhs.uk",
       "royal.uk",
+      "victimandwitnessinformation.org.uk",
     ]
 
     permitted_hosts.any? { |permitted_host| host =~ /(?:^|\.)#{permitted_host}$/ }


### PR DESCRIPTION
This allows users to feature "Victim and Witness Information" content on their organisation homepage.

Requested (and approved by Policy & Strategy) in
https://govuk.zendesk.com/agent/tickets/5632486.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
