### PR TITLE
Add No. 10 brand colour as an option on org edit pages

### DIFF
--- a/app/models/organisation_brand_colour.rb
+++ b/app/models/organisation_brand_colour.rb
@@ -167,4 +167,9 @@ class OrganisationBrandColour
     title: "Department for Science, Innovation & Technology",
     class_name: "department-for-science-innovation-and-technology",
   )
+  PrimeMinistersOffice10DowningStreet = create!(
+    id: 33,
+    title: "Prime Minister's Office, 10 Downing Street",
+    class_name: "prime-ministers-office-10-downing-street",
+  )
 end

--- a/app/models/organisation_logo_type.rb
+++ b/app/models/organisation_logo_type.rb
@@ -52,7 +52,7 @@ class OrganisationLogoType
   DepartmentForBusinessAndTrade = create!(
     id: 15, title: "Department for Business & Trade", class_name: "dbt",
   )
-  PrimeMinistersOffice10DowningStread = create!(
+  PrimeMinistersOffice10DowningStreet = create!(
     id: 16, title: "Prime Minister's Office, 10 Downing Street", class_name: "no10",
   )
 end


### PR DESCRIPTION
## What / Why
- Adds the No 10. brand colour as an option to the organisation edit pages
- The No 10. org page is currently using the Cabinet Office brand colour setting which means on `/government/organisations` it has a blue left border instead of a black one
- Therefore this change should allow us to set it to No 10 and fix this
- https://trello.com/c/nWxYU9zF/132-fix-no10-organisation-colour-on-organisations-page
- I got the `class_name` value from https://github.com/alphagov/govuk_publishing_components/blob/f5c17f86ab4a99dada752385927f18502af2ce27/app/assets/stylesheets/govuk_publishing_components/components/helpers/_brand-colours.scss#L58


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
