### PR TITLE
Allow overriding government attempt 3

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -238,6 +238,7 @@ private
       :additional_related_mainstream_content_url,
       :corporate_information_page_type_id,
       :political,
+      :government_id,
       :read_consultation_principles,
       :all_nation_applicability,
       :speaker_radios,

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -347,6 +347,8 @@ class Edition < ApplicationRecord
   end
 
   def government
+    return @government ||= Government.find(government_id) if government_id.present?
+
     @government ||= Government.on_date(date_for_government) unless date_for_government.nil?
   end
 

--- a/db/migrate/20240822112802_add_governments_foreign_key_to_editions.rb
+++ b/db/migrate/20240822112802_add_governments_foreign_key_to_editions.rb
@@ -1,0 +1,8 @@
+class AddGovernmentsForeignKeyToEditions < ActiveRecord::Migration[7.1]
+  def change
+    change_table :editions do |t|
+      t.integer :government_id
+    end
+    add_foreign_key :editions, :governments, on_delete: :nullify
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_31_143537) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_22_112802) do
   create_table "assets", charset: "utf8mb3", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.string "variant", null: false
@@ -447,10 +447,12 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_31_143537) do
     t.string "logo_formatted_name"
     t.string "analytics_identifier"
     t.boolean "visual_editor"
+    t.integer "government_id"
     t.index ["alternative_format_provider_id"], name: "index_editions_on_alternative_format_provider_id"
     t.index ["closing_at"], name: "index_editions_on_closing_at"
     t.index ["document_id"], name: "index_editions_on_document_id"
     t.index ["first_published_at"], name: "index_editions_on_first_published_at"
+    t.index ["government_id"], name: "fk_rails_6875303236"
     t.index ["main_office_id"], name: "index_editions_on_main_office_id"
     t.index ["opening_at"], name: "index_editions_on_opening_at"
     t.index ["operational_field_id"], name: "index_editions_on_operational_field_id"
@@ -1287,6 +1289,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_31_143537) do
   add_foreign_key "content_block_editions", "content_block_documents", column: "document_id"
   add_foreign_key "documents", "editions", column: "latest_edition_id", on_update: :cascade, on_delete: :nullify
   add_foreign_key "documents", "editions", column: "live_edition_id", on_update: :cascade, on_delete: :nullify
+  add_foreign_key "editions", "governments"
   add_foreign_key "link_checker_api_report_links", "link_checker_api_reports"
   add_foreign_key "related_mainstreams", "editions"
   add_foreign_key "statistics_announcements", "statistics_announcement_dates", column: "current_release_date_id", on_update: :cascade, on_delete: :nullify

--- a/test/functional/admin/generic_editions_controller_tests/political_document_test.rb
+++ b/test/functional/admin/generic_editions_controller_tests/political_document_test.rb
@@ -2,9 +2,22 @@ require "test_helper"
 
 class Admin::GenericEditionsController::PolticalDocumentsTest < ActionController::TestCase
   tests Admin::NewsArticlesController
+  enable_url_helpers
 
   setup do
     login_as :writer
+  end
+
+  test "can override the government associated with a political edition" do
+    create(:current_government)
+    previous_government = create(:previous_government)
+    published_edition = create(:published_news_article, political: true)
+    new_draft = create(:news_article, document: published_edition.document, political: true)
+
+    put :update, params: { id: new_draft, edition: { government_id: previous_government.id } }
+
+    assert_redirected_to admin_edition_path(new_draft)
+    assert_equal previous_government, new_draft.reload.government
   end
 
   view_test "displays the political checkbox for privileged users " do

--- a/test/functional/admin/generic_editions_controller_tests/political_document_test.rb
+++ b/test/functional/admin/generic_editions_controller_tests/political_document_test.rb
@@ -8,6 +8,17 @@ class Admin::GenericEditionsController::PolticalDocumentsTest < ActionController
     login_as :writer
   end
 
+  test "can mark a document as political" do
+    create(:current_government)
+    published_edition = create(:published_news_article)
+    new_draft = create(:news_article, document: published_edition.document)
+
+    put :update, params: { id: new_draft, edition: { political: true } }
+
+    assert_redirected_to admin_edition_path(new_draft)
+    assert new_draft.reload.political?
+  end
+
   test "can override the government associated with a political edition" do
     create(:current_government)
     previous_government = create(:previous_government)

--- a/test/unit/app/models/edition_test.rb
+++ b/test/unit/app/models/edition_test.rb
@@ -799,6 +799,13 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal "First published date must be between 1/1/1900 and the present", edition.errors.full_messages.first
   end
 
+  test "#government returns the associated government when the edition has a specific government_id" do
+    create(:current_government)
+    previous_government = create(:previous_government)
+    edition = create(:edition, first_published_at: Time.zone.now, government_id: previous_government.id)
+    assert_equal previous_government, edition.government
+  end
+
   test "#government returns the current government for a newly published edition" do
     government = create(:current_government)
     edition = create(:edition, first_published_at: Time.zone.now)


### PR DESCRIPTION
Trello: https://trello.com/c/II8jgMR7

This PR puts the basic mechanisms in place for enabling GDS editors and admins to override the government. However, it does not include a user interface, which will be hidden behind a feature flag initially so that the content team can test it out.

## Implementation Notes

The `government_id` column that we're adding to the editions table is indexed, because I foresee a need when we come to [facilitating changes to historic governments](https://trello.com/c/VwTpDOEa) to be able to query for all of the editions associated with a government, in order to make sure that any overrides aren't deleted. I wanted to use `on_delete: restrict` for this to prevent governments from being deleted but realised that I wouldn't be able to because we won't be able to change the overrides for superseded editions. So we'll have to do that in the application layer instead :cry:

I originally planned to achieve this feature by replacing the `political` attribute on the edition with the `government_id` column (hence this being attempt 3), but that would make changing governments very difficult indeed because of the number of documents that might need to be updated to make sure the overrides were maintained. I wasn't able to envision an automated process to achieve that and the burden on GDS admins would have been excessive. I've therefore decided to make `government_id` be just an override for the government selection for an edition.
