### PR TITLE
Content modelling/337 ContentBlockEditions can be updated

### DIFF
--- a/db/migrate/20240718152824_add_latest_edition_state_to_content_block_documents.rb
+++ b/db/migrate/20240718152824_add_latest_edition_state_to_content_block_documents.rb
@@ -1,0 +1,19 @@
+class AddLatestEditionStateToContentBlockDocuments < ActiveRecord::Migration[7.1]
+  def up
+    change_table :content_block_documents, bulk: true do |t|
+      t.column :latest_edition_id, :integer
+      t.column :live_edition_id, :integer
+      t.index :latest_edition_id
+      t.index :live_edition_id
+    end
+  end
+
+  def down
+    change_table :content_block_documents, bulk: true do |t|
+      t.remove :latest_edition_id
+      t.remove :live_edition_id
+      t.remove_index :latest_edition_id
+      t.remove_index :live_edition_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_18_091749) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_18_152824) do
   create_table "assets", charset: "utf8mb3", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.string "variant", null: false
@@ -197,6 +197,10 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_18_091749) do
     t.string "block_type"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
+    t.integer "latest_edition_id"
+    t.integer "live_edition_id"
+    t.index ["latest_edition_id"], name: "index_content_block_documents_on_latest_edition_id"
+    t.index ["live_edition_id"], name: "index_content_block_documents_on_live_edition_id"
   end
 
   create_table "content_block_edition_authors", charset: "utf8mb3", force: :cascade do |t|

--- a/lib/engines/content_object_store/app/components/content_object_store/content_block_edition/show/summary_list_component.rb
+++ b/lib/engines/content_object_store/app/components/content_object_store/content_block_edition/show/summary_list_component.rb
@@ -15,12 +15,17 @@ private
     {
       field: "Title",
       value: content_block_edition.title,
+      edit: edit_action,
     }
   end
 
   def details_items
-    @content_block_edition.details.map do |key, value|
-      { field: key.humanize, value: }
+    content_block_edition.details.map do |key, value|
+      {
+        field: key.humanize,
+        value:,
+        edit: edit_action,
+      }
     end
   end
 
@@ -28,6 +33,13 @@ private
     {
       field: "Creator",
       value: content_block_edition.creator.name,
+    }
+  end
+
+  def edit_action
+    {
+      href: helpers.content_object_store.edit_content_object_store_content_block_edition_path(content_block_edition),
+      link_text: "Change",
     }
   end
 end

--- a/lib/engines/content_object_store/app/controllers/content_object_store/content_block_editions_controller.rb
+++ b/lib/engines/content_object_store/app/controllers/content_object_store/content_block_editions_controller.rb
@@ -27,6 +27,32 @@ class ContentObjectStore::ContentBlockEditionsController < Admin::BaseController
     render :new
   end
 
+  def edit
+    @content_block_edition = ContentObjectStore::ContentBlockEdition.find(params[:id])
+    @schema = ContentObjectStore::ContentBlockSchema.find_by_block_type(@content_block_edition.document.block_type)
+  end
+
+  def update
+    @content_block_edition = ContentObjectStore::ContentBlockEdition.find(params[:id])
+    @schema = ContentObjectStore::ContentBlockSchema.find_by_block_type(@content_block_edition.document.block_type)
+
+    @new_content_block_edition = ContentObjectStore::ContentBlockEdition.create!(
+      details: edition_params[:details],
+      content_block_document: @content_block_edition.content_block_document,
+      creator: current_user,
+    )
+
+    document_params = edition_params[:content_block_document_attributes]
+    document_params[:latest_edition_id] = @new_content_block_edition.id
+    document_params[:live_edition_id] = @new_content_block_edition.id
+    document_params.delete(:block_type)
+
+    @content_block_edition.document.update!(document_params)
+
+    redirect_to content_object_store.content_object_store_content_block_edition_path(@new_content_block_edition),
+                flash: { notice: "#{@schema.name} changed and published successfully" }
+  end
+
 private
 
   def root_params

--- a/lib/engines/content_object_store/app/controllers/content_object_store/content_block_editions_controller.rb
+++ b/lib/engines/content_object_store/app/controllers/content_object_store/content_block_editions_controller.rb
@@ -43,6 +43,9 @@ class ContentObjectStore::ContentBlockEditionsController < Admin::BaseController
 
     redirect_to content_object_store.content_object_store_content_block_edition_path(@new_content_block_edition),
                 flash: { notice: "#{@schema.name} changed and published successfully" }
+  rescue ActiveRecord::RecordInvalid => e
+    @content_block_edition = e.record
+    render :edit
   end
 
 private

--- a/lib/engines/content_object_store/app/controllers/content_object_store/content_block_editions_controller.rb
+++ b/lib/engines/content_object_store/app/controllers/content_object_store/content_block_editions_controller.rb
@@ -36,18 +36,10 @@ class ContentObjectStore::ContentBlockEditionsController < Admin::BaseController
     @content_block_edition = ContentObjectStore::ContentBlockEdition.find(params[:id])
     @schema = ContentObjectStore::ContentBlockSchema.find_by_block_type(@content_block_edition.document.block_type)
 
