### PR TITLE
Implement exiting the visual editor experience for private-beta users (Editions)

### DIFF
--- a/app/assets/javascripts/components/govspeak-editor.js
+++ b/app/assets/javascripts/components/govspeak-editor.js
@@ -17,9 +17,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {}
     this.textareaWrapper = this.module.querySelector(
       '.app-c-govspeak-editor__textarea'
     )
-    this.textarea = this.module.querySelector(
-      this.previewButton.getAttribute('data-content-target')
-    )
+    this.textarea = this.textareaWrapper.querySelector('textarea')
     this.shouldTrackToggle =
       this.previewButton.getAttribute('data-preview-toggle-tracking') === 'true'
 

--- a/app/assets/javascripts/components/visual-editor.js
+++ b/app/assets/javascripts/components/visual-editor.js
@@ -5,24 +5,63 @@ window.GOVUK.Modules = window.GOVUK.Modules || {}
 ;(function (Modules) {
   function VisualEditor(module) {
     this.module = module
-
-    this.content = module.querySelector('.app-c-visual-editor__content')
-    this.container = module.querySelector('.app-c-visual-editor__container')
-    this.textarea = module.querySelector(
-      '.app-c-visual-editor__textarea-wrapper textarea'
-    )
   }
 
   VisualEditor.prototype.init = function () {
-    this.textarea.classList.add('app-c-visual-editor__textarea--hidden')
-    const id = this.textarea.getAttribute('id')
-    this.textarea.removeAttribute('id')
+    this.content = this.module.querySelector('.app-c-visual-editor__content')
+    this.container = this.module.querySelector(
+      '.app-c-visual-editor__container'
+    )
+    this.textarea = this.module.querySelector(
+      '.app-c-visual-editor__govspeak-editor-wrapper textarea'
+    )
 
     new window.GovspeakVisualEditor(this.content, this.container, this.textarea) // eslint-disable-line no-new
 
-    this.container
-      .querySelector('div[contenteditable="true"]')
-      .setAttribute('id', id)
+    this.govspeakEditorwrapper = this.module.querySelector(
+      '.app-c-visual-editor__govspeak-editor-wrapper'
+    )
+    this.visualEditorWrapper = this.module.querySelector(
+      '.app-c-visual-editor__visual-editor-wrapper'
+    )
+    this.exitButton = this.module.querySelector(
+      '.js-app-c-visual-editor__exit-button'
+    )
+    this.visual_editor_flag = document.querySelector(
+      '.app-c-visual-editor__hidden-field'
+    )
+    this.contentEditable = this.container.querySelector(
+      'div[contenteditable="true"]'
+    )
+
+    this.exitButton.addEventListener('click', this.hideVisualEditor.bind(this))
+    this.showVisualEditor()
+  }
+
+  VisualEditor.prototype.showVisualEditor = function () {
+    this.govspeakEditorwrapper.classList.add(
+      'app-c-visual-editor__govspeak-editor-wrapper--hidden'
+    )
+    this.visualEditorWrapper.classList.add(
+      'app-c-visual-editor__visual-editor-wrapper--show'
+    )
+    this.visual_editor_flag.value = true
+
+    this.contentEditable.setAttribute('id', this.textarea.getAttribute('id'))
+    this.textarea.removeAttribute('id')
+  }
+
+  VisualEditor.prototype.hideVisualEditor = function () {
+    this.govspeakEditorwrapper.classList.remove(
+      'app-c-visual-editor__govspeak-editor-wrapper--hidden'
+    )
+    this.visualEditorWrapper.classList.remove(
+      'app-c-visual-editor__visual-editor-wrapper--show'
+    )
+    this.visual_editor_flag.value = false
+
+    this.textarea.setAttribute('id', this.contentEditable.getAttribute('id'))
+    this.contentEditable.removeAttribute('id')
   }
 
   Modules.VisualEditor = VisualEditor

--- a/app/assets/stylesheets/components/_visual-editor.scss
+++ b/app/assets/stylesheets/components/_visual-editor.scss
@@ -1,6 +1,11 @@
 @import "govspeak-visual-editor/dist/style";
 
 .app-c-visual-editor__content,
-.app-c-visual-editor__textarea--hidden {
+.app-c-visual-editor__visual-editor-wrapper,
+.app-c-visual-editor__govspeak-editor-wrapper--hidden {
   display: none;
+}
+
+.app-c-visual-editor__visual-editor-wrapper--show {
+  display: block;
 }

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -239,6 +239,7 @@ private
       :read_consultation_principles,
       :all_nation_applicability,
       :speaker_radios,
+      :visual_editor,
       :logo_formatted_name,
       {
         all_nation_applicability: [],
@@ -338,6 +339,9 @@ private
     edition_locale = edition_params[:primary_locale] || I18n.default_locale
     I18n.with_locale(edition_locale) do
       @edition = LocalisedModel.new(new_edition, edition_locale)
+      if @edition.visual_editor.nil?
+        @edition.visual_editor = Flipflop.govspeak_visual_editor? && current_user.can_see_visual_editor_private_beta?
+      end
     end
   end
 

--- a/app/views/admin/attachments/_form.html.erb
+++ b/app/views/admin/attachments/_form.html.erb
@@ -49,10 +49,16 @@
               heading_size: "l",
             },
             name: "attachment[govspeak_content_attributes][body]",
+            rows: 20,
+            id: "attachment_govspeak_content_body",
             value: form.object.govspeak_content.body,
             error_items: errors_for(attachment.errors, :"govspeak_content.body"),
             right_to_left:  form.object.rtl_locale?,
-            id: "attachment_govspeak_content_body",
+            data_attributes: {
+              image_ids: @edition && @edition.images.any? ? @edition.images.map { |img| img[:id] } : [],
+              attachment_ids: [], # HTML attachments cannot embed Attachments from their parent Edition
+            },
+            hidden_field_name: nil,
           } %>
         <% else %>
         <%= render "components/govspeak_editor", {

--- a/app/views/admin/editions/_standard_fields.html.erb
+++ b/app/views/admin/editions/_standard_fields.html.erb
@@ -64,17 +64,24 @@
   </div>
 
   <div class="govuk-!-margin-bottom-8 js-locale-switcher-field">
-    <% if Flipflop.govspeak_visual_editor? && current_user.can_see_visual_editor_private_beta? %>
+    <% if Flipflop.govspeak_visual_editor? && current_user.can_see_visual_editor_private_beta? && form.object.visual_editor %>
       <%= render "components/visual_editor", {
         label: {
           text: "Body" + "#{' (required)' if form.object.body_required?}",
           heading_size: "m",
         },
         name: "edition[body]",
+        id: "edition_body",
         value: edition.body,
+        rows: 20,
         error_items: errors_for(edition.errors, :body),
         right_to_left: form.object.translation_rtl?,
-        id: "edition_body",
+        data_attributes: {
+          image_ids: edition.images.map { |img| img[:id] }.to_json,
+          attachment_ids: edition.allows_inline_attachments? ? edition.attachments.map(&:id) : [],
+          alternative_format_provider_id: (edition.alternative_format_provider_id || current_user.organisation.try(:id)),
+        },
+        hidden_field_name: "edition[visual_editor]",
       } %>
     <% else %>
       <%= render "components/govspeak_editor", {
@@ -94,6 +101,7 @@
           alternative_format_provider_id: (edition.alternative_format_provider_id || current_user.organisation.try(:id)),
         },
       } %>
+      <%= hidden_field_tag "edition[visual_editor]", false %>
     <% end %>
   </div>
 

--- a/app/views/components/_visual_editor.html.erb
+++ b/app/views/components/_visual_editor.html.erb
@@ -1,37 +1,54 @@
 <%
   id ||= "#{name}-#{SecureRandom.hex(4)}"
-  error_items ||= nil
-  right_to_left ||= false
-  rows ||= 20
+  label_id = "#{id}-label"
   value ||= nil
-
-  data_attributes ||= {}
-  data_attributes[:module] ||= ""
-  data_attributes[:module] << "visual-editor"
+  error_items ||= nil
 
   error_class = "govuk-form-group--error" if error_items
 %>
 
-<%= tag.div class: error_class, data: data_attributes do %>
-  <div class="app-c-visual-editor__textarea-wrapper">
-    <%= render "govuk_publishing_components/components/textarea", {
-      name: name,
-      id: id,
-      label: label,
-      rows: rows,
-      value: value,
-      error_items: error_items,
-      margin_bottom: 0,
-      right_to_left: right_to_left,
-      right_to_left_help: false,
+<%= tag.div class: error_class, "data-module": "visual-editor" do %>
+  <div class="app-c-visual-editor__govspeak-editor-wrapper">
+    <%= render "components/govspeak_editor", {
+      label:,
+      name:,
+      id:,
+      value:,
+      rows:,
+      error_items:,
+      right_to_left:,
+      data_attributes:,
     } %>
   </div>
 
-  <div class="app-c-visual-editor__content">
-    <%= govspeak_to_admin_html value, [], [], nil %>
+  <div class="app-c-visual-editor__visual-editor-wrapper">
+    <%= render "govuk_publishing_components/components/label", {
+        id: label_id,
+        html_for: id,
+      }.merge(label.symbolize_keys) %>
+    <div class="js-app-c-visual-editor__inset-text">
+    <%= render "govuk_publishing_components/components/inset_text", {
+    } do %>
+      <p class="govuk-body">Thanks for being part of the beta trial to experiment the visual editor. This is an early version and does not support all content design and formatting needs.</p>
+      <p class="govuk-body">If you are blocked you can save your work so far and continue with the markdown editor.</p>
+      <p class="govuk-body">Note that you will not be able switch back to the visual editor only for this document. Visual editor will be available on a new document.</p>
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Continue in markdown editor",
+        secondary_solid: true,
+        type: "button",
+        classes: "js-app-c-visual-editor__exit-button",
+      } %>
+    <% end %>
+    </div>
+
+    <div class="app-c-visual-editor__content">
+      <%= govspeak_to_admin_html value, [], [], nil %>
+    </div>
+
+    <div class="app-c-visual-editor__container"></div>
   </div>
 
-  <div class="app-c-visual-editor__container"></div>
+  <%= hidden_field_tag hidden_field_name, false, {class: "app-c-visual-editor__hidden-field"} %>
 <% end %>
 
 <%= javascript_include_tag "components/visual-editor", :type => "module" %>

--- a/db/migrate/20240501173819_add_visual_editor_to_editions.rb
+++ b/db/migrate/20240501173819_add_visual_editor_to_editions.rb
@@ -1,0 +1,5 @@
+class AddVisualEditorToEditions < ActiveRecord::Migration[7.1]
+  def change
+    add_column :editions, :visual_editor, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_04_22_091946) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_01_173819) do
   create_table "assets", charset: "utf8mb3", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.string "variant", null: false
