### PR TITLE
Always show "Political" checkbox on published editions (all formats)

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -147,10 +147,6 @@ class Edition < ApplicationRecord
     change_note.present? || minor_change
   end
 
-  def can_be_marked_political?
-    true
-  end
-
   def can_index_in_search?
     false
   end

--- a/app/models/editionable_worldwide_organisation.rb
+++ b/app/models/editionable_worldwide_organisation.rb
@@ -177,10 +177,6 @@ class EditionableWorldwideOrganisation < Edition
     false
   end
 
-  def can_be_marked_political?
-    false
-  end
-
   def skip_world_location_validation?
     false
   end

--- a/app/models/fatality_notice.rb
+++ b/app/models/fatality_notice.rb
@@ -47,8 +47,4 @@ class FatalityNotice < Announcement
   def publishing_api_presenter
     PublishingApi::FatalityNoticePresenter
   end
-
-  def can_be_marked_political?
-    false
-  end
 end

--- a/app/presenters/publishing_api/fatality_notice_presenter.rb
+++ b/app/presenters/publishing_api/fatality_notice_presenter.rb
@@ -67,6 +67,7 @@ module PublishingApi
         roll_call_introduction: item.roll_call_introduction,
       }
       details_hash.merge!(PayloadBuilder::FirstPublicAt.for(item))
+      details_hash.merge!(PayloadBuilder::PoliticalDetails.for(item))
     end
   end
 end

--- a/app/views/admin/editions/_standard_fields.html.erb
+++ b/app/views/admin/editions/_standard_fields.html.erb
@@ -129,7 +129,7 @@
 
   <%= render "additional_significant_fields", form: form, edition: form.object %>
 
-  <% if edition.document&.live? && edition.can_be_marked_political? && can?(:mark_political, edition) %>
+  <% if edition.document&.live? && can?(:mark_political, edition) %>
     <div class="govuk-!-margin-bottom-8">
       <%= form.hidden_field :political, value: "0" %>
 

--- a/docs/history_mode.md
+++ b/docs/history_mode.md
@@ -10,23 +10,10 @@ Publishers cannot set the political flag on the first edition of a document. Ins
 
 After the first edition is published, publishers can override the political flag on subsequent editions via the edition editing form. Overriding the flag requires that the publisher has managing editor or GDS editor permissions. The flag can be overridden on any type of document via the user interface, irrespective of its eligibility as determined by the [Political Content Identifier](../lib/political_content_identifier.rb). Note, however, that this doesn't necessarily mean history mode can be applied to the document ([see exclusions](#exclusions)).
 