-    @new_content_block_edition = ContentObjectStore::ContentBlockEdition.create!(
-      details: edition_params[:details],
-      content_block_document: @content_block_edition.content_block_document,
-      creator: current_user,
-    )
-
-    document_params = edition_params[:content_block_document_attributes]
-    document_params[:latest_edition_id] = @new_content_block_edition.id
-    document_params[:live_edition_id] = @new_content_block_edition.id
-    document_params.delete(:block_type)
-
-    @content_block_edition.document.update!(document_params)
+    @new_content_block_edition = ContentObjectStore::UpdateEditionService.new(
+      @schema,
+      @content_block_edition,
+    ).call(edition_params)
 
     redirect_to content_object_store.content_object_store_content_block_edition_path(@new_content_block_edition),
                 flash: { notice: "#{@schema.name} changed and published successfully" }

--- a/lib/engines/content_object_store/app/lib/content_object_store/publishable.rb
+++ b/lib/engines/content_object_store/app/lib/content_object_store/publishable.rb
@@ -16,6 +16,7 @@ module ContentObjectStore
           details: details.to_h,
         )
         publish_publishing_api_edition(content_id:)
+        update_content_block_document_with_latest_edition(content_block_edition)
       rescue PublishingFailureError => e
         discard_publishing_api_edition(content_id:)
         raise e
@@ -42,6 +43,13 @@ module ContentObjectStore
 
     def discard_publishing_api_edition(content_id:)
       Services.publishing_api.discard_draft(content_id)
+    end
+
+    def update_content_block_document_with_latest_edition(content_block_edition)
+      content_block_edition.document.update!(
+        live_edition_id: content_block_edition.id,
+        latest_edition_id: content_block_edition.id,
+      )
     end
   end
 end

--- a/lib/engines/content_object_store/app/services/content_object_store/update_edition_service.rb
+++ b/lib/engines/content_object_store/app/services/content_object_store/update_edition_service.rb
@@ -1,0 +1,50 @@
+module ContentObjectStore
+  class UpdateEditionService
+    include Publishable
+
+    def initialize(schema, original_content_block_edition)
+      @schema = schema
+      @original_content_block_edition = original_content_block_edition
+    end
+
+    def call(edition_params)
+      raise ArgumentError, "Edition params must be provided" if edition_params.blank? || edition_params[:details].blank?
+
+      title = edition_params.dig(:content_block_document_attributes, :title) || @original_content_block_edition.document.title
+      details = edition_params[:details]
+      update_document_params = edition_params[:content_block_document_attributes] || {}
+
+      publish_with_rollback(schema: @schema, title:, details:) do
+        @new_content_block_edition = create_new_content_block_edition_for_document(edition_params:)
+
+        update_content_block_document(
+          new_content_block_edition: @new_content_block_edition,
+          update_document_params:,
+        )
+
+        @new_content_block_edition
+      end
+
+      @new_content_block_edition
+    end
+
+  private
+
+    def create_new_content_block_edition_for_document(edition_params:)
+      new_content_block_edition = ContentObjectStore::ContentBlockEdition.new(edition_params)
+      new_content_block_edition.document = @original_content_block_edition.document
+      new_content_block_edition.save!
+      new_content_block_edition
+    end
+
+    def update_content_block_document(new_content_block_edition:, update_document_params:)
+      update_document_params[:latest_edition_id] = new_content_block_edition.id
+      update_document_params[:live_edition_id] = new_content_block_edition.id
+
+      # Updates to a Document should never change its block type
+      update_document_params.delete(:block_type)
+
+      new_content_block_edition.document.update!(update_document_params)
+    end
+  end
+end

--- a/lib/engines/content_object_store/app/views/content_object_store/content_block_editions/_form.html.erb
+++ b/lib/engines/content_object_store/app/views/content_object_store/content_block_editions/_form.html.erb
@@ -30,15 +30,15 @@ content_object_store.content_object_store_content_block_editions_path do |f| %>
 
   <div class="govuk-button-group govuk-!-margin-bottom-6">
     <%= render "govuk_publishing_components/components/button", {
-      text: "Save and continue",
-      name: "save_and_continue",
-      value: "Save and continue",
+      text: "Save and publish",
+      name: "save_and_publish",
+      value: "Save and publish",
       type: "submit",
       data_attributes: {
         module: "gem-track-click",
         "track-category": "form-button",
         "track-action": "#{f.object.class.name.demodulize.underscore.dasherize}-button",
-        "track-label": "Save and continue",
+        "track-label": "Save and publish",
       },
     } %>
     <%= link_to("Cancel", content_object_store.content_object_store_content_block_editions_path, class: "govuk-link") %>

