### PR TITLE
Make government a real association of editions

### DIFF
--- a/app/components/admin/editions/history_mode_form_control.html.erb
+++ b/app/components/admin/editions/history_mode_form_control.html.erb
@@ -1,0 +1,33 @@
+<div class="govuk-!-margin-bottom-8">
+  <% if can_select_government? %>
+    <%= render "govuk_publishing_components/components/select", {
+      name: "edition[government_id]",
+      id: "edition_political",
+      heading: "Political",
+      heading_size: "l",
+      label: "Associate this document with a government",
+      options: government_options_for_select,
+    } %>
+  <% else %>
+    <%= render "govuk_publishing_components/components/input", {
+      name: "edition[government_id]",
+      type: "hidden",
+      value: "",
+    } %>
+    <%= render "govuk_publishing_components/components/checkboxes", {
+      name: "edition[government_id]",
+      id: "edition_political",
+      heading: "Political",
+      heading_size: "l",
+      no_hint_text: true,
+      items: [
+        {
+          label: "Associate with government of the time.",
+          value: @edition.government&.id || @edition.default_government&.id,
+          checked: @edition.government&.id,
+        },
+      ],
+    } %>
+  <% end %>
+  <p class="govuk-body"><%= link_to "Read the history mode guidance", "https://www.gov.uk/guidance/how-to-publish-on-gov-uk/creating-and-updating-pages#history-mode", class: "govuk-link" %> for more information as to what this means.</p>
+</div>

--- a/app/components/admin/editions/history_mode_form_control.rb
+++ b/app/components/admin/editions/history_mode_form_control.rb
@@ -1,0 +1,25 @@
+class Admin::Editions::HistoryModeFormControl < ViewComponent::Base
+  def initialize(edition:, current_user:)
+    @edition = edition
+    @enforcer = Whitehall::Authority::Enforcer.new(current_user, edition)
+  end
+
+  def render?
+    @edition.document.live? && @edition.can_be_marked_political? && @enforcer.can?(:mark_political)
+  end
+
+  def can_select_government?
+    @enforcer.can?(:select_government)
+  end
+
+  def government_options_for_select
+    [
+      {
+        text: "Not associated with any government",
+        value: "",
+      },
+    ].concat(
+      Government.order(start_date: :desc).all.map { |government| { text: government.name, value: government.id, selected: government == @edition.government } },
+    )
+  end
+end

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -237,7 +237,7 @@ private
       :related_mainstream_content_url,
       :additional_related_mainstream_content_url,
       :corporate_information_page_type_id,
-      :political,
+      :government_id,
       :read_consultation_principles,
       :all_nation_applicability,
       :speaker_radios,

--- a/app/models/detailed_guide.rb
+++ b/app/models/detailed_guide.rb
@@ -111,10 +111,6 @@ class DetailedGuide < Edition
     end
   end
 
-  def government
-    @government ||= Government.on_date(date_for_government) unless date_for_government.nil?
-  end
-
   def persist_content_ids
     related_mainstreams.delete_all
     related_mainstreams.create!(content_id: related_mainstream_content_ids[0]) if related_mainstream_content_ids[0]

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -50,6 +50,8 @@ class Edition < ApplicationRecord
   has_many :depended_upon_contacts, through: :edition_dependencies, source: :dependable, source_type: "Contact"
   has_many :depended_upon_editions, through: :edition_dependencies, source: :dependable, source_type: "Edition"
 
+  belongs_to :government, optional: true
+
   validates_with SafeHtmlValidator
   validates_with NoFootnotesInGovspeakValidator, attribute: :body
   validates_with TaxonValidator, on: :publish, if: :requires_taxon?
@@ -346,18 +348,20 @@ class Edition < ApplicationRecord
     true
   end
 
-  def government
-    @government ||= Government.on_date(date_for_government) unless date_for_government.nil?
+  def default_government
+    Government.on_date(date_for_government) unless date_for_government.nil?
   end
 
   def search_government_name
     government.name if government
   end
 
-  def historic?
-    return false unless government
+  def political?
+    government.present?
+  end
 
-    political? && !government.current?
+  def historic?
+    government.present? && !government.current?
   end
 
   def withdrawn?

