### PR TITLE
Add bulk republishing page for all about us pages

### DIFF
--- a/app/controllers/admin/bulk_republishing_controller.rb
+++ b/app/controllers/admin/bulk_republishing_controller.rb
@@ -1,0 +1,40 @@
+class Admin::BulkRepublishingController < Admin::BaseController
+  include Admin::RepublishingHelper
+
+  before_action :enforce_permissions!
+
+  def confirm_all
+    @bulk_content_type_metadata = bulk_content_type_metadata[params[:bulk_content_type].underscore.to_sym]
+    return render "admin/errors/not_found", status: :not_found unless @bulk_content_type_metadata
+
+    @republishing_event = RepublishingEvent.new
+  end
+
+  def republish_all_organisation_about_us_pages
+    bulk_content_type_key = :all_organisation_about_us_pages
+    bulk_content_type_value = RepublishingEvent.bulk_content_types.fetch(bulk_content_type_key)
+    @bulk_content_type_metadata = bulk_content_type_metadata.fetch(bulk_content_type_key)
+    action = "#{@bulk_content_type_metadata[:name].upcase_first} have been queued for republishing"
+
+    @republishing_event = build_republishing_event(action:, bulk_content_type: bulk_content_type_value)
+
+    if @republishing_event.save
+      BulkRepublisher.new.republish_all_organisation_about_us_pages
+
+      flash[:notice] = action
+      redirect_to(admin_republishing_index_path)
+    else
+      render "confirm_all"
+    end
+  end
+
+private
+
+  def enforce_permissions!
+    enforce_permission!(:administer, :republish_content)
+  end
+
+  def build_republishing_event(action:, bulk_content_type:)
+    RepublishingEvent.new(user: current_user, reason: params.fetch(:reason), action:, bulk_content_type:, bulk: true)
+  end
+end

--- a/app/controllers/admin/republishing_controller.rb
+++ b/app/controllers/admin/republishing_controller.rb
@@ -1,4 +1,6 @@
 class Admin::RepublishingController < Admin::BaseController
+  include Admin::RepublishingHelper
+
   before_action :enforce_permissions!
 
   def index

--- a/app/controllers/admin/republishing_controller.rb
+++ b/app/controllers/admin/republishing_controller.rb
@@ -224,6 +224,6 @@ private
   end
 
   def build_republishing_event(action:, content_id:)
-    RepublishingEvent.new(user: current_user, reason: params.fetch(:reason), action:, content_id:)
+    RepublishingEvent.new(user: current_user, reason: params.fetch(:reason), action:, content_id:, bulk: false)
   end
 end

--- a/app/helpers/admin/republishing_helper.rb
+++ b/app/helpers/admin/republishing_helper.rb
@@ -1,0 +1,14 @@
+module Admin::RepublishingHelper
+  include Rails.application.routes.url_helpers
+
+  def bulk_content_type_metadata
+    @bulk_content_type_metadata ||= {
+      all_organisation_about_us_pages: {
+        id: "all-organisation-about-us-pages",
+        name: "all organisation 'About Us' pages",
+        republishing_path: admin_bulk_republishing_all_organisation_about_us_pages_republish_path,
+        confirmation_path: admin_bulk_republishing_all_confirm_path("all-organisation-about-us-pages"),
+      }
+    }
+  end
+end

--- a/app/helpers/admin/republishing_helper.rb
+++ b/app/helpers/admin/republishing_helper.rb
@@ -8,7 +8,23 @@ module Admin::RepublishingHelper
         name: "all organisation 'About Us' pages",
         republishing_path: admin_bulk_republishing_all_organisation_about_us_pages_republish_path,
         confirmation_path: admin_bulk_republishing_all_confirm_path("all-organisation-about-us-pages"),
-      }
+      },
     }
+  end
+
+  def republishing_index_bulk_republishing_rows
+    bulk_content_type_metadata.values.map do |content_type|
+      [
+        {
+          text: content_type[:name].upcase_first,
+        },
+        {
+          text: link_to(sanitize("Republish #{tag.span(content_type[:name], class: 'govuk-visually-hidden')}"),
+                        content_type[:confirmation_path],
+                        id: content_type[:id],
+                        class: "govuk-link"),
+        },
+      ]
+    end
   end
 end

