### PR TITLE
Reduce the number of queries used to build ministers index links

### DIFF
--- a/app/presenters/publishing_api/ministers_index_enable_reshuffle_presenter.rb
+++ b/app/presenters/publishing_api/ministers_index_enable_reshuffle_presenter.rb
@@ -1,5 +1,7 @@
 module PublishingApi
   class MinistersIndexEnableReshufflePresenter < MinistersIndexPresenter
+    include GovspeakHelper
+
     def links
       {
         ordered_cabinet_ministers: [],


### PR DESCRIPTION
The ministers index presenter was not leveraging eager loading and consequently was running huge numbers of queries. This has the potential to cause performance issues in the Sidekiq queues, as indeed was recently the case with the embassies index presenter.

We also remove the unused govspeak helper from the presenter.

I've tested this in integration and it produces exactly the same list of links as the current presenter.
