### PR TITLE
Handle a not found response from Asset Manager

### DIFF
--- a/lib/tasks/asset_manager.rake
+++ b/lib/tasks/asset_manager.rake
@@ -9,7 +9,11 @@ namespace :asset_manager do
       next if (attachables.map(&:state) - %w[unpublished superseded]).any?
 
       attachment_data.assets.map do |asset|
-        asset_manager_response = GdsApi.asset_manager.asset(asset.asset_manager_id).to_h
+        begin
+          asset_manager_response = GdsApi.asset_manager.asset(asset.asset_manager_id).to_h
+        rescue GdsApi::HTTPNotFound
+          next
+        end
 
         next unless asset_manager_response["deleted"] == false
 

--- a/test/unit/lib/tasks/asset_manager_test.rb
+++ b/test/unit/lib/tasks/asset_manager_test.rb
@@ -29,10 +29,22 @@ class AssetManagerTest < ActiveSupport::TestCase
         end
       end
 
-      context "when asset is deleted from asset manager" do
+      context "when asset is soft deleted from asset manager" do
         before do
           attachment.attachment_data.assets.each do |asset|
             stub_asset_manager_has_an_asset(asset.asset_manager_id, { deleted: true, file_url: asset.filename })
+          end
+        end
+
+        test "it should not include the attachment in the report" do
+          refute_output(/#{attachment.attachment_data.assets.first.filename},#{edition.public_url},#{edition.state}/) { task.invoke }
+        end
+      end
+
+      context "when asset is hard deleted from asset manager" do
+        before do
+          attachment.attachment_data.assets.each do |asset|
+            stub_asset_manager_does_not_have_an_asset(asset.asset_manager_id)
           end
         end
 


### PR DESCRIPTION
In [the rake task](https://github.com/alphagov/whitehall/pull/9351) to report on deleted assets that are still present in Asset Manager, we need to handle the possibility of an asset being hard deleted from Asset Manager and therefore a 404 response being returned.

[Trello card](https://trello.com/c/e9N6IfPR)