### PR TITLE
Content-modelling/367: Add a 'review' journey when creating an Edition

### DIFF
--- a/db/migrate/20240730134237_add_state_to_content_block_editions.rb
+++ b/db/migrate/20240730134237_add_state_to_content_block_editions.rb
@@ -1,0 +1,13 @@
+class AddStateToContentBlockEditions < ActiveRecord::Migration[7.1]
+  def up
+    change_table :content_block_editions, bulk: true do |t|
+      t.string "state", default: "draft", null: false
+    end
+  end
+
+  def down
+    change_table :content_block_editions, bulk: true do |t|
+      t.remove :state
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_25_144121) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_30_134237) do
   create_table "assets", charset: "utf8mb3", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.string "variant", null: false
@@ -218,6 +218,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_25_144121) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.bigint "user_id"
+    t.string "state", default: "draft", null: false
     t.index ["document_id"], name: "index_content_block_editions_on_document_id"
     t.index ["user_id"], name: "index_content_block_editions_on_user_id"
   end

--- a/lib/engines/content_object_store/app/components/content_object_store/content_block_edition/show/confirm_summary_list_component.html.erb
+++ b/lib/engines/content_object_store/app/components/content_object_store/content_block_edition/show/confirm_summary_list_component.html.erb
@@ -1,0 +1,3 @@
+<%= render "govuk_publishing_components/components/summary_list", {
+  items:,
+} %>

--- a/lib/engines/content_object_store/app/components/content_object_store/content_block_edition/show/confirm_summary_list_component.rb
+++ b/lib/engines/content_object_store/app/components/content_object_store/content_block_edition/show/confirm_summary_list_component.rb
@@ -1,0 +1,36 @@
+class ContentObjectStore::ContentBlockEdition::Show::ConfirmSummaryListComponent < ViewComponent::Base
+  def initialize(content_block_edition:)
+    @content_block_edition = content_block_edition
+  end
+
+private
+
+  attr_reader :content_block_edition
+
+  def items
+    details_items.push(confirm_item).push(date_item)
+  end
+
+  def details_items
+    content_block_edition.details.map do |key, value|
+      {
+        field: "New #{key.humanize.downcase}",
+        value:,
+      }
+    end
+  end
+
+  def confirm_item
+    {
+      field: "Confirm",
+      value: "I confirm that I am happy for the content block to be changed on these pages.",
+    }
+  end
+
+  def date_item
+    {
+      field: "Publish date",
+      value: Date.current.strftime("%d %B %Y"),
+    }
+  end
+end

--- a/lib/engines/content_object_store/app/controllers/content_object_store/content_block/editions_controller.rb
+++ b/lib/engines/content_object_store/app/controllers/content_object_store/content_block/editions_controller.rb
@@ -16,10 +16,14 @@ class ContentObjectStore::ContentBlock::EditionsController < ContentObjectStore:
 
     new_edition = ContentObjectStore::CreateEditionService.new(@schema).call(edition_params)
 
-    redirect_to content_object_store.content_object_store_content_block_document_path(new_edition.document), flash: { notice: "#{@schema.name} created successfully" }
+    redirect_to content_object_store.review_content_object_store_content_block_edition_path(new_edition)
   rescue ActiveRecord::RecordInvalid => e
     @form = ContentObjectStore::ContentBlock::EditionForm::Create.new(content_block_edition: e.record, schema: @schema)
     render :new
+  end
+
+  def review
+    @content_block_edition = ContentObjectStore::ContentBlock::Edition.find(params[:id])
   end
 
   def edit

--- a/lib/engines/content_object_store/app/controllers/content_object_store/content_block/workflow_controller.rb
+++ b/lib/engines/content_object_store/app/controllers/content_object_store/content_block/workflow_controller.rb
@@ -1,0 +1,15 @@
+class ContentObjectStore::ContentBlock::WorkflowController < ContentObjectStore::BaseController
+  def publish
+    edition = ContentObjectStore::ContentBlock::Edition.find(params[:id])
+    schema = ContentObjectStore::ContentBlock::Schema.find_by_block_type(edition.document.block_type)
+    new_edition = ContentObjectStore::PublishEditionService.new(
+      schema,
+    ).call(edition)
+    redirect_to content_object_store.content_object_store_content_block_document_path(new_edition.document),
+                flash: { notice: "#{new_edition.block_type.humanize} created successfully" }
+    # TODO: error handling
+    # else
+    #   redirect_to admin_edition_path(@edition), alert: edition_publisher.failure_reason
+    # end
+  end
+end

