### PR TITLE
Add UI for bulk republishing by organisation

### DIFF
--- a/app/controllers/admin/bulk_republishing_controller.rb
+++ b/app/controllers/admin/bulk_republishing_controller.rb
@@ -67,13 +67,56 @@ class Admin::BulkRepublishingController < Admin::BaseController
     end
   end
 
+  def new_documents_by_organisation; end
+
+  def search_documents_by_organisation
+    @organisation = Organisation.find_by(slug: params[:organisation_slug])
+
+    unless @organisation
+      flash[:alert] = "Organisation with slug '#{params[:organisation_slug]}' not found"
+      return redirect_to(admin_bulk_republishing_documents_by_organisation_new_path)
+    end
+
+    redirect_to(admin_bulk_republishing_documents_by_organisation_confirm_path(params[:organisation_slug]))
+  end
+
+  def confirm_documents_by_organisation
+    unless @organisation&.slug == params[:organisation_slug]
+      @organisation = Organisation.find_by(slug: params[:organisation_slug])
+      render "admin/errors/not_found", status: :not_found unless @organisation
+    end
+
+    @bulk_content_type_metadata = bulk_content_type_metadata.fetch(:all_documents_by_organisation)
+    @republishing_event = RepublishingEvent.new
+  end
+
+  def republish_documents_by_organisation
+    @organisation = Organisation.find_by(slug: params[:organisation_slug])
+    return render "admin/errors/not_found", status: :not_found unless @organisation
+
+    bulk_content_type_key = :all_documents_by_organisation
+    @bulk_content_type_metadata = bulk_content_type_metadata.fetch(bulk_content_type_key)
+    action = "#{@bulk_content_type_metadata[:name].upcase_first} '#{@organisation.name}' have been queued for republishing"
+    bulk_content_type_value = RepublishingEvent.bulk_content_types.fetch(bulk_content_type_key)
+    @republishing_event = build_republishing_event(action:, bulk_content_type: bulk_content_type_value, organisation_id: @organisation.id)
+
+    if @republishing_event.save
+      @bulk_content_type_metadata[:republish_method].call(@organisation)
+
+      flash[:notice] = action
+      redirect_to(admin_republishing_index_path)
+    else
+      render "confirm_documents_by_organisation"
+    end
+  end
+
 private
 
   def enforce_permissions!
     enforce_permission!(:administer, :republish_content)
   end
 
-  def build_republishing_event(action:, bulk_content_type:, content_type: nil)
-    RepublishingEvent.new(user: current_user, reason: params.fetch(:reason), action:, bulk_content_type:, bulk: true, content_type:)
+  def build_republishing_event(action:, bulk_content_type:, content_type: nil, organisation_id: nil)
+    RepublishingEvent.new(user: current_user, reason: params.fetch(:reason), action:, bulk_content_type:, bulk: true, content_type:, organisation_id:)
   end
 end

--- a/app/helpers/admin/republishing_helper.rb
+++ b/app/helpers/admin/republishing_helper.rb
@@ -51,6 +51,12 @@ module Admin::RepublishingHelper
         new_path: admin_bulk_republishing_by_type_new_path,
         republish_method: ->(type) { BulkRepublisher.new.republish_all_by_type(type) },
       },
+      all_documents_by_organisation: {
+        id: "all-documents-by-organisation",
+        name: "all documents by organisation",
+        new_path: admin_bulk_republishing_documents_by_organisation_new_path,
+        republish_method: ->(organisation) { BulkRepublisher.new.republish_all_documents_by_organisation(organisation) },
+      },
     }
   end
 

--- a/app/models/republishing_event.rb
+++ b/app/models/republishing_event.rb
@@ -10,6 +10,9 @@ class RepublishingEvent < ApplicationRecord
   validates :content_type, presence: true, if: -> { bulk_content_type == "all_by_type" }
   validates :content_type, absence: true, unless: -> { bulk_content_type == "all_by_type" }
 
+  validates :organisation_id, presence: true, if: -> { bulk_content_type == "all_documents_by_organisation" }
+  validates :organisation_id, absence: true, unless: -> { bulk_content_type == "all_documents_by_organisation" }
+
   enum :bulk_content_type, %i[
     all_documents
     all_documents_with_pre_publication_editions
@@ -18,5 +21,6 @@ class RepublishingEvent < ApplicationRecord
     all_documents_with_publicly_visible_editions_with_html_attachments
     all_published_organisation_about_us_pages
     all_by_type
+    all_documents_by_organisation
   ]
 end

