### PR TITLE
Content modelling/364: Review changes (Links)

### DIFF
--- a/lib/engines/content_object_store/app/components/content_object_store/content_block/document/show/linked_editions_table_component.html.erb
+++ b/lib/engines/content_object_store/app/components/content_object_store/content_block/document/show/linked_editions_table_component.html.erb
@@ -1,3 +1,7 @@
+
+<!-- TODO: The prototype wants to show a counter beneath the title but
+before the table, the existing component doesn't support that so I've left
+it out for now-->
 <%= render "govuk_publishing_components/components/table", {
   caption:,
   caption_classes: "govuk-heading-l",
@@ -14,3 +18,17 @@
   ],
   rows:,
 } %>
+
+<% if @page_data.total_pages > 1 %>
+  <% Admin::PaginationHelper.pagination_hash(
+    current_page: @page_data.current_page.to_i,
+    total_pages: @page_data.total_pages.to_i,
+    path: @page_path,
+  ).tap do |hash| %>
+    <%= render "components/pagination", {
+      previous_href: hash[:previous_href],
+      next_href: hash[:next_href],
+      items: hash[:items],
+    } %>
+  <% end %>
+<% end %>

--- a/lib/engines/content_object_store/app/components/content_object_store/content_block/document/show/linked_editions_table_component.rb
+++ b/lib/engines/content_object_store/app/components/content_object_store/content_block/document/show/linked_editions_table_component.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
 class ContentObjectStore::ContentBlock::Document::Show::LinkedEditionsTableComponent < ViewComponent::Base
-  def initialize(caption:, linked_content_items:)
+  def initialize(caption:, linked_content_items:, page_data:, page_path:)
     @caption = caption
     @linked_content_items = linked_content_items
+    @page_data = page_data
+    @page_path = page_path
   end
 
 private

--- a/lib/engines/content_object_store/app/components/content_object_store/content_block/document/show/summary_list_component.rb
+++ b/lib/engines/content_object_store/app/components/content_object_store/content_block/document/show/summary_list_component.rb
@@ -59,7 +59,7 @@ private
 
   def edit_action
     {
-      href: helpers.content_object_store.edit_content_object_store_content_block_edition_path(content_block_document.latest_edition),
+      href: helpers.content_object_store.edit_content_object_store_content_block_edition_path(content_block_document.latest_edition, step: ContentObjectStore::ContentBlock::EditionsController::EDIT_FORM_STEPS[:edit_block]),
       link_text: "Change",
     }
   end

--- a/lib/engines/content_object_store/app/controllers/content_object_store/content_block/editions_controller.rb
+++ b/lib/engines/content_object_store/app/controllers/content_object_store/content_block/editions_controller.rb
@@ -27,19 +27,32 @@ class ContentObjectStore::ContentBlock::EditionsController < ContentObjectStore:
     @content_block_edition = ContentObjectStore::ContentBlock::Edition.find(params[:id])
   end
 
-  def edit
-    content_block_edition = ContentObjectStore::ContentBlock::Edition.find(params[:id])
-    @schema = ContentObjectStore::ContentBlock::Schema.find_by_block_type(content_block_edition.document.block_type)
+  EDIT_FORM_STEPS = {
+    edit_block: "edit_block",
+    review_links: "review_links",
+  }.freeze
 
+  def edit
+    step = params[:step]
+    @content_block_edition = ContentObjectStore::ContentBlock::Edition.find(params[:id])
+    @schema = ContentObjectStore::ContentBlock::Schema.find_by_block_type(@content_block_edition.document.block_type)
+
+    case step
+    when EDIT_FORM_STEPS[:edit_block]
+      edit_block
+    when EDIT_FORM_STEPS[:review_links]
+      review_links
+    end
+  end
+
+  def edit_block
     @form = ContentObjectStore::ContentBlock::EditionForm::Update.new(
-      content_block_edition:, schema: @schema, edition_to_update_id: content_block_edition.id,
+      content_block_edition: @content_block_edition, schema: @schema, edition_to_update_id: @content_block_edition.id,
     )
   end
 
   def review_links
