### PR TITLE
Add UI for bulk republishing by type

### DIFF
--- a/app/controllers/admin/bulk_republishing_controller.rb
+++ b/app/controllers/admin/bulk_republishing_controller.rb
@@ -3,6 +3,43 @@ class Admin::BulkRepublishingController < Admin::BaseController
 
   before_action :enforce_permissions!
 
+  def new_by_type
+    @republishable_content_types_select_options = republishable_content_types_select_options
+  end
+
+  def new_by_type_redirect
+    redirect_to(admin_bulk_republishing_by_type_confirm_path(params[:content_type]))
+  end
+
+  def confirm_by_type
+    content_type = republishable_content_types.find { |type| type == params[:content_type].underscore.camelcase }
+    return render "admin/errors/not_found", status: :not_found unless content_type
+
+    @bulk_content_type_metadata = bulk_content_type_metadata.fetch(:all_by_type)
+    @content_type = content_type
+    @republishing_event = RepublishingEvent.new
+  end
+
+  def republish_by_type
+    content_type = republishable_content_types.find { |type| type == params[:content_type].underscore.camelcase }
+    return render "admin/errors/not_found", status: :not_found unless content_type
+
+    bulk_content_type_key = :all_by_type
+    @bulk_content_type_metadata = bulk_content_type_metadata.fetch(bulk_content_type_key)
+    action = "#{@bulk_content_type_metadata[:name].upcase_first} '#{content_type}' have been queued for republishing"
+    bulk_content_type_value = RepublishingEvent.bulk_content_types.fetch(bulk_content_type_key)
+    @republishing_event = build_republishing_event(action:, bulk_content_type: bulk_content_type_value, content_type:)
+
+    if @republishing_event.save
+      @bulk_content_type_metadata[:republish_method].call(content_type)
+
+      flash[:notice] = action
+      redirect_to(admin_republishing_index_path)
+    else
+      render "confirm_by_type"
+    end
+  end
+
   def confirm
     bulk_content_type_key = params[:bulk_content_type].underscore.to_sym
     @bulk_content_type_metadata = bulk_content_type_metadata[bulk_content_type_key]
@@ -36,7 +73,7 @@ private
     enforce_permission!(:administer, :republish_content)
   end
 
-  def build_republishing_event(action:, bulk_content_type:)
-    RepublishingEvent.new(user: current_user, reason: params.fetch(:reason), action:, bulk_content_type:, bulk: true)
+  def build_republishing_event(action:, bulk_content_type:, content_type: nil)
+    RepublishingEvent.new(user: current_user, reason: params.fetch(:reason), action:, bulk_content_type:, bulk: true, content_type:)
   end
 end

--- a/app/helpers/admin/republishing_helper.rb
+++ b/app/helpers/admin/republishing_helper.rb
@@ -49,15 +49,13 @@ module Admin::RepublishingHelper
   end
 
   def republishable_content_types
-    document_types = Edition.descendants.select { |descendant|
+    editionable_content_types = Edition.descendants.select { |descendant|
       next(false) if descendant == EditionableWorldwideOrganisation && !Flipflop.editionable_worldwide_organisations?
 
       descendant.descendants.count.zero?
     }.map(&:to_s)
 
-    includes_publish_to_publishing_api = ApplicationRecord.subclasses.select { |subclass| subclass.included_modules.include? PublishesToPublishingApi }.map(&:to_s)
-
-    [document_types, includes_publish_to_publishing_api].flatten.sort
+    [editionable_content_types, non_editionable_content_types].flatten.sort
   end
 
   def republishing_index_bulk_republishing_rows
@@ -74,5 +72,9 @@ module Admin::RepublishingHelper
         },
       ]
     end
+  end
+
+  def non_editionable_content_types
+    ApplicationRecord.subclasses.select { |subclass| subclass.included_modules.include? PublishesToPublishingApi }.map(&:to_s)
   end
 end

--- a/app/helpers/admin/republishing_helper.rb
+++ b/app/helpers/admin/republishing_helper.rb
@@ -45,6 +45,12 @@ module Admin::RepublishingHelper
         confirmation_path: admin_bulk_republishing_confirm_path("all-published-organisation-about-us-pages"),
         republish_method: -> { BulkRepublisher.new.republish_all_published_organisation_about_us_pages },
       },