--- a/app/services/bulk_republisher.rb
+++ b/app/services/bulk_republisher.rb
@@ -58,6 +58,17 @@ class BulkRepublisher
     end
   end
 
+  def republish_all_documents_by_organisation(organisation)
+    raise "Argument must be an organisation" unless organisation.is_a?(Organisation)
+
+    document_ids = Edition
+      .latest_edition
+      .in_organisation(organisation)
+      .pluck(:document_id)
+
+    republish_by_document_ids(document_ids)
+  end
+
 private
 
   def republish_by_document_ids(document_ids)

--- a/app/views/admin/bulk_republishing/confirm_documents_by_organisation.html.erb
+++ b/app/views/admin/bulk_republishing/confirm_documents_by_organisation.html.erb
@@ -1,0 +1,16 @@
+<% content_for :page_title, "Republish #{@bulk_content_type_metadata[:name]} '#{@organisation.name}'" %>
+<% content_for :title, "Are you sure you want to republish #{@bulk_content_type_metadata[:name]} '#{@organisation.name}'?" %>
+<% content_for :title_margin_bottom, 6 %>
+<% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @republishing_event)) %>
+
+<div class="govuk-grid-row">
+  <section class="govuk-grid-column-two-thirds">
+    <p class="govuk-body govuk-!-margin-bottom-7">
+      This will queue all documents associated with the organisation <%= link_to @organisation.name, @organisation.public_url, { class: "govuk-link" } %> to be republished.
+    </p>
+    <%= render partial: "shared/republishing_form", locals: {
+      republishing_event: @republishing_event,
+      republishing_path: admin_bulk_republishing_documents_by_organisation_republish_path(@organisation.slug),
+    } %>
+  </section>
+</div>

--- a/app/views/admin/bulk_republishing/new_documents_by_organisation.html.erb
+++ b/app/views/admin/bulk_republishing/new_documents_by_organisation.html.erb
@@ -1,0 +1,20 @@
+<% content_for :page_title, "Republish all by organisation" %>
+<% content_for :title, "What organisation's documents would you like to republish?" %>
+<% content_for :title_margin_bottom, 6 %>
+
+<div class="govuk-grid-row">
+  <section class="govuk-grid-column-two-thirds">
+    <%= form_with(url: admin_bulk_republishing_documents_by_organisation_search_path, method: :post) do %>
+      <%= render "govuk_publishing_components/components/input", {
+        label: {
+          text: "Enter the slug for the organisation",
+        },
+        hint: "You can get the slug from the last part of the public URL - everything after '/government/organisations/'.",
+        name: "organisation_slug",
+      } %>
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Continue",
+      } %>
+    <% end %>
+  </section>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -59,6 +59,12 @@ Whitehall::Application.routes.draw do
             get "/:content_type/confirm" => "bulk_republishing#confirm_by_type", as: :bulk_republishing_by_type_confirm
             post "/:content_type/republish" => "bulk_republishing#republish_by_type", as: :bulk_republishing_by_type_republish
           end
+          scope "documents-by-organisation" do
+            get "/new" => "bulk_republishing#new_documents_by_organisation", as: :bulk_republishing_documents_by_organisation_new
+            post "/search" => "bulk_republishing#search_documents_by_organisation", as: :bulk_republishing_documents_by_organisation_search
+            get "/:organisation_slug/confirm" => "bulk_republishing#confirm_documents_by_organisation", as: :bulk_republishing_documents_by_organisation_confirm
+            post "/:organisation_slug/republish" => "bulk_republishing#republish_documents_by_organisation", as: :bulk_republishing_documents_by_organisation_republish
+          end
           get "/:bulk_content_type/confirm" => "bulk_republishing#confirm", as: :bulk_republishing_confirm
           post "/:bulk_content_type/republish" => "bulk_republishing#republish", as: :bulk_republishing_republish
         end

--- a/db/migrate/20240618123401_add_organisation_id_to_republishing_event.rb
+++ b/db/migrate/20240618123401_add_organisation_id_to_republishing_event.rb
@@ -1,0 +1,5 @@
+class AddOrganisationIdToRepublishingEvent < ActiveRecord::Migration[7.1]
+  def change
+    add_column :republishing_events, :organisation_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_17_110912) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_18_123401) do
   create_table "assets", charset: "utf8mb3", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.string "variant", null: false
@@ -866,6 +866,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_17_110912) do
     t.boolean "bulk", null: false
     t.integer "bulk_content_type"
     t.string "content_type"
