### PR TITLE
Fix republishing index headings

### DIFF
--- a/app/views/admin/republishing/index.html.erb
+++ b/app/views/admin/republishing/index.html.erb
@@ -27,7 +27,7 @@
       </div>
     </details>
 
-    <h2>Individual pages</h2>
+    <h2 class="govuk-heading-m">Individual pages</h2>
 
     <p class="govuk-body">
       You can schedule a selection of individual pages for republishing using the links below. If the page you wish to republish is not listed below, you may be able to use the 'Document' link in the next section.
@@ -58,7 +58,7 @@
       end,
     } %>
 
-    <h2>Other individual content</h2>
+    <h2 class="govuk-heading-m">Other individual content</h2>
 
     <p class="govuk-body">
       You can republish certain types of other indidivual content using the following actions.
@@ -129,7 +129,7 @@
       ],
     } %>
 
-    <h2>Bulk republishing</h2>
+    <h2 class="govuk-heading-m">Bulk republishing</h2>
 
     <p class="govuk-body">
       You can schedule multiple pieces of content for republishing using the links below. Note that this might take some time to take effect since bulk republishing jobs are added to a low priority queue.


### PR DESCRIPTION
[Trello](https://trello.com/c/SLUV6Cav/1349-add-govuk-heading-m-class-to-republish-content-pages)

These were missing the `govuk-heading-<size>` class. They used to render with the correct style, but perhaps a publishing components upgrade has changed that. Most `h2`s in this repo use `govuk-heading-m`, so I've opted for that

## Screenshots

### Before

<img width="753" alt="image" src="https://github.com/user-attachments/assets/610a8cd5-38ac-454a-9272-3c2b6af255d6">

### After

<img width="750" alt="image" src="https://github.com/user-attachments/assets/6e13cfc6-73c6-4fde-b7c6-6a418c85cc1c">

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
