### PR TITLE
Improve unique title error message

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -493,7 +493,7 @@ private
   end
 
   def construct_similar_slug_warning_error
-    @edition.errors.add(:title, "is already used on GOV.UK. Please create a unique title") if show_similar_slugs_warning?(@edition)
+    @edition.errors.add(:title, "has been used before on GOV.UK, although the page may no longer exist. Please use another title") if show_similar_slugs_warning?(@edition)
   end
 
   def updater

--- a/app/views/admin/editions/show/_sidebar_notices.html.erb
+++ b/app/views/admin/editions/show/_sidebar_notices.html.erb
@@ -21,7 +21,7 @@
   <% end %>
   <% if show_similar_slugs_warning?(@edition) %>
     <%= render "components/inset_prompt", {
-      description: "This title is already used on GOV.UK. Please create a unique title.",
+      description: "This title has been used before on GOV.UK, although the page may no longer exist. Please use another title.",
       error: true,
     } %>
   <% end %>

--- a/test/functional/admin/generic_editions_controller_test.rb
+++ b/test/functional/admin/generic_editions_controller_test.rb
@@ -89,7 +89,7 @@ class Admin::GenericEditionsControllerTest < ActionController::TestCase
 
     get :edit, params: { id: edition_with_same_title }
 
-    assert_select ".govuk-error-summary a", text: "Title is already used on GOV.UK. Please create a unique title", href: "#edition_title"
+    assert_select ".govuk-error-summary a", text: "Title has been used before on GOV.UK, although the page may no longer exist. Please use another title", href: "#edition_title"
   end
 
   view_test "GET :show renders preview link if publically visible and change note is present" do


### PR DESCRIPTION
This change is intended to make it clearer to users that they may not be able to find the document that has a similar slug, and that they should use a different title anyway.

This should reduce the likelihood of users opening support tickets when they are unable to find a document with a similar title.

Zendesk ticket: https://govuk.zendesk.com/agent/tickets/5853617
