### PR TITLE
Legacy ContentBlockDocuments are updated with their latest edition ids

### DIFF
--- a/db/migrate/20240725144121_add_latest_edition_info_to_content_block_documents.rb
+++ b/db/migrate/20240725144121_add_latest_edition_info_to_content_block_documents.rb
@@ -1,0 +1,19 @@
+class AddLatestEditionInfoToContentBlockDocuments < ActiveRecord::Migration[7.1]
+  def up
+    ContentObjectStore::ContentBlockDocument.find_each do |document|
+      if document.latest_edition_id.nil? || document.live_edition_id.nil?
+        document.update!(
+          latest_edition_id: document.content_block_editions.last.id,
+          live_edition_id: document.content_block_editions.last.id,
+        )
+      end
+    end
+  end
+
+  def down
+    ContentObjectStore::ContentBlockDocument.update_all(
+      latest_edition_id: nil,
+      live_edition_id: nil,
+    )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_24_094936) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_25_144121) do
   create_table "assets", charset: "utf8mb3", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.string "variant", null: false


### PR DESCRIPTION
During https://github.com/alphagov/whitehall/pull/9305 we added in the association to `ContentBlockDocuments` and then started using `latest_edition` in anger here https://github.com/alphagov/whitehall/pull/9307.

This works locally on a clean database.

Whilst we no real users are using this service, theoretically the team could have used the service on integration and on their own environments to create `Documents`. If those `Documents` were prior to the association then they’ll not have a `latest_edition` and so their views will break, as we found when pairing this afternoon.

This was a miss first time around and belonged in the original migration.

It looks like there is support for a data migration (as opposed to a normal Rails migration) however I don’t think we fit any of the criteria[2]:

```
* requires interacting with another system, such as publishing-api or the search
  index
* depends on specific data being present in the database - for example, a third
  party running our code won't have access to a copy of our production data
* is a long-running data change which you want the flexibility to be able to run
  during quiet times
```

Also we see another recent migration doing updates[1] which points to this being a conventional way of doing this within Whitehall.

[1](https://github.com/alphagov/whitehall/blob/main/db/migrate/20240723115422_rename_editionable_worldwide_organisation_polymorphic_relationships.rb)
[2](https://github.com/alphagov/whitehall/blob/main/db/data_migration/README.md)