### PR TITLE
Refactor `PublishingApiDocumentRepublishingWorker` and associated tests

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -143,6 +143,22 @@ class Document < ApplicationRecord
     )
   end
 
+  def has_republishable_editions?
+    (latest_unpublished_edition || live_edition || pre_publication_edition).present?
+  end
+
+  def latest_unpublished_edition
+    editions.unpublished.last
+  end
+
+  def published_edition
+    live_edition if live_edition&.state == "published"
+  end
+
+  def withdrawn_edition
+    live_edition if live_edition&.state == "withdrawn"
+  end
+
 private
 
   def destroy_all_editions

--- a/app/workers/publishing_api_document_republishing_worker.rb
+++ b/app/workers/publishing_api_document_republishing_worker.rb
@@ -26,7 +26,7 @@ class PublishingApiDocumentRepublishingWorker < WorkerBase
     @pre_publication_edition = document.pre_publication_edition
     @latest_unpublished_edition = document.editions.unpublished.last
 
-    return unless the_document_has_non_superseded_editions_to_republish?
+    return unless document_has_republishable_editions?
 
     Document.transaction do
       document.lock!
@@ -52,8 +52,8 @@ class PublishingApiDocumentRepublishingWorker < WorkerBase
 
 private
 
-  def the_document_has_non_superseded_editions_to_republish?
-    pre_publication_edition || live_edition || latest_unpublished_edition
+  def document_has_republishable_editions?
+    (pre_publication_edition || live_edition || latest_unpublished_edition).present?
   end
 
   def the_document_has_been_unpublished?

--- a/test/unit/app/models/document_test.rb
+++ b/test/unit/app/models/document_test.rb
@@ -374,4 +374,65 @@ class DocumentTest < ActiveSupport::TestCase
 
     assert_equal document.id.to_s, document.reload.slug
   end
+
+  ["unpublished", Edition::PUBLICLY_VISIBLE_STATES, Edition::PRE_PUBLICATION_STATES].flatten.each do |edition_state|
+    test "#has_republishable_editions? returns true when there's an #{edition_state} edition" do
+      document = create(:document, editions: [build(:"#{edition_state}_edition")])
+      assert_equal document.has_republishable_editions?, true
+    end
+  end
+
+  Edition::FROZEN_STATES.each do |edition_state|
+    test "#has_republishable_editions? returns false when there are only editions with a state #{edition_state}" do
+      document = create(:document, editions: [build(:"#{edition_state}_edition")])
+      assert_equal document.has_republishable_editions?, false
+    end
+  end
+
+  test "#has_republishable_editions? returns false when there are no editions" do
+    document = create(:document, editions: [])
+    assert_equal document.has_republishable_editions?, false
+  end
+
+  test "#latest_unpublished_edition returns the latest unpublished edition when one exists" do
+    unpublished_edition_2 = build(:unpublished_edition)
+
+    document = create(:document, editions: [build(:unpublished_edition), unpublished_edition_2, build(:draft_edition)])
+
+    assert_equal document.latest_unpublished_edition, unpublished_edition_2
+  end
+
+  test "#latest_unpublished_edition returns nil when there are no unpublished editions" do
+    document = create(:document, editions: [build(:draft_edition)])
+
+    assert_nil document.latest_unpublished_edition
+  end
+
+  test "#published_edition returns the published edition when one exists" do
+    published_edition = build(:published_edition)
+
+    document = create(:document, editions: [published_edition, build(:draft_edition)])
+
+    assert_equal document.published_edition, published_edition
+  end
+
+  test "#published_edition returns nil when there is no published edition" do
+    document = create(:document, editions: [build(:draft_edition)])
+
+    assert_nil document.published_edition
+  end
+
+  test "#withdrawn_edition returns the withdrawn edition when one exists" do
+    withdrawn_edition = build(:withdrawn_edition)
+
+    document = create(:document, editions: [withdrawn_edition, build(:draft_edition)])
+
+    assert_equal document.withdrawn_edition, withdrawn_edition
+  end
+
+  test "#withdrawn_edition returns nil when there is no withdrawn edition" do
+    document = create(:document, editions: [build(:draft_edition)])
+
+    assert_nil document.withdrawn_edition
+  end
 end

