### PR TITLE
Fix reorder whips form action

### DIFF
--- a/app/views/admin/cabinet_ministers/reorder_whip_roles.html.erb
+++ b/app/views/admin/cabinet_ministers/reorder_whip_roles.html.erb
@@ -3,6 +3,6 @@
 
 <%= render "reorder",
   roles: @roles,
-  form_url: order_cabinet_minister_roles_admin_cabinet_ministers_path,
+  form_url: order_whip_roles_admin_cabinet_ministers_path,
   cancel_path: admin_cabinet_ministers_path(anchor: "whips"),
   name: "ministerial_roles[ordering]" %>

--- a/features/step_definitions/cabinet_ministers_steps.rb
+++ b/features/step_definitions/cabinet_ministers_steps.rb
@@ -65,8 +65,8 @@ end
 
 Given(/^there are multiple Whip roles$/) do
   organisation = create(:organisation)
-  create(:ministerial_role, name: "Role 1", whip_organisation_id: 2, organisations: [organisation], whip_ordering: 1)
-  create(:ministerial_role, name: "Role 2", whip_organisation_id: 2, organisations: [organisation], whip_ordering: 0)
+  create(:ministerial_role, name: "Role 1", whip_organisation_id: 2, organisations: [organisation], whip_ordering: 0)
+  create(:ministerial_role, name: "Role 2", whip_organisation_id: 2, organisations: [organisation], whip_ordering: 1)
 end
 
 Given(/^there are multiple organisations with ministerial ordering$/) do


### PR DESCRIPTION
The reorder whips form action was pointing to the route for reordering cabinet ministers.

We had failed to notice this because the feature test already set the whips up in the order that was being tested for. This commit also corrects the setup.

Trello: https://trello.com/c/d0cdMYni
