### PR TITLE
URL uses content_id in case of special characters in html attachment …

### DIFF
--- a/app/models/html_attachment.rb
+++ b/app/models/html_attachment.rb
@@ -83,7 +83,9 @@ class HtmlAttachment < Attachment
   end
 
   def identifier
-    sluggable_locale? ? slug : content_id
+    return slug if slug_eligible?
+
+    content_id
   end
 
   def base_path
@@ -127,6 +129,10 @@ private
 
   def sluggable_string
     sluggable_locale? ? title : nil
+  end
+
+  def slug_eligible?
+    title.ascii_only? && sluggable_locale?
   end
 
   def clear_slug_if_non_english_locale

--- a/test/unit/app/models/html_attachment_test.rb
+++ b/test/unit/app/models/html_attachment_test.rb
@@ -94,6 +94,13 @@ class HtmlAttachmentTest < ActiveSupport::TestCase
     assert_equal "/government/publications/#{edition.slug}/#{attachment.content_id}", attachment.url
   end
 
+  test "#url works when an attachment with english locale has special characters in title" do
+    edition = create(:published_publication, :with_html_attachment)
+    attachment = edition.attachments.first
+    attachment.update!(locale: "en", title: "首次中英高级别安全对话成果声明")
+    assert_equal "/government/publications/#{edition.slug}/#{attachment.content_id}", attachment.url
+  end
+
   test "#url works with statistics" do
     statistics = create(:published_national_statistics)
     attachment = statistics.attachments.last


### PR DESCRIPTION
**What**

While looking at Sentry errors we noticed that a lot of HTML attachments do not have a valid URL. This occurs when an html attachment has special characters in the title, but are not on a foreign only document.

This causes issues when stuff is passed in. A html attachments slug is constructed by downcasing and underscoring the title (and some other stuff). But when special chars are passed in it returns an empty string.

New attachments blow up and can’t be created as Publishing API rejects them. There’s a small subset of older HTML Attachments which have been pushed to Publishing API and have an invalid URL that can’t be visited. See this page for example https://www.gov.uk/government/publications/china-uk-high-level-security-dialogue-official-statement

**PR changes**

Have modified a method in the html attachment model to ensure that content with locales that are not suitable for direct slug generation from titles or similar attributes (due to potential issues with special characters, non-Latin scripts, etc.) still receives a unique and URL-safe slug. By using the content_id as a fallback, the method guarantees that each piece of content can be referenced by a unique and stable URL.

<img width="1073" alt="Screenshot 2024-07-24 at 14 20 15" src="https://github.com/user-attachments/assets/fb6eff8d-63a9-430b-a69f-a9b93999c0b6">


[Trello](https://trello.com/c/ZkPnDPrg/2279-html-attachments-break-if-special-characters-are-used-in-the-title)