### PR TITLE
Get content that embeds a target via GDS API Adapters

### DIFF
--- a/lib/engines/content_object_store/app/services/content_object_store/get_host_content_items.rb
+++ b/lib/engines/content_object_store/app/services/content_object_store/get_host_content_items.rb
@@ -31,24 +31,8 @@ module ContentObjectStore
 
     def content_items
       @content_items ||= begin
-        # TODO: A temporary solution to get the content items from the new publishing-api endpoint.
-        # To be replaced with a new method via GDS Adapters when it's implemented.
-        url = URI.parse("#{Plek.find('publishing-api')}/v2/content/#{@content_id}/embedded")
-        http = Net::HTTP.new(url.host, url.port)
-        http.use_ssl = true if url.scheme == "https"
-
-        request = Net::HTTP::Get.new(url.request_uri)
-        response = http.request(request)
-
-        @content_items = if response.is_a?(Net::HTTPSuccess)
-                           JSON.parse(response.body)
-                         else
-                           {
-                             "target_content_id" => @content_id,
-                             "total" => 0,
-                             "results" => [],
-                           }
-                         end
+        response = Services.publishing_api.get_content_by_embedded_document(@content_id)
+        response.parsed_content
       end
     end
   end

--- a/lib/engines/content_object_store/features/step_definitions/content_object_store_steps.rb
+++ b/lib/engines/content_object_store/features/step_definitions/content_object_store_steps.rb
@@ -284,7 +284,7 @@ When(/^dependent content exists for a content block$/) do
     }
   end
 
-  stub_dependent_content(results: @dependent_content, total: @dependent_content.length)
+  stub_publishing_api_has_embedded_content(content_id: anything, results: @dependent_content, total: @dependent_content.length)
 end
 
 Then(/^I should see the dependent content listed$/) do

--- a/lib/engines/content_object_store/features/support/stubs.rb
+++ b/lib/engines/content_object_store/features/support/stubs.rb
@@ -1,12 +1,3 @@
 Before do
-  stub_dependent_content(content_id: anything, total: 0, results: [])
-end
-
-def stub_dependent_content(results:, content_id: anything, total: 0)
-  stub_request(:get, %r{\A#{Plek.find('publishing-api')}/v2/content/[0-9a-fA-F-]{36}/embedded})
-    .to_return(body: {
-      "content_id" => content_id,
-      "total" => total,
-      "results" => results,
-    }.to_json)
+  stub_publishing_api_has_embedded_content(content_id: anything, total: 0, results: [])
 end


### PR DESCRIPTION
## Changes in this PR

* We switch our a request to the Publishing API. Replacing a Net::HTTP request with a conventional GDS API Adapter call
* Change in our error handling. Instead of defaulting to an empty list of results in the case of an error we now throw. When users are managing content it's important they can see the full reach of their reusable content. To see an empty list could be dangerously misleading, implying there was in fact no reuse.

Naming continues to be a battle. Coining a concise term that captures the concept and the relationships of reusable content. We have 'reusable' editions which are _embedded_ and linked to by ‘normal’ editions. When we call this endpoint we want to know where a piece of content has been embedded but our results should be references to the normal editions. We're using "content which embeds our target content" which is accurate but a little awkward.