### PR TITLE
Make draft admin links previewable

### DIFF
--- a/lib/govspeak/admin_link_replacer.rb
+++ b/lib/govspeak/admin_link_replacer.rb
@@ -20,11 +20,9 @@ module Govspeak
     def replacement_html_for_admin_link(anchor)
       edition = Whitehall::AdminLinkLookup.find_edition(anchor["href"])
 
-      if edition.present? && edition.linkable?
-        public_url = edition.public_url
+      if edition.present?
+        public_url = edition.public_url(draft: !edition.linkable?)
         new_html = convert_link(anchor, public_url)
-      else
-        new_html = anchor.inner_text
       end
 
       block_given? ? yield(new_html, edition) : new_html

--- a/test/unit/lib/govspeak/admin_link_replacer_test.rb
+++ b/test/unit/lib/govspeak/admin_link_replacer_test.rb
@@ -15,15 +15,14 @@ module Govspeak
       assert_select_within_html fragment.to_html, "a[href='#{public_url}']", text: "that"
     end
 
-    test "unpublished edition links are replaced with plain text" do
+    test "rewrites admin links to draft origin links for draft editions" do
       draft_speech = create(:draft_speech)
-      _admin_path  = admin_speech_path(draft_speech)
+      public_url = draft_speech.public_url(draft: true)
       fragment     = govspeak_to_nokogiri_fragment("this is an [unpublished thing](/government/admin/speeches/#{draft_speech.id})")
 
       AdminLinkReplacer.new(fragment).replace!
 
-      refute_select_within_html fragment.to_html, "a"
-      assert_select_within_html fragment.to_html, "p", text: "this is an unpublished thing"
+      assert_select_within_html fragment.to_html, "a[href='#{public_url}']", text: "unpublished thing"
     end
 
     test "rewrites admin links to published corporate information pages" do


### PR DESCRIPTION
It is common that publishers may work on documents that need to be published more or less simultaneously. In such cases, the desired functionality is that a draft edition should be previewable from another draft edition.

Until now, if the edition was not "linkable" (i.e. not live or about to be published due to it being scheduled), its associated admin link would render as plain text. An admin link is an internal link in the format `govuk/admin/...`. As a workaround, users had to use draft-origin full public URLs when drafting, and then change them to admin links before publishing.

These changes ensure we manipulate an admin link so that it serves the draft origin version if the edition is in draft, and live if the edition has been published.

If the user published a document containing a draft link, the linked draft edition will not get published. Nonetheless, there is now a risk that the draft link will be rendered on the live document where it is embedded, as opposed to rendering as plain text as it used to. The publishers would be required to exercise caution and ensure the correct order of publishing.

[Trello card](https://trello.com/c/sUCmuGwy/1473-make-admin-links-visible-in-whitehall-page-preview)
