### PR TITLE
Preview mode for Ministers page when in "reshuffle mode"

### DIFF
--- a/app/controllers/admin/cabinet_ministers_controller.rb
+++ b/app/controllers/admin/cabinet_ministers_controller.rb
@@ -2,6 +2,8 @@ class Admin::CabinetMinistersController < Admin::BaseController
   include ReshuffleMode
   before_action :enforce_permissions!
 
+  helper_method :reshuffle_in_progress?
+
   def show
     @cabinet_minister_roles = MinisterialRole.includes(:translations).where(cabinet_member: true).order(:seniority)
     @also_attends_cabinet_roles = MinisterialRole.includes(:translations).also_attends_cabinet.order(:seniority)

--- a/app/controllers/admin/cabinet_ministers_controller.rb
+++ b/app/controllers/admin/cabinet_ministers_controller.rb
@@ -1,4 +1,5 @@
 class Admin::CabinetMinistersController < Admin::BaseController
+  include ReshuffleMode
   before_action :enforce_permissions!
 
   def show
@@ -14,7 +15,7 @@ class Admin::CabinetMinistersController < Admin::BaseController
 
   def order_cabinet_minister_roles
     MinisterialRole.reorder_without_callbacks!(order_ministerial_roles_params, :seniority)
-    PresentPageToPublishingApiWorker.perform_async("PublishingApi::MinistersIndexPresenter")
+    republish_ministers_index_page_to_publishing_api
 
     redirect_to admin_cabinet_ministers_path(anchor: "cabinet_minister")
   end
@@ -25,7 +26,7 @@ class Admin::CabinetMinistersController < Admin::BaseController
 
   def order_also_attends_cabinet_roles
     MinisterialRole.reorder_without_callbacks!(order_ministerial_roles_params, :seniority)
-    PresentPageToPublishingApiWorker.perform_async("PublishingApi::MinistersIndexPresenter")
+    republish_ministers_index_page_to_publishing_api
 
     redirect_to admin_cabinet_ministers_path(anchor: "also_attends_cabinet")
   end
@@ -36,7 +37,7 @@ class Admin::CabinetMinistersController < Admin::BaseController
 
   def order_whip_roles
     MinisterialRole.reorder_without_callbacks!(order_ministerial_roles_params, :whip_ordering)
-    PresentPageToPublishingApiWorker.perform_async("PublishingApi::MinistersIndexPresenter")
+    republish_ministers_index_page_to_publishing_api
 
     redirect_to admin_cabinet_ministers_path(anchor: "whips")
   end
@@ -47,7 +48,7 @@ class Admin::CabinetMinistersController < Admin::BaseController
 
   def order_ministerial_organisations
     Organisation.reorder_without_callbacks!(order_ministerial_organisations_params, :ministerial_ordering)
-    PresentPageToPublishingApiWorker.perform_async("PublishingApi::MinistersIndexPresenter")
+    republish_ministers_index_page_to_publishing_api
 
     redirect_to admin_cabinet_ministers_path(anchor: "organisations")
   end

--- a/app/controllers/admin/republishing_controller.rb
+++ b/app/controllers/admin/republishing_controller.rb
@@ -1,5 +1,6 @@
 class Admin::RepublishingController < Admin::BaseController
   include Admin::RepublishingHelper
+  include ReshuffleMode
 
   before_action :enforce_permissions!
 
@@ -20,6 +21,11 @@ class Admin::RepublishingController < Admin::BaseController
   def republish_page
     page_to_republish = republishable_pages.find { |page| page[:slug] == params[:page_slug] }
     return render "admin/errors/not_found", status: :not_found unless page_to_republish
+
+    if reshuffle_in_progress? && %w[how-government-works ministers].include?(params[:page_slug])
+      flash[:alert] = "Cannot republish #{params[:page_slug]} page while in reshuffle mode"
+      return redirect_to(admin_republishing_index_path)
+    end
 
     action = "The page '#{page_to_republish[:title]}' has been scheduled for republishing"
 

--- a/app/models/concerns/reshuffle_mode.rb
+++ b/app/models/concerns/reshuffle_mode.rb
@@ -6,5 +6,13 @@ module ReshuffleMode
       PresentPageToPublishingApiWorker.perform_async("PublishingApi::HowGovernmentWorksPresenter")
       PresentPageToPublishingApiWorker.perform_async("PublishingApi::MinistersIndexPresenter")
     end
+
+    def republish_ministers_index_page_to_publishing_api
+      PresentPageToPublishingApiWorker.perform_async("PublishingApi::MinistersIndexPresenter")
+    end
+
+    def republish_how_government_works_page_to_publishing_api
+      PresentPageToPublishingApiWorker.perform_async("PublishingApi::HowGovernmentWorksPresenter")
+    end
   end
 end

--- a/app/models/concerns/reshuffle_mode.rb
+++ b/app/models/concerns/reshuffle_mode.rb
@@ -3,20 +3,27 @@ module ReshuffleMode
 
   included do
     def republish_ministerial_pages_to_publishing_api
-      PresentPageToPublishingApiWorker.perform_async("PublishingApi::HowGovernmentWorksPresenter")
-      PresentPageToPublishingApiWorker.perform_async("PublishingApi::MinistersIndexPresenter")
+      PresentPageToPublishingApiWorker.perform_async("PublishingApi::HowGovernmentWorksPresenter", update_live?)
+      PresentPageToPublishingApiWorker.perform_async("PublishingApi::MinistersIndexPresenter", update_live?)
     end
 
     def republish_ministers_index_page_to_publishing_api
-      PresentPageToPublishingApiWorker.perform_async("PublishingApi::MinistersIndexPresenter")
+      PresentPageToPublishingApiWorker.perform_async("PublishingApi::MinistersIndexPresenter", update_live?)
     end
 
     def republish_how_government_works_page_to_publishing_api
