### PR TITLE
Remove validation for 'summary' field for Response fields

### DIFF
--- a/app/models/call_for_evidence_response.rb
+++ b/app/models/call_for_evidence_response.rb
@@ -7,7 +7,6 @@ class CallForEvidenceResponse < ApplicationRecord
   date_attributes(:published_on)
 
   validates :published_on, comparison: { greater_than: Date.parse("1900-01-01"), message: "should be greater than 1900" }
-  validates :summary, presence: { unless: :has_attachments }
   validates_with SafeHtmlValidator
   validates_with NoFootnotesInGovspeakValidator, attribute: :summary
   delegate :auth_bypass_id, to: :call_for_evidence
@@ -57,10 +56,6 @@ class CallForEvidenceResponse < ApplicationRecord
   delegate :public_timestamp, :first_published_version?, :slug, :document, :images, :content_id, to: :call_for_evidence
 
 private
-
-  def has_attachments
-    attachments.any?
-  end
 
   def parent_attachable
     call_for_evidence || Attachable::Null.new

--- a/app/models/consultation_response.rb
+++ b/app/models/consultation_response.rb
@@ -7,7 +7,6 @@ class ConsultationResponse < ApplicationRecord
   date_attributes(:published_on)
 
   validates :published_on, comparison: { greater_than: Date.parse("1900-01-01"), message: "should be greater than 1900" }
-  validates :summary, presence: { unless: :has_attachments }
   validates_with SafeHtmlValidator
   validates_with NoFootnotesInGovspeakValidator, attribute: :summary
   delegate :auth_bypass_id, to: :consultation
@@ -57,10 +56,6 @@ class ConsultationResponse < ApplicationRecord
   delegate :public_timestamp, :first_published_version?, :slug, :document, :images, :content_id, to: :consultation
 
 private
-
-  def has_attachments
-    attachments.any?
-  end
 
   def parent_attachable
     consultation || Attachable::Null.new

--- a/test/functional/admin/call_for_evidence_responses_controller_test.rb
+++ b/test/functional/admin/call_for_evidence_responses_controller_test.rb
@@ -47,13 +47,6 @@ class Admin::CallForEvidenceResponsesControllerTest < ActionController::TestCase
     assert_equal "Outcome summary", outcome.summary
   end
 
-  view_test "POST :create with invalid params re-renders the form" do
-    post :create, params: { call_for_evidence_id: @call_for_evidence, call_for_evidence_outcome: { summary: "", published_on: Time.zone.today }, type: "CallForEvidenceOutcome" }
-
-    assert_response :success
-    assert_select "textarea[name='call_for_evidence_outcome[summary]']"
-  end
-
   view_test "GET :edit renders the edit form for an outcome" do
     outcome = create_outcome
     get :edit, params: { call_for_evidence_id: @call_for_evidence, type: "CallForEvidenceOutcome" }

--- a/test/functional/admin/consultation_responses_controller_test.rb
+++ b/test/functional/admin/consultation_responses_controller_test.rb
@@ -73,13 +73,6 @@ class Admin::ConsultationResponsesControllerTest < ActionController::TestCase
     assert_equal "Feedback summary", public_feedback.summary
   end
 
-  view_test "POST :create with invalid params re-renders the form" do
-    post :create, params: { consultation_id: @consultation, consultation_outcome: { summary: "", published_on: Time.zone.today }, type: "ConsultationOutcome" }
-
-    assert_response :success
-    assert_select "textarea[name='consultation_outcome[summary]']"
-  end
-
   view_test "GET :edit renders the edit form for an outcome" do
     outcome = create_outcome
     get :edit, params: { consultation_id: @consultation, type: "ConsultationOutcome" }

--- a/test/unit/app/models/call_for_evidence_response_test.rb
+++ b/test/unit/app/models/call_for_evidence_response_test.rb
@@ -1,14 +1,6 @@
 require "test_helper"
 
 class CallForEvidenceResponseTest < ActiveSupport::TestCase
-  test "responses without a summary are only valid if they have attachments" do
-    response = build(:call_for_evidence_outcome, summary: nil)
-    assert_not response.valid?
-
-    response.attachments << build(:file_attachment)
-    assert response.valid?, response.errors.full_messages.inspect
-  end
-
   test "should return the alternative_format_contact_email of the call for evidence" do
     call_for_evidence = build(:call_for_evidence)
     call_for_evidence.stubs(alternative_format_contact_email: "alternative format contact email")

--- a/test/unit/app/models/consultation_response_test.rb
+++ b/test/unit/app/models/consultation_response_test.rb
@@ -1,14 +1,6 @@
 require "test_helper"
 
 class ConsultationResponseTest < ActiveSupport::TestCase
-  test "responses without a summary are only valid if they have attachments" do
-    response = build(:consultation_outcome, summary: nil)
-    assert_not response.valid?
-
-    response.attachments << build(:file_attachment)
-    assert response.valid?, response.errors.full_messages.inspect
-  end
-
   test "should return the alternative_format_contact_email of the consultation" do
     consultation = build(:consultation)
     consultation.stubs(alternative_format_contact_email: "alternative format contact email")


### PR DESCRIPTION
A [commit](https://github.com/alphagov/whitehall/commit/ff971c0e09de8c322891327b0c6a756749f72af4) added 11 years ago meant that the 'summary' field of "Public feedback consultations" could only be blank if there is an associated attachment (for ConsultationPublicFeedback, rather than Consultation itself). However, this can easily lead to cases where the document gets stuck in a published state, and publishers are unable to create new draft editions from them:

1. Open a Consultation that has Public Feedback with an attachment
2. Create new edition
3. Delete the Public Feedback summary (set textarea to empty)
4. Delete public feedback attachment
5. Save and force publish the edition
6. Now when we attempt to create a new edition, we get a
   "Something went wrong" error.

There are a few ways of trying to prevent this happening (such as preventing deletion of attachments if the summary is blank, or moving the validation logic to occur at publish-time rather than at save-time) but they are all far more 
 complicated than simply removing the summary presence validation, the existence of which provides questionable value.

Trello: https://trello.com/c/AVhwYYgP/2737-investigate-consultation-not-allowing-new-edition-to-be-created

---
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
