### PR TITLE
Allow Better Errors to work with Docker

### DIFF
--- a/config/initializers/better_errors.rb
+++ b/config/initializers/better_errors.rb
@@ -1,0 +1,3 @@
+if Rails.env.development?
+  BetterErrors::Middleware.allow_ip! "0.0.0.0/0"
+end


### PR DESCRIPTION
I noticed that, in some circumstances, error traces were showing in plaintext when using Whitehall in Docker. After some research I found [this issue][1], the solution for which allows the host machine, Docker and Better Errors to play together nicely!

[1]: https://github.com/BetterErrors/better_errors/issues/270