--- a/app/models/republishing_event.rb
+++ b/app/models/republishing_event.rb
@@ -3,5 +3,12 @@ class RepublishingEvent < ApplicationRecord
 
   validates :action, presence: true
   validates :reason, presence: true
-  validates :content_id, presence: true
+  validates :content_id, presence: true, unless: -> { bulk }
+
+  validates :bulk, inclusion: [true, false]
+  validates :bulk_content_type, presence: true, if: -> { bulk }
+
+  enum :bulk_content_type, %i[
+    all_organisation_about_us_pages
+  ]
 end

--- a/app/services/bulk_republisher.rb
+++ b/app/services/bulk_republisher.rb
@@ -1,0 +1,13 @@
+class BulkRepublisher
+  def republish_all_organisation_about_us_pages
+    document_ids = Organisation.all.map(&:about_us).compact.pluck(:document_id)
+
+    document_ids.each do |document_id|
+      PublishingApiDocumentRepublishingWorker.perform_async_in_queue(
+        "bulk_republishing",
+        document_id,
+        true,
+      )
+    end
+  end
+end

--- a/app/views/admin/bulk_republishing/confirm_all.html.erb
+++ b/app/views/admin/bulk_republishing/confirm_all.html.erb
@@ -8,6 +8,9 @@
     <p class="govuk-body govuk-!-margin-bottom-7">
       This will schedule <%= @bulk_content_type_metadata[:name] %> to be republished.
     </p>
-    <%= render partial: "shared/republishing_form", locals: { republishing_path: @bulk_content_type_metadata[:republishing_path] } %>
+    <%= render partial: "shared/republishing_form", locals: {
+      republishing_event: @republishing_event,
+      republishing_path: @bulk_content_type_metadata[:republishing_path],
+    } %>
   </section>
 </div>

--- a/app/views/admin/bulk_republishing/confirm_all.html.erb
+++ b/app/views/admin/bulk_republishing/confirm_all.html.erb
@@ -1,0 +1,13 @@
+<% content_for :page_title, "Republish #{@bulk_content_type_metadata[:name]}" %>
+<% content_for :title, "Are you sure you want to republish #{@bulk_content_type_metadata[:name]}?" %>
+<% content_for :title_margin_bottom, 6 %>
+<% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @republishing_event)) %>
+
+<div class="govuk-grid-row">
+  <section class="govuk-grid-column-two-thirds">
+    <p class="govuk-body govuk-!-margin-bottom-7">
+      This will schedule <%= @bulk_content_type_metadata[:name] %> to be republished.
+    </p>
+    <%= render partial: "shared/republishing_form", locals: { republishing_url: @bulk_content_type_metadata[:republishing_path] } %>
+  </section>
+</div>

--- a/app/views/admin/bulk_republishing/confirm_all.html.erb
+++ b/app/views/admin/bulk_republishing/confirm_all.html.erb
@@ -8,6 +8,6 @@
     <p class="govuk-body govuk-!-margin-bottom-7">
       This will schedule <%= @bulk_content_type_metadata[:name] %> to be republished.
     </p>
-    <%= render partial: "shared/republishing_form", locals: { republishing_url: @bulk_content_type_metadata[:republishing_path] } %>
+    <%= render partial: "shared/republishing_form", locals: { republishing_path: @bulk_content_type_metadata[:republishing_path] } %>
   </section>
 </div>

--- a/app/views/admin/republishing/_form.html.erb
+++ b/app/views/admin/republishing/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(url: republishing_url, method: :post, data: {
+<%= form_with(url: republishing_path, method: :post, data: {
     module: "prevent-multiple-form-submissions",
   }) do %>
     <%= render("govuk_publishing_components/components/textarea", {

--- a/app/views/admin/republishing/confirm_document.html.erb
+++ b/app/views/admin/republishing/confirm_document.html.erb
@@ -30,6 +30,6 @@
           ]
         end,
     } %>
-    <%= render "form", republishing_url: admin_republishing_document_republish_path(@document.slug) %>
+    <%= render partial: "shared/republishing_form", locals: { republishing_url: admin_republishing_document_republish_path(@document.slug) } %>
   </section>
 </div>

--- a/app/views/admin/republishing/confirm_document.html.erb
+++ b/app/views/admin/republishing/confirm_document.html.erb
@@ -30,6 +30,9 @@
           ]
         end,
     } %>
