### PR TITLE
Fix error message matching in `assert_raises`

### DIFF
--- a/lib/tasks/clone_published_html_attachment_to_draft_edition.rake
+++ b/lib/tasks/clone_published_html_attachment_to_draft_edition.rake
@@ -3,7 +3,7 @@ task :clone_published_html_attachment_to_draft_edition, %i[html_attachment_id] =
   html_attachment = HtmlAttachment.find(args[:html_attachment_id])
 
   edition = html_attachment.attachable
-  raise "The HTML attachment must belong to a published or superseded edition" if %w[published superseded].exclude?(edition.state)
+  raise "The HTML attachment must belong to a published or superseded edition" if %w[published superseded].exclude?(edition&.state)
 
   latest_edition  = edition.document.latest_edition
   raise "The HTML attachments associated document must have an edition in a pre-published state." if Edition::PRE_PUBLICATION_STATES.exclude?(latest_edition.state)

--- a/test/unit/app/models/corporate_information_page_test.rb
+++ b/test/unit/app/models/corporate_information_page_test.rb
@@ -91,7 +91,7 @@ class CorporateInformationPageTest < ActiveSupport::TestCase
       organisation:,
     )
 
-    assert_raises(RuntimeError, "only worldwide about pages should redirect") { corporate_information_page.api_presenter_redirect_to }
+    assert_raises(RuntimeError, match: "only worldwide about pages should redirect") { corporate_information_page.api_presenter_redirect_to }
   end
 
   test "republishes owning organisation after commit when present" do

--- a/test/unit/app/models/promotional_feature_item_test.rb
+++ b/test/unit/app/models/promotional_feature_item_test.rb
@@ -71,7 +71,7 @@ class PromotionalFeatureItemTest < ActiveSupport::TestCase
   test "#youtube_video_id raises an exception when an youtube_video_id cannot be parsed form the youtube_video_url" do
     promotional_feature_item = build(:promotional_feature_item_with_youtube_video_url, youtube_video_url: "https://www.gov.uk/government/organisations/government-digital-service")
 
-    assert_raises "youtube_video_url: #{promotional_feature_item.youtube_video_url} is invalid for PromotionalFeatureItem id: #{promotional_feature_item.id}" do
+    assert_raises StandardError, match: "youtube_video_url: #{promotional_feature_item.youtube_video_url} is invalid for PromotionalFeatureItem id: #{promotional_feature_item.id}" do
       promotional_feature_item.youtube_video_id
     end
   end

--- a/test/unit/app/models/related_mainstream_test.rb
+++ b/test/unit/app/models/related_mainstream_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class RelatedMainstreamTest < ActiveSupport::TestCase
   test "raises an error if creating a record with a nil content_id" do
     detailed_guide = create(:detailed_guide)
-    assert_raises "cannot create Related Mainstream record with nil content_id" do
+    assert_raises StandardError, match: "Validation failed: Content can't be blank" do
       RelatedMainstream.create!(edition_id: detailed_guide.id, content_id: nil)
     end
   end
@@ -12,14 +12,14 @@ class RelatedMainstreamTest < ActiveSupport::TestCase
     detailed_guide = create(:detailed_guide)
     RelatedMainstream.create!(edition_id: detailed_guide.id, content_id: "5a2fea6a-360a-49ba-97b3-46d3612ec198")
 
-    assert_raises "cannot create Related Mainstream record with duplicate content_id" do
+    assert_raises StandardError, match: "Validation failed: Content has already been taken" do
       RelatedMainstream.create!(edition_id: detailed_guide.id, content_id: "5a2fea6a-360a-49ba-97b3-46d3612ec198", additional: true)
     end
     assert_equal 1, RelatedMainstream.count
   end
 
   test "raises an error if creating a record with a nil edition" do
-    assert_raises "cannot create Related Mainstream record with a nil edition_id" do
+    assert_raises StandardError, match: "Validation failed: Edition can't be blank" do
       RelatedMainstream.create!(edition_id: nil, content_id: "5a2fea6a-360a-49ba-97b3-46d3612ec198")
     end
   end

--- a/test/unit/lib/tasks/clone_published_html_attachment_to_draft_edition_test.rb
+++ b/test/unit/lib/tasks/clone_published_html_attachment_to_draft_edition_test.rb
@@ -37,11 +37,11 @@ class ClonePublishedHtmlAttachmentToDraftEditionRake < ActiveSupport::TestCase
   end
 
   (STATES - %w[published superseded]).each do |state|
-    test "it raises an error if the html attachments edition is in the #{state} state" do
-      edition = create(:edition, state)
+    test "it raises an error if the html attachment's edition is in the #{state} state" do
+      edition = create(:edition, state:)
       html_attachment = create(:html_attachment, attachable: edition, body: "test")
 
-      assert_raises(StandardError, "The HTML attachment must belong to a published or superseded edition") do
+      assert_raises(StandardError, match: "The HTML attachment must belong to a published or superseded edition") do
         Rake.application.invoke_task("clone_published_html_attachment_to_draft_edition[#{html_attachment.id}]")
       end
     end
@@ -58,7 +58,7 @@ class ClonePublishedHtmlAttachmentToDraftEditionRake < ActiveSupport::TestCase
         major_change_published_at: state == "published" ? Time.zone.now : nil,
       )
 
-      assert_raises(StandardError, "The HTML attachments associated document must have an edition in a pre-published state.") do
+      assert_raises(StandardError, match: "The HTML attachments associated document must have an edition in a pre-published state.") do
         Rake.application.invoke_task("clone_published_html_attachment_to_draft_edition[#{html_attachment.id}]")
       end
     end

--- a/test/unit/lib/tasks/publishing_api_test.rb
+++ b/test/unit/lib/tasks/publishing_api_test.rb
@@ -314,7 +314,7 @@ class PublishingApiRake < ActiveSupport::TestCase
       describe "for non-existent document types" do
         test "it returns an error" do
           document_type = "SomeDocumentTypeThatDoesntExist"
-          assert_raises(SystemExit, /Unknown document type #{document_type}/) do
+          assert_raises(SystemExit, match: /Unknown document type #{document_type}/) do
             capture_io { task.invoke(document_type) }
           end
         end

--- a/test/unit/lib/tasks/remove_access_limiting_test.rb
+++ b/test/unit/lib/tasks/remove_access_limiting_test.rb
@@ -16,7 +16,7 @@ class RemoveAccessLimitingTest < ActiveSupport::TestCase
   end
 
   test "raises error if edition cannot be found" do
-    assert_raises(StandardError, "Cannot find edition of ID 12345.") do
+    assert_raises(StandardError, match: "Cannot find edition of ID 12345.") do
       Rake.application.invoke_task("remove_access_limiting[12345]")
     end
   end


### PR DESCRIPTION
Some tests using `assert_raises` were including a string, presumably to check that the error message looked correct. However, the `assert_raises` method requires that this is a keyword argument using `match`, which the tests were not using. This updates the tests to use this, in some places fixing the expected error messages and in one place making a minor change to the code to match the expected behaviour (see below)

## Note on the `clone_published_html_attachment_to_draft_edition`

The default scope of an `Edition` excludes those with a state of `deleted` (from `Edition::Workflow`), which I believe means that when `.attachable` is called on an attachment with a deleted edition, it will return `nil`

I couldn't find exactly how the `attachable` method works at a glance, but presumably it searches for an instance of the `attachable_type` with the `attachable_id`, which is where the default scope excludes the deleted editions

Using the safe navigation operator, the intended exception-raising behaviour of the rake task as documented in the tests is retained

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
