### PR TITLE
Add republishable content types method

### DIFF
--- a/app/helpers/admin/republishing_helper.rb
+++ b/app/helpers/admin/republishing_helper.rb
@@ -48,6 +48,18 @@ module Admin::RepublishingHelper
     }
   end
 
+  def republishable_content_types
+    document_types = Edition.descendants.select { |descendant|
+      next(false) if descendant == EditionableWorldwideOrganisation && !Flipflop.editionable_worldwide_organisations?
+
+      descendant.descendants.count.zero?
+    }.map(&:to_s)
+
+    includes_publish_to_publishing_api = ApplicationRecord.subclasses.select { |subclass| subclass.included_modules.include? PublishesToPublishingApi }.map(&:to_s)
+
+    [document_types, includes_publish_to_publishing_api].flatten.sort
+  end
+
   def republishing_index_bulk_republishing_rows
     bulk_content_type_metadata.values.map do |content_type|
       [

--- a/test/unit/app/helpers/admin/republishing_helper_test.rb
+++ b/test/unit/app/helpers/admin/republishing_helper_test.rb
@@ -1,6 +1,33 @@
 require "test_helper"
 
 class Admin::RepublishingHelperTest < ActionView::TestCase
+  test "#republishable_content_types returns a sorted list combining valid document types and other publishable content types" do
+    # we need to eager load here to ensure we have all the models
+    Rails.application.eager_load!
+
+    feature_flags.switch! :editionable_worldwide_organisations, true
+
+    expected_content_types = [
+      content_types[:omnipresent],
+      content_types[:editionable_worldwide_organisations_enabled],
+    ].flatten.sort
+    result_minus_test_types = republishable_content_types.reject { |type| content_types[:test_specific].include? type }
+
+    assert_equal expected_content_types, result_minus_test_types
+  end
+
+  test "#republishable_content_types excludes `EditionableWorldwideOrganisation` when the editionable_worldwide_organisations feature flag is disabled" do
+    # we need to eager load here to ensure we have all the models
+    Rails.application.eager_load!
+
+    feature_flags.switch! :editionable_worldwide_organisations, false
+
+    expected_document_types = content_types[:omnipresent]
+    result_minus_test_types = republishable_content_types.reject { |type| content_types[:test_specific].include? type }
+
+    assert_equal expected_document_types, result_minus_test_types
+  end
+
   test "#republishing_index_bulk_republishing_rows capitalises the first letter of the bulk content type" do
     first_bulk_content_type = republishing_index_bulk_republishing_rows.first.first[:text]
 
@@ -13,4 +40,42 @@ class Admin::RepublishingHelperTest < ActionView::TestCase
 
     assert_equal first_link, expected_link
   end
+end
+
+def content_types
+  { omnipresent: %w[CallForEvidence
+                    CaseStudy
+                    Consultation
+                    Contact
+                    CorporateInformationPage
+                    DetailedGuide
+                    DocumentCollection
+                    FatalityNotice
+                    Government
+                    HistoricalAccount
+                    NewsArticle
+                    OperationalField
+                    Organisation
+                    Person
+                    PolicyGroup
+                    Publication
+                    Role
+                    RoleAppointment
+                    Speech
+                    StatisticalDataSet
+                    StatisticsAnnouncement
+                    TakePartPage
+                    TopicalEvent
+                    TopicalEventAboutPage
+                    WorldLocationNews
+                    WorldwideOffice
+                    WorldwideOrganisation],
+    test_specific: %w[GenericEdition
+                      Edition::AlternativeFormatProviderTest::EditionWithAlternativeFormat
+                      Edition::AppointmentTest::EditionWithAppointment
+                      Edition::EditionableWorldwideOrganisationTest::EditionWithWorldwideOrganisations
+                      Edition::ImagesTest::EditionWithImages
+                      Edition::StatisticalDataSetsTest::EditionWithStatisticalDataSets
+                      Edition::LimitedAccessTest::LimitedByDefaultEdition],
+    editionable_worldwide_organisations_enabled: "EditionableWorldwideOrganisation" }
 end

--- a/test/unit/app/helpers/admin/republishing_helper_test.rb
+++ b/test/unit/app/helpers/admin/republishing_helper_test.rb
@@ -1,16 +1,16 @@
 require "test_helper"
 
 class Admin::RepublishingHelperTest < ActionView::TestCase
-  setup do
-    @first_row = republishing_index_bulk_republishing_rows.first
-  end
-
   test "#republishing_index_bulk_republishing_rows capitalises the first letter of the bulk content type" do
-    assert_equal @first_row.first[:text], "All documents"
+    first_bulk_content_type = republishing_index_bulk_republishing_rows.first.first[:text]
+
+    assert_equal first_bulk_content_type, "All documents"
   end
 
   test "#republishing_index_bulk_republishing_rows creates a link to the specific bulk republishing confirmation page" do
+    first_link = republishing_index_bulk_republishing_rows.first[1][:text]
     expected_link = '<a id="all-documents" class="govuk-link" href="/government/admin/republishing/bulk/all-documents/confirm">Republish <span class="govuk-visually-hidden">all documents</span></a>'
-    assert_equal @first_row[1][:text], expected_link
+
+    assert_equal first_link, expected_link
   end
 end


### PR DESCRIPTION
We'll soon be adding the UI for bulk republishing content by type. The plan is to provide a select element with the republishable content types as options. This adds a couple of methods to support that

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
