### PR TITLE
Fix ContentBlockEdition tests by stubbing the new id

### DIFF
--- a/lib/engines/content_object_store/test/unit/app/models/content_block_edition_test.rb
+++ b/lib/engines/content_object_store/test/unit/app/models/content_block_edition_test.rb
@@ -2,9 +2,8 @@ require "test_helper"
 
 class ContentObjectStore::ContentBlockEditionTest < ActiveSupport::TestCase
   setup do
-    ContentObjectStore::ContentBlockEdition.any_instance.stubs(:create_random_id) do
-      @new_content_id = SecureRandom.uuid
-    end
+    @new_content_id = SecureRandom.uuid
+    ContentObjectStore::ContentBlockEdition.any_instance.stubs(:create_random_id).returns(@new_content_id)
 
     @created_at = Time.zone.local(2000, 12, 31, 23, 59, 59).utc
     @updated_at = Time.zone.local(2000, 12, 31, 23, 59, 59).utc


### PR DESCRIPTION
I noticed 2 deprecation warnings when running the test suite this morning, eg:

```
DEPRECATED: Use assert_nil if expecting nil from lib/engines/content_object_store/test/unit/app/models/content_block_edition_test.rb:55. This will fail in Minitest 6.
```

I looked at the line `assert_equal @content_block_edition.document.content_id, @new_content_id` and found that both sides of the assertion was nil. So instead of using assert_nil there was probably a problem with th test.

I figure that @new_content_id was only available from within the stub block so we move things around to give it a file wide scope.
