### PR TITLE
Data migration to remove organisation role linkage for old role

### DIFF
--- a/db/data_migration/202407121629400_remove_organisation_link_for_minister_for_disabled_people_health_work_role.rb
+++ b/db/data_migration/202407121629400_remove_organisation_link_for_minister_for_disabled_people_health_work_role.rb
@@ -1,0 +1,19 @@
+role_to_merge = Role.find_by(id: 2377)
+role_to_keep = Role.find_by(id: 4494)
+
+unless role_to_merge && role_to_keep
+  puts "Roles not found - exiting."
+  return
+end
+
+puts "checking organisation_roles..."
+affected_organisation_role = OrganisationRole.where(role_id: role_to_merge.id)
+puts "organisations affected: ", affected_organisation_role.count
+
+puts "republishing affected organisations..."
+affected_organisation_role.each do |organisation_role|
+  print "."
+  organisation_role.role_id = role_to_keep.id
+  organisation_role.save! # trigger callbacks
+end
+puts "done"


### PR DESCRIPTION
Previous PR https://github.com/alphagov/whitehall/pull/9231 added a data migration to migrate role appointments and organisations, however there was a missing line to actually update role ID for organisations. This should hopefully allow users to delete the redundant old role.

https://trello.com/c/9kQl9yH4/2625-merge-role-pages

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