--- a/app/presenters/publishing_api/html_attachment_presenter.rb
+++ b/app/presenters/publishing_api/html_attachment_presenter.rb
@@ -80,7 +80,7 @@ module PublishingApi
     end
 
     def political?
-      item&.attachable.is_a?(Edition) ? item&.attachable&.political : false
+      item&.attachable.is_a?(Edition) ? item&.attachable&.political? : false
     end
 
     def public_timestamp

--- a/app/presenters/publishing_api/payload_builder/links.rb
+++ b/app/presenters/publishing_api/payload_builder/links.rb
@@ -73,7 +73,7 @@ module PublishingApi::PayloadBuilder
     end
 
     def government_id
-      [item.government&.content_id].compact
+      [item.government&.content_id || item.default_government&.content_id].compact
     end
   end
 end

--- a/app/presenters/publishing_api/speech_presenter.rb
+++ b/app/presenters/publishing_api/speech_presenter.rb
@@ -40,7 +40,6 @@ module PublishingApi
 
       details = {
         body:,
-        political: item.political,
         delivered_on: item.delivered_on.iso8601,
         change_history: changes_with_public_timestamps.as_json,
         location: item.location,

--- a/app/services/edition_publisher.rb
+++ b/app/services/edition_publisher.rb
@@ -65,7 +65,8 @@ private
 
   def flag_if_political_content!
     return if edition.document.live?
+    return unless PoliticalContentIdentifier.political?(edition)
 
-    edition.political = PoliticalContentIdentifier.political?(edition)
+    edition.government = edition.default_government
   end
 end

--- a/app/views/admin/editions/_standard_fields.html.erb
+++ b/app/views/admin/editions/_standard_fields.html.erb
@@ -123,29 +123,7 @@
 
   <%= render "additional_significant_fields", form: form, edition: form.object %>
 
-  <% if edition.document&.live? && edition.can_be_marked_political? && can?(:mark_political, edition) %>
-    <div class="govuk-!-margin-bottom-8">
-      <%= form.hidden_field :political, value: "0" %>
-
-      <%= render "govuk_publishing_components/components/checkboxes", {
-        name: "edition[political]",
-        id: "edition_political",
-        heading: "Political",
-        heading_size: "l",
-        no_hint_text: true,
-        error: errors_for_input(edition.errors, :political),
-        items: [
-          {
-            label: "Associate with government of the time (currently set to #{edition.government&.name}).",
-            value: "1",
-            checked: edition.political,
-          },
-        ],
-      } %>
-
-      <p class="govuk-body"><%= link_to "Read the history mode guidance", "https://www.gov.uk/guidance/how-to-publish-on-gov-uk/creating-and-updating-pages#history-mode", class: "govuk-link" %> for more information as to what this means.</p>
-    </div>
-  <% end %>
+  <%= render Admin::Editions::HistoryModeFormControl.new(edition: @edition, current_user:) %>
 </div>
 
 <%= render Admin::Editions::FirstPublishedAtComponent.new(

--- a/db/data_migration/202408131234400_assign_governments_to_political_content.rb
+++ b/db/data_migration/202408131234400_assign_governments_to_political_content.rb
@@ -1,0 +1,9 @@
+political_editions = Edition.where(political: true).where("state != ?", "superseded")
+
+puts "Assigning a government to #{political_editions.count} political editions"
+
+political_editions.find_each do |edition|
+  edition.update_column(:government_id, edition.default_government&.id)
+end
+
+puts "done"

--- a/db/migrate/20240809145731_add_government_association_to_editions.rb
+++ b/db/migrate/20240809145731_add_government_association_to_editions.rb
@@ -1,0 +1,7 @@
+class AddGovernmentAssociationToEditions < ActiveRecord::Migration[7.1]
+  def change
+    change_table :editions do |t|
+      t.belongs_to :government, foreign_key: true, type: :integer
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_31_143537) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_09_145731) do
   create_table "assets", charset: "utf8mb3", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.string "variant", null: false
@@ -447,10 +447,12 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_31_143537) do
     t.string "logo_formatted_name"
     t.string "analytics_identifier"
     t.boolean "visual_editor"
