### PR TITLE
Remove usages of override government feature flag

### DIFF
--- a/app/components/admin/editions/history_mode_form_controls.rb
+++ b/app/components/admin/editions/history_mode_form_controls.rb
@@ -9,7 +9,7 @@ class Admin::Editions::HistoryModeFormControls < ViewComponent::Base
   end
 
   def renders_government_selector?
-    Flipflop.override_government? && @enforcer.can?(:select_government_for_history_mode)
+    @enforcer.can?(:select_government_for_history_mode)
   end
 
   # noinspection RubyMismatchedArgumentType

--- a/test/components/admin/editions/history_mode_form_controls_test.rb
+++ b/test/components/admin/editions/history_mode_form_controls_test.rb
@@ -1,21 +1,7 @@
 require "test_helper"
 
 class Admin::Editions::HistoryModeFormControlsTest < ViewComponent::TestCase
-  setup do
-    @test_strategy = Flipflop::FeatureSet.current.test!
-  end
-
-  test "hides the government selector for GDS editor users when the feature flag is disabled" do
-    @test_strategy.switch!(:override_government, false)
-    government = create(:current_government)
-    published_edition = create(:published_news_article, government_id: government.id)
-    new_draft = create(:news_article, document: published_edition.document, government_id: government.id)
-    render_inline(Admin::Editions::HistoryModeFormControls.new(new_draft, create(:gds_editor)))
-    assert_selector "select#edition_government_id", count: 0
-  end
-
   test "conditionally displays the government selector for gds editor users" do
-    @test_strategy.switch!(:override_government, true)
     previous_government = create(:previous_government)
     governments = [create(:current_government), previous_government]
     published_edition = create(:published_news_article, government_id: previous_government.id)
@@ -30,7 +16,6 @@ class Admin::Editions::HistoryModeFormControlsTest < ViewComponent::TestCase
   end
 
   test "displays a hidden political input set to false for managing editor users " do
-    @test_strategy.switch!(:override_government, true)
     published_edition = create(:published_news_article)
     new_draft = create(:news_article, document: published_edition.document)
     render_inline(Admin::Editions::HistoryModeFormControls.new(new_draft, create(:managing_editor)))
@@ -38,7 +23,6 @@ class Admin::Editions::HistoryModeFormControlsTest < ViewComponent::TestCase
   end
 
   test "displays the political checkbox for managing editor users " do
-    @test_strategy.switch!(:override_government, true)
     published_edition = create(:published_news_article)
     new_draft = create(:news_article, document: published_edition.document)
     render_inline(Admin::Editions::HistoryModeFormControls.new(new_draft, create(:managing_editor)))
@@ -46,7 +30,6 @@ class Admin::Editions::HistoryModeFormControlsTest < ViewComponent::TestCase
   end
 
   test "doesn't display the government selector for managing editor users " do
-    @test_strategy.switch!(:override_government, true)
     published_edition = create(:published_news_article)
     new_draft = create(:news_article, document: published_edition.document)
     render_inline(Admin::Editions::HistoryModeFormControls.new(new_draft, create(:managing_editor)))
@@ -54,7 +37,6 @@ class Admin::Editions::HistoryModeFormControlsTest < ViewComponent::TestCase
   end
 
   test "doesn't display the political checkbox for writer users " do
-    @test_strategy.switch!(:override_government, true)
     published_edition = create(:published_news_article)
     new_draft = create(:news_article, document: published_edition.document)
     render_inline(Admin::Editions::HistoryModeFormControls.new(new_draft, create(:writer)))
@@ -62,7 +44,6 @@ class Admin::Editions::HistoryModeFormControlsTest < ViewComponent::TestCase
   end
 
   test "doesn't display the political checkbox on creation" do
-    @test_strategy.switch!(:override_government, true)
     new_draft = create(:news_article)
     render_inline(Admin::Editions::HistoryModeFormControls.new(new_draft, create(:managing_editor)))
     assert_selector "#edition_political", count: 0


### PR DESCRIPTION
This feature is now in production use, so no need to keep the feature flag around. Will follow up with a separate PR to remove the flag itself and the database record of the flag.

Trello: https://trello.com/c/Q7tCtSXy