--- a/lib/engines/content_object_store/app/lib/content_object_store/publishable.rb
+++ b/lib/engines/content_object_store/app/lib/content_object_store/publishable.rb
@@ -16,7 +16,8 @@ module ContentObjectStore
           details: details.to_h,
         )
         publish_publishing_api_edition(content_id:)
-        update_content_block_document_with_latest_edition(content_block_edition)
+        update_content_block_document_with_live_edition(content_block_edition)
+        content_block_edition.public_send(:publish!)
       rescue PublishingFailureError => e
         discard_publishing_api_edition(content_id:)
         raise e
@@ -47,9 +48,12 @@ module ContentObjectStore
 
     def update_content_block_document_with_latest_edition(content_block_edition)
       content_block_edition.document.update!(
-        live_edition_id: content_block_edition.id,
         latest_edition_id: content_block_edition.id,
       )
+    end
+
+    def update_content_block_document_with_live_edition(content_block_edition)
+      content_block_edition.document.update!(live_edition_id: content_block_edition.id)
     end
   end
 end

--- a/lib/engines/content_object_store/app/models/concerns/content_object_store/workflow.rb
+++ b/lib/engines/content_object_store/app/models/concerns/content_object_store/workflow.rb
@@ -1,0 +1,22 @@
+module ContentObjectStore::Workflow
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    def valid_state?(state)
+      %w[draft published].include?(state)
+    end
+  end
+
+  included do
+    include ActiveRecord::Transitions
+
+    state_machine auto_scopes: true do
+      state :draft
+      state :published
+
+      event :publish do
+        transitions from: %i[draft], to: :published
+      end
+    end
+  end
+end

--- a/lib/engines/content_object_store/app/models/content_object_store/content_block/edition.rb
+++ b/lib/engines/content_object_store/app/models/content_object_store/content_block/edition.rb
@@ -5,6 +5,7 @@ module ContentObjectStore
       include ContentObjectStore::ValidatesDetails
       include ContentObjectStore::HasAuthors
       include ContentObjectStore::HasAuditTrail
+      include ContentObjectStore::Workflow
     end
   end
 end

--- a/lib/engines/content_object_store/app/services/content_object_store/create_edition_service.rb
+++ b/lib/engines/content_object_store/app/services/content_object_store/create_edition_service.rb
@@ -7,13 +7,9 @@ module ContentObjectStore
     end
 
     def call(edition_params)
-      title = edition_params[:document_attributes][:title]
-      details = edition_params[:details]
-
-      publish_with_rollback(schema: @schema, title:, details:) do
-        @new_edition = ContentObjectStore::ContentBlock::Edition.create!(edition_params)
-      end
-
+      @new_edition = ContentObjectStore::ContentBlock::Edition.create!(edition_params)
+      update_content_block_document_with_latest_edition(@new_edition)
+      # TODO: error scenario?
       @new_edition
     end
   end

--- a/lib/engines/content_object_store/app/services/content_object_store/publish_edition_service.rb
+++ b/lib/engines/content_object_store/app/services/content_object_store/publish_edition_service.rb
@@ -1,0 +1,18 @@
+module ContentObjectStore
+  class PublishEditionService
+    include Publishable
+
+    def initialize(schema)
+      @schema = schema
+    end
+
+    def call(edition)
+      title = edition.title
+      details = edition.details
+      publish_with_rollback(schema: @schema, title:, details:) do
+        edition
+      end
+      edition
+    end
+  end
+end

