### PR TITLE
Speed up EmbassiesIndexPresenter

### DIFF
--- a/app/models/embassy.rb
+++ b/app/models/embassy.rb
@@ -6,7 +6,7 @@ class Embassy
   delegate :name, to: :@world_location
 
   def organisations_with_embassy_offices
-    @world_location.worldwide_organisations.published.select do |org|
+    @world_location.published_worldwide_organisations.select do |org|
       org.embassy_offices.any?
     end
   end
@@ -40,7 +40,7 @@ class Embassy
 private
 
   def offices
-    @world_location.worldwide_organisations.published.map(&:embassy_offices).flatten
+    @world_location.published_worldwide_organisations.map(&:embassy_offices).flatten
   end
 
   def can_assist_in_other_location?

--- a/app/models/world_location.rb
+++ b/app/models/world_location.rb
@@ -17,6 +17,10 @@ class WorldLocation < ApplicationRecord
   has_many :worldwide_organisations,
            through: :edition_worldwide_organisations,
            source: :edition
+  has_many :published_worldwide_organisations,
+           -> { where(state: "published") },
+           through: :edition_worldwide_organisations,
+           source: :edition
 
   has_one :world_location_news
   accepts_nested_attributes_for :world_location_news

--- a/app/presenters/publishing_api/embassies_index_presenter.rb
+++ b/app/presenters/publishing_api/embassies_index_presenter.rb
@@ -8,21 +8,23 @@ module PublishingApi
     end
 
     def content
-      content = BaseItemPresenter.new(
-        nil,
-        title:,
-        update_type: "minor",
-      ).base_attributes
+      @content ||= begin
+        content = BaseItemPresenter.new(
+          nil,
+          title:,
+          update_type: "minor",
+        ).base_attributes
 
-      content.merge!(
-        base_path:,
-        details:,
-        document_type: "embassies_index",
-        rendering_app: Whitehall::RenderingApp::COLLECTIONS_FRONTEND,
-        schema_name: "embassies_index",
-      )
+        content.merge!(
+          base_path:,
+          details:,
+          document_type: "embassies_index",
+          rendering_app: Whitehall::RenderingApp::COLLECTIONS_FRONTEND,
+          schema_name: "embassies_index",
+        )
 
-      content.merge!(PayloadBuilder::Routes.for(base_path))
+        content.merge!(PayloadBuilder::Routes.for(base_path))
+      end
     end
 
     def links

--- a/app/presenters/publishing_api/embassies_index_presenter.rb
+++ b/app/presenters/publishing_api/embassies_index_presenter.rb
@@ -68,7 +68,22 @@ module PublishingApi
     end
 
     def world_locations
-      WorldLocation.geographical.order(:slug).map { |location|
+      WorldLocation.geographical.order(:slug)
+        .includes(
+          published_worldwide_organisations: [
+            :document,
+            :translations,
+            {
+              offices: [
+                {
+                  contact: [{ country: :translations }, :translations],
+                  edition: %i[document translations],
+                },
+              ],
+            },
+          ],
+        )
+        .map { |location|
         # We don't want to show the UK on the embassies page.
         next if location.name.in?(["United Kingdom"])
 

--- a/test/unit/app/models/world_location_test.rb
+++ b/test/unit/app/models/world_location_test.rb
@@ -53,6 +53,13 @@ class WorldLocationTest < ActiveSupport::TestCase
     assert_equal related_organisations, world_location.worldwide_organisations_with_organisations
   end
 
+  test ".published_worldwide_organisations returns all published worldwide organisations" do
+    published_wworg_1, published_wworg_2 = create_list(:published_worldwide_organisation, 2)
+    world_location = create(:world_location, worldwide_organisations: [published_wworg_1, published_wworg_2, create(:draft_worldwide_organisation)])
+
+    assert_equal [published_wworg_1, published_wworg_2], world_location.published_worldwide_organisations
+  end
+
   test "ordered_by_name sorts by the I18n.default_locale translation for name" do
     world_location1 = create(:world_location, name: "Neverland")
     world_location2 = create(:world_location, name: "Middle Earth")

--- a/test/unit/app/presenters/publishing_api/embassies_index_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/embassies_index_presenter_test.rb
@@ -63,6 +63,15 @@ class PublishingApi::EmbassiesIndexPresenterTest < ActiveSupport::TestCase
     assert_valid_embassies_index_document
   end
 
+  test "caches the result of #content so as not to perform an expensive query multiple times" do
+    PublishingApi::BaseItemPresenter.any_instance.expects(:base_attributes).returns({})
+    presenter = PublishingApi::EmbassiesIndexPresenter.new
+    presenter.content
+
+    PublishingApi::BaseItemPresenter.any_instance.expects(:base_attributes).never
+    presenter.content
+  end
+
   def assert_valid_embassies_index_document
     presented_page = @presenter.content
 


### PR DESCRIPTION
[Trello card](https://trello.com/c/u6rgcwqi/1258-incident-action-investigate-and-fix-the-issue-with-the-embassiesindex-page-which-is-no-longer-being-updated-in-response-to-event)

## Changes in this PR

In response to an incident last week (see linked Trello card) where republishes of the Embassies Index page (`/world/embassies`) hogged resources on the `whitehall-admin-worker`, preventing attachments from being uploaded to Asset Manager, we temporarily disabled republishing the embassies index at all [here](https://github.com/alphagov/whitehall/commit/38a978996c515a92cc466108068f21dd0bb14bd4).

In #9328 we turn the republishing back on, but reduce the number of times we're calling the "republish" method. Here we speed up the `content` method using Rails caching, lazy loading and memoisation, the combination of which drastically speed up the `#content` method.

On my local branch, using a recent dump of Integration data, these changes reduce the time taken running `PublishingApi::EmbassiesIndexPresenter.new.content` from ~15 seconds to ~0.5 seconds.