### PR TITLE
Define list of delegated methods in Worldwide Organisations

### DIFF
--- a/app/models/worldwide_office.rb
+++ b/app/models/worldwide_office.rb
@@ -19,11 +19,24 @@ class WorldwideOffice < ApplicationRecord
   extend HomePageList::ContentItem
   is_stored_on_home_page_lists
 
-  # WorldOffice quacks like a Contact
-  contact_methods = Contact.column_names +
-    Contact::Translation.column_names +
-    %w[contact_numbers country country_code country_name has_postal_address?] -
-    %w[id contactable_id contactable_type contact_id locale created_at updated_at content_id]
+  contact_methods = %w[
+    comments
+    contact_form_url
+    contact_numbers
+    contact_type_id
+    country
+    country_code
+    country_id
+    country_name
+    email
+    has_postal_address?
+    locality
+    postal_code
+    recipient
+    region
+    street_address
+    title
+  ]
 
   delegate(*contact_methods, to: :contact, allow_nil: true)
   delegate(:non_english_translated_locales, to: :worldwide_organisation)

--- a/test/unit/app/models/worldwide_office_test.rb
+++ b/test/unit/app/models/worldwide_office_test.rb
@@ -33,23 +33,22 @@ class WorldwideOfficeTest < ActiveSupport::TestCase
     )
     office = create(:worldwide_office, contact:)
 
-    # attributes
-    assert_equal contact.email, office.email
-    assert_equal contact.contact_form_url, office.contact_form_url
-    assert_equal contact.title, office.title
     assert_equal contact.comments, office.comments
-    assert_equal contact.recipient, office.recipient
-    assert_equal contact.street_address, office.street_address
-    assert_equal contact.locality, office.locality
-    assert_equal contact.region, office.region
-    assert_equal contact.postal_code, office.postal_code
-    # associations
-    assert_equal contact.country, office.country
+    assert_equal contact.contact_form_url, office.contact_form_url
     assert_equal contact.contact_numbers, office.contact_numbers
-    # methods
+    assert_equal contact.contact_type_id, office.contact_type_id
+    assert_equal contact.country, office.country
     assert_equal contact.country_code, office.country_code
+    assert_equal contact.country_id, office.country_id
     assert_equal contact.country_name, office.country_name
+    assert_equal contact.email, office.email
     assert_equal contact.has_postal_address?, office.has_postal_address?
+    assert_equal contact.locality, office.locality
+    assert_equal contact.postal_code, office.postal_code
+    assert_equal contact.recipient, office.recipient
+    assert_equal contact.region, office.region
+    assert_equal contact.street_address, office.street_address
+    assert_equal contact.title, office.title
   end
 
   test "sets a slug based on the title" do


### PR DESCRIPTION
We currently retrieve a list of methods that could be delegated to contacts in the Worldwide Organisation model, add some hardcoded methods, then remove a number of these.

As contacts haven't changed for many years, this dynamic code seems unnecessary and is more difficult to understand than if the methods were just hardcoded.

Therefore replacing with a list of methods. The delegation remains tested in the `WorldwideOfficeTest`.

Also removes a comment about "quacking" 🦆, which contains the wrong model name and also caused confusion as to what it actually meant when I first saw it.