--- a/lib/engines/content_object_store/app/views/content_object_store/content_block/editions/review.html.erb
+++ b/lib/engines/content_object_store/app/views/content_object_store/content_block/editions/review.html.erb
@@ -1,0 +1,34 @@
+<% content_for :context, "Manage #{add_indefinite_article @content_block_edition.block_type.humanize.downcase}" %>
+<% content_for :title, "Check your answers" %>
+<% content_for :back_link do %>
+  <%= render "govuk_publishing_components/components/back_link", {
+    href: content_object_store.content_object_store_content_block_documents_path,
+  } %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= render(
+          ContentObjectStore::ContentBlockEdition::Show::ConfirmSummaryListComponent.new(
+            content_block_edition: @content_block_edition,
+            ),
+          ) %>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= form_with(url: content_object_store.publish_content_object_store_content_block_edition_path, method: :post) do %>
+      <%= hidden_field_tag "content_block_edition[id]", @content_block_edition.id, id: "content-block-edition-id" %>
+      <div class="govuk-button-group govuk-!-margin-bottom-6">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Accept and publish",
+          name: "accept_and_publish",
+          value: "Accept and publish",
+          type: "submit",
+        } %>
+        <%= link_to("Cancel", content_object_store.content_object_store_content_block_documents_path, class: "govuk-link") %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/lib/engines/content_object_store/config/routes.rb
+++ b/lib/engines/content_object_store/config/routes.rb
@@ -5,7 +5,10 @@ ContentObjectStore::Engine.routes.draw do
     namespace :content_block, path: "content-block" do
       resources :documents, only: %i[index show], path_names: { new: "(:block_type)/new" }
       resources :editions, only: %i[new create edit update], path_names: { new: "(:block_type)/new" } do
-        get :review, on: :member
+        member do
+          get :review
+          post :publish, to: "workflow#publish"
+        end
       end
     end
   end

--- a/lib/engines/content_object_store/config/routes.rb
+++ b/lib/engines/content_object_store/config/routes.rb
@@ -4,7 +4,9 @@ ContentObjectStore::Engine.routes.draw do
 
     namespace :content_block, path: "content-block" do
       resources :documents, only: %i[index show], path_names: { new: "(:block_type)/new" }
-      resources :editions, only: %i[new create edit update], path_names: { new: "(:block_type)/new" }
+      resources :editions, only: %i[new create edit update], path_names: { new: "(:block_type)/new" } do
+        get :review, on: :member
+      end
     end
   end
 end

--- a/lib/engines/content_object_store/features/create_object.feature
+++ b/lib/engines/content_object_store/features/create_object.feature
@@ -22,6 +22,8 @@ Feature: Create a content object
     When I complete the form with the following fields:
       | title            | email_address   | department |
       | my email address | foo@example.com | Somewhere  |
+    Then I am asked to check my answers
+    When I accept and publish
     Then the edition should have been created successfully
     And I should be taken back to the document page
 

--- a/lib/engines/content_object_store/features/step_definitions/content_object_store_steps.rb
+++ b/lib/engines/content_object_store/features/step_definitions/content_object_store_steps.rb
@@ -238,3 +238,11 @@ Then("I should see the update on the timeline") do
   assert_text "Email address changed"
   expect(page).to have_selector(".timeline__byline", text: "by #{@user.name}", count: 2)
 end
+
+Then("I am asked to check my answers") do
+  assert_text "Check your answers"
+end
+
+Then("I accept and publish") do
+  click_on "Accept and publish"
+end

--- a/lib/engines/content_object_store/test/components/content_block_edition/show/confirm_summary_list_component_test.rb
+++ b/lib/engines/content_object_store/test/components/content_block_edition/show/confirm_summary_list_component_test.rb
@@ -1,0 +1,19 @@
+require "test_helper"
+
+class ContentObjectStore::ContentBlockEdition::Show::ConfirmSummaryListComponentTest < ViewComponent::TestCase
+  test "renders a summary list component with the edition details to confirm" do
+    @user = create(:user)
+    @content_block_edition = create(:content_block_edition, :email_address, details: { "interesting_fact" => "value of fact" })
+
+    render_inline(ContentObjectStore::ContentBlockEdition::Show::ConfirmSummaryListComponent.new(
+                    content_block_edition: @content_block_edition,
+                  ))
+
+    assert_selector ".govuk-summary-list__key", text: "New interesting fact"
+    assert_selector ".govuk-summary-list__value", text: "value of fact"
+    assert_selector ".govuk-summary-list__key", text: "Confirm"
+    assert_selector ".govuk-summary-list__value", text: "I confirm that I am happy for the content block to be changed on these pages."
+    assert_selector ".govuk-summary-list__key", text: "Publish date"
+    assert_selector ".govuk-summary-list__value", text: @content_block_edition.created_at.strftime("%d %B %Y")
+  end
+end

