### PR TITLE
Move take part rendering to frontend

### DIFF
--- a/app/presenters/publishing_api/take_part_presenter.rb
+++ b/app/presenters/publishing_api/take_part_presenter.rb
@@ -20,7 +20,7 @@ module PublishingApi
         details:,
         document_type: "take_part",
         public_updated_at: item.updated_at,
-        rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
+        rendering_app: Whitehall::RenderingApp::FRONTEND,
         schema_name: "take_part",
       )
       content.merge!(PayloadBuilder::PolymorphicPath.for(item))

--- a/test/unit/app/presenters/publishing_api/take_part_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/take_part_presenter_test.rb
@@ -19,7 +19,7 @@ class PublishingApi::TakePartPresenterTest < ActiveSupport::TestCase
       locale: "en",
       public_updated_at: take_part_page.updated_at,
       publishing_app: Whitehall::PublishingApp::WHITEHALL,
-      rendering_app: "government-frontend",
+      rendering_app: "frontend",
       routes: [
         { path: "/government/get-involved/take-part/#{take_part_page.slug}", type: "exact" },
       ],


### PR DESCRIPTION
As part of implementing [RFC-175](https://github.com/alphagov/govuk-rfcs/blob/main/rfc-175-frontend-fewer-apps.md) we are beginning to move document types that were previously served by government-frontend into frontend. 

⚠️ Do Not Merge before:
- https://github.com/alphagov/frontend/pull/4218 ⚠️

https://trello.com/c/0LYU5bSd/318-move-route-document-type-takepart-from-governmentfrontend-to-frontend