-    @content_block_edition = ContentObjectStore::ContentBlock::Edition.find(params[:id])
     @content_block_document = @content_block_edition.document
-    @schema = ContentObjectStore::ContentBlock::Schema.find_by_block_type(@content_block_edition.document.block_type)
     @edition_params = edition_params
 
     new_edition = ContentObjectStore::ContentBlock::Edition.new(@edition_params)
@@ -53,6 +66,8 @@ class ContentObjectStore::ContentBlock::EditionsController < ContentObjectStore:
 
       @linked_content_items = linked_item_service.items
       @page_data = linked_item_service.page_data
+
+      render :review_links
     else
       @form = ContentObjectStore::ContentBlock::EditionForm::Update.new(
         content_block_edition: new_edition,

--- a/lib/engines/content_object_store/app/forms/content_object_store/content_block/edition_form.rb
+++ b/lib/engines/content_object_store/app/forms/content_object_store/content_block/edition_form.rb
@@ -4,7 +4,7 @@
 class ContentObjectStore::ContentBlock::EditionForm
   include ContentObjectStore::Engine.routes.url_helpers
 
-  attr_reader :content_block_edition, :schema
+  attr_reader :content_block_edition, :schema, :url
 
   def initialize(content_block_edition:, schema:)
     @content_block_edition = content_block_edition
@@ -12,6 +12,10 @@ class ContentObjectStore::ContentBlock::EditionForm
   end
 
   class Create < ContentObjectStore::ContentBlock::EditionForm
+    def url
+      content_object_store_content_block_editions_path
+    end
+
     def attributes
       @schema.fields.each_with_object({}) do |field, hash|
         hash[field] = nil
@@ -25,6 +29,10 @@ class ContentObjectStore::ContentBlock::EditionForm
   end
 
   class Update < ContentObjectStore::ContentBlock::EditionForm
+    def url
+      review_links_content_object_store_content_block_edition_path(id: @content_block_edition.id)
+    end
+
     def attributes
       @content_block_edition.details
     end

--- a/lib/engines/content_object_store/app/forms/content_object_store/content_block/edition_form.rb
+++ b/lib/engines/content_object_store/app/forms/content_object_store/content_block/edition_form.rb
@@ -35,7 +35,7 @@ class ContentObjectStore::ContentBlock::EditionForm
     end
 
     def url
-      review_links_content_object_store_content_block_edition_path(id: @edition_to_update_id)
+      edit_content_object_store_content_block_edition_path(id: @edition_to_update_id, step: ContentObjectStore::ContentBlock::EditionsController::EDIT_FORM_STEPS[:review_links])
     end
 
     def attributes

--- a/lib/engines/content_object_store/app/forms/content_object_store/content_block/edition_form.rb
+++ b/lib/engines/content_object_store/app/forms/content_object_store/content_block/edition_form.rb
@@ -29,8 +29,13 @@ class ContentObjectStore::ContentBlock::EditionForm
   end
 
   class Update < ContentObjectStore::ContentBlock::EditionForm
+    def initialize(edition_to_update_id:, **args)
+      @edition_to_update_id = edition_to_update_id
+      super(**args)
+    end
+
     def url
-      review_links_content_object_store_content_block_edition_path(id: @content_block_edition.id)
+      review_links_content_object_store_content_block_edition_path(id: @edition_to_update_id)
     end
 
     def attributes

--- a/lib/engines/content_object_store/app/views/content_object_store/content_block/documents/show.html.erb
+++ b/lib/engines/content_object_store/app/views/content_object_store/content_block/documents/show.html.erb
@@ -14,25 +14,14 @@
 
 <div class="govuk-grid-row govuk-!-padding-top-8">
   <div class="govuk-grid-column-full">
-    <!-- TODO: The prototype wants to show a counter beneath the title but
-    before the table, the existing component doesn't support that so I've left
-    it out for now-->
     <%= render(
       ContentObjectStore::ContentBlock::Document::Show::LinkedEditionsTableComponent.new(
         caption: "Content appears in",
         linked_content_items: @linked_content_items,
+        page_data: @page_data,
+        page_path: request.url,
       ),
     ) %>
-
-    <% if @page_data.total_pages > 1 %>
-      <% Admin::PaginationHelper.pagination_hash(current_page: @page_data.current_page.to_i, total_pages: @page_data.total_pages.to_i, path: request.url).tap do |hash| %>
-        <%= render "components/pagination", {
-          previous_href: hash[:previous_href],
-          next_href: hash[:next_href],
-          items: hash[:items],
-        } %>
-      <% end %>
-    <% end %>
   </div>
 </div>
 

--- a/lib/engines/content_object_store/app/views/content_object_store/content_block/editions/_form.html.erb
+++ b/lib/engines/content_object_store/app/views/content_object_store/content_block/editions/_form.html.erb
@@ -39,7 +39,7 @@
       {
         text: name,
         value: id,
-        selected: id == @form.content_block_edition.lead_organisation&.id,
+        selected: id == @form.content_block_edition.edition_organisation&.organisation_id,
       }
     end,
     error_message: errors_for_input(@form.content_block_edition.errors, "lead_organisation".to_sym),

--- a/lib/engines/content_object_store/app/views/content_object_store/content_block/editions/_form.html.erb
+++ b/lib/engines/content_object_store/app/views/content_object_store/content_block/editions/_form.html.erb
@@ -1,6 +1,9 @@
 <% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @form.content_block_edition)) %>
 
