### PR TITLE
Content block edition form reused for both create and update journeys

### DIFF
--- a/lib/engines/content_object_store/app/controllers/content_object_store/content_block_editions_controller.rb
+++ b/lib/engines/content_object_store/app/controllers/content_object_store/content_block_editions_controller.rb
@@ -13,17 +13,9 @@ class ContentObjectStore::ContentBlockEditionsController < ContentObjectStore::B
       @schemas = ContentObjectStore::ContentBlockSchema.all
     else
       @schema = ContentObjectStore::ContentBlockSchema.find_by_block_type(params[:block_type].underscore)
-
-      form_attributes = @schema.fields.each_with_object({}) do |field, hash|
-        hash[field] = nil
-        hash
-      end
-
-      @form = ContentObjectStore::ContentBlockEditionForm.new(
+      @form = ContentObjectStore::ContentBlockEditionForm::Create.new(
         content_block_edition: ContentObjectStore::ContentBlockEdition.new,
         schema: @schema,
-        attributes: form_attributes,
-        back_path: content_object_store.content_object_store_content_block_editions_path,
       )
     end
   end
@@ -35,12 +27,7 @@ class ContentObjectStore::ContentBlockEditionsController < ContentObjectStore::B
 
     redirect_to content_object_store.content_object_store_content_block_editions_path, flash: { notice: "#{@schema.name} created successfully" }
   rescue ActiveRecord::RecordInvalid => e
-    @form = ContentObjectStore::ContentBlockEditionForm.new(
-      content_block_edition: e.record,
-      schema: @schema,
-      attributes: @schema.fields,
-      back_path: content_object_store.content_object_store_content_block_editions_path,
-    )
+    @form = ContentObjectStore::ContentBlockEditionForm::Create.new(content_block_edition: e.record, schema: @schema)
     render :new
   end
 
@@ -48,12 +35,7 @@ class ContentObjectStore::ContentBlockEditionsController < ContentObjectStore::B
     content_block_edition = ContentObjectStore::ContentBlockEdition.find(params[:id])
     @schema = ContentObjectStore::ContentBlockSchema.find_by_block_type(content_block_edition.document.block_type)
 
-    @form = ContentObjectStore::ContentBlockEditionForm.new(
-      content_block_edition:,
-      schema: @schema,
-      attributes: content_block_edition.details,
-      back_path: content_object_store.content_object_store_content_block_edition_path(content_block_edition),
-    )
+    @form = ContentObjectStore::ContentBlockEditionForm::Update.new(content_block_edition:, schema: @schema)
   end
 
   def update
@@ -68,12 +50,7 @@ class ContentObjectStore::ContentBlockEditionsController < ContentObjectStore::B
     redirect_to content_object_store.content_object_store_content_block_edition_path(new_content_block_edition),
                 flash: { notice: "#{@schema.name} changed and published successfully" }
   rescue ActiveRecord::RecordInvalid => e
-    @form = ContentObjectStore::ContentBlockEditionForm.new(
-      content_block_edition: e.record,
-      schema: @schema,
-      attributes: content_block_edition.details,
-      back_path: content_object_store.content_object_store_content_block_edition_path(content_block_edition),
-    )
+    @form = ContentObjectStore::ContentBlockEditionForm::Update.new(content_block_edition: e.record, schema: @schema)
 
     render :edit
   end

--- a/lib/engines/content_object_store/app/controllers/content_object_store/content_block_editions_controller.rb
+++ b/lib/engines/content_object_store/app/controllers/content_object_store/content_block_editions_controller.rb
@@ -29,23 +29,36 @@ class ContentObjectStore::ContentBlockEditionsController < ContentObjectStore::B
   end
 
   def edit
-    @content_block_edition = ContentObjectStore::ContentBlockEdition.find(params[:id])
-    @schema = ContentObjectStore::ContentBlockSchema.find_by_block_type(@content_block_edition.document.block_type)
+    content_block_edition = ContentObjectStore::ContentBlockEdition.find(params[:id])
+    @schema = ContentObjectStore::ContentBlockSchema.find_by_block_type(content_block_edition.document.block_type)
+
+    @form = ContentObjectStore::ContentBlockEditionForm.new(
+      content_block_edition:,
+      schema: @schema,
+      attributes: content_block_edition.details,
+      back_path: content_object_store.content_object_store_content_block_edition_path(content_block_edition),
+    )
   end
 
   def update
-    @content_block_edition = ContentObjectStore::ContentBlockEdition.find(params[:id])
-    @schema = ContentObjectStore::ContentBlockSchema.find_by_block_type(@content_block_edition.document.block_type)
+    content_block_edition = ContentObjectStore::ContentBlockEdition.find(params[:id])
+    @schema = ContentObjectStore::ContentBlockSchema.find_by_block_type(content_block_edition.document.block_type)
 
-    @new_content_block_edition = ContentObjectStore::UpdateEditionService.new(
+    new_content_block_edition = ContentObjectStore::UpdateEditionService.new(
       @schema,
-      @content_block_edition,
+      content_block_edition,
     ).call(edition_params)
 
-    redirect_to content_object_store.content_object_store_content_block_edition_path(@new_content_block_edition),
+    redirect_to content_object_store.content_object_store_content_block_edition_path(new_content_block_edition),
                 flash: { notice: "#{@schema.name} changed and published successfully" }
   rescue ActiveRecord::RecordInvalid => e
-    @content_block_edition = e.record
+    @form = ContentObjectStore::ContentBlockEditionForm.new(
+      content_block_edition: e.record,
+      schema: @schema,
+      attributes: content_block_edition.details,
+      back_path: content_object_store.content_object_store_content_block_edition_path(content_block_edition),
+    )
+
     render :edit
   end
 

--- a/lib/engines/content_object_store/app/controllers/content_object_store/content_block_editions_controller.rb
+++ b/lib/engines/content_object_store/app/controllers/content_object_store/content_block_editions_controller.rb
@@ -13,7 +13,18 @@ class ContentObjectStore::ContentBlockEditionsController < ContentObjectStore::B
       @schemas = ContentObjectStore::ContentBlockSchema.all
     else
       @schema = ContentObjectStore::ContentBlockSchema.find_by_block_type(params[:block_type].underscore)
-      @content_block_edition = ContentObjectStore::ContentBlockEdition.new
+
+      form_attributes = @schema.fields.each_with_object({}) do |field, hash|
+        hash[field] = nil
+        hash
+      end
+
+      @form = ContentObjectStore::ContentBlockEditionForm.new(
+        content_block_edition: ContentObjectStore::ContentBlockEdition.new,
+        schema: @schema,
+        attributes: form_attributes,
+        back_path: content_object_store.content_object_store_content_block_editions_path,
+      )
     end
   end
 
@@ -24,7 +35,12 @@ class ContentObjectStore::ContentBlockEditionsController < ContentObjectStore::B
 
     redirect_to content_object_store.content_object_store_content_block_editions_path, flash: { notice: "#{@schema.name} created successfully" }
   rescue ActiveRecord::RecordInvalid => e
-    @content_block_edition = e.record
+    @form = ContentObjectStore::ContentBlockEditionForm.new(
+      content_block_edition: e.record,
+      schema: @schema,
+      attributes: @schema.fields,
+      back_path: content_object_store.content_object_store_content_block_editions_path,
+    )
     render :new
   end
 

--- a/lib/engines/content_object_store/app/forms/content_object_store/content_block_edition_form.rb
+++ b/lib/engines/content_object_store/app/forms/content_object_store/content_block_edition_form.rb
@@ -1,15 +1,36 @@
 # A form object to reuse the same form partial for creating and editing a content block edition
 # - Creating an object requires dynamic attributes from a schema
-# - Editing an object requires attributes from the object itself
+# # - Editing an object requires attributes from the object itself
 class ContentObjectStore::ContentBlockEditionForm
   include ContentObjectStore::Engine.routes.url_helpers
 
-  attr_reader :content_block_edition, :schema, :attributes, :back_path
+  attr_reader :content_block_edition, :schema
 
-  def initialize(content_block_edition:, schema:, attributes:, back_path:)
+  def initialize(content_block_edition:, schema:)
     @content_block_edition = content_block_edition
     @schema = schema
-    @attributes = attributes
-    @back_path = back_path
+  end
+end
+
+class ContentObjectStore::ContentBlockEditionForm::Create < ContentObjectStore::ContentBlockEditionForm
+  def attributes
+    @schema.fields.each_with_object({}) do |field, hash|
+      hash[field] = nil
+      hash
+    end
+  end
+
+  def back_path
+    content_object_store_content_block_editions_path
+  end
+end
+
+class ContentObjectStore::ContentBlockEditionForm::Update < ContentObjectStore::ContentBlockEditionForm
+  def attributes
+    @content_block_edition.details
+  end
+
+  def back_path
+    content_object_store_content_block_edition_path(@content_block_edition)
   end
 end

--- a/lib/engines/content_object_store/app/forms/content_object_store/content_block_edition_form.rb
+++ b/lib/engines/content_object_store/app/forms/content_object_store/content_block_edition_form.rb
@@ -1,0 +1,13 @@
+# A form object to reuse the same form partial for creating and editing a content block edition
+# - Creating an object requires dynamic attributes from a schema
+# - Editing an object requires attributes from the object itself
+class ContentObjectStore::ContentBlockEditionForm
+  attr_reader :content_block_edition, :schema, :attributes, :back_path
+
+  def initialize(content_block_edition:, schema:, attributes:, back_path:)
+    @content_block_edition = content_block_edition
+    @schema = schema
+    @attributes = attributes
+    @back_path = back_path
+  end
+end

--- a/lib/engines/content_object_store/app/forms/content_object_store/content_block_edition_form.rb
+++ b/lib/engines/content_object_store/app/forms/content_object_store/content_block_edition_form.rb
@@ -2,6 +2,8 @@
 # - Creating an object requires dynamic attributes from a schema
 # - Editing an object requires attributes from the object itself
 class ContentObjectStore::ContentBlockEditionForm
+  include ContentObjectStore::Engine.routes.url_helpers
+
   attr_reader :content_block_edition, :schema, :attributes, :back_path
 
   def initialize(content_block_edition:, schema:, attributes:, back_path:)

--- a/lib/engines/content_object_store/app/views/content_object_store/content_block_editions/_form.html.erb
+++ b/lib/engines/content_object_store/app/views/content_object_store/content_block_editions/_form.html.erb
@@ -1,9 +1,8 @@
-<% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: content_block_edition)) %>
+<% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @form.content_block_edition)) %>
 