@@ -407,6 +407,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_22_091946) do
     t.integer "main_office_id"
     t.string "logo_formatted_name"
     t.string "analytics_identifier"
+    t.boolean "visual_editor"
     t.index ["alternative_format_provider_id"], name: "index_editions_on_alternative_format_provider_id"
     t.index ["closing_at"], name: "index_editions_on_closing_at"
     t.index ["document_id"], name: "index_editions_on_document_id"

--- a/features/renders_govspeak_editor_no_js.feature
+++ b/features/renders_govspeak_editor_no_js.feature
@@ -6,8 +6,15 @@ Feature: Renders govspeak editor if JS is disabled
 
   Scenario: I create a new publication
     When I start creating a new publication
-    Then I should see the textarea instead of the visual editor
+    Then I should see the govspeak editor instead of the visual editor
+
+  Scenario: I edit a publication saved with visual editor
+    When I edit a publication saved with visual editor
+    Then I should see the govspeak editor instead of the visual editor
+    When I update the publication in the govspeak editor
+    And I save and go to document summary
+    Then I should see the govspeak editor on subsequent edits of the publication
 
   Scenario: I create a new HTML attachment
     When I start creating a new HTML attachment for publication "Publication with HTML attachments and visual editor"
-    Then I should see the textarea instead of the visual editor
+    Then I should see the govspeak editor instead of the visual editor