-<%= form_for [content_object_store, @form.content_block_edition] do |f| %>
+<%= form_with(
+      url: @form.url,
+      method: :post,
+      model: [content_object_store, @form.content_block_edition]) do |f| %>
   <%= hidden_field_tag "content_block_edition[document_attributes][block_type]",
     @form.schema.block_type,
     id: "content_object_store/content_block_edition_document_block_type" %>

--- a/lib/engines/content_object_store/app/views/content_object_store/content_block/editions/review_links.html.erb
+++ b/lib/engines/content_object_store/app/views/content_object_store/content_block/editions/review_links.html.erb
@@ -1,0 +1,44 @@
+<% content_for :context, "Manage #{add_indefinite_article @content_block_document.block_type.humanize}" %>
+<% content_for :title, "Where the change will appear" %>
+<% content_for :title_margin_bottom, 4 %>
+<% content_for :back_link do %>
+  <%= render "govuk_publishing_components/components/back_link", {
+    href: content_object_store.edit_content_object_store_content_block_edition_path(@content_block_edition),
+  } %>
+<% end %>
+
+<p class="govuk-body">The new <%= @content_block_document.block_type.humanize.downcase %> will appear on the following content after you publish the change.</p>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= render(
+          ContentObjectStore::ContentBlock::Document::Show::LinkedEditionsTableComponent.new(
+            caption: "Content it appears in",
+            linked_content_items: @linked_content_items,
+            page_data: @page_data,
+            page_path: content_object_store.review_links_content_object_store_content_block_edition_path(content_block_edition: @edition_params),
+            ),
+          ) %>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+        <%= form_with(url: content_object_store.content_object_store_content_block_edition_path(content_block_edition: @edition_params), method: :patch) do %>
+          <div class="govuk-button-group govuk-!-margin-bottom-6">
+            <%= render "govuk_publishing_components/components/button", {
+              text: "Accept and publish",
+              name: "accept_and_publish",
+              value: "Accept and publish",
+              type: "submit",
+            } %>
+            <%= link_to("Cancel", content_object_store.content_object_store_content_block_documents_path, class: "govuk-link") %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+
+  </div>
+</div>

--- a/lib/engines/content_object_store/app/views/content_object_store/content_block/editions/review_links.html.erb
+++ b/lib/engines/content_object_store/app/views/content_object_store/content_block/editions/review_links.html.erb
@@ -3,7 +3,7 @@
 <% content_for :title_margin_bottom, 4 %>
 <% content_for :back_link do %>
   <%= render "govuk_publishing_components/components/back_link", {
-    href: content_object_store.edit_content_object_store_content_block_edition_path(@content_block_edition),
+    href: content_object_store.edit_content_object_store_content_block_edition_path(@content_block_edition, step: ContentObjectStore::ContentBlock::EditionsController::EDIT_FORM_STEPS[:edit_block]),
   } %>
 <% end %>
 