+    t.integer "government_id"
     t.index ["alternative_format_provider_id"], name: "index_editions_on_alternative_format_provider_id"
     t.index ["closing_at"], name: "index_editions_on_closing_at"
     t.index ["document_id"], name: "index_editions_on_document_id"
     t.index ["first_published_at"], name: "index_editions_on_first_published_at"
+    t.index ["government_id"], name: "index_editions_on_government_id"
     t.index ["main_office_id"], name: "index_editions_on_main_office_id"
     t.index ["opening_at"], name: "index_editions_on_opening_at"
     t.index ["operational_field_id"], name: "index_editions_on_operational_field_id"
@@ -1287,6 +1289,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_31_143537) do
   add_foreign_key "content_block_editions", "content_block_documents", column: "document_id"
   add_foreign_key "documents", "editions", column: "latest_edition_id", on_update: :cascade, on_delete: :nullify
   add_foreign_key "documents", "editions", column: "live_edition_id", on_update: :cascade, on_delete: :nullify
+  add_foreign_key "editions", "governments"
   add_foreign_key "link_checker_api_report_links", "link_checker_api_reports"
   add_foreign_key "related_mainstreams", "editions"
   add_foreign_key "statistics_announcements", "statistics_announcement_dates", column: "current_release_date_id", on_update: :cascade, on_delete: :nullify

--- a/lib/tasks/attachments/republish_historically_political_html_attachments.rake
+++ b/lib/tasks/attachments/republish_historically_political_html_attachments.rake
@@ -4,7 +4,7 @@ task republish_historically_political_html_attachments: :environment do
 
   document_ids = Edition
     .publicly_visible
-    .where(id: HtmlAttachment.where("attachable_type = 'Edition' AND political = true AND first_published_at < ?", government_start_date).select(:attachable_id))
+    .where(id: HtmlAttachment.where("attachable_type = 'Edition' AND government_id IS NOT NULL AND first_published_at < ?", government_start_date).select(:attachable_id))
     .pluck(:document_id)
 
   puts "Enqueueing #{document_ids.count} documents with historically political html attachments"

--- a/lib/tasks/search.rake
+++ b/lib/tasks/search.rake
@@ -112,7 +112,8 @@ namespace :search do
   desc "Update search index for all political content"
   task political: :environment do
     Edition
-      .where(political: true, state: "published")
+      .where(state: "published")
+      .where("government_id IS NOT NULL")
       .find_each { |edition| edition&.update_in_search_index }
   end
 

--- a/lib/whitehall/authority/rules/edition_rules.rb
+++ b/lib/whitehall/authority/rules/edition_rules.rb
@@ -19,6 +19,7 @@ module Whitehall::Authority::Rules
         review_editorial_remark
         review_fact_check
         see
+        select_government
         unpublish
         unwithdraw
         update
@@ -171,7 +172,7 @@ module Whitehall::Authority::Rules
         can_publish?
       when :force_publish
         can_force_publish?
-      when :unpublish, :mark_political, :perform_administrative_tasks
+      when :unpublish, :mark_political, :perform_administrative_tasks, :select_government
         false
       else
         true
@@ -201,6 +202,7 @@ module Whitehall::Authority::Rules
         reject
         mark_political
         perform_administrative_tasks
+        select_government
       ]
 
       disallowed_actions.include?(action) == false

