### PR TITLE
Add UI for republishing all documents with pre-publication editions with HTML attachments

### DIFF
--- a/app/helpers/admin/republishing_helper.rb
+++ b/app/helpers/admin/republishing_helper.rb
@@ -17,6 +17,13 @@ module Admin::RepublishingHelper
         confirmation_path: admin_bulk_republishing_all_confirm_path("all-documents-with-pre-publication-editions"),
         republish_method: -> { BulkRepublisher.new.republish_all_documents_with_pre_publication_editions },
       },
+      all_documents_with_pre_publication_editions_with_html_attachments: {
+        id: "all-documents-with-pre-publication-editions-with-html-attachments",
+        name: "all documents with pre-publication editions with HTML attachments",
+        republishing_path: admin_bulk_republishing_all_republish_path("all-documents-with-pre-publication-editions-with-html-attachments"),
+        confirmation_path: admin_bulk_republishing_all_confirm_path("all-documents-with-pre-publication-editions-with-html-attachments"),
+        republish_method: -> { BulkRepublisher.new.republish_all_documents_with_pre_publication_editions_with_html_attachments },
+      },
       all_published_organisation_about_us_pages: {
         id: "all-published-organisation-about-us-pages",
         name: "all published organisation 'About us' pages",

--- a/app/models/republishing_event.rb
+++ b/app/models/republishing_event.rb
@@ -11,6 +11,7 @@ class RepublishingEvent < ApplicationRecord
   enum :bulk_content_type, %i[
     all_documents
     all_documents_with_pre_publication_editions
+    all_documents_with_pre_publication_editions_with_html_attachments
     all_published_organisation_about_us_pages
   ]
 end

--- a/app/services/bulk_republisher.rb
+++ b/app/services/bulk_republisher.rb
@@ -24,4 +24,15 @@ class BulkRepublisher
       PublishingApiDocumentRepublishingWorker.perform_async_in_queue("bulk_republishing", edition.document.id, true)
     end
   end
+
+  def republish_all_documents_with_pre_publication_editions_with_html_attachments
+    document_ids = Edition
+      .in_pre_publication_state
+      .where(id: HtmlAttachment.where(attachable_type: "Edition").select(:attachable_id))
+      .pluck(:document_id)
+
+    document_ids.each do |document_id|
+      PublishingApiDocumentRepublishingWorker.perform_async_in_queue("bulk_republishing", document_id, true)
+    end
+  end
 end

--- a/features/bulk-republishing-content.feature
+++ b/features/bulk-republishing-content.feature
@@ -16,6 +16,11 @@ Feature: Bulk republishing content
     When I request a bulk republishing of all documents with pre-publication editions
     Then I can see that all documents with pre-publication editions have been queued for republishing
 
+  Scenario: Republish all documents with pre-publication editions with HTML attachments
+    Given Documents with pre-publication editions with HTML attachments exist
+    When I request a bulk republishing of all documents with pre-publication editions with HTML attachments
+    Then I can see that all documents with pre-publication editions with HTML attachments have been queued for republishing
+
   Scenario: Republish all published Organisation "About us" pages
     Given Published organisation "About us" pages exist
     When I request a bulk republishing of all published organisation "About us" pages

--- a/features/step_definitions/bulk_republishing_content_steps.rb
+++ b/features/step_definitions/bulk_republishing_content_steps.rb
@@ -28,6 +28,25 @@ Then(/^I can see that all documents with pre-publication editions have been queu
   expect(page).to have_selector(".gem-c-success-alert", text: "All documents with pre-publication editions have been queued for republishing")
 end
 
+Given(/^Documents with pre-publication editions with HTML attachments exist$/) do
+  2.times do
+    draft_edition = build(:draft_edition)
+    create(:document, editions: [build(:published_edition), draft_edition])
+    create(:html_attachment, attachable_type: "Edition", attachable_id: draft_edition.id)
+  end
+end
+
+When(/^I request a bulk republishing of all documents with pre-publication editions with HTML attachments$/) do
+  visit admin_republishing_index_path
+  find("#all-documents-with-pre-publication-editions-with-html-attachments").click
+  fill_in "What is the reason for republishing?", with: "It needs republishing"
+  click_button("Confirm republishing")
+end
+
+Then(/^I can see that all documents with pre-publication editions with HTML attachments have been queued for republishing$/) do
+  expect(page).to have_selector(".gem-c-success-alert", text: "All documents with pre-publication editions with HTML attachments have been queued for republishing")
+end
+
 Given(/^Published organisation "About us" pages exist$/) do
   2.times { create(:about_corporate_information_page) }
 end

--- a/test/functional/admin/republishing_controller_test.rb
+++ b/test/functional/admin/republishing_controller_test.rb
@@ -21,7 +21,8 @@ class Admin::RepublishingControllerTest < ActionController::TestCase
 
     assert_select ".govuk-table:nth-of-type(3) .govuk-table__body .govuk-table__row:nth-child(1) .govuk-table__cell:nth-child(2) a[href='/government/admin/republishing/bulk/all-documents/confirm']", text: "Republish all documents"
     assert_select ".govuk-table:nth-of-type(3) .govuk-table__body .govuk-table__row:nth-child(2) .govuk-table__cell:nth-child(2) a[href='/government/admin/republishing/bulk/all-documents-with-pre-publication-editions/confirm']", text: "Republish all documents with pre-publication editions"
-    assert_select ".govuk-table:nth-of-type(3) .govuk-table__body .govuk-table__row:nth-child(3) .govuk-table__cell:nth-child(2) a[href='/government/admin/republishing/bulk/all-published-organisation-about-us-pages/confirm']", text: "Republish all published organisation 'About us' pages"
+    assert_select ".govuk-table:nth-of-type(3) .govuk-table__body .govuk-table__row:nth-child(3) .govuk-table__cell:nth-child(2) a[href='/government/admin/republishing/bulk/all-documents-with-pre-publication-editions-with-html-attachments/confirm']", text: "Republish all documents with pre-publication editions with HTML attachments"
+    assert_select ".govuk-table:nth-of-type(3) .govuk-table__body .govuk-table__row:nth-child(4) .govuk-table__cell:nth-child(2) a[href='/government/admin/republishing/bulk/all-published-organisation-about-us-pages/confirm']", text: "Republish all published organisation 'About us' pages"
 
     assert_response :ok
   end

--- a/test/unit/app/services/bulk_republisher_test.rb
+++ b/test/unit/app/services/bulk_republisher_test.rb
@@ -75,4 +75,46 @@ class BulkRepublisherTest < ActiveSupport::TestCase
       BulkRepublisher.new.republish_all_documents_with_pre_publication_editions
     end
   end
+
+  describe "#republish_all_documents_with_pre_publication_editions_with_html_attachments" do
+    test "queues all documents with pre-publication editions with HTML attachments for republishing" do
+      queue_sequence = sequence("queue")
+
+      2.times do
+        draft_edition = build(:draft_edition)
+        document = create(:document, editions: [build(:published_edition), draft_edition])
+        create(:html_attachment, attachable_type: "Edition", attachable_id: draft_edition.id)
+
+        PublishingApiDocumentRepublishingWorker
+          .expects(:perform_async_in_queue)
+          .with("bulk_republishing", document.id, true)
+          .in_sequence(queue_sequence)
+      end
+
+      BulkRepublisher.new.republish_all_documents_with_pre_publication_editions_with_html_attachments
+    end
+
+    test "doesn't queue documents for republishing if the editions with HTML attachments aren't pre-publication editions" do
+      document = create(:document, editions: [build(:published_edition)])
+      create(:html_attachment, attachable_type: "Edition", attachable_id: document.live_edition_id)
+
+      PublishingApiDocumentRepublishingWorker
+        .expects(:perform_async_in_queue)
+        .with("bulk_republishing", document.id, true)
+        .never
+
+      BulkRepublisher.new.republish_all_documents_with_pre_publication_editions_with_html_attachments
+    end
+
+    test "doesn't queue documents republishing when there are pre-publication editions but none have HTML attachments" do
+      document = create(:document, editions: [build(:published_edition), build(:draft_edition)])
+
+      PublishingApiDocumentRepublishingWorker
+        .expects(:perform_async_in_queue)
+        .with("bulk_republishing", document.id, true)
+        .never
+
+      BulkRepublisher.new.republish_all_documents_with_pre_publication_editions_with_html_attachments
+    end
+  end
 end


### PR DESCRIPTION
[Trello](https://trello.com/c/FEs1nEuo/1168-add-a-user-interface-for-whitehalls-all-documents-with-pre-publication-editions-with-html-attachments-republishing-rake-task)

This adds the UI for republishing all documents with pre-publication editions with HTML attachments

## Screenshots

### Before

<img width="789" alt="image" src="https://github.com/alphagov/whitehall/assets/40244233/3106376a-66ce-4113-b049-b19efb5a832b">

### After

<img width="793" alt="image" src="https://github.com/alphagov/whitehall/assets/40244233/18c6fb73-c7b4-487c-a9c3-37aff82e949d">

<img width="796" alt="image" src="https://github.com/alphagov/whitehall/assets/40244233/51c2a61d-1894-4de5-9fcf-1aba8285dee3">

<img width="1176" alt="image" src="https://github.com/alphagov/whitehall/assets/40244233/01a9cc61-4b37-4006-9e9f-e736dd0b6d91">

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
