### PR TITLE
Fix Edition Roles bug

### DIFF
--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -74,6 +74,8 @@ class Role < ApplicationRecord
 
   def republish_associated_editions_to_publishing_api
     edition_roles.each do |edition_role|
+      next unless edition_role.edition
+
       PublishingApiDocumentRepublishingWorker.perform_async(edition_role.edition.document_id)
     end
   end

--- a/test/unit/app/models/role_test.rb
+++ b/test/unit/app/models/role_test.rb
@@ -249,6 +249,16 @@ class RoleTest < ActiveSupport::TestCase
     role.update!(name: "New role name")
   end
 
+  test "doesn't republish a worldwide organisation when a role is updated if the worldwide org is deleted" do
+    worldwide_organisation = create(:worldwide_organisation, :deleted)
+    role = create(:role_without_organisations)
+    create(:edition_role, role:, edition: worldwide_organisation)
+
+    PublishingApiDocumentRepublishingWorker.expects(:perform_async).with(worldwide_organisation.document_id).never
+
+    role.update!(name: "New role name")
+  end
+
   context "for a ministerial role" do
     let(:role) { create(:ministerial_role, name: "Prime Minister, Cabinet Office") }
 


### PR DESCRIPTION
Adds a simple guard clause to prevent republishing or WorldwideOrganisations being triggered by the updating of associated roles after they have been deleted. 

Trello: https://trello.com/c/6BkaykOY/1276-fix-issue-with-some-roles-being-unable-to-be-edited

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
