### PR TITLE
Remove unused callback

### DIFF
--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -23,7 +23,7 @@ class Contact < ApplicationRecord
   after_create :republish_organisation_to_publishing_api
   after_destroy :republish_organisation_to_publishing_api
 
-  # after_commit :republish_embassies_index_page_to_publishing_api, :republish_worldwide_office_to_publishing_api
+  # after_commit :republish_embassies_index_page_to_publishing_api
 
   include TranslatableModel
   translates :title,
@@ -52,10 +52,6 @@ class Contact < ApplicationRecord
 
   def republish_organisation_to_publishing_api
     Whitehall::PublishingApi.republish_async(contactable) if contactable.is_a?(Organisation)
-  end
-
-  def republish_worldwide_office_to_publishing_api
-    Whitehall::PublishingApi.republish_async(contactable) if contactable.is_a?(WorldwideOffice) && !contactable.edition
   end
 
   def contactable_name


### PR DESCRIPTION
Since the removal on non-editionable worldwide organisations, there is now never a situation where a worldwide office does not have an edition (covered in 650640f4ea160452ac453d758b43db5fc818d27e).

Therefore this callback is redundant.

The tests had already been deleted, so removing the callback itself.