### PR TITLE
Update Publishing API in more predictable order when toggling reshuffle mode

### DIFF
--- a/app/controllers/admin/cabinet_ministers_controller.rb
+++ b/app/controllers/admin/cabinet_ministers_controller.rb
@@ -17,7 +17,7 @@ class Admin::CabinetMinistersController < Admin::BaseController
 
   def order_cabinet_minister_roles
     MinisterialRole.reorder_without_callbacks!(order_ministerial_roles_params, :seniority)
-    republish_ministers_index_page_to_publishing_api
+    patch_links_ministers_index_page_to_publishing_api
 
     redirect_to admin_cabinet_ministers_path(anchor: "cabinet_minister")
   end
@@ -28,7 +28,7 @@ class Admin::CabinetMinistersController < Admin::BaseController
 
   def order_also_attends_cabinet_roles
     MinisterialRole.reorder_without_callbacks!(order_ministerial_roles_params, :seniority)
-    republish_ministers_index_page_to_publishing_api
+    patch_links_ministers_index_page_to_publishing_api
 
     redirect_to admin_cabinet_ministers_path(anchor: "also_attends_cabinet")
   end
@@ -39,7 +39,7 @@ class Admin::CabinetMinistersController < Admin::BaseController
 
   def order_whip_roles
     MinisterialRole.reorder_without_callbacks!(order_ministerial_roles_params, :whip_ordering)
-    republish_ministers_index_page_to_publishing_api
+    patch_links_ministers_index_page_to_publishing_api
 
     redirect_to admin_cabinet_ministers_path(anchor: "whips")
   end
@@ -50,7 +50,7 @@ class Admin::CabinetMinistersController < Admin::BaseController
 
   def order_ministerial_organisations
     Organisation.reorder_without_callbacks!(order_ministerial_organisations_params, :ministerial_ordering)
-    republish_ministers_index_page_to_publishing_api
+    patch_links_ministers_index_page_to_publishing_api
 
     redirect_to admin_cabinet_ministers_path(anchor: "organisations")
   end

--- a/app/models/concerns/reshuffle_mode.rb
+++ b/app/models/concerns/reshuffle_mode.rb
@@ -2,8 +2,8 @@ module ReshuffleMode
   extend ActiveSupport::Concern
 
   included do
-    def republish_ministers_index_page_to_publishing_api
-      PresentPageToPublishingApiWorker.perform_async("PublishingApi::MinistersIndexPresenter", update_live?)
+    def patch_links_ministers_index_page_to_publishing_api
+      PatchLinksPublishingApiWorker.perform_async("PublishingApi::MinistersIndexPresenter")
     end
 
     def republish_how_government_works_page_to_publishing_api

--- a/app/models/concerns/reshuffle_mode.rb
+++ b/app/models/concerns/reshuffle_mode.rb
@@ -2,11 +2,6 @@ module ReshuffleMode
   extend ActiveSupport::Concern
 
   included do
-    def republish_ministerial_pages_to_publishing_api
-      PresentPageToPublishingApiWorker.perform_async("PublishingApi::HowGovernmentWorksPresenter", update_live?)
-      PresentPageToPublishingApiWorker.perform_async("PublishingApi::MinistersIndexPresenter", update_live?)
-    end
-
     def republish_ministers_index_page_to_publishing_api
       PresentPageToPublishingApiWorker.perform_async("PublishingApi::MinistersIndexPresenter", update_live?)
     end

--- a/app/models/concerns/reshuffle_mode.rb
+++ b/app/models/concerns/reshuffle_mode.rb
@@ -7,15 +7,15 @@ module ReshuffleMode
     end
 
     def republish_how_government_works_page_to_publishing_api
-      PresentPageToPublishingApiWorker.perform_async("PublishingApi::HowGovernmentWorksPresenter", update_live?)
+      if reshuffle_in_progress?
+        PresentPageToPublishingApiWorker.perform_async("PublishingApi::HowGovernmentWorksEnableReshufflePresenter")
+      else
+        PresentPageToPublishingApiWorker.perform_async("PublishingApi::HowGovernmentWorksPresenter")
+      end
     end
 
     def reshuffle_in_progress?
       SitewideSetting.find_by(key: :minister_reshuffle_mode)&.on || false
     end
-  end
-
-  def update_live?
-    !reshuffle_in_progress?
   end
 end

--- a/app/models/ministerial_role.rb
+++ b/app/models/ministerial_role.rb
@@ -7,7 +7,7 @@ class MinisterialRole < Role
   has_many :news_articles, -> { where("editions.type" => "NewsArticle").distinct }, through: :role_appointments
   has_many :speeches, through: :role_appointments
 
-  after_save :republish_ministers_index_page_to_publishing_api, :republish_how_government_works_page_to_publishing_api
+  after_save :patch_links_ministers_index_page_to_publishing_api, :republish_how_government_works_page_to_publishing_api
 
   def published_speeches(options = {})
     speeches

