### PR TITLE
Refactor edition model

### DIFF
--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -1,5 +1,7 @@
 # @abstract
 class Announcement < Edition
+  include Edition::Searchable
+
   include Edition::Images
   include Edition::Organisations
   include Edition::TaggableOrganisations

--- a/app/models/case_study.rb
+++ b/app/models/case_study.rb
@@ -1,4 +1,6 @@
 class CaseStudy < Edition
+  include Edition::Searchable
+
   include Edition::Images
   include Edition::FactCheckable
   include Edition::CustomLeadImage

--- a/app/models/concerns/edition/base_permission_methods.rb
+++ b/app/models/concerns/edition/base_permission_methods.rb
@@ -1,0 +1,29 @@
+# Sets all default overwritable permission methods for an Edition
+module Edition::BasePermissionMethods
+  extend ActiveSupport::Concern
+
+  %w[
+    can_be_associated_with_social_media_accounts?
+    can_be_associated_with_topical_events?
+    can_be_associated_with_roles?
+    can_be_associated_with_role_appointments?
+    can_be_associated_with_worldwide_organisations?
+    can_be_fact_checked?
+    can_be_related_to_mainstream_content?
+    can_be_related_to_organisations?
+    can_apply_to_subset_of_nations?
+    allows_attachments?
+    allows_attachment_references?
+    allows_inline_attachments?
+    can_be_grouped_in_collections?
+    has_operational_field?
+    can_apply_to_local_government?
+    national_statistic?
+    has_consultation_participation?
+    is_associated_with_a_minister?
+    statistics?
+    can_be_tagged_to_worldwide_taxonomy?
+  ].each do |method|
+    define_method(method) { false }
+  end
+end

