### PR TITLE
Change the content and button for Visual Editor exit button

### DIFF
--- a/app/views/components/_visual_editor.html.erb
+++ b/app/views/components/_visual_editor.html.erb
@@ -29,14 +29,15 @@
     <div class="js-app-c-visual-editor__inset-text">
     <%= render "govuk_publishing_components/components/inset_text", {
     } do %>
-      <p class="govuk-body">Thanks for being part of the beta trial to experiment the visual editor. This is an early version and does not support all content design and formatting needs.</p>
-      <p class="govuk-body">If you are blocked you can save your work so far and continue with the markdown editor.</p>
-      <p class="govuk-body">Note that you will not be able switch back to the visual editor only for this document. Visual editor will be available on a new document.</p>
+      <p class="govuk-body">Continue to edit in markdown if you have to add or format content that is not available.</p>
+      <p class="govuk-body">Visual Editor can only be used once per document and subsequent editing needs to be done in markdown.</p>
+      <p class="govuk-body">All changes made in Visual Editor will be saved when you press save and exit to markdown.</p>
       <%= render "govuk_publishing_components/components/button", {
-        text: "Continue in markdown editor",
+        text: "Continue editing in markdown",
         secondary_solid: true,
         type: "button",
         classes: "js-app-c-visual-editor__exit-button",
+        destructive: true,
       } %>
     <% end %>
     </div>

--- a/features/step_definitions/visual_editor_steps.rb
+++ b/features/step_definitions/visual_editor_steps.rb
@@ -82,7 +82,7 @@ And(/^I save the HTML attachment$/) do
 end
 
 And(/^I exit the visual editor experience$/) do
-  click_on "Continue in markdown editor"
+  click_on "Continue editing in markdown"
 end
 
 When(/^I edit a pre-existing publication$/) do


### PR DESCRIPTION
Updated based on user feedback to make the button more prominent and easier to understand

<img width="843" alt="image" src="https://github.com/alphagov/whitehall/assets/568730/e0067ac3-5874-4994-b5b6-9bd3a52404e0">


https://trello.com/c/EimbAV1J/2669-changes-to-exit-button

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