+      all_by_type: {
+        id: "all-by-type",
+        name: "all by type",
+        new_path: admin_bulk_republishing_by_type_new_path,
+        republish_method: ->(type) { BulkRepublisher.new.republish_all_by_type(type) },
+      },
     }
   end
 
@@ -58,6 +64,15 @@ module Admin::RepublishingHelper
     [editionable_content_types, non_editionable_content_types].flatten.sort
   end
 
+  def republishable_content_types_select_options
+    republishable_content_types.map do |type|
+      {
+        text: type,
+        value: type.underscore.dasherize,
+      }
+    end
+  end
+
   def republishing_index_bulk_republishing_rows
     bulk_content_type_metadata.values.map do |content_type|
       [
@@ -66,7 +81,7 @@ module Admin::RepublishingHelper
         },
         {
           text: link_to(sanitize("Republish #{tag.span(content_type[:name], class: 'govuk-visually-hidden')}"),
-                        content_type[:confirmation_path],
+                        content_type[:new_path] || content_type[:confirmation_path],
                         id: content_type[:id],
                         class: "govuk-link"),
         },

--- a/app/models/republishing_event.rb
+++ b/app/models/republishing_event.rb
@@ -7,6 +7,9 @@ class RepublishingEvent < ApplicationRecord
   validates :content_id, presence: true, unless: -> { bulk }
   validates :bulk_content_type, presence: true, if: -> { bulk }
 
+  validates :content_type, presence: true, if: -> { bulk_content_type == "all_by_type" }
+  validates :content_type, absence: true, unless: -> { bulk_content_type == "all_by_type" }
+
   enum :bulk_content_type, %i[
     all_documents
     all_documents_with_pre_publication_editions
@@ -14,5 +17,6 @@ class RepublishingEvent < ApplicationRecord
     all_documents_with_publicly_visible_editions_with_attachments
     all_documents_with_publicly_visible_editions_with_html_attachments
     all_published_organisation_about_us_pages
+    all_by_type
   ]
 end

--- a/app/views/admin/bulk_republishing/confirm_by_type.html.erb
+++ b/app/views/admin/bulk_republishing/confirm_by_type.html.erb
@@ -1,0 +1,16 @@
+<% content_for :page_title, "Republish #{@bulk_content_type_metadata[:name]} '#{@content_type}'" %>
+<% content_for :title, "Are you sure you want to republish #{@bulk_content_type_metadata[:name]} '#{@content_type}'?" %>
+<% content_for :title_margin_bottom, 6 %>
+<% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @republishing_event)) %>
+
+<div class="govuk-grid-row">
+  <section class="govuk-grid-column-two-thirds">
+    <p class="govuk-body govuk-!-margin-bottom-7">
+      This will queue <%= @bulk_content_type_metadata[:name] %> '<%= @content_type %>' to be republished.
+    </p>
+    <%= render partial: "shared/republishing_form", locals: {
+      republishing_event: @republishing_event,
+      republishing_path: admin_bulk_republishing_by_type_republish_path(@content_type.underscore.dasherize),
+    } %>
+  </section>
+</div>

--- a/app/views/admin/bulk_republishing/new_by_type.html.erb
+++ b/app/views/admin/bulk_republishing/new_by_type.html.erb
@@ -1,0 +1,18 @@
+<% content_for :page_title, "Republish all by type" %>
+<% content_for :title, "What type of content would you like to republish?" %>
+<% content_for :title_margin_bottom, 6 %>
+
+<div class="govuk-grid-row">
+  <section class="govuk-grid-column-two-thirds">
+    <%= form_with(url: admin_bulk_republishing_by_type_new_redirect_path, method: :post) do %>
+      <%= render "govuk_publishing_components/components/select", {
+        id: "content_type",
+        label: "Choose a content type",
+        options: @republishable_content_types_select_options,
+      } %>
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Continue",
+      } %>
+    <% end %>
+  </section>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,6 +53,12 @@ Whitehall::Application.routes.draw do
           post "/:document_slug/republish" => "republishing#republish_document", as: :republishing_document_republish
         end
         scope :bulk do
