### PR TITLE
Enabled strict mode for all javascripts

### DIFF
--- a/app/assets/javascripts/admin/domain-config.js
+++ b/app/assets/javascripts/admin/domain-config.js
@@ -1,3 +1,4 @@
+'use strict'
 window.GOVUK = window.GOVUK || {}
 window.GOVUK.vars = window.GOVUK.vars || {}
 window.GOVUK.vars.extraDomains = [

--- a/app/assets/javascripts/admin/modules/add-another.js
+++ b/app/assets/javascripts/admin/modules/add-another.js
@@ -1,3 +1,4 @@
+'use strict'
 window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {}
 ;(function (Modules) {

--- a/app/assets/javascripts/admin/modules/document-history-paginator.js
+++ b/app/assets/javascripts/admin/modules/document-history-paginator.js
@@ -1,3 +1,4 @@
+'use strict'
 window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {}
 ;(function (Modules) {

--- a/app/assets/javascripts/admin/modules/ga4-button-setup.js
+++ b/app/assets/javascripts/admin/modules/ga4-button-setup.js
@@ -1,3 +1,4 @@
+'use strict'
 window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {}
 ;(function (Modules) {

--- a/app/assets/javascripts/admin/modules/ga4-form-setup.js
+++ b/app/assets/javascripts/admin/modules/ga4-form-setup.js
@@ -1,3 +1,4 @@
+'use strict'
 window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {}
 ;(function (Modules) {

--- a/app/assets/javascripts/admin/modules/ga4-link-setup.js
+++ b/app/assets/javascripts/admin/modules/ga4-link-setup.js
@@ -1,3 +1,4 @@
+'use strict'
 window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {}
 ;(function (Modules) {

--- a/app/assets/javascripts/admin/modules/ga4-page-view-tracking.js
+++ b/app/assets/javascripts/admin/modules/ga4-page-view-tracking.js
@@ -1,3 +1,4 @@
+'use strict'
 window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {}
 ;(function (Modules) {

--- a/app/assets/javascripts/admin/modules/ga4-visual-editor-event-handlers.js
+++ b/app/assets/javascripts/admin/modules/ga4-visual-editor-event-handlers.js
@@ -1,3 +1,4 @@
+'use strict'
 window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {}
 ;(function (Modules) {

--- a/app/assets/javascripts/admin/modules/locale-switcher.js
+++ b/app/assets/javascripts/admin/modules/locale-switcher.js
@@ -1,3 +1,4 @@
+'use strict'
 /* This module is used where only certain elements within a form are required to update the value of their `dir` attribute in response to a change in a `select` element.
  ** By default it will affect this change on `input` and `textarea` elements but can be extended to other elements as below.
  ** Usage:

--- a/app/assets/javascripts/admin/modules/navbar-toggle.js
+++ b/app/assets/javascripts/admin/modules/navbar-toggle.js
@@ -1,3 +1,4 @@
+'use strict'
 window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {}
 ;(function (Modules) {

--- a/app/assets/javascripts/admin/modules/paste-html-to-govspeak.js
+++ b/app/assets/javascripts/admin/modules/paste-html-to-govspeak.js
@@ -1,4 +1,5 @@
 //= require paste-html-to-govspeak/dist/paste-html-to-markdown.js
+'use strict'
 
 window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {}

--- a/app/assets/javascripts/admin/modules/prevent-multiple-form-submissions.js
+++ b/app/assets/javascripts/admin/modules/prevent-multiple-form-submissions.js
@@ -1,3 +1,4 @@
+'use strict'
 window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {}
 ;(function (Modules) {

--- a/app/assets/javascripts/admin/stop-scripts-nomodule.js
+++ b/app/assets/javascripts/admin/stop-scripts-nomodule.js
@@ -1,3 +1,4 @@
+'use strict'
 // In browsers that do not support ES6 modules
 if (!('noModule' in HTMLScriptElement.prototype)) {
   // Remove any JavaScript reliant style changes.

--- a/app/assets/javascripts/admin/views/broken-links-report.js
+++ b/app/assets/javascripts/admin/views/broken-links-report.js
@@ -1,3 +1,4 @@
+'use strict'
 window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {}
 ;(function (Modules) {

--- a/app/assets/javascripts/admin/views/edition-form.js
+++ b/app/assets/javascripts/admin/views/edition-form.js
@@ -1,3 +1,4 @@
+'use strict'
 window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {}
 ;(function (Modules) {

--- a/app/assets/javascripts/admin/views/organisation-form.js
+++ b/app/assets/javascripts/admin/views/organisation-form.js
@@ -1,3 +1,4 @@
+'use strict'
 window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {}
 ;(function (Modules) {

--- a/app/assets/javascripts/admin/views/unpublish-display-conditions.js
+++ b/app/assets/javascripts/admin/views/unpublish-display-conditions.js
@@ -1,3 +1,4 @@
+'use strict'
 window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {}
 ;(function (Modules) {

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -27,5 +27,6 @@
 //= require admin/views/organisation-form
 //= require admin/views/unpublish-display-conditions
 
+'use strict'
 window.GOVUK.approveAllCookieTypes()
 window.GOVUK.cookie('cookies_preferences_set', 'true', { days: 365 })

--- a/app/assets/javascripts/components/autocomplete.js
+++ b/app/assets/javascripts/components/autocomplete.js
@@ -1,4 +1,5 @@
 //= require accessible-autocomplete/dist/accessible-autocomplete.min.js
+'use strict'
 window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {}
 ;(function (Modules) {

--- a/app/assets/javascripts/components/govspeak-editor.js
+++ b/app/assets/javascripts/components/govspeak-editor.js
@@ -1,3 +1,4 @@
+'use strict'
 window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {}
 ;(function (Modules) {

--- a/app/assets/javascripts/components/image-cropper.js
+++ b/app/assets/javascripts/components/image-cropper.js
@@ -1,4 +1,5 @@
 //= require cropperjs/dist/cropper.js
+'use strict'
 window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {}
 ;(function (Modules) {

--- a/app/assets/javascripts/components/miller-columns.js
+++ b/app/assets/javascripts/components/miller-columns.js
@@ -1,4 +1,5 @@
 //= require miller-columns-element
+'use strict'
 window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {}
 ;(function (Modules) {

--- a/app/assets/javascripts/components/select-with-search.js
+++ b/app/assets/javascripts/components/select-with-search.js
@@ -1,4 +1,5 @@
 //= require choices.js/public/assets/scripts/choices.min.js
+'use strict'
 window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {}
 ;(function (Modules) {

--- a/app/assets/javascripts/components/visual-editor.js
+++ b/app/assets/javascripts/components/visual-editor.js
@@ -1,4 +1,5 @@
 //= require govspeak-visual-editor/dist/govspeak-visual-editor.js
+'use strict'
 
 window.GOVUK = window.GOVUK || {}
 window.GOVUK.Modules = window.GOVUK.Modules || {}


### PR DESCRIPTION
This is a pre-requisite for upgrading to GOV.UK Publishing Components v40, which requires us to have JS code compatible with GOV.UK Frontend v5, which requires the use of strict mode.

Trello: https://trello.com/c/W12S9N8P
