### PR TITLE
Remove empty ministerial roles

### DIFF
--- a/app/controllers/admin/cabinet_ministers_controller.rb
+++ b/app/controllers/admin/cabinet_ministers_controller.rb
@@ -5,14 +5,14 @@ class Admin::CabinetMinistersController < Admin::BaseController
   helper_method :reshuffle_in_progress?
 
   def show
-    @cabinet_minister_roles = MinisterialRole.includes(:translations).where(cabinet_member: true).order(:seniority)
+    @cabinet_minister_roles = MinisterialRole.ministerial_roles_with_current_appointments
     @also_attends_cabinet_roles = MinisterialRole.includes(:translations).also_attends_cabinet.order(:seniority)
     @whip_roles = MinisterialRole.includes(:translations).whip.order(:whip_ordering)
     @organisations = Organisation.ministerial_departments.excluding_govuk_status_closed.order(:ministerial_ordering)
   end
 
   def reorder_cabinet_minister_roles
-    @roles = MinisterialRole.includes(:translations).where(cabinet_member: true).order(:seniority)
+    @roles = MinisterialRole.ministerial_roles_with_current_appointments
   end
 
   def order_cabinet_minister_roles

--- a/app/controllers/admin/cabinet_ministers_controller.rb
+++ b/app/controllers/admin/cabinet_ministers_controller.rb
@@ -6,8 +6,8 @@ class Admin::CabinetMinistersController < Admin::BaseController
 
   def show
     @cabinet_minister_roles = MinisterialRole.ministerial_roles_with_current_appointments
-    @also_attends_cabinet_roles = MinisterialRole.includes(:translations).also_attends_cabinet.order(:seniority)
-    @whip_roles = MinisterialRole.includes(:translations).whip.order(:whip_ordering)
+    @also_attends_cabinet_roles = MinisterialRole.also_attends_cabinet_roles
+    @whip_roles = MinisterialRole.whip_roles
     @organisations = Organisation.ministerial_departments.excluding_govuk_status_closed.order(:ministerial_ordering)
   end
 
@@ -23,7 +23,7 @@ class Admin::CabinetMinistersController < Admin::BaseController
   end
 
   def reorder_also_attends_cabinet_roles
-    @roles = MinisterialRole.includes(:translations).also_attends_cabinet.order(:seniority)
+    @roles = MinisterialRole.also_attends_cabinet_roles
   end
 
   def order_also_attends_cabinet_roles
@@ -34,7 +34,7 @@ class Admin::CabinetMinistersController < Admin::BaseController
   end
 
   def reorder_whip_roles
-    @roles = MinisterialRole.includes(:translations).whip.order(:whip_ordering)
+    @roles = MinisterialRole.whip_roles
   end
 
   def order_whip_roles

--- a/app/models/ministerial_role.rb
+++ b/app/models/ministerial_role.rb
@@ -30,6 +30,18 @@ class MinisterialRole < Role
     where(cabinet_member: true).alphabetical_by_person
   end
 
+  def self.ministerial_roles_with_current_appointments
+    includes(:translations).cabinet_members.order(:seniority).joins(:current_role_appointments)
+  end
+
+  def self.also_attends_cabinet_roles
+    includes(:translations).also_attends_cabinet.order(:seniority)
+  end
+
+  def self.whip_roles
+    includes(:translations).whip.order(:whip_ordering)
+  end
+
   def ministerial?
     true
   end

--- a/app/models/ministerial_role.rb
+++ b/app/models/ministerial_role.rb
@@ -9,6 +9,9 @@ class MinisterialRole < Role
 
   after_save :patch_links_ministers_index_page_to_publishing_api, :republish_how_government_works_page_to_publishing_api
 
+  scope :cabinet_members,
+        -> { where(cabinet_member: true) }
+
   def published_speeches(options = {})
     speeches
       .live_edition.published

--- a/features/cabinet-ministers.feature
+++ b/features/cabinet-ministers.feature
@@ -17,7 +17,7 @@ Feature: Reordering of Cabinet ministers and Organisations
     Then I should not see a preview link to the ministers index page
 
   Scenario: Reordering Cabinet ministers
-    Given there are multiple Cabinet minister roles
+    Given there are multiple Cabinet minister roles with active appointments
     When I visit the Cabinet ministers order page
     And I click the reorder link in the "#cabinet_minister" tab
     And I set the order of the roles to:

--- a/features/step_definitions/cabinet_ministers_steps.rb
+++ b/features/step_definitions/cabinet_ministers_steps.rb
@@ -14,10 +14,13 @@ Then(/^I should not see a preview link to the ministers index page$/) do
   expect(page).to_not have_selector(".govuk-link[data-track-action=ministers-index-page-button]")
 end
 
