### PR TITLE
Fix paste tracker module and spec

### DIFF
--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -15,13 +15,13 @@
            environment: environment,
            browser_title: ("Error: " if yield(:error_summary).present?).to_s + sanitized_title do %>
 
-  <div data-module="GA4PageViewTracking GA4PasteTracker" data-attributes='<%= track_analytics_data_on_load(sanitized_title) %>'></div>
+  <div data-module="GA4PageViewTracking" data-attributes='<%= track_analytics_data_on_load(sanitized_title) %>'></div>
 
   <%= render "govuk_publishing_components/components/skip_link" %>
 
   <%= render partial: "shared/header" %>
 
-  <div class="govuk-width-container" data-module="ga4-event-tracker">
+  <div class="govuk-width-container" data-module="ga4-event-tracker ga4-paste-tracker">
     <%= render "shared/phase_banner", {
       show_feedback_banner: t("admin.feedback.show_banner"),
     } %>

--- a/spec/javascripts/admin/modules/ga4-paste-tracker.spec.js
+++ b/spec/javascripts/admin/modules/ga4-paste-tracker.spec.js
@@ -5,9 +5,7 @@ describe('GOVUK.Modules.Ga4PasteTracker', function () {
       'applySchemaAndSendData'
     )
 
-    const ga4PasteTracker = new GOVUK.Modules.Ga4VisualEditorEventHandlers(
-      document
-    )
+    const ga4PasteTracker = new GOVUK.Modules.Ga4PasteTracker(document)
     ga4PasteTracker.init()
     window.dispatchEvent(new ClipboardEvent('paste', {}))
 


### PR DESCRIPTION
Rename the spec file and move the module initialisation, the previous location was not working.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
