### PR TITLE
Upgrading to GOV.UK Frontend v5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -300,7 +300,7 @@ GEM
     govuk_personalisation (0.16.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
-    govuk_publishing_components (39.2.5)
+    govuk_publishing_components (43.1.1)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -2,4 +2,5 @@
 //= link_tree ../builds
 //= link application.js
 //= link admin/domain-config.js
+//= link es6-components.js
 //= link components/visual-editor.js

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,8 +1,13 @@
 //= require admin/stop-scripts-nomodule
 
 //= require govuk_publishing_components/dependencies
-//= require govuk_publishing_components/all_components
 //= require govuk_publishing_components/analytics-ga4
+//= require govuk_publishing_components/components/copy-to-clipboard
+//= require govuk_publishing_components/components/govspeak
+//= require govuk_publishing_components/components/reorderable-list
+//= require govuk_publishing_components/components/table
+//= require govuk_publishing_components/lib/trigger-event
+//= require govuk_publishing_components/lib/cookie-functions
 
 //= require components/autocomplete
 //= require components/govspeak-editor

--- a/app/assets/javascripts/es6-components.js
+++ b/app/assets/javascripts/es6-components.js
@@ -1,0 +1,17 @@
+// These modules from govuk_publishing_components
+// depend on govuk-frontend modules. govuk-frontend
+// now targets browsers that support `type="module"`.
+//
+// To gracefully prevent execution of these scripts
+// on browsers that don't support ES6, this script
+// should be included in a `type="module"` script tag
+// which will ensure they are never loaded.
+
+//= require govuk_publishing_components/components/button
+//= require govuk_publishing_components/components/checkboxes
+//= require govuk_publishing_components/components/character-count
+//= require govuk_publishing_components/components/error-summary
+//= require govuk_publishing_components/components/layout-header
+//= require govuk_publishing_components/components/radio
+//= require govuk_publishing_components/components/skip-link
+//= require govuk_publishing_components/components/tabs

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -5,6 +5,7 @@
     <meta name="govuk:components_gem_version" content="<%= GovukPublishingComponents::VERSION %>">
     <%= javascript_include_tag "admin/domain-config" %>
     <%= javascript_include_tag "govuk_publishing_components/load-analytics" %>
+    <%= javascript_include_tag "es6-components", type: "module" %>
   <% end %>
 <% end %>
 


### PR DESCRIPTION
Components that contain code from GOV.UK Frontend have been moved to a separate file, `es6-components.js`. This approach is used to prevent Grade X Browsers evaluating JavaScript that isn't supported by adding the type=”module” attribute to the script tag.

Bumps [govuk_publishing_components](https://github.com/alphagov/govuk_publishing_components) from 39.2.5 to 43.1.1.
- [Changelog](https://github.com/alphagov/govuk_publishing_components/blob/main/CHANGELOG.md)
- [Commits](alphagov/govuk_publishing_components@v39.2.5...v43.1.1)

Followed upgrade steps [here](https://docs.google.com/document/d/1uwip7pzQwM7t5ghn9_8KrsWXLePSRUltFPZ5fYw6Ab8/edit).

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
