### PR TITLE
Stop Fatality Notices from being able to be marked as political

### DIFF
--- a/app/models/fatality_notice.rb
+++ b/app/models/fatality_notice.rb
@@ -47,4 +47,8 @@ class FatalityNotice < Announcement
   def publishing_api_presenter
     PublishingApi::FatalityNoticePresenter
   end
+
+  def can_be_marked_political?
+    false
+  end
 end

--- a/test/unit/app/models/fatality_notice_test.rb
+++ b/test/unit/app/models/fatality_notice_test.rb
@@ -42,6 +42,11 @@ class FatalityNoticeTest < ActiveSupport::TestCase
     assert_equal operational_field.slug, fatality_notice.search_index["operational_field"]
   end
 
+  test "is not able to be marked political" do
+    fatality_notice = build(:fatality_notice)
+    assert_not fatality_notice.can_be_marked_political?
+  end
+
   test "is rendered by government-frontend" do
     assert FatalityNotice.new.rendering_app == Whitehall::RenderingApp::GOVERNMENT_FRONTEND
   end


### PR DESCRIPTION
Editions are allowed to be marked as political,
[by default](https://github.com/alphagov/whitehall/blob/ac55508560d3b1da05507c1fb5bff1ddedb13ac7/app/models/edition.rb#L150-L152). This causes the history mode checkbox to appear on fatality notices (once they've gone live).

The checkbox actually had no effect, given the `FatalityNoticePresenter` doesn't pull in the required [PoliticalDetails
links](https://github.com/alphagov/whitehall/blob/268e390cf866e631ccc8e7f84252aab99e43ac81/app/presenters/publishing_api/payload_builder/political_details.rb#L3) that [other presenters pull in](https://github.com/alphagov/whitehall/blob/d8f5013d0ab3eefbb78c007e860942aa43e970a5/app/presenters/publishing_api/speech_presenter.rb#L51).

We've already said in the [guidance](https://www.gov.uk/guidance/how-to-publish-on-gov-uk/creating-and-updating-pages#history-mode) that fatality notices don't get history mode, so we had the option of either going against that guidance and fixing the checkbox for fatality notices, or removing the checkbox.

On the basis that no Fatality Notices have been marked as political in Whitehall to date, it is safe to remove the checkbox:

```
FatalityNotice.all.map(&:political?).uniq
=> [false]
```

Trello: https://trello.com/c/jhhdPAgX/2703-remove-or-fix-history-mode-option-in-fatality-notice-and-statistics

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
