### PR TITLE
Add new No. 10 logo option to OrganisationLogoType

### DIFF
--- a/app/models/organisation_logo_type.rb
+++ b/app/models/organisation_logo_type.rb
@@ -52,4 +52,7 @@ class OrganisationLogoType
   DepartmentForBusinessAndTrade = create!(
     id: 15, title: "Department for Business & Trade", class_name: "dbt",
   )
+  PrimeMinistersOffice10DowningStread = create!(
+    id: 16, title: "Prime Minister's Office, 10 Downing Street", class_name: "no10",
+  )
 end


### PR DESCRIPTION
- Logo with id no10 already exists in components gem

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