--- a/test/components/admin/editions/history_mode_form_control_test.rb
+++ b/test/components/admin/editions/history_mode_form_control_test.rb
@@ -1,0 +1,83 @@
+require "test_helper"
+
+class Admin::Editions::HistoryModeFormControlTest < ViewComponent::TestCase
+  test "doesn't render unless document has a previously published edition" do
+    edition = create(:draft_news_article)
+    render_inline(Admin::Editions::HistoryModeFormControl.new(edition:, current_user: create(:managing_editor)))
+
+    assert page.text.blank?
+  end
+
+  test "doesn't render if the edition cannot be marked political" do
+    previous_edition = create(:published_fatality_notice)
+    edition = create(:draft_fatality_notice, document: previous_edition.document)
+
+    render_inline(Admin::Editions::HistoryModeFormControl.new(edition:, current_user: create(:managing_editor)))
+
+    assert page.text.blank?
+  end
+
+  test "does not render if the user does not have permission to mark documents as political" do
+    previous_edition = create(:published_news_article)
+    edition = create(:draft_news_article, document: previous_edition.document)
+
+    render_inline(Admin::Editions::HistoryModeFormControl.new(edition:, current_user: create(:writer)))
+
+    assert page.text.blank?
+  end
+
+  test "renders government selector when user has permission to override government" do
+    previous_edition = create(:published_news_article)
+    edition = create(:draft_news_article, document: previous_edition.document)
+    governments = [create(:current_government), create(:previous_government)]
+
+    render_inline(Admin::Editions::HistoryModeFormControl.new(edition:, current_user: create(:gds_editor)))
+
+    assert_selector "select#edition_political[name='edition[government_id]']"
+    governments.each do |government|
+      assert_selector "select#edition_political[name='edition[government_id]'] option[value='#{government.id}']"
+    end
+  end
+
+  test "displays selected government when edition is associated with government" do
+    government = create(:current_government)
+    previous_edition = create(:published_news_article)
+    edition = create(:draft_news_article, document: previous_edition.document, government:)
+
+    render_inline(Admin::Editions::HistoryModeFormControl.new(edition:, current_user: create(:gds_editor)))
+
+    assert_selector "select#edition_political[name='edition[government_id]']"
+    assert_selector "select#edition_political[name='edition[government_id]'] option[value='#{government.id}'][selected='selected']"
+  end
+
+  test "renders political checkbox and hidden default input when user does not have permission to override government" do
+    create(:current_government)
+    previous_edition = create(:published_news_article)
+    edition = create(:draft_news_article, document: previous_edition.document)
+
+    render_inline(Admin::Editions::HistoryModeFormControl.new(edition:, current_user: create(:managing_editor)))
+
+    assert_selector "input[type='hidden'][name='edition[government_id]'][value='']", { visible: false }
+    assert_selector "#edition_political input[type='checkbox']"
+  end
+
+  test "sets political checkbox value to edition's default government ID when it doesn't have an associated government" do
+    create(:government, start_date: 3.years.ago, end_date: 1.year.ago)
+    previous_edition = create(:published_news_article)
+    edition = create(:draft_news_article, document: previous_edition.document, first_published_at: 2.years.ago)
+
+    render_inline(Admin::Editions::HistoryModeFormControl.new(edition:, current_user: create(:managing_editor)))
+
+    assert_selector "#edition_political input[type='checkbox'][value='#{edition.default_government.id}']"
+  end
+
+  test "checks box and sets value to associated government ID when edition has associated government" do
+    government = create(:government, start_date: 3.years.ago, end_date: 1.year.ago)
+    previous_edition = create(:published_news_article)
+    edition = create(:draft_news_article, document: previous_edition.document, government:)
+
+    render_inline(Admin::Editions::HistoryModeFormControl.new(edition:, current_user: create(:managing_editor)))
+
+    assert_selector "#edition_political input[type='checkbox'][value='#{edition.government.id}'][checked='checked']"
+  end
+end

--- a/test/functional/admin/generic_editions_controller_tests/political_document_test.rb
+++ b/test/functional/admin/generic_editions_controller_tests/political_document_test.rb
@@ -2,18 +2,31 @@ require "test_helper"
 
 class Admin::GenericEditionsController::PolticalDocumentsTest < ActionController::TestCase
   tests Admin::NewsArticlesController
+  enable_url_helpers
 
   setup do
     login_as :writer
   end
 
-  view_test "displays the political checkbox for privileged users " do
-    create(:current_government)
+  view_test "displays the history mode form control for managing editor users" do
+    current_government = create(:current_government)
     login_as :managing_editor
     published_edition = create(:published_news_article, first_published_at: 2.days.ago)
     new_draft = create(:news_article, document: published_edition.document, first_published_at: 2.days.ago)
     get :edit, params: { id: new_draft }
-    assert_select "#edition_political"
+    assert_select "#edition_political input[type='checkbox'][name='edition[government_id]'][value='#{current_government.id}']"
+  end
+
+  test "gds editors can override the government associated with an edition" do
+    current_government = create(:current_government)
+    previous_government = create(:previous_government)
+    published_edition = create(:published_news_article, first_published_at: 2.days.ago, government: current_government)
+    new_draft = create(:news_article, document: published_edition.document, first_published_at: 2.days.ago)
+
+    put :update, params: { id: new_draft, edition: { government_id: previous_government.id } }
+
+    assert_redirected_to admin_edition_path(new_draft)
+    assert_equal previous_government, new_draft.reload.government
   end
 
   view_test "doesn't display the political checkbox for non-privileged users " do