+          scope "by-type" do
+            get "/new" => "bulk_republishing#new_by_type", as: :bulk_republishing_by_type_new
+            post "/new" => "bulk_republishing#new_by_type_redirect", as: :bulk_republishing_by_type_new_redirect
+            get "/:content_type/confirm" => "bulk_republishing#confirm_by_type", as: :bulk_republishing_by_type_confirm
+            post "/:content_type/republish" => "bulk_republishing#republish_by_type", as: :bulk_republishing_by_type_republish
+          end
           get "/:bulk_content_type/confirm" => "bulk_republishing#confirm", as: :bulk_republishing_confirm
           post "/:bulk_content_type/republish" => "bulk_republishing#republish", as: :bulk_republishing_republish
         end

--- a/db/migrate/20240617110912_add_content_type_to_republishing_events.rb
+++ b/db/migrate/20240617110912_add_content_type_to_republishing_events.rb
@@ -1,0 +1,5 @@
+class AddContentTypeToRepublishingEvents < ActiveRecord::Migration[7.1]
+  def change
+    add_column :republishing_events, :content_type, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_05_104148) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_17_110912) do
   create_table "assets", charset: "utf8mb3", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.string "variant", null: false
@@ -865,6 +865,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_05_104148) do
     t.string "content_id"
     t.boolean "bulk", null: false
     t.integer "bulk_content_type"
+    t.string "content_type"
     t.index ["user_id"], name: "index_republishing_events_on_user_id"
   end
 

--- a/features/bulk-republishing-content.feature
+++ b/features/bulk-republishing-content.feature
@@ -35,3 +35,13 @@ Feature: Bulk republishing content
     Given Published organisation "About us" pages exist
     When I request a bulk republishing of all published organisation "About us" pages
     Then I can see all published organisation "About us" pages have been queued for republishing
+
+  Scenario: Republish non-editionable content types
+    Given Contacts exist
+    When I select all of type "Contact" for republishing
+    Then I can see all of type "Contact" have been queued for republishing
+
+  Scenario: Republish editionable content types
+    Given Case Studies exist
+    When I select all of type "CaseStudy" for republishing
+    Then I can see all of type "CaseStudy" have been queued for republishing

--- a/features/step_definitions/bulk_republishing_content_steps.rb
+++ b/features/step_definitions/bulk_republishing_content_steps.rb
@@ -97,3 +97,24 @@ end
 Then(/^I can see all published organisation "About us" pages have been queued for republishing$/) do
   expect(page).to have_selector(".gem-c-success-alert", text: "All published organisation 'About us' pages have been queued for republishing")
 end
+
+Given(/Contacts exist$/) do
+  2.times { create(:contact) }
+end
+
+Given(/Case Studies exist$/) do
+  2.times { create(:case_study) }
+end
+
+When(/^I select all of type "([^"]*)" for republishing$/) do |content_type|
+  visit admin_republishing_index_path
+  find("#all-by-type").click
+  select content_type, from: "content_type"
+  click_button("Continue")
+  fill_in "What is the reason for republishing?", with: "It needs republishing"
+  click_button("Confirm republishing")
+end
+
+Then(/^I can see all of type "([^"]*)" have been queued for republishing$/) do |content_type|
+  expect(page).to have_selector(".gem-c-success-alert", text: "All by type '#{content_type}' have been queued for republishing")
+end

--- a/test/factories/republishing_events.rb
+++ b/test/factories/republishing_events.rb
@@ -1,0 +1,14 @@
+FactoryBot.define do
+  factory :republishing_event do
+    action { "Content item scheduled for republishing" }
+    bulk { false }
+    reason { "this needs republishing" }
+    content_id { "611a6777-1d65-4661-a880-a9314628a14b" }
+  end
+
+  trait :bulk do
+    bulk { true }
+    bulk_content_type { "all_documents" }
+    content_id { nil }
+  end
+end

