### PR TITLE
Prevent long Nation Inapplicability Alternative URLs from breaking the database transaction

### DIFF
--- a/app/models/nation_inapplicability.rb
+++ b/app/models/nation_inapplicability.rb
@@ -10,6 +10,7 @@ class NationInapplicability < ApplicationRecord
 
   validates :nation_id, inclusion: { in: Nation.potentially_inapplicable.map(&:id) }
   validates :alternative_url, uri: true, allow_blank: true
+  validates :alternative_url, length: { maximum: 255 }
 
   attr_accessor :excluded
 

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -1,5 +1,8 @@
 en:
   activerecord:
+    attributes:
+      publication/nation_inapplicabilities:
+        alternative_url: "Alternative URL for excluded nation"
     errors:
       messages:
         invalid_date: "is not in the correct format"
@@ -11,3 +14,7 @@ en:
               invalid_date: First published date is not in the correct format
               blank: Enter a first published date
               inclusion: First published date must be between 1/1/1900 and the present
+        nation_inapplicability:
+          attributes:
+            alternative_url:
+              too_long: "is too long. Please shorten the URL to less than 255 characters."

--- a/test/unit/app/models/nation_inapplicability_test.rb
+++ b/test/unit/app/models/nation_inapplicability_test.rb
@@ -21,6 +21,19 @@ class NationInapplicabilityTest < ActiveSupport::TestCase
     assert inapplicability.valid?
   end
 
+  test "should be valid with 255 character alternative url" do
+    alternative_url_255_character = "https://1HHGPav0JgJ6r1rJR34wO2Tksnimp6DjWIrJU02iQgcUK6H7he4aWZ5wrtNGOifEHoLO9afMMfNIZxoOTj6BkQE7NcBwY4fvYpCXwCFaBjnXkRqyl3LfFAIJc5GUXz64LGwQvHQHiOkFdP2fk43HkM2Dx6aHoHxdgRHRB7jVzGNLNwUBQtFdjlLv4CBHRTFMnHBtSsskEXhSGlv0TubV2uouqlUkoLSOwC3AJHa4XN1bcD23112.com"
+    inapplicability = build(:nation_inapplicability, alternative_url: alternative_url_255_character)
+    assert inapplicability.valid?
+  end
+
+  test "should error with more than 255 character alternative url" do
+    alternative_url_256_character = "https://1HHGPav0JgJ6r1rJR34wO2Tksnimp6DjWIrJU02iQgcUK6H7he4aWZ5wrtNGOifEHoLO9afMMfNIZxoOTj6BkQE7NcBwY4fvYpCXwCFaBjnXkRqyl3LfFAIJc5GUXz64LGwQvHQHiOkFdP2fk43HkM2Dx6aHoHxdgRHRB7jVzGNLNwUBQtFdjlLv4CBHRTFMnHBtSsskEXhSGlv0TubV2uouqlUkoLSOwC3AJHa4XN1bcD231125.com"
+    inapplicability = build(:nation_inapplicability, alternative_url: alternative_url_256_character)
+    assert_not inapplicability.valid?
+    assert_includes inapplicability.errors.messages[:alternative_url], I18n.t("activerecord.errors.models.nation_inapplicability.attributes.alternative_url.too_long")
+  end
+
   test "has a virtual attribute to indicate exclusion" do
     nation_inapplicability = create(:nation_inapplicability)
 


### PR DESCRIPTION

URLs which are longer than 255 characters break the database limit, so we are introducing a character limit for URLs to prevent this from happening. Users should seek to shorten their URLs.

https://trello.com/c/CPM8XMsf

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