@@ -30,11 +43,11 @@ class Admin::GenericEditionsController::PolticalDocumentsTest < ActionController
   end
 
   def edit_historic_document
-    create(:previous_government, name: "old")
+    previous_government = create(:previous_government, name: "old")
     create(:current_government, name: "new")
 
     published_edition = create(:published_news_article, first_published_at: 3.years.ago)
-    new_draft = create(:news_article, political: true, first_published_at: 3.years.ago, document: published_edition.document)
+    new_draft = create(:news_article, government: previous_government, first_published_at: 3.years.ago, document: published_edition.document)
 
     get :edit, params: { id: new_draft }
   end

--- a/test/integration/attachment_replacement_integration_test.rb
+++ b/test/integration/attachment_replacement_integration_test.rb
@@ -18,6 +18,7 @@ class AttachmentReplacementIntegrationTest < ActionDispatch::IntegrationTest
 
     before do
       login_as(managing_editor)
+      create(:current_government)
       edition.attachments << attachment
 
       setup_publishing_api_for(edition)

--- a/test/unit/app/models/call_for_evidence_test.rb
+++ b/test/unit/app/models/call_for_evidence_test.rb
@@ -379,14 +379,6 @@ class CallForEvidenceTest < ActiveSupport::TestCase
     assert call_for_evidence_with_command_paper_outcome.search_index[:has_act_paper]
   end
 
-  test "#government returns the government active on the first_public_at date" do
-    create(:current_government)
-    previous_government = create(:previous_government)
-    call_for_evidence = create(:call_for_evidence, first_published_at: 4.years.ago)
-
-    assert_equal previous_government, call_for_evidence.government
-  end
-
   test "#save triggers call for evidence opening in the future to be republished twice" do
     opening_at = 2.days.from_now
     closing_at = 3.days.from_now

--- a/test/unit/app/models/consultation_test.rb
+++ b/test/unit/app/models/consultation_test.rb
@@ -419,14 +419,6 @@ class ConsultationTest < ActiveSupport::TestCase
     assert consultation_with_command_paper_outcome.search_index[:has_act_paper]
   end
 
-  test "#government returns the government active on the first_public_at date" do
-    create(:current_government)
-    previous_government = create(:previous_government)
-    consultation = create(:consultation, first_published_at: 4.years.ago)
-
-    assert_equal previous_government, consultation.government
-  end
-
   test "#save triggers consultation opening in the future to be republished twice" do
     opening_at = 2.days.from_now
     closing_at = 3.days.from_now

--- a/test/unit/app/models/speech_test.rb
+++ b/test/unit/app/models/speech_test.rb
@@ -174,26 +174,6 @@ class SpeechTest < ActiveSupport::TestCase
     assert_not build(:speech, primary_locale: :es).translatable?
   end
 
-  test "#government returns the government active on the delivered_on date" do
-    create(:current_government)
-    previous_government = create(:previous_government)
-    speech = create(:speech, first_published_at: 1.day.ago, delivered_on: 4.years.ago)
-
-    assert_equal previous_government, speech.government
-  end
-
-  test "#government returns the current government for an speech delivered at an unspecified time" do
-    current_government = create(:current_government)
-    speech = create(:deleted_speech, delivered_on: nil)
-    assert_equal current_government, speech.government
-  end
-
-  test "#government returns the current government for an speech in the future" do
-    current_government = create(:current_government)
-    speech = create(:speech, delivered_on: 2.weeks.from_now)
-    assert_equal current_government, speech.government
-  end
-
   test "Speech is rendered by government-frontend" do
     assert_equal Speech.new.rendering_app, Whitehall::RenderingApp::GOVERNMENT_FRONTEND
   end

--- a/test/unit/app/presenters/publishing_api/detailed_guide_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/detailed_guide_presenter_test.rb
@@ -144,7 +144,7 @@ class PublishingApi::DetailedGuidePresenterTest < ActiveSupport::TestCase
       title: "Some detailed guide",
       summary: "Some summary",
       body: "Some content",
