### PR TITLE
Content modelling/410 schedule publishing

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -2,6 +2,7 @@
 :concurrency: 8
 :queues:
   - scheduled_publishing
+  - content_block_publishing
   - default
   - publishing_api
   - asset_manager

--- a/db/migrate/20240829130419_add_scheduled_publication_to_content_block_edition.rb
+++ b/db/migrate/20240829130419_add_scheduled_publication_to_content_block_edition.rb
@@ -1,0 +1,13 @@
+class AddScheduledPublicationToContentBlockEdition < ActiveRecord::Migration[7.1]
+  def up
+    change_table :content_block_editions, bulk: true do |t|
+      t.datetime "scheduled_publication", precision: nil
+    end
+  end
+
+  def down
+    change_table :content_block_editions, bulk: true do |t|
+      t.remove :scheduled_publication
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_22_112802) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_29_130419) do
   create_table "assets", charset: "utf8mb3", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.string "variant", null: false
@@ -227,6 +227,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_22_112802) do
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.string "state", default: "draft", null: false
+    t.datetime "scheduled_publication", precision: nil
     t.index ["document_id"], name: "index_content_block_editions_on_document_id"
   end
 

--- a/lib/engines/content_object_store/app/components/content_object_store/content_block/document/show/summary_list_component.rb
+++ b/lib/engines/content_object_store/app/components/content_object_store/content_block/document/show/summary_list_component.rb
@@ -14,6 +14,8 @@ private
       organisation_item,
       creator_item,
       embed_code_item,
+      state_item,
+      scheduled_item,
     ]
   end
 
@@ -54,6 +56,20 @@ private
     {
       field: "Creator",
       value: content_block_document.latest_edition.creator.name,
+    }
+  end
+
+  def state_item
+    {
+      field: "State",
+      value: content_block_document.latest_edition.state,
+    }
+  end
+
+  def scheduled_item
+    {
+      field: "Scheduled for publication at",
+      value: content_block_document.latest_edition.scheduled_publication&.strftime("%e %B %Y at %I:%M%P"),
     }
   end
 

--- a/lib/engines/content_object_store/app/controllers/content_object_store/base_controller.rb
+++ b/lib/engines/content_object_store/app/controllers/content_object_store/base_controller.rb
@@ -4,4 +4,28 @@ class ContentObjectStore::BaseController < Admin::BaseController
   def check_object_store_feature_flag
     forbidden! unless Flipflop.content_object_store?
   end
+
+  def scheduled_publication_params
+    params.require(:scheduled_at).permit("scheduled_publication(1i)",
+                                         "scheduled_publication(2i)",
+                                         "scheduled_publication(3i)",
+                                         "scheduled_publication(4i)",
+                                         "scheduled_publication(5i)")
+  end
+
+  def edition_params
+    params.require(:content_block_edition)
+          .permit(
+            :organisation_id,
+            :creator,
+            "scheduled_publication(1i)",
+            "scheduled_publication(2i)",
+            "scheduled_publication(3i)",
+            "scheduled_publication(4i)",
+            "scheduled_publication(5i)",
+            document_attributes: %w[title block_type],
+            details: @schema.fields,
+          )
+          .merge!(creator: current_user)
+  end
 end

--- a/lib/engines/content_object_store/app/controllers/content_object_store/content_block/editions_controller.rb
+++ b/lib/engines/content_object_store/app/controllers/content_object_store/content_block/editions_controller.rb
@@ -90,31 +90,7 @@ private
     params.require(:content_object_store_content_block_edition)
   end
 
-  def edition_params
-    params.require(:content_block_edition)
-      .permit(
-        :organisation_id,
-        :creator,
-        "scheduled_publication(1i)",
-        "scheduled_publication(2i)",
-        "scheduled_publication(3i)",
-        "scheduled_publication(4i)",
-        "scheduled_publication(5i)",
-        document_attributes: %w[title block_type],
-        details: @schema.fields,
-      )
-      .merge!(creator: current_user)
-  end
-
   def block_type_param
     params.require(:content_block_edition).require("document_attributes").require(:block_type)
-  end
-
-  def scheduled_publication_params
-    params.require(:scheduled_at).permit("scheduled_publication(1i)",
-                                         "scheduled_publication(2i)",
-                                         "scheduled_publication(3i)",
-                                         "scheduled_publication(4i)",
-                                         "scheduled_publication(5i)")
   end
 end

--- a/lib/engines/content_object_store/app/controllers/content_object_store/content_block/editions_controller.rb
+++ b/lib/engines/content_object_store/app/controllers/content_object_store/content_block/editions_controller.rb
@@ -84,36 +84,6 @@ class ContentObjectStore::ContentBlock::EditionsController < ContentObjectStore:
     render :schedule_publishing
   end
 
-  def update
-    content_block_edition = ContentObjectStore::ContentBlock::Edition.find(params[:id])
-    @schema = ContentObjectStore::ContentBlock::Schema.find_by_block_type(content_block_edition.document.block_type)
-
-    new_edition = edition_params
-    if params[:schedule_publishing] == "schedule"
-      new_edition = edition_params.merge!(scheduled_publication_params)
-      new_content_block_edition = ContentObjectStore::ScheduleEditionService.new(
-        content_block_edition,
-      ).call(new_edition)
-      flash_text = "#{@schema.name} scheduled successfully"
-    else
-      new_content_block_edition = ContentObjectStore::UpdateEditionService.new(
-        @schema,
-        content_block_edition,
-      ).call(new_edition)
-      flash_text = "#{@schema.name} changed and published successfully"
-    end
-
-    redirect_to content_object_store.content_object_store_content_block_document_path(new_content_block_edition.document),
-                flash: { notice: flash_text }
-  rescue ActiveRecord::RecordInvalid => e
-    @form = ContentObjectStore::ContentBlock::EditionForm::Update.new(
-      content_block_edition: e.record, schema: @schema,
-      edition_to_update_id: content_block_edition.id
-    )
-
-    render :edit
-  end
-
 private
 
   def root_params

--- a/lib/engines/content_object_store/app/controllers/content_object_store/content_block/workflow_controller.rb
+++ b/lib/engines/content_object_store/app/controllers/content_object_store/content_block/workflow_controller.rb
@@ -41,30 +41,4 @@ class ContentObjectStore::ContentBlock::WorkflowController < ContentObjectStore:
 
     render "content_object_store/content_block/editions/schedule_publishing"
   end
-
-private
-
-  def scheduled_publication_params
-    params.require(:scheduled_at).permit("scheduled_publication(1i)",
-                                         "scheduled_publication(2i)",
-                                         "scheduled_publication(3i)",
-                                         "scheduled_publication(4i)",
-                                         "scheduled_publication(5i)")
-  end
-
-  def edition_params
-    params.require(:content_block_edition)
-          .permit(
-            :organisation_id,
-            :creator,
-            "scheduled_publication(1i)",
-            "scheduled_publication(2i)",
-            "scheduled_publication(3i)",
-            "scheduled_publication(4i)",
-            "scheduled_publication(5i)",
-            document_attributes: %w[title block_type],
-            details: @schema.fields,
-          )
-          .merge!(creator: current_user)
-  end
 end

--- a/lib/engines/content_object_store/app/lib/content_object_store/publishable.rb
+++ b/lib/engines/content_object_store/app/lib/content_object_store/publishable.rb
@@ -23,6 +23,7 @@ module ContentObjectStore
         )
         publish_publishing_api_edition(content_id:)
         update_content_block_document_with_live_edition(content_block_edition)
+        update_content_block_document_with_latest_edition(content_block_edition)
         content_block_edition.public_send(:publish!)
       rescue PublishingFailureError => e
         discard_publishing_api_edition(content_id:)
@@ -36,6 +37,7 @@ module ContentObjectStore
       ActiveRecord::Base.transaction do
         content_block_edition = yield
 
+        update_content_block_document_with_latest_edition(content_block_edition)
         content_block_edition.schedule!
         ContentObjectStore::SchedulePublishingWorker.queue(content_block_edition)
       end

--- a/lib/engines/content_object_store/app/lib/content_object_store/publishable.rb
+++ b/lib/engines/content_object_store/app/lib/content_object_store/publishable.rb
@@ -30,6 +30,17 @@ module ContentObjectStore
       end
     end
 