-      PresentPageToPublishingApiWorker.perform_async("PublishingApi::HowGovernmentWorksPresenter")
+      PresentPageToPublishingApiWorker.perform_async("PublishingApi::HowGovernmentWorksPresenter", update_live?)
     end
 
     def reshuffle_in_progress?
       SitewideSetting.find_by(key: :minister_reshuffle_mode)&.on || false
     end
+  end
+
+  def update_live?
+    # should be false when reshuffle mode is on - we'll reuse
+    # https://github.com/alphagov/whitehall/blob/685e3ce1687872ed5567bc1d907b822fbd77035e/app/presenters/publishing_api/ministers_index_presenter.rb#L71-L73
+    # in a future commit
+    true
   end
 end

--- a/app/models/concerns/reshuffle_mode.rb
+++ b/app/models/concerns/reshuffle_mode.rb
@@ -14,5 +14,9 @@ module ReshuffleMode
     def republish_how_government_works_page_to_publishing_api
       PresentPageToPublishingApiWorker.perform_async("PublishingApi::HowGovernmentWorksPresenter")
     end
+
+    def reshuffle_in_progress?
+      SitewideSetting.find_by(key: :minister_reshuffle_mode)&.on || false
+    end
   end
 end

--- a/app/models/concerns/reshuffle_mode.rb
+++ b/app/models/concerns/reshuffle_mode.rb
@@ -21,9 +21,6 @@ module ReshuffleMode
   end
 
   def update_live?
-    # should be false when reshuffle mode is on - we'll reuse
-    # https://github.com/alphagov/whitehall/blob/685e3ce1687872ed5567bc1d907b822fbd77035e/app/presenters/publishing_api/ministers_index_presenter.rb#L71-L73
-    # in a future commit
-    true
+    !reshuffle_in_progress?
   end
 end

--- a/app/models/concerns/reshuffle_mode.rb
+++ b/app/models/concerns/reshuffle_mode.rb
@@ -1,0 +1,10 @@
+module ReshuffleMode
+  extend ActiveSupport::Concern
+
+  included do
+    def republish_ministerial_pages_to_publishing_api
+      PresentPageToPublishingApiWorker.perform_async("PublishingApi::HowGovernmentWorksPresenter")
+      PresentPageToPublishingApiWorker.perform_async("PublishingApi::MinistersIndexPresenter")
+    end
+  end
+end

--- a/app/models/ministerial_role.rb
+++ b/app/models/ministerial_role.rb
@@ -1,4 +1,5 @@
 class MinisterialRole < Role
+  include ReshuffleMode
   include UserOrderable
 
   has_many :editions, -> { distinct }, through: :role_appointments
@@ -38,10 +39,5 @@ private
 
   def default_person_name
     name
-  end
-
-  def republish_ministerial_pages_to_publishing_api
-    PresentPageToPublishingApiWorker.perform_async("PublishingApi::HowGovernmentWorksPresenter")
-    PresentPageToPublishingApiWorker.perform_async("PublishingApi::MinistersIndexPresenter")
   end
 end

--- a/app/models/sitewide_setting.rb
+++ b/app/models/sitewide_setting.rb
@@ -17,11 +17,13 @@ class SitewideSetting < ApplicationRecord
   def republish_downstream_if_reshuffle
     return unless key == "minister_reshuffle_mode"
 
-    payload = PublishingApi::MinistersIndexPresenter.new
-
-    Services.publishing_api.put_content(payload.content_id, payload.content)
-    Services.publishing_api.publish(payload.content_id, nil, locale: "en")
-
-    PresentPageToPublishingApiWorker.perform_async("PublishingApi::HowGovernmentWorksPresenter")
+    update_live = true
+    if on
+      PresentPageToPublishingApiWorker.perform_async("PublishingApi::HowGovernmentWorksEnableReshufflePresenter", update_live)
+      PresentPageToPublishingApiWorker.perform_async("PublishingApi::MinistersIndexEnableReshufflePresenter", update_live)
+    else
+      PresentPageToPublishingApiWorker.perform_async("PublishingApi::HowGovernmentWorksPresenter", update_live)
+      PresentPageToPublishingApiWorker.perform_async("PublishingApi::MinistersIndexPresenter", update_live)
+    end
   end
 end

--- a/app/models/sitewide_setting.rb
+++ b/app/models/sitewide_setting.rb
@@ -19,8 +19,12 @@ class SitewideSetting < ApplicationRecord
 
     update_live = true
     if on
-      PresentPageToPublishingApiWorker.perform_async("PublishingApi::HowGovernmentWorksEnableReshufflePresenter", update_live)
-      PresentPageToPublishingApiWorker.perform_async("PublishingApi::MinistersIndexEnableReshufflePresenter", update_live)
+      # These have to be sent synchronously so we can guarantee the order in which they're processed.
+      # First, send 'page is currently being updated' message to Draft and promote to Live
+      PresentPageToPublishingApiWorker.new.perform("PublishingApi::HowGovernmentWorksEnableReshufflePresenter", update_live)
+      PresentPageToPublishingApiWorker.new.perform("PublishingApi::MinistersIndexEnableReshufflePresenter", update_live)
+      # Finally, send normal ministers index payload to draft so that we can use it as a preview
+      PresentPageToPublishingApiWorker.new.perform("PublishingApi::MinistersIndexPresenter", false)
     else
       PresentPageToPublishingApiWorker.perform_async("PublishingApi::HowGovernmentWorksPresenter", update_live)
       PresentPageToPublishingApiWorker.perform_async("PublishingApi::MinistersIndexPresenter", update_live)

--- a/app/presenters/publishing_api/how_government_works_enable_reshuffle_presenter.rb
+++ b/app/presenters/publishing_api/how_government_works_enable_reshuffle_presenter.rb
@@ -1,0 +1,15 @@
+module PublishingApi
+  class HowGovernmentWorksEnableReshufflePresenter < HowGovernmentWorksPresenter
+    def links
+      {
+        current_prime_minister: [],
+      }
+    end
+
+    def details
+      {
+        reshuffle_in_progress: true,
+      }
+    end
+  end
+end

