### PR TITLE
Hide markdown help when visual editor is showing

### DIFF
--- a/app/assets/javascripts/components/visual-editor.js
+++ b/app/assets/javascripts/components/visual-editor.js
@@ -33,6 +33,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {}
     this.contentEditable = this.container.querySelector(
       'div[contenteditable="true"]'
     )
+    this.markdownHelp = document.querySelector('.govspeak-help')
 
     this.exitButton.addEventListener('click', this.hideVisualEditor.bind(this))
     this.showVisualEditor()
@@ -44,6 +45,9 @@ window.GOVUK.Modules = window.GOVUK.Modules || {}
     )
     this.visualEditorWrapper.classList.add(
       'app-c-visual-editor__visual-editor-wrapper--show'
+    )
+    this.markdownHelp.classList.add(
+      'app-c-visual-editor__markdown-help--hidden'
     )
     this.visual_editor_flag.value = true
 
@@ -57,6 +61,9 @@ window.GOVUK.Modules = window.GOVUK.Modules || {}
     )
     this.visualEditorWrapper.classList.remove(
       'app-c-visual-editor__visual-editor-wrapper--show'
+    )
+    this.markdownHelp.classList.remove(
+      'app-c-visual-editor__markdown-help--hidden'
     )
     this.visual_editor_flag.value = false
 

--- a/app/assets/stylesheets/components/_visual-editor.scss
+++ b/app/assets/stylesheets/components/_visual-editor.scss
@@ -2,7 +2,8 @@
 
 .app-c-visual-editor__content,
 .app-c-visual-editor__visual-editor-wrapper,
