### PR TITLE
DRY up date formatting

### DIFF
--- a/lib/engines/content_object_store/app/components/content_object_store/content_block/document/show/document_timeline_component.rb
+++ b/lib/engines/content_object_store/app/components/content_object_store/content_block/document/show/document_timeline_component.rb
@@ -27,9 +27,8 @@ private
   end
 
   def time_html(date_time)
-    formatted_timestamp = date_time.strftime("%d %B %Y at %I:%M%P")
     tag.time(
-      formatted_timestamp,
+      I18n.l(date_time, format: :long_ordinal),
       class: "date",
       datetime: date_time.iso8601,
       lang: "en",

--- a/lib/engines/content_object_store/app/components/content_object_store/content_block/document/show/summary_list_component.rb
+++ b/lib/engines/content_object_store/app/components/content_object_store/content_block/document/show/summary_list_component.rb
@@ -67,9 +67,10 @@ private
   end
 
   def scheduled_item
+    scheduled_date = content_block_document.latest_edition.scheduled_publication
     {
       field: "Scheduled for publication at",
-      value: content_block_document.latest_edition.scheduled_publication&.strftime("%e %B %Y at %I:%M%P"),
+      value: scheduled_date ? I18n.l(scheduled_date, format: :long_ordinal) : nil,
     }
   end
 

--- a/lib/engines/content_object_store/app/components/content_object_store/content_block_edition/show/confirm_summary_list_component.rb
+++ b/lib/engines/content_object_store/app/components/content_object_store/content_block_edition/show/confirm_summary_list_component.rb
@@ -42,7 +42,7 @@ private
   def date_item
     {
       field: "Publish date",
-      value: Date.current.strftime("%d %B %Y"),
+      value: I18n.l(content_block_edition.created_at.to_date, format: :long_ordinal),
     }
   end
 end

--- a/lib/engines/content_object_store/features/step_definitions/content_object_store_steps.rb
+++ b/lib/engines/content_object_store/features/step_definitions/content_object_store_steps.rb
@@ -367,7 +367,7 @@ When("I choose to schedule the change") do
 end
 
 When("I enter a date 7 days in the future") do
-  @future_date = 7.days.since(Time.zone.now).to_date
+  @future_date = 7.days.since(Time.zone.now)
   fill_in_date_and_time_field(@future_date)
 end
 
@@ -403,5 +403,5 @@ end
 
 Then("I should see the scheduled date on the object") do
   expect(page).to have_selector(".govuk-summary-list__key", text: "Scheduled for publication at")
-  expect(page).to have_selector(".govuk-summary-list__value", text: @future_date.strftime("%e %B %Y at %I:%M%P"))
+  expect(page).to have_selector(".govuk-summary-list__value", text: I18n.l(@future_date, format: :long_ordinal).squish)
 end

--- a/lib/engines/content_object_store/test/components/content_block/document/index/summary_card_component_test.rb
+++ b/lib/engines/content_object_store/test/components/content_block/document/index/summary_card_component_test.rb
@@ -11,6 +11,7 @@ class ContentObjectStore::ContentBlock::Document::Index::SummaryCardComponentTes
       details: { foo: "bar", something: "else" },
       creator: build(:user),
       organisation: build(:organisation),
+      scheduled_publication: Time.zone.now,
     )
     content_block_document = content_block_edition.document
 
@@ -41,6 +42,9 @@ class ContentObjectStore::ContentBlock::Document::Index::SummaryCardComponentTes
     assert_selector ".govuk-summary-list__value", text: content_block_document.embed_code
 
     assert_selector ".govuk-summary-list__key", text: "State"
-    assert_selector ".govuk-summary-list__value", text: content_block_edition.scheduled_publication&.strftime("%e %B %Y at %I:%M%P")
+    assert_selector ".govuk-summary-list__value", text: content_block_edition.state
+
+    assert_selector ".govuk-summary-list__key", text: "Scheduled for publication at"
+    assert_selector ".govuk-summary-list__value", text: I18n.l(content_block_edition.scheduled_publication, format: :long_ordinal)
   end
 end

--- a/lib/engines/content_object_store/test/components/content_block/document/show/document_timeline_component_test.rb
+++ b/lib/engines/content_object_store/test/components/content_block/document/show/document_timeline_component_test.rb
@@ -26,14 +26,15 @@ class ContentObjectStore::ContentBlock::Document::Show::DocumentTimelineComponen
                   ))
 
     assert_selector ".timeline__item", count: 2
+
     assert_equal "Email address scheduled", page.all(".timeline__title")[0].text
     assert_equal "by #{@user.name}", page.all(".timeline__byline")[0].text
-    assert_equal @version_3.created_at.strftime("%d %B %Y at %I:%M%P"),
-                 page.all("time[datetime='#{@version_3.created_at.iso8601}']")[0].text
+    assert_equal  I18n.l(@version_3.created_at, format: :long_ordinal),
+                  page.all("time[datetime='#{@version_3.created_at.iso8601}']")[1].text
 
     assert_equal "Email address published", page.all(".timeline__title")[1].text
     assert_equal "by #{@user.name}", page.all(".timeline__byline")[1].text
-    assert_equal  @version_2.created_at.strftime("%d %B %Y at %I:%M%P"),
+    assert_equal  I18n.l(@version_2.created_at, format: :long_ordinal),
                   page.all("time[datetime='#{@version_2.created_at.iso8601}']")[1].text
   end
 end

--- a/lib/engines/content_object_store/test/components/content_block/document/show/summary_list_component_test.rb
+++ b/lib/engines/content_object_store/test/components/content_block/document/show/summary_list_component_test.rb
@@ -10,6 +10,7 @@ class ContentObjectStore::ContentBlock::Document::Show::SummaryListComponentTest
       details: { foo: "bar", something: "else" },
       creator: build(:user),
       organisation:,
+      scheduled_publication: Time.zone.now,
     )
     content_block_document = content_block_edition.document
 
@@ -41,6 +42,6 @@ class ContentObjectStore::ContentBlock::Document::Show::SummaryListComponentTest
     assert_selector ".govuk-summary-list__value", text: content_block_edition.state
 
     assert_selector ".govuk-summary-list__key", text: "Scheduled for publication at"
-    assert_selector ".govuk-summary-list__value", text: content_block_edition.scheduled_publication&.strftime("%e %B %Y at %I:%M%P")
+    assert_selector ".govuk-summary-list__value", text: I18n.l(content_block_edition.scheduled_publication, format: :long_ordinal)
   end
 end

--- a/lib/engines/content_object_store/test/components/content_block/edition/show/confirm_summary_list_component_test.rb
+++ b/lib/engines/content_object_store/test/components/content_block/edition/show/confirm_summary_list_component_test.rb
@@ -22,6 +22,6 @@ class ContentObjectStore::ContentBlockEdition::Show::ConfirmSummaryListComponent
     assert_selector ".govuk-summary-list__key", text: "Confirm"
     assert_selector ".govuk-summary-list__value", text: "I confirm that I am happy for the content block to be changed on these pages."
     assert_selector ".govuk-summary-list__key", text: "Publish date"
-    assert_selector ".govuk-summary-list__value", text: content_block_edition.created_at.strftime("%d %B %Y")
+    assert_selector ".govuk-summary-list__value", text: I18n.l(content_block_edition.created_at.to_date, format: :long_ordinal)
   end
 end


### PR DESCRIPTION
This makes some tweaks to content modelling to ensure we're formatting dates using I18n, rather than handrolling with `strftime` each time