--- a/app/models/concerns/edition/scopes.rb
+++ b/app/models/concerns/edition/scopes.rb
@@ -1,0 +1,158 @@
+module Edition::Scopes
+  extend ActiveSupport::Concern
+
+  included do
+    scope :with_title_or_summary_containing,
+          lambda { |*keywords|
+            pattern = "(#{keywords.map { |k| Regexp.escape(k) }.join('|')})"
+            in_default_locale.where("edition_translations.title REGEXP :pattern OR edition_translations.summary REGEXP :pattern", pattern:)
+          }
+
+    scope :with_title_containing,
+          lambda { |keywords|
+            escaped_like_expression = keywords.gsub(/([%_])/, "%" => '\\%', "_" => '\\_')
+            like_clause = "%#{escaped_like_expression}%"
+
+            scope = in_default_locale.includes(:document)
+            scope
+              .where("edition_translations.title LIKE :like_clause", like_clause:)
+              .or(scope.where(document: { slug: keywords }))
+          }
+
+    scope :in_pre_publication_state, -> { where(state: Edition::PRE_PUBLICATION_STATES) }
+    scope :force_published, -> { where(state: "published", force_published: true) }
+    scope :not_published, -> { where(state: %w[draft submitted rejected]) }
+    scope :without_not_published, -> { where.not(state: %w[draft submitted rejected]) }
+
+    scope :announcements, -> { where(type: Announcement.concrete_descendants.collect(&:name)) }
+    scope :consultations, -> { where(type: "Consultation") }
+    scope :call_for_evidence, -> { where(type: "CallForEvidence") }
+    scope :detailed_guides, -> { where(type: "DetailedGuide") }
+    scope :statistical_publications, -> { where("publication_type_id IN (?)", PublicationType.statistical.map(&:id)) }
+    scope :non_statistical_publications, -> { where("publication_type_id NOT IN (?)", PublicationType.statistical.map(&:id)) }
+    scope :corporate_publications, -> { where(publication_type_id: PublicationType::CorporateReport.id) }
+    scope :corporate_information_pages, -> { where(type: "CorporateInformationPage") }
+    scope :publicly_visible, -> { where(state: Edition::PUBLICLY_VISIBLE_STATES) }
+
+    scope :future_scheduled_editions, -> { scheduled.where(Edition.arel_table[:scheduled_publication].gteq(Time.zone.now)) }
+
+    scope :latest_edition, -> { joins(:document).where("editions.id = documents.latest_edition_id") }
+    scope :live_edition, -> { joins(:document).where("documents.live_edition_id = editions.id") }
+
+    scope :review_overdue,
+          lambda {
+            joins(document: :review_reminder)
+              .where(document: { review_reminders: { review_at: ..Time.zone.today } })
+              .where.not(first_published_at: nil)
+          }
+
+    scope :alphabetical, lambda { |locale = I18n.locale|
+      with_translations(locale).order("edition_translations.title ASC")
+    }
+
+    scope :published_before, lambda { |date|
+      where(arel_table[:public_timestamp].lteq(date))
+    }
+
+    scope :published_after, lambda { |date|
+      where(arel_table[:public_timestamp].gteq(date))
+    }
+
+    scope :in_chronological_order, lambda {
+      order(arel_table[:public_timestamp].asc, arel_table[:document_id].asc)
+    }
+
+    scope :in_reverse_chronological_order, lambda {
+      ids = pluck(:id)
+      Edition
+        .unscoped
+        .where(id: ids)
+        .order(
+          arel_table[:public_timestamp].desc,
+          arel_table[:document_id].desc,
+          arel_table[:id].desc,
+        )
+    }
+
+    scope :without_editions_of_type, lambda { |*edition_classes|
+      where(arel_table[:type].not_in(edition_classes.map(&:name)))
+    }
+
+    scope :authored_by, lambda { |user|
+      if user&.id
+        where(
+          "EXISTS (
+          SELECT * FROM edition_authors ea_authorship_check
+          WHERE
+            ea_authorship_check.edition_id=editions.id
+            AND ea_authorship_check.user_id=?
+          )",
+          user.id,
+        )
+      end
+    }
+
+    scope :by_type, lambda { |type|
+      where(type: type.to_s)
+    }
+
+    scope :by_subtype, lambda { |type, subtype|
+      merge(type.by_subtype(subtype))
+    }
+
+    scope :by_subtypes, lambda { |type, subtype_ids|
+      merge(type.by_subtypes(subtype_ids))
+    }
+
+    scope :by_type_or_subtypes, lambda { |type, subtypes|
+      if subtypes.nil?
+        by_type(type)
+      elsif subtypes.empty?
+        none
+      else
+        by_subtypes(type, subtypes.pluck(:id))
+      end
+    }
+
+    scope :in_world_location, lambda { |world_location|
+      joins(:world_locations).where("world_locations.id" => world_location)
+    }
+
+    scope :from_date, ->(date) { where("editions.updated_at >= ?", date) }
+    scope :to_date, ->(date) { where("editions.updated_at <= ?", date) }
+
+    scope :only_broken_links, lambda {
+      joins(
+        "
+  LEFT JOIN (
+    SELECT id, link_reportable_type, link_reportable_id
+    FROM link_checker_api_reports
+    GROUP BY link_reportable_type, link_reportable_id
+    ORDER BY id DESC
+  ) AS latest_link_checker_api_reports
+    ON latest_link_checker_api_reports.link_reportable_type = 'Edition'
+   AND latest_link_checker_api_reports.link_reportable_id = editions.id
+   AND latest_link_checker_api_reports.id = (SELECT MAX(id) FROM link_checker_api_reports WHERE link_checker_api_reports.link_reportable_type = 'Edition' AND link_checker_api_reports.link_reportable_id = editions.id)",
+      ).where(
+        "
+  EXISTS (
+    SELECT 1
+    FROM link_checker_api_report_links
+    WHERE link_checker_api_report_id = latest_link_checker_api_reports.id
+      AND link_checker_api_report_links.status IN ('broken', 'caution')
+  )",
+      )
+    }
+
+    # NOTE: this scope becomes redundant once Admin::EditionFilterer is backed by an admin-only search_api index
+    scope :with_topical_event, lambda { |topical_event|
+      joins("INNER JOIN topical_event_memberships ON topical_event_memberships.edition_id = editions.id")
+        .where("topical_event_memberships.topical_event_id" => topical_event.id)
+    }
+
+    scope :due_for_publication, lambda { |within_time = 0|
+      cutoff = Time.zone.now + within_time
+      scheduled.where(arel_table[:scheduled_publication].lteq(cutoff))
+    }
+  end
+end

