### PR TITLE
Track remainder of republishing content

### DIFF
--- a/app/controllers/admin/republishing_controller.rb
+++ b/app/controllers/admin/republishing_controller.rb
@@ -134,6 +134,8 @@ class Admin::RepublishingController < Admin::BaseController
       @role = Role.find_by(slug: params[:role_slug])
       render "admin/errors/not_found", status: :not_found unless @role
     end
+
+    @republishing_event = RepublishingEvent.new
   end
 
   def republish_role
@@ -142,9 +144,16 @@ class Admin::RepublishingController < Admin::BaseController
       return render "admin/errors/not_found", status: :not_found unless @role
     end
 
-    @role.publish_to_publishing_api
-    flash[:notice] = "The role '#{@role.name}' has been republished"
-    redirect_to(admin_republishing_index_path)
+    action = "The role '#{@role.name}' has been republished"
+    @republishing_event = build_republishing_event(action)
+
+    if @republishing_event.save
+      @role.publish_to_publishing_api
+      flash[:notice] = action
+      redirect_to(admin_republishing_index_path)
+    else
+      render "confirm_role"
+    end
   end
 
   def find_document; end

--- a/app/controllers/admin/republishing_controller.rb
+++ b/app/controllers/admin/republishing_controller.rb
@@ -94,6 +94,8 @@ class Admin::RepublishingController < Admin::BaseController
       @person = Person.find_by(slug: params[:person_slug])
       render "admin/errors/not_found", status: :not_found unless @person
     end
+
+    @republishing_event = RepublishingEvent.new
   end
 
   def republish_person
@@ -102,9 +104,16 @@ class Admin::RepublishingController < Admin::BaseController
       return render "admin/errors/not_found", status: :not_found unless @person
     end
 
-    @person.publish_to_publishing_api
-    flash[:notice] = "The person '#{@person.name}' has been republished"
-    redirect_to(admin_republishing_index_path)
+    action = "The person '#{@person.name}' has been republished"
+    @republishing_event = build_republishing_event(action)
+
+    if @republishing_event.save
+      @person.publish_to_publishing_api
+      flash[:notice] = action
+      redirect_to(admin_republishing_index_path)
+    else
+      render "confirm_person"
+    end
   end
 
   def find_role; end

--- a/app/controllers/admin/republishing_controller.rb
+++ b/app/controllers/admin/republishing_controller.rb
@@ -54,6 +54,8 @@ class Admin::RepublishingController < Admin::BaseController
       @organisation = Organisation.find_by(slug: params[:organisation_slug])
       render "admin/errors/not_found", status: :not_found unless @organisation
     end
+
+    @republishing_event = RepublishingEvent.new
   end
 
   def republish_organisation
@@ -62,9 +64,16 @@ class Admin::RepublishingController < Admin::BaseController
       return render "admin/errors/not_found", status: :not_found unless @organisation
     end
 
-    @organisation.publish_to_publishing_api
-    flash[:notice] = "The organisation '#{@organisation.name}' has been republished"
-    redirect_to(admin_republishing_index_path)
+    action = "The organisation '#{@organisation.name}' has been republished"
+    @republishing_event = build_republishing_event(action)
+
+    if @republishing_event.save
+      @organisation.publish_to_publishing_api
+      flash[:notice] = action
+      redirect_to(admin_republishing_index_path)
+    else
+      render "confirm_organisation"
+    end
   end
 
   def find_person; end

--- a/app/views/admin/republishing/_form.html.erb
+++ b/app/views/admin/republishing/_form.html.erb
@@ -1,0 +1,17 @@
+<%= form_with(url: republishing_url, method: :post, data: {
+    module: "prevent-multiple-form-submissions",
+  }) do %>
+    <%= render("govuk_publishing_components/components/textarea", {
+      label: {
+        text: "What is the reason for republishing?",
+        heading_size: "m",
+      },
+      name: "reason",
+      id: "republishing_event_reason",
+      error_items: errors_for(@republishing_event.errors, :reason),
+    }) %>
+
+    <%= render("govuk_publishing_components/components/button", {
+      text: "Confirm republishing",
+    }) %>
+<% end %>

