### PR TITLE
Temporarily allow managing editors to edit historical documents

### DIFF
--- a/lib/whitehall/authority/rules/edition_rules.rb
+++ b/lib/whitehall/authority/rules/edition_rules.rb
@@ -54,7 +54,7 @@ module Whitehall::Authority::Rules
       elsif !can_see?
         false
       elsif action != :see && @subject.historic?
-        actor.gds_editor? || actor.gds_admin?
+        actor.gds_editor? || actor.gds_admin? || actor.managing_editor?
       elsif action == :unpublish && actor.managing_editor?
         true
       elsif action == :unwithdraw && actor.managing_editor?

--- a/test/functional/admin/generic_editions_controller_tests/political_document_test.rb
+++ b/test/functional/admin/generic_editions_controller_tests/political_document_test.rb
@@ -45,10 +45,10 @@ class Admin::GenericEditionsController::PolticalDocumentsTest < ActionController
     assert_response :redirect
   end
 
-  view_test "doesn't let managing editors edit historic documents" do
+  view_test "lets managing editors edit historic documents" do
     login_as :managing_editor
     edit_historic_document
-    assert_response :redirect
+    assert_response :success
   end
 
   view_test "lets GDS editors edit historic documents" do

--- a/test/unit/lib/whitehall/authority/managing_editor_test.rb
+++ b/test/unit/lib/whitehall/authority/managing_editor_test.rb
@@ -194,11 +194,11 @@ class ManagingEditorTest < ActiveSupport::TestCase
     assert enforcer_for(managing_editor, normal_edition).can?(:mark_political)
   end
 
-  test "cannot modify historic editions" do
-    assert_not enforcer_for(managing_editor, historic_edition).can?(:modify)
+  test "can modify historic editions" do
+    assert enforcer_for(managing_editor, historic_edition).can?(:modify)
   end
 
-  test "cannot publish historic editions" do
-    assert_not enforcer_for(managing_editor, historic_edition).can?(:publish)
+  test "can publish historic editions" do
+    assert enforcer_for(managing_editor, historic_edition).can?(:publish)
   end
 end


### PR DESCRIPTION
This has been requested by the Election Team. Previously, Content Support has received a lot of requests to change content that is locked down to GDS admins, and they would like to allow Managing Editors to do this themselves.

Reinstates [code taken out](https://github.com/alphagov/whitehall/pull/5220) after the last election. 

[Trello](https://trello.com/c/urxv8kbR/2679-temporarily-remove-restriction-on-who-can-edit-content-in-history-mode)