### PR TITLE
Remove overlapping government validation

### DIFF
--- a/app/models/government.rb
+++ b/app/models/government.rb
@@ -11,8 +11,6 @@ class Government < ApplicationRecord
   validates :content_id, presence: true, uniqueness: { case_sensitive: false }
   validates :start_date, presence: true
 
-  validate :not_overlapping?, if: -> { start_date.present? }
-
   before_validation on: :create do |government|
     government.slug = government.name.to_s.parameterize
   end
@@ -31,59 +29,11 @@ class Government < ApplicationRecord
     self == Government.current
   end
 
-  def overlaps?(other)
-    !before?(other) && !after?(other)
-  end
-
   def ended?
     end_date.present?
   end
 
   def publishing_api_presenter
     PublishingApi::GovernmentPresenter
-  end
-
-private
-
-  def before?(other)
-    starts_before?(other) && ends_before?(other)
-  end
-
-  def after?(other)
-    starts_after?(other) && ends_after?(other)
-  end
-
-  def starts_before?(other)
-    start_date < other.start_date
-  end
-
-  def ends_before?(other)
-    ended? && end_date <= other.start_date
-  end
-
-  def starts_after?(other)
-    other.ended? && start_date >= other.end_date
-  end
-
-  def ends_after?(other)
-    return true unless ended?
-
-    other.ended? && end_date > other.end_date
-  end
-
-  def not_overlapping?
-    self.class.all.find_each do |existing_government|
-      next if self == existing_government
-
-      if overlaps?(existing_government)
-        errors.add(
-          :base,
-          "overlaps #{existing_government.name}:
-          Your new government: #{start_date} -> #{end_date || 'present'},
-          overlapping government: #{existing_government.start_date} -> #{existing_government.end_date || 'present'}
-        ",
-        )
-      end
-    end
   end
 end

--- a/test/unit/app/models/government_test.rb
+++ b/test/unit/app/models/government_test.rb
@@ -32,14 +32,6 @@ class GovernmentTest < ActiveSupport::TestCase
     assert_not nil_government.valid?
   end
 
-  test "doesn't check construct an error for governments overlapping if start date is blank" do
-    nil_government = build(:government, start_date: nil)
-    nil_government.valid?
-
-    assert_equal 1, nil_government.errors.count
-    assert_equal "Start date can't be blank", nil_government.errors.first.full_message
-  end
-
   test "enforces unique names" do
     create(:government, name: "2005 to 2010 Labour government")
     duplicate_government = build(:government, name: "2005 to 2010 Labour government")
@@ -55,75 +47,6 @@ class GovernmentTest < ActiveSupport::TestCase
     labour_government_duplicating_original_name = build(:government, name: "2004 to 2009 Labour government")
 
     assert_not labour_government_duplicating_original_name.valid?
-  end
-
-  test "prevents overlapping governments" do
-    existing_government = create(
-      :government,
-      start_date: "2011-01-01",
-      end_date: "2012-01-01",
-    )
-
-    government_overlapping_start = build(
-      :government,
-      start_date: "2010-06-01",
-      end_date: "2011-06-01",
-    )
-    government_overlapping_end = build(
-      :government,
-      start_date: "2011-06-01",
-      end_date: "2012-06-01",
-    )
-
-    government_before = build(
-      :government,
-      start_date: "2009-06-01",
-      end_date: "2010-06-01",
-    )
-    government_after = build(
-      :government,
-      start_date: "2012-06-01",
-      end_date: "2013-06-01",
-    )
-
-    government_starting_immediately = build(
-      :government,
-      start_date: existing_government.end_date,
-    )
-
-    assert_not government_overlapping_start.valid?
-    assert_not government_overlapping_end.valid?
-
-    assert government_before.valid?
-    assert government_after.valid?
-
-    assert government_starting_immediately.valid?
-  end
-
-  test "prevents new open governments when one is already open" do
-    current_open_government = create(
-      :government,
-      start_date: "2011-01-01",
-      end_date: nil,
-    )
-
-    historic_government = build(
-      :government,
-      start_date: "2008-01-01",
-      end_date: "2010-01-01",
-    )
-
-    new_open_government = build(
-      :government,
-      start_date: "2015-01-01",
-      end_date: nil,
-    )
-
-    assert historic_government.valid?
-
-    assert_not new_open_government.valid?
-    current_open_government.update!(end_date: "2014-01-01")
-    assert new_open_government.valid?
   end
 
   test "#newest_first returns the current government first" do


### PR DESCRIPTION
The content operations team have asked us to remove this validation on the grounds that it makes their workflow difficult when changing the way that governments are labelled.

For example, when changing from labelling governments by election to labelling governments by Prime Minister, it proves awkward to manipulate the dates in such a way that the overlapping constraints are always satisfied.

This risk seems acceptable as only a very small number of users have permission to edit governments and they are responsible for ensuring that the dates are accurate.

Trello: https://trello.com/c/cHaFg1D2