--- a/lib/engines/content_object_store/test/factories/content_block_edition.rb
+++ b/lib/engines/content_object_store/test/factories/content_block_edition.rb
@@ -17,7 +17,6 @@ FactoryBot.define do
     after(:create) do |content_block_edition, _evaluator|
       document_update_params = {
         latest_edition_id: content_block_edition.id,
-        live_edition_id: content_block_edition.id,
       }
       content_block_edition.document.update!(document_update_params)
     end

--- a/lib/engines/content_object_store/test/integration/content_block/editions_test.rb
+++ b/lib/engines/content_object_store/test/integration/content_block/editions_test.rb
@@ -56,61 +56,9 @@ class ContentObjectStore::ContentBlock::EditionsTest < ActionDispatch::Integrati
     assert_equal new_edition.document_id, new_document.id
     assert_equal new_edition.creator, new_author.user
 
-    assert_equal new_document.live_edition_id, new_edition.id
     assert_equal new_document.latest_edition_id, new_edition.id
 
     assert_equal new_version.whodunnit, new_author.user.id.to_s
-  end
-
-  test "#create posts the new edition to the Publishing API" do
-    document_attributes = {
-      title: "Some Title",
-      block_type: "email_address",
-    }
-    details = {
-      foo: "Foo text",
-      bar: "Bar text",
-    }
-    fake_put_content_response = GdsApi::Response.new(
-      stub("http_response", code: 200, body: {}),
-    )
-    fake_publish_content_response = GdsApi::Response.new(
-      stub("http_response", code: 200, body: {}),
-    )
-
-    # This UUID is created by the database so instead of loading the record
-    # we stub the initial creation so we know what UUID to check for.
-    ContentObjectStore::ContentBlock::Edition.any_instance.stubs(:create_random_id)
-      .returns(@content_id)
-
-    publishing_api_mock = Minitest::Mock.new
-    publishing_api_mock.expect :put_content, fake_put_content_response, [
-      @content_id,
-      {
-        schema_name: "content_block_type",
-        document_type: "content_block_type",
-        publishing_app: "whitehall",
-        title: "Some Title",
-        details: {
-          "foo" => "Foo text",
-          "bar" => "Bar text",
-        },
-      },
-    ]
-    publishing_api_mock.expect :publish, fake_publish_content_response, [
-      @content_id,
-      "major",
-    ]
-
-    Services.stub :publishing_api, publishing_api_mock do
-      post content_object_store.content_object_store_content_block_editions_path, params: {
-        content_block_edition: {
-          document_attributes:,
-          details:,
-        },
-      }
-      publishing_api_mock.verify
-    end
   end
 
   test "#create should render the template when a validation error occurs" do

--- a/lib/engines/content_object_store/test/integration/content_block/workflow_test.rb
+++ b/lib/engines/content_object_store/test/integration/content_block/workflow_test.rb
@@ -1,0 +1,64 @@
+require "test_helper"
+require "capybara/rails"
+
+class ContentObjectStore::ContentBlock::WorkflowTest < ActionDispatch::IntegrationTest
+  include Capybara::DSL
+
+  setup do
+    login_as_admin
+    @content_id = "49453854-d8fd-41da-ad4c-f99dbac601c3"
+
+    stub_request_for_schema("email_address")
+
+    feature_flags.switch!(:content_object_store, true)
+  end
+
+  test "#publish posts the new edition to the Publishing API and marks edition as published" do
+    details = {
+      foo: "Foo text",
+      bar: "Bar text",
+    }
+
+    document = create(:content_block_document, :email_address, content_id: @content_id, title: "Some Title")
+    edition = create(:content_block_edition, document:, details:)
+
+    fake_put_content_response = GdsApi::Response.new(
+      stub("http_response", code: 200, body: {}),
+    )
+    fake_publish_content_response = GdsApi::Response.new(
+      stub("http_response", code: 200, body: {}),
+    )
+
+    publishing_api_mock = Minitest::Mock.new
+    publishing_api_mock.expect :put_content, fake_put_content_response, [
+      @content_id,
+      {
+        schema_name: "content_block_type",
+        document_type: "content_block_type",
+        publishing_app: "whitehall",
+        title: "Some Title",
+        details: {
+          "foo" => "Foo text",
+          "bar" => "Bar text",
+        },
+      },
+    ]
+    publishing_api_mock.expect :publish, fake_publish_content_response, [
+      @content_id,
+      "major",
+    ]
+
+    Services.stub :publishing_api, publishing_api_mock do
+      post content_object_store.publish_content_object_store_content_block_edition_path(id: edition.id), params: {
+        id: edition.id,
+      }
+      publishing_api_mock.verify
+      assert_equal "published", edition.reload.state
+    end
+  end
+end
+
+def stub_request_for_schema(block_type)
+  schema = stub(id: "content_block_type", fields: %w[foo bar], name: "schema", body: {}, block_type:)
+  ContentObjectStore::ContentBlock::Schema.stubs(:find_by_block_type).with(block_type).returns(schema)
+end

