### PR TITLE
Disable republishing of embassies index page

### DIFF
--- a/app/controllers/admin/republishing_controller.rb
+++ b/app/controllers/admin/republishing_controller.rb
@@ -193,7 +193,7 @@ private
       "PublishingApi::HowGovernmentWorksPresenter",
       "PublishingApi::OperationalFieldsIndexPresenter",
       "PublishingApi::MinistersIndexPresenter",
-      "PublishingApi::EmbassiesIndexPresenter",
+      # "PublishingApi::EmbassiesIndexPresenter",
       "PublishingApi::WorldIndexPresenter",
       "PublishingApi::OrganisationsIndexPresenter",
     ].map do |presenter_class_string|

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -23,7 +23,7 @@ class Contact < ApplicationRecord
   after_create :republish_organisation_to_publishing_api
   after_destroy :republish_organisation_to_publishing_api
 
-  after_commit :republish_embassies_index_page_to_publishing_api, :republish_worldwide_office_to_publishing_api
+  # after_commit :republish_embassies_index_page_to_publishing_api, :republish_worldwide_office_to_publishing_api
 
   include TranslatableModel
   translates :title,

--- a/app/models/world_location.rb
+++ b/app/models/world_location.rb
@@ -93,7 +93,7 @@ class WorldLocation < ApplicationRecord
   friendly_id
 
   def republish_index_pages_to_publishing_api
-    PresentPageToPublishingApiWorker.perform_async("PublishingApi::EmbassiesIndexPresenter")
+    # PresentPageToPublishingApiWorker.perform_async("PublishingApi::EmbassiesIndexPresenter")
     PresentPageToPublishingApiWorker.perform_async("PublishingApi::WorldIndexPresenter") if I18n.locale == :en
   end
 

--- a/app/models/worldwide_office.rb
+++ b/app/models/worldwide_office.rb
@@ -5,7 +5,7 @@ class WorldwideOffice < ApplicationRecord
   has_many :services, through: :worldwide_office_worldwide_services, source: :worldwide_service
   validates :contact, :edition, :worldwide_office_type_id, presence: true
 
-  after_commit :republish_embassies_index_page_to_publishing_api
+  # after_commit :republish_embassies_index_page_to_publishing_api
 
   accepts_nested_attributes_for :contact
 

--- a/features/republishing-content.feature
+++ b/features/republishing-content.feature
@@ -27,10 +27,10 @@ Feature: Republishing published documents
     When I request a republish of the "Ministers" page
     Then I can see the "Ministers" page has been scheduled for republishing
 
-  Scenario: Republish the "Find a British embassy, high commission or consulate" page
-    Given a published publication "Find a British embassy, high commission or consulate" exists
-    When I request a republish of the "Find a British embassy, high commission or consulate" page
-    Then I can see the "Find a British embassy, high commission or consulate" page has been scheduled for republishing
+#  Scenario: Republish the "Find a British embassy, high commission or consulate" page
+#    Given a published publication "Find a British embassy, high commission or consulate" exists
+#    When I request a republish of the "Find a British embassy, high commission or consulate" page
+#    Then I can see the "Find a British embassy, high commission or consulate" page has been scheduled for republishing
 
   Scenario: Republish the "Help and services around the world" page
     Given a published publication "Help and services around the world" exists

--- a/test/unit/app/models/contact_test.rb
+++ b/test/unit/app/models/contact_test.rb
@@ -168,7 +168,7 @@ class ContactTest < ActiveSupport::TestCase
   end
 
   test "republishes embassies index page on creation of contact" do
-    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter)
+    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter).never
 
     Sidekiq::Testing.inline! do
       create(:contact)
@@ -178,7 +178,7 @@ class ContactTest < ActiveSupport::TestCase
   test "republishes embassies index page on update of contact" do
     contact = create(:contact_with_country)
 
-    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter)
+    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter).never
 
     Sidekiq::Testing.inline! do
       contact.update!(locality: "new-locality")
@@ -188,7 +188,7 @@ class ContactTest < ActiveSupport::TestCase
   test "republishes embassies index page on deletion of contact" do
     contact = create(:contact)
 
-    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter)
+    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter).never
 
     Sidekiq::Testing.inline! do
       contact.destroy!

--- a/test/unit/app/models/world_location_test.rb
+++ b/test/unit/app/models/world_location_test.rb
@@ -112,7 +112,7 @@ class WorldLocationTest < ActiveSupport::TestCase
   end
 
   test "republishes embassies and world index pages on creation of world location" do
-    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter)
+    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter).never
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::WorldIndexPresenter)
 
     Sidekiq::Testing.inline! do
@@ -123,7 +123,7 @@ class WorldLocationTest < ActiveSupport::TestCase
   test "republishes embassies and world index pages on update of world location" do
     location = create(:world_location)
 
-    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter)
+    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter).never
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::WorldIndexPresenter)
 
     Sidekiq::Testing.inline! do
@@ -134,7 +134,7 @@ class WorldLocationTest < ActiveSupport::TestCase
   test "republishes embassies and world index pages on deletion of world location" do
     location = create(:world_location)
 
-    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter)
+    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter).never
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::WorldIndexPresenter)
 
     Sidekiq::Testing.inline! do

--- a/test/unit/app/models/worldwide_office_test.rb
+++ b/test/unit/app/models/worldwide_office_test.rb
@@ -78,7 +78,7 @@ class WorldwideOfficeTest < ActiveSupport::TestCase
     worldwide_organisation = create(:editionable_worldwide_organisation)
     contact = create(:contact)
 
-    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter).twice
+    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter).never
 
     Sidekiq::Testing.inline! do
       create(:worldwide_office, edition: worldwide_organisation, contact:)
@@ -88,7 +88,7 @@ class WorldwideOfficeTest < ActiveSupport::TestCase
   test "republishes embassies index page on update of worldwide office" do
     office = create(:worldwide_office)
 
-    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter)
+    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter).never
 
     Sidekiq::Testing.inline! do
       office.update!(slug: "new-slug")
@@ -98,7 +98,7 @@ class WorldwideOfficeTest < ActiveSupport::TestCase
   test "republishes embassies index page on deletion of worldwide office" do
     office = create(:worldwide_office)
 
-    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter).twice
+    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter).never
 
     Sidekiq::Testing.inline! do
       office.destroy!


### PR DESCRIPTION
Republishing this page was causing an incident because it was running some extremely slow database queries.

We think a migration run as part of the editionable worldwide organisations cleanup work may have resulted in a loss of performance for queries run during the embassies index presenting process
