### PR TITLE
content-modelling: 550 send publish intents when scheduling a block

### DIFF
--- a/lib/engines/content_object_store/app/lib/content_object_store/publishable.rb
+++ b/lib/engines/content_object_store/app/lib/content_object_store/publishable.rb
@@ -24,7 +24,6 @@ module ContentObjectStore
         publish_publishing_api_edition(content_id:)
         update_content_block_document_with_live_edition(content_block_edition)
         content_block_edition.public_send(:publish!)
-        remove_cache_for_host_content(content_block_edition:)
       rescue PublishingFailureError => e
         discard_publishing_api_edition(content_id:)
         raise e
@@ -51,19 +50,6 @@ module ContentObjectStore
     end
 
   private
-
-    def remove_cache_for_host_content(content_block_edition:)
-      host_content_items = ContentObjectStore::GetHostContentItems.by_embedded_document(
-        content_block_document: content_block_edition.document,
-      )
-      host_content_items.each do |host_content_item|
-        ContentObjectStore::PublishIntentWorker.perform_async(
-          host_content_item.base_path,
-          host_content_item.publishing_app,
-          Time.zone.now.to_s,
-        )
-      end
-    end
 
     def create_publishing_api_edition(content_id:, schema_id:, title:, details:, links:)
       Services.publishing_api.put_content(content_id, {

--- a/lib/engines/content_object_store/test/integration/content_block/workflow_test.rb
+++ b/lib/engines/content_object_store/test/integration/content_block/workflow_test.rb
@@ -12,6 +12,8 @@ class ContentObjectStore::ContentBlock::WorkflowTest < ActionDispatch::Integrati
     stub_request_for_schema("email_address")
 
     feature_flags.switch!(:content_object_store, true)
+
+    stub_publishing_api_has_embedded_content(content_id: @content_id, total: 0, results: [])
   end
 
   test "#publish posts the new edition to the Publishing API and marks edition as published" do
@@ -53,14 +55,6 @@ class ContentObjectStore::ContentBlock::WorkflowTest < ActionDispatch::Integrati
       "major",
     ]
 
-    fake_embedded_content_response = GdsApi::Response.new(stub("http_response",
-                                                               code: 200, body: {
-                                                                 "total" => 0,
-                                                                 "results" => [],
-                                                               }.to_json))
-
-    publishing_api_mock.expect :get_content_by_embedded_document, fake_embedded_content_response, [@content_id]
-
     Services.stub :publishing_api, publishing_api_mock do
       post content_object_store.publish_content_object_store_content_block_edition_path(id: edition.id), params: {
         id: edition.id,
@@ -72,87 +66,6 @@ class ContentObjectStore::ContentBlock::WorkflowTest < ActionDispatch::Integrati
       assert_equal document.live_edition_id, document.latest_edition_id
 
       assert_equal "published", new_edition.state
-    end
-  end
-
-  test "#publish creates publish intents for all host documents" do
-    details = {
-      foo: "Foo text",
-      bar: "Bar text",
-    }
-
-    organisation = create(:organisation)
-    document = create(:content_block_document, :email_address, content_id: @content_id, title: "Some Title")
-    edition = create(:content_block_edition, document:, details:, organisation:)
-
-    fake_put_content_response = GdsApi::Response.new(
-      stub("http_response", code: 200, body: {}),
-    )
-    fake_publish_content_response = GdsApi::Response.new(
-      stub("http_response", code: 200, body: {}),
-    )
-
-    publishing_api_mock = Minitest::Mock.new
-    publishing_api_mock.expect :put_content, fake_put_content_response, [
-      @content_id,
-      {
-        schema_name: "content_block_type",
-        document_type: "content_block_type",
-        publishing_app: "whitehall",
-        title: "Some Title",
-        details: {
-          "foo" => "Foo text",
-          "bar" => "Bar text",
-        },
-        links: {
-          primary_publishing_organisation: [organisation.content_id],
-        },
-      },
-    ]
-    publishing_api_mock.expect :publish, fake_publish_content_response, [
-      @content_id,
-      "major",
-    ]
-
-    host_content =
-      [
-        {
-          "title" => "Content title",
-          "document_type" => "document",
-          "base_path" => "/host-document",
-          "content_id" => "1234abc",
-          "publishing_app" => "host_publisher",
-          "primary_publishing_organisation" => {
-            "content_id" => "456abc",
-            "title" => "Organisation",
-            "base_path" => "/organisation/org",
-          },
-        },
-      ]
-
-    fake_embedded_content_response = GdsApi::Response.new(stub("http_response",
-                                                               code: 200, body: {
-                                                                 "total" => 1,
-                                                                 "results" => host_content,
-                                                               }.to_json))
-
-    publishing_api_mock.expect :get_content_by_embedded_document, fake_embedded_content_response, [@content_id]
-
-    publishing_api_mock.expect :put_intent, {}, ["/host-document",
-                                                 {
-                                                   publish_time: Time.zone.now,
-                                                   publishing_app: "host_publisher",
-                                                   rendering_app: "government-frontend",
-                                                   routes: [{ path: "/host-document", type: "exact" }],
-                                                 }]
-
-    Sidekiq::Testing.inline! do
-      Services.stub :publishing_api, publishing_api_mock do
-        post content_object_store.publish_content_object_store_content_block_edition_path(id: edition.id), params: {
-          id: edition.id,
-        }
-        publishing_api_mock.verify
-      end
     end
   end
 
@@ -235,7 +148,7 @@ class ContentObjectStore::ContentBlock::WorkflowTest < ActionDispatch::Integrati
     end
   end
 
-  test "#update creates publish intents for host content" do
+  test "#update scheduling creates publish intents for host content" do
     details = {
       foo: "Foo text",
       bar: "Bar text",
@@ -300,7 +213,7 @@ class ContentObjectStore::ContentBlock::WorkflowTest < ActionDispatch::Integrati
 
     publishing_api_mock.expect :put_intent, {}, ["/host-document",
                                                  {
-                                                   publish_time: Time.zone.now,
+                                                   publish_time: Time.zone.local(2024, 9, 2, 10, 5, 0),
                                                    publishing_app: "host_publisher",
                                                    rendering_app: "government-frontend",
                                                    routes: [{ path: "/host-document", type: "exact" }],

--- a/lib/engines/content_object_store/test/unit/app/services/publish_edition_service_test.rb
+++ b/lib/engines/content_object_store/test/unit/app/services/publish_edition_service_test.rb
@@ -13,8 +13,6 @@ class ContentObjectStore::PublishEditionServiceTest < ActiveSupport::TestCase
       ContentObjectStore::ContentBlock::Schema.stubs(:find_by_block_type)
                                               .returns(schema)
       @organisation = create(:organisation)
-
-      stub_publishing_api_has_embedded_content(content_id:, total: 0, results: [])
     end
 
     test "returns a ContentBlockEdition" do
@@ -59,13 +57,6 @@ class ContentObjectStore::PublishEditionServiceTest < ActiveSupport::TestCase
         "major",
       ]
 
-      fake_embedded_content_response = GdsApi::Response.new(stub("http_response",
-                                                                 code: 200, body: { "content_id" => "1234abc",
-                                                                                    "total" => 0,
-                                                                                    "results" => [] }.to_json))
-
-      publishing_api_mock.expect :get_content_by_embedded_document, fake_embedded_content_response, [content_id]
-
       Services.stub :publishing_api, publishing_api_mock do
         ContentObjectStore::PublishEditionService.new(schema).call(edition)
 
@@ -73,34 +64,6 @@ class ContentObjectStore::PublishEditionServiceTest < ActiveSupport::TestCase
         assert_equal "published", edition.state
         assert_equal edition.id, document.live_edition_id
       end
-    end
-
-    test "it queues publishing intents for host content on the Publishing API" do
-      host_content =
-        [
-          {
-            "title" => "Content title",
-            "document_type" => "document",
-            "base_path" => "/host-document",
-            "content_id" => "1234abc",
-            "publishing_app" => "example-app",
-            "primary_publishing_organisation" => {
-              "content_id" => "456abc",
-              "title" => "Organisation",
-              "base_path" => "/organisation/org",
-            },
-          },
-        ]
-
-      stub_publishing_api_has_embedded_content(content_id:, total: 0, results: host_content)
-
-      ContentObjectStore::PublishIntentWorker.expects(:perform_async).with(
-        "/host-document",
-        "example-app",
-        Time.zone.now.to_s,
-      ).once
-
-      ContentObjectStore::PublishEditionService.new(schema).call(edition)
     end
 
     test "if the publishing API request fails, the Whitehall ContentBlockEdition and ContentBlockDocument are rolled back" do


### PR DESCRIPTION
we previously sent publish intents for the instant that a block was published, but this was due to misunderstanding of what the intents do and how the cache would work - they only really make sense when scheduling a block https://docs.publishing.service.gov.uk/repos/content-store/publish_intents.html

We are doing this with hopefully a full understanding of the caveats now https://trello.com/c/OEF9GDRy/550-cache-busting-our-object-updates-should-propagate-through-to-citizens-at-the-same-time#comment-66f3d8389b5abea342d04b6a

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
