### PR TITLE
Render government options newest first

### DIFF
--- a/app/components/admin/editions/history_mode_form_controls.rb
+++ b/app/components/admin/editions/history_mode_form_controls.rb
@@ -20,7 +20,7 @@ class Admin::Editions::HistoryModeFormControls < ViewComponent::Base
         value: "",
       },
     ].tap do |options|
-      Government.find_each do |government|
+      Government.newest_first.find_each do |government|
         options << {
           text: government.name,
           value: government.id,

--- a/app/models/government.rb
+++ b/app/models/government.rb
@@ -4,6 +4,8 @@ class Government < ApplicationRecord
 
   date_attributes(:start_date, :end_date)
 
+  scope :newest_first, -> { order(start_date: :desc) }
+
   validates :name, presence: true, uniqueness: { case_sensitive: false }
   validates :slug, presence: true, uniqueness: { case_sensitive: false }
   validates :content_id, presence: true, uniqueness: { case_sensitive: false }

--- a/test/unit/app/models/government_test.rb
+++ b/test/unit/app/models/government_test.rb
@@ -125,6 +125,13 @@ class GovernmentTest < ActiveSupport::TestCase
     current_open_government.update!(end_date: "2014-01-01")
     assert new_open_government.valid?
   end
+
+  test "#newest_first returns the current government first" do
+    previous_government = create(:previous_government)
+    current_government = create(:current_government)
+    assert Government.first == previous_government
+    assert Government.newest_first.first == current_government
+  end
 end
 
 class GovernmentOnDateTest < ActiveSupport::TestCase


### PR DESCRIPTION
In general, content editors are likely to want to select more recent governments when applying history mode to documents, so it makes sense to sort the options newest first.

Trello: https://trello.com/c/7NCKBcTe
