### PR TITLE
Revert "Remove empty ministerial roles from drag and drop"

### DIFF
--- a/app/controllers/admin/cabinet_ministers_controller.rb
+++ b/app/controllers/admin/cabinet_ministers_controller.rb
@@ -5,14 +5,14 @@ class Admin::CabinetMinistersController < Admin::BaseController
   helper_method :reshuffle_in_progress?
 
   def show
-    @cabinet_minister_roles = MinisterialRole.ministerial_roles_with_current_appointments
-    @also_attends_cabinet_roles = MinisterialRole.also_attends_cabinet_roles
-    @whip_roles = MinisterialRole.whip_roles
+    @cabinet_minister_roles = MinisterialRole.includes(:translations).where(cabinet_member: true).order(:seniority)
+    @also_attends_cabinet_roles = MinisterialRole.includes(:translations).also_attends_cabinet.order(:seniority)
+    @whip_roles = MinisterialRole.includes(:translations).whip.order(:whip_ordering)
     @organisations = Organisation.ministerial_departments.excluding_govuk_status_closed.order(:ministerial_ordering)
   end
 
   def reorder_cabinet_minister_roles
-    @roles = MinisterialRole.ministerial_roles_with_current_appointments
+    @roles = MinisterialRole.includes(:translations).where(cabinet_member: true).order(:seniority)
   end
 
   def order_cabinet_minister_roles

--- a/app/models/ministerial_role.rb
+++ b/app/models/ministerial_role.rb
@@ -7,9 +7,6 @@ class MinisterialRole < Role
   has_many :news_articles, -> { where("editions.type" => "NewsArticle").distinct }, through: :role_appointments
   has_many :speeches, through: :role_appointments
 
-  scope :cabinet_members,
-        -> { where(cabinet_member: true) }
-
   after_save :republish_ministerial_pages_to_publishing_api
 
   def published_speeches(options = {})
@@ -28,18 +25,6 @@ class MinisterialRole < Role
 
   def self.cabinet
     where(cabinet_member: true).alphabetical_by_person
-  end
-
-  def self.ministerial_roles_with_current_appointments
-    includes(:translations).cabinet_members.order(:seniority).joins(:role_appointments)
-  end
-
-  def self.also_attends_cabinet_roles
-    includes(:translations).also_attends_cabinet.order(:seniority)
-  end
-
-  def self.whip_roles
-    includes(:translations).whip.order(:whip_ordering)
   end
 
   def ministerial?

--- a/features/cabinet-ministers.feature
+++ b/features/cabinet-ministers.feature
@@ -17,7 +17,7 @@ Feature: Reordering of Cabinet ministers and Organisations
     Then I should not see a preview link to the ministers index page
 
   Scenario: Reordering Cabinet ministers
-    Given there are multiple Cabinet minister roles with appointments
+    Given there are multiple Cabinet minister roles
     When I visit the Cabinet ministers order page
     And I click the reorder link in the "#cabinet_minister" tab
     And I set the order of the roles to:

--- a/features/step_definitions/cabinet_ministers_steps.rb
+++ b/features/step_definitions/cabinet_ministers_steps.rb
@@ -14,13 +14,10 @@ Then(/^I should not see a preview link to the ministers index page$/) do
   expect(page).to_not have_selector(".govuk-link[data-track-action=ministers-index-page-button]")
 end
 
-Given(/^there are multiple Cabinet minister roles with appointments$/) do
+Given(/^there are multiple Cabinet minister roles$/) do
   organisation = create(:organisation)
-  person = create(:person, forename: "Tony")
-  minister_role1 = create(:ministerial_role, name: "Role 1", cabinet_member: true, organisations: [organisation], seniority: 0)
-  minister_role2 = create(:ministerial_role, name: "Role 2", cabinet_member: true, organisations: [organisation], seniority: 1)
-  create(:role_appointment, role: minister_role1, person:)
-  create(:role_appointment, role: minister_role2, person:)
+  create(:ministerial_role, name: "Role 1", cabinet_member: true, organisations: [organisation], seniority: 0)
+  create(:ministerial_role, name: "Role 2", cabinet_member: true, organisations: [organisation], seniority: 1)
 end
 
 When(/^I click the reorder link in the "([^"]*)" tab$/) do |tab|

--- a/test/functional/admin/cabinet_ministers_controller_test.rb
+++ b/test/functional/admin/cabinet_ministers_controller_test.rb
@@ -108,13 +108,9 @@ class Admin::CabinetMinistersControllerTest < ActionController::TestCase
     assert_redirected_to admin_cabinet_ministers_path(anchor: "organisations")
   end
 
-  view_test "should list appointed cabinet ministers and ministerial organisations in separate tabs, in the correct order, with reorder links" do
-    person = create(:person, forename: "Tony")
+  view_test "should list cabinet ministers and ministerial organisations in separate tabs, in the correct order, with reorder links" do
     minister1 = create(:ministerial_role, name: "Non-Executive Director", cabinet_member: true, organisations: [organisation], seniority: 1)
     minister2 = create(:ministerial_role, name: "Prime Minister", cabinet_member: true, organisations: [organisation], seniority: 0)
-    # roles without a current appointment will not show in the list
-    create(:role_appointment, role: minister1, person:)
-    create(:role_appointment, role: minister2, person:)
 
     also_attends_cabinet1 = create(:ministerial_role, name: "Chief Whip and Parliamentary Secretary to the Treasury", attends_cabinet_type_id: 2, organisations: [organisation], seniority: 1)
     also_attends_cabinet2 = create(:ministerial_role, name: "Minister without Portfolio", attends_cabinet_type_id: 1, organisations: [organisation], seniority: 0)
@@ -134,11 +130,8 @@ class Admin::CabinetMinistersControllerTest < ActionController::TestCase
   end
 
   view_test "GET :reorder_cabinet_minister_roles should assign roles correctly and the cancel_path should have the correct anchor" do
-    person = create(:person, forename: "Tony")
     minister1 = create(:ministerial_role, name: "Non-Executive Director", cabinet_member: true, organisations: [organisation], seniority: 1)
     minister2 = create(:ministerial_role, name: "Prime Minister", cabinet_member: true, organisations: [organisation], seniority: 0)
-    create(:role_appointment, role: minister1, person:)
-    create(:role_appointment, role: minister2, person:)
 
     get :reorder_cabinet_minister_roles
 


### PR DESCRIPTION
Reverts alphagov/whitehall#9176

This was causing a lot of duplicate roles to appear.

Trello: https://trello.com/c/Yl4ZZBc2/2690-remove-empty-roles-from-drag-and-drop-ministers-list