### PR TITLE
Do not attempt to redirect unpublished contacts

### DIFF
--- a/test/unit/app/services/service_listeners/publishing_api_associated_documents_test.rb
+++ b/test/unit/app/services/service_listeners/publishing_api_associated_documents_test.rb
@@ -268,9 +268,24 @@ module ServiceListeners
           "en",
         )
 
-        PublishingApiRedirectWorker.any_instance.expects(:perform).with(
+        call(new_edition)
+      end
+
+      test "with a contact on the old version of an editionable worldwide organisation publishes gone for the contact" do
+        worldwide_organisation = create(:published_editionable_worldwide_organisation, :with_main_office)
+
+        new_edition = worldwide_organisation.create_draft(create(:writer))
+        new_edition.main_office.destroy!
+        new_edition.minor_change = true
+        new_edition.submit!
+        new_edition.publish!
+
+        old_office = worldwide_organisation.main_office
+
+        PublishingApiGoneWorker.any_instance.expects(:perform).with(
           old_office.contact.content_id,
-          new_edition.search_link,
+          nil,
+          nil,
           "en",
         )
 

--- a/test/unit/app/services/service_listeners/publishing_api_associated_documents_test.rb
+++ b/test/unit/app/services/service_listeners/publishing_api_associated_documents_test.rb
@@ -271,6 +271,25 @@ module ServiceListeners
         call(new_edition)
       end
 
+      test "with an office on the old version that remains on the new version of an editionable worldwide organisation it does not publish a redirect for the office" do
+        worldwide_organisation = create(:published_editionable_worldwide_organisation, :with_main_office)
+
+        new_edition = worldwide_organisation.create_draft(create(:writer))
+        new_edition.minor_change = true
+        new_edition.submit!
+        new_edition.publish!
+
+        old_office = worldwide_organisation.main_office
+
+        PublishingApiRedirectWorker.any_instance.expects(:perform).with(
+          old_office.content_id,
+          new_edition.search_link,
+          "en",
+        ).never
+
+        call(new_edition)
+      end
+
       test "with a contact on the old version of an editionable worldwide organisation publishes gone for the contact" do
         worldwide_organisation = create(:published_editionable_worldwide_organisation, :with_main_office)
 
@@ -288,6 +307,26 @@ module ServiceListeners
           nil,
           "en",
         )
+
+        call(new_edition)
+      end
+
+      test "with a contact on the old version that remains on the new version of an editionable worldwide organisation it does not publish gone for the contact" do
+        worldwide_organisation = create(:published_editionable_worldwide_organisation, :with_main_office)
+
+        new_edition = worldwide_organisation.create_draft(create(:writer))
+        new_edition.minor_change = true
+        new_edition.submit!
+        new_edition.publish!
+
+        old_office = worldwide_organisation.main_office
+
+        PublishingApiGoneWorker.any_instance.expects(:perform).with(
+          old_office.contact.content_id,
+          nil,
+          nil,
+          "en",
+        ).never
 
         call(new_edition)
       end


### PR DESCRIPTION
When unpublishing a contact (which is associated with a worldwide office), we can't publish a redirect, since contacts don't have base paths.

Therefore updating to publish 'gone' instead. This mirrors the behaviour in `PublishesToPublishingApi` that was implemented prior to worldwide organisations being made editionable.

[Trello card](https://trello.com/c/T7dF1B7k)