--- a/test/unit/app/workers/publishing_api_document_republishing_worker_test.rb
+++ b/test/unit/app/workers/publishing_api_document_republishing_worker_test.rb
@@ -4,104 +4,321 @@ require "gds_api/test_helpers/publishing_api"
 class PublishingApiDocumentRepublishingWorkerTest < ActiveSupport::TestCase
   extend Minitest::Spec::DSL
 
+  let(:unpublished_edition_a) { build(:unpublished_edition) }
+  let(:unpublished_edition_b) { build(:unpublished_edition) }
+  let(:withdrawn_edition) { build(:withdrawn_edition) }
+  let(:published_edition) { build(:published_edition) }
+  let(:draft_edition) { build(:draft_edition) }
+
+  let(:document) { build(:document, live_edition:, pre_publication_edition:) }
+
+  setup do
+    Document.stubs(:find).returns(document)
+  end
+
   context "#perform" do
-    test "does nothing when the document only has superseded editions" do
-      document = create(:document, editions: [build(:superseded_edition)])
+    context "when the document only has superseded editions" do
+      let(:live_edition) { nil }
+      let(:pre_publication_edition) { nil }
 
-      Whitehall::PublishingApi.expects(:publish).never
-      Whitehall::PublishingApi.expects(:save_draft).never
-      Whitehall::PublishingApi.expects(:patch_links).never
-      PublishingApiUnpublishingWorker.any_instance.expects(:perform).never
-      ServiceListeners::PublishingApiAssociatedDocuments.expects(:process).never
+      setup { document.editions.stubs(:unpublished).returns([]) }
 
-      PublishingApiDocumentRepublishingWorker.new.perform(document.id)
+      it "does nothing" do
+        Whitehall::PublishingApi.expects(:publish).never
+        Whitehall::PublishingApi.expects(:save_draft).never
+        Whitehall::PublishingApi.expects(:patch_links).never
+        PublishingApiUnpublishingWorker.any_instance.expects(:perform).never
+        ServiceListeners::PublishingApiAssociatedDocuments.expects(:process).never
+
+        PublishingApiDocumentRepublishingWorker.new.perform(document.id)
+      end
     end
 
-    context "when there are non-superseded editions" do
-      test "unpublishes the latest unpublished edition when the document has been unpublished" do
-        first_unpublished_edition = build(:unpublished_edition)
-        last_unpublished_edition = build(:unpublished_edition)
-        document = create(:document, editions: [first_unpublished_edition, last_unpublished_edition])
+    context "when the document has one or more non-superseded editions" do
+      context "that are unpublished" do
+        let(:live_edition) { nil }
+        let(:pre_publication_edition) { nil }
 
-        PublishingApiUnpublishingWorker.any_instance.expects(:perform).with(last_unpublished_edition.unpublishing.id, last_unpublished_edition.draft?).once
-        ServiceListeners::PublishingApiAssociatedDocuments.expects(:process).with(last_unpublished_edition, "republish").once
-        Whitehall::PublishingApi.expects(:save_draft).never
-        Whitehall::PublishingApi.expects(:publish).never
-        Whitehall::PublishingApi.expects(:patch_links).never
+        setup { document.editions.stubs(:unpublished).returns([unpublished_edition_a, unpublished_edition_b]) }
 
-        PublishingApiDocumentRepublishingWorker.new.perform(document.id)
-      end
+        it "refreshes the latest unpublished edition" do
+          sequence = sequence("unpublish; handle attachments")
 
