### PR TITLE
Add task to bulk remove / replace links to domains

### DIFF
--- a/lib/govspeak/link_redirector.rb
+++ b/lib/govspeak/link_redirector.rb
@@ -1,0 +1,74 @@
+module Govspeak
+  class LinkRedirector
+    def initialize(input, domain, redirect_url)
+      raise "domain must be at least 6 characters long (#{domain})" if domain.length < 6
+      raise "domain must include a '.' (#{domain})" unless domain.include?(".")
+      raise "redirect_url must start with https://" unless redirect_url.start_with?("https://")
+
+      markdown_pattern = <<~'PATTERN'
+        (                              # start a capturing group to cover the whole pattern
+        (                              # start a capturing group to cover the first part of the pattern - everything up to the URL we're replacing
+        \[                             # a literal open square bracket - the start of a markdown link
+        [^\]]+                         # anything except square brackets - the link text of the markdown link
+        \]                             # a close square bracket - the end of the link text section of the markdown link
+        \(                             # an open round bracket - the start of the URL bit of the markdown link
+        )                              # close the first capturing group - next bit is the URL we're going to replace
+        (?:https?://)?                 # optionally, the protocol of the URL
+        DOMAIN                         # the domain we're looking for, escaped for a Regexp so we don't confuse . characters
+        [^)]*                          # anything except round brackets to capture the remainder of the link
+        (                              # open a second capturing group to capture everything after the URL we're replacing
+        \)                             # closing round bracket - the end of a markdown link
+        )                              # close the second capturing group
+        )                              # finally, close the outer capturing group
+      PATTERN
+      markdown_pattern.sub!("DOMAIN", Regexp.escape(domain))
+      @markdown_pattern = /#{markdown_pattern}/x
+
+      html_pattern = <<~'PATTERN'
+        (                              # start a capturing group to cover the whole pattern
+        (                              # start a capturing group to cover the first part of the pattern - everything up to the URL we're replacing
+        <a                             # start of an HTML opening tag
+        [^>]*                          # anything except the > which closes the opening tag
+        href="                         # the href attribute
+        )                              # close the first capturing group - next bit is the URL we're going to replace
+        (?:https?://)?                 # optionally, the protocol of the URL
+        DOMAIN                         # the domain we're looking for, escaped for a Regexp so we don't confuse . characters
+        [^"]*                          # anything except double quotes
+        (                              # open a second capturing group to capture everything after the URL we're replacing
+        "                              # a double quote to get us to the end of the attribute
+        [^>]*>                         # anything except closing angle bracket, and then a closing angle bracket to get us to the end of the opening tag
+        ([^<]*)                        # anything except opening angle bracket in a capturing group - the link text of the HTML link
+        </a>                           # the closing tag
+        )                              # close the second capturing group
+        )                              # finally, close the outer capturing group
+      PATTERN
+      html_pattern.sub!("DOMAIN", Regexp.escape(domain))
+      @html_pattern = /#{html_pattern}/x
+
+      @input = input
+      @domain = domain
+      @redirect_url = redirect_url
+    end
+
+    def match?
+      @markdown_pattern.match?(@input) || @html_pattern.match?(@input)
+    end
+
+    def describe_replacements
+      all_matches.map { |match| "- will replace '#{match[0]}' with '#{match[1] + @redirect_url + match[2]}'" }.join("\n")
+    end
+
+    def redirect_links_for_domain
+      @input
+        .gsub(@markdown_pattern) { Regexp.last_match[2] + @redirect_url + Regexp.last_match[3] }
+        .gsub(@html_pattern) { Regexp.last_match[2] + @redirect_url + Regexp.last_match[3] }
+    end
+
+  private
+
+    def all_matches
+      @input.to_enum(:scan, @markdown_pattern) { Regexp.last_match } +
+        @input.to_enum(:scan, @html_pattern) { Regexp.last_match }
+    end
+  end
+end

--- a/lib/govspeak/link_remover.rb
+++ b/lib/govspeak/link_remover.rb
@@ -1,0 +1,60 @@
+module Govspeak
+  class LinkRemover
+    def initialize(input, domain)
+      raise "domain must be at least 6 characters long (#{domain})" if domain.length < 6
+      raise "domain must include a '.' (#{domain})" unless domain.include?(".")
+
+      markdown_pattern = <<~'PATTERN'
+        (                              # start a capturing group to cover the whole pattern
+        \[                             # a literal open square bracket - the start of a markdown link
+        ([^\]]+)                       # anything except square brackets in a capturing group - the link text of the markdown link
+        \]                             # a close square bracket - the end of the link text section of the markdown link
+        \(                             # an open round bracket - the start of the URL bit of the markdown link
+        (?:https?://)?                 # optionally, the protocol of the URL
+        DOMAIN                         # the domain we're looking for, escaped for a Regexp so we don't confuse . characters
+        [^)]*                          # anything except round brackets to capture the remainder of the link
+        \)                             # closing round bracket - the end of a markdown link
+        )                              # finally, close the capturing group
+      PATTERN
+      markdown_pattern.sub!("DOMAIN", Regexp.escape(domain))
+      @markdown_pattern = /#{markdown_pattern}/x
+
+      html_pattern = <<~'PATTERN'
+        (                              # start a capturing group to cover the whole pattern
+        <a                             # start of an HTML opening tag
+        [^>]*                          # anything except the > which closes the opening tag
+        href="                         # the href attribute
+        (?:https?://)?                 # optionally, the protocol of the URL
+        DOMAIN                         # the domain we're looking for, escaped for a Regexp so we don't confuse . characters
+        [^"]*"                         # anything except double quotes, and then a double quote to get us to the end of the attribute
+        [^>]*>                         # anything except closing angle bracket, and then a closing angle bracket to get us to the end of the opening tag
+        ([^<]*)                        # anything except opening angle bracket in a capturing group - the link text of the HTML link
+        </a>                           # the closing tag
+        )                              # finally, close the capturing group
+      PATTERN
+      html_pattern.sub!("DOMAIN", Regexp.escape(domain))
+      @html_pattern = /#{html_pattern}/x
+
+      @input = input
+      @domain = domain
+    end
+
+    def match?
+      @markdown_pattern.match?(@input) || @html_pattern.match?(@input)
+    end
+
+    def describe_replacements
+      all_matches.map { |match| "- will replace '#{match[0]}' with '#{match[1]}'" }.join("\n")
+    end
+
+    def remove_links_for_domain
+      @input.gsub(@markdown_pattern, '\2').gsub(@html_pattern, '\2')
+    end
+
+  private
+
+    def all_matches
+      @input.scan(@markdown_pattern) + @input.scan(@html_pattern)
+    end
+  end
+end

--- a/lib/tasks/bulk_content_updates.rake
+++ b/lib/tasks/bulk_content_updates.rake
@@ -1,0 +1,36 @@
+namespace :bulk_content_updates do
+  def editions_matching_domain(domain)
+    Edition
+      .active
+      .joins("INNER JOIN edition_translations ON edition_translations.edition_id = editions.id")
+      .where("edition_translations.body LIKE ?", "%#{domain}%")
+  end
+
+  desc "Remove all links to a particular domain - "
+  task :remove_links_to_domain, %i[domain mode] => :environment do |_, args|
+    domain, mode = args.values_at(:domain, :mode)
+    unless %w[live dry-run].include?(mode)
+      raise "mode should be 'live' or 'dry-run'"
+    end
+
+    editions_matching_domain(domain).find_each do |edition|
+      link_remover = Govspeak::LinkRemover.new(edition.body, domain)
+      next unless link_remover.match?
+
+      puts "Replacing links in #{edition.base_path} (#{mode})"
+      puts link_remover.describe_replacements
+
+      if mode == "dry-run"
+        puts "Skipping changes in dry-run mode"
+      elsif mode == "live"
+        edition.body = link_remover.remove_links_for_domain
+        edition.save!
+        PublishingApiDocumentRepublishingWorker.perform_async_in_queue(
+          "bulk_republishing",
+          edition.document_id,
+          true,
+        )
+      end
+    end
+  end
+end

--- a/test/unit/lib/govspeak/link_redirector_test.rb
+++ b/test/unit/lib/govspeak/link_redirector_test.rb
@@ -1,0 +1,184 @@
+require "test_helper"
+
+module Govspeak
+  class LinkRedirectorTest < ActiveSupport::TestCase
+    test "refuses to operate on domains shorter than 6 characters long" do
+      assert_raises(match: /domain must be at least 6 characters long/) do
+        LinkRedirector.new("", "x.com", "https://replacement-url.com/some-path")
+      end
+    end
+
+    test "refuses to operate on domains which don't include a dot" do
+      assert_raises(match: /domain must include a '[.]'/) do
+        LinkRedirector.new("", "banana", "https://replacement-url.com/some-path")
+      end
+    end
+
+    test "refuses to replace domains with URLs that don't start with https" do
+      assert_raises(match: /redirect_url must start with https:\/\//) do
+        LinkRedirector.new("", "example.com", "example.com/some-path")
+      end
+    end
+
+    test "match returns false if the markdown does not match the patterns" do
+      examples = [
+        "Here is some markdown with a link to example.com",
+        "Here is some markdown with a link to [example.com](http://www.gov.uk)",
+        'Here is some markdown with a link to <a href="www.gov.uk">example.com</a>',
+      ]
+
+      examples.each do |govspeak|
+        result = LinkRedirector.new(govspeak, "example.com", "https://replacement-url.com/some-path").match?
+        assert_equal false, result
+      end
+    end
+
+    test "match returns true if the markdown does match the patterns" do
+      examples = [
+        "Here is some markdown with a link to [example dot com](example.com)",
+        "Here is some markdown with a link to [example dot com](http://example.com)",
+        "Here is some markdown with a link to [example dot com](https://example.com)",
+        "Here is some markdown with a link to [example dot com](https://example.com/some-path)",
+        "Here is some markdown with a link to [example dot com](https://example.com/some-path?some-query)",
+        "Here is some markdown with a link to [example dot com](https://example.com/some-path?some-query#some-search)",
+      ]
+
+      examples.each do |govspeak|
+        result = LinkRedirector.new(govspeak, "example.com", "https://replacement-url.com/some-path").match?
+        assert_equal true, result
+      end
+    end
+
+    test "describes markdown replacements" do
+      govspeak = <<~GOVSPEAK
+        Here is some markdown with a link to [a](example.com),
+        Here is some markdown with a link to [b](http://example.com),
+        Here is some markdown with a link to [c](https://example.com),
+        Here is some markdown with a link to [d](https://example.com/some-path),
+        Here is some markdown with a link to [e](https://example.com/some-path?some-query),
+        Here is some markdown with a link to [f](https://example.com/some-path?some-query#some-search),
+      GOVSPEAK
+
+      expected = <<~EXPECTED
+        - will replace '[a](example.com)' with '[a](https://replacement-url.com/some-path)'
+        - will replace '[b](http://example.com)' with '[b](https://replacement-url.com/some-path)'
+        - will replace '[c](https://example.com)' with '[c](https://replacement-url.com/some-path)'
+        - will replace '[d](https://example.com/some-path)' with '[d](https://replacement-url.com/some-path)'
+        - will replace '[e](https://example.com/some-path?some-query)' with '[e](https://replacement-url.com/some-path)'
+        - will replace '[f](https://example.com/some-path?some-query#some-search)' with '[f](https://replacement-url.com/some-path)'
+      EXPECTED
+
+      result = LinkRedirector.new(govspeak, "example.com", "https://replacement-url.com/some-path").describe_replacements
+      assert_equal expected.strip, result
+    end
+
+    test "describes HTML replacements" do
+      html = <<~HTML
+        Here is some HTML with a link to <a href="example.com">a</a>
+        Here is some HTML with a link to <a href="http://example.com">b</a>
+        Here is some HTML with a link to <a href="https://example.com">c</a>
+        Here is some HTML with a link to <a href="https://example.com/some-path">d</a>
+        Here is some HTML with a link to <a href="https://example.com/some-path?some-query">e</a>
+        Here is some HTML with a link to <a href="https://example.com/some-path?some-query#some-search">f</a>
+      HTML
+
+      expected = <<~'EXPECTED'
+        - will replace '<a href="example.com">a</a>' with '<a href="https://replacement-url.com/some-path">a</a>'
+        - will replace '<a href="http://example.com">b</a>' with '<a href="https://replacement-url.com/some-path">b</a>'
+        - will replace '<a href="https://example.com">c</a>' with '<a href="https://replacement-url.com/some-path">c</a>'
+        - will replace '<a href="https://example.com/some-path">d</a>' with '<a href="https://replacement-url.com/some-path">d</a>'
+        - will replace '<a href="https://example.com/some-path?some-query">e</a>' with '<a href="https://replacement-url.com/some-path">e</a>'
+        - will replace '<a href="https://example.com/some-path?some-query#some-search">f</a>' with '<a href="https://replacement-url.com/some-path">f</a>'
+      EXPECTED
+
+      result = LinkRedirector.new(html, "example.com", "https://replacement-url.com/some-path").describe_replacements
+      assert_equal expected.strip, result
+    end
+
+    test "replaces markdown links to provided domain with provided redirect" do
+      examples = [
+        "Here is some markdown with a link to [example dot com](example.com)",
+        "Here is some markdown with a link to [example dot com](http://example.com)",
+        "Here is some markdown with a link to [example dot com](https://example.com)",
+        "Here is some markdown with a link to [example dot com](https://example.com/some-path)",
+        "Here is some markdown with a link to [example dot com](https://example.com/some-path?some-query)",
+        "Here is some markdown with a link to [example dot com](https://example.com/some-path?some-query#some-search)",
+      ]
+
+      examples.each do |govspeak|
+        result = LinkRedirector.new(govspeak, "example.com", "https://replacement-url.com/some-path").redirect_links_for_domain
+        assert_equal "Here is some markdown with a link to [example dot com](https://replacement-url.com/some-path)", result
+      end
+    end
+
+    test "redirects HTML links to provided domain to provided redirect" do
+      examples = [
+        {
+          input: 'Here is some markdown with a link to <a href="example.com">example dot com</a>',
+          expected: 'Here is some markdown with a link to <a href="https://replacement-url.com/some-path">example dot com</a>'
+        },
+        {
+          input: 'Here is some markdown with a link to <a href="http://example.com">example dot com</a>',
+          expected: 'Here is some markdown with a link to <a href="https://replacement-url.com/some-path">example dot com</a>'
+        },
+        {
+          input: 'Here is some markdown with a link to <a href="https://example.com" class="govuk-link">example dot com</a>',
+          expected: 'Here is some markdown with a link to <a href="https://replacement-url.com/some-path" class="govuk-link">example dot com</a>'
+        },
+        {
+          input: 'Here is some markdown with a link to <a class="govuk-link" href="https://example.com/some-path">example dot com</a>',
+          expected: 'Here is some markdown with a link to <a class="govuk-link" href="https://replacement-url.com/some-path">example dot com</a>'
+        },
+        {
+          input: 'Here is some markdown with a link to <a href="https://example.com/some-path?some-query" rel="noreferrer">example dot com</a>',
+          expected: 'Here is some markdown with a link to <a href="https://replacement-url.com/some-path" rel="noreferrer">example dot com</a>'
+        },
+        {
+          input: 'Here is some markdown with a link to <a href="https://example.com/some-path?some-query#some-search">example dot com</a>',
+          expected: 'Here is some markdown with a link to <a href="https://replacement-url.com/some-path">example dot com</a>'
+        }
+      ]
+
+      examples.each do |example|
+        result = LinkRedirector.new(example[:input], "example.com", "https://replacement-url.com/some-path").redirect_links_for_domain
+        assert_equal example[:expected], result
+      end
+    end
+
+    test "replaces links even in complex markdown" do
+      govspeak = <<~GOVSPEAK
+        ## A heading containing [a link to the domain we're replacing](https://example.com/some-path)
+
+        | table | with headings             |
+        |-------|---------------------------|
+        | cells | [with links](example.com) |
+
+        * lists
+        * [with links](example.com)
+      GOVSPEAK
+      result = LinkRedirector.new(govspeak, "example.com", "https://replacement-url.com/some-path").redirect_links_for_domain
+      assert_equal <<~EXPECTATION, result
+        ## A heading containing [a link to the domain we're replacing](https://replacement-url.com/some-path)
+
+        | table | with headings             |
+        |-------|---------------------------|
+        | cells | [with links](https://replacement-url.com/some-path) |
+
+        * lists
+        * [with links](https://replacement-url.com/some-path)
+      EXPECTATION
+    end
+
+    test "leaves links to other domains" do
+      govspeak = "Here is some markdown with a link to [other-domain dot com](other-domain.com)"
+      result = LinkRedirector.new(govspeak, "example.com", "https://replacement-url.com/some-path").redirect_links_for_domain
+      assert_equal govspeak, result
+    end
+
+    test "leaves links to subdomains" do
+      govspeak = "Here is some markdown with a link to [a subdomain of example.com](www.example.com)"
+      result = LinkRedirector.new(govspeak, "example.com", "https://replacement-url.com/some-path").redirect_links_for_domain
+      assert_equal govspeak, result
+    end
+  end
+end

--- a/test/unit/lib/govspeak/link_remover_test.rb
+++ b/test/unit/lib/govspeak/link_remover_test.rb
@@ -1,0 +1,160 @@
+require "test_helper"
+
+module Govspeak
+  class LinkRemoverTest < ActiveSupport::TestCase
+    test "refuses to operate on domains shorter than 6 characters long" do
+      assert_raises(match: /domain must be at least 6 characters long/) do
+        LinkRemover.new("", "x.com")
+      end
+    end
+
+    test "refuses to operate on domains which don't include a dot" do
+      assert_raises(match: /domain must include a '[.]'/) do
+        LinkRemover.new("", "banana")
+      end
+    end
+
+    test "match returns false if the markdown does not match the patterns" do
+      examples = [
+        "Here is some markdown with a link to example.com",
+        "Here is some markdown with a link to [example.com](http://www.gov.uk)",
+        'Here is some markdown with a link to <a href="www.gov.uk">example.com</a>',
+      ]
+
+      examples.each do |govspeak|
+        result = LinkRemover.new(govspeak, "example.com").match?
+        assert_equal false, result
+      end
+    end
+
+    test "match returns true if the markdown does match the patterns" do
+      examples = [
+        "Here is some markdown with a link to [example dot com](example.com)",
+        "Here is some markdown with a link to [example dot com](http://example.com)",
+        "Here is some markdown with a link to [example dot com](https://example.com)",
+        "Here is some markdown with a link to [example dot com](https://example.com/some-path)",
+        "Here is some markdown with a link to [example dot com](https://example.com/some-path?some-query)",
+        "Here is some markdown with a link to [example dot com](https://example.com/some-path?some-query#some-search)",
+      ]
+
+      examples.each do |govspeak|
+        result = LinkRemover.new(govspeak, "example.com").match?
+        assert_equal true, result
+      end
+    end
+
+    test "describes markdown replacements" do
+      govspeak = <<~GOVSPEAK
+        Here is some markdown with a link to [a](example.com),
+        Here is some markdown with a link to [b](http://example.com),
+        Here is some markdown with a link to [c](https://example.com),
+        Here is some markdown with a link to [d](https://example.com/some-path),
+        Here is some markdown with a link to [e](https://example.com/some-path?some-query),
+        Here is some markdown with a link to [f](https://example.com/some-path?some-query#some-search),
+      GOVSPEAK
+
+      expected = <<~EXPECTED
+        - will replace '[a](example.com)' with 'a'
+        - will replace '[b](http://example.com)' with 'b'
+        - will replace '[c](https://example.com)' with 'c'
+        - will replace '[d](https://example.com/some-path)' with 'd'
+        - will replace '[e](https://example.com/some-path?some-query)' with 'e'
+        - will replace '[f](https://example.com/some-path?some-query#some-search)' with 'f'
+      EXPECTED
+
+      result = LinkRemover.new(govspeak, "example.com").describe_replacements
+      assert_equal expected.strip, result
+    end
+
+    test "describes HTML replacements" do
+      html = <<~HTML
+        Here is some HTML with a link to <a href="example.com">a</a>
+        Here is some HTML with a link to <a href="http://example.com">b</a>
+        Here is some HTML with a link to <a href="https://example.com">c</a>
+        Here is some HTML with a link to <a href="https://example.com/some-path">d</a>
+        Here is some HTML with a link to <a href="https://example.com/some-path?some-query">e</a>
+        Here is some HTML with a link to <a href="https://example.com/some-path?some-query#some-search">f</a>
+      HTML
+
+      expected = <<~EXPECTED
+        - will replace '<a href="example.com">a</a>' with 'a'
+        - will replace '<a href="http://example.com">b</a>' with 'b'
+        - will replace '<a href="https://example.com">c</a>' with 'c'
+        - will replace '<a href="https://example.com/some-path">d</a>' with 'd'
+        - will replace '<a href="https://example.com/some-path?some-query">e</a>' with 'e'
+        - will replace '<a href="https://example.com/some-path?some-query#some-search">f</a>' with 'f'
+      EXPECTED
+
+      result = LinkRemover.new(html, "example.com").describe_replacements
+      assert_equal expected.strip, result
+    end
+
+    test "removes markdown links to provided domain" do
+      examples = [
+        "Here is some markdown with a link to [example dot com](example.com)",
+        "Here is some markdown with a link to [example dot com](http://example.com)",
+        "Here is some markdown with a link to [example dot com](https://example.com)",
+        "Here is some markdown with a link to [example dot com](https://example.com/some-path)",
+        "Here is some markdown with a link to [example dot com](https://example.com/some-path?some-query)",
+        "Here is some markdown with a link to [example dot com](https://example.com/some-path?some-query#some-search)",
+      ]
+
+      examples.each do |govspeak|
+        result = LinkRemover.new(govspeak, "example.com").remove_links_for_domain
+        assert_equal "Here is some markdown with a link to example dot com", result
+      end
+    end
+
+    test "removes HTML links to provided domain" do
+      examples = [
+        'Here is some HTML with a link to <a href="example.com">example dot com</a>',
+        'Here is some HTML with a link to <a href="http://example.com">example dot com</a>',
+        'Here is some HTML with a link to <a href="https://example.com" class="govuk-link">example dot com</a>',
+        'Here is some HTML with a link to <a class="govuk-link" href="https://example.com/some-path">example dot com</a>',
+        'Here is some HTML with a link to <a href="https://example.com/some-path?some-query" rel="noreferrer">example dot com</a>',
+        'Here is some HTML with a link to <a href="https://example.com/some-path?some-query#some-search">example dot com</a>',
+      ]
+
+      examples.each do |govspeak|
+        result = LinkRemover.new(govspeak, "example.com").remove_links_for_domain
+        assert_equal "Here is some HTML with a link to example dot com", result
+      end
+    end
+
+    test "removes links even in complex markdown" do
+      govspeak = <<~GOVSPEAK
+        ## A heading containing [a link to the domain we're removing](https://example.com/some-path)
+
+        | table | with headings             |
+        |-------|---------------------------|
+        | cells | [with links](example.com) |
+
+        * lists
+        * [with links](example.com)
+      GOVSPEAK
+      result = LinkRemover.new(govspeak, "example.com").remove_links_for_domain
+      assert_equal <<~EXPECTATION, result
+        ## A heading containing a link to the domain we're removing
+
+        | table | with headings             |
+        |-------|---------------------------|
+        | cells | with links |
+
+        * lists
+        * with links
+      EXPECTATION
+    end
+
+    test "leaves links to other domains" do
+      govspeak = "Here is some markdown with a link to [other-domain dot com](other-domain.com)"
+      result = LinkRemover.new(govspeak, "example.com").remove_links_for_domain
+      assert_equal govspeak, result
+    end
+
+    test "leaves links to subdomains" do
+      govspeak = "Here is some markdown with a link to [a subdomain of example.com](www.example.com)"
+      result = LinkRemover.new(govspeak, "example.com").remove_links_for_domain
+      assert_equal govspeak, result
+    end
+  end
+end

--- a/test/unit/lib/tasks/bulk_content_updates_test.rb
+++ b/test/unit/lib/tasks/bulk_content_updates_test.rb
@@ -1,0 +1,53 @@
+require "test_helper"
+require "rake"
+
+class BulkContentUpdatesRake < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
+  teardown { task.reenable }
+
+  describe "#remove_links_to_domain" do
+    let(:task) { Rake::Task["bulk_content_updates:remove_links_to_domain"] }
+
+    it "removes links to the provided domain when in live mode" do
+      article = create(:news_article, {
+        body: "Some markdown including [a link to example dot com](https://example.com) and [another link to a different domain](https://www.gov.uk)",
+      })
+
+      out, _err = capture_io { task.invoke("example.com", "live") }
+
+      assert_match(/Replacing links in #{Regexp.escape(article.base_path)} \(live\)/, out)
+      assert_match(/- will replace '\[a link to example dot com\]\(https:\/\/example.com\)' with 'a link to example dot com'/, out)
+
+      assert_equal "Some markdown including a link to example dot com and [another link to a different domain](https://www.gov.uk)", article.reload.body
+    end
+
+    it "reports the links it would remove when in dry-run mode" do
+      article = create(:news_article, {
+        body: "Some markdown including [a link to example dot com](https://example.com) and [another link to a different domain](https://www.gov.uk)",
+      })
+      original_body = article.body
+
+      out, _err = capture_io { task.invoke("example.com", "dry-run") }
+
+      assert_match(/Replacing links in #{Regexp.escape(article.base_path)} \(dry-run\)/, out)
+      assert_match(/- will replace '\[a link to example dot com\]\(https:\/\/example.com\)' with 'a link to example dot com'/, out)
+
+      assert_equal original_body, article.reload.body
+    end
+
+    it "skips documents which match the domain, but don't actually link to it" do
+      article = create(:news_article, {
+        body: "Some markdown including a reference to example.com but not in a markdown / HTML link",
+      })
+
+      original_body = article.body.dup
+
+      out, _err = capture_io { task.invoke("example.com", "live") }
+
+      assert_equal("", out)
+
+      assert_equal original_body, article.reload.body
+    end
+  end
+end


### PR DESCRIPTION
Occasionally, entire domains which are regularly linked to on GOV.UK break. For example, there are over 1000 links to storify.com which was:

> a social network service that let the user create stories or timelines
> using social media such as Twitter, Facebook and Instagram

(https://en.wikipedia.org/wiki/Storify)

... until it went out of business in 2018.

Sometimes these domains just disappear, but occasionally they're hoovered up by some malicious third party and end up doing spammy things, or, worse, phishy things. (Note: storify isn't an example of that - it's simply down).

In these situations, we've got a choice with no clearly good options:

- Leave the links on GOV.UK pointing to malicious sites (not good)
- Attempt to contact the "owners" of the affected pages on GOV.UK and have them fix the links (not practical, since many pages older than a couple of years are effectively unowned)
- Mark up the links in some way to show that they're broken and warn users before they click on them (confusing / scary UX)
- Archive the content (only works if the content with the broken links can actually be archived, which isn't always true. Also it's never true at the moment, as there's no way to meaningfully "archive" content on GOV.UK yet).
- Replace the links with their bare link text (what this PR does) (potentially confusing in some situations, where the link text might be "click here" or similar).
- Redirect the links to a "this link is broken" page on GOV.UK (looks bad, potentially scary UX)
- Redirect the links to another site (only works if there's a sensible place to redirect to) (this will be addressed in a subsequent commit)
- Remove the links entirely, including their link text (would break sentences / potentially make content unreadable / inaccurate)

These two rake tasks are an attempt at automating the removal or redirection of links to bad domains.

I am aware that I am committing a grave sin by [parsing HTML with regex](https://stackoverflow.com/a/1732454), but given that I had to do it for govspeak (because the govspeak parser won't round trip cleanly), I figured it was best to be consistent. The resulting regexes are pretty horrifix, so I've used the extended syntax to comment them.

I'm interested in thoughts on alternative approaches here - I had fun writing this code, but I'm not wedded to it if there's a better way. I don't think "find all the bad URLs and update them by hand" is a very good option though.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

