### PR TITLE
Allow links in editorial remarks

### DIFF
--- a/app/components/admin/editions/editorial_remark_component.html.erb
+++ b/app/components/admin/editions/editorial_remark_component.html.erb
@@ -2,7 +2,7 @@
   <h4 class="govuk-heading-s govuk-!-margin-bottom-1">Internal note</h4>
 
   <p class="govuk-body govuk-!-margin-bottom-0 govuk-!-margin-top-0">
-    <%= editorial_remark.body %>
+    <%= sanitize(editorial_remark.body, tags: %w[a]) %>
   </p>
 
   <p class="app-view-editions-editorial-remark__list-item-datetime govuk-body govuk-body-s govuk-!-margin-bottom-0 govuk-!-margin-top-0">

--- a/test/components/admin/editions/editorial_remark_component_test.rb
+++ b/test/components/admin/editions/editorial_remark_component_test.rb
@@ -22,4 +22,18 @@ class Admin::Editions::EditorialRemarkComponentTest < ViewComponent::TestCase
     assert_equal page.all("p")[0].text.strip, editorial_remark.body
     assert_equal page.all("p")[1].text.strip, "1 January 2020 11:11am by User (removed)"
   end
+
+  test "it includes HTML for links as actual links" do
+    editorial_remark = build_stubbed(:editorial_remark, body: "Remark with <a href=\"/foo\">a link</a>.")
+    render_inline(Admin::Editions::EditorialRemarkComponent.new(editorial_remark:))
+
+    assert_equal page.all("a").first.text, "a link"
+  end
+
+  test "it does not render other HTML" do
+    editorial_remark = build_stubbed(:editorial_remark, body: "Remark with <script>a dodgy script</script>.")
+    render_inline(Admin::Editions::EditorialRemarkComponent.new(editorial_remark:))
+
+    assert_empty page.all("script")
+  end
 end


### PR DESCRIPTION
This will allow links to be included in editorial remarks, e.g. when logging where a corporate information page has been migrated from.

Example:
![Screenshot of the "On this edition" and "On previous editions" section of Whitehall Publisher for an Editionable Worldwide Organisation.  There are a number of links included in the remarks as actual hyperlinks.](https://github.com/alphagov/whitehall/assets/6329861/48c70fb2-25de-45c2-8f27-7db36a4d72a2)

[Trello card](https://trello.com/c/NFYppyyg)