### PR TITLE
Initial spike for object store

### DIFF
--- a/app/controllers/admin/object_store/items_controller.rb
+++ b/app/controllers/admin/object_store/items_controller.rb
@@ -1,6 +1,12 @@
 module Admin::ObjectStore
   class ItemsController < Admin::EditionsController
+    before_action :check_object_store_feature_flag
+
   private
+
+    def check_object_store_feature_flag
+      forbidden! unless Flipflop.object_store?
+    end
 
     def edition_class
       ObjectStore::Item

--- a/app/controllers/admin/object_store/items_controller.rb
+++ b/app/controllers/admin/object_store/items_controller.rb
@@ -1,0 +1,27 @@
+module Admin::ObjectStore
+  class ItemsController < Admin::EditionsController
+  private
+
+    def edition_class
+      ObjectStore::Item
+    end
+
+    def permitted_edition_attributes
+      (super << ObjectStore.item_type_by_name(params[:item_type]).field_names).flatten
+    end
+
+    def show_or_edit_path
+      if params[:save].present?
+        edit_admin_object_store_item_path(@edition.item_type, @edition)
+      else
+        admin_object_store_item_path @edition
+      end
+    end
+
+    def new_edition
+      edition = edition_class.new(item_type: params[:item_type])
+      edition.assign_attributes(new_edition_params)
+      edition
+    end
+  end
+end

--- a/app/helpers/admin/object_store/items_helper.rb
+++ b/app/helpers/admin/object_store/items_helper.rb
@@ -1,0 +1,39 @@
+module Admin
+  module ObjectStore
+    module ItemsHelper
+      def edition_name(edition)
+        edition.item_type.titleize
+      end
+
+      def render_partial_path(edition, partial_name)
+        render partial: partial_path(edition, partial_name), object: edition, as: edition.item_type
+      end
+
+      def partial_path(edition, partial_name)
+        dirname = edition.item_type.pluralize
+        File.join("admin", "object_store", dirname, partial_name)
+      end
+
+      def object_store_item_form(edition)
+        form_for edition, url: form_url_for_object_store_item(edition), as: edition.item_type do |form|
+          yield(form)
+          concat render("govuk_publishing_components/components/button", {
+            text: "Save",
+            value: "save",
+            name: "save",
+            data_attributes: {
+              module: "gem-track-click",
+              "track-category": "form-button",
+              "track-action": "object-store-item-button",
+              "track-label": "Save",
+            },
+          })
+        end
+      end
+
+      def form_url_for_object_store_item(edition)
+        admin_object_store_items_path(item_type: edition.item_type)
+      end
+    end
+  end
+end

