### PR TITLE
Remove contact latitude and longitude columns

### DIFF
--- a/db/migrate/20240605104148_remove_contact_latitude_longitude.rb
+++ b/db/migrate/20240605104148_remove_contact_latitude_longitude.rb
@@ -1,0 +1,8 @@
+class RemoveContactLatitudeLongitude < ActiveRecord::Migration[7.1]
+  def change
+    change_table :contacts, bulk: true do |t|
+      t.remove :latitude, type: :decimal, precision: 15, scale: 10
+      t.remove :longitude, type: :decimal, precision: 15, scale: 10
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_30_154757) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_05_104148) do
   create_table "assets", charset: "utf8mb3", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.string "variant", null: false
@@ -181,8 +181,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_30_154757) do
   end
 
   create_table "contacts", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
-    t.decimal "latitude", precision: 15, scale: 10
-    t.decimal "longitude", precision: 15, scale: 10
     t.integer "contactable_id"
     t.string "contactable_type"
     t.string "postal_code"

--- a/test/unit/app/models/worldwide_office_test.rb
+++ b/test/unit/app/models/worldwide_office_test.rb
@@ -19,8 +19,6 @@ class WorldwideOfficeTest < ActiveSupport::TestCase
   test "delegates address-related methods to its contact" do
     contact = create(
       :contact_with_country,
-      latitude: "67890",
-      longitude: "12345",
       email: "email@email.com",
       contact_form_url: "http://contact.com/form",
       title: "Consulate General's Office",
@@ -36,8 +34,6 @@ class WorldwideOfficeTest < ActiveSupport::TestCase
     office = create(:worldwide_office, contact:)
 
     # attributes
-    assert_equal contact.latitude, office.latitude
-    assert_equal contact.longitude, office.longitude
     assert_equal contact.email, office.email
     assert_equal contact.contact_form_url, office.contact_form_url
     assert_equal contact.title, office.title


### PR DESCRIPTION
These are not being used anywhere, except in an unrelated test.

Therefore removing these.