--- a/lib/engines/content_object_store/test/unit/app/lib/content_object_store/publishable_test.rb
+++ b/lib/engines/content_object_store/test/unit/app/lib/content_object_store/publishable_test.rb
@@ -13,7 +13,7 @@ class ContentObjectStore::PublishableTest < ActiveSupport::TestCase
 
     assert_raises ArgumentError, "Local database changes not given" do
       test_instance.publish_with_rollback(
-        anything, document_title: anything, details: anything
+        schema: anything, title: anything, details: anything,
       )
     end
   end

--- a/lib/engines/content_object_store/test/unit/app/models/concerns/workflow_test.rb
+++ b/lib/engines/content_object_store/test/unit/app/models/concerns/workflow_test.rb
@@ -1,0 +1,14 @@
+require "test_helper"
+
+class ContentObjectStore::WorkflowTest < ActiveSupport::TestCase
+  test "draft is the default state" do
+    edition = create(:content_block_edition, document: create(:content_block_document, block_type: "email_address"))
+    assert edition.draft?
+  end
+
+  test "publishing a draft edition transitions it into the published state" do
+    edition = create(:content_block_edition, document: create(:content_block_document, block_type: "email_address"))
+    edition.publish!
+    assert edition.published?
+  end
+end

--- a/lib/engines/content_object_store/test/unit/app/services/create_edition_service_test.rb
+++ b/lib/engines/content_object_store/test/unit/app/services/create_edition_service_test.rb
@@ -50,111 +50,20 @@ class ContentObjectStore::CreateEditionServiceTest < ActiveSupport::TestCase
       assert_equal edition_params[:details], new_edition.details
       assert_equal new_edition.document_id, new_document.id
 
-      assert_equal new_document.live_edition_id, new_edition.id
       assert_equal new_document.latest_edition_id, new_edition.id
     end
 
