### PR TITLE
Remove hardcoded logic preventing "foreign language only" visibility

### DIFF
--- a/app/views/admin/editions/_locale_fields.html.erb
+++ b/app/views/admin/editions/_locale_fields.html.erb
@@ -1,4 +1,4 @@
-<div class="govuk-!-margin-bottom-8 app-view-edit-edition__locale-field js-locale-switcher-selector <%= "app-view-edit-edition__locale-field--hidden" unless edition.locale_can_be_changed? && (edition.is_a?(Consultation) || edition.is_a?(DocumentCollection) || edition.is_a?(NewsArticle) && edition.world_news_story?) %>">
+<div class="govuk-!-margin-bottom-8 app-view-edit-edition__locale-field js-locale-switcher-selector <%= "app-view-edit-edition__locale-field--hidden" unless edition.locale_can_be_changed? %>">
   <%= render "govuk_publishing_components/components/checkboxes", {
     name: "edition[create_foreign_language_only]",
     id: "edition_create_foreign_language_only",


### PR DESCRIPTION
These extra conditionals appear to have been added without context in December 2022:
https://github.com/alphagov/whitehall/commit/1cddcbb7e54855e9daed9558202d081785973827

Consultations and World News Stories continued to work because they were included in the hardcoded logic, but other formats that should support "foreign language only" mode would have the field hidden and unusable. These formats are:

- [Call for Evidence](https://github.com/alphagov/whitehall/blob/62f85ecbbb1aa9bb4a86416f4ec68a28d9ef6d14/app/models/call_for_evidence.rb#L147-L149)
- [Document Collection](https://github.com/alphagov/whitehall/blob/3915f372e344b274e8d198b6fe64c0a3d4fffa9c/app/models/document_collection.rb#L51-L53)

We should be relying solely on the `locale_can_be_changed?` method to drive this view logic.

Solves Zendesk ticket https://govuk.zendesk.com/agent/tickets/5509163

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
