### PR TITLE
Introduce paste tracking

### DIFF
--- a/app/assets/javascripts/admin/modules/ga4-paste-tracker.js
+++ b/app/assets/javascripts/admin/modules/ga4-paste-tracker.js
@@ -1,0 +1,23 @@
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {}
+;(function (Modules) {
+  function Ga4PasteTracker(module) {
+    this.module = module
+  }
+
+  Ga4PasteTracker.prototype.init = function () {
+    window.addEventListener('paste', this.trackPaste.bind(this))
+  }
+
+  Ga4PasteTracker.prototype.trackPaste = function (event) {
+    const data = {
+      event_name: 'paste',
+      type: 'paste',
+      action: 'paste',
+      method: 'browser paste'
+    }
+    window.GOVUK.analyticsGa4.core.applySchemaAndSendData(data, 'event_data')
+  }
+
+  Modules.Ga4PasteTracker = Ga4PasteTracker
+})(window.GOVUK.Modules)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -17,6 +17,7 @@
 //= require admin/modules/ga4-form-setup
 //= require admin/modules/ga4-visual-editor-event-handlers
 //= require admin/modules/ga4-page-view-tracking
+//= require admin/modules/ga4-paste-tracker
 //= require admin/modules/locale-switcher
 //= require admin/modules/navbar-toggle
 //= require admin/modules/paste-html-to-govspeak

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -15,7 +15,7 @@
            environment: environment,
            browser_title: ("Error: " if yield(:error_summary).present?).to_s + sanitized_title do %>
 
-  <div data-module="GA4PageViewTracking" data-attributes='<%= track_analytics_data_on_load(sanitized_title) %>'></div>
+  <div data-module="GA4PageViewTracking GA4PasteTracker" data-attributes='<%= track_analytics_data_on_load(sanitized_title) %>'></div>
 
   <%= render "govuk_publishing_components/components/skip_link" %>
 

--- a/spec/javascripts/admin/modules/ga4-paste-tracker.js
+++ b/spec/javascripts/admin/modules/ga4-paste-tracker.js
@@ -1,0 +1,26 @@
+describe('GOVUK.Modules.Ga4PasteTracker', function () {
+  it('triggers ga4 tracking on paste event', function () {
+    const mockGa4SendData = spyOn(
+      window.GOVUK.analyticsGa4.core,
+      'applySchemaAndSendData'
+    )
+
+    const ga4PasteTracker = new GOVUK.Modules.Ga4VisualEditorEventHandlers(
+      document
+    )
+    ga4PasteTracker.init()
+    window.dispatchEvent(new ClipboardEvent('paste', {}))
+
+    const expectedAttributes = {
+      event_name: 'paste',
+      type: 'paste',
+      action: 'paste',
+      method: 'browser paste'
+    }
+
+    expect(mockGa4SendData).toHaveBeenCalledWith(
+      expectedAttributes,
+      'event_data'
+    )
+  })
+})


### PR DESCRIPTION
- Add a js module to listen for paste events on the `window` and send GA4 tracking data when that occurs
- https://trello.com/c/SL1HtOiG/2742-ga4-paste-content

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
