### PR TITLE
Begin modelling a Content Library within Whitehall

### DIFF
--- a/app/controllers/admin/object_store/items_controller.rb
+++ b/app/controllers/admin/object_store/items_controller.rb
@@ -1,0 +1,27 @@
+module Admin::ObjectStore
+  class ItemsController < Admin::EditionsController
+  private
+
+    def edition_class
+      ObjectStore::Item
+    end
+
+    def permitted_edition_attributes
+      (super << ObjectStore.field_names_for_item_type(params[:item_type])).flatten
+    end
+
+    def show_or_edit_path
+      if params[:save].present?
+        edit_admin_object_store_item_path(@edition.item_type, @edition)
+      else
+        admin_object_store_item_path @edition
+      end
+    end
+
+    def new_edition
+      edition = edition_class.new(item_type: params[:item_type])
+      edition.assign_attributes(new_edition_params)
+      edition
+    end
+  end
+end

--- a/app/helpers/admin/object_store/items_helper.rb
+++ b/app/helpers/admin/object_store/items_helper.rb
@@ -1,0 +1,39 @@
+module Admin
+  module ObjectStore
+    module ItemsHelper
+      def edition_name(edition)
+        edition.item_type.titleize
+      end
+
+      def render_partial_path(edition, partial_name)
+        render partial: partial_path(edition, partial_name), object: edition, as: edition.item_type
+      end
+
+      def partial_path(edition, partial_name)
+        dirname = edition.item_type.pluralize
+        File.join("admin", "object_store", dirname, partial_name)
+      end
+
+      def object_store_item_form(edition)
+        form_for edition, url: form_url_for_object_store_item(edition), as: edition.item_type do |form|
+          yield(form)
+          concat render("govuk_publishing_components/components/button", {
+            text: "Save",
+            value: "save",
+            name: "save",
+            data_attributes: {
+              module: "gem-track-click",
+              "track-category": "form-button",
+              "track-action": "object-store-item-button",
+              "track-label": "Save",
+            },
+          })
+        end
+      end
+
+      def form_url_for_object_store_item(edition)
+        admin_object_store_items_path(item_type: edition.item_type)
+      end
+    end
+  end
+end

--- a/app/models/object_store/item.rb
+++ b/app/models/object_store/item.rb
@@ -4,6 +4,10 @@ module ObjectStore
 
     after_initialize :add_field_accessors
 
+    validates :item_type, presence: true, on: :create
+    validate :item_type_cannot_change
+    validates :item_type, inclusion: { in: ObjectStore.item_types }
+
     def summary_required?
       false
     end
@@ -28,6 +32,12 @@ module ObjectStore
       end
     rescue UnknownItemType
       # Ignored
+    end
+
+    def item_type_cannot_change
+      if persisted? && item_type_changed?
+        errors.add :item_type, "cannot be changed after creation"
+      end
     end
   end
 end

--- a/app/models/object_store/item.rb
+++ b/app/models/object_store/item.rb
@@ -1,0 +1,33 @@
+module ObjectStore
+  class Item < Edition
+    store_accessor :details, :item_type
+
+    after_initialize :add_field_accessors
+
+    def summary_required?
+      false
+    end
+
+    def body_required?
+      false
+    end
+
+    def previously_published
+      false
+    end
+
+  private
+
+    def add_field_accessors
+      properties = ObjectStore.fields_for_item_type(item_type)
+      properties.each_key do |k|
+        singleton_class.class_eval { store_accessor :details, k }
+        if ObjectStore.field_is_required?(item_type, k)
+          singleton_class.class_eval { validates k, presence: true }
+        end
+      end
+    rescue UnknownItemType
+      # Ignored
+    end
+  end
+end

--- a/app/views/admin/object_store/email_addresses/_form.html.erb
+++ b/app/views/admin/object_store/email_addresses/_form.html.erb
@@ -1,0 +1,21 @@
+<%= object_store_item_form(email_address) do |form| %>
+  <%= render "govuk_publishing_components/components/input", {
+    label: {
+      text: "Title",
+    },
+    heading_size: "m",
+    value: form.object.title,
+    name: "edition[title]",
+    id: "edition_title",
+  } %>
+
+  <%= render "govuk_publishing_components/components/input", {
+    label: {
+      text: "Email address",
+    },
+    heading_size: "m",
+    value: form.object.email_address,
+    name: "edition[email_address]",
+    id: "edition_email_address",
+  } %>
+<% end %>

