### PR TITLE
Add MHCLG brand colour option

### DIFF
--- a/app/models/organisation_brand_colour.rb
+++ b/app/models/organisation_brand_colour.rb
@@ -172,4 +172,9 @@ class OrganisationBrandColour
     title: "Prime Minister's Office, 10 Downing Street",
     class_name: "prime-ministers-office-10-downing-street",
   )
+  MinistryOfHousingCommunitiesAndLocalGovernment = create!(
+    id: 34,
+    title: "Ministry of Housing, Communities & Local Government",
+    class_name: "ministry-of-housing-communities-and-local-government",
+  )
 end


### PR DESCRIPTION
Adds the brand colour as an option for the organisation in Whitehall.

Not to be merged until https://github.com/alphagov/govuk_publishing_components/pull/4100 has been merged and the gem bumped in collections, government-frontend and whitehall.