### PR TITLE
Content modelling/Documents can find their latest_edition

### DIFF
--- a/lib/engines/content_object_store/app/models/content_object_store/content_block_document.rb
+++ b/lib/engines/content_object_store/app/models/content_object_store/content_block_document.rb
@@ -7,4 +7,9 @@ class ContentObjectStore::ContentBlockDocument < ApplicationRecord
   attr_readonly :block_type
 
   validates :block_type, :title, presence: true
+
+  has_one :latest_edition,
+          -> { joins(:content_block_document).where("content_block_documents.latest_edition_id = content_block_editions.id") },
+          class_name: "ContentBlockEdition",
+          inverse_of: :content_block_document
 end

--- a/lib/engines/content_object_store/test/components/content_block_edition/show/timeline_component_test.rb
+++ b/lib/engines/content_object_store/test/components/content_block_edition/show/timeline_component_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class ContentObjectStore::ContentBlockEdition::Show::TimelineComponentTest < ViewComponent::TestCase
   test "renders a timeline component with a created event" do
     @user = create(:user)
-    @content_block_edition = create(:content_block_edition)
+    @content_block_edition = create(:content_block_edition, :email_address)
     @content_block_version = create(
       :content_block_version,
       item: @content_block_edition,

--- a/lib/engines/content_object_store/test/factories/content_block_edition.rb
+++ b/lib/engines/content_object_store/test/factories/content_block_edition.rb
@@ -6,26 +6,18 @@ FactoryBot.define do
     schema { build(:content_block_schema) }
     creator
 
-    content_block_document_attributes { FactoryBot.attributes_for(:content_block_document, :email_address) }
+    content_block_document_id { nil }
 
     ContentObjectStore::ContentBlockSchema.valid_schemas.each do |type|
       trait type.to_sym do
-        content_block_document_attributes do
-          FactoryBot.attributes_for(:content_block_document, :email_address, block_type: type)
-        end
+        content_block_document { build(:content_block_document, block_type: type) }
       end
     end
 
-    after(:build) do |content_block_edition, evaluator|
-      document = build(:content_block_document, evaluator.content_block_document_attributes)
-      content_block_edition.content_block_document = document
-    end
-
-    after(:create) do |content_block_edition, evaluator|
-      unless content_block_edition.content_block_document_id
-        document = create(:content_block_document, evaluator.content_block_document_attributes)
-        content_block_edition.update!(content_block_document_id: document.id)
-      end
+    after(:create) do |content_block_edition, _evaluator|
+      document_update_params = {
+      }
+      content_block_edition.document.update!(document_update_params)
     end
   end
 end

--- a/lib/engines/content_object_store/test/factories/content_block_edition.rb
+++ b/lib/engines/content_object_store/test/factories/content_block_edition.rb
@@ -16,6 +16,8 @@ FactoryBot.define do
 
     after(:create) do |content_block_edition, _evaluator|
       document_update_params = {
+        latest_edition_id: content_block_edition.id,
+        live_edition_id: content_block_edition.id,
       }
       content_block_edition.document.update!(document_update_params)
     end

--- a/lib/engines/content_object_store/test/unit/app/models/content_block_document_test.rb
+++ b/lib/engines/content_object_store/test/unit/app/models/content_block_document_test.rb
@@ -39,4 +39,14 @@ class ContentObjectStore::ContentBlockDocumentTest < ActiveSupport::TestCase
     content_block_document.update!(live_edition_id: 1)
     assert content_block_document.reload.live_edition_id, 1
   end
+
+  describe "latest_edition" do
+    it "returns the latest edition" do
+      document = create(:content_block_document, :email_address)
+      _first_edition = create(:content_block_edition, content_block_document: document)
+      second_edition = create(:content_block_edition, content_block_document: document)
+
+      assert_equal second_edition, document.latest_edition
+    end
+  end
 end

--- a/lib/engines/content_object_store/test/unit/app/services/update_edition_service_test.rb
+++ b/lib/engines/content_object_store/test/unit/app/services/update_edition_service_test.rb
@@ -4,13 +4,9 @@ class ContentObjectStore::UpdateEditionServiceTest < ActiveSupport::TestCase
   extend Minitest::Spec::DSL
 
   setup do
-    document_attributes = FactoryBot.attributes_for(:content_block_document, :email_address, content_id:)
-
-    @original_content_block_edition = create(
-      :content_block_edition,
-      details: { "foo" => "Foo text", "bar" => "Bar text" },
-      content_block_document_attributes: document_attributes,
-    )
+    @original_content_block_edition = create(:content_block_edition,
+                                             content_block_document: create(:content_block_document, :email_address, content_id:),
+                                             details: { "foo" => "Foo text", "bar" => "Bar text" })
   end
 
   describe "#call" do


### PR DESCRIPTION
With the move to reorganise the user journey around a document we now need to make sure that the document has an easy way to find it's latest edition.

We spend some time updating the factory to support this change. Whilst on the main redesign branch it became clear that we don't have a way to ask our factories to create multiple `Editions` with the same `Document`, we fix this by adding a transient attribute. More context can be found on the commit.