### PR TITLE
Ensure history mode government select options appear in correct order

### DIFF
--- a/app/components/admin/editions/history_mode_form_controls.rb
+++ b/app/components/admin/editions/history_mode_form_controls.rb
@@ -20,7 +20,7 @@ class Admin::Editions::HistoryModeFormControls < ViewComponent::Base
         value: "",
       },
     ].tap do |options|
-      Government.newest_first.find_each do |government|
+      Government.newest_first.each do |government|
         options << {
           text: government.name,
           value: government.id,


### PR DESCRIPTION
Because `find_each` loads results in batches, the governments were not respecting the newest first ordering, so we switch to using a simple each
