### PR TITLE
Prevent duplicate person links on editions

### DIFF
--- a/app/presenters/publishing_api/payload_builder/people.rb
+++ b/app/presenters/publishing_api/payload_builder/people.rb
@@ -21,7 +21,8 @@ module PublishingApi
         {
           people: role_appointments
             .map(&:person)
-            .collect(&:content_id),
+            .collect(&:content_id)
+            .uniq,
         }
       end
 

--- a/test/unit/app/presenters/publishing_api/payload_builder/people_test.rb
+++ b/test/unit/app/presenters/publishing_api/payload_builder/people_test.rb
@@ -52,6 +52,21 @@ module PublishingApi
 
         assert_equal expected_hash, People.for(stubbed_edition)
       end
+
+      test "filters out duplicate people" do
+        person = create(:person)
+        role_appointments = 2.times.map do
+          create(:role_appointment, person:)
+        end
+
+        stubbed_edition = stub(role_appointments:)
+
+        expected_hash = {
+          people: [role_appointments[0].person.content_id],
+        }
+
+        assert_equal expected_hash, People.for(stubbed_edition)
+      end
     end
   end
 end


### PR DESCRIPTION
Publishing API rejects duplicate content IDs in the people links object on editions. This commit ensures that only unique person content IDs are included in the content update request to Publishing API.

Trello: https://trello.com/c/rVCC1bTe