-.app-c-visual-editor__govspeak-editor-wrapper--hidden {
+.app-c-visual-editor__govspeak-editor-wrapper--hidden,
+.app-c-visual-editor__markdown-help--hidden {
   display: none;
 }
 

--- a/test/functional/admin/attachments_controller_test.rb
+++ b/test/functional/admin/attachments_controller_test.rb
@@ -281,7 +281,7 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
     assert_select "option[value='#{Attachment.parliamentary_sessions.first}']"
   end
 
-  view_test "GET :new shows visual editor if permission and feature flag are enabled" do
+  view_test "GET :new shows visual editor and no markdown help if permission and feature flag are enabled" do
     feature_flags.switch!(:govspeak_visual_editor, true)
     current_user.permissions << User::Permissions::VISUAL_EDITOR_PRIVATE_BETA
 
@@ -289,6 +289,7 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
     get :new, params: { edition_id: publication, type: "html" }
 
     assert_select(".app-c-visual-editor__container")
+    assert_select ".govspeak-help", visible: false, count: 1
   end
 
   test "POST :create with bad data does not save the attachment and re-renders the new template" do
@@ -309,7 +310,7 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
     assert_select "input[type=file]"
   end
 
-  view_test "GET :edit shows visual editor if permission and feature flag are enabled, and attachment has been saved with visual editor" do
+  view_test "GET :edit shows visual editor and no markdown help if permission and feature flag are enabled, and attachment has been saved with visual editor" do
     feature_flags.switch!(:govspeak_visual_editor, true)
     current_user.permissions << User::Permissions::VISUAL_EDITOR_PRIVATE_BETA
 
@@ -317,9 +318,10 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
     get :edit, params: { edition_id: @edition, id: attachment }
 
     assert_select(".app-c-visual-editor__container")
+    assert_select ".govspeak-help", visible: false, count: 1
   end
 
-  view_test "edit form does not render visual editor for exited attachments" do
+  view_test "edit form does not render visual editor, and renders the markdown help, for exited attachments" do
     feature_flags.switch!(:govspeak_visual_editor, true)
     current_user.permissions << User::Permissions::VISUAL_EDITOR_PRIVATE_BETA
 
@@ -327,9 +329,10 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
     get :edit, params: { edition_id: @edition, id: attachment }
 
     assert_select ".app-c-visual-editor__container", count: 0
+    assert_select ".govspeak-help", count: 1
   end
 
-  view_test "edit form does not render visual editor for pre-existing attachments" do
+  view_test "edit form does not render visual editor, and renders the markdown help, for pre-existing attachments" do
     feature_flags.switch!(:govspeak_visual_editor, true)
     current_user.permissions << User::Permissions::VISUAL_EDITOR_PRIVATE_BETA
 
@@ -337,6 +340,7 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
     get :edit, params: { edition_id: @edition, id: attachment }
 
     assert_select ".app-c-visual-editor__container", count: 0
+    assert_select ".govspeak-help", count: 1
   end
 
   test "PUT :update for HTML attachment updates the attachment" do

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -60,13 +60,14 @@ module AdminEditionControllerTestHelpers
         assert_select(".js-app-c-govspeak-editor__preview-button")
       end
 
-      view_test "new form has visual editor when flip flop enabled and user has permission" do
+      view_test "new form has visual editor and no markdown help when flip flop enabled and user has permission" do
         feature_flags.switch!(:govspeak_visual_editor, true)
         current_user.permissions << User::Permissions::VISUAL_EDITOR_PRIVATE_BETA
 
         get :new
 
         assert_select(".app-c-visual-editor__container")
+        assert_select ".govspeak-help", visible: false, count: 1
       end
 
       view_test "new form has cancel link which takes the user to the list of drafts" do
@@ -192,7 +193,7 @@ module AdminEditionControllerTestHelpers
         assert_select(".js-app-c-govspeak-editor__preview-button")
       end
 
-      view_test "edit form renders visual editor when feature flag is enabled, user has permission, and edition has been saved with visual editor" do
+      view_test "edit form renders visual editor and no markdown help when feature flag is enabled, user has permission, and edition has been saved with visual editor" do
         feature_flags.switch!(:govspeak_visual_editor, true)
         current_user.permissions << User::Permissions::VISUAL_EDITOR_PRIVATE_BETA
 
@@ -201,9 +202,10 @@ module AdminEditionControllerTestHelpers
         get :edit, params: { id: edition }
 
         assert_select(".app-c-visual-editor__container")
+        assert_select ".govspeak-help", visible: false, count: 1
       end
 
-      view_test "edit form does not render visual editor for exited editions" do
+      view_test "edit form does not render visual editor, and renders the markdown help, for exited editions" do
         feature_flags.switch!(:govspeak_visual_editor, true)
         current_user.permissions << User::Permissions::VISUAL_EDITOR_PRIVATE_BETA
 
@@ -212,9 +214,10 @@ module AdminEditionControllerTestHelpers
         get :edit, params: { id: edition }
 
         assert_select ".app-c-visual-editor__container", count: 0
+        assert_select ".govspeak-help", count: 1
       end
 
-      view_test "edit form does not render visual editor for pre-existing editions" do
+      view_test "edit form does not render visual editor, and renders the markdown help, for pre-existing editions" do
         feature_flags.switch!(:govspeak_visual_editor, true)
         current_user.permissions << User::Permissions::VISUAL_EDITOR_PRIVATE_BETA
 
@@ -223,6 +226,7 @@ module AdminEditionControllerTestHelpers
         get :edit, params: { id: edition }
 
         assert_select ".app-c-visual-editor__container", count: 0
+        assert_select ".govspeak-help", count: 1
       end
 
       view_test "edit form has cancel link which takes the user back to edition" do


### PR DESCRIPTION
## User story
As a Private Beta user
I do not want to see the GovSpeak Markdown guidance whilst using the VIsual Editor
So that I don’t get confused as it is not usable with the Visual Editor

## Acceptance Criteria
**Given** I am a Private Beta trial user
**When** I edit a new document
**And** I see the Visual Editor
**Then** the Markdown Help Guidance on the right side is not shown


[Trello card](https://trello.com/c/8Cqmgw0E/2490-hide-markdown-guidance-when-using-the-visual-editor)
