### PR TITLE
No need to set SECRET_KEY_BASE_DUMMY here.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ COPY package.json yarn.lock ./
 RUN yarn install --production --frozen-lockfile --non-interactive --link-duplicates
 COPY . .
 RUN bootsnap precompile --gemfile .
-RUN SECRET_KEY_BASE_DUMMY=1 rails assets:precompile && rm -fr log
+RUN rails assets:precompile && rm -fr log
 
 
 FROM --platform=$TARGETPLATFORM $base_image


### PR DESCRIPTION
govuk-ruby-builder image [already sets](https://github.com/alphagov/govuk-ruby-images/blob/6cd1b32/builder.Dockerfile#L16) this.