### PR TITLE
Fix republish dependent editions on contact update

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -16,7 +16,7 @@ class Contact < ApplicationRecord
 
   validate :parent_edition_has_locales, if: :attached_to_editionable_worldwide_organisation?
 
-  after_update :republish_dependent_editions
+  after_commit :republish_dependent_editions, on: :update
   after_update :republish_dependent_policy_groups
   after_update :republish_organisation_to_publishing_api
 

--- a/test/unit/app/models/contact_test.rb
+++ b/test/unit/app/models/contact_test.rb
@@ -128,7 +128,7 @@ class ContactTest < ActiveSupport::TestCase
       ServiceListeners::EditionDependenciesPopulator.new(corp_info_page).populate!
 
       PresentPageToPublishingApi.any_instance.stubs(:publish).with(PublishingApi::EmbassiesIndexPresenter)
-      expect_publishing(contact)
+      expect_publishing(contact, content_entries: { title: "Changed contact title" })
       expect_republishing(news_article, corp_info_page)
 
       contact.update!(title: "Changed contact title")


### PR DESCRIPTION
This came through as a Zendesk ticket. A user had updated a contact on an organisation page, but an editions using that contact (as markdown) did not update.

By investigating the callback, it seems plausible that the async calls to republish may execute before the db transaction of updating the contact and its relationships has finished. So the calls are being made, but on stale data.

I was not able to reproduce this, and the existing tests, which run Sidekiq inline, seem to send the correct load to pub api. Nonetheless, it seems a safe bet to replace the callback in order to prevent further issues. Will restrict the callback to only run on update. 

Risk of change: `after_commit` has some transaction rollback implications, meaning we lose the guarantee of rolling back the update, which we get when using `after_update`.

[Trello](https://trello.com/c/1SLSKKac/2729-investigate-apparent-issue-with-contacts-not-updating)
