### PR TITLE
Add GA4 tracking on page load

### DIFF
--- a/app/assets/javascripts/admin/modules/ga4-page-view-tracking.js
+++ b/app/assets/javascripts/admin/modules/ga4-page-view-tracking.js
@@ -1,0 +1,14 @@
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {}
+;(function (Modules) {
+  function GA4PageViewTracking(module) {
+    this.module = module
+  }
+
+  GA4PageViewTracking.prototype.init = function () {
+    this.trackingData = this.module.getAttribute('data-attributes')
+    window.GOVUK.analyticsGa4.core.sendData(JSON.parse(this.trackingData))
+  }
+
+  Modules.GA4PageViewTracking = GA4PageViewTracking
+})(window.GOVUK.Modules)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -18,6 +18,7 @@
 //= require admin/modules/document-history-paginator
 //= require admin/modules/ga4-button-setup
 //= require admin/modules/ga4-visual-editor-event-handlers
+//= require admin/modules/ga4-page-view-tracking
 //= require admin/modules/locale-switcher
 //= require admin/modules/navbar-toggle
 //= require admin/modules/paste-html-to-govspeak

--- a/app/helpers/admin/analytics_helper.rb
+++ b/app/helpers/admin/analytics_helper.rb
@@ -8,5 +8,18 @@ module Admin
         "track-label" => ActionController::Base.helpers.strip_tags(label),
       }
     end
+
+    def track_analytics_data_on_load(title)
+      {
+        event_name: "page_view",
+        page_view: {
+          government_department_name: "Government Digital Service",
+          access_level: current_user&.permissions,
+          publishing_app: "Whitehall",
+          user_created_at: current_user&.created_at&.to_date,
+          document_type: title,
+        },
+      }.to_json
+    end
   end
 end

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -9,13 +9,16 @@
   <% end %>
 <% end %>
 
+<% sanitized_title = sanitize((yield(:page_title).presence || yield(:title))) %>
+
 <%= render "govuk_publishing_components/components/layout_for_admin",
            product_name: "Whitehall Publisher",
            environment: environment,
-           browser_title: ("Error: " if yield(:error_summary).present?).to_s + sanitize((yield(:page_title).presence || yield(:title))) do %>
+           browser_title: ("Error: " if yield(:error_summary).present?).to_s + sanitized_title do %>
 
   <!-- This element exists to initialise the JS module that configures custom Universal Analytics behaviour -->
   <div data-module="app-analytics"></div>
+  <div data-module="GA4PageViewTracking" data-attributes='<%= track_analytics_data_on_load(sanitized_title) %>'></div>
 
   <%= render "govuk_publishing_components/components/skip_link" %>
 


### PR DESCRIPTION
Sending user and page data to GA4, on page load.

[Trello](https://trello.com/c/R7Bl3Y8n/2693-ga4-add-attributes-tracking-on-page-load)