--- a/app/views/admin/object_store/items/edit.html.erb
+++ b/app/views/admin/object_store/items/edit.html.erb
@@ -1,0 +1,10 @@
+<% content_for :page_title, "Object Store - Edit #{edition_name(@edition)}" %>
+<% content_for :context, "Object Store" %>
+<% content_for :title, "Edit #{edition_name(@edition)}" %>
+<% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @edition, parent_class: "edition")) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render_partial_path(@edition, "form") %>
+  </div>
+</div>

--- a/app/views/admin/object_store/items/new.html.erb
+++ b/app/views/admin/object_store/items/new.html.erb
@@ -1,0 +1,10 @@
+<% content_for :page_title, "Object Store - New #{edition_name(@edition)}" %>
+<% content_for :context, "Object Store" %>
+<% content_for :title, "New #{edition_name(@edition)}" %>
+<% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @edition, parent_class: "edition")) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render_partial_path(@edition, "form") %>
+  </div>
+</div>

--- a/config/initializers/object_store.rb
+++ b/config/initializers/object_store.rb
@@ -1,0 +1,7 @@
+require "object_store"
+
+config_file_path = Rails.root.join("config/object_store/fields.yml")
+
+ObjectStore.configure do |config|
+  config.fields = YAML.safe_load(File.read(config_file_path))
+end

--- a/config/object_store/fields.yml
+++ b/config/object_store/fields.yml
@@ -1,0 +1,6 @@
+email_address:
+  properties:
+    email_address:
+      type: string
+  required:
+    - email_address

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -424,6 +424,12 @@ Whitehall::Application.routes.draw do
         get :confirm_destroy
       end
       post "/link-checker-api-callback" => "link_checker_api#callback"
+
+      namespace :object_store do
+        scope "/:item_type", constraints: { item_type: Regexp.compile(ObjectStore.item_types.join("|")) } do
+          resources :items, path: "/"
+        end
+      end
     end
   end
 

--- a/db/migrate/20240529133137_add_details_to_edition.rb
+++ b/db/migrate/20240529133137_add_details_to_edition.rb
@@ -1,0 +1,5 @@
+class AddDetailsToEdition < ActiveRecord::Migration[7.1]
+  def change
+    add_column :editions, :details, :json
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -409,6 +409,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_30_154757) do
     t.string "logo_formatted_name"
     t.string "analytics_identifier"
     t.boolean "visual_editor"
+    t.json "details"
     t.index ["alternative_format_provider_id"], name: "index_editions_on_alternative_format_provider_id"
     t.index ["closing_at"], name: "index_editions_on_closing_at"
     t.index ["document_id"], name: "index_editions_on_document_id"

--- a/lib/object_store.rb
+++ b/lib/object_store.rb
@@ -1,0 +1,39 @@
+module ObjectStore
+  class UnknownItemType < StandardError
+    def initialize(item_type)
+      super("Unknown item type: #{item_type}")
+    end
+  end
+
+  def self.configuration
+    @configuration ||= OpenStruct.new
+  end
+
+  def self.configure
+    yield(configuration)
+  end
+
+  def self.config_for_item_type(item_type)
+    configuration.fields[item_type] || raise(UnknownItemType, item_type)
+  end
+
+  def self.fields_for_item_type(item_type)
+    config_for_item_type(item_type)&.fetch("properties", nil)
+  end
+
+  def self.field_is_required?(item_type, field_name)
+    required_fields_for_item_type(item_type).include?(field_name)
+  end
+
+  def self.required_fields_for_item_type(item_type)
+    config_for_item_type(item_type)&.fetch("required", nil)
+  end
+
+  def self.field_names_for_item_type(item_type)
+    fields_for_item_type(item_type).keys
+  end
+
+  def self.item_types
+    configuration.fields.keys
+  end
+end

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -2,4 +2,4 @@ def image_fixture_file
   @image_fixture_file ||= File.open(Rails.root.join("test/fixtures/minister-of-funk.960x640.jpg"))
 end
 
-Dir[Rails.root.join("test/factories/*.rb")].sort.each { |f| require f }
+Dir[Rails.root.join("test/factories/**/*.rb")].sort.each { |f| require f }

--- a/test/factories/object_store/item.rb
+++ b/test/factories/object_store/item.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :object_store_item, class: ObjectStore::Item, parent: :edition do
+    transient do
+      item_type { "email_address" }
+    end
+
+    title { "object-store-item" }
+
+    initialize_with { ObjectStore::Item.new(item_type:) }
+  end
+end