-      political: true,
+      government:,
     )
 
     presented_item = present(detailed_guide)

--- a/test/unit/app/presenters/publishing_api/document_collection_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/document_collection_presenter_test.rb
@@ -2,12 +2,13 @@ require "test_helper"
 
 class PublishingApi::DocumentCollectionPresenterTest < ActiveSupport::TestCase
   setup do
-    create(:current_government)
+    government = create(:current_government)
 
     @document_collection = create(
       :document_collection,
       title: "Document Collection title",
       summary: "Document Collection summary",
+      government:,
     )
 
     @presented_document_collection = PublishingApi::DocumentCollectionPresenter.new(@document_collection)
@@ -320,68 +321,6 @@ class PublishingApi::DocumentCollectionPresenterUpdateTypeArgumentTest < ActiveS
 
   test "presents based on the supplied update type argument" do
     assert_equal "major", @presented_document_collection.update_type
-  end
-end
-
-class PublishingApi::DocumentCollectionPresenterCurrentGovernmentTest < ActiveSupport::TestCase
-  setup do
-    # Goverments are not explicitly associated with an Edition.
-    # The Government is determined based on date of publication.
-    @current_government = create(
-      :current_government,
-      name: "The Current Government",
-      slug: "the-current-government",
-    )
-    @presented_document_collection = PublishingApi::DocumentCollectionPresenter.new(
-      create(:document_collection),
-    )
-  end
-
-  test "presents a current government" do
-    assert_equal(
-      @current_government.content_id,
-      @presented_document_collection.links.dig(:government, 0),
-    )
-  end
-end
-
-class PublishingApi::DocumentCollectionPresenterPreviousGovernmentTest < ActiveSupport::TestCase
-  setup do
-    # Goverments are not explicitly associated with an Edition.
-    # The Government is determined based on date of publication.
-    create(:current_government)
-    @previous_government = create(
-      :previous_government,
-      name: "A Previous Government",
-      slug: "a-previous-government",
-    )
-    @presented_document_collection = PublishingApi::DocumentCollectionPresenter.new(
-      create(
-        :document_collection,
-        first_published_at: @previous_government.start_date + 1.day,
-      ),
-    )
-  end
-
-  test "presents a previous government" do
-    assert_equal(
-      @previous_government.content_id,
-      @presented_document_collection.links.dig(:government, 0),
-    )
-  end
-end
-
-class PublishingApi::DocumentCollectionPresenterPoliticalTest < ActiveSupport::TestCase
-  setup do
-    document_collection = create(:document_collection)
-    document_collection.stubs(:political?).returns(true)
-    @presented_document_collection = PublishingApi::DocumentCollectionPresenter.new(
-      document_collection,
-    )
-  end
-
-  test "presents political" do
-    assert @presented_document_collection.content[:details][:political]
   end
 end
 

--- a/test/unit/app/presenters/publishing_api/html_attachment_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/html_attachment_presenter_test.rb
@@ -11,7 +11,7 @@ class PublishingApi::HtmlAttachmentPresenterTest < ActiveSupport::TestCase
       :publication,
       :with_html_attachment,
       :published,
-      political: true,
+      government:,
       images: [build(:image)],
     )
 

--- a/test/unit/app/presenters/publishing_api/payload_builder/links_test.rb
+++ b/test/unit/app/presenters/publishing_api/payload_builder/links_test.rb
@@ -81,4 +81,18 @@ class PublishingApi::PayloadBuilder::LinksTest < ActionView::TestCase
       links,
     )
   end
+
+  test "includes a link to an associated government if one is present" do
+    government = create(:government)
+    edition = create(:published_news_article, government:)
+    links = links_for(edition, [:government])
+    assert_equal [government.content_id], links[:government]
+  end
+
+  test "includes a link to the edition's default government if no government is associated with the edition" do
+    government = create(:government, start_date: 4.weeks.ago, end_date: 2.weeks.ago)
+    edition = create(:published_news_article, first_published_at: 3.weeks.ago)
+    links = links_for(edition, [:government])
+    assert_equal [government.content_id], links[:government]
+  end
 end

