### PR TITLE
Add message when the Visual Editor is not shown

### DIFF
--- a/app/views/components/_govspeak_editor.html.erb
+++ b/app/views/components/_govspeak_editor.html.erb
@@ -70,6 +70,18 @@
       } %>
     </div>
   </div>
+  <% if Flipflop.govspeak_visual_editor? && current_user.can_see_visual_editor_private_beta? %>
+    <%= render "govuk_publishing_components/components/inset_text", {
+    } do %>
+      <p class="govuk-body">Visual Editor is not available for this document due to one of the following reasons. The visual editor will be available for new documents.</p>
+      <ul>
+        <li>You or someone else chose to stop using the visual editor for this document</li>
+        <li>You or someone else edited this document using the markdown editor</li>
+        <li>This document was created before the launch of the visual editor</li>
+        <li class="app-no-js">You have JavaScript disabled</li>
+      </ul>
+    <% end %>
+  <% end %>
   <div class="app-c-govspeak-editor__textarea">
     <%= render "govuk_publishing_components/components/textarea", {
       name: name,

--- a/features/step_definitions/visual_editor_steps.rb
+++ b/features/step_definitions/visual_editor_steps.rb
@@ -10,11 +10,13 @@ end
 Then(/^I should see the visual editor instead of the govspeak editor$/) do
   expect(page).to have_selector(".app-c-visual-editor__visual-editor-wrapper", visible: true)
   expect(page).to have_selector(".app-c-visual-editor__govspeak-editor-wrapper", visible: false)
+  expect(page).to have_selector(".app-c-govspeak-editor .govuk-inset-text", visible: false)
 end
 
 Then(/^I should see the govspeak editor instead of the visual editor$/) do
   expect(page).to have_selector(".app-c-visual-editor__govspeak-editor-wrapper", visible: true)
   expect(page).to have_selector(".app-c-visual-editor__visual-editor-wrapper", visible: false)
+  expect(page).to have_selector(".app-c-govspeak-editor .govuk-inset-text", visible: true)
 end
 
 Then(/^I should see the govspeak editor$/) do


### PR DESCRIPTION
## What
Add a message to the govspeak editor to be displayed for users with the visual editor permission

## Why
To explain why they are not seeing the visual editor.

https://trello.com/c/4O1uj1R0/2538-inform-private-beta-users-that-ve-has-been-exited-editions-html-attachments

## Screenshot
<img width="837" alt="Screenshot 2024-05-09 at 14 01 54" src="https://github.com/alphagov/whitehall/assets/9594455/acaddd7b-84d6-4121-940c-4a81b9866d3d">