--- a/app/presenters/publishing_api/how_government_works_presenter.rb
+++ b/app/presenters/publishing_api/how_government_works_presenter.rb
@@ -40,25 +40,17 @@ module PublishingApi
     end
 
     def links
-      return {} if reshuffle_in_progress?
-
       {
         current_prime_minister: [MinisterialRole.find_by(slug: "prime-minister")&.current_person&.content_id],
       }
     end
 
     def details
-      if reshuffle_in_progress?
-        {
-          reshuffle_in_progress: reshuffle_in_progress?,
-        }
-      else
-        {
-          department_counts:,
-          ministerial_role_counts:,
-          reshuffle_in_progress: reshuffle_in_progress?,
-        }
-      end
+      {
+        department_counts:,
+        ministerial_role_counts:,
+        reshuffle_in_progress: reshuffle_in_progress?,
+      }
     end
 
     def department_counts

--- a/app/presenters/publishing_api/how_government_works_presenter.rb
+++ b/app/presenters/publishing_api/how_government_works_presenter.rb
@@ -1,5 +1,6 @@
 module PublishingApi
   class HowGovernmentWorksPresenter
+    include ReshuffleMode
     attr_accessor :update_type
 
     def initialize(update_type: nil)
@@ -78,10 +79,6 @@ module PublishingApi
     end
 
   private
-
-    def reshuffle_in_progress?
-      SitewideSetting.find_by(key: :minister_reshuffle_mode)&.on || false
-    end
 
     def prime_minister
       1

--- a/app/presenters/publishing_api/ministers_index_enable_reshuffle_presenter.rb
+++ b/app/presenters/publishing_api/ministers_index_enable_reshuffle_presenter.rb
@@ -1,0 +1,24 @@
+module PublishingApi
+  class MinistersIndexEnableReshufflePresenter < MinistersIndexPresenter
+    def links
+      {
+        ordered_cabinet_ministers: [],
+        ordered_also_attends_cabinet: [],
+        ordered_ministerial_departments: [],
+        ordered_house_of_commons_whips: [],
+        ordered_junior_lords_of_the_treasury_whips: [],
+        ordered_assistant_whips: [],
+        ordered_house_lords_whips: [],
+        ordered_baronesses_and_lords_in_waiting_whips: [],
+      }
+    end
+
+  private
+
+    def details
+      {
+        reshuffle: { message: bare_govspeak_to_html(SitewideSetting.find_by(key: :minister_reshuffle_mode).govspeak) },
+      }
+    end
+  end
+end

--- a/app/presenters/publishing_api/ministers_index_presenter.rb
+++ b/app/presenters/publishing_api/ministers_index_presenter.rb
@@ -1,6 +1,7 @@
 module PublishingApi
   class MinistersIndexPresenter
     include GovspeakHelper
+    include ReshuffleMode
 
     attr_accessor :update_type
 
@@ -77,10 +78,6 @@ module PublishingApi
           body: "Read biographies and responsibilities of <a href=\"#cabinet-ministers\" class=\"govuk-link\">Cabinet ministers</a> and all <a href=\"#ministers-by-department\" class=\"govuk-link\">ministers by department</a>, as well as the <a href=\"#whips\" class=\"govuk-link\">whips</a> who help co-ordinate parliamentary business.",
         }
       end
-    end
-
-    def reshuffle_in_progress?
-      SitewideSetting.find_by(key: :minister_reshuffle_mode)&.on || false
     end
 
     def ordered_cabinet_ministers_content_ids

--- a/app/presenters/publishing_api/ministers_index_presenter.rb
+++ b/app/presenters/publishing_api/ministers_index_presenter.rb
@@ -1,7 +1,6 @@
 module PublishingApi
   class MinistersIndexPresenter
     include GovspeakHelper
-    include ReshuffleMode
 
     attr_accessor :update_type
 
@@ -33,29 +32,16 @@ module PublishingApi
     end
 
     def links
-      if reshuffle_in_progress?
-        {
-          ordered_cabinet_ministers: [],
-          ordered_also_attends_cabinet: [],
-          ordered_ministerial_departments: [],
-          ordered_house_of_commons_whips: [],
-          ordered_junior_lords_of_the_treasury_whips: [],
-          ordered_assistant_whips: [],
-          ordered_house_lords_whips: [],
-          ordered_baronesses_and_lords_in_waiting_whips: [],
-        }
-      else
-        {
-          ordered_cabinet_ministers: ordered_cabinet_ministers_content_ids,
-          ordered_also_attends_cabinet: ordered_also_attends_cabinet_content_ids,
-          ordered_ministerial_departments: ordered_ministerial_departments_content_ids,
-          ordered_house_of_commons_whips: ordered_whips_content_ids(Whitehall::WhipOrganisation::WhipsHouseOfCommons),
-          ordered_junior_lords_of_the_treasury_whips: ordered_whips_content_ids(Whitehall::WhipOrganisation::JuniorLordsoftheTreasury),
-          ordered_assistant_whips: ordered_whips_content_ids(Whitehall::WhipOrganisation::AssistantWhips),
-          ordered_house_lords_whips: ordered_whips_content_ids(Whitehall::WhipOrganisation::WhipsHouseofLords),
-          ordered_baronesses_and_lords_in_waiting_whips: ordered_whips_content_ids(Whitehall::WhipOrganisation::BaronessAndLordsInWaiting),
-        }
-      end
+      {
+        ordered_cabinet_ministers: ordered_cabinet_ministers_content_ids,
+        ordered_also_attends_cabinet: ordered_also_attends_cabinet_content_ids,
+        ordered_ministerial_departments: ordered_ministerial_departments_content_ids,
+        ordered_house_of_commons_whips: ordered_whips_content_ids(Whitehall::WhipOrganisation::WhipsHouseOfCommons),
+        ordered_junior_lords_of_the_treasury_whips: ordered_whips_content_ids(Whitehall::WhipOrganisation::JuniorLordsoftheTreasury),
+        ordered_assistant_whips: ordered_whips_content_ids(Whitehall::WhipOrganisation::AssistantWhips),
+        ordered_house_lords_whips: ordered_whips_content_ids(Whitehall::WhipOrganisation::WhipsHouseofLords),
+        ordered_baronesses_and_lords_in_waiting_whips: ordered_whips_content_ids(Whitehall::WhipOrganisation::BaronessAndLordsInWaiting),
+      }
     end
 
     def title