--- a/test/unit/app/presenters/publishing_api/publication_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/publication_presenter_test.rb
@@ -55,7 +55,7 @@ class PublishingApi::PublicationPresenterTest < ActiveSupport::TestCase
     topical_event = create(:topical_event)
     publication.topical_event_memberships.create!(topical_event_id: topical_event.id)
     expected_links = {
-      government: [publication.government.content_id],
+      government: [publication.default_government.content_id],
       primary_publishing_organisation: publication.lead_organisations.map(&:content_id),
       original_primary_publishing_organisation: publication.lead_organisations.map(&:content_id),
       organisations: publication.lead_organisations.map(&:content_id),

--- a/test/unit/app/presenters/publishing_api/speech_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/speech_presenter_test.rb
@@ -49,6 +49,7 @@ class PublishingApi::SpeechPresenterTest < ActiveSupport::TestCase
           body: "# Woo!\nSome content",
           role_appointment:,
           location: "A location",
+          government: @current_government,
         )
       end
 
@@ -69,7 +70,7 @@ class PublishingApi::SpeechPresenterTest < ActiveSupport::TestCase
         assert_equal([speech.auth_bypass_id], presented.content[:auth_bypass_ids])
 
         details = presented.content[:details]
-        assert_not(details[:political])
+        assert(details[:political])
         assert_equal(expected_body, details[:body])
         assert_match(iso8601_regex, details[:delivered_on])
         assert_match("A location", details[:location])

--- a/test/unit/app/presenters/publishing_api/statistical_data_set_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/statistical_data_set_presenter_test.rb
@@ -212,39 +212,13 @@ class PublishingApi::StatisticalDataSetPresenterCurrentGovernmentTest < ActiveSu
       slug: "the-current-government",
     )
     @presented_statistical_data_set = PublishingApi::StatisticalDataSetPresenter.new(
-      create(:statistical_data_set),
+      create(:statistical_data_set, government: @current_government),
     )
   end
 
   test "presents a current government" do
     assert_equal(
       @current_government.content_id,
-      @presented_statistical_data_set.links.dig(:government, 0),
-    )
-  end
-end
-
-class PublishingApi::StatisticalDataSetPresenterPreviousGovernmentTest < ActiveSupport::TestCase
-  setup do
-    # Goverments are not explicitly associated with an Edition.
-    # The Government is determined based on date of publication.
-    create(:current_government)
-    @previous_government = create(
-      :previous_government,
-      name: "A Previous Government",
-      slug: "a-previous-government",
-    )
-    @presented_statistical_data_set = PublishingApi::StatisticalDataSetPresenter.new(
-      create(
-        :statistical_data_set,
-        first_published_at: @previous_government.start_date + 1.day,
-      ),
-    )
-  end
-
-  test "presents a previous government" do
-    assert_equal(
-      @previous_government.content_id,
       @presented_statistical_data_set.links.dig(:government, 0),
     )
   end

--- a/test/unit/app/services/edition_publisher_test.rb
+++ b/test/unit/app/services/edition_publisher_test.rb
@@ -127,6 +127,7 @@ class EditionPublisherTest < ActiveSupport::TestCase
   end
 
   test "#perform! sets political flag for political content on first publish" do
+    create(:government, start_date: 1.week.ago)
     edition = create(:submitted_edition)
 
     assert_not edition.political?
@@ -172,6 +173,7 @@ class EditionPublisherTest < ActiveSupport::TestCase
   end
 
   test "#perform! sets a political flag on political content that has a first_published_at set" do
+    create(:government, start_date: 4.weeks.ago)
     edition = create(:submitted_edition, first_published_at: 3.weeks.ago)
 
     assert_not edition.political?

--- a/test/unit/lib/tasks/attachments/republish_historically_political_html_attachments_test.rb
+++ b/test/unit/lib/tasks/attachments/republish_historically_political_html_attachments_test.rb
@@ -2,22 +2,22 @@ require "test_helper"
 require "rake"
 class RepublishHistoricallyPoliticalHtmlAttachmentsRake < ActiveSupport::TestCase
   test "it republishes documents with historically political HtmlAttachments" do
