### PR TITLE
Remove Ghostscript and PDF thumb generation.

### DIFF
--- a/.github/workflows/cucumber.yml
+++ b/.github/workflows/cucumber.yml
@@ -17,12 +17,10 @@ jobs:
       - name: Setup Redis
         uses: alphagov/govuk-infrastructure/.github/actions/setup-redis@main
 
-      - name: Install additional system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends ghostscript
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          show-progress: false
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/minitest.yml
+++ b/.github/workflows/minitest.yml
@@ -29,16 +29,12 @@ jobs:
       - name: Setup Redis
         uses: alphagov/govuk-infrastructure/.github/actions/setup-redis@main
 
-      - name: Install additional system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends ghostscript
-
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           repository: alphagov/whitehall
           ref: ${{ inputs.ref || github.ref }}
+          show-progress: false
 
       - name: Checkout Publishing API (for Content Schemas)
         uses: actions/checkout@v4
@@ -46,6 +42,7 @@ jobs:
           repository: alphagov/publishing-api
           ref: ${{ inputs.publishingApiRef }}
           path: vendor/publishing-api
+          show-progress: false
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
@@ -80,4 +77,3 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: echo "All MiniTest tests have passed 🚀"
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN rails assets:precompile && rm -fr log
 
 
 FROM --platform=$TARGETPLATFORM $base_image
-RUN install_packages ghostscript imagemagick unzip zip
+RUN install_packages imagemagick unzip zip
 
 ENV GOVUK_APP_NAME=whitehall
 

--- a/app/helpers/attachments_helper.rb
+++ b/app/helpers/attachments_helper.rb
@@ -42,7 +42,7 @@ module AttachmentsHelper
       params[:file_size] = attachment.file_size
     end
 
-    # PDF attachments get a thumbnail
+    # PDF attachments used to have a thumbnail, now just a generic icon.
     if attachment.pdf?
       params[:thumbnail_url] = attachment.file.thumbnail.url
       params[:number_of_pages] = attachment.number_of_pages

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -171,29 +171,6 @@
     {
       "warning_type": "Command Injection",
       "warning_code": 14,
-      "fingerprint": "82dea23cb472eca9cd5c4217767e59cab37e956a57572095a7f225d47aff2db8",
-      "check_name": "Execute",
-      "message": "Possible command injection",
-      "file": "app/uploaders/attachment_uploader.rb",
-      "line": 54,
-      "link": "https://brakemanscanner.org/docs/warning_types/command_injection/",
-      "code": "`#{pdf_thumbnail_command(width, height)}`",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "AttachmentUploader",
-        "method": "get_first_page_as_png"
-      },
-      "user_input": "pdf_thumbnail_command(width, height)",
-      "confidence": "Medium",
-      "cwe_id": [
-        77
-      ],
-      "note": ""
-    },
-    {
-      "warning_type": "Command Injection",
-      "warning_code": 14,
       "fingerprint": "83cb07b23845591c7f6f25cf9670c4d48c87e8a7fd77abce67a88f2ca3912733",
       "check_name": "Execute",
       "message": "Possible command injection",

--- a/docs/assets.md
+++ b/docs/assets.md
@@ -134,11 +134,6 @@ that manage the successes and failures of the file uploads.
 > Whitehall creates up to 7 image sizes of each uploaded image. Urls to these images are published as part of the content
 > so that rendering applications can then show the best image size for the use case. 
 
-#### *Members of the public* want to see a thumbnail of pdfs where an embedded link to the pdf is provided
-
-> Whitehall generates thumbnails for pdf file attachments. Urls to both the pdf and its thumbnail are 
-> published as part of the content and then used by the rendering applications.
-
 #### *Members of the public* should see document content with working image and attachment urls
 
 > For *Editionable Content* types, such as **News Articles** or **Publication** - Publishing is prevented for documents


### PR DESCRIPTION
gov-frontend no longer uses PDF thumbnails, so we can drop Ghostscript etc.

For now, we keep the (probably disused) thumbnail_url field and use the "fallback" icon for new PDFs. Can probably remove the field and the icon altogether soon after.

Fixes #7480.

See also:
https://trello.com/c/vjSowrs7 (dup)
https://trello.com/c/oh4MXlUA (related)