### PR TITLE
Allow overriding government attempt 3 part 2

### DIFF
--- a/app/components/admin/editions/history_mode_form_controls.erb
+++ b/app/components/admin/editions/history_mode_form_controls.erb
@@ -1,0 +1,31 @@
+<div class="govuk-!-margin-bottom-8">
+  <%= render "govuk_publishing_components/components/input", {
+    name: "edition[political]",
+    type: "hidden",
+    value: "",
+  } %>
+
+  <%= render "govuk_publishing_components/components/checkboxes", {
+    name: "edition[political]",
+    id: "edition_political",
+    heading: "Political",
+    heading_size: "l",
+    no_hint_text: true,
+    items: [
+      {
+        label: "Associate with government of the time (currently set to #{@edition.government&.name}).",
+        value: "1",
+        checked: @edition.political,
+        conditional: renders_government_selector? ? (render "govuk_publishing_components/components/select", {
+          name: "edition[government_id]",
+          label: "Or, associate this document with a different government",
+          id: "edition_government_id",
+          options:,
+        }) : "",
+      },
+    ],
+  } %>
+
+  <p class="govuk-body"><%= link_to "Read the history mode guidance", "https://www.gov.uk/guidance/how-to-publish-on-gov-uk/creating-and-updating-pages#history-mode", class: "govuk-link" %>
+    for more information as to what this means.</p>
+</div>

--- a/app/components/admin/editions/history_mode_form_controls.rb
+++ b/app/components/admin/editions/history_mode_form_controls.rb
@@ -1,0 +1,32 @@
+class Admin::Editions::HistoryModeFormControls < ViewComponent::Base
+  def initialize(edition, current_user)
+    @edition = edition
+    @enforcer = Whitehall::Authority::Enforcer.new(current_user, edition)
+  end
+
+  def render?
+    @edition.document&.live? && @edition.can_be_marked_political? && @enforcer.can?(:mark_political)
+  end
+
+  def renders_government_selector?
+    Flipflop.override_government? && @enforcer.can?(:select_government_for_history_mode)
+  end
+
+  # noinspection RubyMismatchedArgumentType
+  def options
+    [
+      {
+        text: "Associate with default government",
+        value: "",
+      },
+    ].tap do |options|
+      Government.find_each do |government|
+        options << {
+          text: government.name,
+          value: government.id,
+          selected: government.id == @edition.government_id,
+        }
+      end
+    end
+  end
+end

--- a/app/views/admin/editions/_standard_fields.html.erb
+++ b/app/views/admin/editions/_standard_fields.html.erb
@@ -123,29 +123,7 @@
 
   <%= render "additional_significant_fields", form: form, edition: form.object %>
 
-  <% if edition.document&.live? && edition.can_be_marked_political? && can?(:mark_political, edition) %>
-    <div class="govuk-!-margin-bottom-8">
-      <%= form.hidden_field :political, value: "0" %>
-
-      <%= render "govuk_publishing_components/components/checkboxes", {
-        name: "edition[political]",
-        id: "edition_political",
-        heading: "Political",
-        heading_size: "l",
-        no_hint_text: true,
-        error: errors_for_input(edition.errors, :political),
-        items: [
-          {
-            label: "Associate with government of the time (currently set to #{edition.government&.name}).",
-            value: "1",
-            checked: edition.political,
-          },
-        ],
-      } %>
-
-      <p class="govuk-body"><%= link_to "Read the history mode guidance", "https://www.gov.uk/guidance/how-to-publish-on-gov-uk/creating-and-updating-pages#history-mode", class: "govuk-link" %> for more information as to what this means.</p>
-    </div>
-  <% end %>
+  <%= render Admin::Editions::HistoryModeFormControls.new(@edition, current_user) %>
 </div>
 
 <%= render Admin::Editions::FirstPublishedAtComponent.new(

--- a/config/features.rb
+++ b/config/features.rb
@@ -23,4 +23,5 @@ Flipflop.configure do
   #   description: "Take over the world."
   feature :govspeak_visual_editor, description: "Enables a visual editor for Govspeak fields", default: false
   feature :content_object_store, description: "Enables the object store for sharable content", default: Rails.env.development?
+  feature :override_government, description: "Enables GDS Editors and Admins to override the government associated with a document", default: false
 end

--- a/lib/whitehall/authority/rules/edition_rules.rb
+++ b/lib/whitehall/authority/rules/edition_rules.rb
@@ -19,6 +19,7 @@ module Whitehall::Authority::Rules
         review_editorial_remark
         review_fact_check
         see
+        select_government_for_history_mode
         unpublish
         unwithdraw
         update
@@ -171,7 +172,7 @@ module Whitehall::Authority::Rules
         can_publish?
       when :force_publish
         can_force_publish?
-      when :unpublish, :mark_political, :perform_administrative_tasks
+      when :unpublish, :mark_political, :perform_administrative_tasks, :select_government_for_history_mode
         false
       else
         true
@@ -200,6 +201,7 @@ module Whitehall::Authority::Rules
         force_publish
         reject
         mark_political
+        select_government_for_history_mode
         perform_administrative_tasks
       ]
 

