### PR TITLE
Make publishing api associated documents handle translations

### DIFF
--- a/app/controllers/admin/attachments_controller.rb
+++ b/app/controllers/admin/attachments_controller.rb
@@ -201,13 +201,11 @@ private
   def save_attachment
     result = attachment.save(context: :user_input)
 
-    if result && attachment.is_a?(HtmlAttachment)
-      Whitehall::PublishingApi.save_draft(attachment)
-    end
-
     if attachable_is_an_edition?
       draft_updater = Whitehall.edition_services.draft_updater(attachable)
       draft_updater.perform!
+    elsif result && attachment.is_a?(HtmlAttachment)
+      Whitehall::PublishingApi.save_draft(attachment)
     end
 
     result

--- a/app/services/service_listeners/publishing_api_associated_documents.rb
+++ b/app/services/service_listeners/publishing_api_associated_documents.rb
@@ -36,9 +36,8 @@ module ServiceListeners
 
     def update_draft(update_type: nil)
       current_associated_documents.each do |associated_document|
-        Whitehall::PublishingApi.save_draft_translation(
+        Whitehall::PublishingApi.save_draft(
           associated_document,
-          locale_for_document(associated_document),
           update_type || (edition.minor_change? ? "minor" : "major"),
         )
       end

--- a/test/factories/editionable_worldwide_organisations.rb
+++ b/test/factories/editionable_worldwide_organisations.rb
@@ -48,6 +48,12 @@ FactoryBot.define do
       end
     end
 
+    trait(:with_translated_page) do
+      after :create do |organisation, _evaluator|
+        organisation.pages = [build(:worldwide_organisation_page, translated_into: :fr)]
+      end
+    end
+
     trait(:with_pages) do
       after :create do |organisation, _evaluator|
         organisation.pages = [

--- a/test/functional/admin/attachments_controller_test.rb
+++ b/test/functional/admin/attachments_controller_test.rb
@@ -149,7 +149,7 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
 
     Whitehall::PublishingApi
       .expects(:save_draft)
-      .with(instance_of(HtmlAttachment))
+      .with(instance_of(HtmlAttachment), "major")
 
     post :create, params: { edition_id: @edition.id, type: "html", attachment: }
   end
@@ -368,7 +368,7 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
 
     Whitehall::PublishingApi
       .expects(:save_draft)
-      .with(attachment)
+      .with(attachment, "major")
 
     put :update,
         params: {

--- a/test/functional/admin/worldwide_offices_controller_test.rb
+++ b/test/functional/admin/worldwide_offices_controller_test.rb
@@ -395,6 +395,8 @@ class Admin::WorldwideOfficesControllerTest < ActionController::TestCase
     worldwide_organisation = create(:draft_editionable_worldwide_organisation)
 
     Whitehall::PublishingApi.expects(:save_draft).with(worldwide_organisation)
+    Whitehall::PublishingApi.expects(:save_draft).with(instance_of(WorldwideOffice), "major").at_least_once
+    Whitehall::PublishingApi.expects(:save_draft).with(instance_of(Contact), "major").at_least_once
 
     post :create,
          params: {
@@ -415,6 +417,8 @@ class Admin::WorldwideOfficesControllerTest < ActionController::TestCase
     office = create(:worldwide_office, edition: create(:draft_editionable_worldwide_organisation), worldwide_organisation: nil)
 
     Whitehall::PublishingApi.expects(:save_draft).with(office.edition)
+    Whitehall::PublishingApi.expects(:save_draft).with(office, "major")
+    Whitehall::PublishingApi.expects(:save_draft).with(office.contact, "major")
 
     put :update,
         params: {

--- a/test/unit/app/models/worldwide_organisation_page_test.rb
+++ b/test/unit/app/models/worldwide_organisation_page_test.rb
@@ -4,7 +4,9 @@ class WorldwideOrganisationPageTest < ActiveSupport::TestCase
   test "creating a new page republishes the associated worldwide organisation" do
     worldwide_organisation = create(:editionable_worldwide_organisation)
     Whitehall::PublishingApi.expects(:save_draft).with(worldwide_organisation).once
-    create(:worldwide_organisation_page, edition: worldwide_organisation)
+    page = build(:worldwide_organisation_page, edition: worldwide_organisation)
+    Whitehall::PublishingApi.expects(:save_draft).with(page, "major").once
+    page.save!
   end
 
   test "updating an existing page republishes the associated worldwide organisation" do
@@ -12,6 +14,7 @@ class WorldwideOrganisationPageTest < ActiveSupport::TestCase
     page = create(:worldwide_organisation_page, edition: worldwide_organisation)
     page.body = "updated"
     Whitehall::PublishingApi.expects(:save_draft).with(worldwide_organisation).once
+    Whitehall::PublishingApi.expects(:save_draft).with(page, "major").once
     page.save!
   end
 

--- a/test/unit/app/services/service_listeners/publishing_api_associated_documents_test.rb
+++ b/test/unit/app/services/service_listeners/publishing_api_associated_documents_test.rb
@@ -290,11 +290,10 @@ module ServiceListeners
       test "with an html attachment on a new document saves it as a draft" do
         publication = create(:draft_publication)
         attachment = publication.html_attachments.first
-        Whitehall::PublishingApi.expects(:save_draft_translation).with(
+        Whitehall::PublishingApi.expects(:save_draft).with(
           attachment,
-          "en",
           "major",
-        )
+        ).once
         call(publication)
       end
 
@@ -303,11 +302,10 @@ module ServiceListeners
         new_edition = publication.create_draft(create(:writer))
 
         attachment = new_edition.html_attachments.first
-        Whitehall::PublishingApi.expects(:save_draft_translation).with(
+        Whitehall::PublishingApi.expects(:save_draft).with(
           attachment,
-          "en",
           "major",
-        )
+        ).once
 
         call(new_edition)
       end
@@ -328,11 +326,10 @@ module ServiceListeners
         new_edition.attachments = [build(:html_attachment)]
 
         new_attachment = new_edition.html_attachments.first
-        Whitehall::PublishingApi.expects(:save_draft_translation).with(
+        Whitehall::PublishingApi.expects(:save_draft).with(
           new_attachment,
-          "en",
           "major",
-        )
+        ).once
 
         call(new_edition)
       end
@@ -355,17 +352,15 @@ module ServiceListeners
       test "with an office on a new editionable worldwide organisation saves the office as draft" do
         worldwide_organisation = create(:editionable_worldwide_organisation, :with_main_office)
 
-        Whitehall::PublishingApi.expects(:save_draft_translation).with(
+        Whitehall::PublishingApi.expects(:save_draft).with(
           worldwide_organisation.main_office,
-          "en",
           "major",
-        )
+        ).once
 
-        Whitehall::PublishingApi.expects(:save_draft_translation).with(
+        Whitehall::PublishingApi.expects(:save_draft).with(
           worldwide_organisation.main_office.contact,
-          "en",
           "major",
-        )
+        ).once
 
         call(worldwide_organisation)
       end
@@ -668,34 +663,30 @@ module ServiceListeners
       test "for a draft publication with an attachment saves the draft" do
         publication = create(:draft_publication)
         attachment = publication.html_attachments.first
-        Whitehall::PublishingApi.expects(:save_draft_translation).with(
+        Whitehall::PublishingApi.expects(:save_draft).with(
           attachment,
-          "en",
           "republish",
-        )
+        ).once
         call(publication)
       end
 
       test "for a draft editionable worldwide organisation with an office and page publishes the draft office and page" do
         worldwide_organisation = create(:draft_editionable_worldwide_organisation, :with_main_office, :with_page)
 
-        Whitehall::PublishingApi.expects(:save_draft_translation).with(
+        Whitehall::PublishingApi.expects(:save_draft).with(
           worldwide_organisation.main_office,
-          "en",
           "republish",
-        )
+        ).once
 
-        Whitehall::PublishingApi.expects(:save_draft_translation).with(
+        Whitehall::PublishingApi.expects(:save_draft).with(
           worldwide_organisation.main_office.contact,
-          "en",
           "republish",
-        )
+        ).once
 
-        Whitehall::PublishingApi.expects(:save_draft_translation).with(
+        Whitehall::PublishingApi.expects(:save_draft).with(
           worldwide_organisation.pages.first,
-          "en",
           "republish",
-        )
+        ).once
 
         call(worldwide_organisation)
       end


### PR DESCRIPTION
This makes the publishing api associated documents service responsible for translations. Any associated document that has a translation will now be updated (published, withdrawn, discarded etc) along with the english language version. 

Trello - https://trello.com/c/wTxdEIMS/1122-make-publishingapiassociateddocuments-handle-translations

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
