### PR TITLE
Remove surprising `Timecop` that freezes time for all tests

### DIFF
--- a/test/support/admin_edition_controller_scheduled_publishing_test_helpers.rb
+++ b/test/support/admin_edition_controller_scheduled_publishing_test_helpers.rb
@@ -14,8 +14,9 @@ module AdminEditionControllerScheduledPublishingTestHelpers
 
   module ClassMethods
     def should_allow_scheduled_publication_of(edition_type)
+      Timecop.freeze(2011, 11, 11, 11, 11, 11)
       document_type_class = edition_type.to_s.classify.constantize
-
+    
       view_test "new displays scheduled_publication date and time fields" do
         get :new
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -64,7 +64,6 @@ class ActiveSupport::TestCase
 
   setup do
     @feature_flags = Flipflop::FeatureSet.current.test!
-    Timecop.freeze(2011, 11, 11, 11, 11, 11)
     Sidekiq::Worker.clear_all
     stub_any_publishing_api_call
     stub_publishing_api_publish_intent


### PR DESCRIPTION
This line of code was setting the system time to 11:11:11am on November 11th, 2011.

Overriding the system time using Timecop is fine, but should really be done on a per-test (or per-test-file) basis.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
