### PR TITLE
Enable content object store in staging/integration

### DIFF
--- a/config/features.rb
+++ b/config/features.rb
@@ -22,6 +22,6 @@ Flipflop.configure do
   #   default: true,
   #   description: "Take over the world."
   feature :govspeak_visual_editor, description: "Enables a visual editor for Govspeak fields", default: false
-  feature :content_object_store, description: "Enables the object store for sharable content", default: Rails.env.development?
+  feature :content_object_store, description: "Enables the object store for sharable content", default: Rails.env.development? || Whitehall.integration_or_staging?
   feature :override_government, description: "Enables GDS Editors and Admins to override the government associated with a document", default: false
 end


### PR DESCRIPTION
This ensures we can still work on the service in non-production environments without having to expressly turn on the feature flag