### PR TITLE
Stop republishing Embassies Index so much

### DIFF
--- a/app/controllers/admin/republishing_controller.rb
+++ b/app/controllers/admin/republishing_controller.rb
@@ -193,7 +193,7 @@ private
       "PublishingApi::HowGovernmentWorksPresenter",
       "PublishingApi::OperationalFieldsIndexPresenter",
       "PublishingApi::MinistersIndexPresenter",
-      # "PublishingApi::EmbassiesIndexPresenter",
+      "PublishingApi::EmbassiesIndexPresenter",
       "PublishingApi::WorldIndexPresenter",
       "PublishingApi::OrganisationsIndexPresenter",
     ].map do |presenter_class_string|

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -23,7 +23,7 @@ class Contact < ApplicationRecord
   after_create :republish_organisation_to_publishing_api
   after_destroy :republish_organisation_to_publishing_api
 
-  # after_commit :republish_embassies_index_page_to_publishing_api
+  after_commit :republish_embassies_index_page_to_publishing_api
 
   include TranslatableModel
   translates :title,

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -23,8 +23,6 @@ class Contact < ApplicationRecord
   after_create :republish_organisation_to_publishing_api
   after_destroy :republish_organisation_to_publishing_api
 
-  after_commit :republish_embassies_index_page_to_publishing_api
-
   include TranslatableModel
   translates :title,
              :comments,
@@ -91,10 +89,6 @@ class Contact < ApplicationRecord
 
   def missing_translations
     super & contactable.non_english_translated_locales
-  end
-
-  def republish_embassies_index_page_to_publishing_api
-    PresentPageToPublishingApiWorker.perform_async("PublishingApi::EmbassiesIndexPresenter")
   end
 
   def publishing_api_presenter

--- a/app/models/world_location.rb
+++ b/app/models/world_location.rb
@@ -93,7 +93,7 @@ class WorldLocation < ApplicationRecord
   friendly_id
 
   def republish_index_pages_to_publishing_api
-    # PresentPageToPublishingApiWorker.perform_async("PublishingApi::EmbassiesIndexPresenter")
+    PresentPageToPublishingApiWorker.perform_async("PublishingApi::EmbassiesIndexPresenter")
     PresentPageToPublishingApiWorker.perform_async("PublishingApi::WorldIndexPresenter") if I18n.locale == :en
   end
 

--- a/app/models/worldwide_office.rb
+++ b/app/models/worldwide_office.rb
@@ -5,8 +5,6 @@ class WorldwideOffice < ApplicationRecord
   has_many :services, through: :worldwide_office_worldwide_services, source: :worldwide_service
   validates :contact, :edition, :worldwide_office_type_id, presence: true
 
-  after_commit :republish_embassies_index_page_to_publishing_api
-
   accepts_nested_attributes_for :contact
 
   extend FriendlyId
@@ -58,10 +56,6 @@ class WorldwideOffice < ApplicationRecord
 
   def available_in_multiple_languages?
     false
-  end
-
-  def republish_embassies_index_page_to_publishing_api
-    PresentPageToPublishingApiWorker.perform_async("PublishingApi::EmbassiesIndexPresenter")
   end
 
   def base_path

--- a/app/models/worldwide_office.rb
+++ b/app/models/worldwide_office.rb
@@ -5,7 +5,7 @@ class WorldwideOffice < ApplicationRecord
   has_many :services, through: :worldwide_office_worldwide_services, source: :worldwide_service
   validates :contact, :edition, :worldwide_office_type_id, presence: true
 
-  # after_commit :republish_embassies_index_page_to_publishing_api
+  after_commit :republish_embassies_index_page_to_publishing_api
 
   accepts_nested_attributes_for :contact
 

--- a/features/republishing-content.feature
+++ b/features/republishing-content.feature
@@ -27,10 +27,10 @@ Feature: Republishing published documents
     When I request a republish of the "Ministers" page
     Then I can see the "Ministers" page has been scheduled for republishing
 
