### PR TITLE
Remove non-editionable worldwide organisation code that was missed

### DIFF
--- a/app/models/concerns/edition/lead_image.rb
+++ b/app/models/concerns/edition/lead_image.rb
@@ -62,8 +62,6 @@ private
       lead_organisations.first.default_news_image
     elsif organisations.any? && organisations.first.default_news_image
       organisations.first.default_news_image
-    elsif respond_to?(:worldwide_organisations) && worldwide_organisations.any? && worldwide_organisations.first.default_news_image
-      worldwide_organisations.first.default_news_image
     elsif respond_to?(:editionable_worldwide_organisations) && published_editionable_worldwide_organisations.any? && published_editionable_worldwide_organisations.first.default_news_image
       published_editionable_worldwide_organisations.first.default_news_image
     end

--- a/test/unit/app/models/featured_image_data_test.rb
+++ b/test/unit/app/models/featured_image_data_test.rb
@@ -114,17 +114,6 @@ class FeaturedImageDataTest < ActiveSupport::TestCase
     organisation.default_news_image.republish_on_assets_ready
   end
 
-  test "#republish_on_assets_ready should republish worldwide organisation and associations if assets are ready" do
-    worldwide_organisation = create(:editionable_worldwide_organisation, :with_default_news_image)
-    news_article = create(:news_article_world_news_story, :published, editionable_worldwide_organisations: [worldwide_organisation])
-    create(:news_article_world_news_story, :draft, editionable_worldwide_organisations: [worldwide_organisation], document: news_article.document)
-
-    Whitehall::PublishingApi.expects(:republish_document_async).with(worldwide_organisation.document).once
-    Whitehall::PublishingApi.expects(:republish_document_async).with(news_article.document).once
-
-    worldwide_organisation.default_news_image.republish_on_assets_ready
-  end
-
   test "#republish_on_assets_ready should republish editionable worldwide organisation and associations if assets are ready" do
     worldwide_organisation = create(:published_editionable_worldwide_organisation, :with_default_news_image)
     news_article = create(:news_article_world_news_story, :published, editionable_worldwide_organisations: [worldwide_organisation])

--- a/test/unit/app/models/news_article_test.rb
+++ b/test/unit/app/models/news_article_test.rb
@@ -116,7 +116,6 @@ class WorldNewsStoryTypeNewsArticleTest < ActiveSupport::TestCase
 
     assert_not news_article.valid?
     assert news_article.errors[:editionable_worldwide_organisations].include?("at least one required")
-    assert_not news_article.errors[:worldwide_organisations].present?
   end
 
   test "are invalid if associated with a minister" do


### PR DESCRIPTION
This removes some non-editionable worldwide organisation code that was missed in https://github.com/alphagov/whitehall/pull/9216.

[Trello card](https://trello.com/c/y8BtTlEF)