--- a/lib/engines/content_object_store/app/views/content_object_store/content_block_editions/edit.html.erb
+++ b/lib/engines/content_object_store/app/views/content_object_store/content_block_editions/edit.html.erb
@@ -1,0 +1,53 @@
+<% content_for :context, "Object store" %>
+<% content_for :title, "Change #{@schema.name}" %>
+
+<% content_for :back_link do %>
+  <%= render "govuk_publishing_components/components/back_link", {
+    href: content_object_store.content_object_store_content_block_edition_path(@content_block_edition),
+  } %>
+<% end %>
+
+<% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @content_block_edition)) %>
+<%= form_with model: @content_block_edition, as: :content_block_edition, url: content_object_store.content_object_store_content_block_edition_path do |f| %>
+  <%= hidden_field_tag "content_block_edition[content_block_document_attributes][block_type]",
+    @schema.block_type,
+    id: "content_object_store/content_block_edition_content_block_document_block_type" %>
+
+  <%= render "govuk_publishing_components/components/input", {
+    label: {
+      text: "Title",
+    },
+    name: "content_block_edition[content_block_document_attributes][title]",
+    id: "content_object_store/content_block_edition_content_block_document_title",
+    value: @content_block_edition.content_block_document&.title,
+    error_items: errors_for(@content_block_edition.errors, "content_block_document.title".to_sym),
+  } %>
+
+  <% @content_block_edition.details.each do |field, value| %>
+    <%= render "govuk_publishing_components/components/input", {
+      label: {
+        text: field.humanize,
+      },
+      name: "content_block_edition[details[#{field}]]",
+      id: "content_object_store/content_block_edition_details_#{field}",
+      value: value,
+      error_items: errors_for(@content_block_edition.errors, "details_#{field}".to_sym),
+    } %>
+  <% end %>
+
+  <div class="govuk-button-group govuk-!-margin-bottom-6">
+    <%= render "govuk_publishing_components/components/button", {
+      text: "Save and publish",
+      name: "save_and_publish",
+      value: "Save and publish",
+      type: "submit",
+      data_attributes: {
+        module: "gem-track-click",
+        "track-category": "form-button",
+        "track-action": "#{f.object.class.name.demodulize.underscore.dasherize}-button",
+        "track-label": "Save and publish",
+      },
+    } %>
+    <%= link_to("Cancel", content_object_store.content_object_store_content_block_edition_path(@content_block_edition), class: "govuk-link") %>
+  </div>
+<% end %>

--- a/lib/engines/content_object_store/config/routes.rb
+++ b/lib/engines/content_object_store/config/routes.rb
@@ -4,7 +4,7 @@ ContentObjectStore::Engine.routes.draw do
     root to: "health_check#index", via: :get
 
     resources :content_block_editions, path: "content-block-editions",
-                                       only: %i[index new create show],
+                                       only: %i[index new create show edit update],
                                        path_names: { new: "(:block_type)/new" }
   end
 end

--- a/lib/engines/content_object_store/features/edit_object.feature
+++ b/lib/engines/content_object_store/features/edit_object.feature
@@ -14,3 +14,29 @@ Feature: Edit a content object
     Then I should see the edit form
     When I fill out the form
     Then the edition should have been updated successfully
+
+  Scenario: GDS editor sees validation errors for missing fields
+    Given I am a GDS admin
+    And a schema "email_address" exists with the following fields:
+    | field         | type   | format | required |
+    | email_address | string | email  | true     |
+    And an email address content block has been created
+    When I visit the object store
+    When I click to view the content block
+    When I click the first change link
+    And I set all fields to blank
+    Then I should see errors for the required fields
+
+  Scenario: GDS editor sees validation errors for invalid fields
+    Given I am a GDS admin
+    And a schema "email_address" exists with the following fields:
+    | field         | type   | format | required |
+    | email_address | string | email  | true     |
+    And an email address content block has been created
+    When I visit the object store
+    When I click to view the content block
+    When I click the first change link
+    When I complete the form with the following fields:
+    | title            | email_address   |
+    | my email address | xxxxx           |
+    Then I should see a message that the "email_address" field is an invalid "email"

--- a/lib/engines/content_object_store/features/edit_object.feature
+++ b/lib/engines/content_object_store/features/edit_object.feature
@@ -1,0 +1,16 @@
+Feature: Edit a content object
+
+  Scenario: GDS Editor edits a content object
+    Given I am a GDS admin
+    And a schema "email_address" exists with the following fields:
+      | field         | type   | format | required |
+      | email_address | string | email  | true     |
+    And an email address content block has been created
+    When I visit the object store
+    Then I should see the details for all content blocks
+    When I click to view the content block
+    Then I should see the details for the email address content block
+    When I click the first change link
+    Then I should see the edit form
+    When I fill out the form
+    Then the edition should have been updated successfully

--- a/lib/engines/content_object_store/features/step_definitions/content_object_store_steps.rb
+++ b/lib/engines/content_object_store/features/step_definitions/content_object_store_steps.rb
@@ -99,7 +99,7 @@ Then("I should see the details for all content blocks") do
   assert_text "All content blocks"
 
   @content_blocks.each do |block|
-    should_show_summary_details_for_email_address_content_block(block, block.details[:email_address])
+    should_show_summary_card_for_email_address_content_block(block, block.details[:email_address])
   end
 end
 
@@ -110,10 +110,17 @@ end
 Then("I should see the details for the email address content block") do
   assert_text "Manage an Email address"
 
-  should_show_summary_details_for_email_address_content_block(@content_block, @email_address)
+  should_show_summary_list_for_email_address_content_block(@content_block, @email_address)
 end
 
-def should_show_summary_details_for_email_address_content_block(content_block, email_address)
+def should_show_summary_card_for_email_address_content_block(content_block, email_address)
+  expect(page).to have_selector(".govuk-summary-list__key", text: "Title")
+  expect(page).to have_selector(".govuk-summary-list__value", text: content_block.document.title)
+  expect(page).to have_selector(".govuk-summary-list__key", text: "Email address")
+  expect(page).to have_selector(".govuk-summary-list__value", text: email_address)
+end
+
+def should_show_summary_list_for_email_address_content_block(content_block, email_address)
   expect(page).to have_selector(".govuk-summary-list__key", text: "Title")
   expect(page).to have_selector(".govuk-summary-list__value", text: content_block.document.title)
   expect(page).to have_selector(".govuk-summary-list__key", text: "Email address")

