### PR TITLE
Spike: approach for storing republishing actions

### DIFF
--- a/app/controllers/admin/republishing_controller.rb
+++ b/app/controllers/admin/republishing_controller.rb
@@ -21,6 +21,13 @@ class Admin::RepublishingController < Admin::BaseController
 
     PresentPageToPublishingApiWorker.perform_async(page_to_republish[:presenter])
     flash[:notice] = "The '#{page_to_republish[:title]}' page has been scheduled for republishing"
+
+    RepublishingEvent.create!(
+      action: "Republished page: #{page_to_republish[:title]}",
+      reason: params[:reason],
+      user: current_user
+    )
+
     redirect_to(admin_republishing_index_path)
   end
 

--- a/app/models/republishing_event.rb
+++ b/app/models/republishing_event.rb
@@ -1,0 +1,3 @@
+class RepublishingEvent < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,7 @@ class User < ApplicationRecord
   has_many :user_world_locations
   has_many :world_locations, through: :user_world_locations
   has_many :statistics_announcements, foreign_key: :creator_id
+  has_many :republishing_events
 
   serialize :permissions, coder: YAML, type: Array
 

--- a/app/views/admin/republishing/confirm_page.html.erb
+++ b/app/views/admin/republishing/confirm_page.html.erb
@@ -9,10 +9,19 @@
     </p>
     <%= form_with(url: @republishing_path, method: :post, data: {
         module: "prevent-multiple-form-submissions",
-      }) do
-        render("govuk_publishing_components/components/button", {
+      }) do %>
+        <%= render("govuk_publishing_components/components/textarea", {
+          label: {
+            text: "What is the reason for republishing this page?",
+            heading_size: "m",
+          },
+          name: "reason",
+          id: "reason",
+        }) %>
+
+        <%= render("govuk_publishing_components/components/button", {
           text: "Confirm republishing",
-        })
-      end %>
+        }) %>
+   <% end %>
   </section>
 </div>

--- a/db/migrate/20240509112004_create_republishing_events.rb
+++ b/db/migrate/20240509112004_create_republishing_events.rb
@@ -1,0 +1,11 @@
+class CreateRepublishingEvents < ActiveRecord::Migration[7.1]
+  def change
+    create_table :republishing_events do |t|
+      t.text :action
+      t.text :reason
+      t.references :user, index: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_03_090316) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_09_112004) do
   create_table "assets", charset: "utf8mb3", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.string "variant", null: false
@@ -855,6 +855,15 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_03_090316) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.index ["edition_id"], name: "index_related_mainstreams_on_edition_id"
+  end
+
+  create_table "republishing_events", charset: "utf8mb3", force: :cascade do |t|
+    t.text "action"
+    t.text "reason"
+    t.bigint "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_republishing_events_on_user_id"
   end
 
   create_table "review_reminders", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|

--- a/test/models/republishing_event_test.rb
+++ b/test/models/republishing_event_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class RepublishingEventTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
This is a very basic proof of concept for how we might want to record the number of republishings that have happened in Whitehall, with a reason as to why this has happened. Clicking "Confirm" on a republish page will create a `RepublishingEvent` with the user who clicked the button, the reason for clicking the button and the action that took place, e.g. "Republished page: PAGE_TITLE"

## Screenshot

<img width="1307" alt="Screenshot 2024-05-09 at 16 52 56" src="https://github.com/alphagov/whitehall/assets/19826940/0a310d43-a541-4e36-bd17-12637dbe137a">

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
