### PR TITLE
Make summary required for Editionable Worldwide Organisations and their pages

### DIFF
--- a/app/models/editionable_worldwide_organisation.rb
+++ b/app/models/editionable_worldwide_organisation.rb
@@ -182,10 +182,6 @@ class EditionableWorldwideOrganisation < Edition
     false
   end
 
-  def summary_required?
-    false
-  end
-
   def translatable?
     true
   end

--- a/app/models/worldwide_organisation_page.rb
+++ b/app/models/worldwide_organisation_page.rb
@@ -6,6 +6,7 @@ class WorldwideOrganisationPage < ApplicationRecord
   validates :corporate_information_page_type_id,
             presence: true,
             exclusion: { in: [CorporateInformationPageType::AboutUs.id], message: "Type cannot be `About us`" }
+  validates :summary, presence: true
   validate :unique_worldwide_organisation_and_page_type, on: :create, if: :edition
   validate :parent_edition_has_locales, if: :edition
 

--- a/app/views/admin/worldwide_organisation_page_translations/edit.html.erb
+++ b/app/views/admin/worldwide_organisation_page_translations/edit.html.erb
@@ -10,7 +10,7 @@
         textarea: {
           label: {
             heading_size: "l",
-            text: "Translated summary",
+            text: "Translated summary (required)",
           },
           name: "page[summary]",
           id: "page_summary",

--- a/app/views/admin/worldwide_organisation_pages/_form.html.erb
+++ b/app/views/admin/worldwide_organisation_pages/_form.html.erb
@@ -24,7 +24,7 @@
   <%= render "govuk_publishing_components/components/character_count", {
     textarea: {
       label: {
-        text: "Summary",
+        text: "Summary (required)",
         heading_size: "l",
       },
       name: "worldwide_organisation_page[summary]",

--- a/test/unit/app/models/editionable_worldwide_organisation_test.rb
+++ b/test/unit/app/models/editionable_worldwide_organisation_test.rb
@@ -396,4 +396,8 @@ class EditionableWorldwideOrganisationTest < ActiveSupport::TestCase
     organisation = build(:editionable_worldwide_organisation)
     organisation.attachments << build(:file_attachment)
   end
+
+  test "should not be valid without a summary" do
+    assert_not build(:editionable_worldwide_organisation, summary: nil).valid?
+  end
 end

--- a/test/unit/app/models/editionable_worldwide_organisation_test.rb
+++ b/test/unit/app/models/editionable_worldwide_organisation_test.rb
@@ -397,7 +397,9 @@ class EditionableWorldwideOrganisationTest < ActiveSupport::TestCase
     organisation.attachments << build(:file_attachment)
   end
 
-  test "should not be valid without a summary" do
-    assert_not build(:editionable_worldwide_organisation, summary: nil).valid?
+  %w[body summary title].each do |param|
+    test "should not be valid without a #{param}" do
+      assert_not build(:editionable_worldwide_organisation, param.to_sym => nil).valid?
+    end
   end
 end

--- a/test/unit/app/models/worldwide_organisation_page_test.rb
+++ b/test/unit/app/models/worldwide_organisation_page_test.rb
@@ -32,7 +32,7 @@ class WorldwideOrganisationPageTest < ActiveSupport::TestCase
     page.destroy!
   end
 
-  %w[body corporate_information_page_type_id].each do |param|
+  %w[body corporate_information_page_type_id summary].each do |param|
     test "should not be valid without a #{param}" do
       assert_not build(:worldwide_organisation_page, param.to_sym => nil).valid?
     end


### PR DESCRIPTION
We are currently not requiring a summary field for Editionable Worldwide Organisations or their pages.  By making it mandatory, we are making these consistent with most other editionable content types.

[Trello card](https://trello.com/c/vne3i08V)