### PR TITLE
Remove `tool_name` from error summary tracking

### DIFF
--- a/app/components/admin/error_summary_component.rb
+++ b/app/components/admin/error_summary_component.rb
@@ -34,7 +34,6 @@ private
             text: error.full_message.to_s.humanize,
             section: error.attribute.to_s.humanize,
             action: "error",
-            tool_name: "Whitehall",
           }.to_json,
         },
       }

--- a/test/components/admin/error_summary_component_test.rb
+++ b/test/components/admin/error_summary_component_test.rb
@@ -63,7 +63,6 @@ class Admin::ErrorSummaryComponentTest < ViewComponent::TestCase
     assert_equal first_link_data["text"], "Title can't be blank"
     assert_equal first_link_data["section"], "Title"
     assert_equal first_link_data["action"], "error"
-    assert_equal first_link_data["tool_name"], "Whitehall"
 
     assert_equal second_link["data-module"], "ga4-auto-tracker"
     assert_equal second_link_data["event_name"], "form_error"
@@ -71,7 +70,6 @@ class Admin::ErrorSummaryComponentTest < ViewComponent::TestCase
     assert_equal second_link_data["text"], "Date can't be blank"
     assert_equal second_link_data["section"], "Date"
     assert_equal second_link_data["action"], "error"
-    assert_equal second_link_data["tool_name"], "Whitehall"
 
     assert_equal third_link["data-module"], "ga4-auto-tracker"
     assert_equal third_link_data["event_name"], "form_error"
@@ -79,7 +77,6 @@ class Admin::ErrorSummaryComponentTest < ViewComponent::TestCase
     assert_equal third_link_data["text"], "Date is invalid"
     assert_equal third_link_data["section"], "Date"
     assert_equal third_link_data["action"], "error"
-    assert_equal third_link_data["tool_name"], "Whitehall"
   end
 
   test "when an errors attribute is base it renders the error as text not a link" do


### PR DESCRIPTION
Tracking `"Whitehall"` as the tool name wasn't useful so we are removing it.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