--- a/test/integration/object_store/create_email_test.rb
+++ b/test/integration/object_store/create_email_test.rb
@@ -1,0 +1,32 @@
+require "test_helper"
+require "capybara/rails"
+
+class CreateEmailTest < ActionDispatch::IntegrationTest
+  include Capybara::DSL
+
+  setup do
+    login_as_admin
+  end
+
+  test "allows an email object to be created" do
+    visit new_admin_object_store_item_path(item_type: "email_address")
+
+    fill_in "Title", with: "Some Title"
+    fill_in "Email address", with: "foo@example.com"
+    click_on "Save"
+
+    created_object = ObjectStore::Item.find_by(title: "Some Title")
+
+    assert_not_nil created_object
+    assert created_object.email_address, "foo@example.com"
+  end
+
+  test "shows errors when missing fields blank" do
+    visit new_admin_object_store_item_path(item_type: "email_address")
+
+    click_on "Save"
+
+    assert_text "Title can't be blank"
+    assert_text "Email address can't be blank"
+  end
+end

--- a/test/integration/object_store/edit_email_test.rb
+++ b/test/integration/object_store/edit_email_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+require "capybara/rails"
+
+class EditEmailTest < ActionDispatch::IntegrationTest
+  include Capybara::DSL
+
+  setup do
+    login_as_admin
+  end
+
+  test "allows an email object to be updated" do
+    item = create(:object_store_item, item_type: "email_address", email_address: "foo@example.com")
+    visit edit_admin_object_store_item_path(item_type: "email_address", id: item.id)
+
+    fill_in "Email address", with: "bar@example.com"
+    click_on "Save"
+
+    item.reload
+
+    assert item.email_address, "bar@example.com"
+  end
+end

--- a/test/unit/app/helpers/admin/object_store/items_helper_test.rb
+++ b/test/unit/app/helpers/admin/object_store/items_helper_test.rb
@@ -1,0 +1,47 @@
+require "test_helper"
+
+class Admin::ObjectStore::ItemsHelperTest < ActionView::TestCase
+  include Admin::ObjectStore::ItemsHelper
+
+  test "#edition_name returns the title for an edition" do
+    edition = build(:object_store_item, item_type: "email_address")
+    assert_equal edition_name(edition), "Email Address"
+  end
+
+  test "#partial_path should return a path for an edition" do
+    edition = build(:object_store_item, item_type: "email_address")
+    path = partial_path(edition, "form")
+    assert_equal path, "admin/object_store/email_addresses/form"
+  end
+
+  test "#render_partial_path should render the correct path with the edition" do
+    edition = build(:object_store_item, item_type: "email_address")
+    partial_name = "form"
+
+    expects(:render).with(partial: partial_path(edition, partial_name), object: edition, as: edition.item_type)
+
+    render_partial_path(edition, partial_name)
+  end
+
+  test "#object_store_item_form renders a form" do
+    edition = build(:object_store_item, item_type: "email_address")
+
+    html = object_store_item_form(edition) do |_form|
+      concat("Some text here")
+    end
+
+    assert_includes html, "Some text here"
+    assert_includes html, form_url_for_object_store_item(edition)
+    assert_includes html, render("govuk_publishing_components/components/button", {
+      text: "Save",
+      value: "save",
+      name: "save",
+      data_attributes: {
+        module: "gem-track-click",
+        "track-category": "form-button",
+        "track-action": "object-store-item-button",
+        "track-label": "Save",
+      },
+    })
+  end
+end

--- a/test/unit/app/models/object_store/item_test.rb
+++ b/test/unit/app/models/object_store/item_test.rb
@@ -1,0 +1,30 @@
+require "test_helper"
+
+class ObjectStore::ItemTest < ActiveSupport::TestCase
+  setup do
+    @item = build(:object_store_item, item_type: "email_address")
+  end
+
+  test "it creates accessors for an email address" do
+    @item.email_address = "foo@example.com"
+
+    assert_equal @item.email_address, "foo@example.com"
+  end
+
+  test "it validates the presence of an email address" do
+    assert_not @item.valid?
+    assert @item.errors[:email_address].any?
+  end
+
+  test "#summary_required? returns false" do
+    assert_equal @item.summary_required?, false
+  end
+
+  test "#body_required? returns false" do
+    assert_equal @item.body_required?, false
+  end
+
+  test "#previously_published returns false" do
+    assert_equal @item.previously_published, false
+  end
+end

