### PR TITLE
Remove UpdateOrganisationsIndexPageWorker

### DIFF
--- a/app/workers/update_organisations_index_page_worker.rb
+++ b/app/workers/update_organisations_index_page_worker.rb
@@ -1,5 +1,0 @@
-class UpdateOrganisationsIndexPageWorker < WorkerBase
-  def perform
-    PublishOrganisationsIndexPage.new.publish
-  end
-end


### PR DESCRIPTION
It doesn't appear to be used anywhere.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
