### PR TITLE
Bug fix - Only delete removed translations upon publish or force publish

### DIFF
--- a/app/services/service_listeners/publishing_api_pusher.rb
+++ b/app/services/service_listeners/publishing_api_pusher.rb
@@ -7,13 +7,9 @@ module ServiceListeners
     end
 
     def push(event:, options: {})
-      # This is done synchronously before the rest of the publishing.
-      # Currently (02/11/2016) publishing-api links
-      # are not recalculated on parent documents when their translations are unpublished.
-      handle_translations
-
       case event
       when "force_publish", "publish"
+        unpublish_removed_translations
         api.publish(edition)
       when "update_draft"
         api.patch_links(edition)
@@ -51,7 +47,7 @@ module ServiceListeners
       end
     end
 
-    def handle_translations
+    def unpublish_removed_translations
       previous_edition = edition.previous_edition
 
       if previous_edition

--- a/test/integration/translations_publishing_test.rb
+++ b/test/integration/translations_publishing_test.rb
@@ -1,0 +1,26 @@
+require "test_helper"
+require "gds_api/test_helpers/publishing_api"
+
+class TranslationsPublishingTest < ActiveSupport::TestCase
+  test "should not send any unpublishings to Publishing API after translations removed and draft saved" do
+    edition = build(:published_detailed_guide)
+    with_locale(:es) { edition.title = "spanish-title" }
+    edition.save!
+    draft_edition = edition.create_draft(build(:user))
+    draft_edition.change_note = "change-note"
+    draft_edition.save!
+
+    draft_publication_presenter = PublishingApiPresenters.presenter_for(draft_edition)
+
+    WebMock.reset!
+
+    requests = [
+      stub_publishing_api_put_content(draft_publication_presenter.content_id, with_locale(:en) { draft_publication_presenter.content }),
+    ]
+
+    draft_edition.translations.where(locale: :es).first.destroy!
+    Whitehall.edition_services.draft_updater(draft_edition).perform!
+
+    assert_all_requested(requests)
+  end
+end


### PR DESCRIPTION
At the moment, on every action of the publishing API pusher, deleted translations are unpublished from Publishing API. This has caused some bugs where live translations were deleted when only the draft has been updated. This is due to the unpublish-gone redirect taking only a content ID, and hence unable to differentiate between removing the draft or removing the live edition on Publishing API. The draft of the translation that has been deleted is removed from Publishing API already during the translation deletion step.

This change will fix live translations being pulled prematurely. The only problem we have left to solve is the preview not reflecting exactly the correct translation status of the new draft edition.

https://trello.com/c/CDd3uwCj/2564-fix-bug-that-triggers-deletion-of-live-translation-when-in-draft-state


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
