### PR TITLE
Fix start/end date defaults on government pages 

### DIFF
--- a/app/views/admin/governments/_form.html.erb
+++ b/app/views/admin/governments/_form.html.erb
@@ -43,7 +43,7 @@
           },
           day: {
             id: "government_start_date_3i",
-            value: params.dig("government", "start_date(3i)") || government.start_date&.month,
+            value: params.dig("government", "start_date(3i)") || government.start_date&.day,
             name: "government[start_date(3i)]",
             label: "Day",
             width: 2,

--- a/app/views/admin/governments/_form.html.erb
+++ b/app/views/admin/governments/_form.html.erb
@@ -76,7 +76,7 @@
           },
           day: {
             id: "government_end_date_3i",
-            value: params.dig("government", "end_date(3i)") || government.end_date&.month,
+            value: params.dig("government", "end_date(3i)") || government.end_date&.day,
             name: "government[end_date(3i)]",
             label: "Day",
             width: 2,

--- a/test/functional/admin/governments_controller_test.rb
+++ b/test/functional/admin/governments_controller_test.rb
@@ -78,6 +78,22 @@ class Admin::GovernmentsControllerTest < ActionController::TestCase
     assert_select "a[href='#{prepare_to_close_admin_government_path(@government)}']", text: "Prepare to close this government"
   end
 
+  view_test "edit renders the correct fields when editing a past government" do
+    @government = FactoryBot.build(:government, end_date: "2011-12-13")
+    @government.save!(validate: false) # fiddly making a past government that doesn't cause an 'overlap' validation error
+
+    login_as :gds_admin
+    get :edit, params: { id: @government.id }
+
+    assert_select "input[name='government[name]'][value='#{@government.name}']"
+    assert_select "input[name='government[start_date(1i)]'][value='#{@government.start_date.year}']"
+    assert_select "input[name='government[start_date(2i)]'][value='#{@government.start_date.month}']"
+    assert_select "input[name='government[start_date(3i)]'][value='#{@government.start_date.day}']"
+    assert_select "input[name='government[end_date(1i)]'][value='2011']"
+    assert_select "input[name='government[end_date(2i)]'][value='12']"
+    assert_select "input[name='government[end_date(3i)]'][value='13']"
+  end
+
   view_test "edit does not render the prepare to close link when editing a previous government" do
     @government.update!(end_date: 1.minute.ago)
     create(:government, start_date: Time.zone.now)

--- a/test/functional/admin/governments_controller_test.rb
+++ b/test/functional/admin/governments_controller_test.rb
@@ -23,18 +23,14 @@ class Admin::GovernmentsControllerTest < ActionController::TestCase
   end
 
   view_test "new should have the correct form fields and default start date of today" do
+    Timecop.freeze(2020, 4, 17)
     login_as :gds_admin
     get :new
     assert_select "input[name='government[name]']"
-    assert_select "input[name='government[start_date(1i)]']" do |element|
-      element.attr("value").value == @government.start_date.year.to_s
-    end
-    assert_select "input[name='government[start_date(2i)]']" do |element|
-      element.attr("value").value == @government.start_date.month.to_s
-    end
-    assert_select "input[name='government[start_date(3i)]']" do |element|
-      element.attr("value").value == @government.start_date.day.to_s
-    end
+    assert_select "input[name='government[start_date(1i)]'][value='2020']"
+    assert_select "input[name='government[start_date(2i)]'][value='4']"
+    assert_select "input[name='government[start_date(3i)]'][value='17']"
+
     assert_select "input[name='government[end_date(1i)]']"
     assert_select "input[name='government[end_date(2i)]']"
     assert_select "input[name='government[end_date(3i)]']"
@@ -73,15 +69,9 @@ class Admin::GovernmentsControllerTest < ActionController::TestCase
     get :edit, params: { id: @government.id }
 
     assert_select "input[name='government[name]'][value='#{@government.name}']"
-    assert_select "input[name='government[start_date(1i)]']" do |element|
-      element.attr("value").value == @government.start_date.year.to_s
-    end
-    assert_select "input[name='government[start_date(2i)]']" do |element|
-      element.attr("value").value == @government.start_date.month.to_s
-    end
-    assert_select "input[name='government[start_date(3i)]']" do |element|
-      element.attr("value").value == @government.start_date.day.to_s
-    end
+    assert_select "input[name='government[start_date(1i)]'][value='#{@government.start_date.year}']"
+    assert_select "input[name='government[start_date(2i)]'][value='#{@government.start_date.month}']"
+    assert_select "input[name='government[start_date(3i)]'][value='#{@government.start_date.day}']"
     assert_select "input[name='government[end_date(1i)]']"
     assert_select "input[name='government[end_date(2i)]']"
     assert_select "input[name='government[end_date(3i)]']"


### PR DESCRIPTION
The start and end dates were using the 'month' value as the 'day' in the input fields. See screenshot below, which was taken today ("Day" should be 2):

<img src="https://github.com/alphagov/whitehall/assets/5111927/a5940873-d714-43eb-8a93-d61bc93ae6e9" alt="screenshot" width="300px" >

Trello: https://trello.com/c/8d2dVMrj/2713-fix-date-rendering-bug-in-whitehall-government-pages

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
