### PR TITLE
Fail minitest step if any tests fail

### DIFF
--- a/.github/workflows/minitest.yml
+++ b/.github/workflows/minitest.yml
@@ -75,5 +75,13 @@ jobs:
     name: Run Minitest
     needs: minitest-matrix
     runs-on: ubuntu-latest
+    if: always()
     steps:
-      - run: echo "All MiniTest tests have passed 🚀"
+      - name: Fail on workflow error
+        run: exit 1
+        if: >-
+          ${{
+            contains(needs.*.result, 'failure')
+            || contains(needs.*.result, 'cancelled')
+            || contains(needs.*.result, 'skipped')
+          }}


### PR DESCRIPTION
We had a [PR where a failure snuck through when one of the matrix steps failed](https://github.com/alphagov/whitehall/actions/runs/9955264703/job/27502756556), and the success step was skipped, but didn't prevent the PR from being merged. This updates the final `run-minitest` job to expressly fail if any of the steps are in a failing, cancelled or skipped state, which should address this issue.