### PR TITLE
Abstract `republishing_all` controller action

### DIFF
--- a/app/controllers/admin/bulk_republishing_controller.rb
+++ b/app/controllers/admin/bulk_republishing_controller.rb
@@ -4,22 +4,24 @@ class Admin::BulkRepublishingController < Admin::BaseController
   before_action :enforce_permissions!
 
   def confirm_all
-    @bulk_content_type_metadata = bulk_content_type_metadata[params[:bulk_content_type].underscore.to_sym]
+    bulk_content_type_key = params[:bulk_content_type].underscore.to_sym
+    @bulk_content_type_metadata = bulk_content_type_metadata[bulk_content_type_key]
     return render "admin/errors/not_found", status: :not_found unless @bulk_content_type_metadata
 
     @republishing_event = RepublishingEvent.new
   end
 
-  def republish_all_organisation_about_us_pages
-    bulk_content_type_key = :all_organisation_about_us_pages
-    bulk_content_type_value = RepublishingEvent.bulk_content_types.fetch(bulk_content_type_key)
-    @bulk_content_type_metadata = bulk_content_type_metadata.fetch(bulk_content_type_key)
-    action = "#{@bulk_content_type_metadata[:name].upcase_first} have been queued for republishing"
+  def republish_all
+    bulk_content_type_key = params[:bulk_content_type].underscore.to_sym
+    @bulk_content_type_metadata = bulk_content_type_metadata.fetch(bulk_content_type_key, nil)
+    return render "admin/errors/not_found", status: :not_found unless @bulk_content_type_metadata
 
+    action = "#{@bulk_content_type_metadata[:name].upcase_first} have been queued for republishing"
+    bulk_content_type_value = RepublishingEvent.bulk_content_types.fetch(bulk_content_type_key)
     @republishing_event = build_republishing_event(action:, bulk_content_type: bulk_content_type_value)
 
     if @republishing_event.save
-      BulkRepublisher.new.republish_all_organisation_about_us_pages
+      @bulk_content_type_metadata[:republish_method].call
 
       flash[:notice] = action
       redirect_to(admin_republishing_index_path)

--- a/app/helpers/admin/republishing_helper.rb
+++ b/app/helpers/admin/republishing_helper.rb
@@ -6,8 +6,9 @@ module Admin::RepublishingHelper
       all_organisation_about_us_pages: {
         id: "all-organisation-about-us-pages",
         name: "all organisation 'About Us' pages",
-        republishing_path: admin_bulk_republishing_all_organisation_about_us_pages_republish_path,
+        republishing_path: admin_bulk_republishing_all_republish_path("all-organisation-about-us-pages"),
         confirmation_path: admin_bulk_republishing_all_confirm_path("all-organisation-about-us-pages"),
+        republish_method: -> { BulkRepublisher.new.republish_all_organisation_about_us_pages },
       },
     }
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,7 +54,7 @@ Whitehall::Application.routes.draw do
         end
         scope :bulk do
           get "/:bulk_content_type/confirm" => "bulk_republishing#confirm_all", as: :bulk_republishing_all_confirm
-          post "/all-organisation-about-us-pages/republish" => "bulk_republishing#republish_all_organisation_about_us_pages", as: :bulk_republishing_all_organisation_about_us_pages_republish
+          post "/:bulk_content_type/republish" => "bulk_republishing#republish_all", as: :bulk_republishing_all_republish
         end
       end
 


### PR DESCRIPTION
[Trello (groundwork)](https://trello.com/c/Y1k2JPsF/1167-add-a-user-interface-for-whitehalls-all-documents-republishing-rake-task)

In writing the next bulk republishing 'all' action (all documents), it became evident that only two lines needed changing. We'll have six or seven of these, so these abstracts the action and related code so we can keep things DRY

A minor change has been applied to the (already abstract) `confirm_all` action to keep the code and naming more similar between the two actions for easy comparison

This change makes the `metadata` name feel more wrong: having a lambda/method in metadata feels a bit wrong. One to think about

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
