### PR TITLE
Prevent users from enabling access limiting for documents that are not owned by their organisation

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -112,7 +112,7 @@ class Admin::EditionsController < Admin::BaseController
 
       redirect_to show_or_edit_path, saved_confirmation_notice
     else
-      flash.now[:alert] = "There are some problems with the document"
+      flash.now[:alert] = updater.failure_reason
       build_edition_dependencies
       fetch_version_and_remark_trails
       construct_similar_slug_warning_error
@@ -499,7 +499,7 @@ private
   end
 
   def updater
-    @updater ||= Whitehall.edition_services.draft_updater(@edition)
+    @updater ||= Whitehall.edition_services.draft_updater(@edition, { current_user: })
   end
 
   def publisher

--- a/app/services/draft_edition_updater.rb
+++ b/app/services/draft_edition_updater.rb
@@ -10,6 +10,8 @@ class DraftEditionUpdater < EditionService
   def failure_reason
     if !edition.pre_publication?
       "A #{edition.state} edition may not be updated."
+    elsif edition.access_limited? && @options[:current_user].present? && edition.edition_organisations.map(&:organisation_id).exclude?(@options[:current_user].organisation.id)
+      "Access can only be limited by users belonging to an organisation tagged to the document"
     elsif !edition.valid?
       "This edition is invalid: #{edition.errors.full_messages.to_sentence}"
     end

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -1034,6 +1034,24 @@ module AdminEditionControllerTestHelpers
 
         assert publication.reload.access_limited?
       end
+
+      view_test "access limiting document fails if user does not belong to one of the tagged organisations" do
+        controller.current_user.organisation = create(:organisation)
+        controller.current_user.save!
+        organisation = create(:organisation)
+        edition = create(edition_type, access_limited: false, organisations: [organisation])
+
+        put :update,
+            params: {
+              id: edition,
+              edition: {
+                access_limited: "1",
+              },
+            }
+
+        assert_not edition.reload.access_limited?
+        assert_select "div[role='alert']", text: "Access can only be limited by users belonging to an organisation tagged to the document"
+      end
     end
 
     def should_allow_relevance_to_local_government_of(edition_type)

--- a/test/unit/app/services/draft_edition_updater_test.rb
+++ b/test/unit/app/services/draft_edition_updater_test.rb
@@ -28,4 +28,13 @@ class DraftEditionUpdaterTest < ActiveSupport::TestCase
 
     updater.perform!
   end
+
+  test "cannot perform if user is limiting their own access" do
+    edition = create(:draft_news_article, access_limited: true, organisations: [create(:organisation)])
+    updater = DraftEditionUpdater.new(edition, { current_user: create(:user, organisation: create(:organisation)) })
+    updater.expects(:notify!).never
+    updater.expects(:update_publishing_api!).never
+
+    updater.perform!
+  end
 end


### PR DESCRIPTION
Rather than using conventional validation, we added this check to the edition updater. We did this because the check is contextual based on the request, and the edition would actually be perfectly valid if not for the user associated with the request, so validation .

We also provide a more useful error message for users 🖊️ 

Trello: https://trello.com/c/mqle33Bu
