### PR TITLE
Clear organisations links

### DIFF
--- a/app/presenters/publishing_api/person_presenter.rb
+++ b/app/presenters/publishing_api/person_presenter.rb
@@ -28,7 +28,9 @@ module PublishingApi
     end
 
     def links
-      {}
+      {
+        organisations: [],
+      }
     end
 
     def details

--- a/test/unit/app/presenters/publishing_api/person_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/person_presenter_test.rb
@@ -53,7 +53,7 @@ class PublishingApi::PersonPresenterTest < ActiveSupport::TestCase
     presented_item = present(person.reload)
 
     assert_equal expected_hash, presented_item.content
-    assert_equal presented_item.links, {}
+    assert_equal presented_item.links, { organisations: [] }
     assert_equal "major", presented_item.update_type
     assert_equal person.content_id, presented_item.content_id
 

--- a/test/unit/lib/data_hygiene/person_reslugger_test.rb
+++ b/test/unit/lib/data_hygiene/person_reslugger_test.rb
@@ -30,6 +30,7 @@ class PersonSlugChangerTest < ActiveSupport::TestCase
 
     expected_publish_requests = [
       stub_publishing_api_put_content(content_item.content_id, content_item.content),
+      stub_publishing_api_patch_links(content_item.content_id, links: content_item.links),
       stub_publishing_api_publish(content_item.content_id, locale: "en", update_type: nil),
     ]
 


### PR DESCRIPTION

**What**

Clear organisations links from people pages.

**Why**

Change brought about by an issue encountered on [2ndline](https://govuk.zendesk.com/agent/tickets/5848753). 

Currently there is an undesirable scenario in which a person can be associated with a department, not in the sense of a role, but as a piece of organisation content. This fix clears those links, which should prevent updates to people pages being associated with the organisation's latest news, which is what happened in this instance. 

**Before**
<img width="525" alt="Screenshot 2024-06-19 at 09 15 36" src="https://github.com/alphagov/whitehall/assets/41922771/f7f9a3cf-3308-4d61-8ddd-bc98648031f7">

**After**

<img width="414" alt="Screenshot 2024-06-19 at 09 14 57" src="https://github.com/alphagov/whitehall/assets/41922771/578c0217-aef6-4e27-9ff3-f6b5e805dca6">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
