### PR TITLE
Add GA4 tracking handler to visual editor events

### DIFF
--- a/app/assets/javascripts/admin/modules/ga4-visual-editor-event-handlers.js
+++ b/app/assets/javascripts/admin/modules/ga4-visual-editor-event-handlers.js
@@ -1,0 +1,29 @@
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {}
+;(function (Modules) {
+  const gaSelectChangeAttributes = function (selectText) {
+    return {
+      event_name: 'select_content',
+      type: 'select',
+      text: selectText,
+      section: document.title.split(' - ')[0],
+      action: selectText,
+      tool_name: 'Visual Editor'
+    }
+  }
+
+  function Ga4VisualEditorEventHandlers(module) {
+    this.module = module
+  }
+
+  Ga4VisualEditorEventHandlers.prototype.init = function () {
+    this.module.addEventListener('visualEditorSelectChange', (event) => {
+      window.GOVUK.analyticsGa4.core.applySchemaAndSendData(
+        gaSelectChangeAttributes(event.detail.selectText),
+        'event_data'
+      )
+    })
+  }
+
+  Modules.Ga4VisualEditorEventHandlers = Ga4VisualEditorEventHandlers
+})(window.GOVUK.Modules)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -17,6 +17,7 @@
 //= require admin/modules/app-analytics
 //= require admin/modules/document-history-paginator
 //= require admin/modules/ga4-button-setup
+//= require admin/modules/ga4-visual-editor-event-handlers
 //= require admin/modules/locale-switcher
 //= require admin/modules/navbar-toggle
 //= require admin/modules/paste-html-to-govspeak

--- a/app/helpers/admin/editions_helper.rb
+++ b/app/helpers/admin/editions_helper.rb
@@ -93,7 +93,7 @@ module Admin::EditionsHelper
   end
 
   def standard_edition_form(edition)
-    form_for form_url_for_edition(edition), as: :edition, html: { class: edition_form_classes(edition), multipart: true }, data: { module: "EditionForm LocaleSwitcher Ga4ButtonSetup", "rtl-locales": Locale.right_to_left.collect(&:to_param) } do |form|
+    form_for form_url_for_edition(edition), as: :edition, html: { class: edition_form_classes(edition), multipart: true }, data: { module: "EditionForm LocaleSwitcher Ga4ButtonSetup Ga4VisualEditorEventHandlers", "rtl-locales": Locale.right_to_left.collect(&:to_param) } do |form|
       concat render("standard_fields", form:, edition:)
       yield(form)
       concat render("settings_fields", form:, edition:)

