### PR TITLE
Enable history mode for case studies

### DIFF
--- a/app/presenters/publishing_api/case_study_presenter.rb
+++ b/app/presenters/publishing_api/case_study_presenter.rb
@@ -58,6 +58,7 @@ module PublishingApi
                                { url: "", caption: nil, alt_text: "" }
                              end
       details_hash.merge!(PayloadBuilder::TagDetails.for(item))
+      details_hash.merge!(PayloadBuilder::PoliticalDetails.for(item))
     end
 
     def first_public_at

--- a/docs/history_mode.md
+++ b/docs/history_mode.md
@@ -16,9 +16,8 @@ When an edition is sent to Publishing API, the political status of the edition i
 
 There are some content types for which political details are not added to the payload, meaning that **history mode cannot be applied to documents of these types**.
 
-At time of writing, the content types excluded from history mode are:
+At time of writing, the only content type excluded from history mode is:
 
-- Case studies ([presenter](../app/presenters/publishing_api/case_study_presenter.rb))
 - Fatality notices ([presenter](../app/presenters/publishing_api/fatality_notice_presenter.rb))
 
 In the future, it would seem desirable that we re-apply the logic from the [Political Content Identifier](../lib/political_content_identifier.rb) within the [political details payload builder](../app/presenters/publishing_api/payload_builder/political_details.rb), if the eligibility rules are the same. Having the logic all in one place would make the behaviour of history mode easier to understand.

--- a/lib/political_content_identifier.rb
+++ b/lib/political_content_identifier.rb
@@ -1,6 +1,7 @@
 class PoliticalContentIdentifier
   POTENTIALLY_POLITICAL_FORMATS = [
     CallForEvidence,
+    CaseStudy,
     Consultation,
     Speech,
     NewsArticle,

--- a/test/unit/app/presenters/publishing_api/case_study_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/case_study_presenter_test.rb
@@ -33,6 +33,7 @@ class PublishingApi::CaseStudyPresenterTest < ActiveSupport::TestCase
       details: {
         body: "<div class=\"govspeak\"><p>Some content</p></div>",
         format_display_type: "case_study",
+        political: false,
         image: {
           url: "",
           caption: nil,


### PR DESCRIPTION
It has been decided for the July 2024 election that case studies should have history mode enabled.

Sending a political value of "true" to the Publishing API will mean that the historical content banner will be displayed when a case study is associated with a previous government.

Trello: https://trello.com/c/qgXy40mt/2702-make-history-mode-tickbox-work-for-case-study-format