-Given(/^there are multiple Cabinet minister roles$/) do
+Given(/^there are multiple Cabinet minister roles with active appointments$/) do
   organisation = create(:organisation)
-  create(:ministerial_role, name: "Role 1", cabinet_member: true, organisations: [organisation], seniority: 0)
-  create(:ministerial_role, name: "Role 2", cabinet_member: true, organisations: [organisation], seniority: 1)
+  person = create(:person, forename: "Tony")
+  minister_role1 = create(:ministerial_role, name: "Role 1", cabinet_member: true, organisations: [organisation], seniority: 0)
+  minister_role2 = create(:ministerial_role, name: "Role 2", cabinet_member: true, organisations: [organisation], seniority: 1)
+  create(:role_appointment, role: minister_role1, person:)
+  create(:role_appointment, role: minister_role2, person:)
 end
 
 When(/^I click the reorder link in the "([^"]*)" tab$/) do |tab|

--- a/test/functional/admin/cabinet_ministers_controller_test.rb
+++ b/test/functional/admin/cabinet_ministers_controller_test.rb
@@ -108,9 +108,13 @@ class Admin::CabinetMinistersControllerTest < ActionController::TestCase
     assert_redirected_to admin_cabinet_ministers_path(anchor: "organisations")
   end
 
-  view_test "should list cabinet ministers and ministerial organisations in separate tabs, in the correct order, with reorder links" do
+  view_test "should list appointed cabinet ministers and ministerial organisations in separate tabs, in the correct order, with reorder links" do
+    person = create(:person, forename: "Tony")
     minister1 = create(:ministerial_role, name: "Non-Executive Director", cabinet_member: true, organisations: [organisation], seniority: 1)
     minister2 = create(:ministerial_role, name: "Prime Minister", cabinet_member: true, organisations: [organisation], seniority: 0)
+    # roles without a current appointment will not show in the list
+    create(:role_appointment, role: minister1, person:)
+    create(:role_appointment, role: minister2, person:)
 
     also_attends_cabinet1 = create(:ministerial_role, name: "Chief Whip and Parliamentary Secretary to the Treasury", attends_cabinet_type_id: 2, organisations: [organisation], seniority: 1)
     also_attends_cabinet2 = create(:ministerial_role, name: "Minister without Portfolio", attends_cabinet_type_id: 1, organisations: [organisation], seniority: 0)
@@ -130,8 +134,11 @@ class Admin::CabinetMinistersControllerTest < ActionController::TestCase
   end
 
   view_test "GET :reorder_cabinet_minister_roles should assign roles correctly and the cancel_path should have the correct anchor" do
+    person = create(:person, forename: "Tony")
     minister1 = create(:ministerial_role, name: "Non-Executive Director", cabinet_member: true, organisations: [organisation], seniority: 1)
     minister2 = create(:ministerial_role, name: "Prime Minister", cabinet_member: true, organisations: [organisation], seniority: 0)
+    create(:role_appointment, role: minister1, person:)
+    create(:role_appointment, role: minister2, person:)
 
     get :reorder_cabinet_minister_roles
 

--- a/test/unit/app/models/ministerial_role_test.rb
+++ b/test/unit/app/models/ministerial_role_test.rb
@@ -110,4 +110,16 @@ class MinisterialRoleTest < ActiveSupport::TestCase
       role.update(name: "New name")
     end
   end
+
+  test ".ministerial_roles_with_current_appointments only returns roles with active appointments" do
+    person = create(:person, forename: "Tony")
+    minister1 = create(:ministerial_role, name: "Non-Executive Director", cabinet_member: true, seniority: 1)
+    minister2 = create(:ministerial_role, name: "Prime Minister", cabinet_member: true, seniority: 0)
+    minister3 = create(:ministerial_role, name: "Prime Minister", cabinet_member: true, seniority: 0)
+    create(:role_appointment, role: minister1, person:)
+    create(:role_appointment, role: minister2, person:)
+    create(:role_appointment, :ended, role: minister3, person:)
+
+    assert_equal MinisterialRole.ministerial_roles_with_current_appointments, [minister2, minister1]
+  end
 end


### PR DESCRIPTION
In preparation for the election, we are improving the ordering of cabinet ministers. The empty, unappointed roles, were showing in the ordering page (and during drag and drop), which made the process quite cumbersome.

We filtered out the empty roles to streamline the reordering task. The roles will only show if they have active, current appointments. The roles still show in the roles page. Other tabs on the ordering page are not affected (e.g. 'Also attends cabinet ordering').

The [original PR ](https://github.com/alphagov/whitehall/pull/9176)missed checking that the associated appointments are still active, causing role duplication, so it was [reverted](https://github.com/alphagov/whitehall/pull/9187).

[Trello card](https://trello.com/c/Yl4ZZBc2/2690-remove-empty-roles-from-drag-and-drop-ministers-list)