-<%= form_for content_block_edition, url:
-content_object_store.content_object_store_content_block_editions_path do |f| %>
+<%= form_for [content_object_store, @form.content_block_edition] do |f| %>
   <%= hidden_field_tag "content_block_edition[content_block_document_attributes][block_type]",
-    schema.block_type,
+    @form.schema.block_type,
     id: "content_object_store/content_block_edition_content_block_document_block_type" %>
 
   <%= render "govuk_publishing_components/components/input", {
@@ -12,19 +11,19 @@ content_object_store.content_object_store_content_block_editions_path do |f| %>
     },
     name: "content_block_edition[content_block_document_attributes][title]",
     id: "content_object_store/content_block_edition_content_block_document_title",
-    value: content_block_edition.content_block_document&.title,
-    error_items: errors_for(content_block_edition.errors, "content_block_document.title".to_sym),
+    value: @form.content_block_edition.content_block_document&.title,
+    error_items: errors_for(@form.content_block_edition.errors, "content_block_document.title".to_sym),
   } %>
 
-  <% @schema.fields.each do |field| %>
+  <% @form.attributes.each do |field, _value| %>
     <%= render "govuk_publishing_components/components/input", {
       label: {
         text: field.humanize,
       },
       name: "content_block_edition[details[#{field}]]",
       id: "content_object_store/content_block_edition_details_#{field}",
-      value: content_block_edition.details&.fetch(field, nil),
-      error_items: errors_for(content_block_edition.errors, "details_#{field}".to_sym),
+      value: @form.content_block_edition.details&.fetch(field, nil),
+      error_items: errors_for(@form.content_block_edition.errors, "details_#{field}".to_sym),
     } %>
   <% end %>
 
