### PR TITLE
Catch invalid URI when parsing mainstream URL

### DIFF
--- a/app/models/detailed_guide.rb
+++ b/app/models/detailed_guide.rb
@@ -155,11 +155,13 @@ private
   def parse_base_path_from_related_mainstream_url(url)
     return nil if url.blank?
 
-    parsed_url = URI.parse(url.strip)
-    url_is_invalid = !["gov.uk", "www.gov.uk"].include?(parsed_url.host)
-    return nil if url_is_invalid
-
-    parsed_url.path
+    begin
+      parsed_url = URI.parse(url.strip)
+      url_is_invalid = !["gov.uk", "www.gov.uk"].include?(parsed_url.host)
+      url_is_invalid ? nil : parsed_url.path
+    rescue URI::InvalidURIError
+      nil
+    end
   end
 
   def related_mainstream_found

--- a/test/unit/app/models/detailed_guide_test.rb
+++ b/test/unit/app/models/detailed_guide_test.rb
@@ -63,6 +63,11 @@ class DetailedGuideTest < ActiveSupport::TestCase
     assert guide.has_related_mainstream_content?
   end
 
+  test "doesn't error when invalid URL is provided" do
+    guide = build(:detailed_guide, related_mainstream_content_url: "vat return")
+    assert_nil guide.related_mainstream_base_path
+  end
+
   test "can be associated with some additional content in the mainstream application" do
     assert_not build(:detailed_guide).has_additional_related_mainstream_content?
     guide = build(:detailed_guide, additional_related_mainstream_content_url: "http://mainstream/content")


### PR DESCRIPTION
Fixes https://govuk.sentry.io/issues/5657864742/?alert_rule_id=963054&alert_type=issue&notification_uuid=6fae429a-a184-4a8d-bcd4-a2a9aa6cbf89&project=202259&referrer=slack

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
