### PR TITLE
Update the label for the Accredited Official Statistics type of Statistics Announcement

### DIFF
--- a/app/views/admin/statistics_announcements/_form.html.erb
+++ b/app/views/admin/statistics_announcements/_form.html.erb
@@ -17,10 +17,10 @@
       },
       {
         value: 15,
-        text: "National Statistics",
+        text: "Accredited Official Statistics",
         name: "statistics_announcement[publication_type_id]",
         id: "statistics_announcement_publication_type_id_15",
-        hint_text: "Official Statistics approved by the UK Statistics Authority. The National Statistics logo will display on this announcement.",
+        hint_text: "Official Statistics approved by the UK Statistics Authority. The Accredited Official Statistics logo will display on this announcement.",
         bold: true,
         checked: statistics_announcement.publication_type_id == 15,
       },


### PR DESCRIPTION
This was missed during our original work on https://trello.com/c/jkaJlgez

These were previously known as National Statistics, but the name has changed as of 7th June 2024