--- a/app/models/ministerial_role.rb
+++ b/app/models/ministerial_role.rb
@@ -7,7 +7,7 @@ class MinisterialRole < Role
   has_many :news_articles, -> { where("editions.type" => "NewsArticle").distinct }, through: :role_appointments
   has_many :speeches, through: :role_appointments
 
-  after_save :republish_ministerial_pages_to_publishing_api
+  after_save :republish_ministers_index_page_to_publishing_api, :republish_how_government_works_page_to_publishing_api
 
   def published_speeches(options = {})
     speeches

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -208,9 +208,9 @@ class Organisation < ApplicationRecord
   before_destroy { |r| throw :abort unless r.destroyable? }
   after_save :ensure_analytics_identifier
   after_save :republish_how_government_works_page_to_publishing_api, :republish_organisations_index_page_to_publishing_api
-  after_save :republish_ministers_index_page_to_publishing_api, if: :ministerial_department?
+  after_save :patch_links_ministers_index_page_to_publishing_api, if: :ministerial_department?
   after_destroy :republish_organisations_index_page_to_publishing_api
-  after_destroy :republish_ministers_index_page_to_publishing_api, if: :ministerial_department?
+  after_destroy :patch_links_ministers_index_page_to_publishing_api, if: :ministerial_department?
 
   after_save do
     # If the organisation has an about us page and the chart URL changes we need

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -39,7 +39,7 @@ class Person < ApplicationRecord
 
   before_destroy :prevent_destruction_if_appointed
   after_update :touch_role_appointments, :republish_past_prime_ministers_page_to_publishing_api
-  after_update :republish_ministers_index_page_to_publishing_api, :republish_how_government_works_page_to_publishing_api, if: :has_ministerial_appointments?
+  after_update :patch_links_ministers_index_page_to_publishing_api, :republish_how_government_works_page_to_publishing_api, if: :has_ministerial_appointments?
 
   def biography_without_markup
     Govspeak::Document.new(biography).to_text

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -39,7 +39,7 @@ class Person < ApplicationRecord
 
   before_destroy :prevent_destruction_if_appointed
   after_update :touch_role_appointments, :republish_past_prime_ministers_page_to_publishing_api
-  after_update :republish_ministerial_pages_to_publishing_api, if: :has_ministerial_appointments?
+  after_update :republish_ministers_index_page_to_publishing_api, :republish_how_government_works_page_to_publishing_api, if: :has_ministerial_appointments?
 
   def biography_without_markup
     Govspeak::Document.new(biography).to_text

--- a/app/models/role_appointment.rb
+++ b/app/models/role_appointment.rb
@@ -74,7 +74,7 @@ class RoleAppointment < ApplicationRecord
   after_create :make_other_current_appointments_non_current
   before_destroy :prevent_destruction_unless_destroyable
 
-  after_save :republish_ministerial_pages_to_publishing_api, if: :ministerial?
+  after_save :republish_ministers_index_page_to_publishing_api, :republish_how_government_works_page_to_publishing_api, if: :ministerial?
   after_save :republish_associated_editions_to_publishing_api, :republish_organisation_to_publishing_api, :republish_worldwide_organisations_to_publishing_api, :republish_prime_ministers_index_page_to_publishing_api, :republish_role_to_publishing_api
   after_destroy :republish_associated_editions_to_publishing_api, :republish_organisation_to_publishing_api, :republish_worldwide_organisations_to_publishing_api, :republish_prime_ministers_index_page_to_publishing_api, :republish_role_to_publishing_api
 

--- a/app/models/role_appointment.rb
+++ b/app/models/role_appointment.rb
@@ -74,7 +74,7 @@ class RoleAppointment < ApplicationRecord
   after_create :make_other_current_appointments_non_current
   before_destroy :prevent_destruction_unless_destroyable
 
-  after_save :republish_ministers_index_page_to_publishing_api, :republish_how_government_works_page_to_publishing_api, if: :ministerial?
+  after_save :patch_links_ministers_index_page_to_publishing_api, :republish_how_government_works_page_to_publishing_api, if: :ministerial?
   after_save :republish_associated_editions_to_publishing_api, :republish_organisation_to_publishing_api, :republish_worldwide_organisations_to_publishing_api, :republish_prime_ministers_index_page_to_publishing_api, :republish_role_to_publishing_api
   after_destroy :republish_associated_editions_to_publishing_api, :republish_organisation_to_publishing_api, :republish_worldwide_organisations_to_publishing_api, :republish_prime_ministers_index_page_to_publishing_api, :republish_role_to_publishing_api
 

--- a/app/models/sitewide_setting.rb
+++ b/app/models/sitewide_setting.rb
@@ -17,17 +17,33 @@ class SitewideSetting < ApplicationRecord
   def republish_downstream_if_reshuffle
     return unless key == "minister_reshuffle_mode"
 
-    update_live = true
+    ministers_index = PublishingApi::MinistersIndexPresenter.new
     if on
       # These have to be sent synchronously so we can guarantee the order in which they're processed.
