### PR TITLE
Enable html attachment on foreign languages

### DIFF
--- a/app/models/html_attachment.rb
+++ b/app/models/html_attachment.rb
@@ -7,7 +7,7 @@ class HtmlAttachment < Attachment
           autosave: true,
           inverse_of: :html_attachment
 
-  before_validation :clear_slug_if_non_english_locale
+  before_validation :handle_slug_for_foreign_locale
 
   validates :govspeak_content, presence: true
 
@@ -129,9 +129,9 @@ private
     sluggable_locale? ? title : nil
   end
 
-  def clear_slug_if_non_english_locale
-    if locale_changed? && !sluggable_locale?
-      self.slug = nil
+  def handle_slug_for_foreign_locale
+    if !sluggable_locale? && (locale_changed? || slug.blank?)
+      self.slug = content_id.to_s
     end
   end
 end

--- a/db/data_migration/20240722162801_backfill_htmlattachments_with_blank_slugs.rb
+++ b/db/data_migration/20240722162801_backfill_htmlattachments_with_blank_slugs.rb
@@ -1,0 +1,3 @@
+HtmlAttachment.where(slug: nil).find_each do |html_attachment|
+  html_attachment.update_column(:slug, html_attachment.id.to_s)
+end

--- a/test/unit/app/models/html_attachment_test.rb
+++ b/test/unit/app/models/html_attachment_test.rb
@@ -225,15 +225,6 @@ class HtmlAttachmentTest < ActiveSupport::TestCase
     assert_equal "an-html-attachment", second_draft_attachment.slug
   end
 
-  test "slug is not created for non-english attachments" do
-    # Additional attachment to ensure the duplicate detection behaviour isn't triggered
-    create(:html_attachment, locale: "fr")
-    attachment = create(:html_attachment, locale: "ar", title: "المملكة المتحدة والمملكة العربية السعودية")
-
-    assert attachment.slug.blank?
-    assert_equal attachment.id.to_s, attachment.to_param
-  end
-
   test "slug is created for english-only attachments" do
     attachment = create(:html_attachment, locale: "en", title: "We have a bias for action")
 
@@ -241,12 +232,27 @@ class HtmlAttachmentTest < ActiveSupport::TestCase
     assert_equal expected_slug, attachment.slug
     assert_equal expected_slug, attachment.to_param
   end
+  test "slug is set to Html Attachment content_id if title contains special characters" do
+    attachment = create(:html_attachment, locale: "en", title: "首次中英高级别安全")
 
-  test "slug is cleared when changing from english to non-english" do
+    attachment.slug = attachment.content_id.to_s
+    assert_equal attachment.content_id.to_s, attachment.slug
+  end
+
+  test "slug is set to Html Attachment content_id for non-english attachments" do
+    # Additional attachment to ensure the duplicate detection behaviour isn't triggered
+    create(:html_attachment, locale: "fr")
+    attachment = create(:html_attachment, locale: "ar", title: "المملكة المتحدة والمملكة العربية السعودية")
+
+    assert_equal attachment.content_id.to_s, attachment.slug
+    assert_equal attachment.content_id.to_s, attachment.to_param
+  end
+
+  test "slug is set to Html Attachment content_id when changing from english to non-english" do
     attachment = create(:html_attachment, locale: "en")
 
     attachment.update!(locale: "fr")
-    assert attachment.slug.blank?
+    assert_equal attachment.content_id.to_s, attachment.reload.slug
   end
 
   test "#translated_locales lists only the attachment's locale" do


### PR DESCRIPTION
**What**

While looking at Sentry errors we noticed that a lot of HTML attachments do not have a valid URL. This occurs when an html attachment has special characters in the title, but are not on a foreign only document (consultations mainly).

Documents have a concept of using the id as a fallback if the title of an edition creates an invalid slug. HTML attachments don’t and just return an empty string when special characters are used in the title.

This causes issues when stuff  is passed in. A html attachments slug is constructed by downcasing and underscoring the title (and some other stuff). But when special chars are passed in it returns an empty string.

New attachments blow up and can’t be created as Publishing API rejects them. There’s a small subset of older HTML Attachments which have been pushed to Publishing API and have an invalid URL that can’t be visited. See this page for example https://www.gov.uk/government/publications/china-uk-high-level-security-dialogue-official-statement

**PR changes**

Have modified a method in the html attachment model to ensure that content with locales that are not suitable for direct slug generation from titles or similar attributes (due to potential issues with special characters, non-Latin scripts, etc.) still receives a unique and URL-safe slug. By using the `content_id` as a fallback, the method guarantees that each piece of content can be referenced by a unique and stable URL. 

Have also added a migration to backfill the existing Html Attachments that do not currently have slugs on Whitehall. 

[Trello](https://trello.com/c/ZkPnDPrg/2279-html-attachments-break-if-special-characters-are-used-in-the-title)