-      test "unpublishes the latest unpublished edition and draft edition when the document has been unpublished and there's also a draft edition" do
-        first_unpublished_edition = build(:unpublished_edition)
-        last_unpublished_edition = build(:unpublished_edition)
-        draft_edition = build(:draft_edition)
-        document = create(:document, editions: [first_unpublished_edition, last_unpublished_edition, draft_edition])
+          PublishingApiUnpublishingWorker
+            .any_instance
+            .expects(:perform)
+            .with(unpublished_edition_b.unpublishing.id, unpublished_edition_b.draft?)
+            .once
+            .in_sequence(sequence)
+          ServiceListeners::PublishingApiAssociatedDocuments
+            .expects(:process)
+            .with(unpublished_edition_b, "republish")
+            .once
+            .in_sequence(sequence)
 
-        PublishingApiUnpublishingWorker.any_instance.expects(:perform).with(last_unpublished_edition.unpublishing.id, last_unpublished_edition.draft?).once
-        ServiceListeners::PublishingApiAssociatedDocuments.expects(:process).with(last_unpublished_edition, "republish").once
-        Whitehall::PublishingApi.expects(:save_draft).with(draft_edition, "republish", bulk_publishing: false).once
-        ServiceListeners::PublishingApiAssociatedDocuments.expects(:process).with(draft_edition, "republish").once
-        Whitehall::PublishingApi.expects(:publish).never
-        Whitehall::PublishingApi.expects(:patch_links).never
-
-        PublishingApiDocumentRepublishingWorker.new.perform(document.id)
-      end
-
-      test "republishes then unpublishes the live edition when the document has not been unpublished but has been withdrawn" do
-        live_withdrawn_edition = build(:withdrawn_edition)
-        document = create(:document, live_edition: live_withdrawn_edition, editions: [live_withdrawn_edition])
-
-        Whitehall::PublishingApi.expects(:publish).with(live_withdrawn_edition, "republish", bulk_publishing: false).once
-        ServiceListeners::PublishingApiAssociatedDocuments.expects(:process).with(live_withdrawn_edition, "republish").once
-        PublishingApiUnpublishingWorker.any_instance.expects(:perform).with(live_withdrawn_edition.unpublishing.id, live_withdrawn_edition.draft?).once
-        ServiceListeners::PublishingApiAssociatedDocuments.expects(:process).with(live_withdrawn_edition, "republish").once
-        Whitehall::PublishingApi.expects(:save_draft).never
-        Whitehall::PublishingApi.expects(:patch_links).never
-
-        PublishingApiDocumentRepublishingWorker.new.perform(document.id)
-      end
-
-      context "when the document has not been unpublished or withdrawn" do
-        test "patches links then republishes the draft edition when there's only a draft edition" do
-          draft_edition = build(:draft_edition)
-          document = create(:document, editions: [draft_edition])
-
-          Whitehall::PublishingApi.expects(:patch_links).with(draft_edition, bulk_publishing: false).once
-          Whitehall::PublishingApi.expects(:save_draft).with(draft_edition, "republish", bulk_publishing: false).once
-          ServiceListeners::PublishingApiAssociatedDocuments.expects(:process).with(draft_edition, "republish").once
-          Whitehall::PublishingApi.expects(:publish).never
-          PublishingApiUnpublishingWorker.any_instance.expects(:perform).never
-
-          PublishingApiDocumentRepublishingWorker.new.perform(document.id)
-        end
-
-        test "patches links then republishes the live edition when there's only a live edition" do
-          live_edition = build(:published_edition)
-          document = create(:document, live_edition:, editions: [live_edition])
-
-          Whitehall::PublishingApi.expects(:patch_links).with(live_edition, bulk_publishing: false).once
-          Whitehall::PublishingApi.expects(:publish).with(live_edition, "republish", bulk_publishing: false).once
-          ServiceListeners::PublishingApiAssociatedDocuments.expects(:process).with(live_edition, "republish").once
           Whitehall::PublishingApi.expects(:save_draft).never