--- a/test/functional/admin/bulk_republishing_controller_test.rb
+++ b/test/functional/admin/bulk_republishing_controller_test.rb
@@ -64,4 +64,87 @@ class Admin::BulkRepublishingControllerTest < ActionController::TestCase
     post :republish, params: { bulk_content_type: "all-published-organisation-about-us-pages", reason: "this needs republishing" }
     assert_response :forbidden
   end
+
+  test "GDS Admin users should be able to GET :new_by_type" do
+    get :new_by_type
+    assert_response :ok
+  end
+
+  test "Non-GDS Admin users should not be able to GET :new_by_type" do
+    login_as :writer
+
+    get :new_by_type
+    assert_response :forbidden
+  end
+
+  test "GDS Admin users should be redirected to :confirm_by_type on POST :new_by_type" do
+    post :new_by_type_redirect, params: { content_type: "organisation" }
+    assert_redirected_to admin_bulk_republishing_by_type_confirm_path(content_type: "organisation")
+  end
+
+  test "Non-GDS Admin users should not be able to POST :new_by_type" do
+    login_as :writer
+
+    post :new_by_type_redirect, params: { content_type: "organisation" }
+    assert_response :forbidden
+  end
+
+  test "GDS Admin users should be able to GET :confirm_by_type with a valid content type" do
+    get :confirm_by_type, params: { content_type: "organisation" }
+    assert_response :ok
+  end
+
+  test "GDS Admin users should see a 404 page when trying to GET :confirm_by_type with an invalid content type" do
+    get :confirm_by_type, params: { content_type: "not-a-content-type" }
+    assert_response :not_found
+  end
+
+  test "Non-GDS Admin users should not be able to access :confirm_by_type" do
+    login_as :writer
+
+    get :confirm_by_type, params: { content_type: "organisation" }
+    assert_response :forbidden
+  end
+
+  test "GDS Admin users should be able to POST :republish_by_type with a valid content type and a reason, creating a RepublishingEvent for the current user" do
+    BulkRepublisher.any_instance.expects(:republish_all_by_type).with("Organisation").once
+
+    post :republish_by_type, params: { content_type: "organisation", reason: "this needs republishing" }
+
+    newly_created_event = RepublishingEvent.last
+    assert_equal newly_created_event.user, current_user
+    assert_equal newly_created_event.reason, "this needs republishing"
+    assert_equal newly_created_event.action, "All by type 'Organisation' have been queued for republishing"
+    assert_equal newly_created_event.bulk, true
+    assert_equal newly_created_event.bulk_content_type, "all_by_type"
+    assert_equal newly_created_event.content_type, "Organisation"
+
+    assert_redirected_to admin_republishing_index_path
+    assert_equal "All by type 'Organisation' have been queued for republishing", flash[:notice]
+  end
+
+  test "GDS Admin users should encounter an error on POST :republish_by_type without a `reason` and be sent back to the confirm page" do
+    BulkRepublisher.expects(:new).never
+
+    post :republish_by_type, params: { content_type: "organisation", reason: "" }
+
+    assert_equal ["Reason can't be blank"], assigns(:republishing_event).errors.full_messages
+    assert_template "confirm_by_type"
+  end
+
+  test "GDS Admin users should see a 404 page when trying to POST :republish_by_type with an invalid content type" do
+    BulkRepublisher.expects(:new).never
+
+    post :republish_by_type, params: { content_type: "not-a-content-type", reason: "this needs republishing" }
+    assert_response :not_found
+  end
+
+  test "Non-GDS Admin users should not be able to POST :republish_by_type" do
+    BulkRepublisher.expects(:new).never
+
+    login_as :writer
+
+    post :republish_by_type, params: { content_type: "organisation", reason: "this needs republishing" }
+    assert_response :forbidden
+  end
 end