-      # First, send 'page is currently being updated' message to Draft and promote to Live
-      PresentPageToPublishingApiWorker.new.perform("PublishingApi::HowGovernmentWorksEnableReshufflePresenter", update_live)
-      PresentPageToPublishingApiWorker.new.perform("PublishingApi::MinistersIndexEnableReshufflePresenter", update_live)
-      # Finally, send normal ministers index payload to draft so that we can use it as a preview
-      PresentPageToPublishingApiWorker.new.perform("PublishingApi::MinistersIndexPresenter", false)
+      # First, send 'page is currently being updated' message to draft stack
+      Services.publishing_api.put_content(
+        ministers_index.content_id,
+        PublishingApi::MinistersIndexEnableReshufflePresenter.new.content,
+      )
+      # Then promote what's on draft, to live
+      Services.publishing_api.publish(ministers_index.content_id, nil, locale: ministers_index.content[:locale])
+
+      # Then, send normal ministers index payload to draft so that we can use it as a preview
+      Services.publishing_api.put_content(ministers_index.content_id, ministers_index.content)
+      # We're now done with the ministers index page. There is no 'patch links' step required here
+      # as we're only changing body content.
+      #
+      # Finally, we'll republish the How Government Works page, to remove the number of ministers
+      # section. There's no need to maintain separate draft/live versions of this page, so we
+      # can just use the normal worker.
+      PresentPageToPublishingApiWorker.perform_async("PublishingApi::HowGovernmentWorksEnableReshufflePresenter")
     else
-      PresentPageToPublishingApiWorker.perform_async("PublishingApi::HowGovernmentWorksPresenter", update_live)
-      PresentPageToPublishingApiWorker.perform_async("PublishingApi::MinistersIndexPresenter", update_live)
+      # Whatever is on the draft stack, let's publish to the live stack
+      Services.publishing_api.publish(ministers_index.content_id, nil, locale: ministers_index.content[:locale])
+
+      # Republish How Government Works page (needs link patching, putting to draft and promoting
+      # to live, so use the worker)
+      PresentPageToPublishingApiWorker.perform_async("PublishingApi::HowGovernmentWorksPresenter")
     end
   end
 end

--- a/app/workers/patch_links_publishing_api_worker.rb
+++ b/app/workers/patch_links_publishing_api_worker.rb
@@ -1,0 +1,5 @@
+class PatchLinksPublishingApiWorker < WorkerBase
+  def perform(presenter)
+    PresentPageToPublishingApi.new.patch_links(presenter.constantize)
+  end
+end

--- a/app/workers/present_page_to_publishing_api_worker.rb
+++ b/app/workers/present_page_to_publishing_api_worker.rb
@@ -1,9 +1,5 @@
 class PresentPageToPublishingApiWorker < WorkerBase
-  def perform(presenter, update_live = true)
-    if update_live
-      PresentPageToPublishingApi.new.publish(presenter.constantize)
-    else
-      PresentPageToPublishingApi.new.save_draft(presenter.constantize)
-    end
+  def perform(presenter)
+    PresentPageToPublishingApi.new.publish(presenter.constantize)
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -90,7 +90,7 @@ if WorldLocation.where(name: "Test International Delegation").blank?
     Person.skip_callback(:commit, :after, :publish_to_publishing_api)
     RoleAppointment.skip_callback(:commit, :after, :publish_to_publishing_api)
     RoleAppointment.skip_callback(:save, :after, :republish_prime_ministers_index_page_to_publishing_api)
-    RoleAppointment.skip_callback(:save, :after, :republish_ministers_index_page_to_publishing_api)
+    RoleAppointment.skip_callback(:save, :after, :patch_links_ministers_index_page_to_publishing_api)
     RoleAppointment.skip_callback(:save, :after, :republish_how_government_works_page_to_publishing_api)
     HistoricalAccount.skip_callback(:commit, :after, :publish_to_publishing_api)
     HistoricalAccount.skip_callback(:save, :after, :republish_prime_ministers_index_page_to_publishing_api)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -90,7 +90,8 @@ if WorldLocation.where(name: "Test International Delegation").blank?
     Person.skip_callback(:commit, :after, :publish_to_publishing_api)
     RoleAppointment.skip_callback(:commit, :after, :publish_to_publishing_api)
     RoleAppointment.skip_callback(:save, :after, :republish_prime_ministers_index_page_to_publishing_api)
-    RoleAppointment.skip_callback(:save, :after, :republish_ministerial_pages_to_publishing_api)
+    RoleAppointment.skip_callback(:save, :after, :republish_ministers_index_page_to_publishing_api)
+    RoleAppointment.skip_callback(:save, :after, :republish_how_government_works_page_to_publishing_api)
     HistoricalAccount.skip_callback(:commit, :after, :publish_to_publishing_api)
     HistoricalAccount.skip_callback(:save, :after, :republish_prime_ministers_index_page_to_publishing_api)
 

--- a/lib/present_page_to_publishing_api.rb
+++ b/lib/present_page_to_publishing_api.rb
@@ -6,6 +6,11 @@ class PresentPageToPublishingApi
     Services.publishing_api.publish(payload.content_id, nil, locale: payload.content[:locale])
   end
 
