### PR TITLE
Hide scheduled at row for unscheduled objects

### DIFF
--- a/lib/engines/content_object_store/app/components/content_object_store/content_block/document/show/summary_list_component.rb
+++ b/lib/engines/content_object_store/app/components/content_object_store/content_block/document/show/summary_list_component.rb
@@ -8,7 +8,7 @@ private
   attr_reader :content_block_document
 
   def items
-    [
+    items = [
       title_item,
       *details_items,
       organisation_item,
@@ -62,7 +62,7 @@ private
   def state_item
     {
       field: "State",
-      value: content_block_document.latest_edition.state,
+      value: content_block_document.latest_edition.state.titleize,
     }
   end
 

--- a/lib/engines/content_object_store/app/components/content_object_store/content_block/document/show/summary_list_component.rb
+++ b/lib/engines/content_object_store/app/components/content_object_store/content_block/document/show/summary_list_component.rb
@@ -8,7 +8,7 @@ private
   attr_reader :content_block_document
 
   def items
-    items = [
+    [
       title_item,
       *details_items,
       organisation_item,
@@ -16,7 +16,7 @@ private
       embed_code_item,
       state_item,
       scheduled_item,
-    ]
+    ].compact
   end
 
   def embed_code_item
@@ -67,11 +67,12 @@ private
   end
 
   def scheduled_item
-    scheduled_date = content_block_document.latest_edition.scheduled_publication
-    {
-      field: "Scheduled for publication at",
-      value: scheduled_date ? I18n.l(scheduled_date, format: :long_ordinal) : nil,
-    }
+    if content_block_document.latest_edition.state == "scheduled"
+      {
+        field: "Scheduled for publication at",
+        value: I18n.l(content_block_document.latest_edition.scheduled_publication, format: :long_ordinal),
+      }
+    end
   end
 
   def edit_action

--- a/lib/engines/content_object_store/features/schedule_object.feature
+++ b/lib/engines/content_object_store/features/schedule_object.feature
@@ -11,13 +11,11 @@ Feature: Schedule a content object
   Scenario: GDS Editor schedules a content object
     When I am updating a content block
     Then I am asked when I want to publish the change
-    When I choose to schedule the change
-    And I enter a date 7 days in the future
-    And I accept and publish
+    And I schedule the change for 7 days in the future
     Then the edition should have been scheduled successfully
     And I should be taken back to the document page
     And I should see the scheduled date on the object
-    And I should see 2 publish events on the timeline
+    And I should see the scheduled event on the timeline
 
   Scenario: A scheduled content object is published
     When I am updating a content block

--- a/lib/engines/content_object_store/features/step_definitions/content_object_store_steps.rb
+++ b/lib/engines/content_object_store/features/step_definitions/content_object_store_steps.rb
@@ -398,7 +398,7 @@ end
 Then("published state of the object is shown") do
   visit content_object_store.content_object_store_content_block_document_path(@content_block.document)
   expect(page).to have_selector(".govuk-summary-list__key", text: "State")
-  expect(page).to have_selector(".govuk-summary-list__value", text: "published")
+  expect(page).to have_selector(".govuk-summary-list__value", text: "Published")
 end
 
 Then("I should see the scheduled date on the object") do

--- a/lib/engines/content_object_store/features/step_definitions/content_object_store_steps.rb
+++ b/lib/engines/content_object_store/features/step_definitions/content_object_store_steps.rb
@@ -287,6 +287,11 @@ Then("I should see the publish event on the timeline") do
   expect(page).to have_selector(".timeline__byline", text: "by Scheduled Publishing Robot")
 end
 
+Then("I should see the scheduled event on the timeline") do
+  expect(page).to have_selector(".timeline__title", text: "Email address scheduled")
+  expect(page).to have_selector(".timeline__byline", text: "by #{@user.name}")
+end
+
 Then("I am asked to check my answers") do
   assert_text "Check your answers"
 end
@@ -366,9 +371,14 @@ When("I choose to schedule the change") do
   choose "Schedule the change for the future"
 end
 
-When("I enter a date 7 days in the future") do
+When("I schedule the change for 7 days in the future") do
+  choose "Schedule the change for the future"
   @future_date = 7.days.since(Time.zone.now)
   fill_in_date_and_time_field(@future_date)
+
+  Sidekiq::Testing.fake! do
+    click_on "Accept and publish"
+  end
 end
 
 When("I enter an invalid date") do

--- a/lib/engines/content_object_store/test/components/content_block/document/index/summary_card_component_test.rb
+++ b/lib/engines/content_object_store/test/components/content_block/document/index/summary_card_component_test.rb
@@ -1,10 +1,12 @@
 require "test_helper"
 
 class ContentObjectStore::ContentBlock::Document::Index::SummaryCardComponentTest < ViewComponent::TestCase
+  extend Minitest::Spec::DSL
+
   include ContentObjectStore::Engine.routes.url_helpers
 
-  test "it renders a content block as a summary card" do
-    content_block_edition = create(
+  let(:content_block_edition) do
+    create(
       :content_block_edition,
       :email_address,
       id: 123,
@@ -12,16 +14,20 @@ class ContentObjectStore::ContentBlock::Document::Index::SummaryCardComponentTes
       creator: build(:user),
       organisation: build(:organisation),
       scheduled_publication: Time.zone.now,
+      state: "published",
     )
-    content_block_document = content_block_edition.document
+  end
 
+  let(:content_block_document) { content_block_edition.document }
+
+  it "renders a published content block as a summary card" do
     render_inline(ContentObjectStore::ContentBlock::Document::Index::SummaryCardComponent.new(content_block_document:))
 
     assert_selector ".govuk-summary-card__title", text: content_block_edition.title
     assert_selector ".govuk-summary-card__action", count: 1
     assert_selector ".govuk-summary-card__action .govuk-link[href='#{content_object_store_content_block_document_path(content_block_document)}']"
 
-    assert_selector ".govuk-summary-list__row", count: 8
+    assert_selector ".govuk-summary-list__row", count: 7
 
     assert_selector ".govuk-summary-list__key", text: "Title"
     assert_selector ".govuk-summary-list__value", text: content_block_edition.title
@@ -42,7 +48,15 @@ class ContentObjectStore::ContentBlock::Document::Index::SummaryCardComponentTes
     assert_selector ".govuk-summary-list__value", text: content_block_document.embed_code
 
     assert_selector ".govuk-summary-list__key", text: "State"
-    assert_selector ".govuk-summary-list__value", text: content_block_edition.state
+    assert_selector ".govuk-summary-list__value", text: content_block_edition.state.titleize
+  end
+
+  it "renders a scheduled content block as a summary card" do
+    content_block_document.latest_edition.state = "scheduled"
+
+    render_inline(ContentObjectStore::ContentBlock::Document::Index::SummaryCardComponent.new(content_block_document:))
+
+    assert_selector ".govuk-summary-list__row", count: 8
 
     assert_selector ".govuk-summary-list__key", text: "Scheduled for publication at"
     assert_selector ".govuk-summary-list__value", text: I18n.l(content_block_edition.scheduled_publication, format: :long_ordinal)

--- a/lib/engines/content_object_store/test/components/content_block/document/show/summary_list_component_test.rb
+++ b/lib/engines/content_object_store/test/components/content_block/document/show/summary_list_component_test.rb
@@ -39,7 +39,7 @@ class ContentObjectStore::ContentBlock::Document::Show::SummaryListComponentTest
     assert_selector ".govuk-summary-list__value", text: content_block_document.embed_code
 
     assert_selector ".govuk-summary-list__key", text: "State"
-    assert_selector ".govuk-summary-list__value", text: content_block_edition.state
+    assert_selector ".govuk-summary-list__value", text: content_block_edition.state.titleize
 
     assert_selector ".govuk-summary-list__key", text: "Scheduled for publication at"
     assert_selector ".govuk-summary-list__value", text: I18n.l(content_block_edition.scheduled_publication, format: :long_ordinal)

--- a/lib/engines/content_object_store/test/components/content_block/document/show/summary_list_component_test.rb
+++ b/lib/engines/content_object_store/test/components/content_block/document/show/summary_list_component_test.rb
@@ -1,22 +1,26 @@
 require "test_helper"
 
 class ContentObjectStore::ContentBlock::Document::Show::SummaryListComponentTest < ViewComponent::TestCase
-  test "renders a content block correctly" do
-    organisation = create(:organisation, name: "Department for Example")
+  extend Minitest::Spec::DSL
 
-    content_block_edition = create(
+  let(:organisation) { create(:organisation, name: "Department for Example") }
+  let(:content_block_edition) do
+    create(
       :content_block_edition,
       :email_address,
       details: { foo: "bar", something: "else" },
       creator: build(:user),
       organisation:,
       scheduled_publication: Time.zone.now,
+      state: "published",
     )
-    content_block_document = content_block_edition.document
+  end
+  let(:content_block_document) { content_block_edition.document }
 
+  it "renders a published content block correctly" do
     render_inline(ContentObjectStore::ContentBlock::Document::Show::SummaryListComponent.new(content_block_document:))
 
-    assert_selector ".govuk-summary-list__row", count: 8
+    assert_selector ".govuk-summary-list__row", count: 7
     assert_selector ".govuk-summary-list__key", text: "Title"
     assert_selector ".govuk-summary-list__value", text: content_block_document.title
     assert_selector ".govuk-summary-list__actions", text: "Change"
@@ -40,6 +44,14 @@ class ContentObjectStore::ContentBlock::Document::Show::SummaryListComponentTest
 
     assert_selector ".govuk-summary-list__key", text: "State"
     assert_selector ".govuk-summary-list__value", text: content_block_edition.state.titleize
+  end
+
+  it "renders a scheduled content block correctly" do
+    content_block_document.latest_edition.state = "scheduled"
+
+    render_inline(ContentObjectStore::ContentBlock::Document::Show::SummaryListComponent.new(content_block_document:))
+
+    assert_selector ".govuk-summary-list__row", count: 8
 
     assert_selector ".govuk-summary-list__key", text: "Scheduled for publication at"
     assert_selector ".govuk-summary-list__value", text: I18n.l(content_block_edition.scheduled_publication, format: :long_ordinal)


### PR DESCRIPTION
At the moment, we show “Scheduled at” for any blocks that have ever been scheduled, even if they have since been published. Additionally, we show a blank line for blocks that have never been scheduled. 

This hides the "Scheduled at" row unless something is currently awaiting publication.

I've also titleized the block's status, which looks a bit nicer

## Screenshots

### Before

![image](https://github.com/user-attachments/assets/37dcb342-21b8-465d-b3a1-ff431cfa77d3)

![image](https://github.com/user-attachments/assets/1ea6791c-a920-4682-84bc-471b86851667)

### After

![image](https://github.com/user-attachments/assets/fd0ec653-4779-4073-bab9-fde3daea8662)

![image](https://github.com/user-attachments/assets/93faf83b-2550-41f6-aecc-df98b23d626c)