-          PublishingApiUnpublishingWorker.any_instance.expects(:perform).never
+          Whitehall::PublishingApi.expects(:publish).never
+          Whitehall::PublishingApi.expects(:patch_links).never
 
           PublishingApiDocumentRepublishingWorker.new.perform(document.id)
         end
 
-        test "patches links with the live edition then republishes the live edition then republishes the draft edition when there's both a live and draft edition" do
-          live_edition = build(:published_edition)
-          draft_edition = build(:draft_edition)
-          document = create(:document, live_edition:, editions: [live_edition, draft_edition])
+        context "and there's also a draft edition" do
+          let(:live_edition) { nil }
+          let(:pre_publication_edition) { draft_edition }
 
-          Whitehall::PublishingApi.expects(:patch_links).with(live_edition, bulk_publishing: false).once
-          Whitehall::PublishingApi.expects(:publish).with(live_edition, "republish", bulk_publishing: false).once
-          ServiceListeners::PublishingApiAssociatedDocuments.expects(:process).with(live_edition, "republish").once
-          Whitehall::PublishingApi.expects(:save_draft).with(draft_edition, "republish", bulk_publishing: false).once
-          ServiceListeners::PublishingApiAssociatedDocuments.expects(:process).with(draft_edition, "republish").once
-          PublishingApiUnpublishingWorker.any_instance.expects(:perform).never
+          setup { document.editions.stubs(:unpublished).returns([unpublished_edition_a, unpublished_edition_b]) }
+
+          it "refreshes the latest unpublished edition and the draft edition" do
+            sequence = sequence("unpublish; handle unpublished attachments; save draft; handle draft attachments")
+
+            PublishingApiUnpublishingWorker
+              .any_instance
+              .expects(:perform)
+              .with(unpublished_edition_b.unpublishing.id, unpublished_edition_b.draft?)
+              .once
+              .in_sequence(sequence)
+            ServiceListeners::PublishingApiAssociatedDocuments
+              .expects(:process)
+              .with(unpublished_edition_b, "republish")
+              .once
+              .in_sequence(sequence)
+            Whitehall::PublishingApi
+              .expects(:save_draft)
+              .with(draft_edition, "republish", bulk_publishing: false)
+              .once
+              .in_sequence(sequence)
+            ServiceListeners::PublishingApiAssociatedDocuments
+              .expects(:process)
+              .with(draft_edition, "republish")
+              .once
+              .in_sequence(sequence)
+
+            Whitehall::PublishingApi.expects(:publish).never
+            Whitehall::PublishingApi.expects(:patch_links).never
+
+            PublishingApiDocumentRepublishingWorker.new.perform(document.id)
+          end
+
+          context "but the draft edition is invalid" do
+            setup { draft_edition.stubs(:valid?).returns(false) }
+
+            it "refreshes the latest unpublished edition but not the draft edition" do
+              sequence = sequence("unpublish; handle unpublished attachments")
+
+              PublishingApiUnpublishingWorker
+                .any_instance
+                .expects(:perform)
+                .with(unpublished_edition_b.unpublishing.id, unpublished_edition_b.draft?)
+                .once
+                .in_sequence(sequence)
+              ServiceListeners::PublishingApiAssociatedDocuments
+                .expects(:process)
+                .with(unpublished_edition_b, "republish")
+                .once
+                .in_sequence(sequence)
+
+              Whitehall::PublishingApi.expects(:save_draft).never
+              ServiceListeners::PublishingApiAssociatedDocuments.expects(:process).with(draft_edition, "republish").never
+              Whitehall::PublishingApi.expects(:publish).never
+              Whitehall::PublishingApi.expects(:patch_links).never
+
+              PublishingApiDocumentRepublishingWorker.new.perform(document.id)
+            end
+          end
+        end
+      end
+
+      context "and the live edition is withdrawn" do
+        let(:live_edition) { withdrawn_edition }
+        let(:pre_publication_edition) { nil }
+
+        setup { document.editions.stubs(:unpublished).returns([]) }
+
+        it "refreshes the withdrawn edition" do
+          sequence = sequence("republish; handle attachments; unpublish; handle attachments")
+
+          Whitehall::PublishingApi
+            .expects(:publish)
+            .with(withdrawn_edition, "republish", bulk_publishing: false)
+            .once
+            .in_sequence(sequence)
+          ServiceListeners::PublishingApiAssociatedDocuments
+            .expects(:process)
+            .with(withdrawn_edition, "republish")
+            .once
+            .in_sequence(sequence)
+          PublishingApiUnpublishingWorker
+            .any_instance
+            .expects(:perform)
+            .with(withdrawn_edition.unpublishing.id, withdrawn_edition.draft?)
+            .once
+            .in_sequence(sequence)
+          ServiceListeners::PublishingApiAssociatedDocuments
+            .expects(:process)
+            .with(withdrawn_edition, "republish")
+            .once
+            .in_sequence(sequence)
+
+          Whitehall::PublishingApi.expects(:save_draft).never
+          Whitehall::PublishingApi.expects(:patch_links).never
 
           PublishingApiDocumentRepublishingWorker.new.perform(document.id)