--- a/app/models/concerns/edition/searchable.rb
+++ b/app/models/concerns/edition/searchable.rb
@@ -1,0 +1,55 @@
+module Edition::Searchable
+  extend ActiveSupport::Concern
+
+  def search_title
+    title
+  end
+
+  def search_link
+    base_path
+  end
+
+  def search_format_types
+    [Edition.search_format_type]
+  end
+
+  def refresh_index_if_required
+    if document.editions.published.any?
+      document.editions.published.last.update_in_search_index
+    else
+      remove_from_search_index
+    end
+  end
+
+  included do
+    include Searchable
+
+    searchable(
+      id: :id,
+      title: :search_title,
+      link: :search_link,
+      format: ->(d) { d.format_name.tr(" ", "_") },
+      content: :indexable_content,
+      description: :summary,
+      people: nil,
+      roles: nil,
+      display_type: :display_type,
+      detailed_format: :detailed_format,
+      public_timestamp: :public_timestamp,
+      relevant_to_local_government: :relevant_to_local_government?,
+      world_locations: nil,
+      only: :search_only,
+      index_after: [],
+      unindex_after: [],
+      search_format_types: :search_format_types,
+      attachments: nil,
+      operational_field: nil,
+      latest_change_note: :most_recent_change_note,
+      is_political: :political?,
+      is_historic: :historic?,
+      is_withdrawn: :withdrawn?,
+      government_name: :search_government_name,
+      content_store_document_type: :content_store_document_type,
+    )
+  end
+end

--- a/app/models/detailed_guide.rb
+++ b/app/models/detailed_guide.rb
@@ -1,4 +1,6 @@
 class DetailedGuide < Edition
+  include Edition::Searchable
+
   include Edition::Images
   include Edition::NationalApplicability
 

--- a/app/models/document_collection.rb
+++ b/app/models/document_collection.rb
@@ -1,4 +1,6 @@
 class DocumentCollection < Edition
+  include Edition::Searchable
+
   include Edition::Organisations
   include Edition::TaggableOrganisations
 

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -20,6 +20,7 @@ class Edition < ApplicationRecord
 
   include Edition::ActiveEditors
   include Edition::Translatable
+  include Edition::Scopes
 
   include Dependable
 
@@ -61,50 +62,6 @@ class Edition < ApplicationRecord
   POST_PUBLICATION_STATES = %w[published superseded withdrawn unpublished].freeze
   PUBLICLY_VISIBLE_STATES = %w[published withdrawn].freeze
 
-  scope :with_title_or_summary_containing,
-        lambda { |*keywords|
-          pattern = "(#{keywords.map { |k| Regexp.escape(k) }.join('|')})"
-          in_default_locale.where("edition_translations.title REGEXP :pattern OR edition_translations.summary REGEXP :pattern", pattern:)
-        }
-
-  scope :with_title_containing,
-        lambda { |keywords|
-          escaped_like_expression = keywords.gsub(/([%_])/, "%" => '\\%', "_" => '\\_')
-          like_clause = "%#{escaped_like_expression}%"
-
-          scope = in_default_locale.includes(:document)
-          scope
-            .where("edition_translations.title LIKE :like_clause", like_clause:)
-            .or(scope.where(document: { slug: keywords }))
-        }
-
-  scope :in_pre_publication_state, -> { where(state: Edition::PRE_PUBLICATION_STATES) }
-  scope :force_published, -> { where(state: "published", force_published: true) }
-  scope :not_published, -> { where(state: %w[draft submitted rejected]) }
-  scope :without_not_published, -> { where.not(state: %w[draft submitted rejected]) }
-
-  scope :announcements, -> { where(type: Announcement.concrete_descendants.collect(&:name)) }
-  scope :consultations, -> { where(type: "Consultation") }
-  scope :call_for_evidence, -> { where(type: "CallForEvidence") }
-  scope :detailed_guides, -> { where(type: "DetailedGuide") }
-  scope :statistical_publications, -> { where("publication_type_id IN (?)", PublicationType.statistical.map(&:id)) }
-  scope :non_statistical_publications, -> { where("publication_type_id NOT IN (?)", PublicationType.statistical.map(&:id)) }
-  scope :corporate_publications, -> { where(publication_type_id: PublicationType::CorporateReport.id) }
-  scope :corporate_information_pages, -> { where(type: "CorporateInformationPage") }
-  scope :publicly_visible, -> { where(state: PUBLICLY_VISIBLE_STATES) }
-
-  scope :future_scheduled_editions, -> { scheduled.where(Edition.arel_table[:scheduled_publication].gteq(Time.zone.now)) }
-
-  scope :latest_edition, -> { joins(:document).where("editions.id = documents.latest_edition_id") }
-  scope :live_edition, -> { joins(:document).where("documents.live_edition_id = editions.id") }
-
-  scope :review_overdue,
-        lambda {
-          joins(document: :review_reminder)
-            .where(document: { review_reminders: { review_at: ..Time.zone.today } })
-            .where.not(first_published_at: nil)
-        }
-
   # @!group Callbacks
   before_create :set_auth_bypass_id
   before_save :set_public_timestamp