-    <%= render partial: "shared/republishing_form", locals: { republishing_path: admin_republishing_document_republish_path(@document.slug) } %>
+    <%= render partial: "shared/republishing_form", locals: {
+      republishing_event: @republishing_event,
+      republishing_path: admin_republishing_document_republish_path(@document.slug),
+    } %>
   </section>
 </div>

--- a/app/views/admin/republishing/confirm_document.html.erb
+++ b/app/views/admin/republishing/confirm_document.html.erb
@@ -30,6 +30,6 @@
           ]
         end,
     } %>
-    <%= render partial: "shared/republishing_form", locals: { republishing_url: admin_republishing_document_republish_path(@document.slug) } %>
+    <%= render partial: "shared/republishing_form", locals: { republishing_path: admin_republishing_document_republish_path(@document.slug) } %>
   </section>
 </div>

--- a/app/views/admin/republishing/confirm_organisation.html.erb
+++ b/app/views/admin/republishing/confirm_organisation.html.erb
@@ -8,6 +8,9 @@
     <p class="govuk-body govuk-!-margin-bottom-7">
       This will republish the organisation <%= link_to @organisation.name, @organisation.public_url, { class: "govuk-link" } %>.
     </p>
-    <%= render partial: "shared/republishing_form", locals: { republishing_path: admin_republishing_organisation_republish_path(@organisation.slug) } %>
+    <%= render partial: "shared/republishing_form", locals: {
+      republishing_event: @republishing_event,
+      republishing_path: admin_republishing_organisation_republish_path(@organisation.slug),
+    } %>
   </section>
 </div>

--- a/app/views/admin/republishing/confirm_organisation.html.erb
+++ b/app/views/admin/republishing/confirm_organisation.html.erb
@@ -8,6 +8,6 @@
     <p class="govuk-body govuk-!-margin-bottom-7">
       This will republish the organisation <%= link_to @organisation.name, @organisation.public_url, { class: "govuk-link" } %>.
     </p>
-    <%= render "form", republishing_url: admin_republishing_organisation_republish_path(@organisation.slug) %>
+    <%= render partial: "shared/republishing_form", locals: { republishing_url: admin_republishing_organisation_republish_path(@organisation.slug) } %>
   </section>
 </div>

--- a/app/views/admin/republishing/confirm_organisation.html.erb
+++ b/app/views/admin/republishing/confirm_organisation.html.erb
@@ -8,6 +8,6 @@
     <p class="govuk-body govuk-!-margin-bottom-7">
       This will republish the organisation <%= link_to @organisation.name, @organisation.public_url, { class: "govuk-link" } %>.
     </p>
-    <%= render partial: "shared/republishing_form", locals: { republishing_url: admin_republishing_organisation_republish_path(@organisation.slug) } %>
+    <%= render partial: "shared/republishing_form", locals: { republishing_path: admin_republishing_organisation_republish_path(@organisation.slug) } %>
   </section>
 </div>

--- a/app/views/admin/republishing/confirm_page.html.erb
+++ b/app/views/admin/republishing/confirm_page.html.erb
@@ -8,6 +8,6 @@
     <p class="govuk-body govuk-!-margin-bottom-7">
       This will schedule the page to be republished.
     </p>
-    <%= render "form", republishing_url: @republishing_path %>
+    <%= render partial: "shared/republishing_form", locals: { republishing_url: @republishing_path } %>
   </section>
 </div>

--- a/app/views/admin/republishing/confirm_page.html.erb
+++ b/app/views/admin/republishing/confirm_page.html.erb
@@ -8,6 +8,9 @@
     <p class="govuk-body govuk-!-margin-bottom-7">
       This will schedule the page to be republished.
     </p>
