### PR TITLE
Capture `content_id` when republishing content

### DIFF
--- a/app/controllers/admin/republishing_controller.rb
+++ b/app/controllers/admin/republishing_controller.rb
@@ -21,7 +21,7 @@ class Admin::RepublishingController < Admin::BaseController
 
     action = "The page '#{page_to_republish[:title]}' has been scheduled for republishing"
 
-    @republishing_event = build_republishing_event(action)
+    @republishing_event = build_republishing_event(action:, content_id: page_to_republish[:presenter].constantize.new.content_id)
 
     if @republishing_event.save
       PresentPageToPublishingApiWorker.perform_async(page_to_republish[:presenter])
@@ -65,7 +65,7 @@ class Admin::RepublishingController < Admin::BaseController
     end
 
     action = "The organisation '#{@organisation.name}' has been republished"
-    @republishing_event = build_republishing_event(action)
+    @republishing_event = build_republishing_event(action:, content_id: @organisation.content_id)
 
     if @republishing_event.save
       @organisation.publish_to_publishing_api
@@ -105,7 +105,7 @@ class Admin::RepublishingController < Admin::BaseController
     end
 
     action = "The person '#{@person.name}' has been republished"
-    @republishing_event = build_republishing_event(action)
+    @republishing_event = build_republishing_event(action:, content_id: @person.content_id)
 
     if @republishing_event.save
       @person.publish_to_publishing_api
@@ -145,7 +145,7 @@ class Admin::RepublishingController < Admin::BaseController
     end
 
     action = "The role '#{@role.name}' has been republished"
-    @republishing_event = build_republishing_event(action)
+    @republishing_event = build_republishing_event(action:, content_id: @role.content_id)
 
     if @republishing_event.save
       @role.publish_to_publishing_api
@@ -185,7 +185,7 @@ class Admin::RepublishingController < Admin::BaseController
     end
 
     action = "Editions for the document with slug '#{@document.slug}' have been republished"
-    @republishing_event = build_republishing_event(action)
+    @republishing_event = build_republishing_event(action:, content_id: @document.content_id)
 
     if @republishing_event.save
       PublishingApiDocumentRepublishingWorker.new.perform(@document.id)
@@ -223,7 +223,7 @@ private
     end
   end
 
-  def build_republishing_event(action)
-    RepublishingEvent.new(user: current_user, reason: params.fetch(:reason), action:)
+  def build_republishing_event(action:, content_id:)
+    RepublishingEvent.new(user: current_user, reason: params.fetch(:reason), action:, content_id:)
   end
 end

--- a/app/models/republishing_event.rb
+++ b/app/models/republishing_event.rb
@@ -3,4 +3,5 @@ class RepublishingEvent < ApplicationRecord
 
   validates :action, presence: true
   validates :reason, presence: true
+  validates :content_id, presence: true
 end

--- a/db/migrate/20240521084537_add_content_id_to_republishing_events.rb
+++ b/db/migrate/20240521084537_add_content_id_to_republishing_events.rb
@@ -1,0 +1,5 @@
+class AddContentIdToRepublishingEvents < ActiveRecord::Migration[7.1]
+  def change
+    add_column :republishing_events, :content_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_20_155856) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_21_084537) do
   create_table "assets", charset: "utf8mb3", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.string "variant", null: false
@@ -864,6 +864,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_20_155856) do
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "content_id"
     t.index ["user_id"], name: "index_republishing_events_on_user_id"
   end
 

--- a/test/functional/admin/republishing_controller_test.rb
+++ b/test/functional/admin/republishing_controller_test.rb
@@ -55,6 +55,7 @@ class Admin::RepublishingControllerTest < ActionController::TestCase
     assert_equal newly_created_event.user, current_user
     assert_equal newly_created_event.reason, "this needs republishing"
     assert_equal newly_created_event.action, "The page 'Past Prime Ministers' has been scheduled for republishing"
+    assert_equal newly_created_event.content_id, PublishingApi::HistoricalAccountsIndexPresenter.new.content_id
 
     assert_redirected_to admin_republishing_index_path
     assert_equal "The page 'Past Prime Ministers' has been scheduled for republishing", flash[:notice]
@@ -144,7 +145,7 @@ class Admin::RepublishingControllerTest < ActionController::TestCase
   end
 
   test "GDS Admin users should be able to POST :republish_organisation with an existing organisation slug, creating a RepublishingEvent for the current user" do
-    create(:organisation, slug: "an-existing-organisation", name: "An Existing Organisation")
+    create(:organisation, slug: "an-existing-organisation", name: "An Existing Organisation", content_id: "6de2fd22-4a87-49b7-be49-915f12dfe6fe")
 
     Organisation.any_instance.expects(:publish_to_publishing_api).once
 