+  def patch_links(presenter_class)
+    payload = presenter_class.new
+    Services.publishing_api.patch_links(payload.content_id, links: payload.links)
+  end
+
   def save_draft(presenter_class)
     payload = presenter_class.new
     Services.publishing_api.put_content(payload.content_id, payload.content)

--- a/lib/present_page_to_publishing_api.rb
+++ b/lib/present_page_to_publishing_api.rb
@@ -10,10 +10,4 @@ class PresentPageToPublishingApi
     payload = presenter_class.new
     Services.publishing_api.patch_links(payload.content_id, links: payload.links)
   end
-
-  def save_draft(presenter_class)
-    payload = presenter_class.new
-    Services.publishing_api.put_content(payload.content_id, payload.content)
-    Services.publishing_api.patch_links(payload.content_id, links: payload.links)
-  end
 end

--- a/test/functional/admin/cabinet_ministers_controller_test.rb
+++ b/test/functional/admin/cabinet_ministers_controller_test.rb
@@ -11,13 +11,13 @@ class Admin::CabinetMinistersControllerTest < ActionController::TestCase
     @organisation ||= create(:organisation)
   end
 
-  test "PATCH :order_cabinet_minister_roles should reorder ministerial roles and republish the ministers index page" do
+  test "PATCH :order_cabinet_minister_roles should reorder ministerial roles and patches the ministers index page" do
     role2 = create(:ministerial_role, name: "Non-Executive Director", cabinet_member: true, organisations: [organisation])
     role1 = create(:ministerial_role, name: "Prime Minister", cabinet_member: true, organisations: [organisation])
 
     service = mock
     PresentPageToPublishingApi.expects(:new).returns(service)
-    service.expects(:publish).with(PublishingApi::MinistersIndexPresenter)
+    service.expects(:patch_links).with(PublishingApi::MinistersIndexPresenter)
 
     Sidekiq::Testing.inline! do
       patch :order_cabinet_minister_roles,
@@ -35,13 +35,13 @@ class Admin::CabinetMinistersControllerTest < ActionController::TestCase
     assert_redirected_to admin_cabinet_ministers_path(anchor: "cabinet_minister")
   end
 
-  test "PATCH :order_also_attends_cabinet_roles should reorder people who also attend cabinet and republish the ministers index page" do
+  test "PATCH :order_also_attends_cabinet_roles should reorder people who also attend cabinet and patches the ministers index page" do
     role2 = create(:ministerial_role, name: "Chief Whip and Parliamentary Secretary to the Treasury", attends_cabinet_type_id: 2, organisations: [organisation])
     role1 = create(:ministerial_role, name: "Minister without Portfolio", attends_cabinet_type_id: 1, organisations: [organisation])
 
     service = mock
     PresentPageToPublishingApi.expects(:new).returns(service)
-    service.expects(:publish).with(PublishingApi::MinistersIndexPresenter)
+    service.expects(:patch_links).with(PublishingApi::MinistersIndexPresenter)
 
     Sidekiq::Testing.inline! do
       patch :order_also_attends_cabinet_roles,
@@ -59,13 +59,13 @@ class Admin::CabinetMinistersControllerTest < ActionController::TestCase
     assert_redirected_to admin_cabinet_ministers_path(anchor: "also_attends_cabinet")
   end
 
-  test "PATCH :order_whip_roles should reorder whips and republish the ministers index page" do
+  test "PATCH :order_whip_roles should reorder whips and patches the ministers index page" do
     role2 = create(:ministerial_role, name: "Whip 1", whip_organisation_id: 2, organisations: [organisation])
     role1 = create(:ministerial_role, name: "Whip 2", whip_organisation_id: 2, organisations: [organisation])
 
     service = mock
     PresentPageToPublishingApi.expects(:new).returns(service)
-    service.expects(:publish).with(PublishingApi::MinistersIndexPresenter)
+    service.expects(:patch_links).with(PublishingApi::MinistersIndexPresenter)
 
     Sidekiq::Testing.inline! do
       patch :order_whip_roles,
@@ -84,13 +84,13 @@ class Admin::CabinetMinistersControllerTest < ActionController::TestCase
     assert_redirected_to admin_cabinet_ministers_path(anchor: "whips")
   end
 
-  test "PATCH :order_ministerial_organisations should reorder ministerial organisations and republish the ministers index page" do
+  test "PATCH :order_ministerial_organisations should reorder ministerial organisations and patches the ministers index page" do
     org2 = create(:organisation)
     org1 = create(:organisation)
 
     service = mock
     PresentPageToPublishingApi.expects(:new).returns(service)
-    service.expects(:publish).with(PublishingApi::MinistersIndexPresenter)
+    service.expects(:patch_links).with(PublishingApi::MinistersIndexPresenter)
 
     Sidekiq::Testing.inline! do
       put :order_ministerial_organisations,

