### PR TITLE
Namespace migration code

### DIFF
--- a/db/migrate/20240725144121_add_latest_edition_info_to_content_block_documents.rb
+++ b/db/migrate/20240725144121_add_latest_edition_info_to_content_block_documents.rb
@@ -1,6 +1,6 @@
 class AddLatestEditionInfoToContentBlockDocuments < ActiveRecord::Migration[7.1]
   def up
-    ContentObjectStore::ContentBlockDocument.find_each do |document|
+    ContentObjectStore::ContentBlock::Document.find_each do |document|
       if document.latest_edition_id.nil? || document.live_edition_id.nil?
         document.update!(
           latest_edition_id: document.content_block_editions.last.id,
@@ -11,7 +11,7 @@ class AddLatestEditionInfoToContentBlockDocuments < ActiveRecord::Migration[7.1]
   end
 
   def down
-    ContentObjectStore::ContentBlockDocument.update_all(
+    ContentObjectStore::ContentBlock::Document.update_all(
       latest_edition_id: nil,
       live_edition_id: nil,
     )


### PR DESCRIPTION
If someone hasn’t run these migrations after the namespace change has occurred, they’ll get an error, so we should fix this.