### PR TITLE
Index editions updated_at

### DIFF
--- a/db/migrate/20240520155856_add_index_to_editions_updated_at.rb
+++ b/db/migrate/20240520155856_add_index_to_editions_updated_at.rb
@@ -1,0 +1,5 @@
+class AddIndexToEditionsUpdatedAt < ActiveRecord::Migration[7.1]
+  def change
+    add_index(:editions, :updated_at)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_09_112004) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_20_155856) do
   create_table "assets", charset: "utf8mb3", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.string "variant", null: false
@@ -424,6 +424,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_09_112004) do
     t.index ["state", "type"], name: "index_editions_on_state_and_type"
     t.index ["state"], name: "index_editions_on_state"
     t.index ["type"], name: "index_editions_on_type"
+    t.index ["updated_at"], name: "index_editions_on_updated_at"
   end
 
   create_table "editorial_remarks", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|


### PR DESCRIPTION
[EditionFilter](https://github.com/alphagov/whitehall/blob/main/app/models/admin/edition_filter.rb) is used to find and paginate editions on the editions index page. It sorts editions descending on updated_at, which has been the behaviour since 2011 (24b2a027).

Without an index covering updated_at, the only way to find the most recent editions matching some set of criteria is to do a full table scan. With an index, the database can go through the editions most recent first and stop when it's found 25 editions matching the criteria.

If we compare two `select * from editions where ... order by COLUMN limit 25` queries, the first one using the `updated_at` column which has no index, and the second one using the `public_timestamp` column, which has, we can see the performance difference on the table.

In integration:

```
EXPLAIN ANALYZE SELECT * FROM `editions` WHERE `editions`.`state` != 'deleted' ORDER BY editions.updated_at DESC LIMIT 25 OFFSET 0
    -> Limit: 25 row(s)  (cost=134443 rows=25) (actual time=4847..4847 rows=25 loops=1)
        -> Sort: editions.updated_at DESC, limit input to 25 row(s) per chunk  (cost=134443 rows=1.31e+6) (actual time=4847..4847 rows=25 loops=1)
            -> Filter: (editions.state <> 'deleted')  (cost=134443 rows=1.31e+6) (actual time=0.767..4035 rows=1.28e+6 loops=1)
                -> Table scan on editions  (cost=134443 rows=1.31e+6) (actual time=0.0331..3810 rows=1.43e+6 loops=1)
```
```
EXPLAIN ANALYZE SELECT * FROM `editions` WHERE `editions`.`state` != 'deleted' ORDER BY editions.public_timestamp DESC LIMIT 25 OFFSET 0
    -> Limit: 25 row(s)  (cost=2.59 rows=24.5) (actual time=0.0439..0.17 rows=25 loops=1)
        -> Filter: (editions.state <> 'deleted')  (cost=2.59 rows=24.5) (actual time=0.0432..0.167 rows=25 loops=1)
            -> Index scan on editions using index_editions_on_public_timestamp (reverse)  (cost=2.59 rows=49) (actual time=0.0413..0.161 rows=25 loops=1)
```

Note the difference in actual time between the Table scan (3810ms) and the Index scan (0.161ms) - 23,000 times faster. If executing the query was equivalent to walking 1 meter, this is the difference between travelling at 0.5 mph (coincidentally, around [the speed of a relatively fast tortoise](https://tortoisetips.com/are-tortoises-fast/) 🐢) and Mach 18 (around [the speed of the HTV-2 hypersonic glide vehicle](https://en.wikipedia.org/wiki/Hypersonic_Technology_Vehicle_2) 🚀 ).

In practice though we don't want to sort by public_timestamp, we actually do want to sort by updated_at. So the right thing to do seems to be to add an index to this column.

We tried adding an index to this column in 03277d8, but then reverted it in 2993674e because we were worried about locking the editions table while the migration ran. I don't think those concerns are valid anymore, because we've since upgraded from MySQL 5.5 to MySQL 8. [MySQL 5.5 used to lock the table for writes while adding secondary indexes](https://downloads.mysql.com/docs/innodb-1.1-en.a4.pdf), but in MySQL 8 "[the table remains available for read and write operations while the index is being created](https://dev.mysql.com/doc/refman/8.0/en/innodb-online-ddl-operations.html#online-ddl-index-syntax-notes)".

I haven't yet tested:
- ~how long this index will take to add initially~ (The index took 6 seconds to add in integration)
- whether it will lock the table while it's being added (Shouldn't do - see the notes above about [MySQL 8's behaviour](https://dev.mysql.com/doc/refman/8.0/en/innodb-online-ddl-operations.html#online-ddl-index-syntax-notes))
- what effect it will have on insert performance (I assume minimal)
- how much extra storage the index will take up (I assume minimal again - should be no more than the other similar indexes on this table)
- what the real world effect will be on page loads - this isn't the only slow query on the editions index page

For all of these things, I think the best option is to run the migration in integration and see what happens.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
