### PR TITLE
Add link to editionable worldwide organisation index

### DIFF
--- a/app/helpers/admin/url_helper.rb
+++ b/app/helpers/admin/url_helper.rb
@@ -16,7 +16,13 @@ module Admin::UrlHelper
   end
 
   def admin_worldwide_organisations_link
-    admin_link "Worldwide organisations", admin_worldwide_organisations_path unless Flipflop.editionable_worldwide_organisations?
+    path = if Flipflop.editionable_worldwide_organisations?
+             admin_editions_path(type: "editionable_worldwide_organisation")
+           else
+             admin_worldwide_organisations_path
+           end
+
+    admin_link "Worldwide organisations", path
   end
 
   def admin_world_location_news_link

--- a/test/functional/admin/more_controller_test.rb
+++ b/test/functional/admin/more_controller_test.rb
@@ -47,22 +47,22 @@ class Admin::MoreControllerTest < ActionController::TestCase
     refute_select "a.govuk-link", text: "Sitewide settings"
   end
 
-  view_test "GET #index renders Worldwide Organisations when the editionable_worldwide_organisations feature flag is switched off" do
+  view_test "GET #index renders Worldwide Organisations with link to non-editionable index when the editionable_worldwide_organisations feature flag is switched off" do
     feature_flags.switch! :editionable_worldwide_organisations, false
 
     get :index
 
     assert_select ".govuk-list"
-    assert_select "a.govuk-link", text: "Worldwide organisations"
+    assert_select "a.govuk-link[href=?]", "/government/admin/worldwide_organisations", text: "Worldwide organisations"
   end
 
-  view_test "GET #index does not render Worldwide Organisations when the editionable_worldwide_organisations feature flag is switched on" do
+  view_test "GET #index renders Worldwide Organisations with link to editions index when the editionable_worldwide_organisations feature flag is switched on" do
     feature_flags.switch! :editionable_worldwide_organisations, true
 
     get :index
 
     assert_select ".govuk-list"
-    refute_select "a.govuk-link", text: "Worldwide organisations"
+    assert_select "a.govuk-link[href=?]", "/government/admin/editions?type=editionable_worldwide_organisation", text: "Worldwide organisations"
   end
 
   view_test "GET #index does not render Emergency Banner option when the user is not a GDS Admin." do


### PR DESCRIPTION
This adds a link to the index for editionable worldwide organisations when the editionable worldwide organisation feature flag is switched on.

[Trello card](https://trello.com/c/glWY59Je)