-    <%= render partial: "shared/republishing_form", locals: { republishing_path: @republishing_path } %>
+    <%= render partial: "shared/republishing_form", locals: {
+      republishing_event: @republishing_event,
+      republishing_path: @republishing_path,
+    } %>
   </section>
 </div>

--- a/app/views/admin/republishing/confirm_page.html.erb
+++ b/app/views/admin/republishing/confirm_page.html.erb
@@ -8,6 +8,6 @@
     <p class="govuk-body govuk-!-margin-bottom-7">
       This will schedule the page to be republished.
     </p>
-    <%= render partial: "shared/republishing_form", locals: { republishing_url: @republishing_path } %>
+    <%= render partial: "shared/republishing_form", locals: { republishing_path: @republishing_path } %>
   </section>
 </div>

--- a/app/views/admin/republishing/confirm_person.html.erb
+++ b/app/views/admin/republishing/confirm_person.html.erb
@@ -8,6 +8,9 @@
     <p class="govuk-body govuk-!-margin-bottom-7">
       This will republish the person <%= link_to @person.name, @person.public_url, { class: "govuk-link" } %>.
     </p>
-    <%= render partial: "shared/republishing_form", locals: { republishing_path: admin_republishing_person_republish_path(@person.slug) } %>
+    <%= render partial: "shared/republishing_form", locals: {
+      republishing_event: @republishing_event,
+      republishing_path: admin_republishing_person_republish_path(@person.slug),
+    } %>
   </section>
 </div>

--- a/app/views/admin/republishing/confirm_person.html.erb
+++ b/app/views/admin/republishing/confirm_person.html.erb
@@ -8,6 +8,6 @@
     <p class="govuk-body govuk-!-margin-bottom-7">
       This will republish the person <%= link_to @person.name, @person.public_url, { class: "govuk-link" } %>.
     </p>
-    <%= render "form", republishing_url: admin_republishing_person_republish_path(@person.slug) %>
+    <%= render partial: "shared/republishing_form", locals: { republishing_url: admin_republishing_person_republish_path(@person.slug) } %>
   </section>
 </div>

--- a/app/views/admin/republishing/confirm_person.html.erb
+++ b/app/views/admin/republishing/confirm_person.html.erb
@@ -8,6 +8,6 @@
     <p class="govuk-body govuk-!-margin-bottom-7">
       This will republish the person <%= link_to @person.name, @person.public_url, { class: "govuk-link" } %>.
     </p>
-    <%= render partial: "shared/republishing_form", locals: { republishing_url: admin_republishing_person_republish_path(@person.slug) } %>
+    <%= render partial: "shared/republishing_form", locals: { republishing_path: admin_republishing_person_republish_path(@person.slug) } %>
   </section>
 </div>

--- a/app/views/admin/republishing/confirm_role.html.erb
+++ b/app/views/admin/republishing/confirm_role.html.erb
@@ -12,6 +12,6 @@
         This will republish the role '<%= @role.name %>'.
       <% end %>
     </p>
-    <%= render "form", republishing_url: admin_republishing_role_republish_path(@role.slug) %>
+    <%= render partial: "shared/republishing_form", locals: { republishing_url: admin_republishing_role_republish_path(@role.slug) } %>
   </section>
 </div>

--- a/app/views/admin/republishing/confirm_role.html.erb
+++ b/app/views/admin/republishing/confirm_role.html.erb
@@ -12,6 +12,6 @@
         This will republish the role '<%= @role.name %>'.
       <% end %>
     </p>
-    <%= render partial: "shared/republishing_form", locals: { republishing_url: admin_republishing_role_republish_path(@role.slug) } %>
+    <%= render partial: "shared/republishing_form", locals: { republishing_path: admin_republishing_role_republish_path(@role.slug) } %>
   </section>
 </div>

--- a/app/views/admin/republishing/confirm_role.html.erb
+++ b/app/views/admin/republishing/confirm_role.html.erb
@@ -12,6 +12,9 @@
         This will republish the role '<%= @role.name %>'.
       <% end %>
     </p>
