### PR TITLE
Content modelling/467 timeline

### DIFF
--- a/db/migrate/20240902102908_add_state_to_content_block_versions.rb
+++ b/db/migrate/20240902102908_add_state_to_content_block_versions.rb
@@ -1,0 +1,13 @@
+class AddStateToContentBlockVersions < ActiveRecord::Migration[7.1]
+  def up
+    change_table :content_block_versions, bulk: true do |t|
+      t.text "state"
+    end
+  end
+
+  def down
+    change_table :content_block_versions, bulk: true do |t|
+      t.remove :state
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_29_130419) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_02_102908) do
   create_table "assets", charset: "utf8mb3", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.string "variant", null: false
@@ -237,6 +237,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_29_130419) do
     t.integer "event", null: false
     t.string "whodunnit"
     t.datetime "created_at", precision: nil, null: false
+    t.text "state"
     t.index ["item_id"], name: "index_content_block_versions_on_item_id"
     t.index ["item_type"], name: "index_content_block_versions_on_item_type"
   end

--- a/lib/engines/content_object_store/app/components/content_object_store/content_block/document/show/document_timeline_component.rb
+++ b/lib/engines/content_object_store/app/components/content_object_store/content_block/document/show/document_timeline_component.rb
@@ -9,21 +9,17 @@ private
   attr_reader :content_block_versions
 
   def items
-    content_block_versions.map do |version|
+    content_block_versions.reject { |version| version.state.nil? }.map do |version|
       {
         title: title(version),
-        byline: User.find_by_id(version.whodunnit).name,
+        byline: User.find_by_id(version.whodunnit)&.name || "unknown user",
         date: time_html(version.created_at),
       }
     end
   end
 
   def title(version)
-    if version.id == first_created_edition.id
-      "#{version.item.block_type.humanize} created"
-    else
-      "#{version.item.block_type.humanize} changed"
-    end
+    "#{version.item.block_type.humanize} #{version.state}"
   end
 
   def first_created_edition

--- a/lib/engines/content_object_store/app/models/concerns/content_object_store/has_audit_trail.rb
+++ b/lib/engines/content_object_store/app/models/concerns/content_object_store/has_audit_trail.rb
@@ -3,7 +3,7 @@ module ContentObjectStore
     extend ActiveSupport::Concern
 
     included do
-      has_many :versions, -> { order(created_at: :desc, id: :asc) }, as: :item
+      has_many :versions, -> { order(created_at: :desc, id: :desc) }, as: :item
 
       after_create :record_create
     end

--- a/lib/engines/content_object_store/app/models/concerns/content_object_store/has_audit_trail.rb
+++ b/lib/engines/content_object_store/app/models/concerns/content_object_store/has_audit_trail.rb
@@ -2,10 +2,19 @@ module ContentObjectStore
   module HasAuditTrail
     extend ActiveSupport::Concern
 
+    def self.acting_as(actor)
+      original_actor = Current.user
+      Current.user = actor
+      yield
+    ensure
+      Current.user = original_actor
+    end
+
     included do
       has_many :versions, -> { order(created_at: :desc, id: :desc) }, as: :item
 
       after_create :record_create
+      after_update :record_update
     end
 
   private
@@ -13,6 +22,12 @@ module ContentObjectStore
     def record_create
       user = Current.user
       versions.create!(event: "created", user:)
+    end
+
+    def record_update
+      user = Current.user
+      state = try(:state)
+      versions.create!(event: "updated", user:, state:)
     end
   end
 end

--- a/lib/engines/content_object_store/app/models/content_object_store/content_block/version.rb
+++ b/lib/engines/content_object_store/app/models/content_object_store/content_block/version.rb
@@ -1,7 +1,7 @@
 module ContentObjectStore
   module ContentBlock
     class Version < ApplicationRecord
-      enum event: [:created]
+      enum event: %i[created updated]
 
       belongs_to :item, polymorphic: true
       validates :event, presence: true

--- a/lib/engines/content_object_store/app/workers/content_object_store/schedule_publishing_worker.rb
+++ b/lib/engines/content_object_store/app/workers/content_object_store/schedule_publishing_worker.rb
@@ -48,9 +48,11 @@ module ContentObjectStore
 
       schema = ContentObjectStore::ContentBlock::Schema.find_by_block_type(edition.document.block_type)
 
-      ContentObjectStore::PublishEditionService.new(
-        schema,
-      ).call(edition)
+      ContentObjectStore::HasAuditTrail.acting_as(publishing_robot) do
+        ContentObjectStore::PublishEditionService.new(
+          schema,
+        ).call(edition)
+      end
     rescue ContentObjectStore::Publishable::PublishingFailureError => e
       raise SchedulingFailure, e.message
     end

--- a/lib/engines/content_object_store/features/edit_object.feature
+++ b/lib/engines/content_object_store/features/edit_object.feature
@@ -27,7 +27,7 @@ Feature: Edit a content object
     And I accept and publish
     Then the edition should have been updated successfully
     And I should be taken back to the document page