--- a/app/views/admin/republishing/confirm_document.html.erb
+++ b/app/views/admin/republishing/confirm_document.html.erb
@@ -1,6 +1,7 @@
 <% content_for :page_title, "Republish '#{@document.slug}'" %>
 <% content_for :title, "Are you sure you want to republish '#{@document.slug}'?" %>
 <% content_for :title_margin_bottom, 6 %>
+<% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @republishing_event)) %>
 
 <div class="govuk-grid-row">
   <section class="govuk-grid-column-two-thirds">
@@ -29,13 +30,6 @@
           ]
         end,
     } %>
-
-    <%= form_with(url: admin_republishing_document_republish_path(@document.slug), method: :post, data: {
-        module: "prevent-multiple-form-submissions",
-      }) do
-        render("govuk_publishing_components/components/button", {
-          text: "Confirm republishing",
-        })
-      end %>
+    <%= render "form", republishing_url: admin_republishing_document_republish_path(@document.slug) %>
   </section>
 </div>

--- a/app/views/admin/republishing/confirm_organisation.html.erb
+++ b/app/views/admin/republishing/confirm_organisation.html.erb
@@ -1,18 +1,13 @@
 <% content_for :page_title, "Republish '#{@organisation.name}'" %>
 <% content_for :title, "Are you sure you want to republish '#{@organisation.name}'?" %>
 <% content_for :title_margin_bottom, 6 %>
+<% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @republishing_event)) %>
 
 <div class="govuk-grid-row">
   <section class="govuk-grid-column-two-thirds">
     <p class="govuk-body govuk-!-margin-bottom-7">
       This will republish the organisation <%= link_to @organisation.name, @organisation.public_url, { class: "govuk-link" } %>.
     </p>
-    <%= form_with(url: admin_republishing_organisation_republish_path(@organisation.slug), method: :post, data: {
-        module: "prevent-multiple-form-submissions",
-      }) do
-        render("govuk_publishing_components/components/button", {
-          text: "Confirm republishing",
-        })
-      end %>
+    <%= render "form", republishing_url: admin_republishing_organisation_republish_path(@organisation.slug) %>
   </section>
 </div>

--- a/app/views/admin/republishing/confirm_page.html.erb
+++ b/app/views/admin/republishing/confirm_page.html.erb
@@ -8,22 +8,6 @@
     <p class="govuk-body govuk-!-margin-bottom-7">
       This will schedule the page to be republished.
     </p>
-    <%= form_with(url: @republishing_path, method: :post, data: {
-        module: "prevent-multiple-form-submissions",
-      }) do %>
-        <%= render("govuk_publishing_components/components/textarea", {
-          label: {
-            text: "What is the reason for republishing?",
-            heading_size: "m",
-          },
-          name: "reason",
-          id: "republishing_event_reason",
-          error_items: errors_for(@republishing_event.errors, :reason),
-        }) %>
-
-        <%= render("govuk_publishing_components/components/button", {
-          text: "Confirm republishing",
-        }) %>
-   <% end %>
+    <%= render "form", republishing_url: @republishing_path %>
   </section>
 </div>

--- a/app/views/admin/republishing/confirm_person.html.erb
+++ b/app/views/admin/republishing/confirm_person.html.erb
@@ -1,18 +1,13 @@
 <% content_for :page_title, "Republish '#{@person.name}'" %>
 <% content_for :title, "Are you sure you want to republish '#{@person.name}'?" %>
 <% content_for :title_margin_bottom, 6 %>
+<% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @republishing_event)) %>
 
 <div class="govuk-grid-row">
   <section class="govuk-grid-column-two-thirds">
     <p class="govuk-body govuk-!-margin-bottom-7">
       This will republish the person <%= link_to @person.name, @person.public_url, { class: "govuk-link" } %>.
     </p>
-    <%= form_with(url: admin_republishing_person_republish_path(@person.slug), method: :post, data: {
-        module: "prevent-multiple-form-submissions",
-      }) do
-        render("govuk_publishing_components/components/button", {
-          text: "Confirm republishing",
-        })
-      end %>
+    <%= render "form", republishing_url: admin_republishing_person_republish_path(@person.slug) %>
   </section>
 </div>