-    create(:government, start_date: 5.years.ago, end_date: 1.year.ago - 1.day)
-    create(:government, start_date: 1.year.ago)
+    previous_government = create(:government, start_date: 5.years.ago, end_date: 1.year.ago - 1.day)
+    current_government = create(:government, start_date: 1.year.ago)
 
     historically_political_edition = create(
       :edition,
       :with_document,
       :published,
       first_published_at: 2.years.ago,
-      political: true,
+      government: previous_government,
     )
     political_edition = create(
       :edition,
       :with_document,
       :published,
       first_published_at: 1.month.ago,
-      political: true,
+      government: current_government,
     )
 
     historical_edition = create(
@@ -25,7 +25,6 @@ class RepublishHistoricallyPoliticalHtmlAttachmentsRake < ActiveSupport::TestCas
       :with_document,
       :published,
       first_published_at: 5.years.ago,
-      political: false,
     )
 
     unpublished_historically_political_edition = create(
@@ -33,7 +32,6 @@ class RepublishHistoricallyPoliticalHtmlAttachmentsRake < ActiveSupport::TestCas
       :with_document,
       :unpublished,
       first_published_at: 5.years.ago,
-      political: true,
     )
 
     create(:html_attachment, attachable: historically_political_edition)

--- a/test/unit/lib/whitehall/authority/gds_editor_test.rb
+++ b/test/unit/lib/whitehall/authority/gds_editor_test.rb
@@ -194,4 +194,8 @@ class GDSEditorTest < ActiveSupport::TestCase
   test "can modify historic editions" do
     assert enforcer_for(gds_editor, historic_edition).can?(:modify)
   end
+
+  test "can select government for editions" do
+    assert enforcer_for(gds_editor, normal_edition).can?(:select_government)
+  end
 end

--- a/test/unit/lib/whitehall/authority/managing_editor_test.rb
+++ b/test/unit/lib/whitehall/authority/managing_editor_test.rb
@@ -201,4 +201,12 @@ class ManagingEditorTest < ActiveSupport::TestCase
   test "cannot publish historic editions" do
     assert_not enforcer_for(managing_editor, historic_edition).can?(:publish)
   end
+
+  test "cannot select government for editions" do
+    assert_not enforcer_for(managing_editor, normal_edition).can?(:select_government)
+  end
+
+  test "cannot select government for historic editions" do
+    assert_not enforcer_for(managing_editor, historic_edition).can?(:select_government)
+  end
 end


### PR DESCRIPTION
I should have used a feature flag for this so that I could deploy it in small pieces, but I didn't anticipate this requiring me to touch anywhere near the number of files that I have. The code changes were not that substantial but the number of tests that broke was enormous, which perhaps suggests we're testing some aspects of the codebase at the wrong level.

## Major Changes

Currently, Whitehall infers a relationship between editions and governments using the political boolean attribute and a date relating to the edition (usually first edition publishing date).

This means that it isn't possible for content editors to override the government in the event that a piece of content should actually relate to a different government. This is a common situation where content has been published during the days after an election.

This PR makes the government a real association of a document edition, and allows GDS editors to set the value of the association in the edition form using a select element.

## Other Considerations

It also preserves the previous behaviour of setting the initial political status at the time of the publication of the first edition based on the appropriate date attribute for each edition. In this case we select the government that was in power on the specified date. Any edition with a government association is considered to be political.

We preserve the behaviour of sending a government link for each edition to Publishing API regardless of whether or not the edition is political. We use the default government for each edition to do that if no government is set.

## Migration

I have chosen to add a foreign key index on the new `government_id` column as I expect around election time we will want to query all of the editions associated with a particular government, which would be very slow otherwise.

There is also a data migration required here. The data migration affects approx 125,000 editions (I have excluded superseded editions as they will never appear on GOV.UK again). The data migration took approximately 5 minutes to run on integration, so I think this seems reasonable to run in production.

## Follow Up

Once this has been deployed and is running well in production, I will write a migration to drop the political column on the editions table.

I also want to refactor the history mode and government behaviour on the edition model into a concern. This should include an appropriate scope for political and non-political editions to improve readability. I will create separate PRs for these.

I also need to update the History Mode docs in Whitehall!

## Screenshot

![Screenshot 2024-08-13 at 17 09 00](https://github.com/user-attachments/assets/3ad9c0ec-b5ed-43af-96e8-1e2c81654323)

Trello: https://trello.com/c/II8jgMR7