--- a/test/unit/app/models/object_store/item_test.rb
+++ b/test/unit/app/models/object_store/item_test.rb
@@ -27,4 +27,26 @@ class ObjectStore::ItemTest < ActiveSupport::TestCase
   test "#previously_published returns false" do
     assert_equal @item.previously_published, false
   end
+
+  test "item_type is required" do
+    item = build(:object_store_item, item_type: nil)
+    assert_not item.valid?
+    assert item.errors[:item_type].any?
+  end
+
+  test "item_type cannot be changed" do
+    @item.email_address = "foo@example.com"
+    @item.save!
+
+    @item.item_type = "foo"
+    assert_not @item.valid?
+    assert @item.errors[:item_type].include?("cannot be changed after creation")
+  end
+
+  test "item_type must be valid" do
+    item = build(:object_store_item, item_type: "banana")
+
+    assert_not item.valid?
+    assert item.errors[:item_type].any?
+  end
 end

--- a/test/unit/lib/object_store_test.rb
+++ b/test/unit/lib/object_store_test.rb
@@ -1,0 +1,67 @@
+require "test_helper"
+
+class ObjectStoreTest < ActiveSupport::TestCase
+  setup do
+    @fields = {
+      "type_1" => {
+        "properties" => {
+          "my_field" => {
+            "type" => "string",
+          },
+        },
+        "required" => %w[my_field],
+      },
+      "type_2" => {
+        "properties" => {
+          "some_field" => {
+            "type" => "string",
+          },
+          "other_field" => {
+            "type" => "string",
+          },
+        },
+        "required" => %w[some_field],
+      },
+    }
+    ObjectStore.configure do |config|
+      config.fields = @fields
+    end
+  end
+
+  test "#config_for_item_type returns an item type's configuration" do
+    assert_equal ObjectStore.config_for_item_type("type_1"), @fields["type_1"]
+    assert_equal ObjectStore.config_for_item_type("type_2"), @fields["type_2"]
+  end
+
+  test "#config_for_item_type raises an error when an item is missing" do
+    err = assert_raises ObjectStore::UnknownItemType do
+      ObjectStore.config_for_item_type("other_type")
+    end
+    assert_match(/other_type/, err.message)
+  end
+
+  test "#fields_for_item_type returns the properties for a field" do
+    assert_equal ObjectStore.fields_for_item_type("type_1"), @fields["type_1"]["properties"]
+    assert_equal ObjectStore.fields_for_item_type("type_2"), @fields["type_2"]["properties"]
+  end
+
+  test "#field_is_required? returns if a field is required for a particular type" do
+    assert ObjectStore.field_is_required?("type_1", "my_field")
+    assert ObjectStore.field_is_required?("type_2", "some_field")
+    assert_equal ObjectStore.field_is_required?("type_2", "other_field"), false
+  end
+
+  test "#required_fields_for_item_type returns required fields" do
+    assert_equal ObjectStore.required_fields_for_item_type("type_1"), %w[my_field]
+    assert_equal ObjectStore.required_fields_for_item_type("type_2"), %w[some_field]
+  end
+
+  test "#field_names_for_item_type returns the keys of all fields" do
+    assert_equal ObjectStore.field_names_for_item_type("type_1"), %w[my_field]
+    assert_equal ObjectStore.field_names_for_item_type("type_2"), %w[some_field other_field]
+  end
+
+  test "#item_types returns all configured item types" do
+    assert_equal ObjectStore.item_types, %w[type_1 type_2]
+  end
+end


### PR DESCRIPTION
In the Content Modelling team, we're beginning a piece of work to build a Content Library that will enable the embedding and sharing of discrete pieces of content across the Publishing estate. We wanted to ensure the following:

- Content Library items have the same publishing process as documents (2i etc)
- Content Library items can be categorised with meaning (so they're not just blocks of text)
- Content Library items can have a structure which is customisable

With this in mind, it made sense to host this within Whitehall and have Content Items inherit from the `Edition` model. To save polluting the codebase and ensure it was clear what this new code belonged to, I've decided to namespace all the code so far in a `ContentLibrary` module (I did consider an engine, but decided that _might_ be overkill).

To ensure extendability for Content Library Items, I've added a new JSON field to Editions, which ensures we can make the schemas for Content Items as flexible as we can without having to add a ton of extra fields to the table (I know there's already a ton of fields that are used in some places, but not others).

I'm not usually a big fan of pushing code that isn't used anywhere yet, but I wanted to ensure that this code got under the noses of enough people so the wider Whitehall team is aware of what we're planning and make sure I'm not going down a route that doesn't fit with the wider technical direction.

Thoughts welcome!