### PR TITLE
Fix logic in Worldwide Organisation Presenter

### DIFF
--- a/app/presenters/publishing_api/worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/worldwide_organisation_presenter.rb
@@ -63,7 +63,11 @@ module PublishingApi
     end
 
     def body
-      Whitehall::GovspeakRenderer.new.govspeak_edition_to_html(about_us) || ""
+      if about_us&.body.present?
+        Whitehall::GovspeakRenderer.new.govspeak_edition_to_html(about_us)
+      else
+        ""
+      end
     end
 
     def public_updated_at

--- a/test/unit/app/presenters/publishing_api/worldwide_organisation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/worldwide_organisation_presenter_test.rb
@@ -320,4 +320,28 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
 
     assert_equal worldwide_organisation.updated_at, presented_item.content[:public_updated_at]
   end
+
+  test "does not convert an absent body to govspeak" do
+    worldwide_org = create(:worldwide_organisation)
+    create(:about_corporate_information_page,
+           organisation: nil,
+           body: nil,
+           worldwide_organisation: worldwide_org)
+
+    presented_item = present(worldwide_org.reload)
+
+    assert_equal "", presented_item.content.dig(:details, :body)
+  end
+
+  test "does not convert an empty body to govspeak" do
+    worldwide_org = create(:worldwide_organisation)
+    create(:about_corporate_information_page,
+           organisation: nil,
+           body: "",
+           worldwide_organisation: worldwide_org)
+
+    presented_item = present(worldwide_org.reload)
+
+    assert_equal "", presented_item.content.dig(:details, :body)
+  end
 end


### PR DESCRIPTION
This presenter has untested logic that should produce an empty string if there is no body text, however we're checking for the return value of the govspeak helper method instead of the body itself.

As the govspeak method always returns some text, it is never possible for the string to be returned empty.

Therefore updating the logic to reflect how this should work and including tests to that effect.

[Trello card](https://trello.com/c/NFYppyyg)