### PR TITLE
Change department brand class names

### DIFF
--- a/app/models/organisation_brand_colour.rb
+++ b/app/models/organisation_brand_colour.rb
@@ -150,7 +150,7 @@ class OrganisationBrandColour
   DepartmentForBusinessAndTrade = create!(
     id: 29,
     title: "Department for Business & Trade",
-    class_name: "department-for-business-and-trade",
+    class_name: "department-for-business-trade",
   )
   ForeignCommonwealthDevelopmentOffice = create!(
     id: 30,
@@ -175,6 +175,6 @@ class OrganisationBrandColour
   MinistryOfHousingCommunitiesAndLocalGovernment = create!(
     id: 34,
     title: "Ministry of Housing, Communities & Local Government",
-    class_name: "ministry-of-housing-communities-and-local-government",
+    class_name: "ministry-of-housing-communities-local-government",
   )
 end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
Rename two of the department brand class names to match what they will shortly be called in `govuk-frontend`.

- ministry of housing: https://github.com/alphagov/govuk-frontend/blob/main/packages/govuk-frontend/src/govuk/settings/_colours-organisations.scss#L152
- department for business and trade: https://github.com/alphagov/govuk-frontend/blob/main/packages/govuk-frontend/src/govuk/settings/_colours-organisations.scss#L42

We'll be rolling out this change in https://github.com/alphagov/govuk_publishing_components/pull/4160 and will merge and deploy this PR at the appropriate time.

## Why
These class names were updated in `govuk-frontend` between 5.1 (current version in `govuk_publishing_components`) and 5.5 (about to be upgraded to).

## Visual changes
None.

Trello card: https://trello.com/c/l2yxZZ9k/274-upgrade-to-govuk-frontend-55
