### PR TITLE
Update `.gitignore` for log files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 .idea
 /.bundle
 /db/*.sqlite3
-/log/*.log
+/log/*.log*
 /tmp/
 /.sass-cache/
 /public/system/


### PR DESCRIPTION
When running locally, log files like `log/development.log.0` are created.

These are currently not being ignored by the `.gitignore` file, so adding these to be ignored.