### PR TITLE
Add translation validations for Editionable Worldwide Organisation parts

### DIFF
--- a/app/models/worldwide_organisation_page.rb
+++ b/app/models/worldwide_organisation_page.rb
@@ -7,6 +7,7 @@ class WorldwideOrganisationPage < ApplicationRecord
             presence: true,
             exclusion: { in: [CorporateInformationPageType::AboutUs.id], message: "Type cannot be `About us`" }
   validate :unique_worldwide_organisation_and_page_type, on: :create, if: :edition
+  validate :parent_edition_has_locales, if: :edition
 
   after_commit :republish_worldwide_organisation_draft
   after_destroy :discard_draft
@@ -75,6 +76,14 @@ private
 
     if duplicate_page
       errors.add(:base, "Another '#{display_type_key.humanize}' page already exists for this worldwide organisation")
+    end
+  end
+
+  def parent_edition_has_locales
+    non_existent_translations = non_english_translated_locales - edition.non_english_translated_locales
+
+    unless non_existent_translations.empty?
+      errors.add(:base, "Translations '#{non_existent_translations.map(&:code).join(', ')}' do not exist for this worldwide organisation")
     end
   end
 end

--- a/test/unit/app/models/contact_test.rb
+++ b/test/unit/app/models/contact_test.rb
@@ -292,4 +292,21 @@ class ContactTest < ActiveSupport::TestCase
       office.contact.destroy!
     end
   end
+
+  test "when associated with a WorldwideOffice should be valid when translated into a language that the worldwide office's associated organisation has" do
+    worldwide_organisation = create(:editionable_worldwide_organisation, translated_into: %i[de es fr])
+    office = create(:worldwide_office, edition: worldwide_organisation, worldwide_organisation: nil)
+    contact = create(:contact, contactable: office, translated_into: %i[fr])
+
+    assert contact.valid?
+  end
+
+  test "when associated with a WorldwideOffice should not be valid when translated into a language that the worldwide office's associated organisation does not have" do
+    worldwide_organisation = create(:editionable_worldwide_organisation, translated_into: %i[de es fr])
+    office = create(:worldwide_office, edition: worldwide_organisation, worldwide_organisation: nil)
+    contact = create(:contact, contactable: office, translated_into: %i[cy es-419])
+
+    assert_not contact.valid?
+    assert contact.errors[:base].include?("Translations 'cy, es-419' do not exist for this worldwide organisation")
+  end
 end

--- a/test/unit/app/models/editionable_worldwide_organisation_test.rb
+++ b/test/unit/app/models/editionable_worldwide_organisation_test.rb
@@ -179,7 +179,7 @@ class EditionableWorldwideOrganisationTest < ActiveSupport::TestCase
 
   test "should clone office and contact associations when new draft of published edition is created" do
     contact = create(:contact, translated_into: [:es])
-    published_worldwide_organisation = create(:editionable_worldwide_organisation, :published)
+    published_worldwide_organisation = create(:editionable_worldwide_organisation, :published, translated_into: [:es])
     create(:worldwide_office, worldwide_organisation: nil, edition: published_worldwide_organisation, contact:)
 
     draft_worldwide_organisation = published_worldwide_organisation.create_draft(create(:writer))

--- a/test/unit/app/models/worldwide_organisation_page_test.rb
+++ b/test/unit/app/models/worldwide_organisation_page_test.rb
@@ -85,4 +85,19 @@ class WorldwideOrganisationPageTest < ActiveSupport::TestCase
     expected_locales = %i[de fr].map { |l| Locale.new(l) }
     assert_equal expected_locales, page.missing_translations
   end
+
+  test "should be valid when translated into a language that the worldwide organisation has" do
+    worldwide_organisation = create(:editionable_worldwide_organisation, translated_into: %i[de es fr])
+    page = create(:worldwide_organisation_page, edition: worldwide_organisation, translated_into: %i[fr])
+
+    assert page.valid?
+  end
+
+  test "should not be valid when translated into a language that the worldwide organisation does not have" do
+    worldwide_organisation = create(:editionable_worldwide_organisation, translated_into: %i[de es fr])
+    page = create(:worldwide_organisation_page, edition: worldwide_organisation, translated_into: %i[cy es-419])
+
+    assert_not page.valid?
+    assert page.errors[:base].include?("Translations 'cy, es-419' do not exist for this worldwide organisation")
+  end
 end


### PR DESCRIPTION
This ensures that Worldwide Organisation Pages and Worldwide Offices can only have a translation if the parent Editionable Worldwide Organisation also has the same translation.

The condition was enforced in the controllers, but adding a validation to the models ensures this conditions is enforced everywhere.

[Trello card](https://trello.com/c/QrJ74EK3)