### PR TITLE
Catch ActiveRecord::RecordInvalid errors when creating editions

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -158,6 +158,8 @@ class Admin::EditionsController < Admin::BaseController
       redirect_to edit_admin_edition_path(@edition.document.latest_edition),
                   alert: new_draft.errors.full_messages.to_sentence
     end
+  rescue ActiveRecord::RecordInvalid => e
+    redirect_to show_or_edit_path, alert: e.to_s
   end
 
   def diff


### PR DESCRIPTION
Until now, these errors would be swallowed up, showing a generic "Something went wrong" message to the user, but not actually generating any Sentry errors developers could go into later to diagnose (since the PUT is treated as a 422 client error, which is ignored by default).

This happened recently, where the underlying error was:

```
ActiveRecord::RecordInvalid
Validation failed: Summary can't be blank
```

We should at least be surfacing such errors to the user, so that it is quicker and easier to get a handle on what the underlying cause may be.

NB, in #9296 the "summary can't be blank" validation was removed, but there are still other kinds of validation errors that could have been swalloed up - in the test example we're now surfacing the "NoFootnotesInGovspeakValidator" result.

Trello: https://trello.com/c/AVhwYYgP/2737-investigate-consultation-not-allowing-new-edition-to-be-created

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
