### PR TITLE
Handle `Addressable::URI::InvalidURIError` errors

### DIFF
--- a/app/models/unpublishing.rb
+++ b/app/models/unpublishing.rb
@@ -88,7 +88,7 @@ private
       return if alternative_url.nil?
 
       Addressable::URI.parse(alternative_url)
-    rescue URI::InvalidURIError
+    rescue URI::InvalidURIError, Addressable::URI::InvalidURIError
       nil
     end
   end


### PR DESCRIPTION
Solves https://govuk.sentry.io/issues/5693834348/?alert_rule_id=963054&alert_type=issue&notification_uuid=7367d0ab-4a38-45d1-86e9-3812e7ffe02b&project=202259&referrer=slack

I had hoped to add to an existing test, but it looks like one wasn't added when the existing `rescue` was added in 9a5467f0b1965790e9032186fdbbdb4f70fcbb41.

It's such a small edge case and a low risk change that we should be fine to just patch this in as-is.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