--- a/features/renders_govspeak_editor_no_permission.feature
+++ b/features/renders_govspeak_editor_no_permission.feature
@@ -6,9 +6,17 @@ Feature: Renders govspeak editor if no visual editor permission is given
   @javascript
   Scenario: I create a new publication
     When I start creating a new publication
-    Then I should see the govspeak editor instead of the visual editor
+    Then I should see the govspeak editor
+
+  @javascript
+  Scenario: I edit a publication saved with visual editor
+    When I edit a publication saved with visual editor
+    Then I should see the govspeak editor
+    When I update the publication in the govspeak editor
+    And I save and go to document summary
+    Then I should see the govspeak editor on subsequent edits of the publication
 
   @javascript
   Scenario: I create a new HTML attachment
     When I start creating a new HTML attachment for publication "Publication with HTML attachments and visual editor"
-    Then I should see the govspeak editor instead of the visual editor
+    Then I should see the govspeak editor

--- a/features/step_definitions/visual_editor_steps.rb
+++ b/features/step_definitions/visual_editor_steps.rb
@@ -8,19 +8,43 @@ When(/^I start creating a new publication$/) do
 end
 
 Then(/^I should see the visual editor instead of the govspeak editor$/) do
-  expect(page).to have_selector(".app-c-visual-editor__container")
-  expect(page).not_to have_selector(".app-c-visual-editor__container:empty")
-  expect(page).not_to have_selector(".app-c-govspeak-editor")
+  expect(page).to have_selector(".app-c-visual-editor__visual-editor-wrapper", visible: true)
+  expect(page).to have_selector(".app-c-visual-editor__govspeak-editor-wrapper", visible: false)
 end
 
 Then(/^I should see the govspeak editor instead of the visual editor$/) do
