### PR TITLE
Set `update_type` when publishing

### DIFF
--- a/lib/engines/content_object_store/app/lib/content_object_store/publishable.rb
+++ b/lib/engines/content_object_store/app/lib/content_object_store/publishable.rb
@@ -35,7 +35,7 @@ module ContentObjectStore
     end
 
     def publish_publishing_api_edition(content_id:)
-      Services.publishing_api.publish(content_id)
+      Services.publishing_api.publish(content_id, "major")
     rescue GdsApi::HTTPErrorResponse => e
       raise PublishingFailureError, "Could not publish #{content_id} because: #{e.message}"
     end

--- a/lib/engines/content_object_store/test/unit/app/services/create_edition_service_test.rb
+++ b/lib/engines/content_object_store/test/unit/app/services/create_edition_service_test.rb
@@ -63,6 +63,7 @@ class ContentObjectStore::CreateEditionServiceTest < ActiveSupport::TestCase
       ]
       publishing_api_mock.expect :publish, fake_publish_content_response, [
         content_id,
+        "major",
       ]
 
       Services.stub :publishing_api, publishing_api_mock do


### PR DESCRIPTION
Publishing API requires an update_type to be set. Let’s set this to major for everything while we decide what to do.