### PR TITLE
Add UI for republishing documents by content IDs

### DIFF
--- a/app/controllers/admin/bulk_republishing_controller.rb
+++ b/app/controllers/admin/bulk_republishing_controller.rb
@@ -79,6 +79,53 @@ class Admin::BulkRepublishingController < Admin::BaseController
     end
   end
 
+  def new_documents_by_content_ids; end
+
+  def search_documents_by_content_ids
+    content_ids = content_ids_string_to_array(params[:content_ids])
+    return if redirect_if_no_requested_content_ids(content_ids)
+
+    matching_document_content_ids = Document.where(content_id: content_ids).pluck(:content_id)
+    return if redirect_if_unfound_content_ids(matching_document_content_ids, content_ids)
+
+    redirect_to(admin_bulk_republishing_documents_by_content_ids_confirm_path(params[:content_ids]))
+  end
+
+  def confirm_documents_by_content_ids
+    @content_ids_string = params[:content_ids]
+    content_ids = content_ids_string_to_array(@content_ids_string)
+    return if redirect_if_no_requested_content_ids(content_ids)
+
+    @matching_documents = Document.where(content_id: content_ids)
+    return if redirect_if_unfound_content_ids(@matching_documents.pluck(:content_id), content_ids)
+
+    @republishing_event = RepublishingEvent.new
+  end
+
+  def republish_documents_by_content_ids
+    @content_ids_string = params[:content_ids]
+    content_ids = content_ids_string_to_array(@content_ids_string)
+    return if redirect_if_no_requested_content_ids(content_ids)
+
+    @matching_documents = Document.where(content_id: content_ids)
+    return if redirect_if_unfound_content_ids(@matching_documents.pluck(:content_id), content_ids)
+
+    bulk_content_type_key = :all_documents_by_content_ids
+    bulk_content_type_metadata_for_content_ids = bulk_content_type_metadata.fetch(bulk_content_type_key)
+    action = "#{bulk_content_type_metadata_for_content_ids[:name].upcase_first} #{content_ids_array_to_string(content_ids)} have been queued for republishing"
+    bulk_content_type_value = RepublishingEvent.bulk_content_types.fetch(bulk_content_type_key)
+    @republishing_event = build_republishing_event(action:, bulk_content_type: bulk_content_type_value, content_ids:)
+
+    if @republishing_event.save
+      bulk_content_type_metadata_for_content_ids[:republish_method].call(@matching_documents.pluck(:id))
+
+      flash[:notice] = action
+      redirect_to(admin_republishing_index_path)
+    else
+      render "confirm_documents_by_content_ids"
+    end
+  end
+
   def confirm
     bulk_content_type_key = params[:bulk_content_type].underscore.to_sym
     @bulk_content_type_metadata = bulk_content_type_metadata[bulk_content_type_key]
@@ -112,7 +159,35 @@ private
     enforce_permission!(:administer, :republish_content)
   end
 
-  def build_republishing_event(action:, bulk_content_type:, content_type: nil, organisation_id: nil)
-    RepublishingEvent.new(user: current_user, reason: params.fetch(:reason), action:, bulk_content_type:, bulk: true, content_type:, organisation_id:)
+  def build_republishing_event(action:, bulk_content_type:, content_type: nil, organisation_id: nil, content_ids: nil)
+    RepublishingEvent.new(
+      user: current_user,
+      reason: params.fetch(:reason),
+      action:,
+      bulk_content_type:,
+      bulk: true,
+      content_type:,
+      organisation_id:,
+      content_ids:,
+    )
+  end
+
+  def redirect_if_no_requested_content_ids(requested_content_ids)
+    if requested_content_ids.empty?
+      flash[:alert] = "No content IDs provided"
+      redirect_to(admin_bulk_republishing_documents_by_content_ids_new_path)
+
+      true
+    end
+  end
+
+  def redirect_if_unfound_content_ids(matching_content_ids, requested_content_ids)
+    unless matching_content_ids.count == requested_content_ids.count
+      unfound_content_ids = requested_content_ids - matching_content_ids
+      flash[:alert] = "Unable to find document(s) with the following content IDs: #{content_ids_array_to_string(unfound_content_ids)}"
+      redirect_to(admin_bulk_republishing_documents_by_content_ids_new_path)
+
+      true
+    end
   end
 end