-#  Scenario: Republish the "Find a British embassy, high commission or consulate" page
-#    Given a published publication "Find a British embassy, high commission or consulate" exists
-#    When I request a republish of the "Find a British embassy, high commission or consulate" page
-#    Then I can see the "Find a British embassy, high commission or consulate" page has been scheduled for republishing
+  Scenario: Republish the "Find a British embassy, high commission or consulate" page
+    Given a published publication "Find a British embassy, high commission or consulate" exists
+    When I request a republish of the "Find a British embassy, high commission or consulate" page
+    Then I can see the "Find a British embassy, high commission or consulate" page has been scheduled for republishing
 
   Scenario: Republish the "Help and services around the world" page
     Given a published publication "Help and services around the world" exists

--- a/test/unit/app/models/contact_test.rb
+++ b/test/unit/app/models/contact_test.rb
@@ -167,34 +167,6 @@ class ContactTest < ActiveSupport::TestCase
     contact.update!(title: "A new name")
   end
 
-  test "republishes embassies index page on creation of contact" do
-    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter)
-
-    Sidekiq::Testing.inline! do
-      create(:contact)
-    end
-  end
-
-  test "republishes embassies index page on update of contact" do
-    contact = create(:contact_with_country)
-
-    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter)
-
-    Sidekiq::Testing.inline! do
-      contact.update!(locality: "new-locality")
-    end
-  end
-
-  test "republishes embassies index page on deletion of contact" do
-    contact = create(:contact)
-
-    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter)
-
-    Sidekiq::Testing.inline! do
-      contact.destroy!
-    end
-  end
-
   test "destroy deletes related contacts" do
     # This test uses organisations as a candidate, but any object with this module
     # can be used here. Ideally a seperate stub ActiveRecord object would be used.

--- a/test/unit/app/models/contact_test.rb
+++ b/test/unit/app/models/contact_test.rb
@@ -168,7 +168,7 @@ class ContactTest < ActiveSupport::TestCase
   end
 
   test "republishes embassies index page on creation of contact" do
-    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter).never
+    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter)
 
     Sidekiq::Testing.inline! do
       create(:contact)
@@ -178,7 +178,7 @@ class ContactTest < ActiveSupport::TestCase
   test "republishes embassies index page on update of contact" do
     contact = create(:contact_with_country)
 
-    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter).never
+    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter)
 
     Sidekiq::Testing.inline! do
       contact.update!(locality: "new-locality")
@@ -188,7 +188,7 @@ class ContactTest < ActiveSupport::TestCase
   test "republishes embassies index page on deletion of contact" do
     contact = create(:contact)
 
-    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter).never
+    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter)
 
     Sidekiq::Testing.inline! do
       contact.destroy!

--- a/test/unit/app/models/world_location_test.rb
+++ b/test/unit/app/models/world_location_test.rb
@@ -112,7 +112,7 @@ class WorldLocationTest < ActiveSupport::TestCase
   end
 
   test "republishes embassies and world index pages on creation of world location" do
-    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter).never
+    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter)
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::WorldIndexPresenter)
 
     Sidekiq::Testing.inline! do
@@ -123,7 +123,7 @@ class WorldLocationTest < ActiveSupport::TestCase
   test "republishes embassies and world index pages on update of world location" do
     location = create(:world_location)
 
-    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter).never
+    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter)
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::WorldIndexPresenter)
 
     Sidekiq::Testing.inline! do
@@ -134,7 +134,7 @@ class WorldLocationTest < ActiveSupport::TestCase
   test "republishes embassies and world index pages on deletion of world location" do
     location = create(:world_location)
 
-    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter).never
+    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter)
     PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::WorldIndexPresenter)
 
     Sidekiq::Testing.inline! do

--- a/test/unit/app/models/worldwide_office_test.rb
+++ b/test/unit/app/models/worldwide_office_test.rb
@@ -73,35 +73,4 @@ class WorldwideOfficeTest < ActiveSupport::TestCase
 
     assert_not list.shown_on_home_page?(office)
   end