--- a/lib/engines/content_object_store/features/step_definitions/content_object_store_steps.rb
+++ b/lib/engines/content_object_store/features/step_definitions/content_object_store_steps.rb
@@ -47,7 +47,7 @@ When("I complete the form with the following fields:") do |table|
   fields.keys.each do |k|
     fill_in "content_object_store/content_block_edition_details_#{k}", with: @details[k]
   end
-  click_on "Save and continue"
+  click_on "Save and publish"
 end
 
 When("I complete the form") do
@@ -58,7 +58,7 @@ When("I complete the form") do
   @details.keys.each do |k|
     fill_in "content_object_store/content_block_edition_details_#{k}", with: @details[k]
   end
-  click_on "Save and continue"
+  click_on "Save and publish"
 end
 
 Then("the edition should have been created successfully") do
@@ -134,7 +134,13 @@ end
 When("I fill out the form") do
   fill_in "Title", with: "Changed title"
   fill_in "Email address", with: "changed@example.com"
-  click_on "Publish now"
+  click_on "Save and publish"
+end
+
+When("I set all fields to blank") do
+  fill_in "Title", with: ""
+  fill_in "Email address", with: ""
+  click_on "Save and publish"
 end
 
 Then("the edition should have been updated successfully") do
@@ -163,7 +169,7 @@ def should_show_edit_form_for_email_address_content_block(document_title, email_
   expect(page).to have_content("Change Email address")
   expect(page).to have_field("Title", with: document_title)
   expect(page).to have_field("Email address", with: email_address)
-  expect(page).to have_content("Publish now")
+  expect(page).to have_content("Save and publish")
   expect(page).to have_content("Cancel")
 end
 

--- a/lib/engines/content_object_store/features/step_definitions/content_object_store_steps.rb
+++ b/lib/engines/content_object_store/features/step_definitions/content_object_store_steps.rb
@@ -99,7 +99,10 @@ Then("I should see the details for all content blocks") do
   assert_text "All content blocks"
 
   @content_blocks.each do |block|
-    should_show_summary_card_for_email_address_content_block(block, block.details[:email_address])
+    should_show_summary_card_for_email_address_content_block(
+      block.document.title,
+      block.details[:email_address]
+    )
   end
 end
 
@@ -110,19 +113,22 @@ end
 Then("I should see the details for the email address content block") do
   assert_text "Manage an Email address"
 
-  should_show_summary_list_for_email_address_content_block(@content_block, @email_address)
+  should_show_summary_list_for_email_address_content_block(
+    @content_block.document.title,
+    @email_address
+  )
 end
 
-def should_show_summary_card_for_email_address_content_block(content_block, email_address)
+def should_show_summary_card_for_email_address_content_block(document_title, email_address)
   expect(page).to have_selector(".govuk-summary-list__key", text: "Title")
-  expect(page).to have_selector(".govuk-summary-list__value", text: content_block.document.title)
+  expect(page).to have_selector(".govuk-summary-list__value", text: document_title)
   expect(page).to have_selector(".govuk-summary-list__key", text: "Email address")
   expect(page).to have_selector(".govuk-summary-list__value", text: email_address)
 end
 
-def should_show_summary_list_for_email_address_content_block(content_block, email_address)
+def should_show_summary_list_for_email_address_content_block(document_title, email_address)
   expect(page).to have_selector(".govuk-summary-list__key", text: "Title")
-  expect(page).to have_selector(".govuk-summary-list__value", text: content_block.document.title)
+  expect(page).to have_selector(".govuk-summary-list__value", text: document_title)
   expect(page).to have_selector(".govuk-summary-list__key", text: "Email address")
   expect(page).to have_selector(".govuk-summary-list__value", text: email_address)
   expect(page).to have_selector(".govuk-summary-list__key", text: "Creator")

--- a/lib/engines/content_object_store/features/step_definitions/content_object_store_steps.rb
+++ b/lib/engines/content_object_store/features/step_definitions/content_object_store_steps.rb
@@ -101,7 +101,7 @@ Then("I should see the details for all content blocks") do
   @content_blocks.each do |block|
     should_show_summary_card_for_email_address_content_block(
       block.document.title,
-      block.details[:email_address]
+      block.details[:email_address],
     )
   end
 end
@@ -115,7 +115,7 @@ Then("I should see the details for the email address content block") do
 
   should_show_summary_list_for_email_address_content_block(
     @content_block.document.title,
-    @email_address
+    @email_address,
   )
 end
 

--- a/lib/engines/content_object_store/features/step_definitions/content_object_store_steps.rb
+++ b/lib/engines/content_object_store/features/step_definitions/content_object_store_steps.rb
@@ -107,6 +107,7 @@ Then("I should see the details for all content blocks") do
 end
 
 When("I click to view the content block") do
+  @schema = @schemas[@content_block.document.block_type]
   click_link href: content_object_store.content_object_store_content_block_edition_path(@content_block)
 end
 

--- a/lib/engines/content_object_store/features/step_definitions/content_object_store_steps.rb
+++ b/lib/engines/content_object_store/features/step_definitions/content_object_store_steps.rb
@@ -119,6 +119,28 @@ Then("I should see the details for the email address content block") do
   )
 end
 