--- a/app/models/concerns/edition/lite_edition.rb
+++ b/app/models/concerns/edition/lite_edition.rb
@@ -1,0 +1,133 @@
+module Edition::LiteEdition
+  extend ActiveSupport::Concern
+
+  UNMODIFIABLE_STATES = %w[scheduled published superseded deleted unpublished].freeze
+
+  def creator
+    edition_authors.first&.user
+  end
+
+  def creator=(user)
+    if new_record?
+      edition_author = edition_authors.first || edition_authors.build
+      edition_author.user = user
+    else
+      raise "author can only be set on new records"
+    end
+  end
+
+  # 'previously_published' is a transient attribute populated
+  # by request parameters, and because it's not persisted it's
+  # not converted to a boolean, hence this manual attr writer method.
+  # NOTE: This method isn't called when the user fails to select an
+  # option for this field and so the value remains nil.
+  def previously_published=(value)
+    @previously_published = value.to_s == "true"
+  end
+
+  def previously_published
+    return first_published_at.present? unless new_record?
+
+    @previously_published
+  end
+
+  def can_set_previously_published?
+    true
+  end
+
+  def can_be_related_to_organisations?
+    false
+  end
+
+  def historic?
+    return false unless government
+
+    political? && !government.current?
+  end
+
+  def government
+    @government ||= Government.on_date(date_for_government) unless date_for_government.nil?
+  end
+
+  def first_public_at
+    first_published_at
+  end
+
+  def previous_edition
+    document.ever_published_editions.where.not(id:).last
+  end
+
+  def display_type
+    I18n.t("document.type.#{display_type_key}", count: 1)
+  end
+
+  def display_type_key
+    format_name.tr(" ", "_")
+  end
+
+  def format_name
+    self.class.format_name
+  end
+
+  def public_path(options = {})
+    return if base_path.nil?
+
+    options[:locale] ||= primary_locale
+    append_url_options(base_path, options)
+  end
+
+  def base_path
+    url_slug = slug || id.to_param
+    "/government/generic-editions/#{url_slug}"
+  end
+
+  def attachables
+    []
+  end
+
+  def unmodifiable?
+    persisted? && UNMODIFIABLE_STATES.include?(state_was)
+  end
+
+  def publishing_api_presenter
+    PublishingApi::GenericEditionPresenter
+  end
+
+  def set_auth_bypass_id
+    self.auth_bypass_id = SecureRandom.uuid
+  end
+
+  included do
+    self.table_name = "editions"
+
+    include Edition::Traits
+    # Adds a statemachine for the publishing workflow. States and methods like
+    # `publish` and `withdraw` are defined here.
+    include Edition::Workflow
+    include Edition::Translatable
+    include Edition::Identifiable
+    include Edition::LimitedAccess
+    include Edition::ActiveEditors
+
+    include AuditTrail
+
+    has_many :edition_authors, dependent: :destroy, foreign_key: :edition_id
+    has_many :authors, through: :edition_authors, source: :user
+
+    validates :title, presence: true, if: :title_required?, length: { maximum: 255 }
+
+    before_create :set_auth_bypass_id
+
+    def self.format_name
+      @format_name ||= model_name.human.downcase
+    end
+  end
+
+private
+
+  def date_for_government
+    published_edition_date = first_public_at.try(:to_date)
+    draft_edition_date = updated_at.try(:to_date)
+    published_edition_date || draft_edition_date
+  end
+end

--- a/app/models/object_store/item.rb
+++ b/app/models/object_store/item.rb
@@ -1,0 +1,33 @@
+module ObjectStore
+  class Item < Edition
+    store_accessor :details, :item_type
+
+    after_initialize :add_field_accessors
+
+    def summary_required?
+      false
+    end
+
+    def body_required?
+      false
+    end
+
+    def previously_published
+      false
+    end
+
+  private
+
+    def add_field_accessors
+      config = ObjectStore.item_type_by_name(item_type)
+      config.fields.each do |field|
+        singleton_class.class_eval { store_accessor :details, field.name }
+        if field.required?
+          singleton_class.class_eval { validates field.name, presence: true }
+        end
+      end
+    rescue UnknownItemType
+      # Ignored
+    end
+  end
+end

--- a/app/models/object_store/item.rb
+++ b/app/models/object_store/item.rb
@@ -4,6 +4,10 @@ module ObjectStore
 
     after_initialize :add_field_accessors
 
+    validates :item_type, presence: true, on: :create
+    validate :item_type_cannot_change
+    validates :item_type, inclusion: { in: ObjectStore.item_types }
+
     def summary_required?
       false
     end
@@ -28,6 +32,12 @@ module ObjectStore
       end
     rescue UnknownItemType
       # Ignored
+    end
+
+    def item_type_cannot_change
+      if persisted? && item_type_changed?
+        errors.add :item_type, "cannot be changed after creation"
+      end
     end
   end
 end

--- a/app/models/object_store/item.rb
+++ b/app/models/object_store/item.rb
@@ -1,5 +1,7 @@
 module ObjectStore
-  class Item < Edition
+  class Item < ApplicationRecord
+    include Edition::LiteEdition
+
     store_accessor :details, :item_type
 
     after_initialize :add_field_accessors
@@ -8,16 +10,8 @@ module ObjectStore
     validate :item_type_cannot_change
     validates :item_type, inclusion: { in: ObjectStore.item_types }
 
-    def summary_required?
-      false
-    end
-
-    def body_required?
-      false
-    end
-
-    def previously_published
-      false
+    def title_required?
+      true
     end
 
   private

--- a/app/views/admin/object_store/email_addresses/_form.html.erb
+++ b/app/views/admin/object_store/email_addresses/_form.html.erb
@@ -1,0 +1,21 @@
+<%= object_store_item_form(email_address) do |form| %>
+  <%= render "govuk_publishing_components/components/input", {
+    label: {
+      text: "Title",
+    },
+    heading_size: "m",
+    value: form.object.title,
+    name: "edition[title]",
+    id: "edition_title",
+  } %>
+
+  <%= render "govuk_publishing_components/components/input", {
+    label: {
+      text: "Email address",
+    },
+    heading_size: "m",
+    value: form.object.email_address,
+    name: "edition[email_address]",
+    id: "edition_email_address",
+  } %>
+<% end %>