@@ -35,6 +34,6 @@ content_object_store.content_object_store_content_block_editions_path do |f| %>
       value: "Save and publish",
       type: "submit",
     } %>
-    <%= link_to("Cancel", content_object_store.content_object_store_content_block_editions_path, class: "govuk-link") %>
+    <%= link_to("Cancel", @form.back_path, class: "govuk-link") %>
   </div>
 <% end %>

--- a/lib/engines/content_object_store/app/views/content_object_store/content_block_editions/edit.html.erb
+++ b/lib/engines/content_object_store/app/views/content_object_store/content_block_editions/edit.html.erb
@@ -1,16 +1,16 @@
 <% content_for :context, "Object store" %>
-<% content_for :title, "Change #{@schema.name}" %>
+<% content_for :title, "Change #{@form.schema.name}" %>
 
 <% content_for :back_link do %>
   <%= render "govuk_publishing_components/components/back_link", {
-    href: content_object_store.content_object_store_content_block_edition_path(@content_block_edition),
+    href: @form.back_path,
   } %>
 <% end %>
 
-<% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @content_block_edition)) %>
-<%= form_with model: @content_block_edition, as: :content_block_edition, url: content_object_store.content_object_store_content_block_edition_path do |f| %>
+<% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @form.content_block_edition)) %>
+<%= form_with model: @form.content_block_edition, as: :content_block_edition, url: content_object_store.content_object_store_content_block_edition_path do |f| %>
   <%= hidden_field_tag "content_block_edition[content_block_document_attributes][block_type]",
