### PR TITLE
Provide GA4 configuration for the staging env

### DIFF
--- a/app/assets/javascripts/admin/domain-config.js
+++ b/app/assets/javascripts/admin/domain-config.js
@@ -10,6 +10,11 @@ window.GOVUK.vars.extraDomains = [
     gaProperty: 'UA-26179049-6'
   },
   {
+    name: 'staging',
+    domains: ['whitehall-admin.staging.publishing.service.gov.uk'],
+    initialiseGA4: false
+  },
+  {
     name: 'integration',
     domains: ['whitehall-admin.integration.publishing.service.gov.uk'],
     initialiseGA4: true,


### PR DESCRIPTION
We've been seeing Smokey failures for the staging environment which are reporting that the browser is unable to initialise the GA4 module correctly.

We're not certain this is the actual cause of the Smokey test failure, but we want to rule it out and prevent the error.

GA4 tracking is not needed for the staging env, so we set the `initialiseGA4` property to false.