@@ -145,111 +102,8 @@ class Edition < ApplicationRecord
 
   validates_with UnmodifiableValidator, if: :unmodifiable?
 
-  def self.alphabetical(locale = I18n.locale)
-    with_translations(locale).order("edition_translations.title ASC")
-  end
-
-  def self.published_before(date)
-    where(arel_table[:public_timestamp].lteq(date))
-  end
-
-  def self.published_after(date)
-    where(arel_table[:public_timestamp].gteq(date))
-  end
-
-  def self.in_chronological_order
-    order(arel_table[:public_timestamp].asc, arel_table[:document_id].asc)
-  end
-
-  def self.in_reverse_chronological_order
-    ids = pluck(:id)
-    Edition
-      .unscoped
-      .where(id: ids)
-      .order(
-        arel_table[:public_timestamp].desc,
-        arel_table[:document_id].desc,
-        arel_table[:id].desc,
-      )
-  end
-
-  def self.without_editions_of_type(*edition_classes)
-    where(arel_table[:type].not_in(edition_classes.map(&:name)))
-  end
-
   def self.format_name
     @format_name ||= model_name.human.downcase
-  end
-
-  def self.authored_by(user)
-    if user && user.id
-      where(
-        "EXISTS (
-        SELECT * FROM edition_authors ea_authorship_check
-        WHERE
-          ea_authorship_check.edition_id=editions.id
-          AND ea_authorship_check.user_id=?
-        )",
-        user.id,
-      )
-    end
-  end
-
-  def self.by_type_or_subtypes(type, subtypes)
-    if subtypes.nil?
-      by_type(type)
-    elsif subtypes.empty?
-      none
-    else
-      by_subtypes(type, subtypes.pluck(:id))
-    end
-  end
-
-  def self.by_type(type)
-    where(type: type.to_s)
-  end
-
-  def self.by_subtype(type, subtype)
-    merge(type.by_subtype(subtype))
-  end
-
-  def self.by_subtypes(type, subtype_ids)
-    merge(type.by_subtypes(subtype_ids))
-  end
-
-  def self.in_world_location(world_location)
-    joins(:world_locations).where("world_locations.id" => world_location)
-  end
-
-  def self.from_date(date)
-    where("editions.updated_at >= ?", date)
-  end
-
-  def self.to_date(date)
-    where("editions.updated_at <= ?", date)
-  end
-
-  def self.only_broken_links
-    joins(
-      "
-LEFT JOIN (
-  SELECT id, link_reportable_type, link_reportable_id
-  FROM link_checker_api_reports
-  GROUP BY link_reportable_type, link_reportable_id
-  ORDER BY id DESC
-) AS latest_link_checker_api_reports
-  ON latest_link_checker_api_reports.link_reportable_type = 'Edition'
- AND latest_link_checker_api_reports.link_reportable_id = editions.id
- AND latest_link_checker_api_reports.id = (SELECT MAX(id) FROM link_checker_api_reports WHERE link_checker_api_reports.link_reportable_type = 'Edition' AND link_checker_api_reports.link_reportable_id = editions.id)",
-    ).where(
-      "
-EXISTS (
-  SELECT 1
-  FROM link_checker_api_report_links
-  WHERE link_checker_api_report_id = latest_link_checker_api_reports.id
-    AND link_checker_api_report_links.status IN ('broken', 'caution')
-)",
-    )
   end
 
   def self.search_format_type