-    test "it creates an Edition and Document in the Publishing API" do
-      fake_put_content_response = GdsApi::Response.new(
-        stub("http_response", code: 200, body: {}),
-      )
-      fake_publish_content_response = GdsApi::Response.new(
-        stub("http_response", code: 200, body: {}),
-      )
-
-      publishing_api_mock = Minitest::Mock.new
-      publishing_api_mock.expect :put_content, fake_put_content_response, [
-        content_id,
-        {
-          schema_name: schema.id,
-          document_type: schema.id,
-          publishing_app: "whitehall",
-          title: "Some Title",
-          details: {
-            "foo" => "Foo text",
-            "bar" => "Bar text",
-          },
-        },
-      ]
-      publishing_api_mock.expect :publish, fake_publish_content_response, [
-        content_id,
-        "major",
-      ]
-
-      Services.stub :publishing_api, publishing_api_mock do
-        ContentObjectStore::CreateEditionService.new(schema).call(edition_params)
-
-        publishing_api_mock.verify
-      end
-    end
-
-    test "if the publishing API request fails, the Whitehall ContentBlockEdition and ContentBlockDocument are rolled back" do
-      exception = GdsApi::HTTPErrorResponse.new(
-        422,
-        "An internal error message",
-        "error" => { "message" => "Some backend error" },
-      )
-      raises_exception = ->(*_args) { raise exception }
-
-      Services.publishing_api.stub :put_content, raises_exception do
-        assert_equal ContentObjectStore::ContentBlock::Document.count, 0 do
-          assert_equal ContentObjectStore::ContentBlock::Edition.count, 0 do
-            assert_raises(GdsApi::HTTPErrorResponse) do
-              ContentObjectStore::CreateEditionService.new(schema).call(edition_params)
-            end
-          end
-        end
-      end
-    end
-
-    test "if the Whitehall creation fails, no call to the Publishing API is made" do
-      exception = ArgumentError.new("Cannot find schema for block_type")
-      raises_exception = ->(*_args) { raise exception }
-
-      Services.publishing_api.expects(:put_content).never
-
-      ContentObjectStore::ContentBlock::Edition.stub :create!, raises_exception do
-        assert_raises(ArgumentError) do
-          ContentObjectStore::CreateEditionService.new(schema).call(nil, {})
-        end
-      end
-    end
-
-    test "if the publish request fails, the latest draft is discarded and the database actions are rolled back" do
-      fake_put_content_response = GdsApi::Response.new(
-        stub("http_response", code: 200, body: {}),
-      )
-      fake_discard_draft_content_response = GdsApi::Response.new(
-        stub("http_response", code: 200, body: {}),
-      )
-
-      publishing_api_mock = Minitest::Mock.new
-      publishing_api_mock.expect :put_content, fake_put_content_response, [
-        String,
-        Hash,
-      ]
-      publishing_api_mock.expect :discard_draft, fake_discard_draft_content_response, [
-        content_id,
-      ]
-
-      exception = GdsApi::HTTPErrorResponse.new(
-        422,
-        "An internal error message",
-        "error" => { "message" => "Some backend error" },
-      )
-      raises_exception = ->(*_args) { raise exception }
-
-      Services.publishing_api.stub :publish, raises_exception do
-        assert_equal ContentObjectStore::ContentBlock::Document.count, 0 do
-          assert_equal ContentObjectStore::ContentBlock::Edition.count, 0 do
-            assert_raises(ContentObjectStore::CreateEditionService::PublishingFailureError, "Could not publish #{content_id} because: Some backend error") do
-              ContentObjectStore::CreateEditionService.new(schema).call(edition_params)
-            end
-
-            publishing_api_mock.verify
-          end
-        end
-      end
-    end
+    # test "if the Whitehall creation fails, no call to the Publishing API is made" do
+    #   exception = ArgumentError.new("Cannot find schema for block_type")
+    #   raises_exception = ->(*_args) { raise exception }
+    #
+    #   Services.publishing_api.expects(:put_content).never
+    #
+    #   ContentObjectStore::ContentBlock::Edition.stub :create!, raises_exception do
+    #     assert_raises(ArgumentError) do
+    #       ContentObjectStore::CreateEditionService.new(schema).call(nil, {})
+    #     end
+    #   end
+    # end
   end
 end

