### PR TITLE
Document government override feature

### DIFF
--- a/docs/history_mode.md
+++ b/docs/history_mode.md
@@ -1,6 +1,6 @@
 # History Mode
 
-Documents published by Whitehall can be marked "political". This means that when there is a change of government, the document will be associated with the government that was in power at the time it was first published. This association will be indicated by a banner on GOV.UK which warns the user that the content is considered "historical" and is therefore no longer likely to be relevant.
+Documents published by Whitehall can be marked "political". This means that when there is a change of government, the document will be associated with the government that was in power at the time it was first published[^1]. This association will be indicated by a banner on GOV.UK which warns the user that the content is considered "historical" and is therefore no longer likely to be relevant.
 
 The `political` flag is stored as a boolean column on the `editions` database table, and its value is copied to each new edition of a document.
 
@@ -22,11 +22,18 @@ At time of writing, the only content type excluded from history mode is:
 
 In the future, it would seem desirable that we re-apply the logic from the [Political Content Identifier](../lib/political_content_identifier.rb) within the [political details payload builder](../app/presenters/publishing_api/payload_builder/political_details.rb), if the eligibility rules are the same. Having the logic all in one place would make the behaviour of history mode easier to understand.
 
+## Overrides
+
+In some cases it is necessary to specify a government other than the default government to appear on the history mode banner. This is usually only required when content is published shortly after a change of government. In that situation, the new government may not be the government that should be associated with the document.
+
+GDS admins and GDS editors have the option to select a particular government for content that has been marked political. If a selection is made, the government ID is stored in the `government_id` field in the `editions` database table. When a government has been specified, Whitehall will link the document to that government instead of the government that was in power on the date the content was published.
+
+Note that should we choose to rearrange historical governments in future (e.g. specify them by election result rather than by Prime Minister) there is no provision to ensure that the correct government is maintained for content with an override in place. We elected not to implement any safeguards here as we think it is unlikely that changes to historical governments will be made in the near future.
+
 ## Applying History Mode
 
 When the government changes, it will be "closed" via the Whitehall user interface by a member of the GOV.UK content team. This will publish an update to the government content item. The content item will have its "current" value set to false, as specified in the [GovernmentPresenter](../app/presenters/publishing_api/government_presenter.rb).
 
 Next, a developer will run the `election:republish_political_content` rake task. This task republishes all documents that have been marked as political. All documents have a link to their associated government, so Publishing API's [link expansion](https://docs.publishing.service.gov.uk/repos/publishing-api/link-expansion.html) feature will ensure that the linked government is "closed" for each document when it is re-presented to the content store. This will result in [government-frontend](https://github.com/alphagov/government-frontend) rendering the historical content banner on the documents. The banner is controlled in government frontend's [political content presenter](https://github.com/alphagov/government-frontend/blob/a643a4a9175af953e5683ee2ca5464ec384ed28e/app/presenters/content_item/political.rb#L19).
 
-
-
+[^1]: Some content is linked to the government that was in power on a different date to the publishing date, e.g. speeches are associated with the government in power on the date the speech was given rather than the date the speech was published on GOV.UK.


### PR DESCRIPTION
This feature was added to Whitehall to enable GDS editors to specify a particular government that should appear on the historical content banner for a document.

This feature is likely to be used mainly for content that was published shortly after a change of government.

Also add a footnote to note that all content types are linked to the government in power when they were first published.

Trello: https://trello.com/c/Q7tCtSXy