--- a/test/functional/admin/republishing_controller_test.rb
+++ b/test/functional/admin/republishing_controller_test.rb
@@ -25,6 +25,7 @@ class Admin::RepublishingControllerTest < ActionController::TestCase
     assert_select ".govuk-table:nth-of-type(3) .govuk-table__body .govuk-table__row:nth-child(4) .govuk-table__cell:nth-child(2) a[href='/government/admin/republishing/bulk/all-documents-with-publicly-visible-editions-with-attachments/confirm']", text: "Republish all documents with publicly-visible editions with attachments"
     assert_select ".govuk-table:nth-of-type(3) .govuk-table__body .govuk-table__row:nth-child(5) .govuk-table__cell:nth-child(2) a[href='/government/admin/republishing/bulk/all-documents-with-publicly-visible-editions-with-html-attachments/confirm']", text: "Republish all documents with publicly-visible editions with HTML attachments"
     assert_select ".govuk-table:nth-of-type(3) .govuk-table__body .govuk-table__row:nth-child(6) .govuk-table__cell:nth-child(2) a[href='/government/admin/republishing/bulk/all-published-organisation-about-us-pages/confirm']", text: "Republish all published organisation 'About us' pages"
+    assert_select ".govuk-table:nth-of-type(3) .govuk-table__body .govuk-table__row:nth-child(7) .govuk-table__cell:nth-child(2) a[href='/government/admin/republishing/bulk/by-type/new']", text: "Republish all by type"
 
     assert_response :ok
   end

--- a/test/unit/app/helpers/admin/republishing_helper_test.rb
+++ b/test/unit/app/helpers/admin/republishing_helper_test.rb
@@ -8,7 +8,7 @@ class Admin::RepublishingHelperTest < ActionView::TestCase
     feature_flags.switch! :editionable_worldwide_organisations, true
 
     expected_content_types = [
-      content_types[:omnipresent],
+      omnipresent_content_types,
       content_types[:editionable_worldwide_organisations_enabled],
     ].flatten.sort
     result_minus_test_types = republishable_content_types.reject { |type| content_types[:test_specific].include? type }
@@ -22,10 +22,17 @@ class Admin::RepublishingHelperTest < ActionView::TestCase
 
     feature_flags.switch! :editionable_worldwide_organisations, false
 
-    expected_document_types = content_types[:omnipresent]
+    expected_content_types = omnipresent_content_types.sort
     result_minus_test_types = republishable_content_types.reject { |type| content_types[:test_specific].include? type }
 
-    assert_equal expected_document_types, result_minus_test_types
+    assert_equal expected_content_types, result_minus_test_types
+  end
+
+  test "#non_editionable_content_types returns a list of non-editionable content types" do
+    # we need to eager load here to ensure we have all the models
+    Rails.application.eager_load!
+
+    assert_equal content_types[:omnipresent_non_editionable], non_editionable_content_types.sort
   end
 
   test "#republishing_index_bulk_republishing_rows capitalises the first letter of the bulk content type" do
@@ -42,34 +49,38 @@ class Admin::RepublishingHelperTest < ActionView::TestCase
   end
 end
 
+def omnipresent_content_types
+  content_types[:omnipresent_editionable].concat(content_types[:omnipresent_non_editionable])
+end
+
 def content_types
