### PR TITLE
Setup up action buttons for GA4 tracking

### DIFF
--- a/app/assets/javascripts/admin/modules/ga4-button-setup.js
+++ b/app/assets/javascripts/admin/modules/ga4-button-setup.js
@@ -13,8 +13,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {}
         type: 'generic_link',
         text: button.textContent,
         section: document.title.split(' - ')[0],
-        action: button.textContent,
-        tool_name: document.title.split(' - ')[0]
+        action: button.textContent
       }
       if (button.dataset.ga4Event) {
         Object.assign(event, JSON.parse(button.dataset.ga4Event))

--- a/app/components/admin/editions/show/sidebar_actions_component.html.erb
+++ b/app/components/admin/editions/show/sidebar_actions_component.html.erb
@@ -1,4 +1,4 @@
-<div class="app-view-summary__sidebar-actions">
+<div class="app-view-summary__sidebar-actions" data-module="ga4-button-setup">
   <%= render "govuk_publishing_components/components/list", {
     extra_spacing: true,
     items: actions,

--- a/spec/javascripts/admin/modules/ga4-button-setup.spec.js
+++ b/spec/javascripts/admin/modules/ga4-button-setup.spec.js
@@ -16,7 +16,7 @@ describe('GOVUK.Modules.Ga4ButtonSetup', function () {
     ga4ButtonSetup.init()
 
     expect(button.dataset.ga4Event).toEqual(
-      '{"event_name":"navigation","type":"generic_link","text":"Button","section":"Title","action":"Button","tool_name":"Title"}'
+      '{"event_name":"navigation","type":"generic_link","text":"Button","section":"Title","action":"Button"}'
     )
   })
 
@@ -27,7 +27,7 @@ describe('GOVUK.Modules.Ga4ButtonSetup', function () {
     ga4ButtonSetup.init()
 
     expect(button.dataset.ga4Event).toEqual(
-      '{"event_name":"form_response","type":"generic_link","text":"Button","section":"Title","action":"Button","tool_name":"Title"}'
+      '{"event_name":"form_response","type":"generic_link","text":"Button","section":"Title","action":"Button"}'
     )
   })
 
@@ -40,7 +40,7 @@ describe('GOVUK.Modules.Ga4ButtonSetup', function () {
     ga4ButtonSetup.init()
 
     expect(button.dataset.ga4Event).toEqual(
-      '{"event_name":"custom_event_name","type":"generic_link","text":"Button","section":"Title","action":"Button","tool_name":"Title"}'
+      '{"event_name":"custom_event_name","type":"generic_link","text":"Button","section":"Title","action":"Button"}'
     )
   })
 
@@ -54,7 +54,7 @@ describe('GOVUK.Modules.Ga4ButtonSetup', function () {
     ga4ButtonSetup.init()
 
     expect(link.dataset.ga4Event).toEqual(
-      '{"event_name":"navigation","type":"generic_link","text":"Link","section":"Title","action":"Link","tool_name":"Title"}'
+      '{"event_name":"navigation","type":"generic_link","text":"Link","section":"Title","action":"Link"}'
     )
   })
 })


### PR DESCRIPTION
Use the `ga4-button-setup` module to set up the action buttons in the document summary sidebar for GA4 tracking.

We had a bunch of conversations around what we want to track. Decisions:
- track all buttons related to publishing by using the buttons module
- do not track any of the confirmation pages (we have these for Publish and Force Publish buttons) - we believe we should be getting enough data by tracking the initial button clicks
- will not be tracking the `Check broken links` button

A few cards belong here:
[Trello card on 2i button](https://trello.com/c/Dx7hN5Yy/2662-add-ga4-tracking-to-submit-for-2i)
[Trello card for force publish](https://trello.com/c/oyovzSHQ/2664-add-ga4-tracking-to-force-publish)
[Rest of the buttons](https://trello.com/c/80fssMqc/2710-apply-ga4-tracking-to-remaining-publishing-buttons-in-right-side-panel)

