### PR TITLE
Remove worldwide organisation field from role edit view when feature flag enabled

### DIFF
--- a/app/views/admin/roles/_form.html.erb
+++ b/app/views/admin/roles/_form.html.erb
@@ -87,18 +87,20 @@
     end,
   } %>
 
-  <%= render "components/autocomplete", {
-    id: "role_worldwide_organisation_ids",
-    label: {
-      text: "Worldwide organisations",
-      heading_size: "l",
-    },
-    name: "role[worldwide_organisation_ids][]",
-    select: {
-      options:  options_from_collection_for_select(WorldwideOrganisation.all, "id", "name", role.worldwide_organisation_ids),
-      multiple: true,
-    },
-  } %>
+  <% unless Flipflop.editionable_worldwide_organisations? %>
+    <%= render "components/autocomplete", {
+      id: "role_worldwide_organisation_ids",
+      label: {
+        text: "Worldwide organisations",
+        heading_size: "l",
+      },
+      name: "role[worldwide_organisation_ids][]",
+      select: {
+        options:  options_from_collection_for_select(WorldwideOrganisation.all, "id", "name", role.worldwide_organisation_ids),
+        multiple: true,
+      },
+    } %>
+  <% end %>
 
   <%= render "components/govspeak_editor", {
     label: {

--- a/features/roles.feature
+++ b/features/roles.feature
@@ -1,8 +1,9 @@
 Feature: Administering Roles
-  tHis feature allows the administration of the various different roles in the system
+  This feature allows the administration of the various different roles in the system
 
   Background:
     Given I am an admin
+    And the editionable worldwide organisation feature flag is disabled
 
   Scenario: Adding a traffic commissioner role
     Given the organisation "Department for Transport" exists
@@ -13,6 +14,14 @@ Feature: Administering Roles
   Scenario: Adding a chief scientist
     Given the organisation "Foreign Office" exists
     And a person called "Susan Scientist"
+    When I add a new "Chief scientific advisor" role named "Chief Scientific Advisor to the FCO" to the "Foreign Office"
+    Then I should be able to appoint "Susan Scientist" to the new role
+
+  Scenario: Adding a new role with the editionable worldwide organisation feature flag enabled
+    Given the organisation "Foreign Office" exists
+    And a person called "Susan Scientist"
+    And the editionable worldwide organisation feature flag is enabled
+    Then I should not see the woldwide organisation input field
     When I add a new "Chief scientific advisor" role named "Chief Scientific Advisor to the FCO" to the "Foreign Office"
     Then I should be able to appoint "Susan Scientist" to the new role
 

--- a/features/step_definitions/role_steps.rb
+++ b/features/step_definitions/role_steps.rb
@@ -1,3 +1,8 @@
+When(/^the editionable worldwide organisation feature flag is (enabled|disabled)$/) do |flag|
+  @test_strategy ||= Flipflop::FeatureSet.current.test!
+  @test_strategy.switch!(:editionable_worldwide_organisations, flag == "enabled")
+end
+
 Given(/^an ambassador role named "([^"]*)" in the "([^"]*)" worldwide organisation$/) do |role_name, worldwide_organisation_name|
   worldwide_organisation = WorldwideOrganisation.find_by!(name: worldwide_organisation_name)
   create(:ambassador_role, name: role_name, worldwide_organisations: [worldwide_organisation])
@@ -34,6 +39,12 @@ When(/^I add a new "([^"]*)" role named "([^"]*)" to the "([^"]*)" worldwide org
   select role_type, from: "Role type"
   select worldwide_organisation_name, from: "Worldwide organisations"
   click_on "Save"
+end
+
+Then(/^I should not see the woldwide organisation input field$/) do
+  visit admin_roles_path
+  click_on "Create new role"
+  expect(page).to_not have_selector("input[id=role_worldwide_organisation_ids]")
 end
 
 When(/^I add a new "([^"]*)" translation to the role "([^"]*)" with:$/) do |locale_name, role_name, table|


### PR DESCRIPTION
For Editionable Worldwide Organisations, we are assigning roles to them through the editionable user interface and through the `EditionRole` relationship.

However the non-editionable version of Worldwide Organisations has them assigned on the role user interface and through the `WorldwideOrganisationRole` relationship.

Therefore disabling the non-editionable way of assigning roles when the editionable worldwide organisation feature flag is enabled.

[Trello card](https://trello.com/c/OlL0qIxn)