### PR TITLE
Fix error caused by some edition types not implementing organisations association

### DIFF
--- a/app/models/concerns/edition/organisations.rb
+++ b/app/models/concerns/edition/organisations.rb
@@ -86,6 +86,10 @@ module Edition::Organisations
     super.merge("organisations" => organisations.map(&:slug))
   end
 
+  def limits_access_via_organisations?
+    true
+  end
+
 private
 
   def at_least_one_lead_organisation

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -446,6 +446,10 @@ class Edition < ApplicationRecord
     []
   end
 
+  def limits_access_via_organisations?
+    false
+  end
+
 private
 
   def date_for_government

--- a/app/services/draft_edition_updater.rb
+++ b/app/services/draft_edition_updater.rb
@@ -10,7 +10,7 @@ class DraftEditionUpdater < EditionService
   def failure_reason
     if !edition.pre_publication?
       "A #{edition.state} edition may not be updated."
-    elsif edition.access_limited? && @options[:current_user].present? && edition.edition_organisations.map(&:organisation_id).exclude?(@options[:current_user].organisation.id)
+    elsif should_check_current_user_will_retain_access? && access_limit_excludes_current_user?
       "Access can only be limited by users belonging to an organisation tagged to the document"
     elsif !edition.valid?
       "This edition is invalid: #{edition.errors.full_messages.to_sentence}"
@@ -19,5 +19,15 @@ class DraftEditionUpdater < EditionService
 
   def verb
     "update_draft"
+  end
+
+private
+
+  def should_check_current_user_will_retain_access?
+    @options[:current_user].present? && edition.access_limited?
+  end
+
+  def access_limit_excludes_current_user?
+    edition.limits_access_via_organisations? && edition.edition_organisations.map(&:organisation_id).exclude?(@options[:current_user].organisation.id)
   end
 end

--- a/test/unit/app/services/draft_edition_updater_test.rb
+++ b/test/unit/app/services/draft_edition_updater_test.rb
@@ -37,4 +37,14 @@ class DraftEditionUpdaterTest < ActiveSupport::TestCase
 
     updater.perform!
   end
+
+  test "updates editions that cannot be tagged to organisations" do
+    organisation = create(:organisation)
+    edition = create(:draft_corporate_information_page, organisation:, access_limited: true)
+    updater = DraftEditionUpdater.new(edition, { current_user: create(:user, organisation:) })
+    updater.expects(:update_publishing_api!).once
+    updater.expects(:notify!).once
+
+    updater.perform!
+  end
 end


### PR DESCRIPTION
This fixes the following Sentry error: https://govuk.sentry.io/issues/5742988523/events/da44c233e7ee47d3b7b30279d7ca1422/

The draft updater checks that the user is not about to limit their own access to a document.

However, not all documents can be access limited, or access is controlled by other means. Corporate information pages are an example of this.

This commit ensures that the updater only validates that the user is not about to limit their own access in contexts where the document is tagged to one or more organisations.

It's pretty ugly. I did initially try encapsulating the validation logic within the access limiting concern that is included in the edition model, rather than in private methods on the updater. However, I didn't want to couple the access limiting concern to the organisations concern, as I think it's possible to use them both independently. I therefore decided on the edition updater for now, but open to revisiting that decision if the reviewer feels strongly about it. This is another good example of having all document types inherit from the edition model is inhibiting the speed of change in Whitehall

Trello: https://trello.com/c/lZMXGcBv
