### PR TITLE
Duplicate contact numbers and services on new edition

### DIFF
--- a/app/models/editionable_worldwide_organisation.rb
+++ b/app/models/editionable_worldwide_organisation.rb
@@ -32,6 +32,10 @@ class EditionableWorldwideOrganisation < Edition
           new_office.contact.contact_numbers << contact_number.dup
         end
 
+        office.services.each do |service|
+          new_office.services << service
+        end
+
         new_office.save!
 
         if @edition.office_shown_on_home_page?(office)

--- a/app/models/editionable_worldwide_organisation.rb
+++ b/app/models/editionable_worldwide_organisation.rb
@@ -28,6 +28,12 @@ class EditionableWorldwideOrganisation < Edition
 
         new_office.contact = office.contact.dup
 
+        office.contact.contact_numbers.each do |contact_number|
+          new_office.contact.contact_numbers << contact_number.dup
+        end
+
+        new_office.save!
+
         if @edition.office_shown_on_home_page?(office)
           new_edition.add_office_to_home_page!(new_office)
         end

--- a/test/factories/contact_numbers.rb
+++ b/test/factories/contact_numbers.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :contact_number do
+  factory :contact_number, traits: [:translated] do
     contact
     label { "fax" }
     number { "123" }

--- a/test/unit/app/models/editionable_worldwide_organisation_test.rb
+++ b/test/unit/app/models/editionable_worldwide_organisation_test.rb
@@ -181,7 +181,13 @@ class EditionableWorldwideOrganisationTest < ActiveSupport::TestCase
     contact = create(:contact, translated_into: [:es])
     create(:contact_number, translated_into: [:es], contact:)
     published_worldwide_organisation = create(:editionable_worldwide_organisation, :published, translated_into: [:es])
-    create(:worldwide_office, worldwide_organisation: nil, edition: published_worldwide_organisation, contact:)
+    create(
+      :worldwide_office,
+      worldwide_organisation: nil,
+      edition: published_worldwide_organisation,
+      contact:,
+      services: [create(:worldwide_service)],
+    )
 
     draft_worldwide_organisation = published_worldwide_organisation.create_draft(create(:writer))
     published_worldwide_organisation.reload
@@ -191,6 +197,9 @@ class EditionableWorldwideOrganisationTest < ActiveSupport::TestCase
 
     assert_equal published_worldwide_organisation.offices.first.contact.attributes.except("id", "contactable_id"),
                  draft_worldwide_organisation.offices.first.contact.attributes.except("id", "contactable_id")
+
+    assert_equal published_worldwide_organisation.offices.first.services,
+                 draft_worldwide_organisation.offices.first.services
 
     assert_equal published_worldwide_organisation.offices.first.contact.contact_numbers.first.attributes.except("id", "contact_id"),
                  draft_worldwide_organisation.offices.first.contact.contact_numbers.first.attributes.except("id", "contact_id")

--- a/test/unit/app/models/editionable_worldwide_organisation_test.rb
+++ b/test/unit/app/models/editionable_worldwide_organisation_test.rb
@@ -179,6 +179,7 @@ class EditionableWorldwideOrganisationTest < ActiveSupport::TestCase
 
   test "should clone office and contact associations when new draft of published edition is created" do
     contact = create(:contact, translated_into: [:es])
+    create(:contact_number, translated_into: [:es], contact:)
     published_worldwide_organisation = create(:editionable_worldwide_organisation, :published, translated_into: [:es])
     create(:worldwide_office, worldwide_organisation: nil, edition: published_worldwide_organisation, contact:)
 
@@ -187,12 +188,22 @@ class EditionableWorldwideOrganisationTest < ActiveSupport::TestCase
 
     assert_equal published_worldwide_organisation.offices.first.attributes.except("id", "edition_id"),
                  draft_worldwide_organisation.offices.first.attributes.except("id", "edition_id")
+
     assert_equal published_worldwide_organisation.offices.first.contact.attributes.except("id", "contactable_id"),
                  draft_worldwide_organisation.offices.first.contact.attributes.except("id", "contactable_id")
+
+    assert_equal published_worldwide_organisation.offices.first.contact.contact_numbers.first.attributes.except("id", "contact_id"),
+                 draft_worldwide_organisation.offices.first.contact.contact_numbers.first.attributes.except("id", "contact_id")
+
+    assert_equal published_worldwide_organisation.offices.first.contact.contact_numbers.first.translations.find_by(locale: :es).attributes.except("id", "contact_number_id", "contact_id"),
+                 draft_worldwide_organisation.offices.first.contact.contact_numbers.first.translations.find_by(locale: :es).attributes.except("id", "contact_number_id", "contact_id")
+
     assert_equal published_worldwide_organisation.main_office.attributes.except("id", "edition_id"),
                  draft_worldwide_organisation.main_office.attributes.except("id", "edition_id")
+
     assert_equal published_worldwide_organisation.offices.first.contact.translations.find_by(locale: :es).attributes.except("id", "contact_id"),
                  draft_worldwide_organisation.offices.first.contact.translations.find_by(locale: :es).attributes.except("id", "contact_id")
+
     assert_equal published_worldwide_organisation.offices.first.contact.translations.find_by(locale: :en).attributes.except("id", "contact_id"),
                  draft_worldwide_organisation.offices.first.contact.translations.find_by(locale: :en).attributes.except("id", "contact_id")
   end


### PR DESCRIPTION
We are currently copying the office and the associated contact when creating a new edition, however not the contact numbers or services.

This adds that duplication, so these things are not lost when a new edition is created.

[Trello card](https://trello.com/c/w7nXW8eZ)