@@ -16,7 +16,7 @@
             caption: "Content it appears in",
             linked_content_items: @linked_content_items,
             page_data: @page_data,
-            page_path: content_object_store.review_links_content_object_store_content_block_edition_path(content_block_edition: @edition_params),
+            page_path: content_object_store.edit_content_object_store_content_block_edition_path(content_block_edition: @edition_params, step: ContentObjectStore::ContentBlock::EditionsController::EDIT_FORM_STEPS[:review_links]),
             ),
           ) %>
   </div>

--- a/lib/engines/content_object_store/config/routes.rb
+++ b/lib/engines/content_object_store/config/routes.rb
@@ -7,6 +7,8 @@ ContentObjectStore::Engine.routes.draw do
       resources :editions, only: %i[new create edit update], path_names: { new: "(:block_type)/new" } do
         member do
           get :review
+          get :review_links
+          post :review_links
           post :publish, to: "workflow#publish"
         end
       end

--- a/lib/engines/content_object_store/config/routes.rb
+++ b/lib/engines/content_object_store/config/routes.rb
@@ -7,9 +7,8 @@ ContentObjectStore::Engine.routes.draw do
       resources :editions, only: %i[new create edit update], path_names: { new: "(:block_type)/new" } do
         member do
           get :review
-          get :review_links
-          post :review_links
           post :publish, to: "workflow#publish"
+          post :edit
         end
       end
     end

--- a/lib/engines/content_object_store/features/edit_object.feature
+++ b/lib/engines/content_object_store/features/edit_object.feature
@@ -3,12 +3,13 @@ Feature: Edit a content object
     Given the content object store feature flag is enabled
     And I am a GDS admin
     And the organisation "Ministry of Example" exists
-
-  Scenario: GDS Editor edits a content object
     And a schema "email_address" exists with the following fields:
       | field         | type   | format | required |
       | email_address | string | email  | true     |
     And an email address content block has been created
+    And dependent content exists for a content block
+
+  Scenario: GDS Editor edits a content object
     When I visit the document object store
     Then I should see the details for all documents
     When I click to view the document
@@ -17,6 +18,9 @@ Feature: Edit a content object
     Then I should see the edit form
     And I should see a back link to the document page
     When I fill out the form
+    Then I am shown where the changes will take place
+    And I should see a back link to the edit page
+    When I continue
     Then the edition should have been updated successfully
     And I should be taken back to the document page
     And I should see the update on the timeline

--- a/lib/engines/content_object_store/features/step_definitions/content_object_store_steps.rb
+++ b/lib/engines/content_object_store/features/step_definitions/content_object_store_steps.rb
@@ -67,6 +67,13 @@ Then("I should see a back link to the show page") do
   expect(page).to have_link("Back", href: content_object_store.content_object_store_content_block_edition_path(id))
 end
 
+Then("I should see a back link to the edit page") do
+  expect(page).to have_link(
+    "Back",
+    href: content_object_store.edit_content_object_store_content_block_edition_path(@content_block),
+  )
+end
+
 When("I complete the form with the following fields:") do |table|
   fields = table.hashes.first
   @title = fields.delete("title")
@@ -292,4 +299,19 @@ end
 
 Then(/^I should see an error prompting me to choose an object type$/) do
   assert_text "You must select a block type"
+end
+
+Then(/^I am shown where the changes will take place$/) do
+  expect(page).to have_selector("h1", text: "Where the change will appear")
+
+  @dependent_content.each do |item|
+    assert_text item[:title]
+    break if item == @dependent_content.last
+
+    click_on "Next"
+  end
+end
+
+When(/^I continue$/) do
+  click_on "Accept and publish"
 end