@@ -69,15 +55,9 @@ module PublishingApi
   private
 
     def details
-      if reshuffle_in_progress?
-        {
-          reshuffle: { message: bare_govspeak_to_html(SitewideSetting.find_by(key: :minister_reshuffle_mode).govspeak) },
-        }
-      else
-        {
-          body: "Read biographies and responsibilities of <a href=\"#cabinet-ministers\" class=\"govuk-link\">Cabinet ministers</a> and all <a href=\"#ministers-by-department\" class=\"govuk-link\">ministers by department</a>, as well as the <a href=\"#whips\" class=\"govuk-link\">whips</a> who help co-ordinate parliamentary business.",
-        }
-      end
+      {
+        body: "Read biographies and responsibilities of <a href=\"#cabinet-ministers\" class=\"govuk-link\">Cabinet ministers</a> and all <a href=\"#ministers-by-department\" class=\"govuk-link\">ministers by department</a>, as well as the <a href=\"#whips\" class=\"govuk-link\">whips</a> who help co-ordinate parliamentary business.",
+      }
     end
 
     def ordered_cabinet_ministers_content_ids

--- a/app/views/admin/cabinet_ministers/show.html.erb
+++ b/app/views/admin/cabinet_ministers/show.html.erb
@@ -1,6 +1,28 @@
 <% content_for :page_title, "Cabinet ministers ordering" %>
 <% content_for :title, "Cabinet ministers ordering" %>
 