+    t.string "organisation_id"
     t.index ["user_id"], name: "index_republishing_events_on_user_id"
   end
 

--- a/features/bulk-republishing-content.feature
+++ b/features/bulk-republishing-content.feature
@@ -45,3 +45,8 @@ Feature: Bulk republishing content
     Given Case Studies exist
     When I select all of type "CaseStudy" for republishing
     Then I can see all of type "CaseStudy" have been queued for republishing
+
+  Scenario: Republish all documents by organisation
+    Given a published organisation "An Existing Organisation" exists
+    When I request a bulk republishing of all documents associated with "An Existing Organisation"
+    Then I can see all documents associated with "An Existing Organisation" have been queued for republishing

--- a/features/republishing-content.feature
+++ b/features/republishing-content.feature
@@ -14,60 +14,50 @@ Feature: Republishing published documents
 
   Scenario: Republish the "How government works" page
     Given a published publication "How government works" exists
-    And the "How government works" page can be republished
     When I request a republish of the "How government works" page
     Then I can see the "How government works" page has been scheduled for republishing
 
   Scenario: Republish the "Fields of operation" page
     Given a published publication "Fields of operation" exists
-    And the "Fields of operation" page can be republished
     When I request a republish of the "Fields of operation" page
     Then I can see the "Fields of operation" page has been scheduled for republishing
 
   Scenario: Republish the "Ministers" page
     Given a published publication "Ministers" exists
-    And the "Ministers" page can be republished
     When I request a republish of the "Ministers" page
     Then I can see the "Ministers" page has been scheduled for republishing
 
   Scenario: Republish the "Find a British embassy, high commission or consulate" page
     Given a published publication "Find a British embassy, high commission or consulate" exists
-    And the "Find a British embassy, high commission or consulate" page can be republished
     When I request a republish of the "Find a British embassy, high commission or consulate" page
     Then I can see the "Find a British embassy, high commission or consulate" page has been scheduled for republishing
 
   Scenario: Republish the "Help and services around the world" page
     Given a published publication "Help and services around the world" exists
-    And the "Help and services around the world" page can be republished
     When I request a republish of the "Help and services around the world" page
     Then I can see the "Help and services around the world" page has been scheduled for republishing
 
   Scenario: Republish the "Departments, agencies and public bodies" page
     Given a published publication "Departments, agencies and public bodies" exists
-    And the "Departments, agencies and public bodies" page can be republished
     When I request a republish of the "Departments, agencies and public bodies" page
     Then I can see the "Departments, agencies and public bodies" page has been scheduled for republishing
 
   Scenario: Republish an organisation
     Given a published organisation "An Existing Organisation" exists
-    And the "An Existing Organisation" organisation can be republished
     When I request a republish of the "An Existing Organisation" organisation
     Then I can see the "An Existing Organisation" organisation has been republished
 
   Scenario: Republish a person
     Given a published person "Existing Person" exists
-    And the "Existing Person" person can be republished
     When I request a republish of the "Existing Person" person
     Then I can see the "Existing Person" person has been republished
 
   Scenario: Republish a role
     Given a published role "An Existing Role" exists
-    And the "An Existing Role" role can be republished
     When I request a republish of the "An Existing Role" role
     Then I can see the "An Existing Role" role has been republished
 
   Scenario: Republish a document
     Given a document with slug "an-existing-document" exists
-    And the "an-existing-document" document's editions can be republished
     When I request a republish of the "an-existing-document" document's editions
     Then I can see the "an-existing-document" document's editions have been republished

--- a/features/step_definitions/bulk_republishing_content_steps.rb
+++ b/features/step_definitions/bulk_republishing_content_steps.rb
@@ -118,3 +118,16 @@ end
 Then(/^I can see all of type "([^"]*)" have been queued for republishing$/) do |content_type|
   expect(page).to have_selector(".gem-c-success-alert", text: "All by type '#{content_type}' have been queued for republishing")
 end
+
+When(/^I request a bulk republishing of all documents associated with "An Existing Organisation"$/) do
+  visit admin_republishing_index_path
+  find("#all-documents-by-organisation").click
+  fill_in "Enter the slug for the organisation", with: "an-existing-organisation"
+  click_button("Continue")
+  fill_in "What is the reason for republishing?", with: "It needs republishing"
+  click_button("Confirm republishing")
+end
+
+Then(/^I can see all documents associated with "An Existing Organisation" have been queued for republishing$/) do
+  expect(page).to have_selector(".gem-c-success-alert", text: "All documents by organisation 'An Existing Organisation' have been queued for republishing")
+end

