### PR TITLE
Update hint text for creating a worldwide organisation

### DIFF
--- a/app/helpers/admin/new_document_helper.rb
+++ b/app/helpers/admin/new_document_helper.rb
@@ -42,7 +42,7 @@ private
       publication: "Use this for standalone government documents, white papers, strategy documents, and reports.",
       speech: "Use this for speeches by ministers or other named spokespeople, and ministerial statements to Parliament.",
       statistical_data_set: "Use this for data that you publish monthly or more often without analysis.",
-      worldwide_organisation: "Use this for worldwide organisations.",
+      worldwide_organisation: "Use this to create a new worldwide organisation page. Do not create a worldwide organisation unless you have permission from your managing editor or GOV.UK department lead.",
     }
     hint_text[new_document_type]
   end


### PR DESCRIPTION
Since rolling out editionable worldwide organisations, we have seen a few instances of users intending to publish world news stories but actually publishing new worldwide organisations.

Updating the hint text to remind publishers that these are only to be created after discussion with the relevant people.

![Screenshot showing the selector form for choosing a document type. The worldwide organisation option has the hint text "Use this to create a new worldwide organisation page. Do not create a worldwide organisation unless you have permission from your managing editor or GOV.UK department lead.".](https://github.com/user-attachments/assets/24de28f0-3491-48e4-97f5-2fbdf829ca6f)

[Trello card](https://trello.com/c/ysHCn2is)