### PR TITLE
Improvements to World Location News admin pages

### DIFF
--- a/app/views/admin/organisations/features.html.erb
+++ b/app/views/admin/organisations/features.html.erb
@@ -44,7 +44,7 @@
         featurable_editions: featurable_editions_for_feature_list(@filter.editions(@feature_list.locale), @feature_list),
         filter_by: [:title, :type, :author, :organisation],
         anchor: "#documents_tab",
-        filter_action: polymorphic_url([:features, :admin, @feature_list.featurable]),
+        filter_action: polymorphic_url([:features, :admin, @feature_list.featurable], locale: @feature_list.locale),
         feature_path: [:new, :admin, @feature_list, :feature],
       ),
     },

--- a/app/views/admin/world_location_news/features.html.erb
+++ b/app/views/admin/world_location_news/features.html.erb
@@ -1,6 +1,6 @@
 <% content_for :back_link do %>
   <%= render "govuk_publishing_components/components/back_link", {
-    href: :admin_world_location_news_index,
+    href: admin_world_location_news_index_path,
   } %>
 <% end %>
 <% content_for :page_title, @world_location_news.name %>

--- a/app/views/admin/world_location_news/features.html.erb
+++ b/app/views/admin/world_location_news/features.html.erb
@@ -44,7 +44,7 @@
         featurable_editions: featurable_editions_for_feature_list(@filter.editions(@feature_list.locale), @feature_list),
         filter_by: [:title, :type, :world_location],
         anchor: "#documents_tab",
-        filter_action: polymorphic_url([:features, :admin, @feature_list.featurable]),
+        filter_action: polymorphic_url([:features, :admin, @feature_list.featurable], locale: @feature_list.locale),
         feature_path: [:new, :admin, @feature_list, :feature],
       ),
     },

--- a/app/views/admin/world_location_news_translations/index.html.erb
+++ b/app/views/admin/world_location_news_translations/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for :back_link do %>
   <%= render "govuk_publishing_components/components/back_link", {
-    href: :admin_world_location_news_index,
+    href: admin_world_location_news_index_path,
   } %>
 <% end %>
 <% content_for :page_title, "#{@world_location_news.name} translations" %>

--- a/features/step_definitions/world_location_news_steps.rb
+++ b/features/step_definitions/world_location_news_steps.rb
@@ -67,7 +67,7 @@ Then(/^I see that I have no featured documents$/) do
   end
 end
 
-Given(/^there is a published document with the tile "([^"]*)"$/) do |title|
+Given(/^there is a published document with the title "([^"]*)"$/) do |title|
   create(:edition, :published, title:)
 end
 

--- a/features/world-location-news.feature
+++ b/features/world-location-news.feature
@@ -29,7 +29,7 @@ Feature: Administering world location news information
       Then I see that I have no featured documents
 
     Scenario: Featuring a document
-      Given there is a published document with the tile "Featured document"
+      Given there is a published document with the title "Featured document"
       When I visit the world location news page
       And filter documents by all organisations
       And I feature "Featured document"

--- a/features/world-location-news.feature
+++ b/features/world-location-news.feature
@@ -35,6 +35,16 @@ Feature: Administering world location news information
       And I feature "Featured document"
       Then I see that "Featured document" has been featured
 
+    Scenario: Searching for a non-English document to feature on a non-English world location news
+      Given a world location news exists and has a Spanish translation
+      And there is a published document, with a Spanish translation, tagged to the world location
+      When I visit the world location news page
+      And select the "Features (Español)" tab
+      And select the "Documents" child tab
+      And search for "Documento destacado"
+      Then I should be on the Spanish search results page
+      And I should see "Featured document" in the document list
+
     Scenario: Featuring a topical event
       Given there is an active topical event with the name "Featured topical event"
       When I visit the world location news page


### PR DESCRIPTION
See commits for details. These fixes arose out of https://govuk.zendesk.com/agent/tickets/5870922.

Trello: https://trello.com/c/tGPqTg76/2735-investigate-non-english-language-featureable-documents-search-issue

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