+<% if reshuffle_in_progress? %>
+  <%= render "govuk_publishing_components/components/heading", {
+    text: "Preview ministers page in reshuffle mode",
+    heading_level: 2,
+    font_size: "m",
+    margin_bottom: 3,
+  } %>
+
+  <p class="govuk-body govuk-!-margin-bottom-9">
+    <%= link_to("Preview on website (opens in new tab)",
+      "#{Plek.external_url_for('draft-origin')}/government/ministers",
+      class: "govuk-link",
+      target: "_blank",
+      data: {
+        module: "gem-track-click",
+        "track-category": "button-clicked",
+        "track-action": "ministers-index-page-button",
+        "track-label": "Preview on website",
+      }, rel: "noopener") %>. Requires Signon access.
+  </p>
+<% end %>
+
 <%= render "govuk_publishing_components/components/tabs", {
   tabs: [
     {

--- a/app/workers/present_page_to_publishing_api_worker.rb
+++ b/app/workers/present_page_to_publishing_api_worker.rb
@@ -2,6 +2,8 @@ class PresentPageToPublishingApiWorker < WorkerBase
   def perform(presenter, update_live = true)
     if update_live
       PresentPageToPublishingApi.new.publish(presenter.constantize)
+    else
+      PresentPageToPublishingApi.new.save_draft(presenter.constantize)
     end
   end
 end

--- a/app/workers/present_page_to_publishing_api_worker.rb
+++ b/app/workers/present_page_to_publishing_api_worker.rb
@@ -1,5 +1,7 @@
 class PresentPageToPublishingApiWorker < WorkerBase
-  def perform(presenter)
-    PresentPageToPublishingApi.new.publish(presenter.constantize)
+  def perform(presenter, update_live = true)
+    if update_live
+      PresentPageToPublishingApi.new.publish(presenter.constantize)
+    end
   end
 end

--- a/features/cabinet-ministers.feature
+++ b/features/cabinet-ministers.feature
@@ -6,6 +6,16 @@ Feature: Reordering of Cabinet ministers and Organisations
   Background:
     Given I am a GDS editor
 
+  Scenario: Previewing changes to the ministers index page during reshuffle
+    Given reshuffle mode is on
+    When I visit the Cabinet ministers order page
+    Then I should see a preview link to the ministers index page
+
+  Scenario: No preview to the ministers index page when not in reshuffle mode
+    Given reshuffle mode is off
+    When I visit the Cabinet ministers order page
+    Then I should not see a preview link to the ministers index page
+
   Scenario: Reordering Cabinet ministers
     Given there are multiple Cabinet minister roles
     When I visit the Cabinet ministers order page

--- a/features/step_definitions/cabinet_ministers_steps.rb
+++ b/features/step_definitions/cabinet_ministers_steps.rb
@@ -1,11 +1,23 @@
-Given(/^there are multiple Cabinet minister roles$/) do
-  organisation = create(:organisation)
-  create(:ministerial_role, name: "Role 1", cabinet_member: true, organisations: [organisation], seniority: 0)
-  create(:ministerial_role, name: "Role 2", cabinet_member: true, organisations: [organisation], seniority: 1)
+Given(/^reshuffle mode is (on|off)$/) do |on_or_off|
+  create(:sitewide_setting, key: :minister_reshuffle_mode, on: on_or_off == "on")
 end
 
 When(/^I visit the Cabinet ministers order page$/) do
   visit admin_cabinet_ministers_path
+end
+
+Then(/^I should see a preview link to the ministers index page$/) do
+  expect(page).to have_selector(".govuk-link[data-track-action=ministers-index-page-button]")
+end
+
+Then(/^I should not see a preview link to the ministers index page$/) do
+  expect(page).to_not have_selector(".govuk-link[data-track-action=ministers-index-page-button]")
+end
+
+Given(/^there are multiple Cabinet minister roles$/) do
+  organisation = create(:organisation)
+  create(:ministerial_role, name: "Role 1", cabinet_member: true, organisations: [organisation], seniority: 0)
+  create(:ministerial_role, name: "Role 2", cabinet_member: true, organisations: [organisation], seniority: 1)
 end
 
 When(/^I click the reorder link in the "([^"]*)" tab$/) do |tab|

--- a/lib/present_page_to_publishing_api.rb
+++ b/lib/present_page_to_publishing_api.rb
@@ -5,4 +5,10 @@ class PresentPageToPublishingApi
     Services.publishing_api.patch_links(payload.content_id, links: payload.links)
     Services.publishing_api.publish(payload.content_id, nil, locale: payload.content[:locale])
   end
+
+  def save_draft(presenter_class)
+    payload = presenter_class.new
+    Services.publishing_api.put_content(payload.content_id, payload.content)
+    Services.publishing_api.patch_links(payload.content_id, links: payload.links)
+  end
 end

--- a/test/functional/admin/republishing_controller_test.rb
+++ b/test/functional/admin/republishing_controller_test.rb
@@ -78,8 +78,6 @@ class Admin::RepublishingControllerTest < ActionController::TestCase
   end
 
   def enable_reshuffle_mode!
-    PresentPageToPublishingApiWorker.expects(:perform_async).with("PublishingApi::HowGovernmentWorksEnableReshufflePresenter", true).once
-    PresentPageToPublishingApiWorker.expects(:perform_async).with("PublishingApi::MinistersIndexEnableReshufflePresenter", true).once
     create(:sitewide_setting, key: :minister_reshuffle_mode, on: true)
   end
 

--- a/test/unit/app/models/reshuffle_mode_test.rb
+++ b/test/unit/app/models/reshuffle_mode_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+
+class ReshuffleModeTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
+  class ClassThatIncludesReshuffleMode < ApplicationRecord
+    self.table_name = "organisations"
+    include ReshuffleMode
+  end
+
+  describe "#reshuffle_in_progress?" do
+    it "returns false when reshuffle mode is switched off" do
+      assert_not ClassThatIncludesReshuffleMode.new.reshuffle_in_progress?
+    end
+
+    it "returns true when reshuffle mode is switched on" do
+      create(:sitewide_setting, key: :minister_reshuffle_mode, on: true)
+
+      assert ClassThatIncludesReshuffleMode.new.reshuffle_in_progress?
+    end
+  end
+end

--- a/test/unit/app/models/reshuffle_mode_test.rb
+++ b/test/unit/app/models/reshuffle_mode_test.rb
@@ -27,6 +27,15 @@ class ReshuffleModeTest < ActiveSupport::TestCase
 
       ClassThatIncludesReshuffleMode.new.republish_ministerial_pages_to_publishing_api
     end
+
+    it "only saves to the draft stack when reshuffle mode is switched on" do
+      PresentPageToPublishingApiWorker.expects(:perform_async).with("PublishingApi::HowGovernmentWorksPresenter", false).once
+      PresentPageToPublishingApiWorker.expects(:perform_async).with("PublishingApi::MinistersIndexPresenter", false).once
+
+      reshuffle_mode = ClassThatIncludesReshuffleMode.new
+      reshuffle_mode.stubs(:reshuffle_in_progress?).returns(true)
+      reshuffle_mode.republish_ministerial_pages_to_publishing_api
+    end
   end
 
   describe "#republish_ministers_index_page_to_publishing_api" do
@@ -35,6 +44,14 @@ class ReshuffleModeTest < ActiveSupport::TestCase
 
       ClassThatIncludesReshuffleMode.new.republish_ministers_index_page_to_publishing_api
     end
+
+    it "only saves to the draft stack when reshuffle mode is switched on" do
+      PresentPageToPublishingApiWorker.expects(:perform_async).with("PublishingApi::MinistersIndexPresenter", false).once
+
+      reshuffle_mode = ClassThatIncludesReshuffleMode.new
+      reshuffle_mode.stubs(:reshuffle_in_progress?).returns(true)
+      reshuffle_mode.republish_ministers_index_page_to_publishing_api
+    end
   end
 
   describe "#republish_how_government_works_page_to_publishing_api" do
@@ -42,6 +59,14 @@ class ReshuffleModeTest < ActiveSupport::TestCase
       PresentPageToPublishingApiWorker.expects(:perform_async).with("PublishingApi::HowGovernmentWorksPresenter", true).once
 
       ClassThatIncludesReshuffleMode.new.republish_how_government_works_page_to_publishing_api
+    end
+
+    it "only saves to the draft stack when reshuffle mode is switched on" do
+      PresentPageToPublishingApiWorker.expects(:perform_async).with("PublishingApi::HowGovernmentWorksPresenter", false).once
+
+      reshuffle_mode = ClassThatIncludesReshuffleMode.new
+      reshuffle_mode.stubs(:reshuffle_in_progress?).returns(true)
+      reshuffle_mode.republish_how_government_works_page_to_publishing_api
     end
   end
 end

--- a/test/unit/app/models/reshuffle_mode_test.rb
+++ b/test/unit/app/models/reshuffle_mode_test.rb
@@ -19,4 +19,29 @@ class ReshuffleModeTest < ActiveSupport::TestCase
       assert ClassThatIncludesReshuffleMode.new.reshuffle_in_progress?
     end
   end
+
+  describe "#republish_ministerial_pages_to_publishing_api" do
+    it "republishes 'How Government Works' and 'Ministers Index' pages" do
+      PresentPageToPublishingApiWorker.expects(:perform_async).with("PublishingApi::HowGovernmentWorksPresenter", true).once
+      PresentPageToPublishingApiWorker.expects(:perform_async).with("PublishingApi::MinistersIndexPresenter", true).once
+
+      ClassThatIncludesReshuffleMode.new.republish_ministerial_pages_to_publishing_api
+    end
+  end
+
+  describe "#republish_ministers_index_page_to_publishing_api" do
+    it "republishes the 'Ministers Index' page" do
+      PresentPageToPublishingApiWorker.expects(:perform_async).with("PublishingApi::MinistersIndexPresenter", true).once
+
+      ClassThatIncludesReshuffleMode.new.republish_ministers_index_page_to_publishing_api
+    end
+  end
+
+  describe "#republish_how_government_works_page_to_publishing_api" do
+    it "republishes the 'How Government Works' page" do
+      PresentPageToPublishingApiWorker.expects(:perform_async).with("PublishingApi::HowGovernmentWorksPresenter", true).once
+
+      ClassThatIncludesReshuffleMode.new.republish_how_government_works_page_to_publishing_api
+    end
+  end
 end

--- a/test/unit/app/models/sitewide_setting_test.rb
+++ b/test/unit/app/models/sitewide_setting_test.rb
@@ -4,8 +4,11 @@ class SitewideSettingTest < ActiveSupport::TestCase
   test "enabling reshuffle mode republishes custom ministers index and how government work pages" do
     setting = create(:sitewide_setting, key: :minister_reshuffle_mode, on: true)
 
-    PresentPageToPublishingApiWorker.expects(:perform_async).with("PublishingApi::HowGovernmentWorksEnableReshufflePresenter", true).once
-    PresentPageToPublishingApiWorker.expects(:perform_async).with("PublishingApi::MinistersIndexEnableReshufflePresenter", true).once
+    mock_worker = mock
+    PresentPageToPublishingApiWorker.stubs(:new).returns(mock_worker)
+    mock_worker.expects(:perform).with("PublishingApi::HowGovernmentWorksEnableReshufflePresenter", true).once
+    mock_worker.expects(:perform).with("PublishingApi::MinistersIndexEnableReshufflePresenter", true).once
+    mock_worker.expects(:perform).with("PublishingApi::MinistersIndexPresenter", false).once
 
     setting.republish_downstream_if_reshuffle
   end

--- a/test/unit/app/models/sitewide_setting_test.rb
+++ b/test/unit/app/models/sitewide_setting_test.rb
@@ -1,35 +1,21 @@
 require "test_helper"
 
 class SitewideSettingTest < ActiveSupport::TestCase
-  test "toggling reshuffle mode republished the ministers index page" do
-    payload = PublishingApi::MinistersIndexPresenter.new
-
-    create(:sitewide_setting, key: :minister_reshuffle_mode, on: true)
-
-    requests = [
-      stub_publishing_api_put_content(payload.content_id, payload.content),
-      stub_publishing_api_publish(payload.content_id, locale: "en", update_type: nil),
-    ]
-
-    assert_all_requested(requests)
-  end
-
-  # moved from duplicate file
-  test "should send the how government works page to publishing api when reshuffle mode is switched on" do
-    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::HowGovernmentWorksPresenter)
-
-    Sidekiq::Testing.inline! do
-      create(:sitewide_setting, key: :minister_reshuffle_mode, on: true)
-    end
-  end
-
-  test "should send the how government works page to publishing api when reshuffle mode is switched off" do
+  test "enabling reshuffle mode republishes custom ministers index and how government work pages" do
     setting = create(:sitewide_setting, key: :minister_reshuffle_mode, on: true)
 
-    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::HowGovernmentWorksPresenter)
+    PresentPageToPublishingApiWorker.expects(:perform_async).with("PublishingApi::HowGovernmentWorksEnableReshufflePresenter", true).once
+    PresentPageToPublishingApiWorker.expects(:perform_async).with("PublishingApi::MinistersIndexEnableReshufflePresenter", true).once
 
