### PR TITLE
Fix breadcrumbs for two admin pages in Whitehall

### DIFF
--- a/app/views/admin/promotional_features/show.html.erb
+++ b/app/views/admin/promotional_features/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for :back_link do %>
   <%= render "govuk_publishing_components/components/back_link", {
-    href: [:admin, @organisation, PromotionalFeature],
+    href: admin_organisation_promotional_features_path(@organisation),
   } %>
 <% end %>
 <% content_for :page_title, "Promotional feature: #{@promotional_feature.title}" %>

--- a/app/views/admin/world_location_news/show.html.erb
+++ b/app/views/admin/world_location_news/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for :back_link do %>
   <%= render "govuk_publishing_components/components/back_link", {
-    href: :admin_world_location_news_index,
+    href: admin_world_location_news_index_path,
   } %>
 <% end %>
 <% content_for :page_title, @world_location_news.name %>


### PR DESCRIPTION
I stumbled across these recently. There may be more.

Trello: https://trello.com/c/R0Bg7uhx/2728-fix-breadcrumbs-in-whitehall

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