--- a/test/components/admin/editions/history_mode_form_controls_test.rb
+++ b/test/components/admin/editions/history_mode_form_controls_test.rb
@@ -1,0 +1,62 @@
+require "test_helper"
+
+class Admin::Editions::HistoryModeFormControlsTest < ViewComponent::TestCase
+  setup do
+    @test_strategy = Flipflop::FeatureSet.current.test!
+  end
+
+  test "hides the government selector for GDS editor users when the feature flag is disabled" do
+    @test_strategy.switch!(:override_government, false)
+    government = create(:current_government)
+    published_edition = create(:published_news_article, government_id: government.id)
+    new_draft = create(:news_article, document: published_edition.document, government_id: government.id)
+    render_inline(Admin::Editions::HistoryModeFormControls.new(new_draft, create(:gds_editor)))
+    assert_selector "select#edition_government_id", count: 0
+  end
+
+  test "conditionally displays the government selector for gds editor users" do
+    @test_strategy.switch!(:override_government, true)
+    previous_government = create(:previous_government)
+    governments = [create(:current_government), previous_government]
+    published_edition = create(:published_news_article, government_id: previous_government.id)
+    new_draft = create(:news_article, document: published_edition.document, government_id: previous_government.id)
+    render_inline(Admin::Editions::HistoryModeFormControls.new(new_draft, create(:gds_editor)))
+    assert_selector "#edition_political-0-conditional-0 select#edition_government_id"
+    assert_selector "option[value='']"
+    governments.each do |government|
+      assert_selector "option[value='#{government.id}']"
+    end
+    assert_selector "option[value='#{previous_government.id}'][selected='selected']"
+  end
+
+  test "displays the political checkbox for managing editor users " do
+    @test_strategy.switch!(:override_government, true)
+    published_edition = create(:published_news_article)
+    new_draft = create(:news_article, document: published_edition.document)
+    render_inline(Admin::Editions::HistoryModeFormControls.new(new_draft, create(:managing_editor)))
+    assert_selector "#edition_political"
+  end
+
+  test "doesn't display the government selector for managing editor users " do
+    @test_strategy.switch!(:override_government, true)
+    published_edition = create(:published_news_article)
+    new_draft = create(:news_article, document: published_edition.document)
+    render_inline(Admin::Editions::HistoryModeFormControls.new(new_draft, create(:managing_editor)))
+    assert_selector "select#edition_government_id", count: 0
+  end
+
+  test "doesn't display the political checkbox for writer users " do
+    @test_strategy.switch!(:override_government, true)
+    published_edition = create(:published_news_article)
+    new_draft = create(:news_article, document: published_edition.document)
+    render_inline(Admin::Editions::HistoryModeFormControls.new(new_draft, create(:writer)))
+    assert_selector "#edition_political", count: 0
+  end
+
+  test "doesn't display the political checkbox on creation" do
+    @test_strategy.switch!(:override_government, true)
+    new_draft = create(:news_article)
+    render_inline(Admin::Editions::HistoryModeFormControls.new(new_draft, create(:managing_editor)))
+    assert_selector "#edition_political", count: 0
+  end
+end

--- a/test/functional/admin/generic_editions_controller_tests/political_document_test.rb
+++ b/test/functional/admin/generic_editions_controller_tests/political_document_test.rb
@@ -31,26 +31,12 @@ class Admin::GenericEditionsController::PolticalDocumentsTest < ActionController
     assert_equal previous_government, new_draft.reload.government
   end
 
-  view_test "displays the political checkbox for privileged users " do
-    create(:current_government)
+  view_test "displays the history mode form controls for privileged users " do
     login_as :managing_editor
-    published_edition = create(:published_news_article, first_published_at: 2.days.ago)
-    new_draft = create(:news_article, document: published_edition.document, first_published_at: 2.days.ago)
-    get :edit, params: { id: new_draft }
-    assert_select "#edition_political"
-  end
-
-  view_test "doesn't display the political checkbox for non-privileged users " do
     published_edition = create(:published_news_article)
     new_draft = create(:news_article, document: published_edition.document)
     get :edit, params: { id: new_draft }
-    assert_select "#edition_political", count: 0
-  end
-
-  view_test "doesn't display the political checkbox on creation" do
-    login_as :managing_editor
-    get :new
-    assert_select "#edition_political", count: 0
+    assert_select "#edition_political"
   end
 
   def edit_historic_document


### PR DESCRIPTION
Depends on  #9388 

This is hidden behind a feature flag so we can safely merge even though we haven't had sign off from content on the implementation.

I separated the history mode fields into a view component in order to be able to test the various conditions from a component test rather than a view test.

Annoyingly, because the conditional checkbox behaviour relies on Javascript, the best we can do to test that is working is assert that the government selection element is wrapped in a conditional div belonging to the political checkbox.

Trello: https://trello.com/c/II8jgMR7

