### PR TITLE
Add warning text when creating worldwide organisations

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -269,6 +269,8 @@ class Edition < ApplicationRecord
     self.class.format_name
   end
 
+  def new_content_warning; end
+
   def has_parent_type?
     true
   end

--- a/app/models/worldwide_organisation.rb
+++ b/app/models/worldwide_organisation.rb
@@ -204,4 +204,8 @@ class WorldwideOrganisation < Edition
   def associated_documents
     [offices, offices.map(&:contact), pages].compact.flatten
   end
+
+  def new_content_warning
+    "Do not create a worldwide organisation unless you have permission from your managing editor or GOV.UK department lead."
+  end
 end

--- a/app/views/admin/editions/new.html.erb
+++ b/app/views/admin/editions/new.html.erb
@@ -9,6 +9,14 @@
       items: secondary_navigation_tabs_items(@edition, request.path),
     } %>
 
+    <% if @edition.new_content_warning %>
+      <div class="format-advice">
+        <%= render "govuk_publishing_components/components/warning_text", {
+          text: @edition.new_content_warning,
+        } %>
+      </div>
+    <% end %>
+
     <%= render "form", edition: @edition %>
   </div>
 

--- a/test/functional/admin/worldwide_organisations_controller_test.rb
+++ b/test/functional/admin/worldwide_organisations_controller_test.rb
@@ -7,6 +7,7 @@ class Admin::WorldwideOrganisationsControllerTest < ActionController::TestCase
 
   should_be_an_admin_controller
   should_allow_creating_of :worldwide_organisation
+  should_show_new_warning_message_for :worldwide_organisation
   should_allow_editing_of :worldwide_organisation
   should_allow_only_lead_organisations_for :worldwide_organisation
   should_prevent_modification_of_unmodifiable :worldwide_organisation

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -461,6 +461,16 @@ module AdminEditionControllerTestHelpers
       end
     end
 
+    def should_show_new_warning_message_for(edition_type)
+      edition_class = class_for(edition_type)
+
+      view_test "new includes warning text" do
+        get :new
+
+        assert_select ".govuk-warning-text__text", /#{edition_class.new.new_content_warning}/
+      end
+    end
+
     def should_allow_lead_and_supporting_organisations_for(edition_type)
       edition_class = class_for(edition_type)
 


### PR DESCRIPTION
Since rolling out editionable worldwide organisations, we have seen a few instances of users intending to publish world news stories but actually publishing new worldwide organisations.

Adding some warning text to remind publishers that these are only to be created after discussion with the relevant people.

This is in a consistent position to format specific advice we show for other formats, e.g. [publications](https://github.com/alphagov/whitehall/blob/2d1417a4980d8aa926539ae1d7ea1b4f02e10cf3/app/views/admin/publications/_form.html.erb#L1-L3).

![Screenshot showing the form to create a new worldwide organisation.  The text "Do not create a worldwide organisation unless you have permission from your managing editor or GOV.UK department lead." appears alongside a symbol of an exclamation mark at the top of the form.](https://github.com/user-attachments/assets/0abc7449-028a-4e1f-98f3-233d914286b7)

[Trello card](https://trello.com/c/7jolFBQr)