### PR TITLE
Import versioned visual editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "accessible-autocomplete": "alphagov/accessible-autocomplete-multiselect",
     "choices.js": "^10.2.0",
     "cropperjs": "^1.6.2",
-    "govspeak-visual-editor": "alphagov/govspeak-visual-editor",
+    "govspeak-visual-editor": "^1.0.5",
     "miller-columns-element": "^2.0.0",
     "paste-html-to-govspeak": "^0.4.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1515,9 +1515,10 @@ gopd@^1.0.1:
   dependencies:
     get-intrinsic "^1.1.3"
 
-govspeak-visual-editor@alphagov/govspeak-visual-editor:
+govspeak-visual-editor@^1.0.5:
   version "1.0.5"
-  resolved "https://codeload.github.com/alphagov/govspeak-visual-editor/tar.gz/626370c4755298736840e4d3493da5a881763199"
+  resolved "https://registry.yarnpkg.com/govspeak-visual-editor/-/govspeak-visual-editor-1.0.5.tgz#a4f2fa0041743aa231d5e98151fa05961c63656c"
+  integrity sha512-uv6S9hx5M4TC3UYYKLGpF/5ZF46WV278PajnycuhKBhmrqDdd3qKtOhWnTcFu7LuKv4jjZTWDEejfYj25YiPKg==
   dependencies:
     govuk-frontend "^4.8.0"
     prosemirror-example-setup "^1.2.2"
@@ -3120,16 +3121,7 @@ statuses@2.0.1:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-2.0.1.tgz#55cb000ccf1d48728bd23c685a063998cf1a1b63"
   integrity sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@4.2.3, string-width@^4.1.0, string-width@^4.2.3, string-width@^5.0.1, string-width@^5.1.2:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@4.2.3, string-width@^4.1.0, string-width@^4.2.3, string-width@^5.0.1, string-width@^5.1.2:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -3229,14 +3221,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==


### PR DESCRIPTION
We were importing the visual editor via direct reference to its github repo. We are now properly releasing versions of the dependency. Updating `package.json` to use latest version

[Trello card](https://trello.com/c/PhgX6wzC/2540-distribute-the-govspeak-visual-editor-via-node-package-manager)