-    <%= render partial: "shared/republishing_form", locals: { republishing_path: admin_republishing_role_republish_path(@role.slug) } %>
+    <%= render partial: "shared/republishing_form", locals: {
+      republishing_event: @republishing_event,
+      republishing_path: admin_republishing_role_republish_path(@role.slug),
+    } %>
   </section>
 </div>

--- a/app/views/admin/republishing/index.html.erb
+++ b/app/views/admin/republishing/index.html.erb
@@ -128,5 +128,23 @@
         ],
       ],
     } %>
+
+    <h2>Bulk republishing</h2>
+
+    <p class="govuk-body">
+      You can schedule multiple pieces of content for republishing using the links below. Note that this might take some time to take effect since bulk republishing jobs are added to a low priority queue.
+    </p>
+
+    <%= render "govuk_publishing_components/components/table", {
+      head: [
+        {
+          text: "Content type",
+        },
+        {
+          text: "Action",
+        },
+      ],
+      rows: republishing_index_bulk_republishing_rows,
+    } %>
   </section>
 </div>

--- a/app/views/shared/_republishing_form.html.erb
+++ b/app/views/shared/_republishing_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_with(url: republishing_url, method: :post, data: {
+<%= form_with(url: republishing_path, method: :post, data: {
     module: "prevent-multiple-form-submissions",
   }) do %>
     <%= render("govuk_publishing_components/components/textarea", {

--- a/app/views/shared/_republishing_form.html.erb
+++ b/app/views/shared/_republishing_form.html.erb
@@ -1,0 +1,17 @@
+<%= form_with(url: republishing_url, method: :post, data: {
+    module: "prevent-multiple-form-submissions",
+  }) do %>
+    <%= render("govuk_publishing_components/components/textarea", {
+      label: {
+        text: "What is the reason for republishing?",
+        heading_size: "m",
+      },
+      name: "reason",
+      id: "republishing_event_reason",
+      error_items: errors_for(@republishing_event.errors, :reason),
+    }) %>
+
+    <%= render("govuk_publishing_components/components/button", {
+      text: "Confirm republishing",
+    }) %>
+<% end %>

--- a/app/views/shared/_republishing_form.html.erb
+++ b/app/views/shared/_republishing_form.html.erb
@@ -8,7 +8,7 @@
       },
       name: "reason",
       id: "republishing_event_reason",
-      error_items: errors_for(@republishing_event.errors, :reason),
+      error_items: errors_for(republishing_event.errors, :reason),
     }) %>
 
     <%= render("govuk_publishing_components/components/button", {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,6 +52,10 @@ Whitehall::Application.routes.draw do
           get "/:document_slug/confirm" => "republishing#confirm_document", as: :republishing_document_confirm
           post "/:document_slug/republish" => "republishing#republish_document", as: :republishing_document_republish
         end
+        scope :bulk do
+          get "/:bulk_content_type/confirm" => "bulk_republishing#confirm_all", as: :bulk_republishing_all_confirm
+          post "/all-organisation-about-us-pages/republish" => "bulk_republishing#republish_all_organisation_about_us_pages", as: :bulk_republishing_all_organisation_about_us_pages_republish
+        end
       end
 
       resources :documents, only: [] do

--- a/db/migrate/20240521150403_add_bulk_and_bulk_content_type_to_republishing_events.rb
+++ b/db/migrate/20240521150403_add_bulk_and_bulk_content_type_to_republishing_events.rb
@@ -1,0 +1,8 @@
+class AddBulkAndBulkContentTypeToRepublishingEvents < ActiveRecord::Migration[7.1]
+  def change
+    change_table :republishing_events, bulk: true do |t|
+      t.boolean :bulk, null: false
+      t.integer :bulk_content_type
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_21_084537) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_21_150403) do
   create_table "assets", charset: "utf8mb3", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.string "variant", null: false
@@ -865,6 +865,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_21_084537) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "content_id"
+    t.boolean "bulk", null: false
+    t.integer "bulk_content_type"
     t.index ["user_id"], name: "index_republishing_events_on_user_id"
   end
 

