### PR TITLE
Renamed national statistics document type to accredited official statistics

### DIFF
--- a/app/models/publication_type.rb
+++ b/app/models/publication_type.rb
@@ -99,7 +99,7 @@ class PublicationType
   StatutoryGuidance      = create!(id: 19, key: "statutory_guidance", singular_name: "Statutory guidance", plural_name: "Statutory guidance", prevalence: :primary, additional_search_format_types: %w[publicationesque-guidance])
   Form                   = create!(id: 4, key: "form", singular_name: "Form", plural_name: "Forms", prevalence: :primary)
   OfficialStatistics     = create!(id: 5, key: "official_statistics", singular_name: "Official Statistics", plural_name: "Official Statistics", prevalence: :primary, access_limited_by_default: true, additional_search_format_types: %w[publicationesque-statistics], detailed_format: "statistics")
-  NationalStatistics     = create!(id: 15, key: "national_statistics", singular_name: "National Statistics", plural_name: "National Statistics", prevalence: :primary, access_limited_by_default: true, additional_search_format_types: %w[publicationesque-statistics], detailed_format: "statistics-national-statistics")
+  NationalStatistics     = create!(id: 15, key: "national_statistics", singular_name: "Accredited Official Statistics", plural_name: "Accredited Official Statistics", prevalence: :primary, access_limited_by_default: true, additional_search_format_types: %w[publicationesque-statistics], detailed_format: "statistics-national-statistics")
   ResearchAndAnalysis    = create!(id: 6, key: "research", singular_name: "Research and analysis", plural_name: "Research and analysis", prevalence: :primary)
   CorporateReport        = create!(id: 7, key: "corporate_report", singular_name: "Corporate report", plural_name: "Corporate reports", prevalence: :primary)
   Map                    = create!(id: 17, key: "map", singular_name: "Map", plural_name: "Maps", prevalence: :primary)

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -439,8 +439,8 @@ cy:
       national_statistics:
         few:
         many:
-        one: Ystadegau Gwladol
-        other: Ystadegau Gwladol
+        one: Ystadegau swyddogol achrededig
+        other: Ystadegau swyddogol achrededig
         two:
         zero:
       news_article:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -248,8 +248,8 @@ en:
         one: Modern Slavery Statement
         other: Modern Slavery Statements
       national_statistics:
-        one: National Statistics
-        other: National Statistics
+        one: Accredited official statistics
+        other: Accredited official statistics
       news_article:
         one: News article
         other: News articles


### PR DESCRIPTION
From the 7th June, National Statistics documents will be known as Accredited Official Statistics, in line with Office for National Statistics Guidance. We will republish all national statistics documents to apply this name change.

Trello: https://trello.com/c/jkaJlgez