@@ -262,17 +116,6 @@ EXISTS (
 
   def self.concrete_descendant_search_format_types
     concrete_descendants.map(&:search_format_type)
-  end
-
-  # NOTE: this scope becomes redundant once Admin::EditionFilterer is backed by an admin-only search_api index
-  def self.with_topical_event(topical_event)
-    joins("INNER JOIN topical_event_memberships ON topical_event_memberships.edition_id = editions.id")
-      .where("topical_event_memberships.topical_event_id" => topical_event.id)
-  end
-
-  def self.due_for_publication(within_time = 0)
-    cutoff = Time.zone.now + within_time
-    scheduled.where(arel_table[:scheduled_publication].lteq(cutoff))
   end
 
   def self.scheduled_for_publication_as(slug)

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -5,6 +5,7 @@ class Edition < ApplicationRecord
 
   include Edition::NullImages
   include Edition::NullWorldLocations
+  include Edition::BasePermissionMethods
 
   include Edition::Identifiable
   include Edition::LimitedAccess
@@ -141,91 +142,6 @@ class Edition < ApplicationRecord
     change_note.present? || minor_change
   end
 
-  # @group Overwritable permission methods
-  def can_be_associated_with_social_media_accounts?
-    false
-  end
-
-  def can_be_associated_with_topical_events?
-    false
-  end
-
-  def can_be_associated_with_roles?
-    false
-  end
-
-  def can_be_associated_with_role_appointments?
-    false
-  end
-
-  def can_be_associated_with_worldwide_organisations?
-    false
-  end
-
-  def can_be_fact_checked?
-    false
-  end
-
-  def can_be_related_to_mainstream_content?
-    false
-  end
-
-  def can_be_related_to_organisations?
-    false
-  end
-
-  def can_apply_to_subset_of_nations?
-    false
-  end
-
-  def allows_attachments?
-    false
-  end
-
-  def allows_attachment_references?
-    false
-  end
-
-  def allows_inline_attachments?
-    false
-  end
-
-  def can_be_grouped_in_collections?
-    false
-  end
-
-  def has_operational_field?
-    false
-  end
-
-  def image_disallowed_in_body_text?(_index)
-    false
-  end
-
-  def can_apply_to_local_government?
-    false
-  end
-
-  def national_statistic?
-    false
-  end
-
-  def has_consultation_participation?
-    false
-  end
-
-  def is_associated_with_a_minister?
-    false
-  end
-
-  def statistics?
-    false
-  end
-
-  def can_be_tagged_to_worldwide_taxonomy?
-    false
-  end
-
   def can_be_marked_political?
     true
   end
@@ -249,8 +165,6 @@ class Edition < ApplicationRecord
   def included_in_statistics_feed?
     search_format_types.include?("publicationesque-statistics")
   end
-
-  # @!endgroup
 
   def create_draft(user, allow_creating_draft_from_deleted_edition: false)
     ActiveRecord::Base.transaction do
@@ -284,6 +198,10 @@ class Edition < ApplicationRecord
 
   def author_names
     edition_authors.map(&:user).map(&:name).uniq
+  end
+
+  def image_disallowed_in_body_text?(_index)
+    false
   end
 
   def rejected_by

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -27,8 +27,6 @@ class Edition < ApplicationRecord
   extend Edition::FindableByOrganisation
   extend Edition::FindableByWorldwideOrganisation
 
-  include Searchable
-
   include DateValidation
 
   date_attributes :scheduled_publication, :first_published_at, :delivered_on, :opening_at, :closing_at
@@ -112,60 +110,12 @@ class Edition < ApplicationRecord
     document.update_slug_if_possible("deleted-#{title(I18n.default_locale)}")
   end
 
-  searchable(
-    id: :id,
-    title: :search_title,
-    link: :search_link,
-    format: ->(d) { d.format_name.tr(" ", "_") },
-    content: :indexable_content,
-    description: :summary,
-    people: nil,
-    roles: nil,
-    display_type: :display_type,
-    detailed_format: :detailed_format,
-    public_timestamp: :public_timestamp,
-    relevant_to_local_government: :relevant_to_local_government?,
-    world_locations: nil,
-    only: :search_only,
-    index_after: [],
-    unindex_after: [],
-    search_format_types: :search_format_types,
-    attachments: nil,
-    operational_field: nil,
-    latest_change_note: :most_recent_change_note,
-    is_political: :political?,
-    is_historic: :historic?,
-    is_withdrawn: :withdrawn?,
-    government_name: :search_government_name,
-    content_store_document_type: :content_store_document_type,
-  )
-
-  def search_title
-    title
-  end
-
-  def search_link
-    base_path
-  end
-
-  def search_format_types
-    [Edition.search_format_type]
-  end
-
   def self.publicly_visible_and_available_in_english
     with_translations(:en).publicly_visible
   end
 
   def self.search_only
     publicly_visible_and_available_in_english
-  end
-
-  def refresh_index_if_required
-    if document.editions.published.any?
-      document.editions.published.last.update_in_search_index
-    else
-      remove_from_search_index
-    end
   end
 
   def creator
@@ -278,6 +228,10 @@ class Edition < ApplicationRecord
 
   def can_be_marked_political?
     true
+  end
+
+  def can_index_in_search?
+    false
   end
 
   def path_name

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -73,33 +73,6 @@ class Edition < ApplicationRecord
 
   accepts_nested_attributes_for :document
 
-  class UnmodifiableValidator < ActiveModel::Validator
-    def validate(record)
-      significant_changed_attributes(record).each do |attribute|
-        record.errors.add(attribute, "cannot be modified when edition is in the #{record.state} state")
-      end
-    end
-
-    def significant_changed_attributes(record)
-      record.changed - modifiable_attributes(record.state_was, record.state)
-    end
-
-    def modifiable_attributes(previous_state, current_state)
-      modifiable = %w[state updated_at force_published]
-      if previous_state == "scheduled"
-        modifiable += %w[major_change_published_at first_published_at access_limited]
-      end
-      if PRE_PUBLICATION_STATES.include?(previous_state) || being_unpublished?(previous_state, current_state)
-        modifiable += %w[published_major_version published_minor_version]
-      end
-      modifiable
-    end
-
-    def being_unpublished?(previous_state, current_state)
-      previous_state == "published" && %w[unpublished withdrawn].include?(current_state)
-    end
-  end
-
   validates_with UnmodifiableValidator, if: :unmodifiable?
 
   def self.format_name

--- a/app/models/editionable_worldwide_organisation.rb
+++ b/app/models/editionable_worldwide_organisation.rb
@@ -3,10 +3,13 @@ class EditionableWorldwideOrganisation < Edition
   SECONDARY_ROLES = [DeputyHeadOfMissionRole].freeze
   OFFICE_ROLES = [WorldwideOfficeStaffRole].freeze
 
+  include Edition::Searchable
+
   include Edition::SocialMediaAccounts
   include Edition::Organisations
   include Edition::Roles
   include Edition::WorldLocations
+
   include Attachable
 
   has_many :pages, class_name: "WorldwideOrganisationPage", foreign_key: :edition_id, dependent: :destroy, autosave: true

--- a/app/models/publicationesque.rb
+++ b/app/models/publicationesque.rb
@@ -8,6 +8,8 @@
 #
 # @abstract
 class Publicationesque < Edition
+  include Edition::Searchable
+
   include Edition::HasDocumentCollections
   include Edition::Organisations
   include Edition::TaggableOrganisations

--- a/app/validators/unmodifiable_validator.rb
+++ b/app/validators/unmodifiable_validator.rb
@@ -1,0 +1,26 @@
+class UnmodifiableValidator < ActiveModel::Validator
+  def validate(record)
+    significant_changed_attributes(record).each do |attribute|
+      record.errors.add(attribute, "cannot be modified when edition is in the #{record.state} state")
+    end
+  end
+
+  def significant_changed_attributes(record)
+    record.changed - modifiable_attributes(record.state_was, record.state)
+  end
+
+  def modifiable_attributes(previous_state, current_state)
+    modifiable = %w[state updated_at force_published]
+    if previous_state == "scheduled"
+      modifiable += %w[major_change_published_at first_published_at access_limited]
+    end
+    if Edition::PRE_PUBLICATION_STATES.include?(previous_state) || being_unpublished?(previous_state, current_state)
+      modifiable += %w[published_major_version published_minor_version]
+    end
+    modifiable
+  end
+
+  def being_unpublished?(previous_state, current_state)
+    previous_state == "published" && %w[unpublished withdrawn].include?(current_state)
+  end
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -313,6 +313,9 @@ en:
       research:
         one: Research
         other: Research
+      searchable_edition:
+        one: Searchable edition
+        other: Searchable editions
       service:
         one: Service
         other: Services

--- a/test/factories/editions.rb
+++ b/test/factories/editions.rb
@@ -87,7 +87,9 @@ FactoryBot.define do
       force_published { false }
       published_major_version { 1 }
       published_minor_version { 0 }
-      after :create, &:refresh_index_if_required
+      after :create do |edition|
+        edition.refresh_index_if_required if edition.can_index_in_search?
+      end
     end
 
     trait(:non_english) { primary_locale { "cy" } }
@@ -99,7 +101,9 @@ FactoryBot.define do
       force_published { true }
       published_major_version { 1 }
       published_minor_version { 0 }
-      after :create, &:refresh_index_if_required
+      after :create do |edition|
+        edition.refresh_index_if_required if edition.can_index_in_search?
+      end
     end
 
     trait(:deleted) { state { "deleted" } }

--- a/test/factories/searchable_editions.rb
+++ b/test/factories/searchable_editions.rb
@@ -1,0 +1,9 @@
+require_relative "../support/searchable_edition"
+
+FactoryBot.define do
+  factory :searchable_edition, class: SearchableEdition, parent: :edition
+
+  factory :published_searchable_edition, parent: :searchable_edition, traits: [:published]
+  factory :withdrawn_searchable_edition, parent: :searchable_edition, traits: [:withdrawn]
+  factory :submitted_searchable_edition, parent: :searchable_edition, traits: [:submitted]
+end

--- a/test/support/searchable_edition.rb
+++ b/test/support/searchable_edition.rb
@@ -1,0 +1,5 @@
+require_relative "./generic_edition"
+
+class SearchableEdition < GenericEdition
+  include Edition::Searchable
+end

--- a/test/unit/app/helpers/admin/republishing_helper_test.rb
+++ b/test/unit/app/helpers/admin/republishing_helper_test.rb
@@ -112,6 +112,7 @@ def content_types
                                     WorldwideOffice
                                     WorldwideOrganisation],
     test_specific: %w[GenericEdition
+                      SearchableEdition
                       Edition::AlternativeFormatProviderTest::EditionWithAlternativeFormat
                       Edition::AppointmentTest::EditionWithAppointment
                       Edition::EditionableWorldwideOrganisationTest::EditionWithWorldwideOrganisations

--- a/test/unit/app/models/edition/appointment_test.rb
+++ b/test/unit/app/models/edition/appointment_test.rb
@@ -2,6 +2,7 @@ require "test_helper"
 
 class Edition::AppointmentTest < ActiveSupport::TestCase
   class EditionWithAppointment < Edition
+    include ::Edition::Searchable
     include ::Edition::Appointment
 
     def search_link

--- a/test/unit/app/models/edition/searchable_test.rb
+++ b/test/unit/app/models/edition/searchable_test.rb
@@ -2,12 +2,12 @@ require "test_helper"
 
 class Edition::SearchableTest < ActiveSupport::TestCase
   test "should return search index suitable for Searchable when published" do
-    edition = create(:published_edition, title: "edition-title")
+    edition = create(:published_searchable_edition, title: "edition-title")
 
     assert_equal "edition-title", edition.search_index["title"]
     assert_equal edition.public_path, edition.search_index["link"]
     assert_equal edition.body, edition.search_index["indexable_content"]
-    assert_equal "generic_edition", edition.search_index["format"]
+    assert_equal "searchable_edition", edition.search_index["format"]
     assert_equal edition.summary, edition.search_index["description"]
     assert_equal edition.id, edition.search_index["id"]
     assert_nil edition.search_index["latest_change_note"]
@@ -22,12 +22,12 @@ class Edition::SearchableTest < ActiveSupport::TestCase
   end
 
   test "should return search index suitable for Searchable when withdrawn" do
-    edition = create(:withdrawn_edition, title: "edition-title")
+    edition = create(:withdrawn_searchable_edition, title: "edition-title")
 
     assert_equal "edition-title", edition.search_index["title"]
     assert_equal edition.public_path, edition.search_index["link"]
     assert_equal edition.body, edition.search_index["indexable_content"]
-    assert_equal "generic_edition", edition.search_index["format"]
+    assert_equal "searchable_edition", edition.search_index["format"]
     assert_equal edition.summary, edition.search_index["description"]
     assert_equal edition.id, edition.search_index["id"]
     assert_nil edition.search_index["latest_change_note"]
@@ -42,18 +42,18 @@ class Edition::SearchableTest < ActiveSupport::TestCase
   end
 
   test "#indexable_content should return the body without markup by default" do
-    edition = create(:published_edition, body: "# header\n\nsome text")
+    edition = create(:published_searchable_edition, body: "# header\n\nsome text")
     assert_equal "header some text", edition.indexable_content
   end
 
   test "should use the result of #indexable_content for the content of #search_index" do
-    edition = create(:published_edition, title: "edition-title")
+    edition = create(:published_searchable_edition, title: "edition-title")
     edition.stubs(:indexable_content).returns("some augmented searchable content")
     assert_equal "some augmented searchable content", edition.search_index["indexable_content"]
   end
 
   test "should add edition to search index on publishing" do
-    edition = create(:submitted_edition)
+    edition = create(:submitted_searchable_edition)
     stub_publishing_api_registration_for(edition)
     SearchApiPresenters.stubs(:searchable_classes).returns([edition.class])
     Whitehall::SearchIndex.expects(:add).with(edition)
@@ -62,7 +62,7 @@ class Edition::SearchableTest < ActiveSupport::TestCase
   end
 
   test "should add edition to search index on withdrawing" do
-    edition = create(:published_edition)
+    edition = create(:published_searchable_edition)
 
     Whitehall::PublishingApi.stubs(:publish_withdrawal_async)
 
@@ -76,7 +76,7 @@ class Edition::SearchableTest < ActiveSupport::TestCase
 
   test "should add latest change note to search index" do
     user  = create(:gds_editor)
-    first = create(:published_edition)
+    first = create(:published_searchable_edition)
 
     major = first.create_draft(user)
     major.change_note = "This was a major change"
@@ -87,7 +87,7 @@ class Edition::SearchableTest < ActiveSupport::TestCase
 
   test "should not add edition to search index if it is not available in English" do
     I18n.locale = :fr
-    french_edition = create(:submitted_edition, title: "French Title", body: "French Body", primary_locale: :fr)
+    french_edition = create(:submitted_searchable_edition, title: "French Title", body: "French Body", primary_locale: :fr)
     stub_publishing_api_registration_for(french_edition)
     I18n.locale = I18n.default_locale
     SearchApiPresenters.stubs(:searchable_classes).returns([french_edition.class])
@@ -97,7 +97,7 @@ class Edition::SearchableTest < ActiveSupport::TestCase
   end
 
   test "should not remove edition from search index when a new edition is published" do
-    edition = create(:published_edition)
+    edition = create(:published_searchable_edition)
 
     Whitehall::SearchIndex.expects(:delete).with(edition).never
 
@@ -107,7 +107,7 @@ class Edition::SearchableTest < ActiveSupport::TestCase
   end
 
   test "should not remove edition from search index when a published edition is withdran" do
-    edition = create(:published_edition)
+    edition = create(:published_searchable_edition)
 
     Whitehall::SearchIndex.expects(:delete).with(edition).never
 
@@ -117,7 +117,7 @@ class Edition::SearchableTest < ActiveSupport::TestCase
   end
 
   test "should remove published edition from search index when it's unpublished" do
-    edition = create(:published_edition)
+    edition = create(:published_searchable_edition)
     create(:unpublishing, edition:)
 
     Whitehall::SearchIndex.expects(:delete).with(edition)

--- a/test/unit/app/models/edition_test.rb
+++ b/test/unit/app/models/edition_test.rb
@@ -454,7 +454,7 @@ class EditionTest < ActiveSupport::TestCase
   end
 
   test "search_format_types tags the edtion as an edition" do
-    edition = build(:edition)
+    edition = build(:searchable_edition)
     assert edition.search_format_types.include?("edition")
   end
 
@@ -501,7 +501,10 @@ class EditionTest < ActiveSupport::TestCase
     )
     create(:draft_publication, title: "draft-publication-title", body: "bits and bobs")
 
