### PR TITLE
Introduce foundations for the Content Object Store with a Rails Engine

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -43,3 +43,8 @@ Style/OptionalBooleanParameter:
 Lint/MissingSuper:
   Exclude:
     - 'app/components/**/*.rb'
+    - 'lib/engines/**/app/components/**/*.rb'
+
+Rails/SaveBang:
+  Exclude:
+    - 'Rakefile'

--- a/Rakefile
+++ b/Rakefile
@@ -8,10 +8,14 @@ ENV["LOG_LEVEL"] = "warn"
 # sensible coverage reports when running a full test suite,
 # without overwriting them when we're just running a single test
 ENV["COVERAGE"] = "true"
-
+require "minitest/test_task"
 require File.expand_path("config/application", __dir__)
 
 Whitehall::Application.load_tasks
+
+Minitest::TestTask.create do |t|
+  t.test_globs = %w[test/**/*_test.rb lib/engines/**/test/**/*_test.rb]
+end
 
 Rake::Task[:default].clear if Rake::Task.task_defined?(:default)
 task default: %i[lint test cucumber jasmine]

--- a/bin/minitest-ci
+++ b/bin/minitest-ci
@@ -4,8 +4,12 @@
 # defined in .github/workflows/minitest.yml.
 # It splits the MiniTest suite into randomly-allocated groups
 # which are executed across multiple GitHub Actions 'matrix' nodes.
+test_files = [
+  Dir["test/**/*_test.rb"],
+  Dir["lib/engines/**/test/**/*_test.rb"],
+].flatten
 
-tests = Dir["test/**/*_test.rb"].
+tests = test_files.
   sort.
   shuffle(random: Random.new(ENV['GITHUB_SHA'].to_i(16))).
   select.

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,6 +15,11 @@ require "rails/test_unit/railtie"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
+# Require all Engines inside the `lib/engines` directory
+Dir.glob("lib/engines/**/engine.rb", base: Rails.root).each do |path|
+  require_relative "../#{path}"
+end
+
 module Whitehall
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.

