### PR TITLE
Present `auth_bypass_ids` for Editionable Worldwide Organisations and their associated documents

### DIFF
--- a/app/presenters/publishing_api/editionable_worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/editionable_worldwide_organisation_presenter.rb
@@ -30,6 +30,7 @@ module PublishingApi
         public_updated_at: item.updated_at,
         rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
         schema_name: "worldwide_organisation",
+        auth_bypass_ids: [item.auth_bypass_id],
       )
       content.merge!(PayloadBuilder::PolymorphicPath.for(item))
       content.merge!(PayloadBuilder::AnalyticsIdentifier.for(item))

--- a/app/presenters/publishing_api/worldwide_office_presenter.rb
+++ b/app/presenters/publishing_api/worldwide_office_presenter.rb
@@ -29,6 +29,7 @@ module PublishingApi
         schema_name: "worldwide_office",
       )
 
+      content.merge!(auth_bypass_ids: [item.edition.auth_bypass_id]) if item.edition
       content.merge!(PayloadBuilder::PolymorphicPath.for(item))
     end
 

--- a/app/presenters/publishing_api/worldwide_organisation_page_presenter.rb
+++ b/app/presenters/publishing_api/worldwide_organisation_page_presenter.rb
@@ -26,6 +26,7 @@ module PublishingApi
         schema_name: "worldwide_corporate_information_page",
         document_type:,
         links: edition_links,
+        auth_bypass_ids: [item.edition.auth_bypass_id],
       )
 
       content.merge!(PayloadBuilder::PolymorphicPath.for(item))

--- a/test/unit/app/presenters/publishing_api/editionable_worldwide_organisation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/editionable_worldwide_organisation_presenter_test.rb
@@ -32,6 +32,7 @@ class PublishingApi::EditionableWorldwideOrganisationPresenterTest < ActiveSuppo
     public_path = worldwide_org.public_path
 
     expected_hash = {
+      auth_bypass_ids: [worldwide_org.auth_bypass_id],
       base_path: public_path,
       title: worldwide_org.title,
       schema_name: "worldwide_organisation",

--- a/test/unit/app/presenters/publishing_api/worldwide_office_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/worldwide_office_presenter_test.rb
@@ -5,13 +5,68 @@ class PublishingApi::WorldwideOfficePresenterTest < ActiveSupport::TestCase
     PublishingApi::WorldwideOfficePresenter.new(...)
   end
 
-  test "presents a Worldwide Office ready for adding to the publishing API" do
+  test "presents a Worldwide Office belonging to a non-editionable worldwide organisation ready for adding to the publishing API" do
     access_and_opening_times = "## About us\r\n\r\nVisit our [profile page](https://www.gov.uk/government/world/organisations/british-consulate-general-atlanta)"
     worldwide_office = build(:worldwide_office, access_and_opening_times:)
     worldwide_office_service = create(:worldwide_office_worldwide_service, worldwide_office:)
     public_path = worldwide_office.public_path
 
     expected_hash = {
+      base_path: public_path,
+      title: worldwide_office.worldwide_organisation.name,
+      schema_name: "worldwide_office",
+      document_type: "worldwide_office",
+      locale: "en",
+      publishing_app: Whitehall::PublishingApp::WHITEHALL,
+      rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
+      public_updated_at: worldwide_office.updated_at,
+      routes: [{ path: public_path, type: "exact" }],
+      redirects: [],
+      details: {
+        access_and_opening_times: Whitehall::GovspeakRenderer.new.govspeak_to_html(worldwide_office.access_and_opening_times),
+        services: [
+          {
+            title: worldwide_office_service.worldwide_service.name,
+            type: worldwide_office_service.worldwide_service.service_type.name,
+          },
+        ],
+        type: worldwide_office.worldwide_office_type.name,
+      },
+      update_type: "major",
+      links: {
+        contact: [
+          worldwide_office.contact.content_id,
+        ],
+        parent: [
+          worldwide_office.worldwide_organisation.content_id,
+        ],
+        worldwide_organisation: [
+          worldwide_office.worldwide_organisation.content_id,
+        ],
+      },
+    }
+
+    expected_links = {}
+
+    presented_item = present(worldwide_office)
+
+    assert_equal expected_hash, presented_item.content
+    assert_hash_includes presented_item.links, expected_links
+    assert_equal "major", presented_item.update_type
+    assert_equal worldwide_office.content_id, presented_item.content_id
+
+    assert_valid_against_publisher_schema(presented_item.content, "worldwide_office")
+    assert_valid_against_links_schema({ links: presented_item.links }, "worldwide_office")
+  end
+
+  test "presents a Worldwide Office belonging to an editionable worldwide organisation ready for adding to the publishing API" do
+    access_and_opening_times = "## About us\r\n\r\nVisit our [profile page](https://www.gov.uk/government/world/organisations/british-consulate-general-atlanta)"
+    worldwide_office = build(:worldwide_office, access_and_opening_times:, worldwide_organisation: nil, edition: create(:editionable_worldwide_organisation))
+    worldwide_office_service = create(:worldwide_office_worldwide_service, worldwide_office:)
+    public_path = worldwide_office.public_path
+
+    expected_hash = {
+      auth_bypass_ids: [worldwide_office.edition.auth_bypass_id],
       base_path: public_path,
       title: worldwide_office.worldwide_organisation.name,
       schema_name: "worldwide_office",

--- a/test/unit/app/presenters/publishing_api/worldwide_organisation_page_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/worldwide_organisation_page_presenter_test.rb
@@ -18,6 +18,7 @@ module PublishingApi::WorldwideOrganisationPagePresenterTest
         public_path = page.public_path
 
         expected_hash = {
+          auth_bypass_ids: [page.edition.auth_bypass_id],
           base_path: public_path,
           title: page.title,
           schema_name: "worldwide_corporate_information_page",


### PR DESCRIPTION
These values were missed from the presenters. By sending them to Publishing API, we are able to offer a shareable preview feature to publishers.

[Trello card](https://trello.com/c/7oAe57mW)