### PR TITLE
add an index endpoint for Content Block Editions

### DIFF
--- a/lib/engines/content_object_store/app/controllers/content_object_store/content_block_editions_controller.rb
+++ b/lib/engines/content_object_store/app/controllers/content_object_store/content_block_editions_controller.rb
@@ -1,0 +1,7 @@
+class ContentObjectStore::ContentBlockEditionsController < ApplicationController
+  include ContentObjectStore::Engine.routes.url_helpers
+  include Whitehall::Application.routes.url_helpers
+  def index
+    @content_block_editions = ContentObjectStore::ContentBlockEdition.all
+  end
+end

--- a/lib/engines/content_object_store/app/views/content_object_store/content_block_editions/index.html.erb
+++ b/lib/engines/content_object_store/app/views/content_object_store/content_block_editions/index.html.erb
@@ -1,0 +1,4 @@
+<h1>Content Block Editions</h1>
+<% @content_block_editions.each do |content_block| %>
+  <p><%= content_block.details %></p>
+<% end %>

--- a/lib/engines/content_object_store/config/routes.rb
+++ b/lib/engines/content_object_store/config/routes.rb
@@ -2,5 +2,7 @@ ContentObjectStore::Engine.routes.draw do
   namespace :content_object_store, path: "/" do
     resources :health_check, path: "health-check", only: %i[index]
     root to: "health_check#index", via: :get
+
+    resources :content_block_editions, path: "content-block-editions", only: %i[index]
   end
 end

--- a/lib/engines/content_object_store/test/integration/content_block_editions_test.rb
+++ b/lib/engines/content_object_store/test/integration/content_block_editions_test.rb
@@ -1,0 +1,17 @@
+require "test_helper"
+require "capybara/rails"
+
+class ContentBlockEditionsTest < ActionDispatch::IntegrationTest
+  include Capybara::DSL
+
+  test "#index returns all Content Block Editions" do
+    content_block_document = create(:content_block_document)
+    create(
+      :content_block_edition,
+      details: '"email_address":"example@example.com"',
+      content_block_document_id: content_block_document.id,
+    )
+    visit "/government/admin/content-object-store/content-block-editions"
+    assert_text '"email_address":"example@example.com"'
+  end
+end


### PR DESCRIPTION
**Can be merged after this PR https://github.com/alphagov/whitehall/pull/9208** ✅ 

## Changes in this PR

* adds a simple JSON response listing all Content Block Editions.

