### PR TITLE
Default to `EMERGENCY_BANNER_REDIS_URL` in Emergency Banner controller

### DIFF
--- a/app/controllers/admin/emergency_banner_controller.rb
+++ b/app/controllers/admin/emergency_banner_controller.rb
@@ -64,6 +64,7 @@ private
 
   def redis_client
     Redis.new(
+      url: ENV.fetch("EMERGENCY_BANNER_REDIS_URL", ENV["REDIS_URL"]),
       reconnect_attempts: 4,
       reconnect_delay: 15,
       reconnect_delay_max: 60,

--- a/test/functional/admin/emergency_banner_controller_test.rb
+++ b/test/functional/admin/emergency_banner_controller_test.rb
@@ -163,4 +163,54 @@ class Admin::EmergencyBannerControllerTest < ActionController::TestCase
       assert_equal expected_response, Redis.new.hgetall("emergency_banner").symbolize_keys
     end
   end
+
+  context "instantiating Redis" do
+    setup do
+      @mock_redis = Minitest::Mock.new
+      def @mock_redis.hgetall(*args); end
+      def @mock_redis.del(*args); end
+    end
+    context "when the EMERGENCY_BANNER_REDIS_URL environment variable has been set" do
+      view_test "uses that value as the URL for the Redis client" do
+        mock_env("EMERGENCY_BANNER_REDIS_URL" => "redis://emergency-banner") do
+          Redis.expects(:new).with(
+            url: "redis://emergency-banner",
+            reconnect_attempts: 4,
+            reconnect_delay: 15,
+            reconnect_delay_max: 60,
+          ).twice.returns(@mock_redis)
+
+          delete :destroy
+        end
+      end
+    end
+
+    context "when the EMERGENCY_BANNER_REDIS_URL environment variable has not been set" do
+      view_test "uses the default REDIS_URL as the URL for the Redis client" do
+        mock_env({
+          "EMERGENCY_BANNER_REDIS_URL" => nil,
+          "REDIS_URL" => "redis://my-redis-url",
+        }) do
+          Redis.expects(:new).with(
+            url: "redis://my-redis-url",
+            reconnect_attempts: 4,
+            reconnect_delay: 15,
+            reconnect_delay_max: 60,
+          ).twice.returns(@mock_redis)
+
+          delete :destroy
+        end
+      end
+    end
+  end
+
+  def mock_env(partial_env_hash)
+    old_env = ENV.to_hash
+    ENV.update partial_env_hash
+    begin
+      yield
+    ensure
+      ENV.replace old_env
+    end
+  end
 end


### PR DESCRIPTION
[Trello card](https://trello.com/c/zkDNXi7x/1400-create-new-redis-instance-for-whitehall-admin-integration)

In https://github.com/alphagov/govuk-helm-charts/pull/2598/commits/501163523cee534667548ab9b288060d2f595ae4 we added a new `EMERGENCY_BANNER_REDIS_URL` environment variable to Whitehall Admin on Integration pointing to the newly-provisioned Redis instance's database (`/1`).

Here we access that value in the Emergency Banner controller.

For environments that don't have this variable set yet (i.e. Staging and Production) we fallback on the default `REDIS_URL`.

This is temporary - once we've moved all environments over to the new URL we can remove this default.

**NB: We'll need to deploy the [corresponding change](https://github.com/alphagov/static/pull/3445) in Static's codebase at the same time as this one to ensure the two are using the same shared instance**

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