--- a/features/step_definitions/republishing_content_steps.rb.rb
+++ b/features/step_definitions/republishing_content_steps.rb.rb
@@ -1,4 +1,4 @@
-Given(/^the "([^"]*)" page can be republished$/) do |_page_title|
+Given(/^the "Past Prime Ministers" page can be republished$/) do
   create(:ministerial_role, name: "Prime Minister", cabinet_member: true)
 end
 
@@ -15,10 +15,6 @@ end
 
 Given(/^a published organisation "An Existing Organisation" exists$/) do
   create(:organisation, name: "An Existing Organisation", slug: "an-existing-organisation")
-end
-
-Given(/^the "An Existing Organisation" organisation can be republished$/) do
-  create(:ministerial_role, name: "Prime Minister", cabinet_member: true)
 end
 
 When(/^I request a republish of the "An Existing Organisation" organisation$/) do
@@ -38,10 +34,6 @@ Given(/^a published person "Existing Person" exists$/) do
   create(:person, forename: "Existing", surname: "Person", slug: "existing-person")
 end
 
-Given(/^the "Existing Person" person can be republished$/) do
-  create(:ministerial_role, name: "Prime Minister", cabinet_member: true)
-end
-
 When(/^I request a republish of the "Existing Person" person$/) do
   visit admin_republishing_index_path
   find("#republish-person").click
@@ -57,10 +49,6 @@ end
 
 Given(/^a published role "An Existing Role" exists$/) do
   create(:role, name: "An Existing Role", slug: "an-existing-role")
-end
-
-Given(/^the "An Existing Role" role can be republished$/) do
-  create(:ministerial_role, name: "Prime Minister", cabinet_member: true)
 end
 
 When(/^I request a republish of the "An Existing Role" role$/) do
@@ -79,10 +67,6 @@ end
 Given(/^a document with slug "an-existing-document" exists$/) do
   edition = build(:published_edition)
   create(:document, slug: "an-existing-document", editions: [edition])