+    def schedule_with_rollback
+      raise ArgumentError, "Local database changes not given" unless block_given?
+
+      ActiveRecord::Base.transaction do
+        content_block_edition = yield
+
+        content_block_edition.schedule!
+        ContentObjectStore::SchedulePublishingWorker.queue(content_block_edition)
+      end
+    end
+
   private
 
     def create_publishing_api_edition(content_id:, schema_id:, title:, details:, links:)

--- a/lib/engines/content_object_store/app/lib/content_object_store/publishable.rb
+++ b/lib/engines/content_object_store/app/lib/content_object_store/publishable.rb
@@ -43,6 +43,43 @@ module ContentObjectStore
       end
     end
 
+    def update_content_block_document(new_content_block_edition:, update_document_params:)
+      # Updates to a Document should never change its block type
+      update_document_params.delete(:block_type)
+
+      new_content_block_edition.document.update!(update_document_params)
+    end
+
+    def create_new_content_block_edition_for_document(edition_params:)
+      @original_content_block_edition.assign_attributes(
+        filter_params_for_validation_check(edition_params),
+      )
+
+      unless @original_content_block_edition.valid?
+        raise ActiveRecord::RecordInvalid, @original_content_block_edition
+      end
+
+      new_content_block_edition = ContentObjectStore::ContentBlock::Edition.new(edition_params)
+      new_content_block_edition.document_id = @original_content_block_edition.document.id
+      new_content_block_edition.save!
+      new_content_block_edition
+    end
+
+    def filter_params_for_validation_check(edition_params)
+      # Remove the `creator` as this is not modifiable and will return a false negative
+      validation_params = edition_params.except(:creator)
+
+      # Remove document `block_type`` as this is not modifiable
+      # Add the original Document ID to avoid `valid?` creating a new Document
+      if validation_params.key?(:document_attributes)
+        validation_params[:document_attributes] = validation_params[:document_attributes]
+                                                    .except(:block_type)
+                                                    .merge(id: @original_content_block_edition.document.id)
+      end
+
+      validation_params
+    end
+
   private
 
     def create_publishing_api_edition(content_id:, schema_id:, title:, details:, links:)

--- a/lib/engines/content_object_store/app/models/concerns/content_object_store/workflow.rb
+++ b/lib/engines/content_object_store/app/models/concerns/content_object_store/workflow.rb
@@ -3,7 +3,7 @@ module ContentObjectStore::Workflow
 
   module ClassMethods
     def valid_state?(state)
-      %w[draft published].include?(state)
+      %w[draft published scheduled].include?(state)
     end
   end
 
@@ -13,9 +13,13 @@ module ContentObjectStore::Workflow
     state_machine auto_scopes: true do
       state :draft
       state :published
+      state :scheduled
 
       event :publish do
-        transitions from: %i[draft], to: :published
+        transitions from: %i[draft scheduled], to: :published
+      end
+      event :schedule do
+        transitions from: %i[draft], to: :scheduled
       end
     end
   end

--- a/lib/engines/content_object_store/app/models/concerns/content_object_store/workflow.rb
+++ b/lib/engines/content_object_store/app/models/concerns/content_object_store/workflow.rb
@@ -1,5 +1,6 @@
 module ContentObjectStore::Workflow
   extend ActiveSupport::Concern
+  include DateValidation
 
   module ClassMethods
     def valid_state?(state)
@@ -9,6 +10,10 @@ module ContentObjectStore::Workflow
 
   included do
     include ActiveRecord::Transitions
+
+    date_attributes :scheduled_publication
+
+    validates_with ContentObjectStore::ScheduledPublicationValidator
 
     state_machine auto_scopes: true do
       state :draft

--- a/lib/engines/content_object_store/app/services/content_object_store/schedule_edition_service.rb
+++ b/lib/engines/content_object_store/app/services/content_object_store/schedule_edition_service.rb
@@ -43,9 +43,6 @@ module ContentObjectStore
     end
 
     def update_content_block_document(new_content_block_edition:, update_document_params:)
-      update_document_params[:latest_edition_id] = new_content_block_edition.id
-      update_document_params[:live_edition_id] = new_content_block_edition.id
-
       # Updates to a Document should never change its block type
       update_document_params.delete(:block_type)
 

--- a/lib/engines/content_object_store/app/services/content_object_store/schedule_edition_service.rb
+++ b/lib/engines/content_object_store/app/services/content_object_store/schedule_edition_service.rb
@@ -24,44 +24,5 @@ module ContentObjectStore
 
       @new_content_block_edition
     end
-
-  private
-
-    def create_new_content_block_edition_for_document(edition_params:)
-      @original_content_block_edition.assign_attributes(
-        filter_params_for_validation_check(edition_params),
-      )
-
-      unless @original_content_block_edition.valid?
-        raise ActiveRecord::RecordInvalid, @original_content_block_edition
-      end
-
-      new_content_block_edition = ContentObjectStore::ContentBlock::Edition.new(edition_params)
-      new_content_block_edition.document_id = @original_content_block_edition.document.id
-      new_content_block_edition.save!
-      new_content_block_edition
-    end
-
-    def update_content_block_document(new_content_block_edition:, update_document_params:)
-      # Updates to a Document should never change its block type
-      update_document_params.delete(:block_type)
-
-      new_content_block_edition.document.update!(update_document_params)
-    end
-
-    def filter_params_for_validation_check(edition_params)
-      # Remove the `creator` as this is not modifiable and will return a false negative
-      validation_params = edition_params.except(:creator)
-
-      # Remove document `block_type`` as this is not modifiable
-      # Add the original Document ID to avoid `valid?` creating a new Document
-      if validation_params.key?(:document_attributes)
-        validation_params[:document_attributes] = validation_params[:document_attributes]
-                                                    .except(:block_type)
-                                                    .merge(id: @original_content_block_edition.document.id)
-      end
-
-      validation_params
-    end
   end
 end

--- a/lib/engines/content_object_store/app/services/content_object_store/schedule_edition_service.rb
+++ b/lib/engines/content_object_store/app/services/content_object_store/schedule_edition_service.rb
@@ -1,0 +1,70 @@
+module ContentObjectStore
+  class ScheduleEditionService
+    include Publishable
+
+    def initialize(original_content_block_edition)
+      @original_content_block_edition = original_content_block_edition
+    end
+
+    def call(edition_params)
+      raise ArgumentError, "Edition params must be provided" if edition_params.blank? || edition_params[:details].blank?
+
+      update_document_params = edition_params[:document_attributes] || {}
+
+      schedule_with_rollback do
+        @new_content_block_edition = create_new_content_block_edition_for_document(edition_params:)
+
+        update_content_block_document(
+          new_content_block_edition: @new_content_block_edition,
+          update_document_params:,
+        )
+
+        @new_content_block_edition
+      end
+
+      @new_content_block_edition
+    end
+
+  private
+
+    def create_new_content_block_edition_for_document(edition_params:)
+      @original_content_block_edition.assign_attributes(
+        filter_params_for_validation_check(edition_params),
+      )
+
+      unless @original_content_block_edition.valid?
+        raise ActiveRecord::RecordInvalid, @original_content_block_edition
+      end
+
+      new_content_block_edition = ContentObjectStore::ContentBlock::Edition.new(edition_params)
+      new_content_block_edition.document_id = @original_content_block_edition.document.id
+      new_content_block_edition.save!
+      new_content_block_edition
+    end
+
+    def update_content_block_document(new_content_block_edition:, update_document_params:)
+      update_document_params[:latest_edition_id] = new_content_block_edition.id
+      update_document_params[:live_edition_id] = new_content_block_edition.id
+
+      # Updates to a Document should never change its block type
+      update_document_params.delete(:block_type)
+
+      new_content_block_edition.document.update!(update_document_params)
+    end
+
+    def filter_params_for_validation_check(edition_params)
+      # Remove the `creator` as this is not modifiable and will return a false negative
+      validation_params = edition_params.except(:creator)
+
+      # Remove document `block_type`` as this is not modifiable
+      # Add the original Document ID to avoid `valid?` creating a new Document
+      if validation_params.key?(:document_attributes)
+        validation_params[:document_attributes] = validation_params[:document_attributes]
+                                                    .except(:block_type)
+                                                    .merge(id: @original_content_block_edition.document.id)
+      end
+
+      validation_params
+    end
+  end
+end

