### PR TITLE
Add rake task to report on deleted assets that are still live

### DIFF
--- a/lib/tasks/asset_manager.rake
+++ b/lib/tasks/asset_manager.rake
@@ -1,0 +1,28 @@
+namespace :asset_manager do
+  desc "Report on attachments that are only attached to non-visible editions in Whitehall but not deleted in Asset Manager"
+  task report_deleted_assets: :environment do
+    output = AttachmentData.find_each.map do |attachment_data|
+      attachables = attachment_data.attachments.map(&:attachable).compact
+
+      next unless attachables.any?
+      next if attachables.detect { |attachable| !attachable.is_a?(Edition) }
+      next if (attachables.map(&:state) - %w[unpublished superseded]).any?
+
+      attachment_data.assets.map do |asset|
+        asset_manager_response = GdsApi.asset_manager.asset(asset.asset_manager_id).to_h
+
+        next unless asset_manager_response["deleted"] == false
+
+        {
+          asset_url: asset_manager_response["file_url"],
+          document_path: attachables.last.public_url,
+          edition_state: attachables.last.state,
+        }
+      end
+    end
+
+    output.flatten.compact.each do |item|
+      puts [item[:asset_url], item[:document_path], item[:edition_state]].join(",")
+    end
+  end
+end

--- a/test/factories/publications.rb
+++ b/test/factories/publications.rb
@@ -39,6 +39,10 @@ FactoryBot.define do
       publication_type_id { PublicationType::Guidance.id }
     end
 
+    trait(:with_alternative_format_provider) do
+      alternative_format_provider { build(:organisation, :with_alternative_format_contact_email) }
+    end
+
     trait(:with_command_paper) do
       attachments { [build(:file_attachment, unnumbered_command_paper: true)] }
       alternative_format_provider { build(:organisation, :with_alternative_format_contact_email) }

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -92,6 +92,10 @@ class ActiveSupport::TestCase
     array.each { |request| assert_requested request }
   end
 
