### PR TITLE
Set Redis reconnection strategy for taxonomy cache

### DIFF
--- a/lib/taxonomy/redis_cache_adapter.rb
+++ b/lib/taxonomy/redis_cache_adapter.rb
@@ -3,7 +3,11 @@ module Taxonomy
     TAXONS_CACHE_KEY = "topic_taxonomy_taxons".freeze
     WORLD_TAXONS_CACHE_KEY = "world_taxonomy_taxons".freeze
 
-    def initialize(redis_client: Redis.new, adapter: PublishingApiAdapter.new)
+    def initialize(redis_client: Redis.new(
+      reconnect_attempts: 4,
+      reconnect_delay: 15,
+      reconnect_delay_max: 60,
+    ), adapter: PublishingApiAdapter.new)
       @redis_client = redis_client
       @adapter = adapter
     end


### PR DESCRIPTION
[Trello](https://trello.com/c/PVZCX1L3/1346-update-connection-retry-strategy-for-whitehall-taxonomy-cache)

This brings `Taxonomy::RedisCacheAdapter` in line with [GOV.UK Sidekiq][1] with regard to its reconnection strategy. We need to do this before migrating Whitehall to use bespoke Redis instances (i.e. ones not shared across the entire GOV.UK suite of apps) in order to ensure that any requests to store data in Redis are not lost by a small amount of downtime, which could affect the ability of Whitehall to refresh its knowledge of the taxonomy

I considered removing the `redis_client` parameter from `RedisCacheAdapter.initialize` and likewise the `adapter` parameter from `TopicTaxonomy.initialize` and `WorldTaxonomy.initialize`, which don't appear to be passed in wherever `.new` is called for any of the three classes. That would mean we could just set the `@redis_client` as below in the `.initialize` method, and do similar with the adapter in the taxonomy classes

```rb
@redis_client = Redis.new(
  reconnect_attempts: 4,
  reconnect_delay: 15,
  reconnect_delay_max: 60,
)
```

However, this smaller change is probably enough. It does mean that we wouldn't be setting the reconnection strategy if a custom Redis client is passed in on instantiation, but as mentioned above, this doesn't seem to be the case anywhere in the current codebase

I'd quite like to be able to test that this retry is working, but we don't appear to test within any alphagov repos that these settings are doing what we expect. To some extent, this would be testing the library

[1]: https://github.com/alphagov/govuk_sidekiq/blob/53c521a187474333d32380debeddff4a8d676297/lib/govuk_sidekiq/sidekiq_initializer.rb#L10-L12

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
