### PR TITLE
Maintain lead organisations first when publishing HTML attachments

### DIFF
--- a/app/models/call_for_evidence_response.rb
+++ b/app/models/call_for_evidence_response.rb
@@ -20,6 +20,10 @@ class CallForEvidenceResponse < ApplicationRecord
 
   delegate :organisations, to: :parent_attachable
 
+  delegate :lead_organisations, to: :parent_attachable
+
+  delegate :supporting_organisations, to: :parent_attachable
+
   delegate :alternative_format_contact_email, to: :call_for_evidence
 
   delegate :publicly_visible?, to: :parent_attachable

--- a/app/models/consultation_response.rb
+++ b/app/models/consultation_response.rb
@@ -20,6 +20,10 @@ class ConsultationResponse < ApplicationRecord
 
   delegate :organisations, to: :parent_attachable
 
+  delegate :lead_organisations, to: :parent_attachable
+
+  delegate :supporting_organisations, to: :parent_attachable
+
   delegate :alternative_format_contact_email, to: :consultation
 
   delegate :publicly_visible?, to: :parent_attachable

--- a/app/presenters/publishing_api/html_attachment_presenter.rb
+++ b/app/presenters/publishing_api/html_attachment_presenter.rb
@@ -38,7 +38,7 @@ module PublishingApi
     def edition_links
       {
         parent: parent_content_ids, # please use the breadcrumb component when migrating document_type to government-frontend
-        organisations: parent.organisations.pluck(:content_id).uniq,
+        organisations: (lead_org_ids + supporting_org_ids).uniq,
         primary_publishing_organisation:,
         government: government_id,
       }
@@ -93,6 +93,14 @@ module PublishingApi
 
     def lead_org_id
       parent.try(:lead_organisations).try(:first).try(:content_id)
+    end
+
+    def lead_org_ids
+      (parent.try(:lead_organisations) || []).pluck(:content_id)
+    end
+
+    def supporting_org_ids
+      (parent.try(:supporting_organisations) || []).pluck(:content_id)
     end
 
     def first_org_id

--- a/test/unit/app/models/call_for_evidence_response_test.rb
+++ b/test/unit/app/models/call_for_evidence_response_test.rb
@@ -141,4 +141,14 @@ class CallForEvidenceResponseTest < ActiveSupport::TestCase
 
     assert_equal [], response.organisations
   end
+
+  test "delegates lead_organisations and supporting_organisations to the parent" do
+    lead_organisation = create(:organisation)
+    supporting_organisation = create(:organisation)
+    call_for_evidence = create(:call_for_evidence, lead_organisations: [lead_organisation], supporting_organisations: [supporting_organisation])
+    response = build(:call_for_evidence_outcome, call_for_evidence:)
+
+    assert_equal [lead_organisation], response.lead_organisations
+    assert_equal [supporting_organisation], response.supporting_organisations
+  end
 end

--- a/test/unit/app/models/consultation_response_test.rb
+++ b/test/unit/app/models/consultation_response_test.rb
@@ -142,6 +142,16 @@ class ConsultationResponseTest < ActiveSupport::TestCase
     assert_equal [], response.organisations
   end
 
+  test "delegates lead_organisations and supporting_organisations to the parent" do
+    lead_organisation = create(:organisation)
+    supporting_organisation = create(:organisation)
+    consultation = create(:consultation, lead_organisations: [lead_organisation], supporting_organisations: [supporting_organisation])
+    response = build(:consultation_outcome, consultation:)
+
+    assert_equal [lead_organisation], response.lead_organisations
+    assert_equal [supporting_organisation], response.supporting_organisations
+  end
+
   test "allows HTML attachments" do
     outcome = build(:consultation_outcome)
     assert outcome.allows_html_attachments?

--- a/test/unit/app/presenters/publishing_api/html_attachment_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/html_attachment_presenter_test.rb
@@ -87,9 +87,32 @@ class PublishingApi::HtmlAttachmentPresenterTest < ActiveSupport::TestCase
     html_attachment = HtmlAttachment.last
     # if an organisation has multiple translations, pluck returns
     # duplicate content_ids because it constructs a left outer join
-    html_attachment.attachable.organisations.expects(:pluck).with(:content_id).returns(%w[abcdef abcdef])
+    lead_orgs = mock
+    lead_orgs.expects(:pluck).with(:content_id).returns(%w[abcdef])
+    html_attachment.attachable.expects(:lead_organisations).returns(lead_orgs).twice
+
+    supporting_orgs = mock
+    supporting_orgs.expects(:pluck).with(:content_id).returns(%w[abcdef])
+    html_attachment.attachable.expects(:supporting_organisations).returns(supporting_orgs)
 
     assert_equal %w[abcdef], present(html_attachment).links[:organisations]
+  end
+
+  test "HtmlAttachment presents lead organisation content_ids before supporting organisation content_ids" do
+    create(:publication, :with_html_attachment, :published)
+
+    html_attachment = HtmlAttachment.last
+    # if an organisation has multiple translations, pluck returns
+    # duplicate content_ids because it constructs a left outer join
+    lead_orgs = mock
+    lead_orgs.expects(:pluck).with(:content_id).returns(%w[abcdef])
+    html_attachment.attachable.expects(:lead_organisations).returns(lead_orgs).twice
+
+    supporting_orgs = mock
+    supporting_orgs.expects(:pluck).with(:content_id).returns(%w[bcdefg])
+    html_attachment.attachable.expects(:supporting_organisations).returns(supporting_orgs)
+
+    assert_equal %w[abcdef bcdefg], present(html_attachment).links[:organisations]
   end
 
   test "HtmlAttachment presents primary_publishing_organisation" do


### PR DESCRIPTION
Currently HTML Attachments are publishing with organisations in default order (which means that there's no way for frontend apps to order by putting lead organisations first in the list). This is in contrast to the attachables, which seem to retain some ordering where lead organisations are listed first, example the two links in this ticket:

https://govuk.zendesk.com/agent/tickets/5448531

https://www.gov.uk/government/consultations/improving-the-experiences-of-people-with-mecfs-interim-delivery-plan
https://www.gov.uk/government/consultations/improving-the-experiences-of-people-with-mecfs-interim-delivery-plan/consultation-document-the-interim-delivery-plan-on-mecfs


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
