### PR TITLE
Avoid touching database when publishing redirecting statistics announcements

### DIFF
--- a/db/data_migration/20240625140000_redirect_published_statistics_announcements.rb
+++ b/db/data_migration/20240625140000_redirect_published_statistics_announcements.rb
@@ -1,3 +1,3 @@
-# Touching the statistics announcement triggers the after_touch callback, which sets up a redirect from the announcement
-# to the data set if the data set has been published
-StatisticsAnnouncement.published.find_each(&:touch)
+StatisticsAnnouncement.published.find_each do |statistics_announcement|
+  Whitehall::PublishingApi.publish_redirect_async(statistics_announcement.content_id, statistics_announcement.publication.base_path) if statistics_announcement.publication.present? && statistics_announcement.publication.published?
+end


### PR DESCRIPTION
Requiring a touch for each statistics announcement was significantly slowing down the data migration when testing on integration. The migration didn't complete so we can try it again.

Trello: https://trello.com/c/9JHwMQJV