--- a/lib/engines/content_object_store/app/services/content_object_store/update_edition_service.rb
+++ b/lib/engines/content_object_store/app/services/content_object_store/update_edition_service.rb
@@ -46,9 +46,6 @@ module ContentObjectStore
     end
 
     def update_content_block_document(new_content_block_edition:, update_document_params:)
-      update_document_params[:latest_edition_id] = new_content_block_edition.id
-      update_document_params[:live_edition_id] = new_content_block_edition.id
-
       # Updates to a Document should never change its block type
       update_document_params.delete(:block_type)
 

--- a/lib/engines/content_object_store/app/services/content_object_store/update_edition_service.rb
+++ b/lib/engines/content_object_store/app/services/content_object_store/update_edition_service.rb
@@ -27,44 +27,5 @@ module ContentObjectStore
 
       @new_content_block_edition
     end
-
-  private
-
-    def create_new_content_block_edition_for_document(edition_params:)
-      @original_content_block_edition.assign_attributes(
-        filter_params_for_validation_check(edition_params),
-      )
-
-      unless @original_content_block_edition.valid?
-        raise ActiveRecord::RecordInvalid, @original_content_block_edition
-      end
-
-      new_content_block_edition = ContentObjectStore::ContentBlock::Edition.new(edition_params)
-      new_content_block_edition.document_id = @original_content_block_edition.document.id
-      new_content_block_edition.save!
-      new_content_block_edition
-    end
-
-    def update_content_block_document(new_content_block_edition:, update_document_params:)
-      # Updates to a Document should never change its block type
-      update_document_params.delete(:block_type)
-
-      new_content_block_edition.document.update!(update_document_params)
-    end
-
-    def filter_params_for_validation_check(edition_params)
-      # Remove the `creator` as this is not modifiable and will return a false negative
-      validation_params = edition_params.except(:creator)
-
-      # Remove document `block_type`` as this is not modifiable
-      # Add the original Document ID to avoid `valid?` creating a new Document
-      if validation_params.key?(:document_attributes)
-        validation_params[:document_attributes] = validation_params[:document_attributes]
-          .except(:block_type)
-          .merge(id: @original_content_block_edition.document.id)
-      end
-
-      validation_params
-    end
   end
 end

--- a/lib/engines/content_object_store/app/validators/content_object_store/scheduled_publication_validator.rb
+++ b/lib/engines/content_object_store/app/validators/content_object_store/scheduled_publication_validator.rb
@@ -1,0 +1,13 @@
+class ContentObjectStore::ScheduledPublicationValidator < ActiveModel::Validator
+  attr_reader :edition
+
+  def validate(edition)
+    if edition.state == "scheduled"
+      if edition.scheduled_publication.blank?
+        edition.errors.add("scheduled_publication", :blank, message: "date and time cannot be blank")
+      elsif edition.scheduled_publication < Time.zone.now
+        edition.errors.add("scheduled_publication", :future_date, message: "date and time must be in the future")
+      end
+    end
+  end
+end

--- a/lib/engines/content_object_store/app/views/content_object_store/content_block/editions/review_links.html.erb
+++ b/lib/engines/content_object_store/app/views/content_object_store/content_block/editions/review_links.html.erb
@@ -24,12 +24,18 @@
   <div class="govuk-grid-column-two-thirds">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">
-        <%= form_with(url: content_object_store.content_object_store_content_block_edition_path(content_block_edition: @edition_params), method: :patch) do %>
+        <%= form_with(
+              url: content_object_store.edit_content_object_store_content_block_edition_path(
+                content_block_edition: @edition_params,
+                step: ContentObjectStore::ContentBlock::EditionsController::EDIT_FORM_STEPS[:schedule_publishing],
+              ),
+              method: :post,
+            ) do %>
           <div class="govuk-button-group govuk-!-margin-bottom-6">
             <%= render "govuk_publishing_components/components/button", {
-              text: "Accept and publish",
-              name: "accept_and_publish",
-              value: "Accept and publish",
+              text: "Save and continue",
+              name: "save_and_continue",
+              value: "Save and continue",
               type: "submit",
             } %>
             <%= link_to("Cancel", content_object_store.content_object_store_content_block_documents_path, class: "govuk-link") %>

--- a/lib/engines/content_object_store/app/views/content_object_store/content_block/editions/schedule_publishing.html.erb
+++ b/lib/engines/content_object_store/app/views/content_object_store/content_block/editions/schedule_publishing.html.erb
@@ -1,0 +1,80 @@
+<% content_for :context, "Manage #{add_indefinite_article @content_block_document.block_type.humanize}" %>
+<% content_for :title, "When do you want to publish the change?" %>
+<% content_for :title_margin_bottom, 4 %>
+<% content_for :back_link do %>
+  <%= render "govuk_publishing_components/components/back_link", {
+    href: content_object_store.edit_content_object_store_content_block_edition_path(
+      id: @content_block_edition.id,
+      content_block_edition: @edition_params,
+      step: ContentObjectStore::ContentBlock::EditionsController::EDIT_FORM_STEPS[:review_links],
+    ),
+  } %>
+<% end %>
+
+<p class="govuk-body">Choose when you would like the change to be made.</p>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with url: content_object_store.content_object_store_content_block_edition_path(content_block_edition: @edition_params), method: :patch do %>
+
+      <%= render "govuk_publishing_components/components/radio", {
+        name: "schedule_publishing",
+        id: "schedule_publishing",
+        heading_size: "xl",
+        items: [
+          {
+            value: "now",
+            text: "Publish the change now",
+          },
+          {
+            value: "schedule",
+            text: "Schedule the change for the future",
+            conditional: render("components/datetime_fields", {
+              heading_size: "s",
+              field_name: "scheduled_publication",
+              prefix: "scheduled_at",
+              date_heading: "Date",
+              date_hint: "For example, 01 08 2025",
+              year: {
+                id: "scheduled_at_scheduled_publication_1i",
+                name: "scheduled_at[scheduled_publication(1i)]",
+                label: "Year",
+                width: 4,
+              },
+              month: {
+                id: "scheduled_at_scheduled_publication_2i",
+                name: "scheduled_at[scheduled_publication(2i)]",
+                label: "Month",
+                width: 2,
+              },
+              day: {
+                id: "scheduled_at_scheduled_publication_3i",
+                name: "scheduled_at[scheduled_publication(3i)]",
+                label: "Day",
+                width: 2,
+              },
+              hour: {
+                id: "scheduled_at_scheduled_publication_4i",
+                name: "scheduled_at[scheduled_publication(4i)]",
+              },
+              minute: {
+                id: "scheduled_at_scheduled_publication_5i",
+                name: "scheduled_at[scheduled_publication(5i)]",
+              },
+            }),
+          },
+        ],
+      } %>
+      <div class="govuk-button-group govuk-!-margin-bottom-6">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Accept and publish",
+          name: "accept_and_publish",
+          value: "Accept and publish",
+          type: "submit",
+        } %>
+        <%= link_to("Cancel", content_object_store.content_object_store_content_block_documents_path, class: "govuk-link") %>
+      </div>
+    <% end %>
+
+  </div>
+</div>

--- a/lib/engines/content_object_store/app/views/content_object_store/content_block/editions/schedule_publishing.html.erb
+++ b/lib/engines/content_object_store/app/views/content_object_store/content_block/editions/schedule_publishing.html.erb
@@ -4,14 +4,25 @@
 <% content_for :back_link do %>
   <%= render "govuk_publishing_components/components/back_link", {
     href: content_object_store.edit_content_object_store_content_block_edition_path(
-      id: @content_block_edition.id,
+      id: @content_block_document.latest_edition.id,
       content_block_edition: @edition_params,
       step: ContentObjectStore::ContentBlock::EditionsController::EDIT_FORM_STEPS[:review_links],
     ),
   } %>
 <% end %>
 