+When("I click the first change link") do
+  first_link = find("a[href='#{content_object_store.edit_content_object_store_content_block_edition_path(@content_block)}']", match: :first)
+  first_link.click
+end
+
+Then("I should see the edit form") do
+  should_show_edit_form_for_email_address_content_block(
+    @content_block.document.title,
+    @email_address,
+  )
+end
+
+When("I fill out the form") do
+  fill_in "Title", with: "Changed title"
+  fill_in "Email address", with: "changed@example.com"
+  click_on "Publish now"
+end
+
+Then("the edition should have been updated successfully") do
+  should_show_summary_list_for_email_address_content_block("Changed title", "changed@example.com")
+end
+
 def should_show_summary_card_for_email_address_content_block(document_title, email_address)
   expect(page).to have_selector(".govuk-summary-list__key", text: "Title")
   expect(page).to have_selector(".govuk-summary-list__value", text: document_title)
@@ -129,10 +151,20 @@ end
 def should_show_summary_list_for_email_address_content_block(document_title, email_address)
   expect(page).to have_selector(".govuk-summary-list__key", text: "Title")
   expect(page).to have_selector(".govuk-summary-list__value", text: document_title)
+  expect(page).to have_selector(".govuk-summary-list__actions", text: "Change")
   expect(page).to have_selector(".govuk-summary-list__key", text: "Email address")
   expect(page).to have_selector(".govuk-summary-list__value", text: email_address)
   expect(page).to have_selector(".govuk-summary-list__key", text: "Creator")
   expect(page).to have_selector(".govuk-summary-list__value", text: @user.name)
+  expect(page).to have_selector(".govuk-summary-list__actions", text: "Change")
+end
+
+def should_show_edit_form_for_email_address_content_block(document_title, email_address)
+  expect(page).to have_content("Change Email address")
+  expect(page).to have_field("Title", with: document_title)
+  expect(page).to have_field("Email address", with: email_address)
+  expect(page).to have_content("Publish now")
+  expect(page).to have_content("Cancel")
 end
 
 Then("I should see errors for the required fields") do

--- a/lib/engines/content_object_store/test/components/content_block_edition/show/summary_list_component_test.rb
+++ b/lib/engines/content_object_store/test/components/content_block_edition/show/summary_list_component_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class ContentObjectStore::ContentBlockEdition::Show::SummaryListComponentTest < ViewComponent::TestCase
   test "renders a content block correctly" do
