### PR TITLE
Add layout for Content Object Store

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -41,6 +41,11 @@ class Admin::BaseController < ApplicationController
   end
   helper_method :preview_design_system?
 
+  def product_name
+    "Whitehall Publisher"
+  end
+  helper_method :product_name
+
 private
 
   def forbidden!

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -11,7 +11,7 @@
 <% sanitized_title = sanitize((yield(:page_title).presence || yield(:title))) %>
 
 <%= render "govuk_publishing_components/components/layout_for_admin",
-           product_name: "Whitehall Publisher",
+           product_name:,
            environment: environment,
            browser_title: ("Error: " if yield(:error_summary).present?).to_s + sanitized_title do %>
 

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -3,7 +3,7 @@
 <% user = current_user %>
 
 <%= render "govuk_publishing_components/components/layout_header", {
-  product_name: "Whitehall Publisher",
+  product_name:,
   environment: environment,
   navigation_items: [
     main_nav_item("Dashboard", admin_root_path),

--- a/lib/engines/content_object_store/app/controllers/content_object_store/base_controller.rb
+++ b/lib/engines/content_object_store/app/controllers/content_object_store/base_controller.rb
@@ -32,4 +32,8 @@ class ContentObjectStore::BaseController < Admin::BaseController
   def set_sentry_tags
     Sentry.set_tags(engine: "content_object_store")
   end
+
+  def product_name
+    "Content Object Store"
+  end
 end

--- a/lib/engines/content_object_store/app/controllers/content_object_store/base_controller.rb
+++ b/lib/engines/content_object_store/app/controllers/content_object_store/base_controller.rb
@@ -1,5 +1,5 @@
 class ContentObjectStore::BaseController < Admin::BaseController
-  before_action :check_object_store_feature_flag, :set_sentry_tags
+  before_action :check_object_store_feature_flag, :set_sentry_tags, :prepend_views
 
   def check_object_store_feature_flag
     forbidden! unless Flipflop.content_object_store?
@@ -35,5 +35,11 @@ class ContentObjectStore::BaseController < Admin::BaseController
 
   def product_name
     "Content Object Store"
+  end
+
+  # This ensures we can override views if we need to without altering the Engine's load order, which
+  # may have unintended consequences
+  def prepend_views
+    prepend_view_path Rails.root.join("lib/engines/content_object_store/app/views")
   end
 end

--- a/lib/engines/content_object_store/app/views/content_object_store/content_block/documents/index.html.erb
+++ b/lib/engines/content_object_store/app/views/content_object_store/content_block/documents/index.html.erb
@@ -1,4 +1,4 @@
-<% content_for :context, "Object store" %>
+<% content_for :context, product_name %>
 <% content_for :title, "All content blocks" %>
 
 <div class="govuk-grid-row govuk-!-margin-bottom-8">

--- a/lib/engines/content_object_store/app/views/content_object_store/content_block/documents/show.html.erb
+++ b/lib/engines/content_object_store/app/views/content_object_store/content_block/documents/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for :context, "Object store" %>
+<% content_for :context, product_name %>
 <% content_for :title, "Manage #{add_indefinite_article @content_block_document.block_type.humanize}" %>
 <% content_for :back_link do %>
   <%= render "govuk_publishing_components/components/back_link", {

--- a/lib/engines/content_object_store/app/views/content_object_store/content_block/editions/edit.html.erb
+++ b/lib/engines/content_object_store/app/views/content_object_store/content_block/editions/edit.html.erb
@@ -1,4 +1,4 @@
-<% content_for :context, "Object store" %>
+<% content_for :context, product_name %>
 <% content_for :title, "Change #{@form.schema.name}" %>
 
 <% content_for :back_link do %>

--- a/lib/engines/content_object_store/app/views/content_object_store/content_block/editions/new.html.erb
+++ b/lib/engines/content_object_store/app/views/content_object_store/content_block/editions/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :context, "Object store" %>
+<% content_for :context, product_name %>
 
 <% if @schemas %>
   <% content_for :back_link do %>

--- a/lib/engines/content_object_store/app/views/shared/_header.html.erb
+++ b/lib/engines/content_object_store/app/views/shared/_header.html.erb
@@ -1,0 +1,18 @@
+<% environment = GovukPublishingComponents::AppHelpers::Environment.current_acceptance_environment %>
+
+<%= render "govuk_publishing_components/components/layout_header", {
+  product_name:,
+  environment: environment,
+  logo_link: content_object_store.content_object_store_root_path,
+  navigation_items: [
+    main_nav_item("Dashboard", content_object_store.content_object_store_root_path),
+    {
+      text: "View website",
+      href: Whitehall.public_root,
+    },
+    {
+      text: "Switch app",
+      href: Plek.external_url_for("signon"),
+    },
+  ],
+} %>

--- a/lib/engines/content_object_store/features/content_object_store.feature
+++ b/lib/engines/content_object_store/features/content_object_store.feature
@@ -1,0 +1,8 @@
+Feature: Content object store
+
+  Scenario: Correct layout is used
+    Given the content object store feature flag is enabled
+    Given I am a GDS admin
+    When I visit the document object store
+    Then I should see the object store's title in the header
+    And I should see the object store's navigation

--- a/lib/engines/content_object_store/features/step_definitions/content_object_store_steps.rb
+++ b/lib/engines/content_object_store/features/step_definitions/content_object_store_steps.rb
@@ -449,3 +449,11 @@ end
 def click_save_and_continue
   click_on "Save and continue"
 end
+
+Then(/^I should see the object store's title in the header$/) do
+  expect(page).to have_selector(".govuk-header__product-name", text: "Content Object Store")
+end
+
+And(/^I should see the object store's navigation$/) do
+  expect(page).to have_selector("a.govuk-header__link[href='#{content_object_store.content_object_store_root_path}']", text: "Dashboard")
+end


### PR DESCRIPTION
## Background

When we began building the Content Object Store, we decided to build it in Whitehall, because we didn't want to maintain multiple apps, repos and deployment pipelines. As we roll out the project, our ambition is to have it linked from signon (in a similar way to the [Homepage editor in Mainstream][1] for two reasons:

1. Users should be able to select what action they want to take directly from signon, rather than understand what app they need to be in first; and
2. The navigation in Whitehall is already quite overloaded, so adding another item to the "Other" page risks causing more confusion.

## This PR

This alters the layout for the Content Object Store so it appears, to all intents and purposes, as a separate app. I've made some minimal changes to the existing layout, so we don't have to repeat ourselves unnecessarily, only specifying the app name and a custom navigation. Other elements, such as the footer etc, should be easy to override too. Conversely, if we decide after user testing that this is not the way to go, we can easily revert it.

## Screenshots

![image](https://github.com/user-attachments/assets/cd9a255d-d4ae-4f71-b3d9-3087b56d6f09)


[1]: https://github.com/alphagov/publisher/blob/41a25c0768aa28240913b0a5f1b5263541779c89/docs/homepage.md?plain=1