--- a/features/bulk-republishing-content.feature
+++ b/features/bulk-republishing-content.feature
@@ -1,0 +1,12 @@
+Feature: Bulk republishing content
+  As an editor
+  I want to be able to republish content in bulk
+  So that they reflect changes to their dependencies when this doesn't happen automatically
+
+  Background:
+    Given I am a GDS admin
+
+  Scenario: Republish all Organisation "About Us" pages
+    Given Published Organisation "About Us" pages exist
+    When I request a bulk republishing of the Organisation "About Us" pages
+    Then I can see the Organisation "About Us" pages have been queued for republishing

--- a/features/step_definitions/bulk_republishing_content_steps.rb
+++ b/features/step_definitions/bulk_republishing_content_steps.rb
@@ -1,0 +1,14 @@
+Given(/^Published Organisation "About Us" pages exist$/) do
+  2.times { create(:about_corporate_information_page) }
+end
+
+When(/^I request a bulk republishing of the Organisation "About Us" pages$/) do
+  visit admin_republishing_index_path
+  find("#all-organisation-about-us-pages").click
+  fill_in "What is the reason for republishing?", with: "It needs republishing"
+  click_button("Confirm republishing")
+end
+
+Then(/^I can see the Organisation "About Us" pages have been queued for republishing$/) do
+  expect(page).to have_selector(".gem-c-success-alert", text: "All organisation 'About Us' pages have been queued for republishing")
+end

--- a/test/functional/admin/bulk_republishing_controller_test.rb
+++ b/test/functional/admin/bulk_republishing_controller_test.rb
@@ -1,0 +1,58 @@
+require "test_helper"
+
+class Admin::BulkRepublishingControllerTest < ActionController::TestCase
+  setup do
+    login_as :gds_admin
+  end
+
+  should_be_an_admin_controller
+
+  test "GDS Admin users should be able to GET :confirm_all with a valid parameterless bulk content type" do
+    get :confirm_all, params: { bulk_content_type: "all-organisation-about-us-pages" }
+    assert_response :ok
+  end
+
+  test "GDS Admin users should see a 404 page when trying to GET :confirm_all with an invalid parameterless bulk content type" do
+    get :confirm_all, params: { bulk_content_type: "fish" }
+    assert_response :not_found
+  end
+
+  test "Non-GDS Admin users should not be able to GET :confirm_all" do
+    login_as :writer
+
+    get :confirm_all, params: { bulk_content_type: "all-organisation-about-us-pages" }
+    assert_response :forbidden
+  end
+
+  test "GDS Admin users should be able to POST :republish_all_organisation_about_us_pages, creating a RepublishingEvent for the current user" do
+    BulkRepublisher.any_instance.expects(:republish_all_organisation_about_us_pages).once
+
+    post :republish_all_organisation_about_us_pages, params: { reason: "this needs republishing" }
+
+    newly_created_event = RepublishingEvent.last
+    assert_equal newly_created_event.user, current_user
+    assert_equal newly_created_event.reason, "this needs republishing"
+    assert_equal newly_created_event.action, "All organisation 'About Us' pages have been queued for republishing"
+    assert_equal newly_created_event.bulk, true
+    assert_equal newly_created_event.bulk_content_type, "all_organisation_about_us_pages"
+
+    assert_redirected_to admin_republishing_index_path
+    assert_equal "All organisation 'About Us' pages have been queued for republishing", flash[:notice]
+  end
+
+  test "GDS Admin users should encounter an error on POST :republish_all_organisation_about_us_pages without a `reason` and be sent back to the confirm_all page" do
+    BulkRepublisher.any_instance.expects(:republish_all_organisation_about_us_pages).never
+
+    post :republish_all_organisation_about_us_pages, params: { reason: "" }
+
+    assert_equal ["Reason can't be blank"], assigns(:republishing_event).errors.full_messages
+    assert_template "confirm_all"
+  end
+
+  test "Non-GDS Admin users should not be able to POST :republish_all_organisation_about_us_pages" do
+    login_as :writer
+
+    post :republish_all_organisation_about_us_pages, params: { reason: "this needs republishing" }
+    assert_response :forbidden
+  end
+end