--- a/app/controllers/admin/republishing_controller.rb
+++ b/app/controllers/admin/republishing_controller.rb
@@ -1,4 +1,5 @@
 class Admin::RepublishingController < Admin::BaseController
+  include Admin::EditionsHelper
   include Admin::RepublishingHelper
   include ReshuffleMode
 

--- a/app/helpers/admin/editions_helper.rb
+++ b/app/helpers/admin/editions_helper.rb
@@ -212,4 +212,8 @@ module Admin::EditionsHelper
 
     sanitize(actions)
   end
+
+  def edition_title_link_or_edition_title(edition)
+    edition.public_url ? sanitize(link_to(edition.title, edition.public_url, { class: "govuk-link" })) : edition.title
+  end
 end

--- a/app/helpers/admin/republishing_helper.rb
+++ b/app/helpers/admin/republishing_helper.rb
@@ -98,4 +98,10 @@ module Admin::RepublishingHelper
   def non_editionable_content_types
     ApplicationRecord.subclasses.select { |subclass| subclass.included_modules.include? PublishesToPublishingApi }.map(&:to_s)
   end
+
+  def content_ids_string_to_array(content_ids_string)
+    content_ids_string
+      .split(Regexp.union([/\s+/, /\s*,+\s*/]))
+      .reject(&:empty?)
+  end
 end

--- a/app/helpers/admin/republishing_helper.rb
+++ b/app/helpers/admin/republishing_helper.rb
@@ -104,4 +104,16 @@ module Admin::RepublishingHelper
       .split(Regexp.union([/\s+/, /\s*,+\s*/]))
       .reject(&:empty?)
   end
+
+  def content_ids_array_to_string(content_ids_array)
+    raise "No IDs provided" if content_ids_array.empty?
+
+    central_string = content_ids_array.to_sentence(
+      words_connector: "', '",
+      two_words_connector: "' and '",
+      last_word_connector: "', and '",
+    )
+
+    "'#{central_string}'"
+  end
 end

--- a/app/helpers/admin/republishing_helper.rb
+++ b/app/helpers/admin/republishing_helper.rb
@@ -58,6 +58,12 @@ module Admin::RepublishingHelper
         new_path: admin_bulk_republishing_documents_by_organisation_new_path,
         republish_method: ->(organisation) { BulkRepublisher.new.republish_all_documents_by_organisation(organisation) },
       },
+      all_documents_by_content_ids: {
+        id: "all-documents-by-content-ids",
+        name: "all documents by content IDs",
+        new_path: admin_bulk_republishing_documents_by_content_ids_new_path,
+        republish_method: ->(document_ids) { BulkRepublisher.new.republish_all_documents_by_ids(document_ids) },
+      },
     }
   end
 

--- a/app/helpers/admin/republishing_helper.rb
+++ b/app/helpers/admin/republishing_helper.rb
@@ -1,5 +1,6 @@
 module Admin::RepublishingHelper
   include Rails.application.routes.url_helpers
+  include Admin::EditionsHelper
 
   def bulk_content_type_metadata
     @bulk_content_type_metadata ||= {
@@ -115,5 +116,17 @@ module Admin::RepublishingHelper
     )
 
     "'#{central_string}'"
+  end
+
+  def confirm_documents_by_content_ids_edition_rows(documents)
+    documents.map { |document|
+      document.republishable_editions.map do |edition|
+        [
+          { text: edition_title_link_or_edition_title(edition) },
+          { text: edition.state.humanize },
+          { text: document.content_id },
+        ]
+      end
+    }.flatten(1)
   end
 end

--- a/app/models/republishing_event.rb
+++ b/app/models/republishing_event.rb
@@ -13,6 +13,10 @@ class RepublishingEvent < ApplicationRecord
   validates :organisation_id, presence: true, if: -> { bulk_content_type == "all_documents_by_organisation" }
   validates :organisation_id, absence: true, unless: -> { bulk_content_type == "all_documents_by_organisation" }
 
