### PR TITLE
Add CallForEvidence as potentially political content

### DIFF
--- a/lib/political_content_identifier.rb
+++ b/lib/political_content_identifier.rb
@@ -1,5 +1,6 @@
 class PoliticalContentIdentifier
   POTENTIALLY_POLITICAL_FORMATS = [
+    CallForEvidence,
     Consultation,
     Speech,
     NewsArticle,


### PR DESCRIPTION
## What

We need to be able to mark a call for evidence as political, so that if there is a change of government the public will be aware that the call for evidence applied to a previous government.

## Why

There's going to be an election at some point in time and so this functionality is required. 

https://trello.com/c/lpFrbCj3/2577-add-call-for-evidence-to-history-mode-logic