-    Sidekiq::Testing.inline! do
-      setting.update!(on: false)
-    end
+    setting.republish_downstream_if_reshuffle
+  end
+
+  test "disabling reshuffle mode republishes ministers index and how government work pages" do
+    setting = create(:sitewide_setting, key: :minister_reshuffle_mode, on: false)
+
+    PresentPageToPublishingApiWorker.expects(:perform_async).with("PublishingApi::HowGovernmentWorksPresenter", true).once
+    PresentPageToPublishingApiWorker.expects(:perform_async).with("PublishingApi::MinistersIndexPresenter", true).once
+
+    setting.republish_downstream_if_reshuffle
   end
 end

--- a/test/unit/app/presenters/publishing_api/how_government_works_enable_reshuffle_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/how_government_works_enable_reshuffle_presenter_test.rb
@@ -1,0 +1,58 @@
+require "test_helper"
+
+class PublishingApi::HowGovernmentWorksEnableReshufflePresenterTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
+  setup do
+    @current_pm = create(:person)
+    pm_role = create(:prime_minister_role)
+    create(:role_appointment, person: @current_pm, role: pm_role)
+
+    create(:role_appointment, person: create(:person), role: create(:ministerial_role, cabinet_member: true))
+    create(:role_appointment, person: create(:person), role: create(:ministerial_role, cabinet_member: true))
+    create(:role_appointment, person: create(:person), role: create(:ministerial_role))
+    create(:role_appointment, person: create(:person), role: create(:ministerial_role))
+    create(:role_appointment, person: create(:person), role: create(:ministerial_role))
+
+    create(:ministerial_department)
+    create(:non_ministerial_department)
+    create(:executive_agency)
+  end
+
+  test "presents a valid content item with minimal details and links" do
+    expected_hash = {
+      base_path: "/government/how-government-works",
+      publishing_app: Whitehall::PublishingApp::WHITEHALL,
+      rendering_app: "government-frontend",
+      schema_name: "how_government_works",
+      document_type: "how_government_works",
+      title: "How government works",
+      description: "About the UK system of government. Understand who runs government, and how government is run.",
+      locale: "en",
+      routes: [
+        {
+          path: "/government/how-government-works",
+          type: "exact",
+        },
+      ],
+      update_type: "major",
+      redirects: [],
+      public_updated_at: Time.zone.now,
+      details: {
+        reshuffle_in_progress: true,
+      },
+    }
+
+    expected_links = {
+      current_prime_minister: [],
+    }
+
+    presenter = PublishingApi::HowGovernmentWorksEnableReshufflePresenter.new
+
+    assert_equal expected_hash, presenter.content
+    assert_valid_against_publisher_schema(presenter.content, "how_government_works")
+
+    assert_equal expected_links, presenter.links
+    assert_valid_against_links_schema({ links: presenter.links }, "how_government_works")
+  end
+end