--- a/test/functional/admin/republishing_controller_test.rb
+++ b/test/functional/admin/republishing_controller_test.rb
@@ -19,6 +19,8 @@ class Admin::RepublishingControllerTest < ActionController::TestCase
     assert_select ".govuk-table:nth-of-type(2) .govuk-table__body .govuk-table__row:nth-child(3) .govuk-table__cell:nth-child(2) a[href='/government/admin/republishing/role/find']", text: "Republish a role"
     assert_select ".govuk-table:nth-of-type(2) .govuk-table__body .govuk-table__row:nth-child(4) .govuk-table__cell:nth-child(2) a[href='/government/admin/republishing/document/find']", text: "Republish a document"
 
+    assert_select ".govuk-table:nth-of-type(3) .govuk-table__body .govuk-table__row:nth-child(1) .govuk-table__cell:nth-child(2) a[href='/government/admin/republishing/bulk/all-organisation-about-us-pages/confirm']", text: "Republish all organisation 'About Us' pages"
+
     assert_response :ok
   end
 

--- a/test/unit/app/helpers/admin/republishing_helper_test.rb
+++ b/test/unit/app/helpers/admin/republishing_helper_test.rb
@@ -1,0 +1,16 @@
+require "test_helper"
+
+class Admin::RepublishingHelperTest < ActionView::TestCase
+  setup do
+    @first_row = republishing_index_bulk_republishing_rows.first
+  end
+
+  test "#republishing_index_bulk_republishing_rows capitalises the first letter of the bulk content type" do
+    assert_equal @first_row.first[:text], "All organisation 'About Us' pages"
+  end
+
+  test "#republishing_index_bulk_republishing_rows creates a link to the specific bulk republishing confirmation page" do
+    expected_link = '<a id="all-organisation-about-us-pages" class="govuk-link" href="/government/admin/republishing/bulk/all-organisation-about-us-pages/confirm">Republish <span class="govuk-visually-hidden">all organisation \'About Us\' pages</span></a>'
+    assert_equal @first_row[1][:text], expected_link
+  end
+end

--- a/test/unit/app/services/bulk_republisher_test.rb
+++ b/test/unit/app/services/bulk_republisher_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+
+class BulkRepublisherTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
+  describe "#republish_all_organisation_about_us_pages" do
+    test "queues Organisation 'About Us' pages for republishing" do
+      queue_sequence = sequence("queue")
+
+      2.times do
+        about_us_page = create(:about_corporate_information_page)
+
+        PublishingApiDocumentRepublishingWorker
+          .expects(:perform_async_in_queue)
+          .with("bulk_republishing", about_us_page.document_id, true)
+          .in_sequence(queue_sequence)
+      end
+
+      BulkRepublisher.new.republish_all_organisation_about_us_pages
+    end
+  end
+end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

[Trello card](https://trello.com/c/EH75S676/1166-add-a-user-interface-for-whitehalls-all-about-us-republishing-rake-task)

## Changes in this PR

Adds new bulk republishing section to the republishing index page

Adds individual page for republishing all Organisation "About Us" pages, submitting the form on which will perform the same behaviour as the `all_about_pages` Rake task [here](https://github.com/alphagov/whitehall/blob/add-bulk-republishing-page-for-all-about-us-pages/lib/tasks/publishing_api.rake#L127).

This should replace the need for developers to run that rake task.

## Screenshots

### New section on index page

![image](https://github.com/alphagov/whitehall/assets/19826940/c8817f0e-dc95-4c2c-851d-82a2805f609b)

### New republishing page

![image](https://github.com/alphagov/whitehall/assets/19826940/3352c4a5-8f88-4ec7-8760-445cc92e67af)

### Confirmation after republishing

![image](https://github.com/alphagov/whitehall/assets/19826940/2f23c8a5-3456-492f-8347-9b78ca78d493)

