### PR TITLE
Rename integration test

### DIFF
--- a/lib/engines/content_object_store/test/integration/base_test.rb
+++ b/lib/engines/content_object_store/test/integration/base_test.rb
@@ -6,7 +6,7 @@ class TestController < ContentObjectStore::BaseController
   end
 end
 
-class ContentObjectStore::BaseControllerTest < ActionDispatch::IntegrationTest
+class ContentObjectStore::BaseTest < ActionDispatch::IntegrationTest
   setup do
     feature_flags.switch!(:content_object_store, true)
     login_as_admin


### PR DESCRIPTION
There is already a `BaseControllerTest` elsewhere and integration tests aren’t testing the controller directly anyway, just the behaviour.