--- a/test/unit/app/presenters/publishing_api/how_government_works_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/how_government_works_presenter_test.rb
@@ -76,39 +76,10 @@ class PublishingApi::HowGovernmentWorksPresenterTest < ActiveSupport::TestCase
       create(:sitewide_setting, key: :minister_reshuffle_mode, on: true)
     end
 
-    test "presents a valid content item without any details or links" do
-      expected_hash = {
-        base_path: "/government/how-government-works",
-        publishing_app: Whitehall::PublishingApp::WHITEHALL,
-        rendering_app: "government-frontend",
-        schema_name: "how_government_works",
-        document_type: "how_government_works",
-        title: "How government works",
-        description: "About the UK system of government. Understand who runs government, and how government is run.",
-        locale: "en",
-        routes: [
-          {
-            path: "/government/how-government-works",
-            type: "exact",
-          },
-        ],
-        update_type: "major",
-        redirects: [],
-        public_updated_at: Time.zone.now,
-        details: {
-          reshuffle_in_progress: true,
-        },
-      }
-
-      expected_links = {}
-
+    test "sets 'reshuffle_in_progress' to true" do
       presenter = PublishingApi::HowGovernmentWorksPresenter.new
 
-      assert_equal expected_hash, presenter.content
-      assert_valid_against_publisher_schema(presenter.content, "how_government_works")
-
-      assert_equal expected_links, presenter.links
-      assert_valid_against_links_schema({ links: presenter.links }, "how_government_works")
+      assert_equal true, presenter.content[:details][:reshuffle_in_progress]
     end
   end
 end

--- a/test/unit/app/presenters/publishing_api/ministers_index_enable_reshuffle_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/ministers_index_enable_reshuffle_presenter_test.rb
@@ -1,0 +1,41 @@
+require "test_helper"
+
+class PublishingApi::MinistersIndexEnableReshufflePresenterTest < ActionView::TestCase
+  def presented_item
+    PublishingApi::MinistersIndexEnableReshufflePresenter.new
+  end
+
+  test "presents a valid content item without information" do
+    I18n.with_locale(:en) do
+      create(
+        :sitewide_setting,
+        key: :minister_reshuffle_mode,
+        on: true,
+        govspeak: "Check [latest appointments](/government/news/ministerial-appointments-february-2023).",
+      )
+
+      expected_details = {
+        reshuffle: {
+          message: "<p>Check <a href=\"/government/news/ministerial-appointments-february-2023\" class=\"govuk-link\">latest appointments</a>.</p>\n",
+        },
+      }
+
+      expected_links = {
+        ordered_cabinet_ministers: [],
+        ordered_also_attends_cabinet: [],
+        ordered_ministerial_departments: [],
+        ordered_house_of_commons_whips: [],
+        ordered_junior_lords_of_the_treasury_whips: [],
+        ordered_assistant_whips: [],
+        ordered_house_lords_whips: [],
+        ordered_baronesses_and_lords_in_waiting_whips: [],
+      }
+
+      assert_equal expected_details, presented_item.content[:details]
+      assert_valid_against_publisher_schema(presented_item.content, "ministers_index")
+
+      assert_equal expected_links, presented_item.links
+      assert_valid_against_links_schema({ links: presented_item.links }, "ministers_index")
+    end
+  end
+end

--- a/test/unit/app/presenters/publishing_api/ministers_index_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/ministers_index_presenter_test.rb
@@ -5,10 +5,8 @@ class PublishingApi::MinistersIndexPresenterTest < ActionView::TestCase
     PublishingApi::MinistersIndexPresenter.new
   end
 
-  test "presents a valid content item containing the correct information when reshuffle mode is off" do
+  test "presents a valid content item containing the correct information" do
     I18n.with_locale(:en) do
-      create(:sitewide_setting, key: :minister_reshuffle_mode, on: false)
-
       ministerial_department_1 = create(:ministerial_department, ministerial_ordering: 2)
       ministerial_department_2 = create(:ministerial_department, ministerial_ordering: 3)
       ministerial_department_3 = create(:ministerial_department, ministerial_ordering: 1)
@@ -92,40 +90,6 @@ class PublishingApi::MinistersIndexPresenterTest < ActionView::TestCase
       }
 
       assert_equal expected_content, presented_item.content
-      assert_valid_against_publisher_schema(presented_item.content, "ministers_index")
-
-      assert_equal expected_links, presented_item.links
-      assert_valid_against_links_schema({ links: presented_item.links }, "ministers_index")
-    end
-  end
-
-  test "presents a valid content item without information when reshuffle mode is on" do
-    I18n.with_locale(:en) do
-      create(
-        :sitewide_setting,
-        key: :minister_reshuffle_mode,
-        on: true,
-        govspeak: "Check [latest appointments](/government/news/ministerial-appointments-february-2023).",
-      )
-
-      expected_details = {
-        reshuffle: {
-          message: "<p>Check <a href=\"/government/news/ministerial-appointments-february-2023\" class=\"govuk-link\">latest appointments</a>.</p>\n",
-        },
-      }
-
-      expected_links = {
-        ordered_cabinet_ministers: [],
-        ordered_also_attends_cabinet: [],
-        ordered_ministerial_departments: [],
-        ordered_house_of_commons_whips: [],
-        ordered_junior_lords_of_the_treasury_whips: [],
-        ordered_assistant_whips: [],
-        ordered_house_lords_whips: [],
-        ordered_baronesses_and_lords_in_waiting_whips: [],
-      }
-
-      assert_equal expected_details, presented_item.content[:details]
       assert_valid_against_publisher_schema(presented_item.content, "ministers_index")
 
       assert_equal expected_links, presented_item.links

