### PR TITLE
Track republishing of Pages in the new Republishing UI

### DIFF
--- a/app/models/republishing_event.rb
+++ b/app/models/republishing_event.rb
@@ -1,0 +1,3 @@
+class RepublishingEvent < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/republishing_event.rb
+++ b/app/models/republishing_event.rb
@@ -1,3 +1,6 @@
 class RepublishingEvent < ApplicationRecord
   belongs_to :user
+
+  validates :action, presence: true
+  validates :reason, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,7 @@ class User < ApplicationRecord
   has_many :user_world_locations
   has_many :world_locations, through: :user_world_locations
   has_many :statistics_announcements, foreign_key: :creator_id
+  has_many :republishing_events
 
   serialize :permissions, coder: YAML, type: Array
 

--- a/app/views/admin/republishing/confirm_page.html.erb
+++ b/app/views/admin/republishing/confirm_page.html.erb
@@ -1,6 +1,7 @@
 <% content_for :page_title, "Republish '#{@title}'" %>
 <% content_for :title, "Are you sure you want to republish '#{@title}'?" %>
 <% content_for :title_margin_bottom, 6 %>
+<% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @republishing_event)) %>
 
 <div class="govuk-grid-row">
   <section class="govuk-grid-column-two-thirds">
@@ -9,10 +10,20 @@
     </p>
     <%= form_with(url: @republishing_path, method: :post, data: {
         module: "prevent-multiple-form-submissions",
-      }) do
-        render("govuk_publishing_components/components/button", {
+      }) do %>
+        <%= render("govuk_publishing_components/components/textarea", {
+          label: {
+            text: "What is the reason for republishing?",
+            heading_size: "m",
+          },
+          name: "reason",
+          id: "republishing_event_reason",
+          error_items: errors_for(@republishing_event.errors, :reason),
+        }) %>
+
+        <%= render("govuk_publishing_components/components/button", {
           text: "Confirm republishing",
-        })
-      end %>
+        }) %>
+   <% end %>
   </section>
 </div>

--- a/db/migrate/20240509112004_create_republishing_events.rb
+++ b/db/migrate/20240509112004_create_republishing_events.rb
@@ -1,0 +1,11 @@
+class CreateRepublishingEvents < ActiveRecord::Migration[7.1]
+  def change
+    create_table :republishing_events do |t|
+      t.text :action, null: false
+      t.text :reason, null: false
+      t.references :user, index: true, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_03_090316) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_09_112004) do
   create_table "assets", charset: "utf8mb3", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.string "variant", null: false
@@ -855,6 +855,15 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_03_090316) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.index ["edition_id"], name: "index_related_mainstreams_on_edition_id"
+  end
+
+  create_table "republishing_events", charset: "utf8mb3", force: :cascade do |t|
+    t.text "action", null: false
+    t.text "reason", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_republishing_events_on_user_id"
   end
 
   create_table "review_reminders", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|

--- a/features/step_definitions/republishing_content_steps.rb.rb
+++ b/features/step_definitions/republishing_content_steps.rb.rb
@@ -5,6 +5,7 @@ end
 When(/^I request a republish of the "([^"]*)" page$/) do |page_title|
   visit admin_republishing_index_path
   find(republishing_link_id_from_page_title(page_title)).click
+  fill_in "What is the reason for republishing?", with: "It needs republishing"
   click_button("Confirm republishing")
 end
 


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## Context

[Trello card](https://trello.com/c/fQLO2W0n/1151-track-republishing-events-in-the-whitehall-republishing-interface)

Now that [we've added a new UI](https://github.com/alphagov/whitehall/pull/8958) for republishing content to replace the running of various rake tasks, we want to know how often it's being used and why.

## Changes in this PR

This PR adds a new `RepublishingEvent` model to Whitehall to keep track of an action being performed (i.e. republishing a thing), a user-entered reason why, and the user who performed the action. The (mandatory) reason for republishing is captured in a newly-added textarea in the Republishing UI for republishing specific Pages, but will shortly be added to the other content types in the interface.

### Screenshot (including validation error)

<img width="1037" alt="image" src="https://github.com/alphagov/whitehall/assets/19826940/1f02c054-3258-496e-b16f-100c61622f5b">