--- a/app/views/admin/republishing/confirm_role.html.erb
+++ b/app/views/admin/republishing/confirm_role.html.erb
@@ -1,6 +1,7 @@
 <% content_for :page_title, "Republish '#{@role.name}'" %>
 <% content_for :title, "Are you sure you want to republish '#{@role.name}'?" %>
 <% content_for :title_margin_bottom, 6 %>
+<% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @republishing_event)) %>
 
 <div class="govuk-grid-row">
   <section class="govuk-grid-column-two-thirds">
@@ -11,12 +12,6 @@
         This will republish the role '<%= @role.name %>'.
       <% end %>
     </p>
-    <%= form_with(url: admin_republishing_role_republish_path(@role.slug), method: :post, data: {
-        module: "prevent-multiple-form-submissions",
-      }) do
-        render("govuk_publishing_components/components/button", {
-          text: "Confirm republishing",
-        })
-      end %>
+    <%= render "form", republishing_url: admin_republishing_role_republish_path(@role.slug) %>
   </section>
 </div>

--- a/features/step_definitions/republishing_content_steps.rb.rb
+++ b/features/step_definitions/republishing_content_steps.rb.rb
@@ -26,6 +26,7 @@ When(/^I request a republish of the "An Existing Organisation" organisation$/) d
   find("#republish-organisation").click
   fill_in "Enter the slug for the organisation", with: "an-existing-organisation"
   click_button("Continue")
+  fill_in "What is the reason for republishing?", with: "It needs republishing"
   click_button("Confirm republishing")
 end
 

--- a/features/step_definitions/republishing_content_steps.rb.rb
+++ b/features/step_definitions/republishing_content_steps.rb.rb
@@ -90,6 +90,7 @@ When(/^I request a republish of the "an-existing-document" document's editions$/
   find("#republish-document").click
   fill_in "Enter the slug for the document", with: "an-existing-document"
   click_button("Continue")
+  fill_in "What is the reason for republishing?", with: "It needs republishing"
   click_button("Confirm republishing")
 end
 

--- a/features/step_definitions/republishing_content_steps.rb.rb
+++ b/features/step_definitions/republishing_content_steps.rb.rb
@@ -47,6 +47,7 @@ When(/^I request a republish of the "Existing Person" person$/) do
   find("#republish-person").click
   fill_in "Enter the slug for the person", with: "existing-person"
   click_button("Continue")
+  fill_in "What is the reason for republishing?", with: "It needs republishing"
   click_button("Confirm republishing")
 end
 

--- a/features/step_definitions/republishing_content_steps.rb.rb
+++ b/features/step_definitions/republishing_content_steps.rb.rb
@@ -68,6 +68,7 @@ When(/^I request a republish of the "An Existing Role" role$/) do
   find("#republish-role").click
   fill_in "Enter the slug for the role", with: "an-existing-role"
   click_button("Continue")
+  fill_in "What is the reason for republishing?", with: "It needs republishing"
   click_button("Confirm republishing")
 end
 


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## Context

[Trello card](https://trello.com/c/fQLO2W0n/1151-track-republishing-events-in-the-whitehall-republishing-interface)

Now that [we've added a new UI](https://github.com/alphagov/whitehall/pull/8958) for republishing content to replace the running of various rake tasks, we want to know how often it's being used and why.

We've recently added tracking for republishing "Page"s in #9042. 

## Changes in this PR

Creates a `RepublishingEvent` when the following content types are republished:
- Organisation
- Person
- Role
- Document

To make this easier, I've also extracted the form for republishing a content type and capturing the republishing reason into a partial.

## Screenshots

### Organisation

![image](https://github.com/alphagov/whitehall/assets/19826940/45eb8c43-2236-4b16-a105-9c0e2d6efd1a)

### Person

![image](https://github.com/alphagov/whitehall/assets/19826940/d1d2449c-7d87-4fa2-81dd-e4a6160e320d)

### Role

![image](https://github.com/alphagov/whitehall/assets/19826940/9ddd7ea8-35d5-4b8c-8bf9-aeae74789275)

### Document

![image](https://github.com/alphagov/whitehall/assets/19826940/95e2125c-ffc8-4c79-b413-ec5257854779)