+  validates :content_ids, presence: true, if: -> { bulk_content_type == "all_documents_by_content_ids" }
+  validates :content_ids, absence: true, unless: -> { bulk_content_type == "all_documents_by_content_ids" }
+  validate :content_ids_is_a_non_empty_array_of_strings, if: -> { bulk_content_type == "all_documents_by_content_ids" }
+
   enum :bulk_content_type, %i[
     all_documents
     all_documents_with_pre_publication_editions
@@ -22,5 +26,13 @@ class RepublishingEvent < ApplicationRecord
     all_published_organisation_about_us_pages
     all_by_type
     all_documents_by_organisation
+    all_documents_by_content_ids
   ]
+
+  def content_ids_is_a_non_empty_array_of_strings
+    return errors.add(:content_ids, "is not an array") unless content_ids.is_a?(Array)
+    return errors.add(:content_ids, "is not a non-empty array") if content_ids.empty?
+
+    errors.add(:content_ids, "is not a non-empty array of strings") unless content_ids.all? { |content_id| content_id.is_a?(String) }
+  end
 end

--- a/app/services/bulk_republisher.rb
+++ b/app/services/bulk_republisher.rb
@@ -69,13 +69,13 @@ class BulkRepublisher
     republish_all_documents_by_ids(document_ids)
   end
 
-private
-
   def republish_all_documents_by_ids(ids)
     ids.each do |id|
       PublishingApiDocumentRepublishingWorker.perform_async_in_queue("bulk_republishing", id, true)
     end
   end
+
+private
 
   def republish_all_by_non_editionable_type(content_type_klass)
     content_type_klass.find_each do |record|

--- a/app/services/bulk_republisher.rb
+++ b/app/services/bulk_republisher.rb
@@ -3,17 +3,17 @@ class BulkRepublisher
 
   def republish_all_published_organisation_about_us_pages
     document_ids = Organisation.all.map(&:about_us).compact.pluck(:document_id)
-    republish_by_document_ids(document_ids)
+    republish_all_documents_by_ids(document_ids)
   end
 
   def republish_all_documents
     document_ids = Document.pluck(:id)
-    republish_by_document_ids(document_ids)
+    republish_all_documents_by_ids(document_ids)
   end
 
   def republish_all_documents_with_pre_publication_editions
     document_ids = Edition.in_pre_publication_state.pluck(:document_id)
-    republish_by_document_ids(document_ids)
+    republish_all_documents_by_ids(document_ids)
   end
 
   def republish_all_documents_with_pre_publication_editions_with_html_attachments
@@ -22,7 +22,7 @@ class BulkRepublisher
       .where(id: HtmlAttachment.where(attachable_type: "Edition").select(:attachable_id))
       .pluck(:document_id)
 
-    republish_by_document_ids(document_ids)
+    republish_all_documents_by_ids(document_ids)
   end
 
   def republish_all_documents_with_publicly_visible_editions_with_attachments
@@ -31,7 +31,7 @@ class BulkRepublisher
       .where(id: Attachment.where(attachable_type: "Edition").select(:attachable_id))
       .pluck(:document_id)
 
-    republish_by_document_ids(document_ids)
+    republish_all_documents_by_ids(document_ids)
   end
 
   def republish_all_documents_with_publicly_visible_editions_with_html_attachments
@@ -40,21 +40,21 @@ class BulkRepublisher
       .where(id: HtmlAttachment.where(attachable_type: "Edition").select(:attachable_id))
       .pluck(:document_id)
 
-    republish_by_document_ids(document_ids)
+    republish_all_documents_by_ids(document_ids)
   end
 
-  def republish_all_by_type(type)
+  def republish_all_by_type(content_type)
     begin
-      content_type_klass = type.constantize
-      raise NameError unless republishable_content_types.include?(type)
+      content_type_klass = content_type.constantize
+      raise NameError unless republishable_content_types.include?(content_type)
     rescue NameError
-      raise "Unknown content type #{type}\nCheck the GOV.UK developer documentation for a list of acceptable document types: https://docs.publishing.service.gov.uk/manual/republishing-content.html#whitehall"
+      raise "Unknown content type #{content_type}\nCheck the GOV.UK developer documentation for a list of acceptable document types: https://docs.publishing.service.gov.uk/manual/republishing-content.html#whitehall"
     end
 