-  { omnipresent: %w[CallForEvidence
-                    CaseStudy
-                    Consultation
-                    Contact
-                    CorporateInformationPage
-                    DetailedGuide
-                    DocumentCollection
-                    FatalityNotice
-                    Government
-                    HistoricalAccount
-                    NewsArticle
-                    OperationalField
-                    Organisation
-                    Person
-                    PolicyGroup
-                    Publication
-                    Role
-                    RoleAppointment
-                    Speech
-                    StatisticalDataSet
-                    StatisticsAnnouncement
-                    TakePartPage
-                    TopicalEvent
-                    TopicalEventAboutPage
-                    WorldLocationNews
-                    WorldwideOffice
-                    WorldwideOrganisation],
+  { omnipresent_editionable: %w[CallForEvidence
+                                CaseStudy
+                                Consultation
+                                CorporateInformationPage
+                                DetailedGuide
+                                DocumentCollection
+                                FatalityNotice
+                                NewsArticle
+                                Publication
+                                Speech
+                                StatisticalDataSet],
+    omnipresent_non_editionable: %w[Contact
+                                    Government
+                                    HistoricalAccount
+                                    OperationalField
+                                    Organisation
+                                    Person
+                                    PolicyGroup
+                                    Role
+                                    RoleAppointment
+                                    StatisticsAnnouncement
+                                    TakePartPage
+                                    TopicalEvent
+                                    TopicalEventAboutPage
+                                    WorldLocationNews
+                                    WorldwideOffice
+                                    WorldwideOrganisation],
     test_specific: %w[GenericEdition
                       Edition::AlternativeFormatProviderTest::EditionWithAlternativeFormat
                       Edition::AppointmentTest::EditionWithAppointment

--- a/test/unit/app/helpers/admin/republishing_helper_test.rb
+++ b/test/unit/app/helpers/admin/republishing_helper_test.rb
@@ -47,6 +47,33 @@ class Admin::RepublishingHelperTest < ActionView::TestCase
 
     assert_equal first_link, expected_link
   end
+
+  test "#republishing_index_bulk_republishing_rows creates a link to the 'new' path for the 'all_by_type' section" do
+    all_by_type_link = republishing_index_bulk_republishing_rows.flatten.find { |column|
+                         column[:text].include?('Republish <span class="govuk-visually-hidden">all by type</span>')
+                       }[:text]
+
+    expected_link = '<a id="all-by-type" class="govuk-link" href="/government/admin/republishing/bulk/by-type/new">Republish <span class="govuk-visually-hidden">all by type</span></a>'
+
+    assert_equal expected_link, all_by_type_link
+  end
+
+  test "#republishable_content_types_select_options creates select options from republishable_content_types" do
+    # we need to eager load here to ensure we have all the models
+    Rails.application.eager_load!
+
+    options = republishable_content_types_select_options
+
+    assert_includes options, {
+      text: "CallForEvidence",
+      value: "call-for-evidence",
+    }
+
+    assert_includes options, {
+      text: "Contact",
+      value: "contact",
+    }
+  end
 end
 
 def omnipresent_content_types

--- a/test/unit/app/models/republishing_event_test.rb
+++ b/test/unit/app/models/republishing_event_test.rb
@@ -1,0 +1,29 @@
+require "test_helper"
+
+class RepublishingEventTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
+  describe "content_type" do
+    context "for an `all_by_type` bulk republishing event" do
+      test "should be valid with a content type" do
+        event = build(:republishing_event, :bulk, bulk_content_type: "all_by_type", content_type: "a content type")
+        assert event.valid?
+      end
+
+      test "should be invalid without a content type" do
+        event = build(:republishing_event, :bulk, bulk_content_type: "all_by_type", content_type: nil)
+        assert_not event.valid?
+      end
+    end
+
+    context "for any other republishing event" do
+      test "must not be present" do
+        bulk_event = build(:republishing_event, :bulk, bulk_content_type: "all_documents", content_type: "all documents")
+        assert_not bulk_event.valid?
+
+        non_bulk_event = build(:republishing_event, content_type: "all documents")
+        assert_not non_bulk_event.valid?
+      end
+    end
+  end
+end


### PR DESCRIPTION
[Trello](https://trello.com/c/2nRbOaFp/1200-add-a-user-interface-for-whitehalls-bulk-republishing-documents-by-type-rake-task)

## Changes in this PR

Adds a UI for bulk republishing all content types by their type to replace the `publishing_api:bulk_republish:document_type[document_type]` rake task.

There are a couple of things that _could_ be a bit neater here, e.g. text formatting of types, but as this isn't an interface that we're hoping will be used very often, I don't think it's worth spending the time making this look any prettier.

## Screenshots

<img width="939" alt="Screenshot 2024-06-13 at 16 04 14" src="https://github.com/alphagov/whitehall/assets/19826940/6515c347-a4ce-4e09-b436-f1c5eaa95474">


<img width="1021" alt="Screenshot 2024-06-13 at 16 04 23" src="https://github.com/alphagov/whitehall/assets/19826940/22f5e56f-52f5-4dd5-96c7-295b61a9804b">

<img width="994" alt="Screenshot 2024-06-13 at 16 04 32" src="https://github.com/alphagov/whitehall/assets/19826940/9374760e-66fd-4479-ac7e-88047c676a90">

<img width="1322" alt="Screenshot 2024-06-13 at 16 04 38" src="https://github.com/alphagov/whitehall/assets/19826940/fade9098-a3ae-449b-86f8-8cc5caf30544">

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