--- a/app/views/admin/object_store/items/edit.html.erb
+++ b/app/views/admin/object_store/items/edit.html.erb
@@ -1,0 +1,10 @@
+<% content_for :page_title, "Object Store - Edit #{edition_name(@edition)}" %>
+<% content_for :context, "Object Store" %>
+<% content_for :title, "Edit #{edition_name(@edition)}" %>
+<% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @edition, parent_class: "edition")) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render_partial_path(@edition, "form") %>
+  </div>
+</div>

--- a/app/views/admin/object_store/items/new.html.erb
+++ b/app/views/admin/object_store/items/new.html.erb
@@ -1,0 +1,10 @@
+<% content_for :page_title, "Object Store - New #{edition_name(@edition)}" %>
+<% content_for :context, "Object Store" %>
+<% content_for :title, "New #{edition_name(@edition)}" %>
+<% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @edition, parent_class: "edition")) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render_partial_path(@edition, "form") %>
+  </div>
+</div>

--- a/config/features.rb
+++ b/config/features.rb
@@ -23,4 +23,5 @@ Flipflop.configure do
   #   description: "Take over the world."
   feature :editionable_worldwide_organisations, description: "Enables editionable worldwide organisations", default: false
   feature :govspeak_visual_editor, description: "Enables a visual editor for Govspeak fields", default: false
+  feature :object_store, description: "Enables the object store for sharable content", default: Rails.env.development?
 end

--- a/config/initializers/object_store.rb
+++ b/config/initializers/object_store.rb
@@ -1,0 +1,7 @@
+require "object_store"
+
+config_file_path = Rails.root.join("config/object_store/fields.yml")
+
+ObjectStore.configure do |config|
+  config.fields = YAML.safe_load(File.read(config_file_path))
+end

--- a/config/object_store/fields.yml
+++ b/config/object_store/fields.yml
@@ -1,0 +1,6 @@
+email_address:
+  properties:
+    email_address:
+      type: string
+  required:
+    - email_address

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -424,6 +424,12 @@ Whitehall::Application.routes.draw do
         get :confirm_destroy
       end
       post "/link-checker-api-callback" => "link_checker_api#callback"
+
+      namespace :object_store do
+        scope "/:item_type", constraints: { item_type: Regexp.compile(ObjectStore.item_types.join("|")) } do
+          resources :items, path: "/"
+        end
+      end
     end
   end
 

--- a/db/migrate/20240529133137_add_details_to_edition.rb
+++ b/db/migrate/20240529133137_add_details_to_edition.rb
@@ -1,5 +1,5 @@
 class AddDetailsToEdition < ActiveRecord::Migration[7.1]
   def change
-    add_column :editions, :details, :json
+    add_column :editions, :details, :json, default: {}
   end
 end

--- a/db/migrate/20240529133137_add_details_to_edition.rb
+++ b/db/migrate/20240529133137_add_details_to_edition.rb
@@ -1,0 +1,5 @@
+class AddDetailsToEdition < ActiveRecord::Migration[7.1]
+  def change
+    add_column :editions, :details, :json
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -407,6 +407,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_05_104148) do
     t.string "logo_formatted_name"
     t.string "analytics_identifier"
     t.boolean "visual_editor"
+    t.json "details"
     t.index ["alternative_format_provider_id"], name: "index_editions_on_alternative_format_provider_id"
     t.index ["closing_at"], name: "index_editions_on_closing_at"
     t.index ["document_id"], name: "index_editions_on_document_id"

