### PR TITLE
Suppress noisy sidekiq logs in test

### DIFF
--- a/lib/engines/content_object_store/features/step_definitions/content_object_store_steps.rb
+++ b/lib/engines/content_object_store/features/step_definitions/content_object_store_steps.rb
@@ -1,5 +1,10 @@
 require_relative "../support/stubs"
 
+# Suppress noisy Sidekiq logging in the test output
+Sidekiq.configure_client do |cfg|
+  cfg.logger.level = ::Logger::WARN
+end
+
 Given(/^the content object store feature flag is (enabled|disabled)$/) do |enabled|
   @test_strategy ||= Flipflop::FeatureSet.current.test!
   @test_strategy.switch!(:content_object_store, enabled == "enabled")

--- a/lib/engines/content_object_store/test/unit/workers/schedule_publishing_worker_test.rb
+++ b/lib/engines/content_object_store/test/unit/workers/schedule_publishing_worker_test.rb
@@ -3,6 +3,13 @@ require "test_helper"
 class ContentObjectStore::SchedulePublishingWorkerTest < ActiveSupport::TestCase
   include SidekiqTestHelpers
 
+  # Suppress noisy Sidekiq logging in the test output
+  setup do
+    Sidekiq.configure_client do |cfg|
+      cfg.logger.level = ::Logger::WARN
+    end
+  end
+
   test "#perform publishes a scheduled edition" do
     schema = build(:content_block_schema, block_type: "content_block_type", body: { "properties" => { "foo" => "", "bar" => "" } })
     document = create(:content_block_document, :email_address)


### PR DESCRIPTION
When running the test suite I noticed we can now see `info` logs for Sidekiq, eg `2011-11-11T11:11:11.000Z pid=1 tid=6z5 INFO: performing content block publishing job for Edition 380`. This provides no value and clutters the test output.

We now suppress this in our worker and cucumber tests.

We add config to our engine tests rather than putting it in the main Whitehall test_helper.rb etc. Whilst they do use sidekiq to queue jobs I’m not sure how this hasn’t come up for them. On a quick look it seems like their tests all use `perform_async` so it’s possible that this means jobs never get processed and so no logging of "performed". In which case they don’t have the same problem and it makes sense to just have this for our noisy tests?

## Before

![Screenshot 2024-09-05 at 16 55 25](https://github.com/user-attachments/assets/d6509f74-5ea9-4664-aaa6-e5923f0b3f03)

## After
![Screenshot 2024-09-05 at 16 55 30](https://github.com/user-attachments/assets/28b3592d-2c83-4b49-b5cd-1ee1ee4c1aee)