--- a/lib/engines/content_object_store/test/unit/app/services/publish_edition_service_test.rb
+++ b/lib/engines/content_object_store/test/unit/app/services/publish_edition_service_test.rb
@@ -1,0 +1,119 @@
+require "test_helper"
+
+class ContentObjectStore::PublishEditionServiceTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
+  describe "#call" do
+    let(:content_id) { "49453854-d8fd-41da-ad4c-f99dbac601c3" }
+    let(:schema) { build(:content_block_schema, block_type: "content_block_type", body: { "properties" => { "foo" => "", "bar" => "" } }) }
+    let(:document) { create(:content_block_document, :email_address, content_id:, title: "Some Title") }
+    let(:edition) { create(:content_block_edition, document:, details: { "foo" => "Foo text", "bar" => "Bar text" }) }
+
+    setup do
+      ContentObjectStore::ContentBlock::Schema.stubs(:find_by_block_type)
+                                              .returns(schema)
+    end
+
+    test "returns a ContentBlockEdition" do
+      result = ContentObjectStore::PublishEditionService.new(schema).call(edition)
+      assert_instance_of ContentObjectStore::ContentBlock::Edition, result
+    end
+
+    test "it publishes the Edition in Whitehall" do
+      ContentObjectStore::PublishEditionService.new(schema).call(edition)
+
+      assert_equal "published", edition.state
+      assert_equal edition.id, document.live_edition_id
+    end
+
+    test "it creates an Edition in the Publishing API" do
+      fake_put_content_response = GdsApi::Response.new(
+        stub("http_response", code: 200, body: {}),
+      )
+      fake_publish_content_response = GdsApi::Response.new(
+        stub("http_response", code: 200, body: {}),
+      )
+
+      publishing_api_mock = Minitest::Mock.new
+      publishing_api_mock.expect :put_content, fake_put_content_response, [
+        content_id,
+        {
+          schema_name: schema.id,
+          document_type: schema.id,
+          publishing_app: "whitehall",
+          title: "Some Title",
+          details: {
+            "foo" => "Foo text",
+            "bar" => "Bar text",
+          },
+        },
+      ]
+      publishing_api_mock.expect :publish, fake_publish_content_response, [
+        content_id,
+        "major",
+      ]
+
+      Services.stub :publishing_api, publishing_api_mock do
+        ContentObjectStore::PublishEditionService.new(schema).call(edition)
+
+        publishing_api_mock.verify
+        assert_equal "published", edition.state
+        assert_equal edition.id, document.live_edition_id
+      end
+    end
+
+    test "if the publishing API request fails, the Whitehall ContentBlockEdition and ContentBlockDocument are rolled back" do
+      exception = GdsApi::HTTPErrorResponse.new(
+        422,
+        "An internal error message",
+        "error" => { "message" => "Some backend error" },
+      )
+      raises_exception = ->(*_args) { raise exception }
+
+      assert_equal "draft", edition.state
+      assert_nil document.live_edition_id
+
+      Services.publishing_api.stub :put_content, raises_exception do
+        assert_raises(GdsApi::HTTPErrorResponse) do
+          ContentObjectStore::PublishEditionService.new(schema).call(edition)
+        end
+        assert_equal "draft", edition.state
+        assert_nil document.live_edition_id
+      end
+    end
+
+    test "if the publish request fails, the latest draft is discarded and the database actions are rolled back" do
+      fake_put_content_response = GdsApi::Response.new(
+        stub("http_response", code: 200, body: {}),
+      )
+      fake_discard_draft_content_response = GdsApi::Response.new(
+        stub("http_response", code: 200, body: {}),
+      )
+
+      publishing_api_mock = Minitest::Mock.new
+      publishing_api_mock.expect :put_content, fake_put_content_response, [
+        String,
+        Hash,
+      ]
+      publishing_api_mock.expect :discard_draft, fake_discard_draft_content_response, [
+        content_id,
+      ]
+
+      exception = GdsApi::HTTPErrorResponse.new(
+        422,
+        "An internal error message",
+        "error" => { "message" => "Some backend error" },
+      )
+      raises_exception = ->(*_args) { raise exception }
+
+      Services.publishing_api.stub :publish, raises_exception do
+        assert_raises(ContentObjectStore::PublishEditionService::PublishingFailureError, "Could not publish #{content_id} because: Some backend error") do
+          ContentObjectStore::PublishEditionService.new(schema).call(edition)
+          publishing_api_mock.verify
+        end
+        assert_equal "draft", edition.state
+        assert_nil document.live_edition_id
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a draft -> publish workflow for the 'create' journey for Editions.
Not included:
* How drafts versus live editions should be shown on a Document - currently we just show the latest edition on a Document view whether it's published or not - I don't think we have designs for how to indicate whether an Edition is a draft? And maybe this should happen in another PR as this is quite big already.
* a path for if the edition is just saved as 'draft' and not published
* updating editions and saving those edits as draft.

Included:
* rather than publishing on `create` of an Edition, we just create the Document and Edition within Whitehall, in a state of Draft
* the `create` Controller action now redirects to a `confirm` page which prompts the user to accept the content and publish
* this `publish` action is in a new Workflow Controller (as in existing Whitehall code) and this handles the publishing process that used to be handled by `create`.
* We introduce a `Workflow` concern (as in Whitehall) that for now just transitions an Edition from `draft` to `published` state.

https://app.mural.co/t/contentmodellingtechnotes1539/m/contentmodellingtechnotes1539/1718976902185/df334d013e46889c0bef873eab5d999bd476f9dd?wid=0-1722338637651 
![Screenshot 2024-07-30 at 12 28 19](https://github.com/user-attachments/assets/0c5db6ca-10c3-4991-84a5-6348912295f9)

Questions

* Should we also send Drafts to the Publishing API?