### PR TITLE
Add feature flag for Content Object Store

### DIFF
--- a/config/features.rb
+++ b/config/features.rb
@@ -23,4 +23,5 @@ Flipflop.configure do
   #   description: "Take over the world."
   feature :editionable_worldwide_organisations, description: "Enables editionable worldwide organisations", default: false
   feature :govspeak_visual_editor, description: "Enables a visual editor for Govspeak fields", default: false
+  feature :content_object_store, description: "Enables the object store for sharable content", default: Rails.env.development?
 end

--- a/lib/engines/content_object_store/app/controllers/content_object_store/base_controller.rb
+++ b/lib/engines/content_object_store/app/controllers/content_object_store/base_controller.rb
@@ -1,0 +1,7 @@
+class ContentObjectStore::BaseController < Admin::BaseController
+  before_action :check_object_store_feature_flag
+
+  def check_object_store_feature_flag
+    forbidden! unless Flipflop.content_object_store?
+  end
+end

--- a/lib/engines/content_object_store/app/controllers/content_object_store/content_block_editions_controller.rb
+++ b/lib/engines/content_object_store/app/controllers/content_object_store/content_block_editions_controller.rb
@@ -1,4 +1,4 @@
-class ContentObjectStore::ContentBlockEditionsController < Admin::BaseController
+class ContentObjectStore::ContentBlockEditionsController < ContentObjectStore::BaseController
   def index
     @content_block_editions = ContentObjectStore::ContentBlockEdition.all
   end

--- a/lib/engines/content_object_store/features/create_object.feature
+++ b/lib/engines/content_object_store/features/create_object.feature
@@ -1,6 +1,7 @@
 Feature: Create a content object
 
   Background:
+    Given the content object store feature flag is enabled
     Given I am a GDS admin
     And a schema "email_address" exists with the following fields:
       | field         | type   | format | required |

--- a/lib/engines/content_object_store/features/object_store_feature_flag.feature
+++ b/lib/engines/content_object_store/features/object_store_feature_flag.feature
@@ -1,0 +1,9 @@
+Feature: Create a content object when feature flag is disabled
+
+  Background:
+    Given the content object store feature flag is disabled
+    Given I am a GDS admin
+
+  Scenario: GDS editor visits object store
+    When I visit the object store
+    Then I should see a permissions error

--- a/lib/engines/content_object_store/features/step_definitions/content_object_store_steps.rb
+++ b/lib/engines/content_object_store/features/step_definitions/content_object_store_steps.rb
@@ -1,3 +1,8 @@
+Given(/^the content object store feature flag is (enabled|disabled)$/) do |enabled|
+  @test_strategy ||= Flipflop::FeatureSet.current.test!
+  @test_strategy.switch!(:content_object_store, enabled == "enabled")
+end
+
 Given("a schema {string} exists with the following fields:") do |block_type, table|
   fields = table.hashes
   @schemas ||= {}
@@ -185,4 +190,8 @@ end
 
 Then("I should see a message that the {string} field is an invalid {string}") do |field_name, format|
   assert_text "#{ContentObjectStore::ContentBlockEdition.human_attribute_name("details_#{field_name}")} is an invalid #{format.titleize}"
+end
+
+Then("I should see a permissions error") do
+  assert_text "Permissions error"
 end

--- a/lib/engines/content_object_store/features/view_object.feature
+++ b/lib/engines/content_object_store/features/view_object.feature
@@ -1,6 +1,7 @@
 Feature: View a content object
 
   Scenario: GDS Editor views a content object
+    Given the content object store feature flag is enabled
     Given I am a GDS admin
     And a schema "email_address" exists with the following fields:
       | email_address |

--- a/lib/engines/content_object_store/test/functional/base_controller_test.rb
+++ b/lib/engines/content_object_store/test/functional/base_controller_test.rb
@@ -1,0 +1,5 @@
+require "test_helper"
+
+class ContentObjectStore::BaseControllerTest < ActionController::TestCase
+  should_be_an_admin_controller
+end

--- a/lib/engines/content_object_store/test/functional/content_block_editions_controller_test.rb
+++ b/lib/engines/content_object_store/test/functional/content_block_editions_controller_test.rb
@@ -1,5 +1,8 @@
 require "test_helper"
 
 class ContentObjectStore::ContentBlockEditionsControllerTest < ActionController::TestCase
-  should_be_an_admin_controller
+  test "should inherit from base controller" do
+    assert @controller.is_a?(ContentObjectStore::BaseController),
+           "the controller should inherit from the object store's base controller"
+  end
 end

--- a/lib/engines/content_object_store/test/integration/content_block_editions_test.rb
+++ b/lib/engines/content_object_store/test/integration/content_block_editions_test.rb
@@ -9,6 +9,8 @@ class ContentBlockEditionsTest < ActionDispatch::IntegrationTest
     @content_id = "49453854-d8fd-41da-ad4c-f99dbac601c3"
 
     stub_request_for_schema("email_address")
+
+    feature_flags.switch!(:content_object_store, true)
   end
 
   test "#index returns all Content Block Editions" do


### PR DESCRIPTION
While we are still developing the object store we do not want it released to the public.

By default this will be turned on in development, but off in other environments until we’re ready to test/roll out.

Feature flag docs: https://github.com/alphagov/whitehall/blob/main/docs/feature_flags.md
