### PR TITLE
Revert "Add state argument to `worldwide_corporate_information_page` task"

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -205,10 +205,9 @@ namespace :publishing_api do
       puts "Finished enqueueing items for Publishing API"
     end
 
-    desc "Republish all Worldwide CorporateInformationPages"
-    task :worldwide_corporate_information_pages, [:states] => :environment do |_, args|
-      states = args[:states]&.split("|") || "published"
-      worldwide_corporate_information_pages = CorporateInformationPage.joins(:worldwide_organisation).where(state: states)
+    desc "Republish all published Worldwide CorporateInformationPages"
+    task worldwide_corporate_information_pages: :environment do
+      worldwide_corporate_information_pages = CorporateInformationPage.joins(:worldwide_organisation).where(state: "published")
       puts "Enqueueing #{worldwide_corporate_information_pages.count} Worldwide CorporateInformationPages"
       worldwide_corporate_information_pages.each do |corporate_information_page|
         PublishingApiDocumentRepublishingWorker.perform_async_in_queue("bulk_republishing", corporate_information_page.document_id, true)

--- a/test/unit/lib/tasks/publishing_api_test.rb
+++ b/test/unit/lib/tasks/publishing_api_test.rb
@@ -324,7 +324,7 @@ class PublishingApiRake < ActiveSupport::TestCase
     describe "#worldwide_corporate_information_pages" do
       let(:task) { Rake::Task["publishing_api:bulk_republish:worldwide_corporate_information_pages"] }
 
-      test "republishes published worldwide corporate information pages (including about pages) by default" do
+      test "republishes published worldwide corporate information pages (including about pages)" do
         create(
           :published_worldwide_organisation_corporate_information_page,
           corporate_information_page_type_id: CorporateInformationPageType::AboutUs.id,
@@ -345,29 +345,6 @@ class PublishingApiRake < ActiveSupport::TestCase
         PublishingApiDocumentRepublishingWorker.expects(:perform_async_in_queue).twice
 
         capture_io { task.invoke }
-      end
-
-      test "republishes worldwide corporate information pages (including about pages) by state when provided as pipe separated args" do
-        create(
-          :published_worldwide_organisation_corporate_information_page,
-          corporate_information_page_type_id: CorporateInformationPageType::AboutUs.id,
-        )
-
-        create(
-          :published_worldwide_organisation_corporate_information_page,
-          corporate_information_page_type_id: CorporateInformationPageType::ComplaintsProcedure.id,
-        )
-
-        create(:corporate_information_page, :draft, worldwide_organisation: create(:worldwide_organisation), organisation: nil)
-
-        create(
-          :published_corporate_information_page,
-          corporate_information_page_type_id: CorporateInformationPageType::ComplaintsProcedure.id,
-        )
-
-        PublishingApiDocumentRepublishingWorker.expects(:perform_async_in_queue).times(3)
-
-        capture_io { task.invoke("published|draft") }
       end
     end
 


### PR DESCRIPTION
This reverts commit 786c16fed2de87faa058eb8df7a3b3af2dcc7512.

This didn't work as expected with drafts on integration and will soon become redudnant when we migrate to editionable wordlwide organisations, so it can be reverted

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
