### PR TITLE
Remove `publishing_api:republish` Rake tasks

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -46,64 +46,6 @@ namespace :publishing_api do
     end
   end
 
-  namespace :republish do
-    desc "Republish an organisation to the Publishing API"
-    task :organisation_by_slug, [:slug] => :environment do |_, args|
-      Organisation.find_by!(slug: args[:slug]).publish_to_publishing_api
-    end
-
-    desc "Republish a person to the Publishing API"
-    task :person_by_slug, [:slug] => :environment do |_, args|
-      Person.find_by!(slug: args[:slug]).publish_to_publishing_api
-    end
-
-    desc "Republish a role to the Publishing API"
-    task :role_by_slug, [:slug] => :environment do |_, args|
-      Role.find_by!(slug: args[:slug]).publish_to_publishing_api
-    end
-
-    desc "Republish a document to the Publishing API"
-    task :document_by_slug, [:slug] => :environment do |_, args|
-      document = Document.find_by!(slug: args[:slug])
-      PublishingApiDocumentRepublishingWorker.new.perform(document.id)
-    end
-
-    desc "Republish the past prime ministers index page to Publishing API"
-    task republish_past_prime_ministers_index: :environment do
-      PresentPageToPublishingApiWorker.perform_async("PublishingApi::HistoricalAccountsIndexPresenter")
-    end
-
-    desc "Republish the how government works page to Publishing API"
-    task republish_how_government_works: :environment do
-      PresentPageToPublishingApiWorker.perform_async("PublishingApi::HowGovernmentWorksPresenter")
-    end
-
-    desc "Republish the fields of operation index page to Publishing API"
-    task republish_operational_fields_index: :environment do
-      PresentPageToPublishingApiWorker.perform_async("PublishingApi::OperationalFieldsIndexPresenter")
-    end
-
-    desc "Republish the ministers index page to Publishing API"
-    task republish_ministers_index: :environment do
-      PresentPageToPublishingApiWorker.perform_async("PublishingApi::MinistersIndexPresenter")
-    end
-
-    desc "Republish the embassies index page to Publishing API"
-    task republish_embassies_index: :environment do
-      PresentPageToPublishingApiWorker.perform_async("PublishingApi::EmbassiesIndexPresenter")
-    end
-
-    desc "Republish the world index page to Publishing API"
-    task republish_world_index: :environment do
-      PresentPageToPublishingApiWorker.perform_async("PublishingApi::WorldIndexPresenter")
-    end
-
-    desc "Republish the organisations index page to Publishing API"
-    task republish_organisations_index: :environment do
-      PresentPageToPublishingApiWorker.perform_async("PublishingApi::OrganisationsIndexPresenter")
-    end
-  end
-
   namespace :patch_links do
     desc "Send links for all organisations to Publishing API."
     task organisations: :environment do

--- a/test/unit/lib/tasks/publishing_api_test.rb
+++ b/test/unit/lib/tasks/publishing_api_test.rb
@@ -61,48 +61,6 @@ class PublishingApiRake < ActiveSupport::TestCase
     end
   end
 
-  describe "republish" do
-    describe "#document_by_slug" do
-      let(:task) { Rake::Task["publishing_api:republish:document_by_slug"] }
-
-      test "republishes document by slug" do
-        document = create(:document)
-        PublishingApiDocumentRepublishingWorker.any_instance.expects(:perform).with(document.id)
-        capture_io { task.invoke(document.slug) }
-      end
-    end
-
-    describe "#organisation_by_slug" do
-      let(:task) { Rake::Task["publishing_api:republish:organisation_by_slug"] }
-
-      test "Republishes organisation by slug" do
-        record = create(:organisation)
-        Organisation.any_instance.expects(:publish_to_publishing_api)
-        capture_io { task.invoke(record.slug) }
-      end
-    end
-
-    describe "#person_by_slug" do
-      let(:task) { Rake::Task["publishing_api:republish:person_by_slug"] }
-
-      test "Republishes person by slug" do
-        record = create(:person)
-        Person.any_instance.expects(:publish_to_publishing_api)
-        capture_io { task.invoke(record.slug) }
-      end
-    end
-
-    describe "#role_by_slug" do
-      let(:task) { Rake::Task["publishing_api:republish:role_by_slug"] }
-
-      test "Republishes role by slug" do
-        record = create(:role)
-        Role.any_instance.expects(:publish_to_publishing_api)
-        capture_io { task.invoke(record.slug) }
-      end
-    end
-  end
-
   describe "patch_links" do
     describe "#organisations" do
       let(:task) { Rake::Task["publishing_api:patch_links:organisations"] }


### PR DESCRIPTION
[Trello](https://trello.com/c/temaFDnM/1150-delete-redundant-republishing-rake-tasks-and-update-docs)

**NOTE:** we should probably merge [changes to the developer docs](https://github.com/alphagov/govuk-developer-docs/pull/4646) first, so I'm leaving this as draft for now

We’ve built the UIs for republishing individual pieces of content, covering all of the Rake tasks in the `republish` namespace. We don’t wish to support multiple methods of carrying out these admin tasks, so we're removing the Rake tasks in favour of the UI approach (which also plays back information to users and asks for confirmation, providing a safety net before taking destructive actions)

The bulk republish tasks are retained - we haven't built UIs for these yet

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