@@ -154,6 +155,8 @@ class Admin::RepublishingControllerTest < ActionController::TestCase
     assert_equal newly_created_event.user, current_user
     assert_equal newly_created_event.reason, "this needs republishing"
     assert_equal newly_created_event.action, "The organisation 'An Existing Organisation' has been republished"
+    assert_equal newly_created_event.content_id, "6de2fd22-4a87-49b7-be49-915f12dfe6fe"
+
     assert_redirected_to admin_republishing_index_path
     assert_equal "The organisation 'An Existing Organisation' has been republished", flash[:notice]
   end
@@ -246,7 +249,7 @@ class Admin::RepublishingControllerTest < ActionController::TestCase
   end
 
   test "GDS Admin users should be able to POST :republish_person with an existing person slug, creating a RepublishingEvent for the current user" do
-    create(:person, slug: "existing-person", forename: "Existing", surname: "Person")
+    create(:person, slug: "existing-person", forename: "Existing", surname: "Person", content_id: "6de2fd22-4a87-49b7-be49-915f12dfe6fe")
 
     Person.any_instance.expects(:publish_to_publishing_api).once
 
@@ -256,6 +259,8 @@ class Admin::RepublishingControllerTest < ActionController::TestCase
     assert_equal newly_created_event.user, current_user
     assert_equal newly_created_event.reason, "this needs republishing"
     assert_equal newly_created_event.action, "The person 'Existing Person' has been republished"
+    assert_equal newly_created_event.content_id, "6de2fd22-4a87-49b7-be49-915f12dfe6fe"
+
     assert_redirected_to admin_republishing_index_path
     assert_equal "The person 'Existing Person' has been republished", flash[:notice]
   end
@@ -348,7 +353,7 @@ class Admin::RepublishingControllerTest < ActionController::TestCase
   end
 
   test "GDS Admin users should be able to POST :republish_role with an existing role slug, creating a RepublishingEvent for the current user" do
-    create(:role, slug: "an-existing-role", name: "An Existing Role")
+    create(:role, slug: "an-existing-role", name: "An Existing Role", content_id: "6de2fd22-4a87-49b7-be49-915f12dfe6fe")
 
     Role.any_instance.expects(:publish_to_publishing_api).once
 
@@ -358,6 +363,8 @@ class Admin::RepublishingControllerTest < ActionController::TestCase
     assert_equal newly_created_event.user, current_user
     assert_equal newly_created_event.reason, "this needs republishing"
     assert_equal newly_created_event.action, "The role 'An Existing Role' has been republished"
+    assert_equal newly_created_event.content_id, "6de2fd22-4a87-49b7-be49-915f12dfe6fe"
+
     assert_redirected_to admin_republishing_index_path
     assert_equal "The role 'An Existing Role' has been republished", flash[:notice]
   end
@@ -450,7 +457,7 @@ class Admin::RepublishingControllerTest < ActionController::TestCase
   end
 
   test "GDS Admin users should be able to POST :republish_document with an existing document slug, creating a RepublishingEvent for the current user" do
-    document = create(:document, slug: "an-existing-document")
+    document = create(:document, slug: "an-existing-document", content_id: "6de2fd22-4a87-49b7-be49-915f12dfe6fe")
 
     PublishingApiDocumentRepublishingWorker.any_instance.expects(:perform).with(document.id).once
 
@@ -460,6 +467,7 @@ class Admin::RepublishingControllerTest < ActionController::TestCase
     assert_equal newly_created_event.user, current_user
     assert_equal newly_created_event.reason, "this needs republishing"
     assert_equal newly_created_event.action, "Editions for the document with slug 'an-existing-document' have been republished"
+    assert_equal newly_created_event.content_id, "6de2fd22-4a87-49b7-be49-915f12dfe6fe"
 
     assert_redirected_to admin_republishing_index_path
     assert_equal "Editions for the document with slug 'an-existing-document' have been republished", flash[:notice]


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## Context

[Trello card](https://trello.com/c/7UxUuAoO/1165-add-contentid-to-whitehalls-republishingevents-and-capture-this-on-republish)

We've recently added a `RepublishingEvent` model to the service to track how people are using the Republishing UI. We figured it might be useful to track a `content_id` here to improve findability of `RepublishingEvent`s later down the line, as the only current identifier is a string `action` field which may become outdated if a piece of content's title were to change.

## Changes in this PR

Adds a `content_id` field to the `RepublishingEvent` model and captures this when creating a new event.
