### PR TITLE
Add GA4 button tracking to attachment form

### DIFF
--- a/app/views/admin/attachments/_form.html.erb
+++ b/app/views/admin/attachments/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for attachment, url: [:admin, typecast_for_attachable_routing(attachable), attachment.becomes(Attachment)], as: :attachment, html: { :class => "app-view-attachments__form", data: { module: "LocaleSwitcher", "rtl-locales": Locale.right_to_left.collect(&:to_param) }}, multipart: true do |form| %>
+<%= form_for attachment, url: [:admin, typecast_for_attachable_routing(attachable), attachment.becomes(Attachment)], as: :attachment, html: { :class => "app-view-attachments__form", data: { module: "LocaleSwitcher Ga4ButtonSetup", "rtl-locales": Locale.right_to_left.collect(&:to_param) }}, multipart: true do |form| %>
   <div class="govuk-!-margin-bottom-8 app-view-attachments__form-title js-locale-switcher-field">
     <%= render "govuk_publishing_components/components/input", {
       label: {


### PR DESCRIPTION
Tracking for save and preview buttons is needed as per the event form and the visual editor exit button tracking was lost in #9147. Using the `ga4-button-setup` module we set up the buttons on the page for tracking.
