### PR TITLE
Empty ministerial links when reshuffle mode is on

### DIFF
--- a/app/presenters/publishing_api/ministers_index_presenter.rb
+++ b/app/presenters/publishing_api/ministers_index_presenter.rb
@@ -32,18 +32,29 @@ module PublishingApi
     end
 
     def links
-      return {} if reshuffle_in_progress?
-
-      {
-        ordered_cabinet_ministers: ordered_cabinet_ministers_content_ids,
-        ordered_also_attends_cabinet: ordered_also_attends_cabinet_content_ids,
-        ordered_ministerial_departments: ordered_ministerial_departments_content_ids,
-        ordered_house_of_commons_whips: ordered_whips_content_ids(Whitehall::WhipOrganisation::WhipsHouseOfCommons),
-        ordered_junior_lords_of_the_treasury_whips: ordered_whips_content_ids(Whitehall::WhipOrganisation::JuniorLordsoftheTreasury),
-        ordered_assistant_whips: ordered_whips_content_ids(Whitehall::WhipOrganisation::AssistantWhips),
-        ordered_house_lords_whips: ordered_whips_content_ids(Whitehall::WhipOrganisation::WhipsHouseofLords),
-        ordered_baronesses_and_lords_in_waiting_whips: ordered_whips_content_ids(Whitehall::WhipOrganisation::BaronessAndLordsInWaiting),
-      }
+      if reshuffle_in_progress?
+        {
+          ordered_cabinet_ministers: [],
+          ordered_also_attends_cabinet: [],
+          ordered_ministerial_departments: [],
+          ordered_house_of_commons_whips: [],
+          ordered_junior_lords_of_the_treasury_whips: [],
+          ordered_assistant_whips: [],
+          ordered_house_lords_whips: [],
+          ordered_baronesses_and_lords_in_waiting_whips: [],
+        }
+      else
+        {
+          ordered_cabinet_ministers: ordered_cabinet_ministers_content_ids,
+          ordered_also_attends_cabinet: ordered_also_attends_cabinet_content_ids,
+          ordered_ministerial_departments: ordered_ministerial_departments_content_ids,
+          ordered_house_of_commons_whips: ordered_whips_content_ids(Whitehall::WhipOrganisation::WhipsHouseOfCommons),
+          ordered_junior_lords_of_the_treasury_whips: ordered_whips_content_ids(Whitehall::WhipOrganisation::JuniorLordsoftheTreasury),
+          ordered_assistant_whips: ordered_whips_content_ids(Whitehall::WhipOrganisation::AssistantWhips),
+          ordered_house_lords_whips: ordered_whips_content_ids(Whitehall::WhipOrganisation::WhipsHouseofLords),
+          ordered_baronesses_and_lords_in_waiting_whips: ordered_whips_content_ids(Whitehall::WhipOrganisation::BaronessAndLordsInWaiting),
+        }
+      end
     end
 
     def title

--- a/test/unit/app/presenters/publishing_api/ministers_index_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/ministers_index_presenter_test.rb
@@ -114,7 +114,16 @@ class PublishingApi::MinistersIndexPresenterTest < ActionView::TestCase
         },
       }
 
-      expected_links = {}
+      expected_links = {
+        ordered_cabinet_ministers: [],
+        ordered_also_attends_cabinet: [],
+        ordered_ministerial_departments: [],
+        ordered_house_of_commons_whips: [],
+        ordered_junior_lords_of_the_treasury_whips: [],
+        ordered_assistant_whips: [],
+        ordered_house_lords_whips: [],
+        ordered_baronesses_and_lords_in_waiting_whips: [],
+      }
 
       assert_equal expected_details, presented_item.content[:details]
       assert_valid_against_publisher_schema(presented_item.content, "ministers_index")


### PR DESCRIPTION
Publishing API doesn't delete links unless you send it an empty array for a specific key.

Therefore updating the presenter to include all the keys that need to be emptied, rather than an empty hash.