### PR TITLE
Add sentry tag for ContentObjectStore controllers

### DIFF
--- a/lib/engines/content_object_store/app/controllers/content_object_store/base_controller.rb
+++ b/lib/engines/content_object_store/app/controllers/content_object_store/base_controller.rb
@@ -1,5 +1,5 @@
 class ContentObjectStore::BaseController < Admin::BaseController
-  before_action :check_object_store_feature_flag
+  before_action :check_object_store_feature_flag, :set_sentry_tags
 
   def check_object_store_feature_flag
     forbidden! unless Flipflop.content_object_store?
@@ -27,5 +27,9 @@ class ContentObjectStore::BaseController < Admin::BaseController
             details: @schema.fields,
           )
           .merge!(creator: current_user)
+  end
+
+  def set_sentry_tags
+    Sentry.set_tags(engine: "content_object_store")
   end
 end

--- a/lib/engines/content_object_store/test/integration/sentry_tags_test.rb
+++ b/lib/engines/content_object_store/test/integration/sentry_tags_test.rb
@@ -1,0 +1,28 @@
+require "test_helper"
+require "sentry/test_helper"
+
+class ContentObjectStore::SentryTagsTest < ActionDispatch::IntegrationTest
+  include Sentry::TestHelper
+
+  setup do
+    setup_sentry_test
+    feature_flags.switch!(:content_object_store, true)
+    login_as_admin
+  end
+
+  teardown do
+    teardown_sentry_test
+  end
+
+  test "throwing an error includes tags" do
+    exception = ArgumentError.new("Cannot find schema for block_type")
+    raises_exception = ->(*_args) { raise exception }
+
+    ContentObjectStore::ContentBlock::Document.stub :all, raises_exception do
+      get content_object_store.content_object_store_content_block_documents_path
+    rescue ArgumentError
+      assert_equal sentry_events.count, 1
+      assert_equal sentry_events[0].tags[:engine], "content_object_store"
+    end
+  end
+end


### PR DESCRIPTION
This adds a `before_action` to all controllers that inherit from the `ContentObjectStore::BaseController` which sets an `engine` tag so we can easily filter Sentry for all content object store related errors.

This won't (yet) work for anything done asynchronously, which is more of a challenge, but we can pick this up once we've confirmed that this works.