-    And I should see the update on the timeline
+    And I should see 2 publish events on the timeline
 
   Scenario: GDS editor sees validation errors for missing fields
     And a schema "email_address" exists with the following fields:

--- a/lib/engines/content_object_store/features/schedule_object.feature
+++ b/lib/engines/content_object_store/features/schedule_object.feature
@@ -17,6 +17,7 @@ Feature: Schedule a content object
     Then the edition should have been scheduled successfully
     And I should be taken back to the document page
     And I should see the scheduled date on the object
+    And I should see 2 publish events on the timeline
 
   Scenario: A scheduled content object is published
     When I am updating a content block
@@ -24,6 +25,7 @@ Feature: Schedule a content object
     When I choose to schedule the change
     And the block is scheduled and published
     Then published state of the object is shown
+    And I should see the publish event on the timeline
 
   Scenario: GDS Editor does not provide date for scheduling
     When I am updating a content block

--- a/lib/engines/content_object_store/features/view_object.feature
+++ b/lib/engines/content_object_store/features/view_object.feature
@@ -13,7 +13,7 @@ Feature: View a content object
     When I click to view the document
     Then I should be taken back to the document page
     And I should see the details for the email address content block
-    And I should see the created event on the timeline
+    And I should see 1 publish events on the timeline
 
   Scenario: GDS Editor views dependent Content
     Given dependent content exists for a content block

--- a/lib/engines/content_object_store/test/factories/content_block_version.rb
+++ b/lib/engines/content_object_store/test/factories/content_block_version.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     event { "created" }
     item {}
     whodunnit {}
+    state {}
   end
 end

--- a/lib/engines/content_object_store/test/factories/content_block_version.rb
+++ b/lib/engines/content_object_store/test/factories/content_block_version.rb
@@ -1,8 +1,16 @@
 FactoryBot.define do
   factory :content_block_version, class: "ContentObjectStore::ContentBlock::Version" do
     event { "created" }
-    item {}
-    whodunnit {}
+    item do
+      create(
+        :content_block_edition,
+        document: create(
+          :content_block_document,
+          block_type: "email_address",
+        ),
+      )
+    end
+    whodunnit { create(:user).id }
     state {}
   end
 end

--- a/lib/engines/content_object_store/test/unit/app/models/concerns/has_audit_trail_test.rb
+++ b/lib/engines/content_object_store/test/unit/app/models/concerns/has_audit_trail_test.rb
@@ -20,19 +20,44 @@ class ContentObjectStore::HasAuditTrailTest < ActiveSupport::TestCase
   end
 
   describe "versions" do
-    it "returns versions in ascending order" do
+    it "returns versions in descending order based on datetime" do
       edition = create(
         :content_block_edition,
         document: create(:content_block_document, :email_address),
       )
       newer_version = edition.versions.first
-      older_version = create(
+      oldest_version = create(
         :content_block_version,
         created_at: 2.days.ago,
         item: edition,
       )
+      middle_version = create(
+        :content_block_version,
+        created_at: 1.day.ago,
+        item: edition,
+      )
       assert_equal edition.versions.first, newer_version
-      assert_equal edition.versions.last, older_version
+      assert_equal edition.versions.last, oldest_version
+      assert_equal edition.versions[1], middle_version
+    end
+
+    it "returns versions in descending order based on id" do
+      edition = create(
+        :content_block_edition,
+        document: create(:content_block_document, :email_address),
+      )
+      first_version = edition.versions.first
+      second_version = create(
+        :content_block_version,
+        item: edition,
+      )
+      third_version = create(
+        :content_block_version,
+        item: edition,
+      )
+      assert_equal edition.versions.first, third_version
+      assert_equal edition.versions[1], second_version
+      assert_equal edition.versions.last, first_version
     end
   end
 end


### PR DESCRIPTION
Previous timeline

![Screenshot 2024-09-03 at 11 26 16](https://github.com/user-attachments/assets/352a2a44-c77b-4fea-8df5-72f2b271f49c)


New timeline

![Screenshot 2024-09-03 at 15 45 26](https://github.com/user-attachments/assets/586d8244-6740-4a37-b2b4-979f2ec62907)


This creates an audit trail for scheduling/updating an Edition, and adds the events to the user-facing timeline of a Document.

Previously we only had events to track when an Edition was created - because our
Content Blocks are published as soon as they are created, this was sufficient, as an Edition would never be 'updated', only superseded by a new Edition.

Now we have introduced Scheduling, an Edition can be updated. It will be created and set in the `scheduled` state, and then `published` by the scheduling worker.

For this reason we introduce the `record_update` method, and create an 'updated' event with the
state - this will also be handy in the future should we ever introduce new states (e.g.withdrawn, draft etc.)

These versions provide an Edition-level database log of events for us, but the user need on a
Document-level view is slightly different. With this new change, we will only show state/update changes to an Edition, as[ this should cover the need-to-know events for now.](https://gds.slack.com/archives/C062Z1FA2ES/p1725375605153839?thread_ts=1725360904.799849&cid=C062Z1FA2ES)