-    if non_editionable_content_types.include?(type)
-      republish_non_editionable_content_types(content_type_klass)
+    if non_editionable_content_types.include?(content_type)
+      republish_all_by_non_editionable_type(content_type_klass)
     else
-      republish_by_document_ids(content_type_klass.pluck(:document_id))
+      republish_all_documents_by_ids(content_type_klass.pluck(:document_id))
     end
   end
 
@@ -66,18 +66,18 @@ class BulkRepublisher
       .in_organisation(organisation)
       .pluck(:document_id)
 
-    republish_by_document_ids(document_ids)
+    republish_all_documents_by_ids(document_ids)
   end
 
 private
 
-  def republish_by_document_ids(document_ids)
-    document_ids.each do |document_id|
-      PublishingApiDocumentRepublishingWorker.perform_async_in_queue("bulk_republishing", document_id, true)
+  def republish_all_documents_by_ids(ids)
+    ids.each do |id|
+      PublishingApiDocumentRepublishingWorker.perform_async_in_queue("bulk_republishing", id, true)
     end
   end
 
-  def republish_non_editionable_content_types(content_type_klass)
+  def republish_all_by_non_editionable_type(content_type_klass)
     content_type_klass.find_each do |record|
       Whitehall::PublishingApi.bulk_republish_async(record)
     end

--- a/app/views/admin/bulk_republishing/confirm_documents_by_content_ids.html.erb
+++ b/app/views/admin/bulk_republishing/confirm_documents_by_content_ids.html.erb
@@ -1,0 +1,25 @@
+<% content_for :page_title, "Republish all documents by given content IDs" %>
+<% content_for :title, "Are you sure you want to republish all documents with the given content IDs?" %>
+<% content_for :title_margin_bottom, 6 %>
+<% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @republishing_event)) %>
+
+<div class="govuk-grid-row">
+  <section class="govuk-grid-column-two-thirds">
+    <p class="govuk-body govuk-!-margin-bottom-7">
+      This will queue the following editions to be republished.
+    </p>
+    <%= render "govuk_publishing_components/components/table", {
+      head: [
+        { text: "Edition" },
+        { text: "State" },
+        { text: "Content ID" },
+      ],
+      rows: confirm_documents_by_content_ids_edition_rows(@matching_documents),
+    } %>
+
+    <%= render partial: "shared/republishing_form", locals: {
+      republishing_event: @republishing_event,
+      republishing_path: admin_bulk_republishing_documents_by_content_ids_republish_path(@content_ids_string),
+    } %>
+  </section>
+</div>

--- a/app/views/admin/bulk_republishing/new_documents_by_content_ids.html.erb
+++ b/app/views/admin/bulk_republishing/new_documents_by_content_ids.html.erb
@@ -1,0 +1,20 @@
+<% content_for :page_title, "Republish all documents by content IDs" %>
+<% content_for :title, "Which documents would you like to republish?" %>
+<% content_for :title_margin_bottom, 6 %>
+
+<div class="govuk-grid-row">
+  <section class="govuk-grid-column-two-thirds">
+    <%= form_with(url: admin_bulk_republishing_documents_by_content_ids_search_path, method: :post) do %>
+      <%= render "govuk_publishing_components/components/textarea", {
+        label: {
+          text: "Enter the content IDs for the documents",
+        },
+        hint: "Use commas and/or new lines to separate each content ID.",
+        name: "content_ids",
+      } %>
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Continue",
+      } %>
+    <% end %>
+  </section>
+</div>