+  def refute_output(regex, &block)
+    assert_output(/^(?!#{regex}).*$/, &block)
+  end
+
   def count_queries
     count = 0
     subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*_args|

--- a/test/unit/lib/tasks/asset_manager_test.rb
+++ b/test/unit/lib/tasks/asset_manager_test.rb
@@ -37,7 +37,7 @@ class AssetManagerTest < ActiveSupport::TestCase
         end
 
         test "it should not include the attachment in the report" do
-          assert_output(/^(?!#{attachment.attachment_data.assets.first.filename},#{edition.public_url},#{edition.state}).*$/) { task.invoke }
+          refute_output(/#{attachment.attachment_data.assets.first.filename},#{edition.public_url},#{edition.state}/) { task.invoke }
         end
       end
     end
@@ -55,7 +55,7 @@ class AssetManagerTest < ActiveSupport::TestCase
       end
 
       test "it should not include the attachment in the report" do
-        assert_output(/^(?!#{attachment.attachment_data.assets.first.filename},#{edition.public_url},#{edition.state}).*$/) { task.invoke }
+        refute_output(/#{attachment.attachment_data.assets.first.filename},#{edition.public_url},#{edition.state}/) { task.invoke }
       end
     end
 
@@ -67,7 +67,7 @@ class AssetManagerTest < ActiveSupport::TestCase
       end
 
       test "it should not include the attachment in the report" do
-        assert_output(/^(?!#{attachment.attachment_data.assets.first.filename},#{edition.public_url},#{edition.state}).*$/) { task.invoke }
+        refute_output(/#{attachment.attachment_data.assets.first.filename},#{edition.public_url},#{edition.state}/) { task.invoke }
       end
     end
   end
@@ -84,7 +84,7 @@ class AssetManagerTest < ActiveSupport::TestCase
       end
 
       test "it should not include the attachment in the report" do
-        assert_output(/^(?!#{attachment.attachment_data.assets.first.filename},#{edition.public_url},#{edition.state}).*$/) { task.invoke }
+        refute_output(/#{attachment.attachment_data.assets.first.filename},#{edition.public_url},#{edition.state}/) { task.invoke }
       end
     end
 
@@ -96,7 +96,7 @@ class AssetManagerTest < ActiveSupport::TestCase
       end
 
       test "it should not include the attachment in the report" do
-        assert_output(/^(?!#{attachment.attachment_data.assets.first.filename},#{edition.public_url},#{edition.state}).*$/) { task.invoke }
+        refute_output(/#{attachment.attachment_data.assets.first.filename},#{edition.public_url},#{edition.state}/) { task.invoke }
       end
     end
   end
@@ -114,7 +114,7 @@ class AssetManagerTest < ActiveSupport::TestCase
       end
 
       test "it should not include the attachment in the report" do
-        assert_output(/^(?!#{attachment.attachment_data.assets.first.filename},(#{Regexp.escape(edition_1.public_url)}|#{Regexp.escape(edition_2.public_url)}),(#{edition_1.state}|#{edition_2.state})).*$/) { task.invoke }
+        refute_output(/#{attachment.attachment_data.assets.first.filename},(#{Regexp.escape(edition_1.public_url)}|#{Regexp.escape(edition_2.public_url)}),(#{edition_1.state}|#{edition_2.state})/) { task.invoke }
       end
     end
 
@@ -126,7 +126,7 @@ class AssetManagerTest < ActiveSupport::TestCase
       end
 
       test "it should not include the attachment in the report" do
-        assert_output(/^(?!#{attachment.attachment_data.assets.first.filename},(#{Regexp.escape(edition_1.public_url)}|#{Regexp.escape(edition_2.public_url)}),(#{edition_1.state}|#{edition_2.state})).*$/) { task.invoke }
+        refute_output(/#{attachment.attachment_data.assets.first.filename},(#{Regexp.escape(edition_1.public_url)}|#{Regexp.escape(edition_2.public_url)}),(#{edition_1.state}|#{edition_2.state})/) { task.invoke }
       end
     end
   end

--- a/test/unit/lib/tasks/asset_manager_test.rb
+++ b/test/unit/lib/tasks/asset_manager_test.rb
@@ -1,0 +1,141 @@
+require "rake"
+require "test_helper"
+require "gds_api/test_helpers/asset_manager"
+
+class AssetManagerTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+  include GdsApi::TestHelpers::AssetManager
+
+  let(:task) { Rake::Task["asset_manager:report_deleted_assets"] }
+
+  teardown do
+    task.reenable
+  end
+
+  %w[unpublished superseded].each do |state|
+    context "for an asset attached only to a #{state} edition" do
+      let(:edition) { create(:"#{state}_publication") }
+      let(:attachment) { create(:file_attachment_with_asset, attachable: edition) }
+
+      context "when asset is not deleted from asset manager" do
+        before do
+          attachment.attachment_data.assets.each do |asset|
+            stub_asset_manager_has_an_asset(asset.asset_manager_id, { deleted: false, file_url: asset.filename })
+          end
+        end
+
+        test "it should include the attachment in the report" do
+          assert_output(/^#{attachment.attachment_data.assets.first.filename},#{edition.public_url},#{edition.state}$/) { task.invoke }
+        end
+      end
+
+      context "when asset is deleted from asset manager" do
+        before do
+          attachment.attachment_data.assets.each do |asset|
+            stub_asset_manager_has_an_asset(asset.asset_manager_id, { deleted: true, file_url: asset.filename })
+          end
+        end
+
+        test "it should not include the attachment in the report" do
+          assert_output(/^(?!#{attachment.attachment_data.assets.first.filename},#{edition.public_url},#{edition.state}).*$/) { task.invoke }
+        end
+      end
+    end
+  end
+
+  context "for an asset attached only to a draft edition" do
+    let(:edition) { create(:draft_publication) }
+    let(:attachment) { create(:file_attachment_with_asset, attachable: edition) }
+
+    context "when asset is not deleted from asset manager" do
+      before do
+        attachment.attachment_data.assets.each do |asset|
+          stub_asset_manager_has_an_asset(asset.asset_manager_id, { deleted: false, file_url: asset.filename })
+        end
+      end
+
+      test "it should not include the attachment in the report" do
+        assert_output(/^(?!#{attachment.attachment_data.assets.first.filename},#{edition.public_url},#{edition.state}).*$/) { task.invoke }
+      end
+    end
+
+    context "when asset is deleted from asset manager" do
+      before do
+        attachment.attachment_data.assets.each do |asset|
+          stub_asset_manager_has_an_asset(asset.asset_manager_id, { deleted: true, file_url: asset.filename })
+        end
+      end
+
+      test "it should not include the attachment in the report" do
+        assert_output(/^(?!#{attachment.attachment_data.assets.first.filename},#{edition.public_url},#{edition.state}).*$/) { task.invoke }
+      end
+    end
+  end
+
+  context "for an asset attached only to a published edition" do
+    let(:edition) { create(:published_publication) }
+    let(:attachment) { create(:file_attachment_with_asset, attachable: edition) }
+
+    context "when asset is not deleted from asset manager" do
+      before do
+        attachment.attachment_data.assets.each do |asset|
+          stub_asset_manager_has_an_asset(asset.asset_manager_id, { deleted: false, file_url: asset.filename })
+        end
+      end
+
+      test "it should not include the attachment in the report" do
+        assert_output(/^(?!#{attachment.attachment_data.assets.first.filename},#{edition.public_url},#{edition.state}).*$/) { task.invoke }
+      end
+    end
+
+    context "when asset is deleted from asset manager" do
+      before do
+        attachment.attachment_data.assets.each do |asset|
+          stub_asset_manager_has_an_asset(asset.asset_manager_id, { deleted: true, file_url: asset.filename })
+        end
+      end
+
+      test "it should not include the attachment in the report" do
+        assert_output(/^(?!#{attachment.attachment_data.assets.first.filename},#{edition.public_url},#{edition.state}).*$/) { task.invoke }
+      end
+    end
+  end
+
+  context "for an asset attached to both published and superseded editions" do
+    let(:attachment) { create(:file_attachment_with_asset) }
+    let(:edition_1) { create(:superseded_publication, :with_alternative_format_provider, attachments: [attachment]) }
+    let(:edition_2) { create(:published_publication, :with_alternative_format_provider, attachments: [attachment]) }
+
+    context "when asset is not deleted from asset manager" do
+      before do
+        attachment.attachment_data.assets.each do |asset|
+          stub_asset_manager_has_an_asset(asset.asset_manager_id, { deleted: false, file_url: asset.filename })
+        end
+      end
+
+      test "it should not include the attachment in the report" do
+        assert_output(/^(?!#{attachment.attachment_data.assets.first.filename},(#{Regexp.escape(edition_1.public_url)}|#{Regexp.escape(edition_2.public_url)}),(#{edition_1.state}|#{edition_2.state})).*$/) { task.invoke }
+      end
+    end
+
+    context "when asset is deleted from asset manager" do
+      before do
+        attachment.attachment_data.assets.each do |asset|
+          stub_asset_manager_has_an_asset(asset.asset_manager_id, { deleted: true, file_url: asset.filename })
+        end
+      end
+
+      test "it should not include the attachment in the report" do
+        assert_output(/^(?!#{attachment.attachment_data.assets.first.filename},(#{Regexp.escape(edition_1.public_url)}|#{Regexp.escape(edition_2.public_url)}),(#{edition_1.state}|#{edition_2.state})).*$/) { task.invoke }
+      end
+    end
+  end
+
+  context "for an asset attached only to something that is not an edition" do
+    let(:attachment) { create(:file_attachment_with_asset, attachable: create(:double)) }
+
+    test "it should include no output in the report" do
+      assert_output("") { task.invoke }
+    end
+  end
+end

--- a/test/unit/lib/tasks/reporting_test.rb
+++ b/test/unit/lib/tasks/reporting_test.rb
@@ -20,11 +20,11 @@ class ReportingRake < ActiveSupport::TestCase
     end
 
     test "it does not print the content IDs of the matching documents from draft editions" do
-      assert_output(/^(?!.*#{@document_2.document.content_id},#{@document_2.base_path}).*$/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
+      refute_output(/#{@document_2.document.content_id},#{@document_2.base_path}/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
     end
 
     test "it does not print the content IDs of the non-matching documents from published editions" do
-      assert_output(/^(?!.*#{@document_3.document.content_id},#{@document_3.base_path}).*$/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
+      refute_output(/#{@document_3.document.content_id},#{@document_3.base_path}/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
     end
   end
 
@@ -40,11 +40,11 @@ class ReportingRake < ActiveSupport::TestCase
     end
 
     test "it does not print the content IDs of the non-matching documents from published HTML attachments" do
-      assert_output(/^(?!.*#{@html_attachment_2.content_id},#{@html_attachment_2.base_path}).*$/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
+      refute_output(/#{@html_attachment_2.content_id},#{@html_attachment_2.base_path}/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
     end
 
     test "it does not print the content IDs of the matching documents from draft HTML attachments" do
-      assert_output(/^(?!.*#{@html_attachment_3.content_id},#{@html_attachment_3.base_path}).*$/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
+      refute_output(/#{@html_attachment_3.content_id},#{@html_attachment_3.base_path}/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
     end
   end
 
@@ -59,7 +59,7 @@ class ReportingRake < ActiveSupport::TestCase
     end
 
     test "it does not print the content IDs of the non-matching documents from people" do
-      assert_output(/^(?!.*#{@person_2.content_id},#{@person_2.base_path}).*$/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
+      refute_output(/#{@person_2.content_id},#{@person_2.base_path}/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
     end
   end
 
@@ -74,7 +74,7 @@ class ReportingRake < ActiveSupport::TestCase
     end
 
     test "it does not print the content IDs of the non-matching documents from policy groups" do
-      assert_output(/^(?!.*#{@policy_group_2.content_id},#{@policy_group_2.base_path}).*$/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
+      refute_output(/#{@policy_group_2.content_id},#{@policy_group_2.base_path}/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
     end
   end
 
@@ -89,7 +89,7 @@ class ReportingRake < ActiveSupport::TestCase
     end
 
     test "it does not print the content IDs of the non-matching documents from world location news" do
-      assert_output(/^(?!.*#{@world_location_news_2.content_id},#{@world_location_news_2.base_path}).*$/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
+      refute_output(/#{@world_location_news_2.content_id},#{@world_location_news_2.base_path}/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
     end
   end
 
@@ -104,7 +104,7 @@ class ReportingRake < ActiveSupport::TestCase
     end
 
     test "it does not print the content IDs of the non-matching documents from worldwide offices" do
-      assert_output(/^(?!.*#{@worldwide_office_2.content_id},#{@worldwide_office_2.base_path}).*$/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
+      refute_output(/#{@worldwide_office_2.content_id},#{@worldwide_office_2.base_path}/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
     end
   end
 end


### PR DESCRIPTION
This adds a rake task which produces a report listing all attachments that are only attached to non-visible editions (i.e. the publisher thinks they are deleted) but are not deleted (and therefore publicly visible) in Asset Manager.

[Trello card](https://trello.com/c/e9N6IfPR)