### PR TITLE
Ensure topical events can be removed from organisations

### DIFF
--- a/app/controllers/admin/organisations_controller.rb
+++ b/app/controllers/admin/organisations_controller.rb
@@ -131,10 +131,10 @@ private
   end
 
   def delete_absent_topical_event_organisations
-    return unless params[:organisation] &&
-      params[:organisation][:topical_event_organisations_attributes]
+    return unless organisation_params &&
+      organisation_params[:topical_event_organisations_attributes]
 
-    params[:organisation][:topical_event_organisations_attributes].each do |p|
+    organisation_params[:topical_event_organisations_attributes].each do |p|
       if p[:topical_event_id].blank?
         p["_destroy"] = true
       end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -94,7 +94,6 @@ class Organisation < ApplicationRecord
   has_many :topical_event_organisations,
            -> { order("topical_event_organisations.ordering") },
            dependent: :destroy
-  has_many :topical_events, through: :topical_event_organisations
 
   has_many :topical_events,
            -> { order("topical_event_organisations.ordering") },

--- a/test/functional/admin/organisations_controller_test.rb
+++ b/test/functional/admin/organisations_controller_test.rb
@@ -338,6 +338,34 @@ class Admin::OrganisationsControllerTest < ActionController::TestCase
     assert_equal "New title", featured_link.reload.title
   end
 
+  test "PUT on :update handles adding and removing topical event attributes" do
+    topical_event_one = create(:topical_event)
+    organisation = create(:organisation, topical_events: [topical_event_one])
+    topical_event_two = create(:topical_event)
+
+    put :update,
+        params: {
+          id: organisation,
+          organisation: {
+            topical_event_organisations_attributes: [
+              {
+                topical_event_id: topical_event_one.id,
+                ordering: 0,
+                id: organisation.topical_event_organisations.first.id,
+                _destroy: "true",
+              },
+              {
+                topical_event_id: topical_event_two.id,
+                ordering: 1,
+              },
+            ],
+          },
+        }
+
+    assert_response :redirect
+    assert_equal [topical_event_two], organisation.reload.topical_events
+  end
+
   test "GET on :show displays 'image is being processed' flash notice when not all image assets are uploaded" do
     organisation = build(:organisation, :with_default_news_image)
     organisation.default_news_image.assets = []


### PR DESCRIPTION
The `delete_absent_topical_event_organisations` method was operating directly on the params object, but the `organisation_params` method that was passed to the organisation model was grabbing a fresh copy of the parameters, and therefore the `_destroy` parameter was not included.

By using the `organisation_params` method inside `delete_absent_topical_event_organisations`, we make sure that topical event organisation associations can be removed.

We also added a test to verify this behaviour.

https://trello.com/c/ZqWZd13U/2760-organisations-cant-be-disassociated-from-topical-events

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