+        end
+      end
+
+      context "none of which are unpublished or withdrawn" do
+        let(:live_edition) { nil }
+        let(:pre_publication_edition) { draft_edition }
+
+        context "and there's only a draft edition" do
+          setup { document.editions.stubs(:unpublished).returns([]) }
+
+          it "patches links for, then refreshes, the draft edition" do
+            sequence = sequence("patch links; save; handle attachments")
+
+            Whitehall::PublishingApi
+              .expects(:patch_links)
+              .with(draft_edition, bulk_publishing: false)
+              .once
+              .in_sequence(sequence)
+            Whitehall::PublishingApi
+              .expects(:save_draft)
+              .with(draft_edition, "republish", bulk_publishing: false)
+              .once
+              .in_sequence(sequence)
+            ServiceListeners::PublishingApiAssociatedDocuments
+              .expects(:process)
+              .with(draft_edition, "republish")
+              .once
+              .in_sequence(sequence)
+
+            Whitehall::PublishingApi.expects(:publish).never
+            PublishingApiUnpublishingWorker.any_instance.expects(:perform).never
+
+            PublishingApiDocumentRepublishingWorker.new.perform(document.id)
+          end
+
+          context "but the draft edition is invalid" do
+            setup { draft_edition.stubs(:valid?).returns(false) }
+
+            it "patches links for, but doesn't refresh, the draft edition" do
+              Whitehall::PublishingApi
+                .expects(:patch_links)
+                .with(draft_edition, bulk_publishing: false)
+                .once
+
+              Whitehall::PublishingApi.expects(:save_draft).never
+              ServiceListeners::PublishingApiAssociatedDocuments.expects(:process).never
+              Whitehall::PublishingApi.expects(:publish).never
+              PublishingApiUnpublishingWorker.any_instance.expects(:perform).never
+
+              PublishingApiDocumentRepublishingWorker.new.perform(document.id)
+            end
+          end
+        end
+
+        context "and there's only a published edition" do
+          let(:live_edition) { published_edition }
+          let(:pre_publication_edition) { nil }
+
+          setup { document.editions.stubs(:unpublished).returns([]) }
+
+          it "patches links for, then refreshes, the published edition" do
+            sequence = sequence("patch links; republish; handle attachments")
+
+            Whitehall::PublishingApi
+              .expects(:patch_links)
+              .with(published_edition, bulk_publishing: false)
+              .once
+              .in_sequence(sequence)
+            Whitehall::PublishingApi
+              .expects(:publish)
+              .with(published_edition, "republish", bulk_publishing: false)
+              .once
+              .in_sequence(sequence)
+            ServiceListeners::PublishingApiAssociatedDocuments
+              .expects(:process)
+              .with(published_edition, "republish")
+              .once
+              .in_sequence(sequence)
+
+            Whitehall::PublishingApi.expects(:save_draft).never
+            PublishingApiUnpublishingWorker.any_instance.expects(:perform).never
+
+            PublishingApiDocumentRepublishingWorker.new.perform(document.id)
+          end
+        end
+
+        context "and there's both a published and draft edition" do
+          let(:live_edition) { published_edition }
+          let(:pre_publication_edition) { draft_edition }
+
+          setup { document.editions.stubs(:unpublished).returns([]) }
+
+          it "patches links for the published edition, then refreshes the published then draft editions" do
+            sequence = sequence("patch links; republish live edition; handle live attachments; save draft; handle draft attachments")
+
+            Whitehall::PublishingApi
+              .expects(:patch_links)
+              .with(published_edition, bulk_publishing: false)
+              .once
+              .in_sequence(sequence)
+            Whitehall::PublishingApi
+              .expects(:publish)
+              .with(published_edition, "republish", bulk_publishing: false)
+              .once
+              .in_sequence(sequence)
+            ServiceListeners::PublishingApiAssociatedDocuments
+              .expects(:process)
+              .with(published_edition, "republish")
+              .once
+              .in_sequence(sequence)
+            Whitehall::PublishingApi
+              .expects(:save_draft)
+              .with(draft_edition, "republish", bulk_publishing: false)
+              .once
+              .in_sequence(sequence)
+            ServiceListeners::PublishingApiAssociatedDocuments
+              .expects(:process)
+              .with(draft_edition, "republish")
+              .once
+              .in_sequence(sequence)
+
+            PublishingApiUnpublishingWorker.any_instance.expects(:perform).never
+
+            PublishingApiDocumentRepublishingWorker.new.perform(document.id)
+          end
+
+          context "but the draft edition is invalid" do
+            setup { draft_edition.stubs(:valid?).returns(false) }
+
+            it "patches links for, then refreshes, the published edition, but not the draft edition" do
+              sequence = sequence("patch links; republish live edition; handle live attachments")
+
+              Whitehall::PublishingApi
+                .expects(:patch_links)
+                .with(published_edition, bulk_publishing: false)
+                .once
+                .in_sequence(sequence)
+              Whitehall::PublishingApi
+                .expects(:publish)
+                .with(published_edition, "republish", bulk_publishing: false)
+                .once
+                .in_sequence(sequence)
+              ServiceListeners::PublishingApiAssociatedDocuments
+                .expects(:process)
+                .with(published_edition, "republish")
+                .once
+                .in_sequence(sequence)
+
+              Whitehall::PublishingApi.expects(:save_draft).never
+              ServiceListeners::PublishingApiAssociatedDocuments.expects(:process).with(draft_edition, "republish").never
+              PublishingApiUnpublishingWorker.any_instance.expects(:perform).never
+
+              PublishingApiDocumentRepublishingWorker.new.perform(document.id)
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
## Tests

In working on #8993, we needed to extend the worker in order to support previewing which editions would be refreshed when calling `#perform`. We added some test coverage in #8998 in order to provide confidence that the refactor wouldn't break any existing functionality. However, when digging into the git history we found that most of these tests already existed before being removed in 56195d5. We agreed with the suggestion in that commit of making better use of mocking, so we've incorporated this into a wider rework of the tests which also aims to improve coverage (further) and structure

## Worker

Being relatively new to GDS/Publishing, we have a (relatively) low level of context on how everything works. With this in mind, we struggled a little to parse the worker class owing to the language and logic of both public and private methods. We've had a go at rewriting this into a more explicit, low context friendly format. We hope that it's now easier to understand the relationship between the various edition states and the actions that happen when calling `#perform`, and that this makes it a little easier to extend/modify the class in future

---

This was done as groundwork for #8993 ([Trello](https://trello.com/c/egFDeEYg))

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
