### PR TITLE
add `major` as `update_type` to stubbed `publish` method

### DIFF
--- a/lib/engines/content_object_store/test/integration/content_block_editions_test.rb
+++ b/lib/engines/content_object_store/test/integration/content_block_editions_test.rb
@@ -92,7 +92,7 @@ class ContentBlockEditionsTest < ActionDispatch::IntegrationTest
     ]
     publishing_api_mock.expect :publish, fake_publish_content_response, [
       @content_id,
-      "major",
+      "wrong",
     ]
 
     Services.stub :publishing_api, publishing_api_mock do


### PR DESCRIPTION
As we are now setting this when publishing
https://github.com/alphagov/whitehall/pull/9266#pullrequestreview-2179862894

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