-
-  test "republishes embassies index page on creation of worldwide office" do
-    worldwide_organisation = create(:worldwide_organisation)
-    contact = create(:contact)
-
-    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter).twice
-
-    Sidekiq::Testing.inline! do
-      create(:worldwide_office, edition: worldwide_organisation, contact:)
-    end
-  end
-
-  test "republishes embassies index page on update of worldwide office" do
-    office = create(:worldwide_office)
-
-    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter)
-
-    Sidekiq::Testing.inline! do
-      office.update!(slug: "new-slug")
-    end
-  end
-
-  test "republishes embassies index page on deletion of worldwide office" do
-    office = create(:worldwide_office)
-
-    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter).twice
-
-    Sidekiq::Testing.inline! do
-      office.destroy!
-    end
-  end
 end

--- a/test/unit/app/models/worldwide_office_test.rb
+++ b/test/unit/app/models/worldwide_office_test.rb
@@ -78,7 +78,7 @@ class WorldwideOfficeTest < ActiveSupport::TestCase
     worldwide_organisation = create(:worldwide_organisation)
     contact = create(:contact)
 
-    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter).never
+    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter).twice
 
     Sidekiq::Testing.inline! do
       create(:worldwide_office, edition: worldwide_organisation, contact:)
@@ -88,7 +88,7 @@ class WorldwideOfficeTest < ActiveSupport::TestCase
   test "republishes embassies index page on update of worldwide office" do
     office = create(:worldwide_office)
 
-    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter).never
+    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter)
 
     Sidekiq::Testing.inline! do
       office.update!(slug: "new-slug")
@@ -98,7 +98,7 @@ class WorldwideOfficeTest < ActiveSupport::TestCase
   test "republishes embassies index page on deletion of worldwide office" do
     office = create(:worldwide_office)
 
-    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter).never
+    PresentPageToPublishingApi.any_instance.expects(:publish).with(PublishingApi::EmbassiesIndexPresenter).twice
 
     Sidekiq::Testing.inline! do
       office.destroy!

--- a/test/unit/app/models/worldwide_organisation_test.rb
+++ b/test/unit/app/models/worldwide_organisation_test.rb
@@ -29,6 +29,24 @@ class WorldwideOrganisationTest < ActiveSupport::TestCase
     worldwide_organisation.create_draft(create(:writer))
   end
 
+  %w[published superseded withdrawn unpublished].each do |post_publication_state|
+    test "republishes embassies index page when the worldwide organisation is #{post_publication_state}" do
+      worldwide_organisation = create(:draft_worldwide_organisation)
+
+      PresentPageToPublishingApiWorker.expects(:perform_async).with("PublishingApi::EmbassiesIndexPresenter").once
+
+      worldwide_organisation.update!(state: post_publication_state)
+    end
+  end
+
+  test "does not republish the embassies index page when editing a draft" do
+    worldwide_organisation = create(:draft_worldwide_organisation)
+
+    PresentPageToPublishingApiWorker.expects(:perform_async).with("PublishingApi::EmbassiesIndexPresenter").never
+
+    worldwide_organisation.update!(title: "New title")
+  end
+
   test "destroys associated worldwide offices" do
     worldwide_organisation = create(:worldwide_organisation)
     worldwide_office = create(:worldwide_office)


### PR DESCRIPTION
[Trello card](https://trello.com/c/u6rgcwqi/1258-incident-action-investigate-and-fix-the-issue-with-the-embassiesindex-page-which-is-no-longer-being-updated-in-response-to-event)

## Changes in this PR

In response to an incident last week (see linked Trello card) where republishes of the Embassies Index page (`/world/embassies`) hogged resources on the `whitehall-admin-worker`, preventing attachments from being uploaded to Asset Manager, we temporarily disabled republishing the embassies index at all [here](https://github.com/alphagov/whitehall/commit/38a978996c515a92cc466108068f21dd0bb14bd4).

We realised we were republishing this page on any edit of a WorldLocation, a Contact or a WorldwideOffice, meaning this would be republished 3 times (once for each model). We should ideally only be republishing it once, so we've moved this republishing `after_commit` to any edits of the parent `WorldwideOrganisation` itself, which should reduce the number of times we republish the index page.

We've left the republishing of a WorldLocation as the model feels independent from a `WorldwideOrganisation` (i.e. it's not governed by it, unlike the other two models, if we're understanding correctly).

## Next steps

The Embassies Index Presenter is still fairly slow, but we vastly improve the speed of its `#content` method in [this next PR](https://github.com/alphagov/whitehall/pull/9329).