--- a/app/views/admin/republishing/confirm_document.html.erb
+++ b/app/views/admin/republishing/confirm_document.html.erb
@@ -22,7 +22,7 @@
         @document.republishable_editions.map do |edition|
           [
             {
-              text: edition.public_url ? sanitize(link_to(edition.title, edition.public_url, { class: "govuk-link" })) : edition.title,
+              text: edition_title_link_or_edition_title(edition),
             },
             {
               text: edition.state.humanize,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,6 +65,12 @@ Whitehall::Application.routes.draw do
             get "/:organisation_slug/confirm" => "bulk_republishing#confirm_documents_by_organisation", as: :bulk_republishing_documents_by_organisation_confirm
             post "/:organisation_slug/republish" => "bulk_republishing#republish_documents_by_organisation", as: :bulk_republishing_documents_by_organisation_republish
           end
+          scope "documents-by-content-ids" do
+            get "/new" => "bulk_republishing#new_documents_by_content_ids", as: :bulk_republishing_documents_by_content_ids_new
+            post "/search" => "bulk_republishing#search_documents_by_content_ids", as: :bulk_republishing_documents_by_content_ids_search
+            get "/:content_ids/confirm" => "bulk_republishing#confirm_documents_by_content_ids", as: :bulk_republishing_documents_by_content_ids_confirm
+            post "/:content_ids/republish" => "bulk_republishing#republish_documents_by_content_ids", as: :bulk_republishing_documents_by_content_ids_republish
+          end
           get "/:bulk_content_type/confirm" => "bulk_republishing#confirm", as: :bulk_republishing_confirm
           post "/:bulk_content_type/republish" => "bulk_republishing#republish", as: :bulk_republishing_republish
         end

--- a/db/migrate/20240618164903_add_content_ids_to_republishing_events.rb
+++ b/db/migrate/20240618164903_add_content_ids_to_republishing_events.rb
@@ -1,0 +1,5 @@
+class AddContentIdsToRepublishingEvents < ActiveRecord::Migration[7.1]
+  def change
+    add_column :republishing_events, :content_ids, :json
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_18_123401) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_18_164903) do
   create_table "assets", charset: "utf8mb3", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.string "variant", null: false
@@ -867,6 +867,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_18_123401) do
     t.integer "bulk_content_type"
     t.string "content_type"
     t.string "organisation_id"
+    t.json "content_ids"
     t.index ["user_id"], name: "index_republishing_events_on_user_id"
   end
 

--- a/features/bulk-republishing-content.feature
+++ b/features/bulk-republishing-content.feature
@@ -50,3 +50,9 @@ Feature: Bulk republishing content
     Given a published organisation "An Existing Organisation" exists
     When I request a bulk republishing of all documents associated with "An Existing Organisation"
     Then I can see all documents associated with "An Existing Organisation" have been queued for republishing
+
+  Scenario: Republish all documents by content IDs
+    Given a document with content ID "abc-123" exists
+    Given a document with content ID "def-456" exists
+    When I request a bulk republishing of all documents with content IDs "abc-123" and "def-456"
+    Then I can see all documents with content IDs "abc-123" and "def-456" have been queued for republishing

--- a/features/step_definitions/bulk_republishing_content_steps.rb
+++ b/features/step_definitions/bulk_republishing_content_steps.rb
@@ -131,3 +131,16 @@ end
 Then(/^I can see all documents associated with "An Existing Organisation" have been queued for republishing$/) do
   expect(page).to have_selector(".gem-c-success-alert", text: "All documents by organisation 'An Existing Organisation' have been queued for republishing")
 end
+
+When(/^I request a bulk republishing of all documents with content IDs "abc-123" and "def-456"$/) do
+  visit admin_republishing_index_path
+  find("#all-documents-by-content-ids").click
+  fill_in "Enter the content IDs for the documents", with: "abc-123, def-456"
+  click_button("Continue")
+  fill_in "What is the reason for republishing?", with: "It needs republishing"
+  click_button("Confirm republishing")
+end
+
+Then(/^I can see all documents with content IDs "abc-123" and "def-456" have been queued for republishing$/) do
+  expect(page).to have_selector(".gem-c-success-alert", text: "All documents by content IDs 'abc-123' and 'def-456' have been queued for republishing")
+end

--- a/features/step_definitions/document_steps.rb
+++ b/features/step_definitions/document_steps.rb
@@ -19,6 +19,10 @@ Given(/^a published document "([^"]*)" exists$/) do |title|
   create(:published_publication, title:)
 end
 
