### PR TITLE
Bump govspeak-visual-editor from 1.0.4 to 1.0.5

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1516,8 +1516,8 @@ gopd@^1.0.1:
     get-intrinsic "^1.1.3"
 
 govspeak-visual-editor@alphagov/govspeak-visual-editor:
-  version "1.0.4"
-  resolved "https://codeload.github.com/alphagov/govspeak-visual-editor/tar.gz/030519ca8010cff4c80c2afe13d35e86ae3c750e"
+  version "1.0.5"
+  resolved "https://codeload.github.com/alphagov/govspeak-visual-editor/tar.gz/626370c4755298736840e4d3493da5a881763199"
   dependencies:
     govuk-frontend "^4.8.0"
     prosemirror-example-setup "^1.2.2"


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