-    @schema.block_type,
+    @form.schema.block_type,
     id: "content_object_store/content_block_edition_content_block_document_block_type" %>
 
   <%= render "govuk_publishing_components/components/input", {
@@ -19,11 +19,11 @@
     },
     name: "content_block_edition[content_block_document_attributes][title]",
     id: "content_object_store/content_block_edition_content_block_document_title",
-    value: @content_block_edition.content_block_document&.title,
-    error_items: errors_for(@content_block_edition.errors, "content_block_document.title".to_sym),
+    value: @form.content_block_edition.content_block_document&.title,
+    error_items: errors_for(@form.content_block_edition.errors, "content_block_document.title".to_sym),
   } %>
 
-  <% @content_block_edition.details.each do |field, value| %>
+  <% @form.attributes.each do |field, value| %>
     <%= render "govuk_publishing_components/components/input", {
       label: {
         text: field.humanize,
@@ -31,7 +31,7 @@
       name: "content_block_edition[details[#{field}]]",
       id: "content_object_store/content_block_edition_details_#{field}",
       value: value,
-      error_items: errors_for(@content_block_edition.errors, "details_#{field}".to_sym),
+      error_items: errors_for(@form.content_block_edition.errors, "details_#{field}".to_sym),
     } %>
   <% end %>
 
@@ -42,6 +42,6 @@
       value: "Save and publish",
       type: "submit",
     } %>
-    <%= link_to("Cancel", content_object_store.content_object_store_content_block_edition_path(@content_block_edition), class: "govuk-link") %>
+    <%= link_to("Cancel", @form.back_path, class: "govuk-link") %>
   </div>
 <% end %>

--- a/lib/engines/content_object_store/app/views/content_object_store/content_block_editions/edit.html.erb
+++ b/lib/engines/content_object_store/app/views/content_object_store/content_block_editions/edit.html.erb
@@ -7,41 +7,4 @@
   } %>
 <% end %>
 
-<% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @form.content_block_edition)) %>
-<%= form_with model: @form.content_block_edition, as: :content_block_edition, url: content_object_store.content_object_store_content_block_edition_path do |f| %>
-  <%= hidden_field_tag "content_block_edition[content_block_document_attributes][block_type]",
-    @form.schema.block_type,
-    id: "content_object_store/content_block_edition_content_block_document_block_type" %>
-
-  <%= render "govuk_publishing_components/components/input", {
-    label: {
-      text: "Title",
-    },
-    name: "content_block_edition[content_block_document_attributes][title]",
-    id: "content_object_store/content_block_edition_content_block_document_title",
-    value: @form.content_block_edition.content_block_document&.title,
-    error_items: errors_for(@form.content_block_edition.errors, "content_block_document.title".to_sym),
-  } %>
-
-  <% @form.attributes.each do |field, value| %>
-    <%= render "govuk_publishing_components/components/input", {
-      label: {
-        text: field.humanize,
-      },
-      name: "content_block_edition[details[#{field}]]",
-      id: "content_object_store/content_block_edition_details_#{field}",
-      value: value,
-      error_items: errors_for(@form.content_block_edition.errors, "details_#{field}".to_sym),
-    } %>
-  <% end %>
-
-  <div class="govuk-button-group govuk-!-margin-bottom-6">
-    <%= render "govuk_publishing_components/components/button", {
-      text: "Save and publish",
-      name: "save_and_publish",
-      value: "Save and publish",
-      type: "submit",
-    } %>
-    <%= link_to("Cancel", @form.back_path, class: "govuk-link") %>
-  </div>
-<% end %>
+<%= render partial: "form", locals: { form: @form } %>

