### PR TITLE
Add, then remove, default `bulk` value for `RepublishingEvent`s

### DIFF
--- a/db/migrate/20240521150403_add_bulk_and_bulk_content_type_to_republishing_events.rb
+++ b/db/migrate/20240521150403_add_bulk_and_bulk_content_type_to_republishing_events.rb
@@ -1,7 +1,7 @@
 class AddBulkAndBulkContentTypeToRepublishingEvents < ActiveRecord::Migration[7.1]
   def change
     change_table :republishing_events, bulk: true do |t|
-      t.boolean :bulk, null: false
+      t.boolean :bulk, null: false # rubocop:disable Rails/NotNullColumn
       t.integer :bulk_content_type
     end
   end

--- a/db/migrate/20240529093425_make_republishing_events_bulk_false_by_default.rb
+++ b/db/migrate/20240529093425_make_republishing_events_bulk_false_by_default.rb
@@ -1,0 +1,7 @@
+class MakeRepublishingEventsBulkFalseByDefault < ActiveRecord::Migration[7.1]
+  def up
+    change_column :republishing_events, :bulk, :boolean, default: false
+  end
+
+  def down; end
+end

--- a/db/migrate/20240529103123_make_republishing_events_bulk_nil_by_default.rb
+++ b/db/migrate/20240529103123_make_republishing_events_bulk_nil_by_default.rb
@@ -1,0 +1,3 @@
+class MakeRepublishingEventsBulkNilByDefault < ActiveRecord::Migration[7.1]
+  change_column_default(:republishing_events, :bulk, nil)
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_21_150403) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_29_093425) do
   create_table "assets", charset: "utf8mb3", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.string "variant", null: false
@@ -865,7 +865,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_21_150403) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "content_id"
-    t.boolean "bulk", null: false
+    t.boolean "bulk", default: false, null: false
     t.integer "bulk_content_type"
     t.index ["user_id"], name: "index_republishing_events_on_user_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_29_093425) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_29_103123) do
   create_table "assets", charset: "utf8mb3", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.string "variant", null: false
@@ -865,7 +865,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_29_093425) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "content_id"
-    t.boolean "bulk", default: false, null: false
+    t.boolean "bulk", null: false
     t.integer "bulk_content_type"
     t.index ["user_id"], name: "index_republishing_events_on_user_id"
   end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## Context

When we added the `bulk` field in https://github.com/alphagov/whitehall/pull/9075/commits/578590b2781ce85e1bbcdac1822a0a11b1c0ee22 it seemed to default to `false` when creating new `RepublishingEvent`s without us needing to set a default value.

It appears that before merging that PR, a rubocop update was merged and the PR branch not rebased with `main` after this. This caused Rubocop to fail on `main` due to this rubocop issue.

## Changes in this PR

Here we add an explicit `false` default value for `RepublishingEvent`s and ignore the Rubocop violation on the previous migration. We then remove the false value as all existing `RepublishingEvent`s will have been migrated to the new default value.

I've had to use `up` rather than `change` here as `change_column` is not reversible. According to a comment on the accepted answer on [this Stack Overflow
post](https://github.com/alphagov/whitehall/pull/9075/commits/578590b2781ce85e1bbcdac1822a0a11b1c0ee22),

```
If you need reversible migrations, put this in an up block rather
than a change block. You can leave the down block empty. It won't revert
the table to the original condition but the migration can be rolled
back.
```