### PR TITLE
Pass edition images to the visual editor

### DIFF
--- a/app/assets/javascripts/components/visual-editor.js
+++ b/app/assets/javascripts/components/visual-editor.js
@@ -17,7 +17,14 @@ window.GOVUK.Modules = window.GOVUK.Modules || {}
       '.app-c-visual-editor__govspeak-editor-wrapper textarea'
     )
 
-    new window.GovspeakVisualEditor(this.content, this.container, this.textarea) // eslint-disable-line no-new
+    const images = JSON.parse(this.module.getAttribute('data-images'))
+
+    new window.GovspeakVisualEditor( // eslint-disable-line no-new
+      this.content,
+      this.container,
+      this.textarea,
+      { images }
+    )
 
     this.govspeakEditorwrapper = this.module.querySelector(
       '.app-c-visual-editor__govspeak-editor-wrapper'

--- a/app/views/admin/editions/_standard_fields.html.erb
+++ b/app/views/admin/editions/_standard_fields.html.erb
@@ -82,6 +82,7 @@
           alternative_format_provider_id: (edition.alternative_format_provider_id || current_user.organisation.try(:id)),
         },
         hidden_field_name: "edition[visual_editor]",
+        images: edition.images.map { |image| [image.url, "[Image: #{image.filename}]"] }.to_h,
       } %>
     <% else %>
       <%= render "components/govspeak_editor", {

--- a/app/views/components/_visual_editor.html.erb
+++ b/app/views/components/_visual_editor.html.erb
@@ -3,11 +3,12 @@
   label_id = "#{id}-label"
   value ||= nil
   error_items ||= nil
+  images ||= {}
 
   error_class = "govuk-form-group--error" if error_items
 %>
 
-<%= tag.div class: error_class, "data-module": "visual-editor" do %>
+<%= tag.div class: error_class, "data-module": "visual-editor", "data-images": images.to_json do %>
   <div class="app-c-visual-editor__govspeak-editor-wrapper">
     <%= render "components/govspeak_editor", {
       label:,

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "accessible-autocomplete": "alphagov/accessible-autocomplete-multiselect",
     "choices.js": "^10.2.0",
     "cropperjs": "^1.6.2",
-    "govspeak-visual-editor": "^2.0.0",
+    "govspeak-visual-editor": "^3.0.0",
     "miller-columns-element": "^2.0.0",
     "paste-html-to-govspeak": "^0.4.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1514,10 +1514,10 @@ gopd@^1.0.1:
   dependencies:
     get-intrinsic "^1.1.3"
 
-govspeak-visual-editor@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/govspeak-visual-editor/-/govspeak-visual-editor-2.0.0.tgz#c085e3a50d1a4d628e5ed7a96d2162c5811aff0d"
-  integrity sha512-nsZoFSym7fB9DGj5TTXvkNHN4DjO3G1HF2gamOFtBWWObWKFH5aXZv5fzf9SyT9ShMi0qiqIxEAxAvVtBSOcmw==
+govspeak-visual-editor@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/govspeak-visual-editor/-/govspeak-visual-editor-3.0.0.tgz#5f110f07d259fee5491a22f4565af635d350c292"
+  integrity sha512-kssdjc5lr+Vs27tKHKR9MramlSTyBzNZcCeBb9kvXkt0vqNqmDfx6hWYfbvu3ieFLRmUEUbXYgTCpAGINCJGVA==
   dependencies:
     govuk-frontend "^4.8.0"
     prosemirror-example-setup "^1.2.2"


### PR DESCRIPTION
- Bump govspeak-visual-editor from 2.0.0 to 3.0.0
- Pass image URLs and govspeak code to the visual editor so that it can be used to preview images.
- https://trello.com/c/JobWLUMd/2759-basic-image-rendering