--- a/app/views/admin/attachments/_form.html.erb
+++ b/app/views/admin/attachments/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for attachment, url: [:admin, typecast_for_attachable_routing(attachable), attachment.becomes(Attachment)], as: :attachment, html: { :class => "app-view-attachments__form", data: { module: "LocaleSwitcher Ga4ButtonSetup", "rtl-locales": Locale.right_to_left.collect(&:to_param) }}, multipart: true do |form| %>
+<%= form_for attachment, url: [:admin, typecast_for_attachable_routing(attachable), attachment.becomes(Attachment)], as: :attachment, html: { :class => "app-view-attachments__form", data: { module: "LocaleSwitcher Ga4ButtonSetup Ga4VisualEditorEventHandlers", "rtl-locales": Locale.right_to_left.collect(&:to_param) }}, multipart: true do |form| %>
   <div class="govuk-!-margin-bottom-8 app-view-attachments__form-title js-locale-switcher-field">
     <%= render "govuk_publishing_components/components/input", {
       label: {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "accessible-autocomplete": "alphagov/accessible-autocomplete-multiselect",
     "choices.js": "^10.2.0",
     "cropperjs": "^1.6.2",
-    "govspeak-visual-editor": "^1.3.0",
+    "govspeak-visual-editor": "^1.4.0",
     "miller-columns-element": "^2.0.0",
     "paste-html-to-govspeak": "^0.4.0"
   },

--- a/spec/javascripts/admin/modules/ga4-visual-editor-event-handlers.spec.js
+++ b/spec/javascripts/admin/modules/ga4-visual-editor-event-handlers.spec.js
@@ -1,0 +1,38 @@
+describe('GOVUK.Modules.Ga4VisualEditorEventHandlers', function () {
+  it('triggers ga4 tracking on visualEditorSelectChange event', function () {
+    document.title = 'Title - Text'
+    const select = document.createElement('select')
+    document.body.appendChild(select)
+
+    const mockGa4SendData = spyOn(
+      window.GOVUK.analyticsGa4.core,
+      'applySchemaAndSendData'
+    )
+
+    const ga4VisualEditorEventHandlers =
+      new GOVUK.Modules.Ga4VisualEditorEventHandlers(document)
+    ga4VisualEditorEventHandlers.init()
+    select.dispatchEvent(
+      new CustomEvent('visualEditorSelectChange', {
+        bubbles: true,
+        detail: {
+          selectText: 'DROPDOWN'
+        }
+      })
+    )
+
+    const expectedAttributes = {
+      event_name: 'select_content',
+      type: 'select',
+      text: 'DROPDOWN',
+      section: 'Title',
+      action: 'DROPDOWN',
+      tool_name: 'Visual Editor'
+    }
+
+    expect(mockGa4SendData).toHaveBeenCalledWith(
+      expectedAttributes,
+      'event_data'
+    )
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1514,19 +1514,19 @@ gopd@^1.0.1:
   dependencies:
     get-intrinsic "^1.1.3"
 
-govspeak-visual-editor@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/govspeak-visual-editor/-/govspeak-visual-editor-1.3.0.tgz#90877265945a7a3fece26babc60d241a64806122"
-  integrity sha512-HfhOjQzS1EwCStThWJmWh44xj5o7pDn62kCSA1tMq6ra+Y5DKYhHmnu5fVI196cPDz2dPzLB7Yy8R3NMxDKnyA==
+govspeak-visual-editor@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/govspeak-visual-editor/-/govspeak-visual-editor-1.4.0.tgz#66e15aa028c17fec60772d362821fe3b388d1394"
+  integrity sha512-1p1yoJOyAfU0ZuHOZquOhEe2UaJKkuwbzMNHH6yMTgnmuPOdMQ8eP71FZvqO3tFygvpibCZFPrcnDotDgHoPog==
   dependencies:
     govuk-frontend "^4.8.0"
     prosemirror-example-setup "^1.2.2"
     prosemirror-keymap "^1.2.2"
-    prosemirror-markdown "^1.11.2"
+    prosemirror-markdown "^1.13.0"
     prosemirror-model "^1.19.3"
     prosemirror-state "^1.4.3"
     prosemirror-transform "^1.8.0"
-    prosemirror-view "^1.32.1"
+    prosemirror-view "^1.33.8"
 
 govuk-frontend@^4.8.0:
   version "4.8.0"
@@ -2691,13 +2691,13 @@ prosemirror-keymap@^1.0.0, prosemirror-keymap@^1.2.2:
     prosemirror-state "^1.0.0"
     w3c-keyname "^2.2.0"
 
-prosemirror-markdown@^1.11.2:
-  version "1.12.0"
-  resolved "https://registry.yarnpkg.com/prosemirror-markdown/-/prosemirror-markdown-1.12.0.tgz#d2de09d37897abf7adb6293d925ff132dac5b0a6"
-  integrity sha512-6F5HS8Z0HDYiS2VQDZzfZP6A0s/I0gbkJy8NCzzDMtcsz3qrfqyroMMeoSjAmOhDITyon11NbXSzztfKi+frSQ==
+prosemirror-markdown@^1.13.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/prosemirror-markdown/-/prosemirror-markdown-1.13.0.tgz#67ebfa40af48a22d1e4ed6cad2e29851eb61e649"
+  integrity sha512-UziddX3ZYSYibgx8042hfGKmukq5Aljp2qoBiJRejD/8MH70siQNz5RB1TrdTPheqLMy4aCe4GYNF10/3lQS5g==
   dependencies:
     markdown-it "^14.0.0"
-    prosemirror-model "^1.0.0"
+    prosemirror-model "^1.20.0"
 
 prosemirror-menu@^1.0.0:
   version "1.2.4"
@@ -2713,6 +2713,13 @@ prosemirror-model@^1.0.0, prosemirror-model@^1.16.0, prosemirror-model@^1.19.3:
   version "1.19.4"
   resolved "https://registry.yarnpkg.com/prosemirror-model/-/prosemirror-model-1.19.4.tgz#e45e84480c97dd3922095dbe579e1c98c86c0704"
   integrity sha512-RPmVXxUfOhyFdayHawjuZCxiROsm9L4FCUA6pWI+l7n2yCBsWy9VpdE1hpDHUS8Vad661YLY9AzqfjLhAKQ4iQ==
+  dependencies:
+    orderedmap "^2.0.0"
+
+prosemirror-model@^1.20.0:
+  version "1.21.1"
+  resolved "https://registry.yarnpkg.com/prosemirror-model/-/prosemirror-model-1.21.1.tgz#023b804cfc7942bc9b3104e65f59b18bf18514c6"
+  integrity sha512-IVBAuMqOfltTr7yPypwpfdGT+6rGAteVOw2FO6GEvCGGa1ZwxLseqC1Eax/EChDvG/xGquB2d/hLdgh3THpsYg==
   dependencies:
     orderedmap "^2.0.0"
 
@@ -2741,12 +2748,21 @@ prosemirror-transform@^1.0.0, prosemirror-transform@^1.1.0, prosemirror-transfor
   dependencies:
     prosemirror-model "^1.0.0"
 
-prosemirror-view@^1.0.0, prosemirror-view@^1.1.0, prosemirror-view@^1.27.0, prosemirror-view@^1.31.0, prosemirror-view@^1.32.1:
+prosemirror-view@^1.0.0, prosemirror-view@^1.1.0, prosemirror-view@^1.27.0, prosemirror-view@^1.31.0:
   version "1.32.7"
   resolved "https://registry.yarnpkg.com/prosemirror-view/-/prosemirror-view-1.32.7.tgz#b9c4e8471daeba79489befa59eaeaeb4cd2e2653"
   integrity sha512-pvxiOoD4shW41X5bYDjRQk3DSG4fMqxh36yPMt7VYgU3dWRmqFzWJM/R6zeo1KtC8nyk717ZbQND3CC9VNeptw==
   dependencies:
     prosemirror-model "^1.16.0"
+    prosemirror-state "^1.0.0"
+    prosemirror-transform "^1.1.0"
+
+prosemirror-view@^1.33.8:
+  version "1.33.8"
+  resolved "https://registry.yarnpkg.com/prosemirror-view/-/prosemirror-view-1.33.8.tgz#cfd76dff421730cbca0b6ea40ce36994daaeda41"
+  integrity sha512-4PhMr/ufz2cdvFgpUAnZfs+0xij3RsFysreeG9V/utpwX7AJtYCDVyuRxzWoMJIEf4C7wVihuBNMPpFLPCiLQw==
+  dependencies:
+    prosemirror-model "^1.20.0"
     prosemirror-state "^1.0.0"
     prosemirror-transform "^1.1.0"
 


### PR DESCRIPTION
Trigger a GA4 tracking event when the select dropdowns on the Visual Editor toolbar changes value.

Tested on integration
![image (11)](https://github.com/alphagov/whitehall/assets/568730/46125785-4c8f-4e13-93ef-8418aa9b03e6)


https://trello.com/c/R7GujwJ3/2684-add-ga4-tracking-to-dropdowns-in-the-toolbar

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
