### PR TITLE
Stop tests from running multiple times (Minitest Spec DSL bug)

### DIFF
--- a/lib/engines/content_object_store/test/unit/app/models/content_block_document_test.rb
+++ b/lib/engines/content_object_store/test/unit/app/models/content_block_document_test.rb
@@ -40,16 +40,6 @@ class ContentObjectStore::ContentBlockDocumentTest < ActiveSupport::TestCase
     assert content_block_document.reload.live_edition_id, 1
   end
 
-  describe "latest_edition" do
-    it "returns the latest edition" do
-      document = create(:content_block_document, :email_address)
-      _first_edition = create(:content_block_edition, document:)
-      second_edition = create(:content_block_edition, document:)
-
-      assert_equal second_edition, document.latest_edition
-    end
-  end
-
   test "it gets its version history from its editions" do
     document = create(:content_block_document, :email_address)
     edition = create(
@@ -59,5 +49,15 @@ class ContentObjectStore::ContentBlockDocumentTest < ActiveSupport::TestCase
     document.update!(editions: [edition])
 
     assert_equal document.versions.first.item.id, edition.id
+  end
+
+  describe "latest_edition" do
+    it "returns the latest edition" do
+      document = create(:content_block_document, :email_address)
+      _first_edition = create(:content_block_edition, document:)
+      second_edition = create(:content_block_edition, document:)
+
+      assert_equal second_edition, document.latest_edition
+    end
   end
 end

--- a/lib/engines/content_object_store/test/unit/app/models/content_block_schema_test.rb
+++ b/lib/engines/content_object_store/test/unit/app/models/content_block_schema_test.rb
@@ -6,15 +6,6 @@ class ContentObjectStore::SchemaTest < ActiveSupport::TestCase
   let(:body) { { "properties" => { "foo" => {}, "bar" => {} } } }
   let(:schema) { build(:content_block_schema, :email_address, body:) }
 
-  describe ".valid_schemas" do
-    test "it returns the contents of the VALID_SCHEMA constant" do
-      assert_equal ContentObjectStore::ContentBlock::Schema.valid_schemas, %w[
-        email_address
-        postal_address
-      ]
-    end
-  end
-
   test "it generates a human-readable name" do
     assert_equal schema.name, "Email address"
   end
@@ -29,6 +20,15 @@ class ContentObjectStore::SchemaTest < ActiveSupport::TestCase
 
   test "it returns a block type" do
     assert_equal schema.block_type, "email_address"
+  end
+
+  describe ".valid_schemas" do
+    test "it returns the contents of the VALID_SCHEMA constant" do
+      assert_equal ContentObjectStore::ContentBlock::Schema.valid_schemas, %w[
+        email_address
+        postal_address
+      ]
+    end
   end
 
   describe ".all" do

--- a/test/unit/app/models/role_test.rb
+++ b/test/unit/app/models/role_test.rb
@@ -198,38 +198,6 @@ class RoleTest < ActiveSupport::TestCase
     assert_not_includes Role.occupied, vacant
   end
 
-  context "for a ministerial role" do
-    let(:role) { create(:ministerial_role, name: "Prime Minister, Cabinet Office") }
-
-    test "public_path returns the correct path for ministerial role" do
-      assert_equal "/government/ministers/prime-minister-cabinet-office", role.public_path
-    end
-
-    test "public_path returns the correct path with options" do
-      assert_equal "/government/ministers/prime-minister-cabinet-office?cachebust=123", role.public_path(cachebust: "123")
-    end
-
-    test "public_url returns the correct path for a Ministerial role" do
-      assert_equal "https://www.test.gov.uk/government/ministers/prime-minister-cabinet-office", role.public_url
-    end
-
-    test "public_url returns the correct path for a Ministerial Role with options" do
-      assert_equal "https://www.test.gov.uk/government/ministers/prime-minister-cabinet-office?cachebust=123", role.public_url(cachebust: "123")
-    end
-  end
-
-  context "for a non-ministerial role" do
-    let(:role) { create(:board_member_role) }
-
-    test "public_path returns `nil``" do
-      assert_nil role.public_path
-    end
-
-    test "public_url returns `nil`" do
-      assert_nil role.public_url
-    end
-  end
-
   test "has removeable translations" do
     stub_any_publishing_api_call
     role = create(:role, translated_into: %i[fr es])
@@ -279,5 +247,37 @@ class RoleTest < ActiveSupport::TestCase
     PublishingApiDocumentRepublishingWorker.expects(:perform_async).with(worldwide_organisation.document_id)
 
     role.update!(name: "New role name")
+  end
+
+  context "for a ministerial role" do
+    let(:role) { create(:ministerial_role, name: "Prime Minister, Cabinet Office") }
+
+    test "public_path returns the correct path for ministerial role" do
+      assert_equal "/government/ministers/prime-minister-cabinet-office", role.public_path
+    end
+
+    test "public_path returns the correct path with options" do
+      assert_equal "/government/ministers/prime-minister-cabinet-office?cachebust=123", role.public_path(cachebust: "123")
+    end
+
+    test "public_url returns the correct path for a Ministerial role" do
+      assert_equal "https://www.test.gov.uk/government/ministers/prime-minister-cabinet-office", role.public_url
+    end
+
+    test "public_url returns the correct path for a Ministerial Role with options" do
+      assert_equal "https://www.test.gov.uk/government/ministers/prime-minister-cabinet-office?cachebust=123", role.public_url(cachebust: "123")
+    end
+  end
+
+  context "for a non-ministerial role" do
+    let(:role) { create(:board_member_role) }
+
+    test "public_path returns `nil``" do
+      assert_nil role.public_path
+    end
+
+    test "public_url returns `nil`" do
+      assert_nil role.public_url
+    end
   end
 end


### PR DESCRIPTION
We have to be very careful about how `test` blocks are defined. Consider:

```
context "foo" do
  test { assert_something }
end

test { assert_something_else }
```

`assert_something_else` will get called _twice_ by Minitest. As described in https://github.com/minitest/minitest/pull/865:

> minitest spec styles deals with tests being included from preceding or ancestor classes within the DSL with the method `Minitest::Spec::DSL#nuke_test_methods!`. This will wipe out existing test methods that have been defined at the time of class initialization (`Minitest::Spec::DSL#create`). However, when tests are defined after a block is declared, they are still included when the instance methods for the class are pulled (since they're pulled with all the ancestor instance methods).

We therefore have to ensure that any `test` definitions are defined in a `describe` or `context` block that is as deeply nested as any preceding `test` definition.

Some tests in this file were running three times, due to their inclusion after the first `context` block. I've therefore moved the `context` blocks to the bottom of the file. This has resulted in fewer runs and assertions, and shaved 2 seconds off the test run time.

Before:

```
$ run rake test TEST=test/unit/app/models/role_test.rb

..................................................

Finished in 7.189464s, 6.9546 runs/s, 9.7365 assertions/s.
50 runs, 70 assertions, 0 failures, 0 errors, 0 skips
```

After:

```
$ run rake test TEST=test/unit/app/models/role_test.rb

........................................

Finished in 5.163601s, 7.7465 runs/s, 10.4578 assertions/s.
40 runs, 54 assertions, 0 failures, 0 errors, 0 skips
```

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