--- a/lib/object_store.rb
+++ b/lib/object_store.rb
@@ -1,0 +1,55 @@
+module ObjectStore
+  class UnknownItemType < StandardError
+    def initialize(item_type)
+      super("Unknown item type: #{item_type}")
+    end
+  end
+
+  class ItemType
+    attr_accessor :name, :fields
+
+    def field_names
+      fields.map(&:name)
+    end
+  end
+
+  class Field
+    attr_accessor :name, :type, :required
+
+    def required?
+      required == true
+    end
+  end
+
+  def self.configuration
+    @configuration ||= OpenStruct.new
+  end
+
+  def self.configure
+    yield(configuration)
+  end
+
+  def self.items
+    @items ||= configuration["fields"].map do |name, config|
+      properties = config["properties"] || []
+      item_type = ItemType.new
+      item_type.name = name
+      item_type.fields = properties.map do |field_name, _v|
+        field = Field.new
+        field.name = field_name
+        field.type = properties.dig(field_name, "type")
+        field.required = config["required"]&.include?(field_name)
+        field
+      end
+      item_type
+    end
+  end
+
+  def self.item_type_by_name(item_type)
+    items.find { |i| i.name == item_type } || raise(UnknownItemType, item_type)
+  end
+
+  def self.item_types
+    items.map(&:name)
+  end
+end

--- a/lib/whitehall/authority/enforcer.rb
+++ b/lib/whitehall/authority/enforcer.rb
@@ -40,6 +40,7 @@ module Whitehall::Authority
     "Symbol" => Rules::MiscellaneousRules,
     "Document" => Rules::DocumentRules,
     "Edition" => Rules::EditionRules,
+    "Edition::LiteEdition" => Rules::EditionRules,
     "FatalityNotice" => Rules::FatalityNoticeRules,
     "MinisterialRole" => Rules::MinisterialRoleRules,
     "Person" => Rules::PersonRules,

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -2,4 +2,4 @@ def image_fixture_file
   @image_fixture_file ||= File.open(Rails.root.join("test/fixtures/minister-of-funk.960x640.jpg"))
 end
 
-Dir[Rails.root.join("test/factories/*.rb")].sort.each { |f| require f }
+Dir[Rails.root.join("test/factories/**/*.rb")].sort.each { |f| require f }

--- a/test/factories/object_store/item.rb
+++ b/test/factories/object_store/item.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :object_store_item, class: ObjectStore::Item, parent: :edition do
+    transient do
+      item_type { "email_address" }
+    end
+
+    title { "object-store-item" }
+
+    initialize_with { ObjectStore::Item.new(item_type:) }
+  end
+end

--- a/test/integration/object_store/create_email_test.rb
+++ b/test/integration/object_store/create_email_test.rb
@@ -1,0 +1,32 @@
+require "test_helper"
+require "capybara/rails"
+
+class CreateEmailTest < ActionDispatch::IntegrationTest
+  include Capybara::DSL
+
+  setup do
+    login_as_admin
+  end
+
+  test "allows an email object to be created" do
+    visit new_admin_object_store_item_path(item_type: "email_address")
+
+    fill_in "Title", with: "Some Title"
+    fill_in "Email address", with: "foo@example.com"
+    click_on "Save"
+
+    created_object = ObjectStore::Item.find_by(title: "Some Title")
+
+    assert_not_nil created_object
+    assert created_object.email_address, "foo@example.com"
+  end
+
+  test "shows errors when missing fields blank" do
+    visit new_admin_object_store_item_path(item_type: "email_address")
+
+    click_on "Save"
+
+    assert_text "Title can't be blank"
+    assert_text "Email address can't be blank"
+  end
+end

--- a/test/integration/object_store/create_email_test.rb
+++ b/test/integration/object_store/create_email_test.rb
@@ -5,6 +5,8 @@ class CreateEmailTest < ActionDispatch::IntegrationTest
   include Capybara::DSL
 
   setup do
+    feature_flags = Flipflop::FeatureSet.current.test!
+    feature_flags.switch!(:object_store, true)
     login_as_admin
   end
 

--- a/test/integration/object_store/edit_email_test.rb
+++ b/test/integration/object_store/edit_email_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+require "capybara/rails"
+
+class EditEmailTest < ActionDispatch::IntegrationTest
+  include Capybara::DSL
+
+  setup do
+    login_as_admin
+  end
+
+  test "allows an email object to be updated" do
+    item = create(:object_store_item, item_type: "email_address", email_address: "foo@example.com")
+    visit edit_admin_object_store_item_path(item_type: "email_address", id: item.id)
+
+    fill_in "Email address", with: "bar@example.com"
+    click_on "Save"
+
+    item.reload
+
+    assert item.email_address, "bar@example.com"
+  end
+end