+Given(/^a document with content ID "([^"]*)" exists$/) do |content_id|
+  create(:document, content_id:)
+end
+
 Given(/^a draft (publication|news article|consultation) "([^"]*)" was produced by the "([^"]*)" organisation$/) do |document_type, title, organisation_name|
   organisation = Organisation.find_by!(name: organisation_name)
   create("draft_#{document_class(document_type).name.underscore}".to_sym, title:, organisations: [organisation])

--- a/test/functional/admin/bulk_republishing_controller_test.rb
+++ b/test/functional/admin/bulk_republishing_controller_test.rb
@@ -205,7 +205,7 @@ class Admin::BulkRepublishingControllerTest < ActionController::TestCase
     assert_response :forbidden
   end
 
-  test "GDS Admin users should be able to POST :republish_documents_by_organisation with an existing organisation slug, creating a RepublishingEvent for the current user" do
+  test "GDS Admin users should be able to POST :republish_documents_by_organisation with an existing organisation slug and a reason, creating a RepublishingEvent for the current user" do
     organisation = create(:organisation, id: "1234", slug: "an-existing-organisation", name: "An Existing Organisation")
 
     BulkRepublisher.any_instance.expects(:republish_all_documents_by_organisation).with(organisation).once

--- a/test/unit/app/helpers/admin/editions_helper_test.rb
+++ b/test/unit/app/helpers/admin/editions_helper_test.rb
@@ -86,4 +86,19 @@ class Admin::EditionsHelperTest < ActionView::TestCase
 
     assert_equal "Worldwide organisation", edition_type(edition)
   end
+
+  test "#edition_title_link_or_edition_title returns a link to the edition with its title as the text when the edition has a public URL" do
+    edition = build(:published_edition, title: "It's my title!")
+    public_url = "https://gov.uk/my-public-url"
+    edition.stubs(:public_url).returns(public_url)
+
+    assert_equal '<a class="govuk-link" href="https://gov.uk/my-public-url">It\'s my title!</a>', edition_title_link_or_edition_title(edition)
+  end
+
+  test "#edition_title_link_or_edition_title returns the edition title when the edition has no public URL" do
+    edition = build(:published_edition, title: "It's my title!")
+    edition.stubs(:public_url).returns(nil)
+
+    assert_equal "It's my title!", edition_title_link_or_edition_title(edition)
+  end
 end

--- a/test/unit/app/helpers/admin/republishing_helper_test.rb
+++ b/test/unit/app/helpers/admin/republishing_helper_test.rb
@@ -77,6 +77,21 @@ class Admin::RepublishingHelperTest < ActionView::TestCase
       value: "contact",
     }
   end
+
+  [
+    { condition: "an empty string", input: "", expected_output: [] },
+    { condition: "commas, space, and new lines with no IDs", input: "  \r ,  \r\n  ", expected_output: [] },
+    { condition: "single IDs", input: "abc-123", expected_output: %w[abc-123] },
+    { condition: "comma-separated IDs", input: "abc-123,def-456,ghi-789", expected_output: %w[abc-123 def-456 ghi-789] },
+    { condition: "space-separated IDs", input: "abc-123 def-456  ghi-789", expected_output: %w[abc-123 def-456 ghi-789] },
+    { condition: "new-line-separated IDs", input: "abc-123\ndef-456\n\rghi-789", expected_output: %w[abc-123 def-456 ghi-789] },
+    { condition: "a mixture of comma-, space-, and new-line-separated IDs", input: "abc-123,def-456\n\rghi-789, jkl-012  \r  mno-345  , \n\r  , pqr-678", expected_output: %w[abc-123 def-456 ghi-789 jkl-012 mno-345 pqr-678] },
+    { condition: "IDs with leading and trailing commas, space, and new lines", input: "\r\n , abc-123, def-456, ghi-789 \r, ", expected_output: %w[abc-123 def-456 ghi-789] },
+  ].each do |test_config|
+    test "#content_ids_string_to_array handles #{test_config[:condition]}" do
+      assert_equal test_config[:expected_output], content_ids_string_to_array(test_config[:input])
+    end
+  end
 end
 
 def omnipresent_content_types

--- a/test/unit/app/helpers/admin/republishing_helper_test.rb
+++ b/test/unit/app/helpers/admin/republishing_helper_test.rb
@@ -92,6 +92,20 @@ class Admin::RepublishingHelperTest < ActionView::TestCase
       assert_equal test_config[:expected_output], content_ids_string_to_array(test_config[:input])
     end
   end