-  expect(page).to have_selector(".app-c-govspeak-editor")
-  expect(page).not_to have_selector(".app-c-visual-editor__container")
+  expect(page).to have_selector(".app-c-visual-editor__govspeak-editor-wrapper", visible: true)
+  expect(page).to have_selector(".app-c-visual-editor__visual-editor-wrapper", visible: false)
 end
 
-Then(/^I should see the textarea instead of the visual editor$/) do
-  expect(page).to have_selector(".app-c-visual-editor__textarea-wrapper textarea", visible: true)
-  expect(page).to have_selector(".app-c-visual-editor__container:empty")
+Then(/^I should see the govspeak editor$/) do
+  # The visual editor component is never rendered
+  expect(page).to have_selector(".app-c-govspeak-editor")
+  expect(page).not_to have_selector(".app-c-visual-editor__visual-editor-wrapper")
+  expect(page).not_to have_selector(".app-c-visual-editor__govspeak-editor-wrapper")
+end
+
+Then(/^I should see the visual editor on subsequent edits of the publication$/) do
+  click_link "Edit draft"
+  expect(page).to have_selector(".app-c-visual-editor__visual-editor-wrapper", visible: true)
+  expect(page).to have_selector(".app-c-visual-editor__govspeak-editor-wrapper", visible: false)
+  expect(page).to have_content("Any old iron")
+end
+
+Then(/^I should see the visual editor on subsequent edits of the HTML attachment$/) do
+  click_link "Edit attachment"
+  expect(page).to have_selector(".app-c-visual-editor__visual-editor-wrapper", visible: true)
+  expect(page).to have_selector(".app-c-visual-editor__govspeak-editor-wrapper", visible: false)
+  expect(page).to have_content("Any old iron")
+end
+
+Then(/^I should see the govspeak editor on subsequent edits of the publication$/) do
+  click_link "Edit draft"
+  expect(page).to have_selector(".app-c-govspeak-editor")
+  # When the document is marked as exited the visual editor is not rendered at all
+  expect(page).not_to have_selector(".app-c-visual-editor__visual-editor-wrapper")
+  expect(page).not_to have_selector(".app-c-visual-editor__govspeak-editor-wrapper")
+  expect(page).to have_content("Any old iron")
 end
 
 When(/^I fill in the required fields for publication "(.*?)" in organisation "(.*?)"$/) do |title, organisation_name|
@@ -29,13 +53,6 @@ end
 
 And(/^I save and go to document summary$/) do
   click_button "Save and go to document summary"
-end
-
-Then(/^I see the visual editor on subsequent edits of the publication$/) do
-  click_link "Edit draft"
-  expect(page).to have_selector(".app-c-visual-editor__container")
-  expect(page).not_to have_selector(".app-c-govspeak-editor")
-  expect(page).to have_content("Any old iron")
 end
 
 When(/^I start creating a new HTML attachment for publication "(.*?)"$/) do |title|
@@ -53,9 +70,29 @@ And(/^I save the HTML attachment$/) do
   click_on "Save"
 end
 
