### PR TITLE
Exclude superseded editions from document collection document search results

### DIFF
--- a/app/controllers/admin/document_collection_group_document_search_controller.rb
+++ b/app/controllers/admin/document_collection_group_document_search_controller.rb
@@ -19,7 +19,7 @@ class Admin::DocumentCollectionGroupDocumentSearchController < Admin::BaseContro
   def add_by_title
     flash.now[:alert] = "Please enter a search query" if params[:title] && params[:title].empty?
     if params[:title].present?
-      results = Edition.with_title_containing(params[:title].strip)
+      results = Edition.active.with_title_containing(params[:title].strip)
       @editions = results
                     .page(params[:page])
                     .per(Admin::EditionFilter::GOVUK_DESIGN_SYSTEM_PER_PAGE)

--- a/test/functional/admin/document_collection_group_document_search_controller_test.rb
+++ b/test/functional/admin/document_collection_group_document_search_controller_test.rb
@@ -108,6 +108,7 @@ class Admin::DocumentCollectionGroupDocumentSearchControllerTest < ActionControl
   view_test "GET :add_by_title with search value only returns published and unpublished editions" do
     create(:published_edition, title: "Something published")
     create(:edition, title: "Something unpublished")
+    create(:superseded_edition, title: "Something superseded")
     @request_params[:title] = "Something "
 
     get :add_by_title, params: @request_params


### PR DESCRIPTION
This was causing a confusing experience for users where they would be asked to select from numerous documents with identical titles.

The active scope on the Edition model excludes superseded editions.

Trello: https://trello.com/c/USevUJuy