--- a/test/integration/object_store/edit_email_test.rb
+++ b/test/integration/object_store/edit_email_test.rb
@@ -5,6 +5,8 @@ class EditEmailTest < ActionDispatch::IntegrationTest
   include Capybara::DSL
 
   setup do
+    feature_flags = Flipflop::FeatureSet.current.test!
+    feature_flags.switch!(:object_store, true)
     login_as_admin
   end
 

--- a/test/unit/app/helpers/admin/object_store/items_helper_test.rb
+++ b/test/unit/app/helpers/admin/object_store/items_helper_test.rb
@@ -1,0 +1,47 @@
+require "test_helper"
+
+class Admin::ObjectStore::ItemsHelperTest < ActionView::TestCase
+  include Admin::ObjectStore::ItemsHelper
+
+  test "#edition_name returns the title for an edition" do
+    edition = build(:object_store_item, item_type: "email_address")
+    assert_equal edition_name(edition), "Email Address"
+  end
+
+  test "#partial_path should return a path for an edition" do
+    edition = build(:object_store_item, item_type: "email_address")
+    path = partial_path(edition, "form")
+    assert_equal path, "admin/object_store/email_addresses/form"
+  end
+
+  test "#render_partial_path should render the correct path with the edition" do
+    edition = build(:object_store_item, item_type: "email_address")
+    partial_name = "form"
+
+    expects(:render).with(partial: partial_path(edition, partial_name), object: edition, as: edition.item_type)
+
+    render_partial_path(edition, partial_name)
+  end
+
+  test "#object_store_item_form renders a form" do
+    edition = build(:object_store_item, item_type: "email_address")
+
+    html = object_store_item_form(edition) do |_form|
+      concat("Some text here")
+    end
+
+    assert_includes html, "Some text here"
+    assert_includes html, form_url_for_object_store_item(edition)
+    assert_includes html, render("govuk_publishing_components/components/button", {
+      text: "Save",
+      value: "save",
+      name: "save",
+      data_attributes: {
+        module: "gem-track-click",
+        "track-category": "form-button",
+        "track-action": "object-store-item-button",
+        "track-label": "Save",
+      },
+    })
+  end
+end

--- a/test/unit/app/helpers/admin/republishing_helper_test.rb
+++ b/test/unit/app/helpers/admin/republishing_helper_test.rb
@@ -54,6 +54,7 @@ def content_types
                     Government
                     HistoricalAccount
                     NewsArticle
+                    ObjectStore::Item
                     OperationalField
                     Organisation
                     Person

--- a/test/unit/app/helpers/admin/republishing_helper_test.rb
+++ b/test/unit/app/helpers/admin/republishing_helper_test.rb
@@ -54,7 +54,6 @@ def content_types
                     Government
                     HistoricalAccount
                     NewsArticle
-                    ObjectStore::Item
                     OperationalField
                     Organisation
                     Person

--- a/test/unit/app/models/object_store/item_test.rb
+++ b/test/unit/app/models/object_store/item_test.rb
@@ -1,0 +1,30 @@
+require "test_helper"
+
+class ObjectStore::ItemTest < ActiveSupport::TestCase
+  setup do
+    @item = build(:object_store_item, item_type: "email_address")
+  end
+
+  test "it creates accessors for an email address" do
+    @item.email_address = "foo@example.com"
+
+    assert_equal @item.email_address, "foo@example.com"
+  end
+
+  test "it validates the presence of an email address" do
+    assert_not @item.valid?
+    assert @item.errors[:email_address].any?
+  end
+
+  test "#summary_required? returns false" do
+    assert_equal @item.summary_required?, false
+  end
+
+  test "#body_required? returns false" do
+    assert_equal @item.body_required?, false
+  end
+
+  test "#previously_published returns false" do
+    assert_equal @item.previously_published, false
+  end
+end

--- a/test/unit/app/models/object_store/item_test.rb
+++ b/test/unit/app/models/object_store/item_test.rb
@@ -27,4 +27,26 @@ class ObjectStore::ItemTest < ActiveSupport::TestCase
   test "#previously_published returns false" do
     assert_equal @item.previously_published, false
   end