+<%
+  year_param = @edition_params["scheduled_publication(1i)"]
+  month_param = @edition_params["scheduled_publication(2i)"]
+  day_param = @edition_params["scheduled_publication(3i)"]
+  hour_param = @edition_params["scheduled_publication(4i)"]
+  minute_param =  @edition_params["scheduled_publication(5i)"]
+  is_scheduled_param = params["schedule_publishing"]
+%>
+
 <p class="govuk-body">Choose when you would like the change to be made.</p>
+
+<% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @content_block_edition)) %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
@@ -24,10 +35,12 @@
         items: [
           {
             value: "now",
+            checked:  is_scheduled_param == "now",
             text: "Publish the change now",
           },
           {
             value: "schedule",
+            checked: is_scheduled_param == "schedule",
             text: "Schedule the change for the future",
             conditional: render("components/datetime_fields", {
               heading_size: "s",
@@ -35,29 +48,36 @@
               prefix: "scheduled_at",
               date_heading: "Date",
               date_hint: "For example, 01 08 2025",
+              time_hint: "For example, 09:30 or 19:30",
+              error_items: errors_for(@content_block_edition.errors, :scheduled_publication),
               year: {
+                value: year_param&.to_i,
                 id: "scheduled_at_scheduled_publication_1i",
                 name: "scheduled_at[scheduled_publication(1i)]",
                 label: "Year",
                 width: 4,
               },
               month: {
+                value: month_param&.to_i,
                 id: "scheduled_at_scheduled_publication_2i",
                 name: "scheduled_at[scheduled_publication(2i)]",
                 label: "Month",
                 width: 2,
               },
               day: {
-                id: "scheduled_at_scheduled_publication_3i",
+                value: day_param&.to_i,
+                id: "content_object_store/content_block/edition_scheduled_publication",
                 name: "scheduled_at[scheduled_publication(3i)]",
                 label: "Day",
                 width: 2,
               },
               hour: {
+                value: hour_param&.to_i,
                 id: "scheduled_at_scheduled_publication_4i",
                 name: "scheduled_at[scheduled_publication(4i)]",
               },
               minute: {
+                value: minute_param&.to_i,
                 id: "scheduled_at_scheduled_publication_5i",
                 name: "scheduled_at[scheduled_publication(5i)]",
               },

--- a/lib/engines/content_object_store/app/workers/content_object_store/schedule_publishing_worker.rb
+++ b/lib/engines/content_object_store/app/workers/content_object_store/schedule_publishing_worker.rb
@@ -1,0 +1,64 @@
+require "sidekiq/api"
+
+# ContentBlockPublishingWorker is a job that is scheduled by the `ScheduleEditionService`.
+# It is never executed immediately but uses the Sidekiq delay mechanism to
+# execute at the time the edition should be published.
+module ContentObjectStore
+  class SchedulePublishingWorker < WorkerBase
+    SchedulingFailure = Class.new(StandardError)
+
+    class << self
+      def queue(edition)
+        perform_at(edition.scheduled_publication, edition.id)
+      end
+
+      def dequeue(edition)
+        Sidekiq::ScheduledSet
+          .new
+          .select { |joby| joby["class"] == name && joby.args[0] == edition.id }
+          .map(&:delete)
+      end
+
+      # Only used by the publishing:scheduled:requeue_all_jobs rake task.
+      def dequeue_all
+        queued_jobs.map(&:delete)
+      end
+
+      def queue_size
+        queued_jobs.size
+      end
+
+      def queued_edition_ids
+        queued_jobs.map { |job| job["args"][0] }
+      end
+
+    private
+
+      def queued_jobs
+        Sidekiq::ScheduledSet.new.select { |job| job["class"] == name }
+      end
+    end
+
+    sidekiq_options queue: :content_block_publishing
+
+    def perform(edition_id)
+      logger.info("performing content block publishing job for Edition #{edition_id}")
+      edition = ContentObjectStore::ContentBlock::Edition.find(edition_id)
+      return if edition.published? || !edition.scheduled?
+
+      schema = ContentObjectStore::ContentBlock::Schema.find_by_block_type(edition.document.block_type)
+
+      ContentObjectStore::PublishEditionService.new(
+        schema,
+      ).call(edition)
+    rescue ContentObjectStore::Publishable::PublishingFailureError => e
+      raise SchedulingFailure, e.message
+    end
+
+  private
+
+    def publishing_robot
+      User.where(name: "Scheduled Publishing Robot", uid: nil).first
+    end
+  end
+end

--- a/lib/engines/content_object_store/config/routes.rb
+++ b/lib/engines/content_object_store/config/routes.rb
@@ -8,6 +8,7 @@ ContentObjectStore::Engine.routes.draw do
         member do
           get :review
           post :publish, to: "workflow#publish"
+          patch :update, to: "workflow#update"
           post :edit
         end
       end

--- a/lib/engines/content_object_store/features/edit_object.feature
+++ b/lib/engines/content_object_store/features/edit_object.feature
@@ -20,7 +20,7 @@ Feature: Edit a content object
     When I fill out the form
     Then I am shown where the changes will take place
     And I should see a back link to the edit page
-    When I continue
+    When I accept and publish
     Then the edition should have been updated successfully
     And I should be taken back to the document page
     And I should see the update on the timeline

--- a/lib/engines/content_object_store/features/edit_object.feature
+++ b/lib/engines/content_object_store/features/edit_object.feature
@@ -20,7 +20,11 @@ Feature: Edit a content object
     When I fill out the form
     Then I am shown where the changes will take place
     And I should see a back link to the edit page
-    When I accept and publish
+    When I save and continue
+    Then I am asked when I want to publish the change
+    And I should see a back link to the review page
+    When I choose to publish the change now
+    And I accept and publish
     Then the edition should have been updated successfully
     And I should be taken back to the document page
     And I should see the update on the timeline

--- a/lib/engines/content_object_store/features/schedule_object.feature
+++ b/lib/engines/content_object_store/features/schedule_object.feature
@@ -1,0 +1,26 @@
+Feature: Schedule a content object
+  Background:
+    Given the content object store feature flag is enabled
+    And I am a GDS admin
+    And the organisation "Ministry of Example" exists
+    And a schema "email_address" exists with the following fields:
+      | field         | type   | format | required |
+      | email_address | string | email  | true     |
+    And an email address content block has been created
+
+  Scenario: GDS Editor schedules a content object
+    When I am updating a content block
+    Then I am asked when I want to publish the change
+    When I choose to schedule the change
+    And I enter a date 7 days in the future
+    And I accept and publish
+    Then the edition should have been scheduled successfully
+    And I should be taken back to the document page
+    And I should see the scheduled date on the object
+
+  Scenario: A scheduled content object is published
+    When I am updating a content block
+    Then I am asked when I want to publish the change
+    When I choose to schedule the change
+    And the block is scheduled and published
+    Then published state of the object is shown

--- a/lib/engines/content_object_store/features/schedule_object.feature
+++ b/lib/engines/content_object_store/features/schedule_object.feature
@@ -24,3 +24,26 @@ Feature: Schedule a content object
     When I choose to schedule the change
     And the block is scheduled and published
     Then published state of the object is shown
+
+  Scenario: GDS Editor does not provide date for scheduling
+    When I am updating a content block
+    Then I am asked when I want to publish the change
+    When I choose to schedule the change
+    And I accept and publish
+    Then I see the errors prompting me to provide a date and time
+
+  Scenario: GDS Editor does not provide a valid date for scheduling
+    When I am updating a content block
+    Then I am asked when I want to publish the change
+    When I choose to schedule the change
+    And I enter an invalid date
+    And I accept and publish
+    Then I see the errors informing me the date is invalid
+
+  Scenario: GDS Editor provides a date in the past for scheduling
+    When I am updating a content block
+    Then I am asked when I want to publish the change
+    When I choose to schedule the change
+    And I enter a date in the past
+    And I accept and publish
+    Then I see the errors informing me the date must be in the future

--- a/lib/engines/content_object_store/features/step_definitions/content_object_store_steps.rb
+++ b/lib/engines/content_object_store/features/step_definitions/content_object_store_steps.rb
@@ -309,6 +309,6 @@ Then(/^I am shown where the changes will take place$/) do
   end
 end
 
-When(/^I continue$/) do
-  click_on "Accept and publish"
+When(/^I save and continue$/) do
+  click_on "Save and continue"
 end

--- a/lib/engines/content_object_store/features/step_definitions/content_object_store_steps.rb
+++ b/lib/engines/content_object_store/features/step_definitions/content_object_store_steps.rb
@@ -250,6 +250,18 @@ Then("I should see errors for the required fields") do
   assert_text "Lead organisation cannot be blank"
 end
 
+Then("I see the errors prompting me to provide a date and time") do
+  assert_text "Scheduled publication date and time cannot be blank", minimum: 2
+end
+
+Then("I see the errors informing me the date is invalid") do
+  assert_text "Scheduled publication is not in the correct format", minimum: 2
+end
+
+Then("I see the errors informing me the date must be in the future") do
+  assert_text "Scheduled publication date and time must be in the future", minimum: 2
+end
+
 Then("I should see a message that the {string} field is an invalid {string}") do |field_name, format|
   assert_text "#{ContentObjectStore::ContentBlock::Edition.human_attribute_name("details_#{field_name}")} is an invalid #{format.titleize}"
 end
@@ -350,6 +362,15 @@ end
 When("I enter a date 7 days in the future") do
   @future_date = 7.days.since(Time.zone.now).to_date
   fill_in_date_and_time_field(@future_date)
+end
+
+When("I enter an invalid date") do
+  fill_in "Year", with: "01"
+end
+
+When("I enter a date in the past") do
+  past_date = 7.days.before(Time.zone.now).to_date
+  fill_in_date_and_time_field(past_date)
 end
 
 Then("the edition should have been scheduled successfully") do

--- a/lib/engines/content_object_store/test/components/content_block/document/index/summary_card_component_test.rb
+++ b/lib/engines/content_object_store/test/components/content_block/document/index/summary_card_component_test.rb
@@ -20,7 +20,7 @@ class ContentObjectStore::ContentBlock::Document::Index::SummaryCardComponentTes
     assert_selector ".govuk-summary-card__action", count: 1
     assert_selector ".govuk-summary-card__action .govuk-link[href='#{content_object_store_content_block_document_path(content_block_document)}']"
 
-    assert_selector ".govuk-summary-list__row", count: 6
+    assert_selector ".govuk-summary-list__row", count: 8
 
     assert_selector ".govuk-summary-list__key", text: "Title"
     assert_selector ".govuk-summary-list__value", text: content_block_edition.title
@@ -39,5 +39,8 @@ class ContentObjectStore::ContentBlock::Document::Index::SummaryCardComponentTes
 
     assert_selector ".govuk-summary-list__key", text: "Embed code"
     assert_selector ".govuk-summary-list__value", text: content_block_document.embed_code
+
+    assert_selector ".govuk-summary-list__key", text: "State"
+    assert_selector ".govuk-summary-list__value", text: content_block_edition.scheduled_publication&.strftime("%e %B %Y at %I:%M%P")
   end
 end

--- a/lib/engines/content_object_store/test/components/content_block/document/show/summary_list_component_test.rb
+++ b/lib/engines/content_object_store/test/components/content_block/document/show/summary_list_component_test.rb
@@ -15,7 +15,7 @@ class ContentObjectStore::ContentBlock::Document::Show::SummaryListComponentTest
 
     render_inline(ContentObjectStore::ContentBlock::Document::Show::SummaryListComponent.new(content_block_document:))
 
-    assert_selector ".govuk-summary-list__row", count: 6
+    assert_selector ".govuk-summary-list__row", count: 8
     assert_selector ".govuk-summary-list__key", text: "Title"
     assert_selector ".govuk-summary-list__value", text: content_block_document.title
     assert_selector ".govuk-summary-list__actions", text: "Change"
@@ -36,5 +36,11 @@ class ContentObjectStore::ContentBlock::Document::Show::SummaryListComponentTest
 
     assert_selector ".govuk-summary-list__key", text: "Embed code"
     assert_selector ".govuk-summary-list__value", text: content_block_document.embed_code
+
+    assert_selector ".govuk-summary-list__key", text: "State"
+    assert_selector ".govuk-summary-list__value", text: content_block_edition.state
+
+    assert_selector ".govuk-summary-list__key", text: "Scheduled for publication at"
+    assert_selector ".govuk-summary-list__value", text: content_block_edition.scheduled_publication&.strftime("%e %B %Y at %I:%M%P")
   end
 end

--- a/lib/engines/content_object_store/test/factories/content_block_edition.rb
+++ b/lib/engines/content_object_store/test/factories/content_block_edition.rb
@@ -10,6 +10,8 @@ FactoryBot.define do
 
     document_id { nil }
 
+    scheduled_publication { nil }
+
     ContentObjectStore::ContentBlock::Schema.valid_schemas.each do |type|
       trait type.to_sym do
         document { build(:content_block_document, block_type: type) }

--- a/lib/engines/content_object_store/test/integration/content_block/editions_test.rb
+++ b/lib/engines/content_object_store/test/integration/content_block/editions_test.rb
@@ -5,7 +5,6 @@ class ContentObjectStore::ContentBlock::EditionsTest < ActionDispatch::Integrati
   include Capybara::DSL
   extend Minitest::Spec::DSL
   include ContentObjectStore::Engine.routes.url_helpers
-  include SidekiqTestHelpers
 
   before do
     login_as_admin
@@ -103,55 +102,6 @@ class ContentObjectStore::ContentBlock::EditionsTest < ActionDispatch::Integrati
       }
 
       assert_template :new
-    end
-  end
-
-  describe "#update" do
-    before do
-      @content_id = "49453854-d8fd-41da-ad4c-f99dbac601c3"
-
-      stub_request_for_schema("email_address")
-    end
-
-    it "schedules the publication of an edition" do
-      organisation = create(:organisation)
-
-      document = create(:content_block_document, :email_address, content_id: @content_id, title: "Some Title")
-
-      edition = create(:content_block_edition, document:, organisation:)
-
-      with_real_sidekiq do
-        patch content_object_store.content_object_store_content_block_edition_path(edition), params: {
-          id: edition.id,
-          schedule_publishing: "schedule",
-          scheduled_at: {
-            "scheduled_publication(3i)": "2",
-            "scheduled_publication(2i)": "9",
-            "scheduled_publication(1i)": "2024",
-            "scheduled_publication(4i)": "10",
-            "scheduled_publication(5i)": "05",
-          },
-          content_block_edition: {
-            creator: "1",
-            details: { foo: "newnew@example.com", bar: "edited" },
-            document_attributes: { block_type: "email_address", title: "Another email" },
-            organisation_id: organisation.id,
-          },
-        }
-
-        document = ContentObjectStore::ContentBlock::Document.find_by!(content_id: @content_id)
-        new_edition = document.editions.last
-
-        assert_equal Time.zone.local(2024, 9, 2, 10, 5, 0), new_edition.scheduled_publication
-        assert_equal "scheduled", new_edition.state
-
-        assert_equal 1, Sidekiq::ScheduledSet.new.size
-
-        job = Sidekiq::ScheduledSet.new.first
-
-        assert_equal job["args"].first, new_edition.id
-        assert_equal job.at.to_i, new_edition.scheduled_publication.to_i
-      end
     end
   end
 end

--- a/lib/engines/content_object_store/test/integration/content_block/workflow_test.rb
+++ b/lib/engines/content_object_store/test/integration/content_block/workflow_test.rb
@@ -58,7 +58,12 @@ class ContentObjectStore::ContentBlock::WorkflowTest < ActionDispatch::Integrati
         id: edition.id,
       }
       publishing_api_mock.verify
-      assert_equal "published", edition.reload.state
+      document = ContentObjectStore::ContentBlock::Document.find_by!(content_id: @content_id)
+      new_edition = ContentObjectStore::ContentBlock::Edition.find(document.live_edition_id)
+
+      assert_equal document.live_edition_id, document.latest_edition_id
+
+      assert_equal "published", new_edition.state
     end
   end
 
@@ -89,7 +94,7 @@ class ContentObjectStore::ContentBlock::WorkflowTest < ActionDispatch::Integrati
       }
 
       document = ContentObjectStore::ContentBlock::Document.find_by!(content_id: @content_id)
-      new_edition = document.editions.last
+      new_edition = document.latest_edition
 
       assert_equal Time.zone.local(2024, 9, 2, 10, 5, 0), new_edition.scheduled_publication
       assert_equal "scheduled", new_edition.state

--- a/lib/engines/content_object_store/test/integration/content_block/workflow_test.rb
+++ b/lib/engines/content_object_store/test/integration/content_block/workflow_test.rb
@@ -3,6 +3,7 @@ require "capybara/rails"
 
 class ContentObjectStore::ContentBlock::WorkflowTest < ActionDispatch::IntegrationTest
   include Capybara::DSL
+  include SidekiqTestHelpers
 
   setup do
     login_as_admin
@@ -58,6 +59,48 @@ class ContentObjectStore::ContentBlock::WorkflowTest < ActionDispatch::Integrati
       }
       publishing_api_mock.verify
       assert_equal "published", edition.reload.state
