### PR TITLE
Speed up republishing index

### DIFF
--- a/app/controllers/admin/republishing_controller.rb
+++ b/app/controllers/admin/republishing_controller.rb
@@ -167,7 +167,7 @@ private
       presenter_instance = presenter_class_string.constantize.new
 
       {
-        title: presenter_instance.content[:title],
+        title: presenter_instance.title,
         public_path: presenter_instance.base_path,
         slug: presenter_instance.base_path.split("/").last,
         presenter: presenter_class_string,

--- a/app/presenters/publishing_api/embassies_index_presenter.rb
+++ b/app/presenters/publishing_api/embassies_index_presenter.rb
@@ -10,7 +10,7 @@ module PublishingApi
     def content
       content = BaseItemPresenter.new(
         nil,
-        title: I18n.t("organisation.embassies.find_an_embassy_title"),
+        title:,
         update_type: "minor",
       ).base_attributes
 
@@ -27,6 +27,10 @@ module PublishingApi
 
     def links
       { parent: [WORLD_INDEX_CONTENT_ID] }
+    end
+
+    def title
+      I18n.t("organisation.embassies.find_an_embassy_title")
     end
 
     def base_path

--- a/app/presenters/publishing_api/historical_accounts_index_presenter.rb
+++ b/app/presenters/publishing_api/historical_accounts_index_presenter.rb
@@ -15,7 +15,7 @@ module PublishingApi
     def content
       content = BaseItemPresenter.new(
         nil,
-        title: "Past Prime Ministers",
+        title:,
         update_type:,
       ).base_attributes
 
@@ -37,6 +37,10 @@ module PublishingApi
       role = Role.friendly.find("prime-minister")
       people_to_present = (role.role_appointments.historic.map(&:person) - HistoricalAccount.all.map(&:person)).uniq
       people_to_present.map { |person| compose_person person, role }
+    end
+
+    def title
+      "Past Prime Ministers"
     end
 
     def base_path

--- a/app/presenters/publishing_api/how_government_works_presenter.rb
+++ b/app/presenters/publishing_api/how_government_works_presenter.rb
@@ -13,7 +13,7 @@ module PublishingApi
     def content
       content = BaseItemPresenter.new(
         nil,
-        title: "How government works",
+        title:,
         update_type:,
       ).base_attributes
 
@@ -28,6 +28,10 @@ module PublishingApi
       )
 
       content.merge!(PayloadBuilder::Routes.for(base_path))
+    end
+
+    def title
+      "How government works"
     end
 
     def base_path

--- a/app/presenters/publishing_api/ministers_index_presenter.rb
+++ b/app/presenters/publishing_api/ministers_index_presenter.rb
@@ -15,7 +15,7 @@ module PublishingApi
     def content
       content = BaseItemPresenter.new(
         nil,
-        title: "Ministers",
+        title:,
         update_type:,
       ).base_attributes
 
@@ -44,6 +44,10 @@ module PublishingApi
         ordered_house_lords_whips: ordered_whips_content_ids(Whitehall::WhipOrganisation::WhipsHouseofLords),
         ordered_baronesses_and_lords_in_waiting_whips: ordered_whips_content_ids(Whitehall::WhipOrganisation::BaronessAndLordsInWaiting),
       }
+    end
+
+    def title
+      "Ministers"
     end
 
     def base_path

--- a/app/presenters/publishing_api/operational_fields_index_presenter.rb
+++ b/app/presenters/publishing_api/operational_fields_index_presenter.rb
@@ -9,7 +9,7 @@ module PublishingApi
     def content
       content = BaseItemPresenter.new(
         nil,
-        title: "Fields of operation",
+        title:,
         update_type:,
       ).base_attributes
 
@@ -31,6 +31,10 @@ module PublishingApi
 
     def content_id
       "53c8e227-3778-4c85-a569-384457c0a281"
+    end
+
+    def title
+      "Fields of operation"
     end
 
     def base_path

--- a/app/presenters/publishing_api/organisations_index_presenter.rb
+++ b/app/presenters/publishing_api/organisations_index_presenter.rb
@@ -7,7 +7,7 @@ module PublishingApi
     def content
       content = BaseItemPresenter.new(
         nil,
-        title: "Departments, agencies and public bodies",
+        title:,
         update_type: "minor",
         locale: "en", # NOTE: the organisations index page is only available in english
       ).base_attributes
@@ -23,6 +23,10 @@ module PublishingApi
       )
 
       content.merge!(PayloadBuilder::Routes.for(base_path))
+    end
+
+    def title
+      "Departments, agencies and public bodies"
     end
 
     def base_path

--- a/app/presenters/publishing_api/world_index_presenter.rb
+++ b/app/presenters/publishing_api/world_index_presenter.rb
@@ -9,7 +9,7 @@ module PublishingApi
     def content
       content = BaseItemPresenter.new(
         nil,
-        title: "Help and services around the world",
+        title:,
         update_type:,
       ).base_attributes
 
@@ -38,6 +38,10 @@ module PublishingApi
 
     def content_id
       "369729ba-7776-4123-96be-2e3e98e153e1"
+    end
+
+    def title
+      "Help and services around the world"
     end
 
     def base_path


### PR DESCRIPTION
The republishing index page is currently very slow to load. It's running the entire `content` method on seven presenters only to use the title. This moves the simple title logic into its own method, so this can be called directly instead of calling a larger method and throwing away most of the data

I've deployed this to integration and the page now loads without noticeable delay

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
