### PR TITLE
Show linked documents

### DIFF
--- a/lib/engines/content_object_store/app/components/content_object_store/content_block/document/show/linked_editions_table_component.html.erb
+++ b/lib/engines/content_object_store/app/components/content_object_store/content_block/document/show/linked_editions_table_component.html.erb
@@ -1,0 +1,16 @@
+<%= render "govuk_publishing_components/components/table", {
+  caption:,
+  caption_classes: "govuk-heading-l",
+  head: [
+    {
+      text: "Title",
+    },
+    {
+      text: "Document Type",
+    },
+    {
+      text: "Publishing organisation",
+    },
+  ],
+  rows:,
+} %>

--- a/lib/engines/content_object_store/app/components/content_object_store/content_block/document/show/linked_editions_table_component.rb
+++ b/lib/engines/content_object_store/app/components/content_object_store/content_block/document/show/linked_editions_table_component.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+class ContentObjectStore::ContentBlock::Document::Show::LinkedEditionsTableComponent < ViewComponent::Base
+  def initialize(caption:, linked_content_items:)
+    @caption = caption
+    @linked_content_items = linked_content_items
+  end
+
+private
+
+  attr_reader :caption, :linked_content_items
+
+  def rows
+    return [] unless linked_content_items
+
+    linked_content_items.map do |content_item|
+      [
+        {
+          text: content_link(content_item),
+        },
+        {
+          text: content_item.document_type.humanize,
+        },
+        {
+          text: organisation_link(content_item.organisation),
+        },
+      ]
+    end
+  end
+
+  def content_link(content_item)
+    link_to(content_item.title, Plek.website_root + content_item.base_path, class: "govuk-link")
+  end
+
+  def organisation_link(organisation)
+    return nil if organisation.nil?
+
+    link_to(organisation.name, admin_organisation_path(organisation), class: "govuk-link")
+  end
+end

--- a/lib/engines/content_object_store/app/controllers/content_object_store/content_block/documents_controller.rb
+++ b/lib/engines/content_object_store/app/controllers/content_object_store/content_block/documents_controller.rb
@@ -6,5 +6,13 @@ class ContentObjectStore::ContentBlock::DocumentsController < ContentObjectStore
   def show
     @content_block_document = ContentObjectStore::ContentBlock::Document.find(params[:id])
     @content_block_versions = @content_block_document.versions
+
+    linked_item_service = ContentObjectStore::GetLinkedContentItems.new(
+      content_block_document: @content_block_document,
+      page: params[:page],
+    )
+
+    @linked_content_items = linked_item_service.items
+    @page_data = linked_item_service.page_data
   end
 end

--- a/lib/engines/content_object_store/app/models/content_object_store/content_item.rb
+++ b/lib/engines/content_object_store/app/models/content_object_store/content_item.rb
@@ -1,0 +1,4 @@
+module ContentObjectStore
+  class ContentItem < Data.define(:title, :base_path, :document_type, :organisation)
+  end
+end

--- a/lib/engines/content_object_store/app/services/content_object_store/get_linked_content_items.rb
+++ b/lib/engines/content_object_store/app/services/content_object_store/get_linked_content_items.rb
@@ -1,0 +1,57 @@
+module ContentObjectStore
+  class GetLinkedContentItems
+    PageData = Data.define(:total_items, :total_pages, :current_page)
+
+    API_FIELDS = %w[title document_type links link_set_links content_id base_path].freeze
+
+    def initialize(content_block_document:, page:)
+      @block_type = content_block_document.block_type
+      @content_id = content_block_document.content_id
+      @page = page || 1
+    end
+
+    def items
+      content_items["results"].map do |item|
+        ContentObjectStore::ContentItem.new(
+          title: item["title"],
+          base_path: item["base_path"],
+          document_type: item["document_type"],
+          organisation: organisations.find { |o| o.content_id == organisation_id_for_content_item(item) },
+        )
+      end
+    end
+
+    def page_data
+      PageData.new(
+        total_items: content_items["total"],
+        total_pages: content_items["pages"],
+        current_page: content_items["current_page"],
+      )
+    end
+
+    def arguments
+      {
+        "link_embed" => content_id,
+        "fields" => API_FIELDS,
+        "page" => page,
+      }
+    end
+
+  private
+
+    attr_reader :block_type, :content_id, :page
+
+    def content_items
+      @content_items ||= Services.publishing_api.get_content_items(**arguments)
+    end
+
+    def organisations
+      Organisation.where(content_id: content_items["results"].map { |o| organisation_id_for_content_item(o) }.compact)
+    end
+
+    def organisation_id_for_content_item(content_item)
+      links = content_item["links"].merge(content_item["link_set_links"])
+      links["primary_publishing_organisation"]&.first
+    end
+  end
+end