+    end
+  end
+
+  test "#update schedules the publication of an edition" do
+    organisation = create(:organisation)
+
+    document = create(:content_block_document, :email_address, content_id: @content_id, title: "Some Title")
+
+    edition = create(:content_block_edition, document:, organisation:)
+
+    with_real_sidekiq do
+      patch content_object_store.content_object_store_content_block_edition_path(edition), params: {
+        id: edition.id,
+        schedule_publishing: "schedule",
+        scheduled_at: {
+          "scheduled_publication(3i)": "2",
+          "scheduled_publication(2i)": "9",
+          "scheduled_publication(1i)": "2024",
+          "scheduled_publication(4i)": "10",
+          "scheduled_publication(5i)": "05",
+        },
+        content_block_edition: {
+          creator: "1",
+          details: { foo: "newnew@example.com", bar: "edited" },
+          document_attributes: { block_type: "email_address", title: "Another email" },
+          organisation_id: organisation.id,
+        },
+      }
+
+      document = ContentObjectStore::ContentBlock::Document.find_by!(content_id: @content_id)
+      new_edition = document.editions.last
+
+      assert_equal Time.zone.local(2024, 9, 2, 10, 5, 0), new_edition.scheduled_publication
+      assert_equal "scheduled", new_edition.state
+
+      assert_equal 1, Sidekiq::ScheduledSet.new.size
+
+      job = Sidekiq::ScheduledSet.new.first
+
+      assert_equal job["args"].first, new_edition.id
+      assert_equal job["queue"], "content_block_publishing"
+      assert_equal job.at.to_i, new_edition.scheduled_publication.to_i
     end
   end
 end

