### PR TITLE
WIP: add rake task to merge one Role into another

### DIFF
--- a/lib/tasks/data_hygiene.rake
+++ b/lib/tasks/data_hygiene.rake
@@ -18,6 +18,35 @@ namespace :data_hygiene do
     DataHygiene::BulkOrganisationUpdater.call(args[:csv_filename])
   end
 
+  desc "Merge one role into another"
+  task :merge_roles, %i[role_to_be_deleted role_to_be_merged_into] => :environment do |_task, _args|
+    role_to_be_deleted = Role.find(role_to_be_deleted) # slug: minister-of-state--48, id: 2377
+    role_to_be_merged_into = Role.find(role_to_be_merged_into) # slug: minister-of-state--150, id: 4494
+
+    ActiveRecord::Base.transaction do
+      role_to_be_deleted.edition_roles.each do |role|
+        role.update!(role: role_to_be_merged_into)
+      end
+      role_to_be_deleted.organisation_roles.each do |role|
+        role.update!(role: role_to_be_merged_into)
+      end
+      role_to_be_deleted.worldwide_organisation_roles.each do |role|
+        role.update!(role: role_to_be_merged_into)
+      end
+      role_to_be_deleted.role_appointments.each do |appointment|
+        appointment.update!(role: role_to_be_merged_into)
+      end
+      role_to_be_deleted.historical_account_role&.update!(role: role_to_be_merged_into)
+      role_to_be_deleted.translations.delete_all
+      role_to_be_merged_into.save! # triggers callbacks to Publishing API
+      # NB: 'Announcements' may continue to be out of date for at least 5 minutes:
+      # https://github.com/alphagov/collections/blob/2586198bdc7e9bce83ac73212b3d1a8314d0f66e/app/lib/services.rb#L10
+    end
+
+    # TODO: Unpublish role_to_be_deleted and redirect to role_to_be_merged_into
+    # and only then delete `role_to_be_deleted.delete` (if at all?)
+  end
+
   desc "Move content from one role to another (DANGER!)."
   task :migrate_role_content, %i[old_role_appointment new_role_appointment] => :environment do |_task, args|
     old_role_app = RoleAppointment.find(args[:old_role_appointment])


### PR DESCRIPTION
To do:
- Ensure 'announcements' are carried over too. Looks like `Role.find(4494).edition_roles => []`, whereas what we might actually need to republish are `Role.find(4494).editions`...? (Need to understand what the difference is between the two. The former seems to get republished after save).
- Add tests
- Spike adding a 'dry run' mode (can we check the status of the commits in the transaction at runtime, and play those back with `puts`?)=
- Think about how to handle duplicate organisation roles post-merge? See:

```
Role.find(4494).organisation_roles
=> 
[#<OrganisationRole:0x0000ffffa0c6d5e0
  id: 2554,
  organisation_id: 10,
  role_id: 4494,
  created_at: Tue, 19 Jul 2016 14:23:05.000000000 BST +01:00,
  updated_at: Fri, 07 Jun 2024 10:40:39.000000000 BST +01:00,
  ordering: 8>,
 #<OrganisationRole:0x0000ffffa0c6d4a0
  id: 4594,
  organisation_id: 1324,
  role_id: 4494,
  created_at: Wed, 16 Dec 2020 17:32:44.000000000 GMT +00:00,
  updated_at: Fri, 07 Jun 2024 10:40:39.000000000 BST +01:00,
  ordering: 1>,
 #<OrganisationRole:0x0000ffffa0c6d360
  id: 4887,
  organisation_id: 1309,
  role_id: 4494,
  created_at: Mon, 20 Sep 2021 08:01:25.000000000 BST +01:00,
  updated_at: Fri, 07 Jun 2024 10:40:39.000000000 BST +01:00,
  ordering: 2>,
 #<OrganisationRole:0x0000ffffa0c6d220
  id: 5442,
  organisation_id: 10,
  role_id: 4494,
  created_at: Fri, 28 Oct 2022 10:55:45.000000000 BST +01:00,
  updated_at: Mon, 18 Dec 2023 08:06:26.000000000 GMT +00:00,
  ordering: 6>,
 #<OrganisationRole:0x0000ffffa0c6d0e0
  id: 5577,
  organisation_id: 1309,
  role_id: 4494,
  created_at: Mon, 13 Feb 2023 15:42:24.000000000 GMT +00:00,
  updated_at: Mon, 13 Feb 2023 15:42:24.000000000 GMT +00:00,
  ordering: 3>,
 #<OrganisationRole:0x0000ffffa0c6cfa0
  id: 5578,
  organisation_id: 1324,
  role_id: 4494,
  created_at: Mon, 13 Feb 2023 15:42:24.000000000 GMT +00:00,
  updated_at: Mon, 13 Feb 2023 15:42:24.000000000 GMT +00:00,
  ordering: 15>]
```

Zendesk ticket: https://govuk.zendesk.com/agent/tickets/5591272
Trello: https://trello.com/c/9kQl9yH4/2625-merge-role-pages

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