--- a/test/unit/app/models/ministerial_role_test.rb
+++ b/test/unit/app/models/ministerial_role_test.rb
@@ -92,7 +92,7 @@ class MinisterialRoleTest < ActiveSupport::TestCase
     create(:ministerial_role_appointment, role:)
 
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::HowGovernmentWorksPresenter)
-    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::MinistersIndexPresenter)
+    PresentPageToPublishingApi.any_instance.expects(:patch_links).with(PublishingApi::MinistersIndexPresenter)
 
     Sidekiq::Testing.inline! do
       role.update(name: "New name")

--- a/test/unit/app/models/organisation_test.rb
+++ b/test/unit/app/models/organisation_test.rb
@@ -1120,7 +1120,7 @@ class OrganisationTest < ActiveSupport::TestCase
 
   test "should send related pages to publishing api when a ministerial department is created" do
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::HowGovernmentWorksPresenter)
-    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::MinistersIndexPresenter)
+    PresentPageToPublishingApi.any_instance.expects(:patch_links).with(PublishingApi::MinistersIndexPresenter)
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::OrganisationsIndexPresenter)
 
     Sidekiq::Testing.inline! do
@@ -1132,7 +1132,7 @@ class OrganisationTest < ActiveSupport::TestCase
     organisation = create(:ministerial_department)
 
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::HowGovernmentWorksPresenter)
-    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::MinistersIndexPresenter)
+    PresentPageToPublishingApi.any_instance.expects(:patch_links).with(PublishingApi::MinistersIndexPresenter)
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::OrganisationsIndexPresenter)
 
     Sidekiq::Testing.inline! do
@@ -1143,7 +1143,7 @@ class OrganisationTest < ActiveSupport::TestCase
   test "should send related pages to publishing api when a ministerial department is deleted" do
     organisation = create(:ministerial_department)
 
-    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::MinistersIndexPresenter)
+    PresentPageToPublishingApi.any_instance.expects(:patch_links).with(PublishingApi::MinistersIndexPresenter)
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::OrganisationsIndexPresenter)
 
     Sidekiq::Testing.inline! do

--- a/test/unit/app/models/person_test.rb
+++ b/test/unit/app/models/person_test.rb
@@ -245,7 +245,7 @@ class PersonTest < ActiveSupport::TestCase
     create(:ministerial_role_appointment, person:)
 
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::HowGovernmentWorksPresenter)
-    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::MinistersIndexPresenter)
+    PresentPageToPublishingApi.any_instance.expects(:patch_links).with(PublishingApi::MinistersIndexPresenter)
 
     Sidekiq::Testing.inline! do
       person.update(forename: "New first name")
@@ -258,7 +258,7 @@ class PersonTest < ActiveSupport::TestCase
     create(:role_appointment, person:, role:)
 
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::HowGovernmentWorksPresenter).never
-    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::MinistersIndexPresenter).never
+    PresentPageToPublishingApi.any_instance.expects(:patch_links).with(PublishingApi::MinistersIndexPresenter).never
 
     Sidekiq::Testing.inline! do
       person.update(forename: "New first name")
@@ -271,7 +271,7 @@ class PersonTest < ActiveSupport::TestCase
 
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::HistoricalAccountsIndexPresenter)
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::HowGovernmentWorksPresenter)
-    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::MinistersIndexPresenter)
+    PresentPageToPublishingApi.any_instance.expects(:patch_links).with(PublishingApi::MinistersIndexPresenter)
 
     Sidekiq::Testing.inline! do
       person.update(forename: "New first name")
@@ -285,7 +285,7 @@ class PersonTest < ActiveSupport::TestCase
 
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::HistoricalAccountsIndexPresenter)
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::HowGovernmentWorksPresenter)
-    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::MinistersIndexPresenter)
+    PresentPageToPublishingApi.any_instance.expects(:patch_links).with(PublishingApi::MinistersIndexPresenter)
 
     Sidekiq::Testing.inline! do
       person.update(forename: "New first name")

--- a/test/unit/app/models/reshuffle_mode_test.rb
+++ b/test/unit/app/models/reshuffle_mode_test.rb
@@ -20,19 +20,11 @@ class ReshuffleModeTest < ActiveSupport::TestCase
     end
   end
 
-  describe "#republish_ministers_index_page_to_publishing_api" do
-    it "republishes the 'Ministers Index' page" do
-      PresentPageToPublishingApiWorker.expects(:perform_async).with("PublishingApi::MinistersIndexPresenter", true).once
+  describe "#patch_links_ministers_index_page_to_publishing_api" do
+    it "patches links on the 'Ministers Index' page" do
+      PatchLinksPublishingApiWorker.expects(:perform_async).with("PublishingApi::MinistersIndexPresenter").once
 