-## Exclusions
-
-When an edition is sent to Publishing API, the political status of the edition is merged into the `details` object using the [political details payload builder](../app/presenters/publishing_api/payload_builder/political_details.rb).
-
-There are some content types for which political details are not added to the payload, meaning that **history mode cannot be applied to documents of these types**.
-
-At time of writing, the only content type excluded from history mode is:
-
-- Fatality notices ([presenter](../app/presenters/publishing_api/fatality_notice_presenter.rb))
-
-In the future, it would seem desirable that we re-apply the logic from the [Political Content Identifier](../lib/political_content_identifier.rb) within the [political details payload builder](../app/presenters/publishing_api/payload_builder/political_details.rb), if the eligibility rules are the same. Having the logic all in one place would make the behaviour of history mode easier to understand.
+It's important to note that the `political` status of the edition has to be sent by the presenter. This is usually, [but not always](../app/presenters/publishing_api/html_attachment_presenter.rb#L62), achieved by merged the [political details payload builder](../app/presenters/publishing_api/payload_builder/political_details.rb (`PoliticalDetails`) into the `details` object. In the future, it would seem desirable to consolidate all 'political' knowledge in one place, e.g. re-apply the logic from the [Political Content Identifier](../lib/political_content_identifier.rb) within `PoliticalDetails`.
 
 ## Applying History Mode
 
 When the government changes, it will be "closed" via the Whitehall user interface by a member of the GOV.UK content team. This will publish an update to the government content item. The content item will have its "current" value set to false, as specified in the [GovernmentPresenter](../app/presenters/publishing_api/government_presenter.rb).
 
 Next, a developer will run the `election:republish_political_content` rake task. This task republishes all documents that have been marked as political. All documents have a link to their associated government, so Publishing API's [link expansion](https://docs.publishing.service.gov.uk/repos/publishing-api/link-expansion.html) feature will ensure that the linked government is "closed" for each document when it is re-presented to the content store. This will result in [government-frontend](https://github.com/alphagov/government-frontend) rendering the historical content banner on the documents. The banner is controlled in government frontend's [political content presenter](https://github.com/alphagov/government-frontend/blob/a643a4a9175af953e5683ee2ca5464ec384ed28e/app/presenters/content_item/political.rb#L19).
-
-
-

--- a/test/functional/admin/generic_editions_controller_tests/political_document_test.rb
+++ b/test/functional/admin/generic_editions_controller_tests/political_document_test.rb
@@ -57,14 +57,3 @@ class Admin::GenericEditionsController::PolticalDocumentsTest < ActionController
     assert_response :success
   end
 end
-
-class Admin::GenericEditionsController::PolticalDocumentsTestWhenCannotBeMarkedPolitical < ActionController::TestCase
-  tests Admin::EditionableWorldwideOrganisationsController
-
-  view_test "does not display the political checkbox for editions which cannot be marked political" do
-    published_edition = create(:published_editionable_worldwide_organisation)
-    new_draft = create(:editionable_worldwide_organisation, document: published_edition.document)
-    get :edit, params: { id: new_draft }
-    assert_select "#edition_political", count: 0
-  end
-end

--- a/test/unit/app/models/fatality_notice_test.rb
+++ b/test/unit/app/models/fatality_notice_test.rb
@@ -42,11 +42,6 @@ class FatalityNoticeTest < ActiveSupport::TestCase
     assert_equal operational_field.slug, fatality_notice.search_index["operational_field"]
   end
 
-  test "is not able to be marked political" do
-    fatality_notice = build(:fatality_notice)
-    assert_not fatality_notice.can_be_marked_political?
-  end
-
   test "is rendered by government-frontend" do
     assert FatalityNotice.new.rendering_app == Whitehall::RenderingApp::GOVERNMENT_FRONTEND
   end


### PR DESCRIPTION
All editions already have a `political` property under the hood; its value is determined on publish, [according to documented criteria](https://github.com/alphagov/whitehall/blob/dcdf572a37ff462c54a857679a301be20217da79/docs/history_mode.md#L9).

After publishing, the boolean value can be overridden manually by using the "Political" form in the UI. However, we choose not to show that form on certain formats: namely the Editionable Worldwide Organisation, for which a `can_be_marked_political?` method was added in #8840. This means it is impossible to manually change the `political` value for Editionable Worldwide Orgs. In #9198, the same setting was applied to Fatality Notices, after we'd noticed that the form was visible despite our [guidance to publishers](https://www.gov.uk/guidance/how-to-publish-on-gov-uk/creating-and-updating-pages#what-content-does-not-get-history-mode) stating that "fatality notices" and "national statistics" do not get "history mode".

In fact, our guidance was partially correct, because checking the box (opting into history mode) had no effect on fatality notices, because its presenters did not include the
[PoliticalDetails](https://github.com/alphagov/whitehall/blob/268e390cf866e631ccc8e7f84252aab99e43ac81/app/presenters/publishing_api/payload_builder/political_details.rb#L3) payload, i.e. we never send the value of `political` to Publishing API, so whether or not its overridden in the UI is irrelevant. In any case, looking at production data, there are no occurrences of Fatality Notices which have been attempted to be marked as political, so the checkbox rendering was removed in #9198.

This is not the case for national statistics, for which the guidance is wrong: the checkbox _is_ visible for that format, and making a national statistic as political _does_ give it 'history mode'. Of the thousands of national statistics (now termed 'accredited official statistics') and official statistics, a small handful have been manually marked as political, so we cannot unilaterally remove the checkbox for that format.

Having [discussed with colleagues in Content](https://gds.slack.com/archives/C06HBEH9TM3/p1719312642793529?thread_ts=1719233645.425039&cid=C06HBEH9TM3), we've decided to make Whitehall simpler and more predictable by simply showing the checkbox for _all_ editionable formats, and trusting publishers to only check the box when appropriate. The guidance will be updated accordingly. The logic for determining whether a format should or shouldn't get `political` status by _default_ remains unchanged.

Trello: https://trello.com/c/jhhdPAgX/2703-remove-or-fix-history-mode-option-in-fatality-notice-and-statistics

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