+
+  [
+    { condition: "one ID", input: %w[abc-123], expected_output: "'abc-123'" },
+    { condition: "two IDs", input: %w[abc-123 def-456], expected_output: "'abc-123' and 'def-456'" },
+    { condition: "three or more IDs", input: %w[abc-123 def-456 ghi-789], expected_output: "'abc-123', 'def-456', and 'ghi-789'" },
+  ].each do |test_config|
+    test "#content_ids_array_to_string handles #{test_config[:condition]}" do
+      assert_equal test_config[:expected_output], content_ids_array_to_string(test_config[:input])
+    end
+  end
+
+  test "#content_ids_array_to_string throws an error if no IDs are provided" do
+    assert_raises(StandardError, match: "No IDs provided") { content_ids_array_to_string([]) }
+  end
 end
 
 def omnipresent_content_types

--- a/test/unit/app/models/republishing_event_test.rb
+++ b/test/unit/app/models/republishing_event_test.rb
@@ -51,5 +51,48 @@ class RepublishingEventTest < ActiveSupport::TestCase
         end
       end
     end
+
+    describe "content_ids" do
+      context "for an `all_documents_by_content_ids` bulk republishing event" do
+        test "should be valid if content IDs is a non-empty array" do
+          event = build(:republishing_event, :bulk, bulk_content_type: "all_documents_by_content_ids", content_ids: %w[1234 5678])
+          assert event.valid?
+        end
+
+        test "should be invalid if content IDs is a hash" do
+          event = build(:republishing_event, :bulk, bulk_content_type: "all_documents_by_content_ids", content_ids: {})
+          assert_not event.valid?
+          assert_includes event.errors.full_messages, "Content ids is not an array"
+        end
+
+        test "should be invalid if content IDs is `nil`" do
+          event = build(:republishing_event, :bulk, bulk_content_type: "all_documents_by_content_ids", content_ids: nil)
+          assert_not event.valid?
+          assert_includes event.errors.full_messages, "Content ids is not an array"
+        end
+
+        test "should be invalid if content IDs is an empty array" do
+          event = build(:republishing_event, :bulk, bulk_content_type: "all_documents_by_content_ids", content_ids: [])
+          assert_not event.valid?
+          assert_includes event.errors.full_messages, "Content ids is not a non-empty array"
+        end
+
+        test "should be invalid if content IDs is an array of integers" do
+          event = build(:republishing_event, :bulk, bulk_content_type: "all_documents_by_content_ids", content_ids: [1234, 5678])
+          assert_not event.valid?
+          assert_includes event.errors.full_messages, "Content ids is not a non-empty array of strings"
+        end
+      end
+
+      context "for any other republishing event" do
+        test "must not be present" do
+          bulk_event = build(:republishing_event, :bulk, bulk_content_type: "all_documents", content_ids: %w[1234 5678])
+          assert_not bulk_event.valid?
+
+          non_bulk_event = build(:republishing_event, content_ids: %w[1234 5678])
+          assert_not non_bulk_event.valid?
+        end
+      end
+    end
   end
 end

--- a/test/unit/app/models/republishing_event_test.rb
+++ b/test/unit/app/models/republishing_event_test.rb
@@ -3,50 +3,52 @@ require "test_helper"
 class RepublishingEventTest < ActiveSupport::TestCase
   extend Minitest::Spec::DSL
 
-  describe "content_type" do
-    context "for an `all_by_type` bulk republishing event" do
-      test "should be valid with a content type" do
-        event = build(:republishing_event, :bulk, bulk_content_type: "all_by_type", content_type: "a content type")
-        assert event.valid?
+  describe "validations" do
+    describe "content_type" do
+      context "for an `all_by_type` bulk republishing event" do
+        test "should be valid with a content type" do
+          event = build(:republishing_event, :bulk, bulk_content_type: "all_by_type", content_type: "a content type")
+          assert event.valid?
+        end
+
+        test "should be invalid without a content type" do
+          event = build(:republishing_event, :bulk, bulk_content_type: "all_by_type", content_type: nil)
+          assert_not event.valid?
+        end
       end
 