-      ClassThatIncludesReshuffleMode.new.republish_ministers_index_page_to_publishing_api
-    end
-
-    it "only saves to the draft stack when reshuffle mode is switched on" do
-      PresentPageToPublishingApiWorker.expects(:perform_async).with("PublishingApi::MinistersIndexPresenter", false).once
-
-      reshuffle_mode = ClassThatIncludesReshuffleMode.new
-      reshuffle_mode.stubs(:reshuffle_in_progress?).returns(true)
-      reshuffle_mode.republish_ministers_index_page_to_publishing_api
+      ClassThatIncludesReshuffleMode.new.patch_links_ministers_index_page_to_publishing_api
     end
   end
 

--- a/test/unit/app/models/reshuffle_mode_test.rb
+++ b/test/unit/app/models/reshuffle_mode_test.rb
@@ -30,13 +30,13 @@ class ReshuffleModeTest < ActiveSupport::TestCase
 
   describe "#republish_how_government_works_page_to_publishing_api" do
     it "republishes the 'How Government Works' page" do
-      PresentPageToPublishingApiWorker.expects(:perform_async).with("PublishingApi::HowGovernmentWorksPresenter", true).once
+      PresentPageToPublishingApiWorker.expects(:perform_async).with("PublishingApi::HowGovernmentWorksPresenter").once
 
       ClassThatIncludesReshuffleMode.new.republish_how_government_works_page_to_publishing_api
     end
 
-    it "only saves to the draft stack when reshuffle mode is switched on" do
-      PresentPageToPublishingApiWorker.expects(:perform_async).with("PublishingApi::HowGovernmentWorksPresenter", false).once
+    it "publishes the 'reshuffle presenter' version when reshuffle mode is on" do
+      PresentPageToPublishingApiWorker.expects(:perform_async).with("PublishingApi::HowGovernmentWorksEnableReshufflePresenter").once
 
       reshuffle_mode = ClassThatIncludesReshuffleMode.new
       reshuffle_mode.stubs(:reshuffle_in_progress?).returns(true)

--- a/test/unit/app/models/reshuffle_mode_test.rb
+++ b/test/unit/app/models/reshuffle_mode_test.rb
@@ -20,24 +20,6 @@ class ReshuffleModeTest < ActiveSupport::TestCase
     end
   end
 
-  describe "#republish_ministerial_pages_to_publishing_api" do
-    it "republishes 'How Government Works' and 'Ministers Index' pages" do
-      PresentPageToPublishingApiWorker.expects(:perform_async).with("PublishingApi::HowGovernmentWorksPresenter", true).once
-      PresentPageToPublishingApiWorker.expects(:perform_async).with("PublishingApi::MinistersIndexPresenter", true).once
-
-      ClassThatIncludesReshuffleMode.new.republish_ministerial_pages_to_publishing_api
-    end
-
-    it "only saves to the draft stack when reshuffle mode is switched on" do
-      PresentPageToPublishingApiWorker.expects(:perform_async).with("PublishingApi::HowGovernmentWorksPresenter", false).once
-      PresentPageToPublishingApiWorker.expects(:perform_async).with("PublishingApi::MinistersIndexPresenter", false).once
-
-      reshuffle_mode = ClassThatIncludesReshuffleMode.new
-      reshuffle_mode.stubs(:reshuffle_in_progress?).returns(true)
-      reshuffle_mode.republish_ministerial_pages_to_publishing_api
-    end
-  end
-
   describe "#republish_ministers_index_page_to_publishing_api" do
     it "republishes the 'Ministers Index' page" do
       PresentPageToPublishingApiWorker.expects(:perform_async).with("PublishingApi::MinistersIndexPresenter", true).once

--- a/test/unit/app/models/role_appointment_test.rb
+++ b/test/unit/app/models/role_appointment_test.rb
@@ -440,7 +440,7 @@ class RoleAppointmentTest < ActiveSupport::TestCase
     role_appointment = create(:role_appointment, person: create(:person), role:)
 
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::HowGovernmentWorksPresenter)
-    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::MinistersIndexPresenter)
+    PresentPageToPublishingApi.any_instance.expects(:patch_links).with(PublishingApi::MinistersIndexPresenter)
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::HistoricalAccountsIndexPresenter)
 
     Sidekiq::Testing.inline! do
@@ -452,7 +452,7 @@ class RoleAppointmentTest < ActiveSupport::TestCase
     role = create(:prime_minister_role)
 
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::HowGovernmentWorksPresenter)
-    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::MinistersIndexPresenter)
+    PresentPageToPublishingApi.any_instance.expects(:patch_links).with(PublishingApi::MinistersIndexPresenter)
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::HistoricalAccountsIndexPresenter).never
 
     Sidekiq::Testing.inline! do
@@ -472,7 +472,7 @@ class RoleAppointmentTest < ActiveSupport::TestCase
                                  role:)
 
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::HowGovernmentWorksPresenter)
-    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::MinistersIndexPresenter)
+    PresentPageToPublishingApi.any_instance.expects(:patch_links).with(PublishingApi::MinistersIndexPresenter)
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::HistoricalAccountsIndexPresenter).never
 
     Sidekiq::Testing.inline! do
