### PR TITLE
Fix loading of GA4 analytics modules

### DIFF
--- a/app/assets/javascripts/admin/analytics-modules/ga4-button-setup.js
+++ b/app/assets/javascripts/admin/analytics-modules/ga4-button-setup.js
@@ -4,26 +4,30 @@ window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {}
 window.GOVUK.analyticsGa4.analyticsModules =
   window.GOVUK.analyticsGa4.analyticsModules || {}
 ;(function (Modules) {
-  function Ga4ButtonSetup(module) {
-    this.module = module
+  Modules.Ga4ButtonSetup = {
+    init: function () {
+      const moduleElements = document.querySelectorAll(
+        "[data-module~='ga4-button-setup']"
+      )
+      moduleElements.forEach(function (moduleElement) {
+        const buttons = moduleElement.querySelectorAll(
+          'button, [role="button"]'
+        )
+        buttons.forEach((button) => {
+          const event = {
+            event_name:
+              button.type === 'submit' ? 'form_response' : 'navigation',
+            type: 'generic_link',
+            text: button.textContent,
+            section: document.title.split(' - ')[0].replace('Error: ', ''),
+            action: button.textContent
+          }
+          if (button.dataset.ga4Event) {
+            Object.assign(event, JSON.parse(button.dataset.ga4Event))
+          }
+          button.dataset.ga4Event = JSON.stringify(event)
+        })
+      })
+    }
   }
-
-  Ga4ButtonSetup.prototype.init = function () {
-    const buttons = this.module.querySelectorAll('button, [role="button"]')
-    buttons.forEach((button) => {
-      const event = {
-        event_name: button.type === 'submit' ? 'form_response' : 'navigation',
-        type: 'generic_link',
-        text: button.textContent,
-        section: document.title.split(' - ')[0].replace('Error: ', ''),
-        action: button.textContent
-      }
-      if (button.dataset.ga4Event) {
-        Object.assign(event, JSON.parse(button.dataset.ga4Event))
-      }
-      button.dataset.ga4Event = JSON.stringify(event)
-    })
-  }
-
-  Modules.Ga4ButtonSetup = Ga4ButtonSetup
 })(window.GOVUK.analyticsGa4.analyticsModules)

--- a/app/assets/javascripts/admin/analytics-modules/ga4-form-setup.js
+++ b/app/assets/javascripts/admin/analytics-modules/ga4-form-setup.js
@@ -4,18 +4,21 @@ window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {}
 window.GOVUK.analyticsGa4.analyticsModules =
   window.GOVUK.analyticsGa4.analyticsModules || {}
 ;(function (Modules) {
-  function Ga4FormSetup(module) {
-    this.module = module
+  Modules.Ga4FormSetup = {
+    init: function () {
+      const moduleElements = document.querySelectorAll(
+        "[data-module~='ga4-form-setup']"
+      )
+      moduleElements.forEach(function (moduleElement) {
+        const submitButton = moduleElement.querySelector(
+          'button[type="submit"]'
+        )
+        moduleElement.dataset.ga4Form = JSON.stringify({
+          event_name: 'form_response',
+          section: document.title.split(' - ')[0].replace('Error: ', ''),
+          action: submitButton.textContent.toLowerCase()
+        })
+      })
+    }
   }
-
-  Ga4FormSetup.prototype.init = function () {
-    const submitButton = this.module.querySelector('button[type="submit"]')
-    this.module.dataset.ga4Form = JSON.stringify({
-      event_name: 'form_response',
-      section: document.title.split(' - ')[0].replace('Error: ', ''),
-      action: submitButton.textContent.toLowerCase()
-    })
-  }
-
-  Modules.Ga4FormSetup = Ga4FormSetup
 })(window.GOVUK.analyticsGa4.analyticsModules)

--- a/app/assets/javascripts/admin/analytics-modules/ga4-link-setup.js
+++ b/app/assets/javascripts/admin/analytics-modules/ga4-link-setup.js
@@ -4,24 +4,25 @@ window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {}
 window.GOVUK.analyticsGa4.analyticsModules =
   window.GOVUK.analyticsGa4.analyticsModules || {}
 ;(function (Modules) {
-  function Ga4LinkSetup(module) {
-    this.module = module
+  Modules.Ga4LinkSetup = {
+    init: function () {
+      const moduleElements = document.querySelectorAll(
+        "[data-module~='ga4-link-setup']"
+      )
+      moduleElements.forEach(function (moduleElement) {
+        const links = moduleElement.querySelectorAll('a')
+        links.forEach((link) => {
+          const event = {
+            event_name: 'navigation',
+            type: 'generic_link',
+            section: document.title.split(' - ')[0].replace('Error: ', '')
+          }
+          if (link.dataset.ga4Event) {
+            Object.assign(event, JSON.parse(link.dataset.ga4Event))
+          }
+          link.dataset.ga4Event = JSON.stringify(event)
+        })
+      })
+    }
   }
-
-  Ga4LinkSetup.prototype.init = function () {
-    const links = this.module.querySelectorAll('a')
-    links.forEach((link) => {
-      const event = {
-        event_name: 'navigation',
-        type: 'generic_link',
-        section: document.title.split(' - ')[0].replace('Error: ', '')
-      }
-      if (link.dataset.ga4Event) {
-        Object.assign(event, JSON.parse(link.dataset.ga4Event))
-      }
-      link.dataset.ga4Event = JSON.stringify(event)
-    })
-  }
-
-  Modules.Ga4LinkSetup = Ga4LinkSetup
 })(window.GOVUK.analyticsGa4.analyticsModules)

--- a/app/assets/javascripts/admin/analytics-modules/ga4-page-view-tracking.js
+++ b/app/assets/javascripts/admin/analytics-modules/ga4-page-view-tracking.js
@@ -4,14 +4,14 @@ window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {}
 window.GOVUK.analyticsGa4.analyticsModules =
   window.GOVUK.analyticsGa4.analyticsModules || {}
 ;(function (Modules) {
-  function GA4PageViewTracking(module) {
-    this.module = module
+  Modules.GA4PageViewTracking = {
+    init: function () {
+      const trackingDataElement = document.querySelector(
+        "[data-module~='ga4-page-view-tracking']"
+      )
+      window.GOVUK.analyticsGa4.core.sendData(
+        JSON.parse(trackingDataElement.dataset.attributes)
+      )
+    }
   }
-
-  GA4PageViewTracking.prototype.init = function () {
-    this.trackingData = this.module.getAttribute('data-attributes')
-    window.GOVUK.analyticsGa4.core.sendData(JSON.parse(this.trackingData))
-  }
-
-  Modules.GA4PageViewTracking = GA4PageViewTracking
 })(window.GOVUK.analyticsGa4.analyticsModules)

--- a/app/assets/javascripts/admin/analytics-modules/ga4-paste-tracker.js
+++ b/app/assets/javascripts/admin/analytics-modules/ga4-paste-tracker.js
@@ -3,23 +3,19 @@ window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {}
 window.GOVUK.analyticsGa4.analyticsModules =
   window.GOVUK.analyticsGa4.analyticsModules || {}
 ;(function (Modules) {
-  function Ga4PasteTracker(module) {
-    this.module = module
-  }
+  Modules.Ga4PasteTracker = {
+    init: function () {
+      window.addEventListener('paste', this.trackPaste.bind(this))
+    },
 
-  Ga4PasteTracker.prototype.init = function () {
-    window.addEventListener('paste', this.trackPaste.bind(this))
-  }
-
-  Ga4PasteTracker.prototype.trackPaste = function (event) {
-    const data = {
-      event_name: 'paste',
-      type: 'paste',
-      action: 'paste',
-      method: 'browser paste'
+    trackPaste: function (event) {
+      const data = {
+        event_name: 'paste',
+        type: 'paste',
+        action: 'paste',
+        method: 'browser paste'
+      }
+      window.GOVUK.analyticsGa4.core.applySchemaAndSendData(data, 'event_data')
     }
-    window.GOVUK.analyticsGa4.core.applySchemaAndSendData(data, 'event_data')
   }
-
-  Modules.Ga4PasteTracker = Ga4PasteTracker
 })(window.GOVUK.analyticsGa4.analyticsModules)

--- a/app/assets/javascripts/admin/analytics-modules/ga4-visual-editor-event-handlers.js
+++ b/app/assets/javascripts/admin/analytics-modules/ga4-visual-editor-event-handlers.js
@@ -28,25 +28,26 @@ window.GOVUK.analyticsGa4.analyticsModules =
     }
   }
 
-  function Ga4VisualEditorEventHandlers(module) {
-    this.module = module
-  }
-
-  Ga4VisualEditorEventHandlers.prototype.init = function () {
-    this.module.addEventListener('visualEditorSelectChange', (event) => {
-      window.GOVUK.analyticsGa4.core.applySchemaAndSendData(
-        gaSelectChangeAttributes(event.detail.selectText),
-        'event_data'
+  Modules.Ga4VisualEditorEventHandlers = {
+    init: function () {
+      const moduleElements = document.querySelectorAll(
+        '[data-module~="ga4-visual-editor-event-handlers"]'
       )
-    })
+      moduleElements.forEach(function (moduleElement) {
+        moduleElement.addEventListener('visualEditorSelectChange', (event) => {
+          window.GOVUK.analyticsGa4.core.applySchemaAndSendData(
+            gaSelectChangeAttributes(event.detail.selectText),
+            'event_data'
+          )
+        })
 
-    this.module.addEventListener('visualEditorButtonClick', (event) => {
-      window.GOVUK.analyticsGa4.core.applySchemaAndSendData(
-        gaButtonClickAttributes(event.detail.buttonText),
-        'event_data'
-      )
-    })
+        moduleElement.addEventListener('visualEditorButtonClick', (event) => {
+          window.GOVUK.analyticsGa4.core.applySchemaAndSendData(
+            gaButtonClickAttributes(event.detail.buttonText),
+            'event_data'
+          )
+        })
+      })
+    }
   }
-
-  Modules.Ga4VisualEditorEventHandlers = Ga4VisualEditorEventHandlers
 })(window.GOVUK.analyticsGa4.analyticsModules)

--- a/app/helpers/admin/analytics_helper.rb
+++ b/app/helpers/admin/analytics_helper.rb
@@ -2,7 +2,7 @@ module Admin
   module AnalyticsHelper
     def track_analytics_data_on_load(title)
       {
-        event_name: "page_view",
+        event: "page_view",
         page_view: {
           publishing_app: "Whitehall",
           user_created_at: current_user&.created_at&.to_date,

--- a/app/helpers/admin/editions_helper.rb
+++ b/app/helpers/admin/editions_helper.rb
@@ -93,7 +93,7 @@ module Admin::EditionsHelper
   end
 
   def standard_edition_form(edition)
-    form_for form_url_for_edition(edition), as: :edition, html: { class: edition_form_classes(edition), multipart: true }, data: { module: "EditionForm LocaleSwitcher Ga4ButtonSetup Ga4VisualEditorEventHandlers", "rtl-locales": Locale.right_to_left.collect(&:to_param) } do |form|
+    form_for form_url_for_edition(edition), as: :edition, html: { class: edition_form_classes(edition), multipart: true }, data: { module: "EditionForm LocaleSwitcher ga4-button-setup ga4-visual-editor-event-handlers", "rtl-locales": Locale.right_to_left.collect(&:to_param) } do |form|
       concat render("standard_fields", form:, edition:)
       yield(form)
       concat render("settings_fields", form:, edition:)

--- a/app/views/admin/attachments/_form.html.erb
+++ b/app/views/admin/attachments/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for attachment, url: [:admin, typecast_for_attachable_routing(attachable), attachment.becomes(Attachment)], as: :attachment, html: { :class => "app-view-attachments__form", data: { module: "LocaleSwitcher Ga4ButtonSetup Ga4VisualEditorEventHandlers", "rtl-locales": Locale.right_to_left.collect(&:to_param) }}, multipart: true do |form| %>
+<%= form_for attachment, url: [:admin, typecast_for_attachable_routing(attachable), attachment.becomes(Attachment)], as: :attachment, html: { :class => "app-view-attachments__form", data: { module: "LocaleSwitcher ga4-button-setup ga4-visual-editor-event-handlers", "rtl-locales": Locale.right_to_left.collect(&:to_param) }}, multipart: true do |form| %>
   <div class="govuk-!-margin-bottom-8 app-view-attachments__form-title js-locale-switcher-field">
     <%= render "govuk_publishing_components/components/input", {
       label: {

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -15,7 +15,7 @@
            environment: environment,
            browser_title: ("Error: " if yield(:error_summary).present?).to_s + sanitized_title do %>
 
-  <div data-module="GA4PageViewTracking" data-attributes='<%= track_analytics_data_on_load(sanitized_title) %>'></div>
+  <div data-module="ga4-page-view-tracking" data-attributes='<%= track_analytics_data_on_load(sanitized_title) %>'></div>
 
   <%= render "govuk_publishing_components/components/skip_link" %>
 

--- a/spec/javascripts/admin/analytics-modules/ga4-button-setup.spec.js
+++ b/spec/javascripts/admin/analytics-modules/ga4-button-setup.spec.js
@@ -5,15 +5,16 @@ describe('GOVUK.analyticsGa4.analyticsModules', function () {
     document.title = 'Title - Text'
 
     container = document.createElement('div')
+    container.setAttribute('data-module', 'ga4-button-setup')
     button = document.createElement('button')
     button.textContent = 'Button'
     button.type = 'button'
     container.appendChild(button)
+    document.body.appendChild(container)
   })
 
   it('adds ga4 event data to buttons contained within', function () {
-    const ga4ButtonSetup =
-      new GOVUK.analyticsGa4.analyticsModules.Ga4ButtonSetup(container)
+    const ga4ButtonSetup = GOVUK.analyticsGa4.analyticsModules.Ga4ButtonSetup
     ga4ButtonSetup.init()
 
     expect(button.dataset.ga4Event).toEqual(
@@ -24,8 +25,7 @@ describe('GOVUK.analyticsGa4.analyticsModules', function () {
   it('uses navigation as the event name from "submit" buttons', function () {
     button.type = 'submit'
 
-    const ga4ButtonSetup =
-      new GOVUK.analyticsGa4.analyticsModules.Ga4ButtonSetup(container)
+    const ga4ButtonSetup = GOVUK.analyticsGa4.analyticsModules.Ga4ButtonSetup
     ga4ButtonSetup.init()
 
     expect(button.dataset.ga4Event).toEqual(
@@ -38,8 +38,7 @@ describe('GOVUK.analyticsGa4.analyticsModules', function () {
       event_name: 'custom_event_name'
     })
 
-    const ga4ButtonSetup =
-      new GOVUK.analyticsGa4.analyticsModules.Ga4ButtonSetup(container)
+    const ga4ButtonSetup = GOVUK.analyticsGa4.analyticsModules.Ga4ButtonSetup
     ga4ButtonSetup.init()
 
     expect(button.dataset.ga4Event).toEqual(
@@ -53,8 +52,7 @@ describe('GOVUK.analyticsGa4.analyticsModules', function () {
     link.role = 'button'
     button.replaceWith(link)
 
-    const ga4ButtonSetup =
-      new GOVUK.analyticsGa4.analyticsModules.Ga4ButtonSetup(container)
+    const ga4ButtonSetup = GOVUK.analyticsGa4.analyticsModules.Ga4ButtonSetup
     ga4ButtonSetup.init()
 
     expect(link.dataset.ga4Event).toEqual(

--- a/spec/javascripts/admin/analytics-modules/ga4-form-setup.spec.js
+++ b/spec/javascripts/admin/analytics-modules/ga4-form-setup.spec.js
@@ -5,16 +5,16 @@ describe('GOVUK.analyticsGa4.analyticsModules.Ga4FormSetup', function () {
     document.title = 'Title - Text'
 
     container = document.createElement('form')
+    container.setAttribute('data-module', 'ga4-form-setup')
     button = document.createElement('button')
     button.type = 'submit'
     button.textContent = 'Button'
     container.appendChild(button)
+    document.body.appendChild(container)
   })
 
   it('adds ga4 event data to the container', function () {
-    const Ga4FormSetup = new GOVUK.analyticsGa4.analyticsModules.Ga4FormSetup(
-      container
-    )
+    const Ga4FormSetup = GOVUK.analyticsGa4.analyticsModules.Ga4FormSetup
     Ga4FormSetup.init()
 
     expect(container.dataset.ga4Form).toEqual(

--- a/spec/javascripts/admin/analytics-modules/ga4-link-setup.spec.js
+++ b/spec/javascripts/admin/analytics-modules/ga4-link-setup.spec.js
@@ -5,15 +5,15 @@ describe('GOVUK.analyticsGa4.analyticsModules.Ga4LinkSetup', function () {
     document.title = 'Title - Text'
 
     container = document.createElement('div')
+    container.setAttribute('data-module', 'ga4-link-setup')
     link = document.createElement('a')
     link.textContent = 'Link'
     container.appendChild(link)
+    document.body.appendChild(container)
   })
 
   it('adds ga4 event data to links contained within', function () {
-    const Ga4LinkSetup = new GOVUK.analyticsGa4.analyticsModules.Ga4LinkSetup(
-      container
-    )
+    const Ga4LinkSetup = GOVUK.analyticsGa4.analyticsModules.Ga4LinkSetup
     Ga4LinkSetup.init()
 
     expect(link.dataset.ga4Event).toEqual(

--- a/spec/javascripts/admin/analytics-modules/ga4-paste-tracker.spec.js
+++ b/spec/javascripts/admin/analytics-modules/ga4-paste-tracker.spec.js
@@ -5,8 +5,7 @@ describe('GOVUK.analyticsGa4.analyticsModules.Ga4PasteTracker', function () {
       'applySchemaAndSendData'
     )
 
-    const ga4PasteTracker =
-      new GOVUK.analyticsGa4.analyticsModules.Ga4PasteTracker(document)
+    const ga4PasteTracker = GOVUK.analyticsGa4.analyticsModules.Ga4PasteTracker
     ga4PasteTracker.init()
     window.dispatchEvent(new ClipboardEvent('paste', {}))
 

--- a/spec/javascripts/admin/analytics-modules/ga4-visual-editor-event-handlers.spec.js
+++ b/spec/javascripts/admin/analytics-modules/ga4-visual-editor-event-handlers.spec.js
@@ -1,8 +1,11 @@
 describe('GOVUK.analyticsGa4.analyticsModules.Ga4VisualEditorEventHandlers', function () {
   it('triggers ga4 tracking on visualEditorSelectChange event', function () {
     document.title = 'Title - Text'
+    const container = document.createElement('div')
     const select = document.createElement('select')
-    document.body.appendChild(select)
+    container.setAttribute('data-module', 'ga4-visual-editor-event-handlers')
+    container.appendChild(select)
+    document.body.appendChild(container)
 
     const mockGa4SendData = spyOn(
       window.GOVUK.analyticsGa4.core,
@@ -10,9 +13,7 @@ describe('GOVUK.analyticsGa4.analyticsModules.Ga4VisualEditorEventHandlers', fun
     )
 
     const ga4VisualEditorEventHandlers =
-      new GOVUK.analyticsGa4.analyticsModules.Ga4VisualEditorEventHandlers(
-        document
-      )
+      GOVUK.analyticsGa4.analyticsModules.Ga4VisualEditorEventHandlers
     ga4VisualEditorEventHandlers.init()
     select.dispatchEvent(
       new CustomEvent('visualEditorSelectChange', {
@@ -40,8 +41,11 @@ describe('GOVUK.analyticsGa4.analyticsModules.Ga4VisualEditorEventHandlers', fun
 
   it('triggers ga4 tracking on visualEditorButtonClick event', function () {
     document.title = 'Title - Text'
+    const container = document.createElement('div')
     const button = document.createElement('button')
-    document.body.appendChild(button)
+    container.setAttribute('data-module', 'ga4-visual-editor-event-handlers')
+    container.appendChild(button)
+    document.body.appendChild(container)
 
     const mockGa4SendData = spyOn(
       window.GOVUK.analyticsGa4.core,
@@ -49,9 +53,7 @@ describe('GOVUK.analyticsGa4.analyticsModules.Ga4VisualEditorEventHandlers', fun
     )
 
     const ga4VisualEditorEventHandlers =
-      new GOVUK.analyticsGa4.analyticsModules.Ga4VisualEditorEventHandlers(
-        document
-      )
+      GOVUK.analyticsGa4.analyticsModules.Ga4VisualEditorEventHandlers
     ga4VisualEditorEventHandlers.init()
     button.dispatchEvent(
       new CustomEvent('visualEditorButtonClick', {


### PR DESCRIPTION
If using the GOV.UK publishing component analytics module loading, the loader does not expect the same structure as the normal GOV.UK module loader. Instead it expects a simple object with an init function to call.

This PR also ensures consistent usage of kebab case for module data attributes

Trello: https://trello.com/c/JGuDLzro