--- a/lib/engines/content_object_store/test/unit/app/models/concerns/workflow_test.rb
+++ b/lib/engines/content_object_store/test/unit/app/models/concerns/workflow_test.rb
@@ -18,6 +18,7 @@ class ContentObjectStore::WorkflowTest < ActiveSupport::TestCase
                        :content_block_document,
                        block_type: "email_address",
                      ),
+                     scheduled_publication: 7.days.since(Time.zone.now).to_date,
                      state: "scheduled")
     edition.publish!
     assert edition.published?
@@ -25,6 +26,7 @@ class ContentObjectStore::WorkflowTest < ActiveSupport::TestCase
 
   test "scheduling an edition transitions it into the scheduled state" do
     edition = create(:content_block_edition,
+                     scheduled_publication: 7.days.since(Time.zone.now).to_date,
                      document: create(
                        :content_block_document,
                        block_type: "email_address",

--- a/lib/engines/content_object_store/test/unit/app/models/concerns/workflow_test.rb
+++ b/lib/engines/content_object_store/test/unit/app/models/concerns/workflow_test.rb
@@ -11,4 +11,25 @@ class ContentObjectStore::WorkflowTest < ActiveSupport::TestCase
     edition.publish!
     assert edition.published?
   end
+
+  test "publishing a scheduled edition transitions it into the published state" do
+    edition = create(:content_block_edition,
+                     document: create(
+                       :content_block_document,
+                       block_type: "email_address",
+                     ),
+                     state: "scheduled")
+    edition.publish!
+    assert edition.published?
+  end
+
+  test "scheduling an edition transitions it into the scheduled state" do
+    edition = create(:content_block_edition,
+                     document: create(
+                       :content_block_document,
+                       block_type: "email_address",
+                     ))
+    edition.schedule!
+    assert edition.scheduled?
+  end
 end

--- a/lib/engines/content_object_store/test/unit/app/services/schedule_edition_service_test.rb
+++ b/lib/engines/content_object_store/test/unit/app/services/schedule_edition_service_test.rb
@@ -131,13 +131,12 @@ class ContentObjectStore::ScheduleEditionServiceTest < ActiveSupport::TestCase
       end
     end
 
-    it "updates the original ContentBlockDocument's latest_edition_id and live_edition_id to the new Edition" do
+    it "updates the original ContentBlockDocument's latest_edition_id to the new Edition" do
       result = ContentObjectStore::ScheduleEditionService.new(@original_content_block_edition)
                                                        .call(edition_params)
 
       @original_content_block_edition.document.reload
 
-      assert_equal @original_content_block_edition.document.live_edition_id, result.id
       assert_equal @original_content_block_edition.document.latest_edition_id, result.id
     end
 
@@ -186,6 +185,9 @@ class ContentObjectStore::ScheduleEditionServiceTest < ActiveSupport::TestCase
               ContentObjectStore::ScheduleEditionService
                 .new(@original_content_block_edition)
                 .call(edition_params)
+
+              @original_content_block_edition.document.reload
+              @original_content_block_edition.document.latest_edition = @original_content_block_edition
             end
           end
         end

--- a/lib/engines/content_object_store/test/unit/app/services/schedule_edition_service_test.rb
+++ b/lib/engines/content_object_store/test/unit/app/services/schedule_edition_service_test.rb
@@ -1,0 +1,210 @@
+require "test_helper"
+
+class ContentObjectStore::ScheduleEditionServiceTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
+  setup do
+    @original_content_block_edition = create(:content_block_edition,
+                                             document: create(:content_block_document, :email_address, content_id:),
+                                             details: { "foo" => "Foo text", "bar" => "Bar text" },
+                                             organisation: create(:organisation))
+  end
+
+  describe "#call" do
+    let(:content_id) { "49453854-d8fd-41da-ad4c-f99dbac601c3" }
+    let(:organisation) { create("organisation") }
+    let(:schema) { build(:content_block_schema, block_type: "content_block_type", body: { "properties" => { "foo" => "", "bar" => "" } }) }
+    let(:edition_params) do
+      {
+        document_attributes: {
+          title: "Some Title",
+          block_type: "email_address",
+        }.with_indifferent_access,
+        details: {
+          "foo" => "Foo text",
+          "bar" => "Bar text",
+        },
+        creator: build(:user),
+        organisation_id: organisation.id.to_s,
+        "scheduled_publication(3i)": "2",
+        "scheduled_publication(2i)": "9",
+        "scheduled_publication(1i)": "2034",
+        "scheduled_publication(4i)": "10",
+        "scheduled_publication(5i)": "05",
+      }
+    end
+
+    setup do
+      # # This UUID is created by the database so instead of loading the record
+      # # we stub the initial creation so we know what UUID to check for.
+      # ContentObjectStore::ContentBlock::Edition.any_instance.stubs(:create_random_id)
+      #                                          .returns(content_id)
+
+      ContentObjectStore::ContentBlock::Schema.stubs(:find_by_block_type)
+                                              .returns(schema)
+    end
+
+    test "it returns the new content block edition so the controller can redirect" do
+      result = ContentObjectStore::ScheduleEditionService.new(@original_content_block_edition)
+                                                       .call(edition_params)
+      assert_instance_of ContentObjectStore::ContentBlock::Edition, result
+    end
+
+    test "it does not create a new ContentBlockDocument" do
+      original_count = ContentObjectStore::ContentBlock::Document.count
+      ContentObjectStore::ScheduleEditionService.new(@original_content_block_edition)
+                                              .call(edition_params)
+      assert_equal original_count, ContentObjectStore::ContentBlock::Document.count
+    end
+
+    test "updates the title field on the original ContentBlockDocument" do
+      result = ContentObjectStore::ScheduleEditionService.new(@original_content_block_edition)
+                                                       .call(edition_params)
+      assert_equal result.document.title, edition_params[:document_attributes][:title]
+    end
+
+    describe "when a document title isn't provided" do
+      test "does not update the document" do
+        edition_params.delete(:document_attributes)
+
+        assert_no_changes -> { @original_content_block_edition.document.title } do
+          ContentObjectStore::ScheduleEditionService
+            .new(@original_content_block_edition)
+            .call(edition_params)
+        end
+      end
+    end
+
+    describe "when no parameters are changed" do
+      it "schedules a new edition with the same values as the original" do
+        duplicate_edition_params = {
+          document_attributes: {
+            title: @original_content_block_edition.document.title,
+            block_type: @original_content_block_edition.document.block_type,
+          }.with_indifferent_access,
+          details: @original_content_block_edition.details,
+          creator: build(:user),
+          organisation_id: @original_content_block_edition.lead_organisation.id.to_s,
+          "scheduled_publication(3i)": "2",
+          "scheduled_publication(2i)": "9",
+          "scheduled_publication(1i)": "2034",
+          "scheduled_publication(4i)": "10",
+          "scheduled_publication(5i)": "05",
+        }
+
+        ContentObjectStore::SchedulePublishingWorker.expects(:queue).with do |content_block_edition|
+          content_block_edition.scheduled? &&
+            content_block_edition.document.title == duplicate_edition_params[:document_attributes][:title] &&
+            content_block_edition.details == duplicate_edition_params[:details] &&
+            content_block_edition.lead_organisation.id.to_s == duplicate_edition_params[:organisation_id]
+        end
+
+        ContentObjectStore::ScheduleEditionService
+            .new(@original_content_block_edition)
+            .call(duplicate_edition_params)
+      end
+    end
+
+    describe "when no params are passed" do
+      it "raises an ArgumentError" do
+        assert_raises(ArgumentError) do
+          ContentObjectStore::ScheduleEditionService
+            .new(@original_content_block_edition)
+            .call({})
+        end
+      end
+    end
+
+    describe "when params attempt to change the block type" do
+      test "does not update the document" do
+        second_schema = build(:content_block_schema, block_type: "postal_address")
+        ContentObjectStore::ContentBlock::Schema.stubs(:find_by_block_type)
+          .returns(second_schema)
+
+        edition_params[:document_attributes][:block_type] = "postal_address"
+
+        assert_no_changes -> { @original_content_block_edition.document.block_type } do
+          ContentObjectStore::ScheduleEditionService
+            .new(@original_content_block_edition)
+            .call(edition_params)
+        end
+      end
+    end
+
+    it "updates the original ContentBlockDocument's latest_edition_id and live_edition_id to the new Edition" do
+      result = ContentObjectStore::ScheduleEditionService.new(@original_content_block_edition)
+                                                       .call(edition_params)
+
+      @original_content_block_edition.document.reload
+
+      assert_equal @original_content_block_edition.document.live_edition_id, result.id
+      assert_equal @original_content_block_edition.document.latest_edition_id, result.id
+    end
+
+    test "it creates a new scheduled ContentBlockEdition in Whitehall" do
+      original_document = ContentObjectStore::ContentBlock::Document.find_by!(content_id:)
+
+      assert_changes -> { ContentObjectStore::ContentBlock::Edition.count }, from: 1, to: 2 do
+        ContentObjectStore::ScheduleEditionService
+          .new(@original_content_block_edition)
+          .call(edition_params)
+      end
+
+      new_edition = original_document.editions.last
+
+      assert_equal edition_params[:details], new_edition.details
+      assert_equal "scheduled", new_edition.state
+      assert_equal Time.zone.local(2034, 9, 2, 10, 0o5), new_edition.scheduled_publication
+    end
+
+    test "it schedules a new Edition via the Content Block Worker" do
+      ContentObjectStore::SchedulePublishingWorker.expects(:queue).with do |content_block_edition|
+        content_block_edition.scheduled? &&
+          content_block_edition.document.title == edition_params[:document_attributes][:title] &&
+          content_block_edition.details == edition_params[:details] &&
+          content_block_edition.lead_organisation.id.to_s == edition_params[:organisation_id] &&
+          content_block_edition.scheduled_publication == Time.zone.local(2034, 9, 2, 10, 0o5)
+      end
+
+      ContentObjectStore::ScheduleEditionService
+        .new(@original_content_block_edition)
+        .call(edition_params)
+    end
+
+    test "if the Worker request fails, the Whitehall ContentBlockEdition and ContentBlockDocument are rolled back" do
+      exception = GdsApi::HTTPErrorResponse.new(
+        422,
+        "An internal error message",
+        "error" => { "message" => "Some backend error" },
+      )
+      raises_exception = ->(*_args) { raise exception }
+
+      ContentObjectStore::SchedulePublishingWorker.stub :queue, raises_exception do
+        assert_equal ContentObjectStore::ContentBlock::Document.count, 1 do
+          assert_equal ContentObjectStore::ContentBlock::Edition.count, 1 do
+            assert_raises(GdsApi::HTTPErrorResponse) do
+              ContentObjectStore::ScheduleEditionService
+                .new(@original_content_block_edition)
+                .call(edition_params)
+            end
+          end
+        end
+      end
+    end
+
+    test "if the Whitehall creation fails, no call to schedule the Edition is made" do
+      exception = ArgumentError.new("Cannot find schema for block_type")
+      raises_exception = ->(*_args) { raise exception }
+
+      ContentObjectStore::SchedulePublishingWorker.expects(:queue).never
+
+      ContentObjectStore::ContentBlock::Edition.stub :create!, raises_exception do
+        assert_raises(ArgumentError) do
+          ContentObjectStore::ScheduleEditionService
+            .new(@original_content_block_edition)
+            .call({})
+        end
+      end
+    end
+  end
+end

--- a/lib/engines/content_object_store/test/unit/workers/schedule_publishing_worker_test.rb
+++ b/lib/engines/content_object_store/test/unit/workers/schedule_publishing_worker_test.rb
@@ -6,7 +6,7 @@ class ContentObjectStore::SchedulePublishingWorkerTest < ActiveSupport::TestCase
   test "#perform publishes a scheduled edition" do
     schema = build(:content_block_schema, block_type: "content_block_type", body: { "properties" => { "foo" => "", "bar" => "" } })
     document = create(:content_block_document, :email_address)
-    edition = create(:content_block_edition, document:, state: "scheduled")
+    edition = create(:content_block_edition, document:, state: "scheduled", scheduled_publication: Time.zone.now)
 
     ContentObjectStore::ContentBlock::Schema.expects(:find_by_block_type).with("email_address").returns(schema)
     publish_service_mock = Minitest::Mock.new
@@ -21,7 +21,7 @@ class ContentObjectStore::SchedulePublishingWorkerTest < ActiveSupport::TestCase
   test "#perform raises an error if the edition cannot be published" do
     schema = build(:content_block_schema, block_type: "content_block_type", body: { "properties" => { "foo" => "", "bar" => "" } })
     document = create(:content_block_document, :email_address)
-    edition = create(:content_block_edition, document:, state: "scheduled")
+    edition = create(:content_block_edition, document:, state: "scheduled", scheduled_publication: 7.days.since(Time.zone.now).to_date)
 
     ContentObjectStore::ContentBlock::Schema.expects(:find_by_block_type).with("email_address").returns(schema)
     publish_service_mock = Minitest::Mock.new

--- a/lib/engines/content_object_store/test/unit/workers/schedule_publishing_worker_test.rb
+++ b/lib/engines/content_object_store/test/unit/workers/schedule_publishing_worker_test.rb
@@ -1,0 +1,148 @@
+require "test_helper"
+
+class ContentObjectStore::SchedulePublishingWorkerTest < ActiveSupport::TestCase
+  include SidekiqTestHelpers
+
+  test "#perform publishes a scheduled edition" do
+    schema = build(:content_block_schema, block_type: "content_block_type", body: { "properties" => { "foo" => "", "bar" => "" } })
+    document = create(:content_block_document, :email_address)
+    edition = create(:content_block_edition, document:, state: "scheduled")
+
+    ContentObjectStore::ContentBlock::Schema.expects(:find_by_block_type).with("email_address").returns(schema)
+    publish_service_mock = Minitest::Mock.new
+    ContentObjectStore::PublishEditionService.expects(:new).with(schema).returns(publish_service_mock)
+    publish_service_mock.expect :call, nil, [edition]
+
+    ContentObjectStore::SchedulePublishingWorker.new.perform(edition.id)
+
+    publish_service_mock.verify
+  end
+
+  test "#perform raises an error if the edition cannot be published" do
+    schema = build(:content_block_schema, block_type: "content_block_type", body: { "properties" => { "foo" => "", "bar" => "" } })
+    document = create(:content_block_document, :email_address)
+    edition = create(:content_block_edition, document:, state: "scheduled")
+
+    ContentObjectStore::ContentBlock::Schema.expects(:find_by_block_type).with("email_address").returns(schema)
+    publish_service_mock = Minitest::Mock.new
+
+    exception = ContentObjectStore::PublishEditionService::PublishingFailureError.new(
+      "Could not publish #{document.content_id} because: Some backend error",
+    )
+
+    ContentObjectStore::PublishEditionService.any_instance.stubs(:call).raises(exception)
+
+    assert_raises(ContentObjectStore::SchedulePublishingWorker::SchedulingFailure, "Could not publish #{document.content_id} because: Some backend error") do
+      ContentObjectStore::SchedulePublishingWorker.new.perform(edition.id)
+    end
+    publish_service_mock.verify
+  end
+
+  test "#perform returns without consequence if the edition is already published" do
+    document = create(:content_block_document, :email_address)
+    edition = create(:content_block_edition, document:, state: "published")
+
+    ContentObjectStore::ContentBlock::Schema.expects(:find_by_block_type).never
+    ContentObjectStore::PublishEditionService.expects(:new).never
+    ContentObjectStore::PublishEditionService.any_instance.expects(:call).never
+
+    ContentObjectStore::SchedulePublishingWorker.new.perform(edition.id)
+  end
+
+  test ".queue queues a job for a scheduled edition" do
+    document = create(:content_block_document, :email_address)
+    edition = create(
+      :content_block_edition,
+      document:, state: "scheduled",
+      scheduled_publication: 1.day.from_now
+    )
+
+    ContentObjectStore::SchedulePublishingWorker.queue(edition)
+
+    assert job = ContentObjectStore::SchedulePublishingWorker.jobs.last
+    assert_equal edition.id, job["args"].first
+    assert_equal edition.scheduled_publication.to_i, job["at"].to_i
+  end
+
+  test ".dequeue removes a job for a scheduled edition" do
+    document = create(:content_block_document, :email_address)
+    edition = create(
+      :content_block_edition,
+      document:,
+      state: "scheduled",
+      scheduled_publication: 1.day.from_now,
+    )
+
+    control_document = create(:content_block_document, :email_address)
+    control_edition = create(
+      :content_block_edition,
+      document: control_document,
+      state: "scheduled",
+      scheduled_publication: 1.day.from_now,
+    )
+
+    with_real_sidekiq do
+      ContentObjectStore::SchedulePublishingWorker.queue(edition)
+      ContentObjectStore::SchedulePublishingWorker.queue(control_edition)
+
+      assert_equal 2, Sidekiq::ScheduledSet.new.size
+
+      ContentObjectStore::SchedulePublishingWorker.dequeue(edition)
+
+      assert_equal 1, Sidekiq::ScheduledSet.new.size
+
+      control_job = Sidekiq::ScheduledSet.new.first
+
+      assert_equal control_job["args"].first, control_edition.id
+      assert_equal control_job.at.to_i, control_edition.scheduled_publication.to_i
+    end
+  end
+
+  test ".dequeue_all removes all content block publishing jobs" do
+    document_1 = create(:content_block_document, :email_address)
+    edition_1 = create(
+      :content_block_edition,
+      document: document_1,
+      state: "scheduled",
+      scheduled_publication: 1.day.from_now,
+    )
+
+    document_2 = create(:content_block_document, :email_address)
+    edition_2 = create(
+      :content_block_edition,
+      document: document_2,
+      state: "scheduled",
+      scheduled_publication: 1.day.from_now,
+    )
+
+    with_real_sidekiq do
+      ContentObjectStore::SchedulePublishingWorker.queue(edition_1)
+      ContentObjectStore::SchedulePublishingWorker.queue(edition_2)
+
+      assert_equal 2, Sidekiq::ScheduledSet.new.size
+
+      ContentObjectStore::SchedulePublishingWorker.dequeue_all
+
+      assert_equal 0, Sidekiq::ScheduledSet.new.size
+    end
+  end
+
+  test ".queue_size returns the number of queued ContentBlockPublishingWorker jobs" do
+    with_real_sidekiq do
+      ContentObjectStore::SchedulePublishingWorker.perform_at(1.day.from_now, "null")
+      assert_equal 1, ContentObjectStore::SchedulePublishingWorker.queue_size
+
+      ContentObjectStore::SchedulePublishingWorker.perform_at(2.days.from_now, "null")
+      assert_equal 2, ContentObjectStore::SchedulePublishingWorker.queue_size
+    end
+  end
+
+  test ".queued_edition_ids returns the edition ids of the currently queued jobs" do
+    with_real_sidekiq do
+      ContentObjectStore::SchedulePublishingWorker.perform_at(1.day.from_now, "3")
+      ContentObjectStore::SchedulePublishingWorker.perform_at(2.days.from_now, "6")
+
+      assert_same_elements %w[3 6], ContentObjectStore::SchedulePublishingWorker.queued_edition_ids
+    end
+  end
+end


### PR DESCRIPTION
**Note: to make this work you will need `Sidekiq Admin` permissions - locally, this can be added to the Test User in `db/seeds.rb`, on integration this can be added to each user through SignOn.**

We want to allow users to schedule the publication of Content Blocks. This is the first attempt at introducing that in the code. As with our other features, we follow Whitehall patterns where possible/where it makes sense. This has included :
* having any actions related to the `workflow` of an Edition in a separate controller
  * @tahb and I discussed renaming the `workflow_controller` to `editions_workflow_controller` to make this more clear, will do in a future PR
* Using a Worker class to put jobs onto a Sidekiq queue.
  * our Worker is almost identical, but calls a different Service to schedule a Content Block Edition. 
  * while Whitehall have a separate `ScheduledEditionPublisher` to publish scheduled Editions, as we don't have any logic to check for scheduled editions, I've just re-used our `PublishEditionService`.
* Using a similar workflow state on the Edition, and a field called `scheduled_publication` to store the datetime in the db 
* Using the same date/time fields component  and error messages in the view.

![Screenshot 2024-08-27 at 12 34 32](https://github.com/user-attachments/assets/2b020b29-2136-4fc8-9a45-44bd9abc8977)


![Screenshot 2024-08-27 at 17 29 13](https://github.com/user-attachments/assets/ab34f044-0706-4fb9-bd1d-072fbb3d205c)

![Screenshot 2024-08-27 at 17 29 28](https://github.com/user-attachments/assets/a9321b93-a188-455c-8c65-9fea1e6a2ef7)


Sidekiq jobs can be viewed at http://whitehall-admin.dev.gov.uk/sidekiq/queues 

## steps for manual testing
* create a content block
* go to 'change' the content block details
* schedule the publication for the next minute or so
* observe job at http://whitehall-admin.dev.gov.uk/sidekiq/queues 
* once published, put content id for the block (found in embed code) and check published on Publishing API http://publishing-api.dev.gov.uk/v2/content/{content-id}

## Todo in future PRs

* if there is another scheduled edition, scheduling should not be allowed or we should supersede the existing scheduled edition
* version history/ audit trail
  * the scheduling action should appear on the Document Timeline as `scheduled` by User
  * the actual publication by Sidekiq should appear as `published` (by who?)
* Interaction design for showing the state of the Block and the publication date. 
* Interaction design to cancel or supersede a scheduled Block
* Understanding how this relates to Documents that have embedded the Block - e.g. superseding logic, notifications etc.  





~~⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️~~

~~Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.~~