@@ -485,7 +485,7 @@ class RoleAppointmentTest < ActiveSupport::TestCase
     create(:prime_minister_role)
 
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::HowGovernmentWorksPresenter)
-    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::MinistersIndexPresenter)
+    PresentPageToPublishingApi.any_instance.expects(:patch_links).with(PublishingApi::MinistersIndexPresenter)
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::HistoricalAccountsIndexPresenter).never
 
     Sidekiq::Testing.inline! do
@@ -497,7 +497,7 @@ class RoleAppointmentTest < ActiveSupport::TestCase
     role = create(:prime_minister_role)
 
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::HowGovernmentWorksPresenter)
-    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::MinistersIndexPresenter)
+    PresentPageToPublishingApi.any_instance.expects(:patch_links).with(PublishingApi::MinistersIndexPresenter)
 
     Sidekiq::Testing.inline! do
       create(:role_appointment, person: create(:person), role:)
@@ -508,7 +508,7 @@ class RoleAppointmentTest < ActiveSupport::TestCase
     role = create(:ministerial_role)
 
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::HowGovernmentWorksPresenter)
-    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::MinistersIndexPresenter)
+    PresentPageToPublishingApi.any_instance.expects(:patch_links).with(PublishingApi::MinistersIndexPresenter)
 
     Sidekiq::Testing.inline! do
       create(:role_appointment, person: create(:person), role:)
@@ -519,7 +519,7 @@ class RoleAppointmentTest < ActiveSupport::TestCase
     role = create(:non_ministerial_role_without_organisations)
 
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::HowGovernmentWorksPresenter).never
-    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::MinistersIndexPresenter).never
+    PresentPageToPublishingApi.any_instance.expects(:patch_links).with(PublishingApi::MinistersIndexPresenter).never
 
     Sidekiq::Testing.inline! do
       create(:role_appointment, person: create(:person), role:)

--- a/test/unit/app/models/sitewide_setting_test.rb
+++ b/test/unit/app/models/sitewide_setting_test.rb
@@ -1,14 +1,17 @@
 require "test_helper"
 
 class SitewideSettingTest < ActiveSupport::TestCase
+  def setup
+    @content_id = "324e4708-2285-40a0-b3aa-cb13af14ec5f"
+  end
+
   test "enabling reshuffle mode republishes custom ministers index and how government work pages" do
     setting = create(:sitewide_setting, key: :minister_reshuffle_mode, on: true)
 
-    mock_worker = mock
-    PresentPageToPublishingApiWorker.stubs(:new).returns(mock_worker)
-    mock_worker.expects(:perform).with("PublishingApi::HowGovernmentWorksEnableReshufflePresenter", true).once
-    mock_worker.expects(:perform).with("PublishingApi::MinistersIndexEnableReshufflePresenter", true).once
-    mock_worker.expects(:perform).with("PublishingApi::MinistersIndexPresenter", false).once
+    Services.publishing_api.expects(:put_content).with(@content_id, PublishingApi::MinistersIndexEnableReshufflePresenter.new.content).once
+    Services.publishing_api.expects(:publish).with(@content_id, nil, locale: "en").once
+    Services.publishing_api.expects(:put_content).with(@content_id, PublishingApi::MinistersIndexPresenter.new.content).once
+    PresentPageToPublishingApiWorker.expects(:perform_async).with("PublishingApi::HowGovernmentWorksEnableReshufflePresenter").once
 
     setting.republish_downstream_if_reshuffle
   end
@@ -16,8 +19,8 @@ class SitewideSettingTest < ActiveSupport::TestCase
   test "disabling reshuffle mode republishes ministers index and how government work pages" do
     setting = create(:sitewide_setting, key: :minister_reshuffle_mode, on: false)
 
-    PresentPageToPublishingApiWorker.expects(:perform_async).with("PublishingApi::HowGovernmentWorksPresenter", true).once
-    PresentPageToPublishingApiWorker.expects(:perform_async).with("PublishingApi::MinistersIndexPresenter", true).once
+    PresentPageToPublishingApiWorker.expects(:perform_async).with("PublishingApi::HowGovernmentWorksPresenter").once
+    Services.publishing_api.expects(:publish).with(@content_id, nil, locale: "en").once
 
     setting.republish_downstream_if_reshuffle
   end

--- a/test/unit/app/workers/patch_links_publishing_api_worker_test.rb
+++ b/test/unit/app/workers/patch_links_publishing_api_worker_test.rb
@@ -1,0 +1,12 @@
+require "test_helper"
+
+class PatchLinksPublishingApiWorkerTest < ActiveSupport::TestCase
+  test "instantiates an instance of PresentPageToPublishingApi and calls #patch_links" do
+    service = mock
+    PresentPageToPublishingApi.expects(:new).returns(service)
+
+    service.expects(:patch_links).with(PublishingApi::HowGovernmentWorksPresenter)
+
+    PatchLinksPublishingApiWorker.new.perform("PublishingApi::HowGovernmentWorksPresenter")
+  end
+end

