### PR TITLE
(354) Send content blocks straight to live

### DIFF
--- a/lib/engines/content_object_store/app/services/content_object_store/create_edition_service.rb
+++ b/lib/engines/content_object_store/app/services/content_object_store/create_edition_service.rb
@@ -1,5 +1,7 @@
 module ContentObjectStore
   class CreateEditionService
+    class PublishingFailureError < StandardError; end
+
     def initialize(schema, edition_params)
       @schema = schema
       @edition_params = edition_params
@@ -11,6 +13,9 @@ module ContentObjectStore
         content_id = content_block_edition.document.content_id
         create_publishing_api_edition(content_id:)
         publish_publishing_api_edition(content_id:)
+      rescue PublishingFailureError => e
+        discard_publishing_api_edition(content_id:)
+        raise e
       end
     end
 
@@ -32,6 +37,12 @@ module ContentObjectStore
 
     def publish_publishing_api_edition(content_id:)
       Services.publishing_api.publish(content_id)
+    rescue GdsApi::HTTPErrorResponse => e
+      raise PublishingFailureError, "Could not publish #{content_id} because: #{e.message}"
+    end
+
+    def discard_publishing_api_edition(content_id:)
+      Services.publishing_api.discard_draft(content_id)
     end
   end
 end

--- a/lib/engines/content_object_store/app/services/content_object_store/create_edition_service.rb
+++ b/lib/engines/content_object_store/app/services/content_object_store/create_edition_service.rb
@@ -8,7 +8,9 @@ module ContentObjectStore
     def call
       ActiveRecord::Base.transaction do
         content_block_edition = create_whitehall_edition
-        create_publishing_api_edition(content_id: content_block_edition.document.content_id)
+        content_id = content_block_edition.document.content_id
+        create_publishing_api_edition(content_id:)
+        publish_publishing_api_edition(content_id:)
       end
     end
 
@@ -26,6 +28,10 @@ module ContentObjectStore
         title: @edition_params[:document_title],
         details: @edition_params[:details].to_h,
       })
+    end
+
+    def publish_publishing_api_edition(content_id:)
+      Services.publishing_api.publish(content_id)
     end
   end
 end

--- a/lib/engines/content_object_store/test/integration/content_block_editions_test.rb
+++ b/lib/engines/content_object_store/test/integration/content_block_editions_test.rb
@@ -67,6 +67,9 @@ class ContentBlockEditionsTest < ActionDispatch::IntegrationTest
     fake_put_content_response = GdsApi::Response.new(
       stub("http_response", code: 200, body: {}),
     )
+    fake_publish_content_response = GdsApi::Response.new(
+      stub("http_response", code: 200, body: {}),
+    )
 
     # This UUID is created by the database so instead of loading the record
     # we stub the initial creation so we know what UUID to check for.
@@ -86,6 +89,9 @@ class ContentBlockEditionsTest < ActionDispatch::IntegrationTest
           "bar" => "Bar text",
         },
       },
+    ]
+    publishing_api_mock.expect :publish, fake_publish_content_response, [
+      @content_id,
     ]
 
     Services.stub :publishing_api, publishing_api_mock do

--- a/lib/engines/content_object_store/test/unit/app/services/create_edition_service_test.rb
+++ b/lib/engines/content_object_store/test/unit/app/services/create_edition_service_test.rb
@@ -51,6 +51,9 @@ class ContentObjectStore::CreateEditionServiceTest < ActiveSupport::TestCase
       fake_put_content_response = GdsApi::Response.new(
         stub("http_response", code: 200, body: {}),
       )
+      fake_publish_content_response = GdsApi::Response.new(
+        stub("http_response", code: 200, body: {}),
+      )
 
       # This UUID is created by the database so instead of loading the record
       # we stub the initial creation so we know what UUID to check for.
@@ -70,6 +73,9 @@ class ContentObjectStore::CreateEditionServiceTest < ActiveSupport::TestCase
             "bar" => "Bar text",
           },
         },
+      ]
+      publishing_api_mock.expect :publish, fake_publish_content_response, [
+        @content_id,
       ]
 
       Services.stub :publishing_api, publishing_api_mock do

--- a/lib/engines/content_object_store/test/unit/app/services/create_edition_service_test.rb
+++ b/lib/engines/content_object_store/test/unit/app/services/create_edition_service_test.rb
@@ -73,7 +73,7 @@ class ContentObjectStore::CreateEditionServiceTest < ActiveSupport::TestCase
     end
 
     test "if the publishing API request fails, the Whitehall ContentBlockEdition and ContentBlockDocument are rolled back" do
-      exception = GdsApi::HTTPUnprocessableEntity.new(
+      exception = GdsApi::HTTPErrorResponse.new(
         422,
         "An internal error message",
         "error" => { "message" => "Some backend error" },
@@ -83,7 +83,7 @@ class ContentObjectStore::CreateEditionServiceTest < ActiveSupport::TestCase
       Services.publishing_api.stub :put_content, raises_exception do
         assert_equal ContentObjectStore::ContentBlockDocument.count, 0 do
           assert_equal ContentObjectStore::ContentBlockEdition.count, 0 do
-            assert_raises(GdsApi::HTTPUnprocessableEntity) do
+            assert_raises(GdsApi::HTTPErrorResponse) do
               ContentObjectStore::CreateEditionService.new(schema, edition_params).call
             end
           end
@@ -100,6 +100,43 @@ class ContentObjectStore::CreateEditionServiceTest < ActiveSupport::TestCase
       ContentObjectStore::ContentBlockEdition.stub :create!, raises_exception do
         assert_raises(ArgumentError) do
           ContentObjectStore::CreateEditionService.new(schema, {}).call
+        end
+      end
+    end
+
+    test "if the publish request fails, the latest draft is discarded and the database actions are rolled back" do
+      fake_put_content_response = GdsApi::Response.new(
+        stub("http_response", code: 200, body: {}),
+      )
+      fake_discard_draft_content_response = GdsApi::Response.new(
+        stub("http_response", code: 200, body: {}),
+      )
+
+      publishing_api_mock = Minitest::Mock.new
+      publishing_api_mock.expect :put_content, fake_put_content_response, [
+        String,
+        Hash,
+      ]
+      publishing_api_mock.expect :discard_draft, fake_discard_draft_content_response, [
+        content_id,
+      ]
+
+      exception = GdsApi::HTTPErrorResponse.new(
+        422,
+        "An internal error message",
+        "error" => { "message" => "Some backend error" },
+      )
+      raises_exception = ->(*_args) { raise exception }
+
+      Services.publishing_api.stub :publish, raises_exception do
+        assert_equal ContentObjectStore::ContentBlockDocument.count, 0 do
+          assert_equal ContentObjectStore::ContentBlockEdition.count, 0 do
+            assert_raises(ContentObjectStore::CreateEditionService::PublishingFailureError, "Could not publish #{content_id} because: Some backend error") do
+              ContentObjectStore::CreateEditionService.new(schema, edition_params).call
+            end
+
+            publishing_api_mock.verify
+          end
         end
       end
     end


### PR DESCRIPTION
This ensures the edition is promoted to live immediately. We aim to have a second pair of eyes process in the longer term, but this gets us over the line while that process is mapped out.

I've also added some belt and braces stuff to delete an edition if a draft is created, but it isn't published. This is unlikely, but worth handling I think.