### PR TITLE
Append "[Closed]" to closed organisations in selects

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -407,7 +407,7 @@ class Organisation < ApplicationRecord
   end
 
   def select_name
-    [name, ("(#{acronym})" if acronym.present?)].compact.join(" ")
+    [name, ("(#{acronym})" if acronym.present?), ("[Closed]" if closed?)].compact.join(" ")
   end
 
   def jobs_url

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -217,10 +217,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_30_134237) do
     t.bigint "document_id", null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
-    t.bigint "user_id"
     t.string "state", default: "draft", null: false
     t.index ["document_id"], name: "index_content_block_editions_on_document_id"
-    t.index ["user_id"], name: "index_content_block_editions_on_user_id"
   end
 
   create_table "content_block_versions", charset: "utf8mb3", force: :cascade do |t|

--- a/test/unit/app/models/organisation_test.rb
+++ b/test/unit/app/models/organisation_test.rb
@@ -676,8 +676,10 @@ class OrganisationTest < ActiveSupport::TestCase
     assert_equal "Blah blah", build(:organisation, acronym: "", name: "Blah blah").display_name
   end
 
-  test "select_name should use full name and acronym if present or not if not" do
+  test "select_name should use full name and acronym and close if present" do
+    assert_equal "Name (Blah) [Closed]", build(:organisation, acronym: "Blah", name: "Name", govuk_status: "closed", govuk_closed_status: "no_longer_exists").select_name
     assert_equal "Name (Blah)", build(:organisation, acronym: "Blah", name: "Name").select_name
+    assert_equal "Name [Closed]", build(:organisation, name: "Name", govuk_status: "closed", govuk_closed_status: "no_longer_exists").select_name
     assert_equal "Name", build(:organisation, acronym: "", name: "Name").select_name
   end
 


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
When selecting Lead and Supporting organisations for an edition, append "[Closed]" to the select name if an organisation is closed.

## Why
This is to make it easier for publishers to recognise when an organisation they have selected is closed.

## Screenshot
<img width="784" alt="Screenshot 2024-08-02 at 16 52 56" src="https://github.com/user-attachments/assets/c7f8d636-f781-402b-9b3d-f305e75ead6a">