--- a/lib/engines/content_object_store/features/step_definitions/content_object_store_steps.rb
+++ b/lib/engines/content_object_store/features/step_definitions/content_object_store_steps.rb
@@ -70,7 +70,7 @@ end
 Then("I should see a back link to the edit page") do
   expect(page).to have_link(
     "Back",
-    href: content_object_store.edit_content_object_store_content_block_edition_path(@content_block),
+    href: content_object_store.edit_content_object_store_content_block_edition_path(@content_block, step: ContentObjectStore::ContentBlock::EditionsController::EDIT_FORM_STEPS[:edit_block]),
   )
 end
 
@@ -176,7 +176,7 @@ Then("I should see the details for the email address content block") do
 end
 
 When("I click the first change link") do
-  first_link = find("a[href='#{content_object_store.edit_content_object_store_content_block_edition_path(@content_block)}']", match: :first)
+  first_link = find("a[href='#{content_object_store.edit_content_object_store_content_block_edition_path(@content_block, step: ContentObjectStore::ContentBlock::EditionsController::EDIT_FORM_STEPS[:edit_block])}']", match: :first)
   first_link.click
 end
 

--- a/lib/engines/content_object_store/test/components/content_block/document/show/linked_editions_table_component_test.rb
+++ b/lib/engines/content_object_store/test/components/content_block/document/show/linked_editions_table_component_test.rb
@@ -3,17 +3,23 @@ require "test_helper"
 class ContentObjectStore::ContentBlock::Document::Show::LinkedEditionsTableComponentTest < ViewComponent::TestCase
   extend Minitest::Spec::DSL
 
+  PageData = Data.define(:total_items, :total_pages, :current_page)
+
   it "renders linked editions with an organisation" do
     caption = "Some caption"
     organisation = build(:organisation, id: 123)
     linked_content_items = [
       ContentObjectStore::ContentItem.new(title: "Some title", base_path: "/foo", document_type: "document_type", organisation:),
     ]
+    page_data = PageData.new(total_items: 0, total_pages: 0, current_page: 0)
+    page_path = "/some-path"
 
     render_inline(
       ContentObjectStore::ContentBlock::Document::Show::LinkedEditionsTableComponent.new(
         caption:,
         linked_content_items:,
+        page_data:,
+        page_path:,
       ),
     )
 
@@ -31,11 +37,15 @@ class ContentObjectStore::ContentBlock::Document::Show::LinkedEditionsTableCompo
     linked_content_items = [
       ContentObjectStore::ContentItem.new(title: "Some title", base_path: "/foo", document_type: "document_type", organisation: nil),
     ]
+    page_data = PageData.new(total_items: 0, total_pages: 0, current_page: 0)
+    page_path = "/some-path"
 
     render_inline(
       ContentObjectStore::ContentBlock::Document::Show::LinkedEditionsTableComponent.new(
         caption:,
         linked_content_items:,
+        page_data:,
+        page_path:,
       ),
     )
 
@@ -46,5 +56,46 @@ class ContentObjectStore::ContentBlock::Document::Show::LinkedEditionsTableCompo
     assert_selector "tbody .govuk-table__cell", text: linked_content_items[0].title
     assert_selector "tbody .govuk-table__cell", text: linked_content_items[0].document_type.humanize
     assert_selector "tbody .govuk-table__cell", text: "Not set"
+  end
+
+  it "doesn't render the pagination when there are no pages" do
+    caption = "Some caption"
+    linked_content_items = [
+      ContentObjectStore::ContentItem.new(title: "Some title", base_path: "/foo", document_type: "document_type", organisation: nil),
+    ]
+    page_data = PageData.new(total_items: 0, total_pages: 0, current_page: 0)
+    page_path = "/some-path"
+
+    render_inline(
+      ContentObjectStore::ContentBlock::Document::Show::LinkedEditionsTableComponent.new(
+        caption:,
+        linked_content_items:,
+        page_data:,
+        page_path:,
+      ),
+    )
+
+    assert_no_css ".govuk-pagination"
+  end
+
+  it "renders the pagination with correct path when there are pages" do
+    caption = "Some caption"
+    linked_content_items = [
+      ContentObjectStore::ContentItem.new(title: "Some title", base_path: "/foo", document_type: "document_type", organisation: nil),
+    ]
+    page_data = PageData.new(total_items: 30, total_pages: 3, current_page: 0)
+    page_path = "/some-path"
+
+    render_inline(
+      ContentObjectStore::ContentBlock::Document::Show::LinkedEditionsTableComponent.new(
+        caption:,
+        linked_content_items:,
+        page_data:,
+        page_path:,
+      ),
+    )
+
+    assert_selector ".govuk-pagination"
+    assert_selector "a[href='#{page_path}?page=1']"
   end
 end

