### PR TITLE
Update base path for Editionable Worldwide Organisations

### DIFF
--- a/app/models/editionable_worldwide_organisation.rb
+++ b/app/models/editionable_worldwide_organisation.rb
@@ -75,7 +75,7 @@ class EditionableWorldwideOrganisation < Edition
   end
 
   def base_path
-    "/editionable-world/organisations/#{slug}"
+    "/world/organisations/#{slug}"
   end
 
   def display_type_key

--- a/test/unit/app/presenters/publishing_api/editionable_worldwide_organisation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/editionable_worldwide_organisation_presenter_test.rb
@@ -63,7 +63,7 @@ class PublishingApi::EditionableWorldwideOrganisationPresenterTest < ActiveSuppo
             title: "Working for Editionable worldwide organisation title",
           },
         ],
-        secondary_corporate_information_pages: "Read about the types of information we routinely publish in our <a class=\"govuk-link\" href=\"/editionable-world/organisations/editionable-worldwide-organisation-title/about/publication-scheme\">Publication scheme</a>. Find out about our commitment to <a class=\"govuk-link\" href=\"/editionable-world/organisations/editionable-worldwide-organisation-title/about/welsh-language-scheme\">publishing in Welsh</a>. Our <a class=\"govuk-link\" href=\"/editionable-world/organisations/editionable-worldwide-organisation-title/about/personal-information-charter\">Personal information charter</a> explains how we treat your personal information.",
+        secondary_corporate_information_pages: "Read about the types of information we routinely publish in our <a class=\"govuk-link\" href=\"/world/organisations/editionable-worldwide-organisation-title/about/publication-scheme\">Publication scheme</a>. Find out about our commitment to <a class=\"govuk-link\" href=\"/world/organisations/editionable-worldwide-organisation-title/about/welsh-language-scheme\">publishing in Welsh</a>. Our <a class=\"govuk-link\" href=\"/world/organisations/editionable-worldwide-organisation-title/about/personal-information-charter\">Personal information charter</a> explains how we treat your personal information.",
         office_contact_associations: [
           {
             office_content_id: worldwide_org.reload.main_office.content_id,


### PR DESCRIPTION
Now we are migrating Worldwide Organisations to be editionable, we want them to have the same base path as the non-editionable version they have replaced.

This will allow us to properly test the user journeys (e.g. in integration).  There will be no effect in production yet, as editionable worldwide organisations remain behind a feature flag.

[Trello card](https://trello.com/c/NFYppyyg)