--- a/config/application.rb
+++ b/config/application.rb
@@ -66,12 +66,13 @@ module Whitehall
     # Custom directories with classes and modules you want to be autoloadable.
     config.eager_load_paths += %W[
       #{config.root}/lib
+      #{config.root}/lib/engines/**
     ]
 
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.
-    config.autoload_lib(ignore: %w[assets tasks])
+    config.autoload_lib(ignore: %w[assets tasks engines])
 
     config.action_mailer.notify_settings = {
       api_key: ENV["GOVUK_NOTIFY_API_KEY"] || "fake-test-api-key",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -473,5 +473,5 @@ Whitehall::Application.routes.draw do
 
   mount GovukPublishingComponents::Engine, at: "/component-guide" unless Rails.env.production?
 
-  mount ContentObjectStore::Engine, at: "/content-object-store"
+  mount ContentObjectStore::Engine, at: "government/admin/content-object-store"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -472,4 +472,6 @@ Whitehall::Application.routes.draw do
   mount Flipflop::Engine => "/flipflop"
 
   mount GovukPublishingComponents::Engine, at: "/component-guide" unless Rails.env.production?
+
+  mount ContentObjectStore::Engine, at: "/content-object-store"
 end

--- a/docs/adr/0004-content-object-store-added-with-a-rails-engine.md
+++ b/docs/adr/0004-content-object-store-added-with-a-rails-engine.md
@@ -1,0 +1,61 @@
+# 4. content-object-store-added-with-a-rails-engine
+
+Date: 2024-06-27
+
+## Status
+
+Accepted
+
+## Context
+
+The content modelling team is going to be building features to allow small
+reusable content objects to be included or embedded into other GOV.UK documents.
+We plan to allow consistent reuse, and edit-once update-everywhere behaviour,
+valuable during uprating for example, or when highly-duplicated content, like
+phone numbers and email addresses change.
+
+- What we build should in theory be able to be used by any publishing app
+  Content Blocks have the same publishing process as documents (drafts, 2i,
+  authorisation etc)
+- When a Content Block is updated, any documents referencing it should also be
+  updated
+- Content Blocks can be categorised with meaning (so they're not just blocks of
+  text)
+- The structure of user-facing content within Content Blocks is customisable
+  (Examples of content are email addresses and tax rates, but could include much
+  more complicated structured data.)
+
+### Further context
+
+- There is a wider principle of not creating new publishing apps
+- We don't have time to prototype this proof of concept in a new temporary app
+- Whitehall offers behaviour that we are also likely to need, though we don't
+  yet have a firm understanding of which parts
+- _Contact_ Blocks already exist to allow some reuse but only within Whitehall.
+  This functionality was added directly into the Whitehall app. There is an
+  opportunity to extract that and bring it closer to Content reuse
+
+## Decisions and Consequences
+
+Our first step towards building this service is to begin building the
+create/edit functionality.
+
+1. We will build the internal user-facing service in Whitehall
+
+    - Our users already have access to Whitehall
+    - Users will be able to add/edit content blocks with new user journeys
+    - We can reuse the existing infrastructure and deployment pipeline
+
+2. We will build it in an engine
+
+    - We want to ensure that we are 'good neighbours' and can create this
+      service in a way that isn't polluting the Whitehall repo.
+    - We also want to build with a view to this service being used outside of
+      Whitehall. It makes sense therefore to put the code in an engine separate
+from the rest of the repo.
+    - We may learn that this publishing journey should be in a separate
+      publishing app, at which point extraction would be easier
+    - Our beta may not solve a problem in the right way, in which case deletion
+      from Whitehall would be easier
+    - We will test the engine approach as a viable route and set an example for
+      other publishing apps who also wish to merge into Whitehall

--- a/lib/engines/content_object_store/app/controllers/content_object_store/health_check_controller.rb
+++ b/lib/engines/content_object_store/app/controllers/content_object_store/health_check_controller.rb
@@ -1,0 +1,5 @@
+class ContentObjectStore::HealthCheckController < ApplicationController
+  def index
+    render json: { status: "OK" }, status: :ok
+  end
+end

--- a/lib/engines/content_object_store/config/routes.rb
+++ b/lib/engines/content_object_store/config/routes.rb
@@ -1,0 +1,6 @@
+ContentObjectStore::Engine.routes.draw do
+  namespace :content_object_store, path: "/" do
+    resources :health_check, path: "health-check", only: %i[index]
+    root to: "health_check#index", via: :get
+  end
+end

--- a/lib/engines/content_object_store/lib/content_object_store.rb
+++ b/lib/engines/content_object_store/lib/content_object_store.rb
@@ -1,0 +1,4 @@
+require_relative "content_object_store/engine"
+
+module ContentObjectStore
+end

--- a/lib/engines/content_object_store/lib/content_object_store/engine.rb
+++ b/lib/engines/content_object_store/lib/content_object_store/engine.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module ContentObjectStore
+  class Engine < ::Rails::Engine
+  end
+end

--- a/lib/engines/content_object_store/test/integration/health_check_test.rb
+++ b/lib/engines/content_object_store/test/integration/health_check_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class HealthcheckTest < ActionDispatch::IntegrationTest
+  test "GET /government/admin/content-object-store/health-check returns 200 to demonstrate the ContentObjectStore engine is installed correctly" do
+    get "/government/admin/content-object-store/health-check"
+    assert_equal 200, status
+  end
+end

--- a/test/factories.rb
+++ b/test/factories.rb
@@ -2,4 +2,7 @@ def image_fixture_file
   @image_fixture_file ||= File.open(Rails.root.join("test/fixtures/minister-of-funk.960x640.jpg"))
 end
 
-Dir[Rails.root.join("test/factories/*.rb")].sort.each { |f| require f }
+[
+  Dir[Rails.root.join("test/factories/*.rb")],
+  Dir[Rails.root.join("lib/engines/**/test/factories/*.rb")],
+].flatten.sort.each { |f| require f }


### PR DESCRIPTION
# Changes in this PR

* We break down [our larger previous spike ](https://github.com/alphagov/whitehall/pull/9180) into a smaller chunk that we think is ready to merge (the rest will follow in varying chunks)
* This slice concerns itself with adding the Content Object Store to Whitehall via a Rails Engine. [The use of a Rails Engine was discussed here](https://gds.slack.com/archives/C0776B04EJU/p1718637232472229?thread_ts=1718613361.943989&cid=C0776B04EJU)
* We add a quick controller called health check to give us some way to prove that the engine is able to respond to a request as well as tests being loaded and run as part of the whole test suite
* ADR for adding code via a Rails Engine. Merging this PR cements that decision.

![Screenshot 2024-06-26 at 18 58 19](https://github.com/alphagov/whitehall/assets/912473/0aab21cd-d6f5-4adf-923e-728d0a6158a9)

## Notes

* @pezholio and I briefly discussed the naming of "Content Object Store". The keen eyed will have seen that changed from "Object store" in the original spike. The wider Reuse team are referring to this service as "the object store" and have decided that more specific names such as Content Library aren't right. We as the Reuse dev team think "object store" runs the risk of being too generic and therefore misleading from the perspective of the Whitehall codebase. There's also the chance that the name might need to change from the user point of view so we shouldn't worry about the codebase being exactly the same. To that end we propose to keep "object store" as language for wider Reuse team but prefix it to be "content object store" for the codebase.