-    content_block_edition = build(
+    content_block_edition = create(
       :content_block_edition,
       :email_address,
       details: { foo: "bar", something: "else" },

--- a/lib/engines/content_object_store/test/components/content_block_edition/show/summary_list_component_test.rb
+++ b/lib/engines/content_object_store/test/components/content_block_edition/show/summary_list_component_test.rb
@@ -13,10 +13,16 @@ class ContentObjectStore::ContentBlockEdition::Show::SummaryListComponentTest < 
     assert_selector ".govuk-summary-list__row", count: 4
     assert_selector ".govuk-summary-list__key", text: "Title"
     assert_selector ".govuk-summary-list__value", text: content_block_edition.title
+    assert_selector ".govuk-summary-list__actions", text: "Change"
+
     assert_selector ".govuk-summary-list__key", text: "Foo"
     assert_selector ".govuk-summary-list__value", text: "bar"
+    assert_selector ".govuk-summary-list__actions", text: "Change"
+
     assert_selector ".govuk-summary-list__key", text: "Something"
     assert_selector ".govuk-summary-list__value", text: "else"
+    assert_selector ".govuk-summary-list__actions", text: "Change"
+
     assert_selector ".govuk-summary-list__key", text: "Creator"
     assert_selector ".govuk-summary-list__value", text: content_block_edition.creator.name
   end

--- a/lib/engines/content_object_store/test/factories/content_block_document.rb
+++ b/lib/engines/content_object_store/test/factories/content_block_document.rb
@@ -4,6 +4,8 @@ FactoryBot.define do
     title { "Title" }
     created_at { Time.zone.now.utc }
     updated_at { Time.zone.now.utc }
+    latest_edition_id { nil }
+    live_edition_id { nil }
 
     ContentObjectStore::ContentBlockSchema.valid_schemas.each do |type|
       trait type.to_sym do

--- a/lib/engines/content_object_store/test/factories/content_block_edition.rb
+++ b/lib/engines/content_object_store/test/factories/content_block_edition.rb
@@ -22,8 +22,10 @@ FactoryBot.define do
     end
 
     after(:create) do |content_block_edition, evaluator|
-      document = create(:content_block_document, evaluator.content_block_document_attributes)
-      content_block_edition.update!(content_block_document_id: document.id)
+      unless content_block_edition.content_block_document_id
+        document = create(:content_block_document, evaluator.content_block_document_attributes)
+        content_block_edition.update!(content_block_document_id: document.id)
+      end
     end
   end
 end

--- a/lib/engines/content_object_store/test/integration/content_block_editions_test.rb
+++ b/lib/engines/content_object_store/test/integration/content_block_editions_test.rb
@@ -59,8 +59,12 @@ class ContentBlockEditionsTest < ActionDispatch::IntegrationTest
     assert_equal content_block_document_attributes[:title], new_document.title
     assert_equal content_block_document_attributes[:block_type], new_document.block_type
     assert_equal details, new_edition.details
+
     assert_equal new_edition.content_block_document_id, new_document.id
     assert_equal new_edition.creator, new_author.user
+
+    assert_equal new_document.live_edition_id, new_edition.id
+    assert_equal new_document.latest_edition_id, new_edition.id
   end
 
   test "#create posts the new edition to the Publishing API" do

--- a/lib/engines/content_object_store/test/unit/app/models/content_block_document_test.rb
+++ b/lib/engines/content_object_store/test/unit/app/models/content_block_document_test.rb
@@ -27,4 +27,16 @@ class ContentObjectStore::ContentBlockDocumentTest < ActiveSupport::TestCase
       content_block_document.update(block_type: "something_else")
     end
   end
+
+  test "it can store the id of the latest edition" do
+    content_block_document = create(:content_block_document, :email_address)
+    content_block_document.update!(latest_edition_id: 1)
+    assert content_block_document.reload.latest_edition_id, 1
+  end
+
+  test "it can store the id of the live edition" do
+    content_block_document = create(:content_block_document, :email_address)
+    content_block_document.update!(live_edition_id: 1)
+    assert content_block_document.reload.live_edition_id, 1
+  end
 end

--- a/lib/engines/content_object_store/test/unit/app/services/create_edition_service_test.rb
+++ b/lib/engines/content_object_store/test/unit/app/services/create_edition_service_test.rb
@@ -39,10 +39,14 @@ class ContentObjectStore::CreateEditionServiceTest < ActiveSupport::TestCase
 
       new_document = ContentObjectStore::ContentBlockDocument.find_by!(content_id:)
       new_edition = new_document.content_block_editions.first
+
       assert_equal edition_params[:content_block_document_attributes][:title], new_document.title
       assert_equal edition_params[:content_block_document_attributes][:block_type], new_document.block_type
       assert_equal edition_params[:details], new_edition.details
       assert_equal new_edition.content_block_document_id, new_document.id
+
+      assert_equal new_document.live_edition_id, new_edition.id
+      assert_equal new_document.latest_edition_id, new_edition.id
     end
 
     test "it creates an Edition and Document in the Publishing API" do

--- a/lib/engines/content_object_store/test/unit/app/services/update_edition_service_test.rb
+++ b/lib/engines/content_object_store/test/unit/app/services/update_edition_service_test.rb
@@ -144,6 +144,9 @@ class ContentObjectStore::UpdateEditionServiceTest < ActiveSupport::TestCase
     it "updates the original ContentBlockDocument's latest_edition_id and live_edition_id to the new Edition" do
       result = ContentObjectStore::UpdateEditionService.new(schema, @original_content_block_edition)
                                                        .call(edition_params)
+
+      @original_content_block_edition.document.reload
+
       assert_equal @original_content_block_edition.document.live_edition_id, result.id
       assert_equal @original_content_block_edition.document.latest_edition_id, result.id
     end

--- a/lib/engines/content_object_store/test/unit/app/services/update_edition_service_test.rb
+++ b/lib/engines/content_object_store/test/unit/app/services/update_edition_service_test.rb
@@ -1,0 +1,276 @@
+require "test_helper"
+
+class ContentObjectStore::UpdateEditionServiceTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
+  setup do
+    document_attributes = FactoryBot.attributes_for(:content_block_document, :email_address, content_id:)
+
+    @original_content_block_edition = create(
+      :content_block_edition,
+      details: { "foo" => "Foo text", "bar" => "Bar text" },
+      content_block_document_attributes: document_attributes,
+    )
+  end
+
+  describe "#call" do
+    let(:content_id) { "49453854-d8fd-41da-ad4c-f99dbac601c3" }
+    let(:schema) { build(:content_block_schema, block_type: "content_block_type", body: { "properties" => { "foo" => "", "bar" => "" } }) }
+    let(:edition_params) do
+      {
+        content_block_document_attributes: {
+          title: "Some Title",
+          block_type: "email_address",
+        }.with_indifferent_access,
+        details: {
+          "foo" => "Foo text",
+          "bar" => "Bar text",
+        },
+        creator: build(:user),
+      }
+    end
+
+    setup do
+      # This UUID is created by the database so instead of loading the record
+      # we stub the initial creation so we know what UUID to check for.
+      ContentObjectStore::ContentBlockEdition.any_instance.stubs(:create_random_id)
+                                             .returns(content_id)
+
+      ContentObjectStore::ContentBlockSchema.stubs(:find_by_block_type)
+                                            .returns(schema)
+    end
+
+    test "it returns the new content block edition so the controller can redirect" do
+      result = ContentObjectStore::UpdateEditionService.new(schema, @original_content_block_edition)
+                                                       .call(edition_params)
+      assert_instance_of ContentObjectStore::ContentBlockEdition, result
+    end
+
+    test "it does not create a new ContentBlockDocument" do
+      original_count = ContentObjectStore::ContentBlockDocument.count
+      ContentObjectStore::UpdateEditionService.new(schema, @original_content_block_edition)
+                                              .call(edition_params)
+      assert_equal original_count, ContentObjectStore::ContentBlockDocument.count
+    end
+
+    test "updates the title field on the original ContentBlockDocument" do
+      result = ContentObjectStore::UpdateEditionService.new(schema, @original_content_block_edition)
+                                                       .call(edition_params)
+      assert_equal result.document.title, edition_params[:content_block_document_attributes][:title]
+    end
+
+    describe "when a document title isn't provided" do
+      test "does not update the document" do
+        edition_params.delete(:content_block_document_attributes)
+
+        assert_no_changes -> { @original_content_block_edition.document.title } do
+          ContentObjectStore::UpdateEditionService
+            .new(schema, @original_content_block_edition)
+            .call(edition_params)
+        end
+      end
+    end
+
+    describe "when no parameters are changed" do
+      it "publishes a new edition with the same values as the original" do
+        duplicate_edition_params = {
+          content_block_document_attributes: {
+            title: @original_content_block_edition.document.title,
+            block_type: @original_content_block_edition.document.block_type,
+          }.with_indifferent_access,
+          details: @original_content_block_edition.details,
+          creator: build(:user),
+        }
+
+        fake_put_content_response = GdsApi::Response.new(
+          stub("http_response", code: 200, body: {}),
+        )
+        fake_publish_content_response = GdsApi::Response.new(
+          stub("http_response", code: 200, body: {}),
+        )
+
+        publishing_api_mock = Minitest::Mock.new
+        publishing_api_mock.expect :put_content, fake_put_content_response, [
+          content_id,
+          {
+            schema_name: schema.id,
+            document_type: schema.id,
+            publishing_app: "whitehall",
+            title: @original_content_block_edition.document.title,
+            details: @original_content_block_edition.details,
+          },
+        ]
+        publishing_api_mock.expect :publish, fake_publish_content_response, [
+          content_id,
+          "major",
+        ]
+
+        Services.stub :publishing_api, publishing_api_mock do
+          ContentObjectStore::UpdateEditionService
+            .new(schema, @original_content_block_edition)
+            .call(duplicate_edition_params)
+
+          publishing_api_mock.verify
+        end
+      end
+    end
+
+    describe "when no params are passed" do
+      it "raises an ArgumentError" do
+        assert_raises(ArgumentError) do
+          ContentObjectStore::UpdateEditionService
+            .new(schema, @original_content_block_edition)
+            .call({})
+        end
+      end
+    end
+
+    describe "when params attempt to change the block type" do
+      test "does not update the document" do
+        second_schema = build(:content_block_schema, block_type: "postal_address")
+        ContentObjectStore::ContentBlockSchema.stubs(:find_by_block_type)
+          .returns(second_schema)
+
+        edition_params[:content_block_document_attributes][:block_type] = "postal_address"
+
+        assert_no_changes -> { @original_content_block_edition.document.block_type } do
+          ContentObjectStore::UpdateEditionService
+            .new(second_schema, @original_content_block_edition)
+            .call(edition_params)
+        end
+      end
+    end
+
+    it "updates the original ContentBlockDocument's latest_edition_id and live_edition_id to the new Edition" do
+      result = ContentObjectStore::UpdateEditionService.new(schema, @original_content_block_edition)
+                                                       .call(edition_params)
+      assert_equal @original_content_block_edition.document.live_edition_id, result.id
+      assert_equal @original_content_block_edition.document.latest_edition_id, result.id
+    end
+
+    test "it creates a new ContentBlockEdition in Whitehall" do
+      original_document = ContentObjectStore::ContentBlockDocument.find_by!(content_id:)
+
+      assert_changes -> { ContentObjectStore::ContentBlockEdition.count }, from: 1, to: 2 do
+        ContentObjectStore::UpdateEditionService
+          .new(schema, @original_content_block_edition)
+          .call(edition_params)
+      end
+
+      new_edition = original_document.content_block_editions.last
+
+      assert_equal edition_params[:details], new_edition.details
+    end
+
+    test "it creates a new Edition in the Publishing API" do
+      fake_put_content_response = GdsApi::Response.new(
+        stub("http_response", code: 200, body: {}),
+      )
+      fake_publish_content_response = GdsApi::Response.new(
+        stub("http_response", code: 200, body: {}),
+      )
+
+      publishing_api_mock = Minitest::Mock.new
+      publishing_api_mock.expect :put_content, fake_put_content_response, [
+        content_id,
+        {
+          schema_name: schema.id,
+          document_type: schema.id,
+          publishing_app: "whitehall",
+          title: "Some Title",
+          details: {
+            "foo" => "Foo text",
+            "bar" => "Bar text",
+          },
+        },
+      ]
+      publishing_api_mock.expect :publish, fake_publish_content_response, [
+        content_id,
+        "major",
+      ]
+
+      Services.stub :publishing_api, publishing_api_mock do
+        ContentObjectStore::UpdateEditionService
+          .new(schema, @original_content_block_edition)
+          .call(edition_params)
+
+        publishing_api_mock.verify
+      end
+    end
+
+    test "if the publishing API request fails, the Whitehall ContentBlockEdition and ContentBlockDocument are rolled back" do
+      exception = GdsApi::HTTPErrorResponse.new(
+        422,
+        "An internal error message",
+        "error" => { "message" => "Some backend error" },
+      )
+      raises_exception = ->(*_args) { raise exception }
+
+      Services.publishing_api.stub :put_content, raises_exception do
+        assert_equal ContentObjectStore::ContentBlockDocument.count, 1 do
+          assert_equal ContentObjectStore::ContentBlockEdition.count, 1 do
+            assert_raises(GdsApi::HTTPErrorResponse) do
+              ContentObjectStore::UpdateEditionService
+                .new(schema, @original_content_block_edition)
+                .call(edition_params)
+            end
+          end
+        end
+      end
+    end
+
+    test "if the Whitehall creation fails, no call to the Publishing API is made" do
+      exception = ArgumentError.new("Cannot find schema for block_type")
+      raises_exception = ->(*_args) { raise exception }
+
+      Services.publishing_api.expects(:put_content).never
+
+      ContentObjectStore::ContentBlockEdition.stub :create!, raises_exception do
+        assert_raises(ArgumentError) do
+          ContentObjectStore::UpdateEditionService
+            .new(schema, @original_content_block_edition)
+            .call({})
+        end
+      end
+    end
+
+    test "if the publish request fails, the latest draft is discarded and the database actions are rolled back" do
+      fake_put_content_response = GdsApi::Response.new(
+        stub("http_response", code: 200, body: {}),
+      )
+      fake_discard_draft_content_response = GdsApi::Response.new(
+        stub("http_response", code: 200, body: {}),
+      )
+
+      publishing_api_mock = Minitest::Mock.new
+      publishing_api_mock.expect :put_content, fake_put_content_response, [
+        String,
+        Hash,
+      ]
+      publishing_api_mock.expect :discard_draft, fake_discard_draft_content_response, [
+        content_id,
+      ]
+
+      exception = GdsApi::HTTPErrorResponse.new(
+        422,
+        "An internal error message",
+        "error" => { "message" => "Some backend error" },
+      )
+      raises_exception = ->(*_args) { raise exception }
+
+      Services.publishing_api.stub :publish, raises_exception do
+        assert_equal ContentObjectStore::ContentBlockDocument.count, 1 do
+          assert_equal ContentObjectStore::ContentBlockEdition.count, 1 do
+            assert_raises(ContentObjectStore::CreateEditionService::PublishingFailureError, "Could not publish #{content_id} because: Some backend error") do
+              ContentObjectStore::UpdateEditionService
+                .new(schema, @original_content_block_edition)
+                .call(edition_params)
+            end
+
+            publishing_api_mock.verify
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Changes in this PR

When a user changes an existing Whitehall Edition we want to create a new Whitehall Edition and a new Edition inside Publishing API. The previous Document (created on the first edition) should not be recreated. In Whitehall the Document is updated to point to the new Edition and the title is changed. 

Within the Publishing API the `title` lives on the `Edition` itself (which threw me at first). Therefore we expect to see the Publishing API `Document` have its `stale_lock_version` number increase for each `Edition` we create. 

In the following diagram blue is the result of create, green is the result of an update, red are some of the fields we change along the way:
![Untitled drawing](https://github.com/user-attachments/assets/5de6667f-856c-4ca7-b541-32c0f892e883)

- We retrofit `ContentBlockDocument.latest_edition_id` and `ContentBlockDocument.latest_edition_id` as I noticed we weren't able to tell the `Document` which the latest `Edition` was - this could be pulled out into another PR
- We can't reuse the same `_form` partial as the create journey, details in the commit
- This does not handle multiple users making modifications at the same time, we will deal with that separately
- We rename the "Save and continue" button from the create journey to "Save and publish" since we have no draft state. The main driver here was I wanted to repurpose the existing cucumber form helpers and actually the button language makes sense in both create and update flows

## Wireframes

https://www.figma.com/design/F2Uq6Ju6fsSk1CEMjXm2va/Content-Modelling?node-id=416-8807&t=O3xRvuT7KEdT4si4-0

![Screenshot 2024-07-22 at 10 47 00](https://github.com/user-attachments/assets/476f6d0a-859e-4505-bbf4-2aa1c14cefc7)

![Screenshot 2024-07-22 at 10 47 21](https://github.com/user-attachments/assets/96c8bcc5-b37a-4d0c-a21c-f2855f1805ed)

## What we've got 

https://github.com/user-attachments/assets/09791cb7-c575-487d-ac52-7f4482196eb9

We aren't yet at the same point of these wireframes since the change form is the same form for every field. We could break this out into one form per attribute with a patch endpoint which would take a bit more effort. 

The problem I see is that we don't have a draft state and are automatically publishing to the Publishing API. To support a form input for each field I think we need to have a draft Edition state that those incremental changes are contributing to.

Without a draft state we will be publishing a new live edition to Whitehall and to Publishing API for every field change. This amount of requests and data created feels excessive and not in the spirit of the existing publishing flow?

## Checking Publishing API

And with `govuk-docker run publishing-api-app bin/rails c` we can hop inside publishing-api to see what changes:

![Screenshot 2024-07-19 at 16 53 20](https://github.com/user-attachments/assets/ca1fe2ac-0229-40b1-be83-3cb21b1aa861)

```ruby
# If you'd like to run the same report as in the screenshot
puts "edition count: #{document.editions.count}", "titles:
#{document.editions.pluck(:title).join("=>")}", "details:
#{document.editions.pluck(:details).join("=>")}", 
"document_id: #{document.editions.pluck(:document_id).join("=>")}"
```