--- a/test/unit/app/workers/present_page_to_publishing_api_worker_test.rb
+++ b/test/unit/app/workers/present_page_to_publishing_api_worker_test.rb
@@ -9,4 +9,13 @@ class PresentPageToPublishingApiWorkerTest < ActiveSupport::TestCase
 
     PresentPageToPublishingApiWorker.new.perform("PublishingApi::HowGovernmentWorksPresenter")
   end
+
+  test "calls `save_draft` method when `update_live` parameter is false" do
+    service = mock
+    PresentPageToPublishingApi.expects(:new).returns(service)
+
+    service.expects(:save_draft).with(PublishingApi::HowGovernmentWorksPresenter)
+
+    PresentPageToPublishingApiWorker.new.perform("PublishingApi::HowGovernmentWorksPresenter", false)
+  end
 end

--- a/test/unit/lib/present_page_to_publishing_api_test.rb
+++ b/test/unit/lib/present_page_to_publishing_api_test.rb
@@ -1,30 +1,36 @@
 require "test_helper"
 class PresentPageToPublishingApiTest < ActiveSupport::TestCase
-  test "send the fields of operation index page to publishing api" do
-    assert_content_is_presented_to_publishing_api(PublishingApi::OperationalFieldsIndexPresenter)
-  end
+  extend Minitest::Spec::DSL
 
-  test "sends the how government works page to publishing api" do
-    assert_content_is_presented_to_publishing_api(PublishingApi::HowGovernmentWorksPresenter)
-  end
+  describe "#publish" do
+    it "send the fields of operation index page to publishing api" do
+      assert_content_is_presented_to_publishing_api(PublishingApi::OperationalFieldsIndexPresenter)
+    end
 
-  test "sends the past prime ministers index page to publishing api" do
-    role = create(:prime_minister_role)
-    person = create(:person, forename: "Some", surname: "Person")
-    create(:historic_role_appointment, person:, role:, started_at: Date.civil(1950), ended_at: Date.civil(1960))
-    create(:historical_account, person:, born: "1900", died: "1975", role:)
+    it "sends the past prime ministers index page to publishing api" do
+      role = create(:prime_minister_role)
+      person = create(:person, forename: "Some", surname: "Person")
+      create(:historic_role_appointment, person:, role:, started_at: Date.civil(1950), ended_at: Date.civil(1960))
+      create(:historical_account, person:, born: "1900", died: "1975", role:)
 
-    assert_content_is_presented_to_publishing_api(PublishingApi::HistoricalAccountsIndexPresenter)
-  end
+      assert_content_is_presented_to_publishing_api(PublishingApi::HistoricalAccountsIndexPresenter)
+    end
 
-  test "should update content, patch links and publish new document with locale" do
-    I18n.with_locale(:cy) do
-      assert_content_is_presented_to_publishing_api(PublishingApi::HowGovernmentWorksPresenter, locale: "cy")
+    it "should update content, patch links and publish new document with locale" do
+      I18n.with_locale(:cy) do
+        assert_content_is_presented_to_publishing_api(PublishingApi::HowGovernmentWorksPresenter, locale: "cy")
+      end
+    end
+
+    it "sends the world index page to publishing api" do
+      assert_content_is_presented_to_publishing_api(PublishingApi::WorldIndexPresenter)
     end
   end
 
-  test "sends the world index page to publishing api" do
-    assert_content_is_presented_to_publishing_api(PublishingApi::WorldIndexPresenter)
+  describe "#save_draft" do
+    it "saves the operation index page to publishing api draft stack" do
+      assert_content_is_presented_to_publishing_api_draft_stack(PublishingApi::OperationalFieldsIndexPresenter)
+    end
   end
 
   def assert_content_is_presented_to_publishing_api(presenter_class, locale: "en")
@@ -36,5 +42,16 @@ class PresentPageToPublishingApiTest < ActiveSupport::TestCase
     Services.publishing_api.expects(:publish).with(presenter.content_id, nil, locale:)
 
     PresentPageToPublishingApi.new.publish(presenter_class)
+  end
+
+  def assert_content_is_presented_to_publishing_api_draft_stack(presenter_class, locale: "en")
+    presenter = presenter_class.new
+    expected_content = presenter.content
+
+    Services.publishing_api.expects(:put_content).with(presenter.content_id, expected_content).once
+    Services.publishing_api.expects(:patch_links).with(presenter.content_id, links: presenter.links).once
+    Services.publishing_api.expects(:publish).with(presenter.content_id, nil, locale:).never
+
+    PresentPageToPublishingApi.new.save_draft(presenter_class)
   end
 end


### PR DESCRIPTION
- Encapsulates "reshuffle mode" into its own 'concern' in Rails
- All callbacks that triggered updating of the 'ministers index' page and the 'how government works' pages are now routed through the concern, and only update the draft stack when reshuffle mode is switched on
- Manual republishing of those pages via the new "Republish" UI feature is also disabled when reshuffle mode is switched on
- A preview link is available from the cabinet ministers reorder page 

Tested on Integration. Updates to the ministers index page take about 1-2 minutes to go through, and attempting to access the page for the first 1-2 minutes after turning on reshuffle mode will result in a "Sorry, we’re experiencing technical difficulties" message. This appears to be because the `patch_links` call is slow for Publishing API to process?

Trello: https://trello.com/c/3y1wYXDP/2674-add-preview-to-ministers-page-when-reshuffle-mode-is-turned-on

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