-    result_titles = Edition.search_index.to_a.map { |r| r["title"] }
+    result_titles = [
+      NewsArticle.search_index.to_a,
+      Publication.search_index.to_a,
+    ].flatten.map { |r| r["title"] }
 
     assert_equal %w[news_article-title publication-title], result_titles
   end

--- a/test/unit/lib/data_hygiene/document_reslugger_test.rb
+++ b/test/unit/lib/data_hygiene/document_reslugger_test.rb
@@ -5,7 +5,7 @@ class DocumentResluggerTest < ActiveSupport::TestCase
     stub_any_publishing_api_call
     @user = create(:user)
     @document = create(:document, slug: "old-slug", document_type: "news_article")
-    @published_edition = create(:edition, :published)
+    @published_edition = create(:searchable_edition, :published)
   end
 
   test "updates the slug to the new slug, updated the publishing API, reindexes the slug on search index and creates an EditorialRemark" do


### PR DESCRIPTION
This does a bit of tidying up of the Edition model, as well as moves the Search behaviour to a Concern. This will allow the Edition model to be inherited without having to override the search functionality if we don't want to include an Edition's content in search results. 

I've been experimenting with a couple of things, including making a "Lite Edition" as documented in https://github.com/alphagov/whitehall/blob/edition-refactoring/docs/adr/0003-introduce-reusable-content-items.md, but I kept coming across issues with existing relations, which were tricky to get around and would result in messy workarounds. This seemed like the cleanest solution available.

Thoughts welcome!