### PR TITLE
Add GA4 tracking handler to visual editor buttons

### DIFF
--- a/app/assets/javascripts/admin/modules/ga4-visual-editor-event-handlers.js
+++ b/app/assets/javascripts/admin/modules/ga4-visual-editor-event-handlers.js
@@ -12,6 +12,19 @@ window.GOVUK.Modules = window.GOVUK.Modules || {}
     }
   }
 
+  const gaButtonClickAttributes = function (buttonText) {
+    return {
+      event_name: 'select_content',
+      type: 'generic_link',
+      text: buttonText,
+      external: 'false',
+      method: 'primary click',
+      section: document.title.split(' - ')[0].replace('Error: ', ''),
+      action: 'select',
+      tool_name: 'Visual Editor'
+    }
+  }
+
   function Ga4VisualEditorEventHandlers(module) {
     this.module = module
   }
@@ -20,6 +33,13 @@ window.GOVUK.Modules = window.GOVUK.Modules || {}
     this.module.addEventListener('visualEditorSelectChange', (event) => {
       window.GOVUK.analyticsGa4.core.applySchemaAndSendData(
         gaSelectChangeAttributes(event.detail.selectText),
+        'event_data'
+      )
+    })
+
+    this.module.addEventListener('visualEditorButtonClick', (event) => {
+      window.GOVUK.analyticsGa4.core.applySchemaAndSendData(
+        gaButtonClickAttributes(event.detail.buttonText),
         'event_data'
       )
     })

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "accessible-autocomplete": "alphagov/accessible-autocomplete-multiselect",
     "choices.js": "^10.2.0",
     "cropperjs": "^1.6.2",
-    "govspeak-visual-editor": "^1.5.0",
+    "govspeak-visual-editor": "^2.0.0",
     "miller-columns-element": "^2.0.0",
     "paste-html-to-govspeak": "^0.4.0"
   },

--- a/spec/javascripts/admin/modules/ga4-visual-editor-event-handlers.spec.js
+++ b/spec/javascripts/admin/modules/ga4-visual-editor-event-handlers.spec.js
@@ -35,4 +35,43 @@ describe('GOVUK.Modules.Ga4VisualEditorEventHandlers', function () {
       'event_data'
     )
   })
+
+  it('triggers ga4 tracking on visualEditorButtonClick event', function () {
+    document.title = 'Title - Text'
+    const button = document.createElement('button')
+    document.body.appendChild(button)
+
+    const mockGa4SendData = spyOn(
+      window.GOVUK.analyticsGa4.core,
+      'applySchemaAndSendData'
+    )
+
+    const ga4VisualEditorEventHandlers =
+      new GOVUK.Modules.Ga4VisualEditorEventHandlers(document)
+    ga4VisualEditorEventHandlers.init()
+    button.dispatchEvent(
+      new CustomEvent('visualEditorButtonClick', {
+        bubbles: true,
+        detail: {
+          buttonText: 'BUTTON'
+        }
+      })
+    )
+
+    const expectedAttributes = {
+      event_name: 'select_content',
+      type: 'generic_link',
+      text: 'BUTTON',
+      external: 'false',
+      method: 'primary click',
+      section: 'Title',
+      action: 'select',
+      tool_name: 'Visual Editor'
+    }
+
+    expect(mockGa4SendData).toHaveBeenCalledWith(
+      expectedAttributes,
+      'event_data'
+    )
+  })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1514,10 +1514,10 @@ gopd@^1.0.1:
   dependencies:
     get-intrinsic "^1.1.3"
 
-govspeak-visual-editor@^1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/govspeak-visual-editor/-/govspeak-visual-editor-1.5.0.tgz#0e9391f21a0f3638201ca79fe02717939939da08"
-  integrity sha512-Ga48kYYwsbeyq0XlCZA2lu8MmNTP3Tpo27bFsRq1sRRXUcyGRcoPBP+LcA8tQsUgYscKEgj63nKjpSuRHoRMOQ==
+govspeak-visual-editor@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/govspeak-visual-editor/-/govspeak-visual-editor-2.0.0.tgz#c085e3a50d1a4d628e5ed7a96d2162c5811aff0d"
+  integrity sha512-nsZoFSym7fB9DGj5TTXvkNHN4DjO3G1HF2gamOFtBWWObWKFH5aXZv5fzf9SyT9ShMi0qiqIxEAxAvVtBSOcmw==
   dependencies:
     govuk-frontend "^4.8.0"
     prosemirror-example-setup "^1.2.2"


### PR DESCRIPTION
- Trigger a GA4 tracking event when the buttons on the Visual Editor toolbar are clicked.
- https://trello.com/c/Lr3RDtvF/2723-refactor-visual-editor-tracking-event-emissions