### PR TITLE
Shorten display name for Editionable Worldwide Organisations

### DIFF
--- a/app/helpers/admin/editions_helper.rb
+++ b/app/helpers/admin/editions_helper.rb
@@ -1,12 +1,16 @@
 module Admin::EditionsHelper
   def edition_type(edition)
-    type = if edition.is_a?(Speech) && edition.speech_type.written_article?
-             edition.speech_type.singular_name
-           else
-             edition.type.underscore.humanize
-           end
+    if edition.has_parent_type?
+      type = if edition.is_a?(Speech) && edition.speech_type.written_article?
+               edition.speech_type.singular_name
+             else
+               edition.type.underscore.humanize
+             end
 
-    [type, edition.display_type].compact.uniq.join(": ")
+      [type, edition.display_type].compact.uniq.join(": ")
+    else
+      edition.display_type
+    end
   end
 
   def admin_organisation_filter_options(selected_organisation)

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -577,6 +577,10 @@ EXISTS (
     self.class.format_name
   end
 
+  def has_parent_type?
+    true
+  end
+
   def display_type
     I18n.t("document.type.#{display_type_key}", count: 1)
   end

--- a/app/models/editionable_worldwide_organisation.rb
+++ b/app/models/editionable_worldwide_organisation.rb
@@ -82,6 +82,10 @@ class EditionableWorldwideOrganisation < Edition
     "editionable_worldwide_organisation"
   end
 
+  def has_parent_type?
+    false
+  end
+
   def self.format_name
     "worldwide organisation"
   end

--- a/test/unit/app/helpers/admin/editions_helper_test.rb
+++ b/test/unit/app/helpers/admin/editions_helper_test.rb
@@ -74,4 +74,16 @@ class Admin::EditionsHelperTest < ActionView::TestCase
 
     assert_equal expected_result, reset_search_fields_query_string_params(user, admin_editions_path, "#anchor")
   end
+
+  test "#edition_type returns a concatenated string where an edition has a parent type" do
+    edition = build(:news_article)
+
+    assert_equal "News article: Press release", edition_type(edition)
+  end
+
+  test "#edition_type returns a single string where an edition does not have a parent type" do
+    edition = build(:editionable_worldwide_organisation)
+
+    assert_equal "Worldwide organisation", edition_type(edition)
+  end
 end


### PR DESCRIPTION
We currently display the document type as `Editionable worldwide organisation: Worldwide organisation`, however most of the words are redundant.

Therefore shortening to `Worldwide organisation`.

![Screenshot of Whitehall showing an example editionable worldwide organisation summary page.  The field labelled "Type of document" has the value "Worldwide organisation".](https://github.com/alphagov/whitehall/assets/6329861/168a20f0-855e-4030-a7e9-e59892bafaf2)

This has been done in a generic way, so we can expand the use of single strings for any other document types that are migrated to be editionable in the future.

[Trello card](https://trello.com/c/u9aBoIVm)