### PR TITLE
Set Redis retry strategy for emergency banner

### DIFF
--- a/app/controllers/admin/emergency_banner_controller.rb
+++ b/app/controllers/admin/emergency_banner_controller.rb
@@ -63,6 +63,10 @@ private
   end
 
   def redis_client
-    Redis.new
+    Redis.new(
+      reconnect_attempts: 4,
+      reconnect_delay: 15,
+      reconnect_delay_max: 60,
+    )
   end
 end


### PR DESCRIPTION
This brings the Redis connection retry strategy in line with the configuration specified in [`govuk_sidekiq`](https://github.com/alphagov/govuk_sidekiq/blob/32def77d86d929ca7eb48f35f08401fedeb8407d/lib/govuk_sidekiq/sidekiq_initializer.rb#L10-L12).

By making this change, the application will be able to cope with short periods of Redis instance downtime.

[Trello card](https://trello.com/c/YJULijF6)