-end
-
-Given(/^the "an-existing-document" document's editions can be republished$/) do
-  create(:ministerial_role, name: "Prime Minister", cabinet_member: true)
 end
 
 When(/^I request a republish of the "an-existing-document" document's editions$/) do

--- a/test/functional/admin/republishing_controller_test.rb
+++ b/test/functional/admin/republishing_controller_test.rb
@@ -119,7 +119,7 @@ class Admin::RepublishingControllerTest < ActionController::TestCase
     assert_response :forbidden
   end
 
-  view_test "GDS Admin users should be able to GET :find_organisation" do
+  test "GDS Admin users should be able to GET :find_organisation" do
     get :find_organisation
 
     assert_response :ok
@@ -223,7 +223,7 @@ class Admin::RepublishingControllerTest < ActionController::TestCase
     assert_response :forbidden
   end
 
-  view_test "GDS Admin users should be able to GET :find_person" do
+  test "GDS Admin users should be able to GET :find_person" do
     get :find_person
 
     assert_response :ok
@@ -327,7 +327,7 @@ class Admin::RepublishingControllerTest < ActionController::TestCase
     assert_response :forbidden
   end
 
-  view_test "GDS Admin users should be able to GET :find_role" do
+  test "GDS Admin users should be able to GET :find_role" do
     get :find_role
 
     assert_response :ok
@@ -431,7 +431,7 @@ class Admin::RepublishingControllerTest < ActionController::TestCase
     assert_response :forbidden
   end
 
-  view_test "GDS Admin users should be able to GET :find_document" do
+  test "GDS Admin users should be able to GET :find_document" do
     get :find_document
 
     assert_response :ok

--- a/test/functional/admin/republishing_controller_test.rb
+++ b/test/functional/admin/republishing_controller_test.rb
@@ -26,6 +26,7 @@ class Admin::RepublishingControllerTest < ActionController::TestCase
     assert_select ".govuk-table:nth-of-type(3) .govuk-table__body .govuk-table__row:nth-child(5) .govuk-table__cell:nth-child(2) a[href='/government/admin/republishing/bulk/all-documents-with-publicly-visible-editions-with-html-attachments/confirm']", text: "Republish all documents with publicly-visible editions with HTML attachments"
     assert_select ".govuk-table:nth-of-type(3) .govuk-table__body .govuk-table__row:nth-child(6) .govuk-table__cell:nth-child(2) a[href='/government/admin/republishing/bulk/all-published-organisation-about-us-pages/confirm']", text: "Republish all published organisation 'About us' pages"
     assert_select ".govuk-table:nth-of-type(3) .govuk-table__body .govuk-table__row:nth-child(7) .govuk-table__cell:nth-child(2) a[href='/government/admin/republishing/bulk/by-type/new']", text: "Republish all by type"
+    assert_select ".govuk-table:nth-of-type(3) .govuk-table__body .govuk-table__row:nth-child(8) .govuk-table__cell:nth-child(2) a[href='/government/admin/republishing/bulk/documents-by-organisation/new']", text: "Republish all documents by organisation"
 
     assert_response :ok
   end

--- a/test/unit/app/helpers/admin/republishing_helper_test.rb
+++ b/test/unit/app/helpers/admin/republishing_helper_test.rb
@@ -41,17 +41,20 @@ class Admin::RepublishingHelperTest < ActionView::TestCase
     assert_equal first_bulk_content_type, "All documents"
   end
 
-  test "#republishing_index_bulk_republishing_rows creates a link to the specific bulk republishing confirmation page" do
-    first_link = republishing_index_bulk_republishing_rows.first[1][:text]
+  test "#republishing_index_bulk_republishing_rows creates a link to the confirmation page for content types that don't require extra input" do
+    all_documents_link = republishing_index_bulk_republishing_rows.flatten.find { |column|
+      column[:text].include?('Republish <span class="govuk-visually-hidden">all documents</span>')
+    }[:text]
+
     expected_link = '<a id="all-documents" class="govuk-link" href="/government/admin/republishing/bulk/all-documents/confirm">Republish <span class="govuk-visually-hidden">all documents</span></a>'
 
-    assert_equal first_link, expected_link
+    assert_equal expected_link, all_documents_link
   end
 
-  test "#republishing_index_bulk_republishing_rows creates a link to the 'new' path for the 'all_by_type' section" do
+  test "#republishing_index_bulk_republishing_rows creates a link to the new page for content types that require extra input" do
     all_by_type_link = republishing_index_bulk_republishing_rows.flatten.find { |column|
-                         column[:text].include?('Republish <span class="govuk-visually-hidden">all by type</span>')
-                       }[:text]
+      column[:text].include?('Republish <span class="govuk-visually-hidden">all by type</span>')
+    }[:text]
 
     expected_link = '<a id="all-by-type" class="govuk-link" href="/government/admin/republishing/bulk/by-type/new">Republish <span class="govuk-visually-hidden">all by type</span></a>'
 

--- a/test/unit/app/models/republishing_event_test.rb
+++ b/test/unit/app/models/republishing_event_test.rb
@@ -26,4 +26,28 @@ class RepublishingEventTest < ActiveSupport::TestCase
       end
     end
   end
+
+  describe "organisation_id" do
+    context "for an `all_documents_by_organisation` bulk republishing event" do
+      test "should be valid with an organisation ID" do
+        event = build(:republishing_event, :bulk, bulk_content_type: "all_documents_by_organisation", organisation_id: "1234")
+        assert event.valid?
+      end
+
+      test "should be invalid without a content type" do
+        event = build(:republishing_event, :bulk, bulk_content_type: "all_documents_by_organisation", organisation_id: nil)
+        assert_not event.valid?
+      end
+    end
+
+    context "for any other republishing event" do
+      test "must not be present" do
+        bulk_event = build(:republishing_event, :bulk, bulk_content_type: "all_documents", organisation_id: "1234")
+        assert_not bulk_event.valid?
+
+        non_bulk_event = build(:republishing_event, organisation_id: "1234")
+        assert_not non_bulk_event.valid?
+      end
+    end
+  end
 end


### PR DESCRIPTION
[Trello](https://trello.com/c/eoJ8GkU2/1198-add-a-user-interface-for-whitehalls-bulk-republishing-documents-by-organisation-rake-task)

This adds a UI for bulk republishing all documents by organisation, and also tidies up a few small things

## Screenshots

<img width="781" alt="image" src="https://github.com/alphagov/whitehall/assets/40244233/ce58aec2-9924-43a1-b4b8-fdb99ad17969">

<img width="787" alt="image" src="https://github.com/alphagov/whitehall/assets/40244233/32f9a6d2-cf1a-49be-9923-479f74d17f72">

<img width="797" alt="image" src="https://github.com/alphagov/whitehall/assets/40244233/187af5bf-1c1b-43d7-bb01-5937fa3a1e33">

<img width="1155" alt="image" src="https://github.com/alphagov/whitehall/assets/40244233/fb2ccb51-2ee0-4b5f-bdd2-3052323b7ef9">

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
