### PR TITLE
Do not republish contacts belonging to worldwide organisations

### DIFF
--- a/app/services/bulk_republisher.rb
+++ b/app/services/bulk_republisher.rb
@@ -78,8 +78,6 @@ class BulkRepublisher
 private
 
   def republish_all_by_non_editionable_type(content_type_klass)
-    content_type_klass.find_each do |record|
-      Whitehall::PublishingApi.bulk_republish_async(record)
-    end
+    content_type_klass.find_each(&:bulk_republish_to_publishing_api_async)
   end
 end

--- a/lib/publishes_to_publishing_api.rb
+++ b/lib/publishes_to_publishing_api.rb
@@ -16,6 +16,12 @@ module PublishesToPublishingApi
     true
   end
 
+  def bulk_republish_to_publishing_api_async
+    if can_publish_to_publishing_api?
+      Whitehall::PublishingApi.bulk_republish_async(self)
+    end
+  end
+
   def republish_to_publishing_api_async
     if can_publish_to_publishing_api?
       Whitehall::PublishingApi.republish_async(self)

--- a/test/unit/app/models/publishes_to_publishing_api_test.rb
+++ b/test/unit/app/models/publishes_to_publishing_api_test.rb
@@ -101,6 +101,16 @@ class PublishesToPublishingApiTest < ActiveSupport::TestCase
     test_object.publish_gone_to_publishing_api
   end
 
+  test "enqueues a worker to bulk republish the document on request" do
+    test_object = TestObject.new
+    class << test_object
+      include PublishesToPublishingApi
+    end
+
+    Whitehall::PublishingApi.expects(:bulk_republish_async).with(test_object).once
+    test_object.bulk_republish_to_publishing_api_async
+  end
+
   test "enqueues a worker to republish the document on request" do
     test_object = TestObject.new
     class << test_object

--- a/test/unit/app/models/publishes_to_publishing_api_test.rb
+++ b/test/unit/app/models/publishes_to_publishing_api_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class PublishesToPublishingApiTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
   class TestObject
     include ActiveModel::Validations
     include ActiveModel::Validations::Callbacks
@@ -101,23 +103,49 @@ class PublishesToPublishingApiTest < ActiveSupport::TestCase
     test_object.publish_gone_to_publishing_api
   end
 
-  test "enqueues a worker to bulk republish the document on request" do
-    test_object = TestObject.new
-    class << test_object
-      include PublishesToPublishingApi
+  context "when object can be published to Publishing API" do
+    before do
+      @test_object = TestObject.new
+      class << @test_object
+        include PublishesToPublishingApi
+
+        def can_publish_to_publishing_api?
+          true
+        end
+      end
     end
 
-    Whitehall::PublishingApi.expects(:bulk_republish_async).with(test_object).once
-    test_object.bulk_republish_to_publishing_api_async
+    test "bulk_republish_async enqueues a worker to bulk republish the document" do
+      Whitehall::PublishingApi.expects(:bulk_republish_async).with(@test_object).once
+      @test_object.bulk_republish_to_publishing_api_async
+    end
+
+    test "republish_async enqueues a worker to republish the document" do
+      Whitehall::PublishingApi.expects(:republish_async).with(@test_object).once
+      @test_object.republish_to_publishing_api_async
+    end
   end
 
-  test "enqueues a worker to republish the document on request" do
-    test_object = TestObject.new
-    class << test_object
-      include PublishesToPublishingApi
+  context "when object cannot be published to Publishing API" do
+    before do
+      @test_object = TestObject.new
+      class << @test_object
+        include PublishesToPublishingApi
+
+        def can_publish_to_publishing_api?
+          false
+        end
+      end
     end
 
-    Whitehall::PublishingApi.expects(:republish_async).with(test_object).once
-    test_object.republish_to_publishing_api_async
+    test "bulk_republish_async does not enqueue a worker to bulk republish the document" do
+      Whitehall::PublishingApi.expects(:bulk_republish_async).never
+      @test_object.bulk_republish_to_publishing_api_async
+    end
+
+    test "republish_async does not enqueue a worker to republish the document" do
+      Whitehall::PublishingApi.expects(:republish_async).never
+      @test_object.republish_to_publishing_api_async
+    end
   end
 end

--- a/test/unit/app/services/bulk_republisher_test.rb
+++ b/test/unit/app/services/bulk_republisher_test.rb
@@ -222,11 +222,23 @@ class BulkRepublisherTest < ActiveSupport::TestCase
       end
     end
 
-    context "for non-editionable content types, like Contact" do
+    context "for non-editionable content types, like Contact, when publishable to Publishing API" do
       test "republishes all content of the specified type via the Whitehall::Publishing API" do
         2.times do
           contact = create(:contact)
+          Contact.any_instance.stubs(:can_publish_to_publishing_api?).returns(true)
           Whitehall::PublishingApi.expects(:bulk_republish_async).with(contact)
+        end
+        BulkRepublisher.new.republish_all_by_type("Contact")
+      end
+    end
+
+    context "for non-editionable content types, like Contact, when not publishable to Publishing API" do
+      test "does not republish content of the specified type via the Whitehall::Publishing API" do
+        2.times do
+          contact = create(:contact)
+          Contact.any_instance.stubs(:can_publish_to_publishing_api?).returns(false)
+          Whitehall::PublishingApi.expects(:bulk_republish_async).with(contact).never
         end
         BulkRepublisher.new.republish_all_by_type("Contact")
       end


### PR DESCRIPTION
We have made worldwide organisations editionable, this means that their offices have contacts that can exist in both draft and live states. These don't use `PublishesToPublishingApi`.

This means we need to ensure when bulk republishing all contacts that we don't send draft contacts to Publishing API as if they were live, otherwise draft content will become live before it is published.

Therefore checking whether the contact (or any other type of object) has `can_publish_to_publishing_api?` before we attempt to republish.

In order to republish contacts for a worldwide organisaion, we need to republish all worldwide organisations and allow
`PublishingApiAssociatedDocuments` handle the republishing of the contact.

This has been implemented in such a way that any other models which have a mixture of values for `can_publish_to_publishing_api?` (e.g. `HistoricalAccount` and `StatisticsAnnouncement`) are also treated correctly.

[Trello card](https://trello.com/c/PxHcUng8)