-      test "should be invalid without a content type" do
-        event = build(:republishing_event, :bulk, bulk_content_type: "all_by_type", content_type: nil)
-        assert_not event.valid?
-      end
-    end
+      context "for any other republishing event" do
+        test "must not be present" do
+          bulk_event = build(:republishing_event, :bulk, bulk_content_type: "all_documents", content_type: "all documents")
+          assert_not bulk_event.valid?
 
-    context "for any other republishing event" do
-      test "must not be present" do
-        bulk_event = build(:republishing_event, :bulk, bulk_content_type: "all_documents", content_type: "all documents")
-        assert_not bulk_event.valid?
-
-        non_bulk_event = build(:republishing_event, content_type: "all documents")
-        assert_not non_bulk_event.valid?
-      end
-    end
-  end
-
-  describe "organisation_id" do
-    context "for an `all_documents_by_organisation` bulk republishing event" do
-      test "should be valid with an organisation ID" do
-        event = build(:republishing_event, :bulk, bulk_content_type: "all_documents_by_organisation", organisation_id: "1234")
-        assert event.valid?
-      end
-
-      test "should be invalid without a content type" do
-        event = build(:republishing_event, :bulk, bulk_content_type: "all_documents_by_organisation", organisation_id: nil)
-        assert_not event.valid?
+          non_bulk_event = build(:republishing_event, content_type: "all documents")
+          assert_not non_bulk_event.valid?
+        end
       end
     end
 
-    context "for any other republishing event" do
-      test "must not be present" do
-        bulk_event = build(:republishing_event, :bulk, bulk_content_type: "all_documents", organisation_id: "1234")
-        assert_not bulk_event.valid?
+    describe "organisation_id" do
+      context "for an `all_documents_by_organisation` bulk republishing event" do
+        test "should be valid with an organisation ID" do
+          event = build(:republishing_event, :bulk, bulk_content_type: "all_documents_by_organisation", organisation_id: "1234")
+          assert event.valid?
+        end
 
-        non_bulk_event = build(:republishing_event, organisation_id: "1234")
-        assert_not non_bulk_event.valid?
+        test "should be invalid without a content type" do
+          event = build(:republishing_event, :bulk, bulk_content_type: "all_documents_by_organisation", organisation_id: nil)
+          assert_not event.valid?
+        end
+      end
+
+      context "for any other republishing event" do
+        test "must not be present" do
+          bulk_event = build(:republishing_event, :bulk, bulk_content_type: "all_documents", organisation_id: "1234")
+          assert_not bulk_event.valid?
+
+          non_bulk_event = build(:republishing_event, organisation_id: "1234")
+          assert_not non_bulk_event.valid?
+        end
       end
     end
   end

--- a/test/unit/app/services/bulk_republisher_test.rb
+++ b/test/unit/app/services/bulk_republisher_test.rb
@@ -294,4 +294,21 @@ class BulkRepublisherTest < ActiveSupport::TestCase
       end
     end
   end
+
+  describe "#republish_all_documents_by_ids" do
+    test "republishes documents with the given IDs" do
+      ids = [1, 2, 3, 4, 5]
+
+      ids.each do |id|
+        create(:document, id:)
+
+        PublishingApiDocumentRepublishingWorker
+          .expects(:perform_async_in_queue)
+          .with("bulk_republishing", id, true)
+          .once
+      end
+
+      BulkRepublisher.new.republish_all_documents_by_ids(ids)
+    end
+  end
 end


### PR DESCRIPTION
[Trello](https://trello.com/c/3Pz8w9D0/1197-add-a-user-interface-for-whitehalls-bulk-republishing-documents-by-content-ids-rake-task)

This adds a UI for republishing documents by content IDs

## Screenshots

<img width="784" alt="image" src="https://github.com/alphagov/whitehall/assets/40244233/f50a36ba-bb43-479e-8dab-547adbf699d0">

<img width="794" alt="image" src="https://github.com/alphagov/whitehall/assets/40244233/1ef64b7b-33f0-4f33-b2be-dd075047d32d">

<img width="790" alt="image" src="https://github.com/alphagov/whitehall/assets/40244233/c2bb2dab-0e54-4817-b1f2-6691a4b99cc8">

<img width="1186" alt="image" src="https://github.com/alphagov/whitehall/assets/40244233/27d61bc7-0605-4d94-94f2-6cbb5c4809cf">

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
