### PR TITLE
Delete blank contacts

### DIFF
--- a/app/controllers/admin/worldwide_offices_controller.rb
+++ b/app/controllers/admin/worldwide_offices_controller.rb
@@ -17,8 +17,17 @@ class Admin::WorldwideOfficesController < Admin::BaseController
   end
 
   def update
-    worldwide_office_params[:service_ids] ||= []
-    if @worldwide_office.update(worldwide_office_params)
+    update_params = worldwide_office_params
+
+    update_params[:service_ids] ||= []
+
+    if update_params.dig(:contact_attributes, :contact_numbers_attributes)
+      update_params.dig(:contact_attributes, :contact_numbers_attributes).each do |_id, contact_number_attribute|
+        contact_number_attribute[:_destroy] = true if contact_number_attribute[:label].empty? && contact_number_attribute[:number].empty?
+      end
+    end
+
+    if @worldwide_office.update(update_params)
       handle_show_on_home_page_param
       republish_draft_worldwide_organisation
       redirect_to admin_worldwide_organisation_worldwide_offices_path(@worldwide_organisation), notice: "#{@worldwide_office.title} has been edited"

--- a/test/functional/admin/worldwide_offices_controller_test.rb
+++ b/test/functional/admin/worldwide_offices_controller_test.rb
@@ -279,7 +279,7 @@ class Admin::WorldwideOfficesControllerTest < ActionController::TestCase
     assert_equal ["Main phone: 5678"], actual_numbers
   end
 
-  test "PUT :update deletes contact numbers that have only blank fields" do
+  test "PUT :update deletes contact numbers that are marked as to be destroyed" do
     worldwide_organisation, office = create_worldwide_organisation_and_office
     contact_number = office.contact.contact_numbers.create!(label: "Phone", number: "1234")
 
@@ -295,6 +295,32 @@ class Admin::WorldwideOfficesControllerTest < ActionController::TestCase
                   label: contact_number.label,
                   number: contact_number.number,
                   _destroy: "true",
+                },
+              },
+            },
+          },
+          id: office,
+          worldwide_organisation_id: worldwide_organisation,
+        }
+
+    assert_not ContactNumber.exists?(contact_number.id)
+  end
+
+  test "PUT :update deletes contact numbers that have only blank fields" do
+    worldwide_organisation, office = create_worldwide_organisation_and_office
+    contact_number = office.contact.contact_numbers.create!(label: "Phone", number: "1234")
+
+    put :update,
+        params: {
+          worldwide_office: {
+            contact_attributes: {
+              id: office.contact.id,
+              title: "Head office",
+              contact_numbers_attributes: {
+                "0" => {
+                  id: contact_number.id,
+                  label: "",
+                  number: "",
                 },
               },
             },


### PR DESCRIPTION
Change to allow blank phone numbers to be submitted for Worldwide Office contact details.

Trello: https://trello.com/c/yaokYwP2/1162-bug-it-is-not-possible-to-delete-the-final-phone-number-from-a-worldwide-office

Credit to @brucebolt for this!

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