--- a/lib/engines/content_object_store/app/views/content_object_store/content_block_editions/new.html.erb
+++ b/lib/engines/content_object_store/app/views/content_object_store/content_block_editions/new.html.erb
@@ -15,5 +15,5 @@
     } %>
   <% end %>
   <% content_for :title, "Create #{@schema.name}" %>
-  <%= render partial: "form", locals: { content_block_edition: @content_block_edition, schema: @schema} %>
+  <%= render partial: "form", locals: { form: @form } %>
 <% end %>

--- a/lib/engines/content_object_store/config/application.rb
+++ b/lib/engines/content_object_store/config/application.rb
@@ -1,5 +1,7 @@
 module ContentObjectStore
   class Engine < ::Rails::Engine
+    config.autoload_paths << Dir[File.join(root, "app", "forms", "**", "*.{rb}")]
+
     initializer "content_object_store.load_locale" do |app|
       app.config.i18n.load_path += Dir[File.join(root, "config", "locales", "**", "*.{rb,yml}")]
     end

--- a/lib/engines/content_object_store/features/create_object.feature
+++ b/lib/engines/content_object_store/features/create_object.feature
@@ -17,6 +17,7 @@ Feature: Create a content object
     Then I should see all the schemas listed
     When I click on the "email_address" schema
     Then I should see a form for the schema
+    And I should see a back link to the select schema page
     When I complete the form with the following fields:
       | title            | email_address   | department |
       | my email address | foo@example.com | Somewhere  |

--- a/lib/engines/content_object_store/features/edit_object.feature
+++ b/lib/engines/content_object_store/features/edit_object.feature
@@ -12,6 +12,7 @@ Feature: Edit a content object
     Then I should see the details for the email address content block
     When I click the first change link
     Then I should see the edit form
+    And I should see a back link to the show page
     When I fill out the form
     Then the edition should have been updated successfully
 

--- a/lib/engines/content_object_store/features/step_definitions/content_object_store_steps.rb
+++ b/lib/engines/content_object_store/features/step_definitions/content_object_store_steps.rb
@@ -42,6 +42,17 @@ Then("I should see a form for the schema") do
   expect(page).to have_content(@schema.name)
 end
 
+Then("I should see a back link to the select schema page") do
+  expect(page).to have_link("Back", href: content_object_store.new_content_object_store_content_block_edition_path)
+end
+
+Then("I should see a back link to the show page") do
+  match_data = URI.parse(page.current_url).path.match(%r{content-block-editions/(\d+)/edit$})
+  id = match_data[1] unless match_data.nil?
+  expect(id).not_to be_nil, "Could not find an existing content block edition ID in the URL"
+  expect(page).to have_link("Back", href: content_object_store.content_object_store_content_block_edition_path(id))
+end
+
 When("I complete the form with the following fields:") do |table|
   fields = table.hashes.first
   @title = fields.delete("title")

--- a/lib/engines/content_object_store/test/integration/content_block_editions_test.rb
+++ b/lib/engines/content_object_store/test/integration/content_block_editions_test.rb
@@ -141,7 +141,6 @@ class ContentBlockEditionsTest < ActionDispatch::IntegrationTest
     }
 
     assert_template :new
-    assert_equal edition, assigns(:content_block_edition)
   end
 end
 

--- a/lib/engines/content_object_store/test/unit/app/forms/content_object_store/content_block_edition_form_test.rb
+++ b/lib/engines/content_object_store/test/unit/app/forms/content_object_store/content_block_edition_form_test.rb
@@ -3,22 +3,23 @@ require "test_helper"
 class ContentObjectStore::ContentBlockEditionFormTest < ActiveSupport::TestCase
   extend Minitest::Spec::DSL
 