--- a/test/unit/app/workers/present_page_to_publishing_api_worker_test.rb
+++ b/test/unit/app/workers/present_page_to_publishing_api_worker_test.rb
@@ -9,13 +9,4 @@ class PresentPageToPublishingApiWorkerTest < ActiveSupport::TestCase
 
     PresentPageToPublishingApiWorker.new.perform("PublishingApi::HowGovernmentWorksPresenter")
   end
-
-  test "calls `save_draft` method when `update_live` parameter is false" do
-    service = mock
-    PresentPageToPublishingApi.expects(:new).returns(service)
-
-    service.expects(:save_draft).with(PublishingApi::HowGovernmentWorksPresenter)
-
-    PresentPageToPublishingApiWorker.new.perform("PublishingApi::HowGovernmentWorksPresenter", false)
-  end
 end

--- a/test/unit/lib/data_hygiene/role_reslugger_test.rb
+++ b/test/unit/lib/data_hygiene/role_reslugger_test.rb
@@ -41,9 +41,7 @@ class MinisterialRoleResluggerTest < ActiveSupport::TestCase
       stub_publishing_api_put_content(PublishingApi::HowGovernmentWorksPresenter.new.content_id, PublishingApi::HowGovernmentWorksPresenter.new.content),
       stub_publishing_api_patch_links(PublishingApi::HowGovernmentWorksPresenter.new.content_id, links: PublishingApi::HowGovernmentWorksPresenter.new.links),
       stub_publishing_api_publish(PublishingApi::HowGovernmentWorksPresenter.new.content_id, locale: "en", update_type: nil),
-      stub_publishing_api_put_content(PublishingApi::MinistersIndexPresenter.new.content_id, PublishingApi::MinistersIndexPresenter.new.content),
       stub_publishing_api_patch_links(PublishingApi::MinistersIndexPresenter.new.content_id, links: PublishingApi::MinistersIndexPresenter.new.links),
-      stub_publishing_api_publish(PublishingApi::MinistersIndexPresenter.new.content_id, locale: "en", update_type: nil),
     ]
 
     Sidekiq::Testing.inline! do

--- a/test/unit/lib/present_page_to_publishing_api_test.rb
+++ b/test/unit/lib/present_page_to_publishing_api_test.rb
@@ -37,12 +37,6 @@ class PresentPageToPublishingApiTest < ActiveSupport::TestCase
     end
   end
 
-  describe "#save_draft" do
-    it "saves the operation index page to publishing api draft stack" do
-      assert_content_is_presented_to_publishing_api_draft_stack(PublishingApi::OperationalFieldsIndexPresenter)
-    end
-  end
-
   def assert_content_is_presented_to_publishing_api(presenter_class, locale: "en")
     presenter = presenter_class.new
     expected_content = presenter.content
@@ -52,16 +46,5 @@ class PresentPageToPublishingApiTest < ActiveSupport::TestCase
     Services.publishing_api.expects(:publish).with(presenter.content_id, nil, locale:)
 
     PresentPageToPublishingApi.new.publish(presenter_class)
-  end
-
-  def assert_content_is_presented_to_publishing_api_draft_stack(presenter_class, locale: "en")
-    presenter = presenter_class.new
-    expected_content = presenter.content
-
-    Services.publishing_api.expects(:put_content).with(presenter.content_id, expected_content).once
-    Services.publishing_api.expects(:patch_links).with(presenter.content_id, links: presenter.links).once
-    Services.publishing_api.expects(:publish).with(presenter.content_id, nil, locale:).never
-
-    PresentPageToPublishingApi.new.save_draft(presenter_class)
   end
 end

--- a/test/unit/lib/present_page_to_publishing_api_test.rb
+++ b/test/unit/lib/present_page_to_publishing_api_test.rb
@@ -27,6 +27,16 @@ class PresentPageToPublishingApiTest < ActiveSupport::TestCase
     end
   end
 
+  describe "#patch_links" do
+    it "patches links" do
+      presenter_class = PublishingApi::OperationalFieldsIndexPresenter
+
+      Services.publishing_api.expects(:patch_links).with(presenter_class.new.content_id, links: presenter_class.new.links)
+
+      PresentPageToPublishingApi.new.patch_links(presenter_class)
+    end
+  end
+
   describe "#save_draft" do
     it "saves the operation index page to publishing api draft stack" do
       assert_content_is_presented_to_publishing_api_draft_stack(PublishingApi::OperationalFieldsIndexPresenter)


### PR DESCRIPTION
This PR does two things:

- Makes the calls to Publishing API more specific and synchronous when toggling reshuffle mode, to minimise any risk of hitting a race condition whereby the republishes happen out of order (which could mean continuing to show the ministers index page when we actually want to show a maintenance message, or visa versa). This is all in the penultimate commit.
- Introduces a new `PatchLinksPublishingApiWorker` which simplifies some of the callback code surrounding the ministers index page. It is enqueued when ministers are reordered, so that we can async patch the ministers index page, and stop putting/publishing the page (which are effectively no-op operations).

Tested on Integration.

Trello: https://trello.com/c/w0L32BNJ/2692-investigate-race-condition-on-ministers-order-page

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
