### PR TITLE
Remove unused helper methods

### DIFF
--- a/app/helpers/admin/edition_routes_helper.rb
+++ b/app/helpers/admin/edition_routes_helper.rb
@@ -38,20 +38,4 @@ module Admin::EditionRoutesHelper
   def edit_admin_edition_path(edition, *args)
     polymorphic_path([:edit, :admin, edition], *args)
   end
-
-  def edit_admin_corporate_information_page_url(edition, *args)
-    polymorphic_url([:edit, :admin, edition.organisation, edition], *args)
-  end
-
-  def edit_admin_corporate_information_page_path(edition, *args)
-    polymorphic_path([:edit, :admin, edition.organisation, edition], *args)
-  end
-
-  def admin_corporate_information_page_path(edition, *args)
-    polymorphic_path([:admin, edition.organisation, edition], *args)
-  end
-
-  def admin_corporate_information_page_url(edition, *args)
-    polymorphic_url([:admin, edition.organisation, edition], *args)
-  end
 end


### PR DESCRIPTION
As far as I can tell, these methods aren't used anywhere.

Moreover, their presence may be causing this Sentry error: https://govuk.sentry.io/issues/5621885705/?alert_rule_id=9401721&alert_type=issue&environment=production&notification_uuid=369d5b4c-e845-411d-b54b-b6c581932dc5&project=202259&referrer=slack

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