+  include ContentObjectStore::Engine.routes.url_helpers
+
   describe "when initialized for a new object" do
     test "it initializes with the correct attributes from the schema" do
       content_block_edition = build(:content_block_edition, :email_address)
       schema = build(:content_block_schema, :email_address, body: { "properties" => { "foo" => "", "bar" => "" } })
 
-      result = ContentObjectStore::ContentBlockEditionForm.new(
+      result = ContentObjectStore::ContentBlockEditionForm::Create.new(
         content_block_edition:,
         schema:,
-        attributes: schema.fields,
-        back_path: "/back",
       )
+      expected_attributes = { "foo" => nil, "bar" => nil }
 
       assert_equal content_block_edition, result.content_block_edition
       assert_equal schema, result.schema
-      assert_equal schema.fields, result.attributes
-      assert_equal "/back", result.back_path
+      assert_equal expected_attributes, result.attributes
+      assert_equal content_object_store_content_block_editions_path, result.back_path
     end
   end
 
@@ -26,17 +27,15 @@ class ContentObjectStore::ContentBlockEditionFormTest < ActiveSupport::TestCase
     test "it initializes with the correct attributes from the object" do
       content_block_edition = create(:content_block_edition, :email_address)
       schema = build(:content_block_schema, :email_address, body: { "properties" => { "foo" => "", "bar" => "" } })
-      result = ContentObjectStore::ContentBlockEditionForm.new(
+      result = ContentObjectStore::ContentBlockEditionForm::Update.new(
         content_block_edition:,
         schema:,
-        attributes: content_block_edition.details,
-        back_path: "/back",
       )
 
       assert_equal content_block_edition, result.content_block_edition
       assert_equal schema, result.schema
       assert_equal content_block_edition.details, result.attributes
-      assert_equal "/back", result.back_path
+      assert_equal content_object_store_content_block_edition_path(content_block_edition), result.back_path
     end
   end
 end

--- a/lib/engines/content_object_store/test/unit/app/forms/content_object_store/content_block_edition_form_test.rb
+++ b/lib/engines/content_object_store/test/unit/app/forms/content_object_store/content_block_edition_form_test.rb
@@ -1,0 +1,42 @@
+require "test_helper"
+
+class ContentObjectStore::ContentBlockEditionFormTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
+  describe "when initialized for a new object" do
+    test "it initializes with the correct attributes from the schema" do
+      content_block_edition = build(:content_block_edition, :email_address)
+      schema = build(:content_block_schema, :email_address, body: { "properties" => { "foo" => "", "bar" => "" } })
+
+      result = ContentObjectStore::ContentBlockEditionForm.new(
+        content_block_edition:,
+        schema:,
+        attributes: schema.fields,
+        back_path: "/back",
+      )
+
+      assert_equal content_block_edition, result.content_block_edition
+      assert_equal schema, result.schema
+      assert_equal schema.fields, result.attributes
+      assert_equal "/back", result.back_path
+    end
+  end
+
+  describe "when initialized for an existing object" do
+    test "it initializes with the correct attributes from the object" do
+      content_block_edition = create(:content_block_edition, :email_address)
+      schema = build(:content_block_schema, :email_address, body: { "properties" => { "foo" => "", "bar" => "" } })
+      result = ContentObjectStore::ContentBlockEditionForm.new(
+        content_block_edition:,
+        schema:,
+        attributes: content_block_edition.details,
+        back_path: "/back",
+      )
+
+      assert_equal content_block_edition, result.content_block_edition
+      assert_equal schema, result.schema
+      assert_equal content_block_edition.details, result.attributes
+      assert_equal "/back", result.back_path
+    end
+  end
+end


### PR DESCRIPTION
# Changes in this PR

[We recently added the ability to update content block editions](https://github.com/alphagov/whitehall/pull/9286). In that change we ended with different create and edit forms due to the differences on where the field values came from.

- Creation takes the form attributes from the Schema
- Updating takes the form attributes from two nested objects (Edition and Document)

In this change we use a slim form object to wrap the objects we need to assemble the form and then remove the duplication.

Some form objects are more involved and take care of things like validation. This is already taken care of, so the use of this pattern may be doing less than what the reader might expect. I've added comments to the form object to set this expectation.

## After

https://github.com/user-attachments/assets/6e48a032-8fb1-482f-aa5d-486a92bc3393

