### PR TITLE
Republish statistical publications for selected political organisations

### DIFF
--- a/db/data_migration/20240709092200_republish_stats_publications_for_political_orgs.rb
+++ b/db/data_migration/20240709092200_republish_stats_publications_for_political_orgs.rb
@@ -1,0 +1,15 @@
+selected_political_org_slugs = %w[
+  department-for-energy-security-and-net-zero
+  department-for-business-and-trade
+  department-for-science-innovation-and-technology
+  department-for-culture-media-and-sport
+  office-for-health-improvement-and-disparities
+]
+
+selected_political_org_slugs.each do |slug|
+  organisation = Organisation.where(slug:).first
+  published_publications = organisation.editions.published.where(type: "publication")
+  published_publications.select(&:statistics?).each do |publication|
+    PublishingApiDocumentRepublishingWorker.perform_async(publication.document_id)
+  end
+end


### PR DESCRIPTION
A number of statistical publications have been identified on GOV.UK that have history mode enabled. Statistical publications are not eligible for history mode, but a bug in a previous version of the election:identify_political_content_for rake task marked them as political incorrectly. Some of the incorrectly marked editions were published to GOV.UK.

The offending statistical publications have since had the political flag removed, but have not yet been republished. Republishing the documents should result in the removal of the history mode banner from the documents.