-Then(/^I see the visual editor on subsequent edits of the HTML attachment$/) do
-  click_link "Edit attachment"
-  expect(page).to have_selector(".app-c-visual-editor__container")
-  expect(page).not_to have_selector(".app-c-govspeak-editor")
-  expect(page).to have_content("Any old iron")
+And(/^I exit the visual editor experience$/) do
+  click_on "Continue in markdown editor"
+end
+
+When(/^I edit a pre-existing publication$/) do
+  publication = create(:publication, visual_editor: nil)
+  visit edit_admin_publication_path(publication)
+end
+
+When(/^I update the publication in the govspeak editor$/) do
+  fill_in "edition_body", with: "Any old iron"
+end
+
+When(/^I update the publication in the visual editor$/) do
+  find(".ProseMirror").base.send_keys("Any old iron")
+end
+
+When(/^I edit a publication saved with visual editor$/) do
+  publication = create(:publication, visual_editor: true)
+  visit edit_admin_publication_path(publication)
+end
+
+When(/^I edit a publication that has been previously exited$/) do
+  publication = create(:publication, visual_editor: false)
+  visit edit_admin_publication_path(publication)
 end

--- a/features/visual-editor.feature
+++ b/features/visual-editor.feature
@@ -10,15 +10,49 @@ Feature: Save edition content with visual editor
     Then I should see the visual editor instead of the govspeak editor
     When I fill in the required fields for publication "Publication with visual editor" in organisation "Visual ministry"
     And I save and go to document summary
-    Then I see the visual editor on subsequent edits of the publication
+    Then I should see the visual editor on subsequent edits of the publication
     And I force publish the publication "Publication with visual editor"
-    
+
+  @javascript
+  Scenario: I create a new publication and exit the visual editor experience
+    When I start creating a new publication
+    Then I should see the visual editor instead of the govspeak editor
+    When I fill in the required fields for publication "Publication with visual editor" in organisation "Visual ministry"
+    And I exit the visual editor experience
+    Then I should see the govspeak editor instead of the visual editor
+    When I save and go to document summary
+    Then I should see the govspeak editor on subsequent edits of the publication
+
+  @javascript
+  Scenario: I edit a publication saved with visual editor
+    When I edit a publication saved with visual editor
+    Then I should see the visual editor instead of the govspeak editor
+    When I update the publication in the visual editor
+    And I exit the visual editor experience
+    And I save and go to document summary
+    Then I should see the govspeak editor on subsequent edits of the publication
+
+  @javascript
+  Scenario: I edit a publication that has been previously exited
+    When I edit a publication that has been previously exited
+    Then I should see the govspeak editor
+    When I update the publication in the govspeak editor
+    And I save and go to document summary
+    Then I should see the govspeak editor on subsequent edits of the publication
+
+  @javascript
+  Scenario: I edit a pre-existing publication (never edited with visual editor)
+    When I edit a pre-existing publication
+    Then I should see the govspeak editor
+    When I update the publication in the govspeak editor
+    And I save and go to document summary
+    Then I should see the govspeak editor on subsequent edits of the publication
+
   @javascript
   Scenario: I create a new HTML attachment
     When I start creating a new HTML attachment for publication "Publication with HTML attachments and visual editor"
     Then I should see the visual editor instead of the govspeak editor
     When I fill in the required fields for HTML attachment "HTML Attachment with visual editor"
     And I save the HTML attachment
-    Then I see the visual editor on subsequent edits of the HTML attachment
+    Then I should see the visual editor on subsequent edits of the HTML attachment
     And I force publish the publication "Publication with HTML attachments and visual editor"
-

--- a/test/components/visual_editor_test.rb
+++ b/test/components/visual_editor_test.rb
@@ -17,6 +17,10 @@ class VisualeditorComponentTest < ComponentTestCase
       label: {
         text: "my-label",
       },
+      rows: 10,
+      right_to_left: false,
+      data_attributes: {},
+      hidden_field_name: "object[name]",
     })
 
     assert_select "div[data-module='visual-editor']"

--- a/test/functional/admin/consultations_controller_test.rb
+++ b/test/functional/admin/consultations_controller_test.rb
@@ -396,6 +396,17 @@ class Admin::ConsultationsControllerTest < ActionController::TestCase
     post :create, params: { edition: attributes }
   end
 
