### PR TITLE
Remove edition roles when edition has been deleted.

### DIFF
--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -74,8 +74,6 @@ class Role < ApplicationRecord
 
   def republish_associated_editions_to_publishing_api
     edition_roles.each do |edition_role|
-      next unless edition_role.edition
-
       PublishingApiDocumentRepublishingWorker.perform_async(edition_role.edition.document_id)
     end
   end

--- a/app/services/edition_deleter.rb
+++ b/app/services/edition_deleter.rb
@@ -27,5 +27,6 @@ private
     edition.save!(validate: false)
     edition.clear_slug
     edition.delete_all_attachments if edition.respond_to?(:delete_all_attachments)
+    edition.edition_roles.clear if edition.respond_to?(:edition_roles)
   end
 end

--- a/db/data_migration/202408151644400_remove_orphaned_edition_roles.rb
+++ b/db/data_migration/202408151644400_remove_orphaned_edition_roles.rb
@@ -1,0 +1,7 @@
+# There were some deleted EditionableWorldwideOrganisation records hanging around to the database that were missed during the
+# migration, so we'll clean those up first.
+Edition.unscoped.where(type: "EditionableWorldwideOrganisation").update_all(type: "WorldwideOrganisation")
+
+# Now remove any edition roles for deleted worldwide orgs. The edition roles should have been deleted when the worldwide
+# organisation was deleted.
+WorldwideOrganisation.unscoped.deleted.each { |wo| wo.edition_roles.clear }

--- a/test/unit/app/services/edition_deleter_test.rb
+++ b/test/unit/app/services/edition_deleter_test.rb
@@ -56,4 +56,13 @@ class EditionDeleterTest < ActiveSupport::TestCase
     assert Attachment.find(attachment1.id).deleted?
     assert Attachment.find(attachment2.id).deleted?
   end
+
+  test "#perform! deletes associated edition roles" do
+    roles = create_list(:role, 2)
+    edition = create(:draft_worldwide_organisation, roles:)
+
+    assert EditionDeleter.new(edition).perform!
+    edition.reload
+    assert edition.roles.empty?
+  end
 end


### PR DESCRIPTION
Since worldwide organisations became an edition deleting them has tranistioned them to deleted state instead of deleting them from the database. This means that the destroy dependancy option on the active record edition roles association no longer worked.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
