### PR TITLE
Republish organisation page when contact is updated

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -16,6 +16,7 @@ class Contact < ApplicationRecord
 
   after_update :republish_dependent_editions
   after_update :republish_dependent_policy_groups
+  after_update :republish_organisation_to_publishing_api
 
   after_create :republish_organisation_to_publishing_api
   after_destroy :republish_organisation_to_publishing_api

--- a/test/unit/app/models/contact_test.rb
+++ b/test/unit/app/models/contact_test.rb
@@ -148,6 +148,13 @@ class ContactTest < ActiveSupport::TestCase
     contact.destroy!
   end
 
+  test "updating a contact republishes the organisation" do
+    test_object = create(:organisation)
+    contact = create(:contact, contactable: test_object)
+    Whitehall::PublishingApi.expects(:republish_async).with(test_object).once
+    contact.update!(title: "A new name")
+  end
+
   test "updating a contact republishes dependent policy groups" do
     contact = create(:contact)
     policy_group = create(


### PR DESCRIPTION
A bug was reported in Zendesk recently:
https://govuk.zendesk.com/agent/tickets/5818031

Someone set a contact to appear on the org homepage, but they never appeared. Running the
`publishing_api:republish:organisation_by_slug` rake task fixes the issue, so clearly the organisation is not being republished when it should be.

We already have callbacks for updating the organisation when a contact is created or destroyed, but not when a contact is updated. I've been able to consistently reproduce the bug whereby editing contact info does not get reflected on the org page. Adding this callback should fix that bug, and should prevent further issues of this nature.

The test is based on the code added in #4552, which describes a similar problem.

Tested on integration, works well: https://whitehall-admin.integration.publishing.service.gov.uk/government/admin/organisations/online-procedure-rule-committee/contacts

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