--- a/lib/engines/content_object_store/app/views/content_object_store/content_block/documents/show.html.erb
+++ b/lib/engines/content_object_store/app/views/content_object_store/content_block/documents/show.html.erb
@@ -14,6 +14,30 @@
 
 <div class="govuk-grid-row govuk-!-padding-top-8">
   <div class="govuk-grid-column-full">
+    <!-- TODO: The prototype wants to show a counter beneath the title but
+    before the table, the existing component doesn't support that so I've left
+    it out for now-->
+    <%= render(
+      ContentObjectStore::ContentBlock::Document::Show::LinkedEditionsTableComponent.new(
+        caption: "Content appears in",
+        linked_content_items: @linked_content_items,
+      ),
+    ) %>
+
+    <% if @page_data.total_pages > 1 %>
+      <% Admin::PaginationHelper.pagination_hash(current_page: @page_data.current_page.to_i, total_pages: @page_data.total_pages.to_i, path: request.url).tap do |hash| %>
+        <%= render "components/pagination", {
+          previous_href: hash[:previous_href],
+          next_href: hash[:next_href],
+          items: hash[:items],
+        } %>
+      <% end %>
+    <% end %>
+  </div>
+</div>
+
+<div class="govuk-grid-row govuk-!-padding-top-8">
+  <div class="govuk-grid-column-full">
     <%= render(
           ContentObjectStore::ContentBlock::Document::Show::DocumentTimelineComponent.new(
             content_block_versions: @content_block_versions,

--- a/lib/engines/content_object_store/features/step_definitions/content_object_store_steps.rb
+++ b/lib/engines/content_object_store/features/step_definitions/content_object_store_steps.rb
@@ -1,3 +1,5 @@
+require_relative "../support/stubs"
+
 Given(/^the content object store feature flag is (enabled|disabled)$/) do |enabled|
   @test_strategy ||= Flipflop::FeatureSet.current.test!
   @test_strategy.switch!(:content_object_store, enabled == "enabled")
@@ -245,4 +247,32 @@ end
 
 Then("I accept and publish") do
   click_on "Accept and publish"
+end
+
+When(/^dependent content exists for a content block$/) do
+  @dependent_content = 10.times.map do |i|
+    {
+      "title": "Content #{i}",
+      "document_type": "document",
+      "links": {},
+      "link_set_links": {},
+      "base_path" => "/",
+      "content_id": SecureRandom.uuid,
+    }
+  end
+
+  @dependent_content.each_with_index do |item, i|
+    stub_dependent_content(results: [item], total: @dependent_content.length, pages: @dependent_content.length, current_page: i + 1)
+  end
+end
+
+Then(/^I should see the dependent content listed$/) do
+  assert_text "Content appears in"
+
+  @dependent_content.each do |item|
+    assert_text item[:title]
+    break if item == @dependent_content.last
+
+    click_on "Next"
+  end
 end

--- a/lib/engines/content_object_store/features/support/stubs.rb
+++ b/lib/engines/content_object_store/features/support/stubs.rb
@@ -1,0 +1,14 @@
+Before do
+  stub_dependent_content(results: [])
+end
+
+def stub_dependent_content(results:, total: 0, pages: 0, current_page: 1)
+  stub_request(:get, %r{\A#{Plek.find('publishing-api')}/v2/content})
+    .with(query: hash_including({ "page" => current_page.to_s }))
+    .to_return(body: {
+      "total" => total,
+      "pages" => pages,
+      "current_page" => current_page,
+      "results" => results,
+    }.to_json)
+end

--- a/lib/engines/content_object_store/features/view_object.feature
+++ b/lib/engines/content_object_store/features/view_object.feature
@@ -1,14 +1,22 @@
 Feature: View a content object
-
-  Scenario: GDS Editor views a content object
+  Background:
     Given the content object store feature flag is enabled
     Given I am a GDS admin
     And a schema "email_address" exists with the following fields:
       | email_address |
     And an email address content block has been created
+
+  Scenario: GDS Editor views a content object
     When I visit the document object store
     Then I should see the details for all documents
     When I click to view the document
     Then I should be taken back to the document page
     And I should see the details for the email address content block
     And I should see the created event on the timeline
+
+  Scenario: GDS Editor views dependent Content
+    Given dependent content exists for a content block
+    When I visit the document object store
+    And I click to view the document
+    Then I should see the dependent content listed
+

--- a/lib/engines/content_object_store/test/components/content_block/document/show/linked_editions_table_component_test.rb
+++ b/lib/engines/content_object_store/test/components/content_block/document/show/linked_editions_table_component_test.rb
@@ -1,0 +1,50 @@
+require "test_helper"
+
+class ContentObjectStore::ContentBlock::Document::Show::LinkedEditionsTableComponentTest < ViewComponent::TestCase
+  extend Minitest::Spec::DSL
+
+  it "renders linked editions with an organisation" do
+    caption = "Some caption"
+    organisation = build(:organisation, id: 123)
+    linked_content_items = [
+      ContentObjectStore::ContentItem.new(title: "Some title", base_path: "/foo", document_type: "document_type", organisation:),
+    ]
+
+    render_inline(
+      ContentObjectStore::ContentBlock::Document::Show::LinkedEditionsTableComponent.new(
+        caption:,
+        linked_content_items:,
+      ),
+    )
+
+    assert_selector ".govuk-table__caption", text: caption
+
+    assert_selector "tbody .govuk-table__row", count: 1
+
+    assert_selector "tbody .govuk-table__cell", text: linked_content_items[0].title
+    assert_selector "tbody .govuk-table__cell", text: linked_content_items[0].document_type.humanize
+    assert_selector "tbody .govuk-table__cell", text: organisation.name
+  end
+
+  it "renders linked editions without an organisation" do
+    caption = "Some caption"
+    linked_content_items = [
+      ContentObjectStore::ContentItem.new(title: "Some title", base_path: "/foo", document_type: "document_type", organisation: nil),
+    ]
+
+    render_inline(
+      ContentObjectStore::ContentBlock::Document::Show::LinkedEditionsTableComponent.new(
+        caption:,
+        linked_content_items:,
+      ),
+    )
+
+    assert_selector ".govuk-table__caption", text: caption
+
+    assert_selector "tbody .govuk-table__row", count: 1
+
+    assert_selector "tbody .govuk-table__cell", text: linked_content_items[0].title
+    assert_selector "tbody .govuk-table__cell", text: linked_content_items[0].document_type.humanize
+    assert_selector "tbody .govuk-table__cell", text: "Not set"
+  end
+end

--- a/lib/engines/content_object_store/test/unit/app/services/get_linked_content_items_test.rb
+++ b/lib/engines/content_object_store/test/unit/app/services/get_linked_content_items_test.rb
@@ -1,0 +1,105 @@
+require "test_helper"
+
+class ContentObjectStore::GetLinkedContentItemsTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
+  let(:organisations) { 5.times.map { build(:organisation, content_id: SecureRandom.uuid) } }
+  let(:response) do
+    {
+      "total" => 100,
+      "pages" => 10,
+      "current_page" => 1,
+      "results" => [
+        "title" => "foo",
+        "base_path" => "/foo",
+        "document_type" => "something",
+        "links" => {},
+        "link_set_links" => {},
+      ],
+    }
+  end
+  let(:content_block_document) { build(:content_block_document) }
+  let(:publishing_api_mock) { MiniTest::Mock.new }
+
+  setup do
+    Services.publishing_api.stubs(:get_content_items).returns(response)
+    Organisation.stubs(:where).returns(organisations)
+  end
+
+  describe "#items" do
+    it "returns items correctly when items do not have an associated organisation" do
+      result = ContentObjectStore::GetLinkedContentItems.new(content_block_document:, page: 1).items
+
+      assert_equal result[0].title, response["results"][0]["title"]
+      assert_equal result[0].base_path, response["results"][0]["base_path"]
+      assert_equal result[0].document_type, response["results"][0]["document_type"]
+      assert_equal result[0].organisation, nil
+    end
+
+    it "returns items correctly when items have an associated organisation in the links response" do
+      response["results"][0]["links"] = {
+        "primary_publishing_organisation" => [
+          organisations.first.content_id,
+        ],
+      }
+
+      result = ContentObjectStore::GetLinkedContentItems.new(content_block_document:, page: 1).items
+
+      assert_equal result[0].title, response["results"][0]["title"]
+      assert_equal result[0].base_path, response["results"][0]["base_path"]
+      assert_equal result[0].document_type, response["results"][0]["document_type"]
+      assert_equal result[0].organisation, organisations.first
+    end
+
+    it "returns items correctly when items have an associated organisation in the link_set_links response" do
+      response["results"][0]["link_set_links"] = {
+        "primary_publishing_organisation" => [
+          organisations.first.content_id,
+        ],
+      }
+
+      result = ContentObjectStore::GetLinkedContentItems.new(content_block_document:, page: 1).items
+
+      assert_equal result[0].title, response["results"][0]["title"]
+      assert_equal result[0].base_path, response["results"][0]["base_path"]
+      assert_equal result[0].document_type, response["results"][0]["document_type"]
+      assert_equal result[0].organisation, organisations.first
+    end
+
+    it "calls the client with the expected arguments" do
+      ContentObjectStore::GetLinkedContentItems.new(content_block_document:, page: 1).items
+    end
+  end
+
+  describe "#page_data" do
+    it "returns page data" do
+      result = ContentObjectStore::GetLinkedContentItems.new(content_block_document:, page: 1).page_data
+
+      assert_equal result.total_items, response["total"]
+      assert_equal result.total_pages, response["pages"]
+      assert_equal result.current_page, response["current_page"]
+    end
+  end
+
+  describe "#arguments" do
+    it "generates the correct arguments" do
+      result = ContentObjectStore::GetLinkedContentItems.new(content_block_document:, page: nil).arguments
+
+      assert_equal result, {
+        "link_embed" => content_block_document.content_id,
+        "fields" => ContentObjectStore::GetLinkedContentItems::API_FIELDS,
+        "page" => 1,
+      }
+    end
+
+    it "generates the correct arguments with a page number" do
+      result = ContentObjectStore::GetLinkedContentItems.new(content_block_document:, page: 2).arguments
+
+      assert_equal result, {
+        "link_embed" => content_block_document.content_id,
+        "fields" => ContentObjectStore::GetLinkedContentItems::API_FIELDS,
+        "page" => 2,
+      }
+    end
+  end
+end


### PR DESCRIPTION
This builds on https://github.com/alphagov/publishing-api/pull/2823 to allow us to fetch linked documents for a given content block. This looks for any documents linked to the Content Block with the link type `embed` and lists the documents, together with their type and organisation (if we can find it)

## Screenshot

![image](https://github.com/user-attachments/assets/b1065bf1-5163-479a-b54d-08a2c2981706)