+
+  test "item_type is required" do
+    item = build(:object_store_item, item_type: nil)
+    assert_not item.valid?
+    assert item.errors[:item_type].any?
+  end
+
+  test "item_type cannot be changed" do
+    @item.email_address = "foo@example.com"
+    @item.save!
+
+    @item.item_type = "foo"
+    assert_not @item.valid?
+    assert @item.errors[:item_type].include?("cannot be changed after creation")
+  end
+
+  test "item_type must be valid" do
+    item = build(:object_store_item, item_type: "banana")
+
+    assert_not item.valid?
+    assert item.errors[:item_type].any?
+  end
 end

--- a/test/unit/app/models/object_store/item_test.rb
+++ b/test/unit/app/models/object_store/item_test.rb
@@ -16,18 +16,6 @@ class ObjectStore::ItemTest < ActiveSupport::TestCase
     assert @item.errors[:email_address].any?
   end
 
-  test "#summary_required? returns false" do
-    assert_equal @item.summary_required?, false
-  end
-
-  test "#body_required? returns false" do
-    assert_equal @item.body_required?, false
-  end
-
-  test "#previously_published returns false" do
-    assert_equal @item.previously_published, false
-  end
-
   test "item_type is required" do
     item = build(:object_store_item, item_type: nil)
     assert_not item.valid?

--- a/test/unit/lib/object_store_test.rb
+++ b/test/unit/lib/object_store_test.rb
@@ -1,0 +1,79 @@
+require "test_helper"
+
+class ObjectStoreTest < ActiveSupport::TestCase
+  setup do
+    @items = ObjectStore.instance_variable_get :@items
+    ObjectStore.instance_variable_set :@items, nil
+
+    @fields = {
+      "type_1" => {
+        "properties" => {
+          "my_field" => {
+            "type" => "string",
+          },
+        },
+        "required" => %w[my_field],
+      },
+      "type_2" => {
+        "properties" => {
+          "some_field" => {
+            "type" => "string",
+          },
+          "other_field" => {
+            "type" => "string",
+          },
+        },
+        "required" => %w[some_field],
+      },
+    }
+    ObjectStore.configure do |config|
+      config.fields = @fields
+    end
+  end
+
+  teardown do
+    ObjectStore.instance_variable_set :@items, @items
+  end
+
+  test "#items casts configuration to objects" do
+    items = ObjectStore.items
+
+    assert_equal items[0].name, "type_1"
+    assert_equal items[0].field_names, %w[my_field]
+
+    assert_equal items[1].name, "type_2"
+    assert_equal items[1].field_names, %w[some_field other_field]
+
+    assert_equal items[0].fields.size, 1
+
+    assert_equal items[0].fields[0].name, "my_field"
+    assert_equal items[0].fields[0].type, "string"
+    assert_equal items[0].fields[0].required?, true
+
+    assert_equal items[1].fields.size, 2
+
+    assert_equal items[1].fields[0].name, "some_field"
+    assert_equal items[1].fields[0].type, "string"
+    assert_equal items[1].fields[0].required?, true
+
+    assert_equal items[1].fields[1].name, "other_field"
+    assert_equal items[1].fields[1].type, "string"
+    assert_equal items[1].fields[1].required?, false
+  end
+
+  test "#item_type_by_name returns an item type" do
+    assert_equal ObjectStore.item_type_by_name("type_1").name, "type_1"
+    assert_equal ObjectStore.item_type_by_name("type_2").name, "type_2"
+  end
+
+  test "#item_type_by_name raises an error when an item is missing" do
+    err = assert_raises ObjectStore::UnknownItemType do
+      ObjectStore.item_type_by_name("other_type")
+    end
+    assert_match(/other_type/, err.message)
+  end
+
+  test "#item_types returns all configured item types" do
+    assert_equal ObjectStore.item_types, %w[type_1 type_2]
+  end
+end


### PR DESCRIPTION
This follows on from https://github.com/alphagov/whitehall/pull/9063 to add the initial scaffolding for an object store in Whitehall, which will allow us to manage reusable blocks of content.

An item for an object store is an editionable object which inherits from the root `Edition` model. We did look at defining a smaller subset of code that would make a model editionable, but this turned out to be too much of a rabbit hole.

Items can have a shape which is defined in config, for now we're having one content type, an email address, but going forward, we will want many different types of object. Ideally, we'd also like these content types to be defined by non-developers.

I've added a very basic create/edit flow for items too (which will need iteration, both for design and functionality), but this gives us a good idea of how this will all fit together, as well as highlighting the changes that need to be made upstream for us to send content to the Publishing API.