--- a/lib/engines/content_object_store/test/unit/app/forms/content_object_store/content_block/edition_form_test.rb
+++ b/lib/engines/content_object_store/test/unit/app/forms/content_object_store/content_block/edition_form_test.rb
@@ -31,6 +31,7 @@ class ContentObjectStore::ContentBlock::EditionFormTest < ActiveSupport::TestCas
       result = ContentObjectStore::ContentBlock::EditionForm::Update.new(
         content_block_edition:,
         schema:,
+        edition_to_update_id: content_block_edition.id,
       )
 
       assert_equal content_block_edition, result.content_block_edition

--- a/lib/engines/content_object_store/test/unit/app/forms/content_object_store/content_block/edition_form_test.rb
+++ b/lib/engines/content_object_store/test/unit/app/forms/content_object_store/content_block/edition_form_test.rb
@@ -20,6 +20,7 @@ class ContentObjectStore::ContentBlock::EditionFormTest < ActiveSupport::TestCas
       assert_equal schema, result.schema
       assert_equal expected_attributes, result.attributes
       assert_equal content_object_store_content_block_documents_path, result.back_path
+      assert_equal content_object_store_content_block_editions_path, result.url
     end
   end
 
@@ -36,6 +37,7 @@ class ContentObjectStore::ContentBlock::EditionFormTest < ActiveSupport::TestCas
       assert_equal schema, result.schema
       assert_equal content_block_edition.details, result.attributes
       assert_equal content_object_store_content_block_document_path(content_block_edition.document), result.back_path
+      assert_equal review_links_content_object_store_content_block_edition_path(id: content_block_edition.id), result.url
     end
   end
 end

--- a/lib/engines/content_object_store/test/unit/app/forms/content_object_store/content_block/edition_form_test.rb
+++ b/lib/engines/content_object_store/test/unit/app/forms/content_object_store/content_block/edition_form_test.rb
@@ -38,7 +38,7 @@ class ContentObjectStore::ContentBlock::EditionFormTest < ActiveSupport::TestCas
       assert_equal schema, result.schema
       assert_equal content_block_edition.details, result.attributes
       assert_equal content_object_store_content_block_document_path(content_block_edition.document), result.back_path
-      assert_equal review_links_content_object_store_content_block_edition_path(id: content_block_edition.id), result.url
+      assert_equal edit_content_object_store_content_block_edition_path(id: content_block_edition.id, step: :review_links), result.url
     end
   end
 end


### PR DESCRIPTION
<img width="1161" alt="Screenshot 2024-08-13 at 17 46 06" src="https://github.com/user-attachments/assets/b46beac3-148b-4cdf-8106-38c7d8ef6cbb">

![Screenshot 2024-08-14 at 11 46 56](https://github.com/user-attachments/assets/cb19184b-e533-4667-a66f-7d9ef619cad4)


When users are editing an Edition/Document, we would like to show users the documents that have embedded that Edition so that users can make an informed decision about the knock-on effects of updating it.

This introduces more custom controller actions for 'interstitial' pages (like `review`) - this an initial solution for a multi-part form - we discussed implementing a form wizard or hand-rolling logic in one action a Controller, and decided to go for the 'dumb' solution for now and iterate when a third step in the form is introduced. (This could be next with Scheduling)

I also have not included:

1. the sort functionality on the table as this would have been added complexity to the PR - I also couldn't find examples of a sortable table in GDS or Whitehall. If we wanted to sort, this could be done in further PR by passing in the `order` param https://github.com/alphagov/publishing-api/blob/main/docs/api.md#get-v2content

2. the checkbox confirmation on the page. This can be done in another PR.
