### PR TITLE
Redirect a number of world location news pages to their world location

### DIFF
--- a/db/data_migration/202407101125900_redirect_international_delegation_news_pages.rb
+++ b/db/data_migration/202407101125900_redirect_international_delegation_news_pages.rb
@@ -1,0 +1,11 @@
+selected_international_delegation_content_ids = %w[
+  52e79dc1-2b32-4895-bbcd-c83a5e4803e4
+  d8463190-7b80-4ef0-8f75-d36dfc3572a1
+  30be2e13-6db3-487b-b97f-910feeb5e6a1
+]
+
+international_delegation_news_pages = WorldLocationNews.where(content_id: selected_international_delegation_content_ids).all
+international_delegation_news_pages.each do |page|
+  puts "Redirecting #{page.base_path} to #{page.world_location.base_path}"
+  Whitehall::PublishingApi.publish_redirect_async(page.content_id, page.world_location.base_path)
+end


### PR DESCRIPTION
Some time ago, world location news pages relating to international delegations were disabled and redirected to their location pages due to the content being effectively identical.

Due to a bug in Whitehall fixed in 148ffa5e1bd667d9ed11ef4dedf44096bc7d0d5b some of the news pages were inadvertently republished.

This data migration reinstates those redirects.

This has been tested against staging.