+  test "saves the visual editor flag" do
+    attributes = controller_attributes_for(
+      :consultation,
+      visual_editor: true,
+    )
+
+    post :create, params: { edition: attributes }
+
+    assert_equal true, Consultation.last.visual_editor
+  end
+
 private
 
   def controller_attributes_for(edition_type, attributes = {})

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -192,15 +192,37 @@ module AdminEditionControllerTestHelpers
         assert_select(".js-app-c-govspeak-editor__preview-button")
       end
 
-      view_test "edit form has visual editor when enabled and user has permission" do
+      view_test "edit form renders visual editor when feature flag is enabled, user has permission, and edition has been saved with visual editor" do
         feature_flags.switch!(:govspeak_visual_editor, true)
         current_user.permissions << User::Permissions::VISUAL_EDITOR_PRIVATE_BETA
 
-        edition = create(edition_type) # rubocop:disable Rails/SaveBang
+        edition = create(edition_type, visual_editor: true)
 
         get :edit, params: { id: edition }
 
         assert_select(".app-c-visual-editor__container")
+      end
+
+      view_test "edit form does not render visual editor for exited editions" do
+        feature_flags.switch!(:govspeak_visual_editor, true)
+        current_user.permissions << User::Permissions::VISUAL_EDITOR_PRIVATE_BETA
+
+        edition = create(edition_type, visual_editor: false)
+
+        get :edit, params: { id: edition }
+
+        assert_select ".app-c-visual-editor__container", count: 0
+      end
+
+      view_test "edit form does not render visual editor for pre-existing editions" do
+        feature_flags.switch!(:govspeak_visual_editor, true)
+        current_user.permissions << User::Permissions::VISUAL_EDITOR_PRIVATE_BETA
+
+        edition = create(edition_type, visual_editor: nil)
+
+        get :edit, params: { id: edition }
+
+        assert_select ".app-c-visual-editor__container", count: 0
       end
 
       view_test "edit form has cancel link which takes the user back to edition" do


### PR DESCRIPTION
As part of releasing a private-beta trial for a new visual editor feature, we are offering the possibility to also exit the trial for a specific document. The private-beta will only offer limited content editing options, so we must ensure that users with advanced markdown needs can fall back to using the standard govspeak markdown editor.

Users in the trial will have a special permission, which has already been implemented.

A user in the trial will always create a new document with the visual editor enabled, and that document wil remain marked with a DB flag ensuring that all other users with permissions will continue editing the document in the visual editor. A user in the trial may exit the visual editor, and that document will remain exited for all subsequent users. A user outside the trial may also irreversibly exit a document. Users with JS disabled, be it in the trial or outside the trial, should always have a seamless experience where they can use the default textarea. Users with JS disabled will
also implicitly exit the document from the trial.

The implementation is done primarily in JS, hiding or showing the visual editor and govspeak editor respectively. We have used a hidden field whose value we set on the server, and then modify on the client via JS. The value of the hidden field gets committed on save.

Changes:
- Add a migration to introduce a visual_editor field to editions
- Set the field to true for all editions created by users in the visual editor experiment
- Render it as a hidden field on the edition form defaulting to false (To handle the non-JS case)
- Toggle the field to true when the visual editor is shown (To ensure persistence of the visual editor)
- Introduce a button to exit the visual editor (Displayed only when the visual editor is shown)
- Always render the Govspeak Editor (instead of a backup textarea as before)
- JS to handle toggling of the editor and hidden field when the button is clicked
- The hidden field name is required in the visual editor template to help facilitate extending the behaviour to other document types (produces a clear error message)
- JS to make sure that the ID is set to either the contenteditable or govspeak textarea as appropriate
to ensure that errors are correctly linked
- Modify the Govspeak Editor JS to get textarea by classname instead of ID to ensure compatibility with previous change

Co-authored-by: Daniel Karaj <daniel.karaj@digital.cabinet-office.gov.uk>

[Trello card](https://trello.com/c/geeWlpCj/2492-implement-exiting-the-visual-editor-editionsl)

![Screenshot 2024-05-03 at 16 06 53](https://github.com/alphagov/whitehall/assets/91544378/a36d520f-bd0c-471d-ad59-3ae750c850ee)
