### PR TITLE
add Postal Address block type schema

### DIFF
--- a/lib/engines/content_object_store/app/models/content_object_store/content_block_schema.rb
+++ b/lib/engines/content_object_store/app/models/content_object_store/content_block_schema.rb
@@ -1,7 +1,7 @@
 class ContentObjectStore::ContentBlockSchema
   SCHEMA_PREFIX = "content_block".freeze
 
-  VALID_SCHEMAS = %w[email_address].freeze
+  VALID_SCHEMAS = %w[email_address postal_address].freeze
   private_constant :VALID_SCHEMAS
 
   def self.valid_schemas

--- a/lib/engines/content_object_store/test/unit/app/models/content_block_schema_test.rb
+++ b/lib/engines/content_object_store/test/unit/app/models/content_block_schema_test.rb
@@ -10,6 +10,7 @@ class ContentObjectStore::SchemaTest < ActiveSupport::TestCase
     test "it returns the contents of the VALID_SCHEMA constant" do
       assert_equal ContentObjectStore::ContentBlockSchema.valid_schemas, %w[
         email_address
+        postal_address
       ]
     end
   end


### PR DESCRIPTION
Not to be merged until the schema has been added here: https://github.com/alphagov/publishing-api/pull/2807

Note: the current schema generator puts fields in alphabetical order which is why this doesn't match the GDS order.

<img width="1149" alt="Screenshot 2024-07-18 at 16 37 47" src="https://github.com/user-attachments/assets/35b06be4-5b0a-4205-9b16-6529cfe1db43">

