### PR TITLE
Only show published worldwide organisations on embassies index

### DIFF
--- a/app/models/embassy.rb
+++ b/app/models/embassy.rb
@@ -6,7 +6,7 @@ class Embassy
   delegate :name, to: :@world_location
 
   def organisations_with_embassy_offices
-    @world_location.worldwide_organisations.select do |org|
+    @world_location.worldwide_organisations.published.select do |org|
       org.embassy_offices.any?
     end
   end
@@ -40,7 +40,7 @@ class Embassy
 private
 
   def offices
-    @world_location.worldwide_organisations.map(&:embassy_offices).flatten
+    @world_location.worldwide_organisations.published.map(&:embassy_offices).flatten
   end
 
   def can_assist_in_other_location?

--- a/test/unit/app/models/embassy_test.rb
+++ b/test/unit/app/models/embassy_test.rb
@@ -29,13 +29,40 @@ class EmbassyTest < ActiveSupport::TestCase
     end
   end
 
-  context "when there are organisations with embassy offices in the world location" do
+  context "when there are only draft organisations" do
     before do
-      organisation = create(:worldwide_organisation, world_locations: [world_location])
+      organisation = create(:draft_editionable_worldwide_organisation, world_locations: [world_location])
       contact = create(:contact_with_country, country: world_location)
       create(:worldwide_office,
              contact:,
-             worldwide_organisation: organisation,
+             edition: organisation,
+             worldwide_office_type: WorldwideOfficeType::EMBASSY_OFFICE_TYPES.first)
+    end
+
+    it "returns false for #can_assist_british_nationals?" do
+      assert_not embassy.can_assist_british_nationals?
+    end
+
+    it "returns false for #can_assist_in_location?" do
+      assert_not embassy.can_assist_in_location?
+    end
+
+    it "returns nil for #remote_office" do
+      assert_nil embassy.remote_office
+    end
+
+    it "returns no #organisations_with_embassy_offices" do
+      assert embassy.organisations_with_embassy_offices.empty?
+    end
+  end
+
+  context "when there are published organisations with embassy offices in the world location" do
+    before do
+      organisation = create(:published_editionable_worldwide_organisation, world_locations: [world_location])
+      contact = create(:contact_with_country, country: world_location)
+      create(:worldwide_office,
+             contact:,
+             edition: organisation,
              worldwide_office_type: WorldwideOfficeType::EMBASSY_OFFICE_TYPES.first)
     end
 
@@ -56,13 +83,13 @@ class EmbassyTest < ActiveSupport::TestCase
     end
   end
 
-  context "when there are organisations with embassy offices in unspecified countries" do
+  context "when there are published organisations with embassy offices in unspecified countries" do
     before do
-      organisation = create(:worldwide_organisation, world_locations: [world_location])
+      organisation = create(:published_editionable_worldwide_organisation, world_locations: [world_location])
       contact = create(:contact, country: nil)
       create(:worldwide_office,
              contact:,
-             worldwide_organisation: organisation,
+             edition: organisation,
              worldwide_office_type: WorldwideOfficeType::EMBASSY_OFFICE_TYPES.first)
     end
 
@@ -108,18 +135,19 @@ class EmbassyTest < ActiveSupport::TestCase
     end
   end
 
-  context "when there are organisations with embassy offices in other world locations" do
+  context "when there are published organisations with embassy offices in other world locations" do
     let(:other_location) { create(:world_location) }
 
     before do
-      organisation = create(:worldwide_organisation,
+      document = create(:document, slug: "org-slug")
+      organisation = create(:published_editionable_worldwide_organisation,
                             world_locations: [world_location],
-                            name: "org-name",
-                            slug: "org-slug")
+                            title: "org-name",
+                            document:)
       contact = create(:contact_with_country, country: other_location)
       create(:worldwide_office,
              contact:,
-             worldwide_organisation: organisation,
+             edition: organisation,
              worldwide_office_type: WorldwideOfficeType::EMBASSY_OFFICE_TYPES.first)
     end
 
@@ -145,23 +173,24 @@ class EmbassyTest < ActiveSupport::TestCase
     end
   end
 
