### PR TITLE
Fix bug with social media accounts on new editions

### DIFF
--- a/app/models/concerns/edition/social_media_accounts.rb
+++ b/app/models/concerns/edition/social_media_accounts.rb
@@ -4,7 +4,7 @@ module Edition::SocialMediaAccounts
   class Trait < Edition::Traits::Trait
     def process_associations_after_save(edition)
       @edition.social_media_accounts.each do |association|
-        new_social_media_account = edition.social_media_accounts.build(association.attributes.except("id", "socialable_id", "socialable_type"))
+        new_social_media_account = edition.social_media_accounts.create!(association.attributes.except("id", "socialable_id", "socialable_type"))
 
         @edition.non_english_translated_locales.map(&:code).each do |locale|
           I18n.with_locale(locale) do

--- a/test/unit/app/models/editionable_worldwide_organisation_test.rb
+++ b/test/unit/app/models/editionable_worldwide_organisation_test.rb
@@ -135,6 +135,20 @@ class EditionableWorldwideOrganisationTest < ActiveSupport::TestCase
     assert_equal [c], worldwide_organisation.office_staff_roles
   end
 
+  test "should clone social media associations which don't have translations when new draft of published edition is created" do
+    published_worldwide_organisation = create(
+      :editionable_worldwide_organisation,
+      :published,
+      :with_social_media_account,
+    )
+    draft_worldwide_organisation = published_worldwide_organisation.create_draft(create(:writer))
+
+    draft_worldwide_organisation.reload
+
+    assert_equal published_worldwide_organisation.social_media_accounts.first.title, draft_worldwide_organisation.social_media_accounts.first.title
+    assert_equal published_worldwide_organisation.social_media_accounts.first.url, draft_worldwide_organisation.social_media_accounts.first.url
+  end
+
   test "should clone social media associations and their translations when new draft of published edition is created" do
     published_worldwide_organisation = create(
       :editionable_worldwide_organisation,
@@ -151,6 +165,8 @@ class EditionableWorldwideOrganisationTest < ActiveSupport::TestCase
     end
 
     draft_worldwide_organisation = published_worldwide_organisation.create_draft(create(:writer))
+
+    draft_worldwide_organisation.reload
 
     assert_equal published_worldwide_organisation.social_media_accounts.first.title, draft_worldwide_organisation.social_media_accounts.first.title
     assert_equal published_worldwide_organisation.social_media_accounts.first.url, draft_worldwide_organisation.social_media_accounts.first.url


### PR DESCRIPTION
When an Editionable Worldwide Organisation was being editioned (i.e. a new draft created), the social media accounts were lost, but only for worldwide organisations that had no translations.

This was because we were using the `build` method to create the record but never saving it.

For the worldwide organisations with translations, the call to `update` saved the record, but this never happened for those without translations.

The tests did not catch this as `create_draft` returns the unsaved object. Therefore reloading the object in the test to ensure we get the persisted object from the database.

[Trello card](https://trello.com/c/DmouRi4q)