-  context "when there is an organisation with two embassy offices, one in an unknown location and one in another world location" do
+  context "when there is a published organisation with two embassy offices, one in an unknown location and one in another world location" do
     let(:other_location) { create(:world_location) }
 
     before do
-      organisation = create(:worldwide_organisation,
+      document = create(:document, slug: "org-slug")
+      organisation = create(:published_editionable_worldwide_organisation,
                             world_locations: [world_location],
-                            name: "org-name",
-                            slug: "org-slug")
+                            title: "org-name",
+                            document:)
       remote_office_contact = create(:contact_with_country, country: other_location)
       unknown_location_contact = create(:contact, country: nil)
       create(:worldwide_office,
              contact: remote_office_contact,
-             worldwide_organisation: organisation,
+             edition: organisation,
              worldwide_office_type: WorldwideOfficeType::EMBASSY_OFFICE_TYPES.first)
       create(:worldwide_office,
              contact: unknown_location_contact,
-             worldwide_organisation: organisation,
+             edition: organisation,
              worldwide_office_type: WorldwideOfficeType::EMBASSY_OFFICE_TYPES.first)
     end
 
@@ -175,24 +204,25 @@ class EmbassyTest < ActiveSupport::TestCase
     end
   end
 
-  context "when there is an organisation with two offices in two remote countries and one isn't an embassy" do
+  context "when there is a published organisation with two offices in two remote countries and one isn't an embassy" do
     let(:second_location) { create(:world_location) }
     let(:third_location) { create(:world_location) }
 
     before do
-      organisation = create(:worldwide_organisation,
+      document = create(:document, slug: "org-slug")
+      organisation = create(:published_editionable_worldwide_organisation,
                             world_locations: [world_location],
-                            name: "org-name",
-                            slug: "org-slug")
+                            title: "org-name",
+                            document:)
       second_location_contact = create(:contact_with_country, country: second_location)
       third_location_contact = create(:contact_with_country, country: third_location)
       create(:worldwide_office,
              contact: second_location_contact,
-             worldwide_organisation: organisation,
+             edition: organisation,
              worldwide_office_type: WorldwideOfficeType::Other)
       create(:worldwide_office,
              contact: third_location_contact,
-             worldwide_organisation: organisation,
+             edition: organisation,
              worldwide_office_type: WorldwideOfficeType::EMBASSY_OFFICE_TYPES.first)
     end
 

--- a/test/unit/app/presenters/publishing_api/embassies_index_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/embassies_index_presenter_test.rb
@@ -40,11 +40,11 @@ class PublishingApi::EmbassiesIndexPresenterTest < ActiveSupport::TestCase
 
   test "generates a valid document for world locations with local embassies" do
     world_location = build(:world_location)
-    organisation = create(:worldwide_organisation, world_locations: [world_location])
+    organisation = create(:editionable_worldwide_organisation, world_locations: [world_location])
     contact = create(:contact_with_country, country: world_location, locality: "locality")
     create(:worldwide_office,
            contact:,
-           worldwide_organisation: organisation,
+           edition: organisation,
            worldwide_office_type: WorldwideOfficeType::EMBASSY_OFFICE_TYPES.first)
 
     assert_valid_embassies_index_document
@@ -53,11 +53,11 @@ class PublishingApi::EmbassiesIndexPresenterTest < ActiveSupport::TestCase
   test "generates a valid document for world locations with remote embassies" do
     world_location = build(:world_location)
     other_location = create(:world_location)
-    organisation = create(:worldwide_organisation, world_locations: [world_location])
+    organisation = create(:editionable_worldwide_organisation, world_locations: [world_location])
     contact = create(:contact_with_country, country: other_location)
     create(:worldwide_office,
            contact:,
-           worldwide_organisation: organisation,
+           edition: organisation,
            worldwide_office_type: WorldwideOfficeType::EMBASSY_OFFICE_TYPES.first)
 
     assert_valid_embassies_index_document


### PR DESCRIPTION
The embassies index page currently includes all non-editionable worldwide organisations, whereas we only want the published editionable worldwide organisations to appear on this page.

[Trello card](https://trello.com/c/y8BtTlEF)