### PR TITLE
Add task to publish empty landing pages

### DIFF
--- a/app/services/publish_landing_page.rb
+++ b/app/services/publish_landing_page.rb
@@ -1,0 +1,35 @@
+# NOTE: Temporary while we work out which
+#       publishing app / CMS to use for landing pages
+class PublishLandingPage
+  attr_reader :landing_page_content_item
+
+  def initialize(landing_page_content_item)
+    @landing_page_content_item = landing_page_content_item
+  end
+
+  def self.call(landing_page_content_item)
+    new(landing_page_content_item).call
+  end
+
+  def call
+    send_to_publishing_api
+  end
+
+private
+
+  def send_to_publishing_api
+    Services.publishing_api.put_content(
+      content_id,
+      landing_page_content_item,
+    )
+    Services.publishing_api.publish(content_id)
+  end
+
+  def content_id
+    @content_id ||= existing_content_id || SecureRandom.uuid
+  end
+
+  def existing_content_id
+    Services.publishing_api.lookup_content_id(base_path: landing_page_content_item["base_path"])
+  end
+end

--- a/lib/landing_pages/programme_for_government.json
+++ b/lib/landing_pages/programme_for_government.json
@@ -1,0 +1,18 @@
+{
+  "base_path": "/programme-for-government",
+  "title": "",
+  "description": "",
+  "locale": "en",
+  "document_type": "landing_page",
+  "schema_name": "generic",
+  "publishing_app": "whitehall",
+  "rendering_app": "frontend",
+  "update_type": "major",
+  "details": {},
+  "routes": [
+    {
+      "type": "exact",
+      "path": "/programme-for-government"
+    }
+  ]
+}

--- a/lib/landing_pages/programme_for_government.json
+++ b/lib/landing_pages/programme_for_government.json
@@ -4,7 +4,7 @@
   "description": "",
   "locale": "en",
   "document_type": "landing_page",
-  "schema_name": "generic",
+  "schema_name": "landing_page",
   "publishing_app": "whitehall",
   "rendering_app": "frontend",
   "update_type": "major",

--- a/lib/landing_pages/programme_for_government_mission_1.json
+++ b/lib/landing_pages/programme_for_government_mission_1.json
@@ -4,7 +4,7 @@
   "description": "",
   "locale": "en",
   "document_type": "landing_page",
-  "schema_name": "generic",
+  "schema_name": "landing_page",
   "publishing_app": "whitehall",
   "rendering_app": "frontend",
   "update_type": "major",

--- a/lib/landing_pages/programme_for_government_mission_1.json
+++ b/lib/landing_pages/programme_for_government_mission_1.json
@@ -1,0 +1,18 @@
+{
+  "base_path": "/programme-for-government/mission-1",
+  "title": "",
+  "description": "",
+  "locale": "en",
+  "document_type": "landing_page",
+  "schema_name": "generic",
+  "publishing_app": "whitehall",
+  "rendering_app": "frontend",
+  "update_type": "major",
+  "details": {},
+  "routes": [
+    {
+      "type": "exact",
+      "path": "/programme-for-government/mission-1"
+    }
+  ]
+}

--- a/lib/landing_pages/programme_for_government_mission_2.json
+++ b/lib/landing_pages/programme_for_government_mission_2.json
@@ -4,7 +4,7 @@
   "description": "",
   "locale": "en",
   "document_type": "landing_page",
-  "schema_name": "generic",
+  "schema_name": "landing_page",
   "publishing_app": "whitehall",
   "rendering_app": "frontend",
   "update_type": "major",

--- a/lib/landing_pages/programme_for_government_mission_2.json
+++ b/lib/landing_pages/programme_for_government_mission_2.json
@@ -1,0 +1,18 @@
+{
+  "base_path": "/programme-for-government/mission-2",
+  "title": "",
+  "description": "",
+  "locale": "en",
+  "document_type": "landing_page",
+  "schema_name": "generic",
+  "publishing_app": "whitehall",
+  "rendering_app": "frontend",
+  "update_type": "major",
+  "details": {},
+  "routes": [
+    {
+      "type": "exact",
+      "path": "/programme-for-government/mission-2"
+    }
+  ]
+}

--- a/lib/tasks/publish_landing_pages.rake
+++ b/lib/tasks/publish_landing_pages.rake
@@ -1,0 +1,13 @@
+# NOTE: Temporary while we work out which
+#       publishing app / CMS to use for landing pages
+namespace :landing_pages do
+  desc "Publish landing pages to the publishing API"
+  task publish: :environment do
+    Dir[Rails.root.join("lib/landing_pages/*.json")].each do |file_path|
+      puts "Publishing #{file_path}"
+
+      content_item = JSON.parse(File.read(file_path))
+      PublishLandingPage.call(content_item)
+    end
+  end
+end

--- a/test/unit/app/services/publish_landing_page_test.rb
+++ b/test/unit/app/services/publish_landing_page_test.rb
@@ -1,0 +1,26 @@
+require "test_helper"
+
+class PublishLandingPageTest < ActiveSupport::TestCase
+  test "it assigns a valid content id the first time it publishes the landing_page" do
+    pfg_landing_page = JSON.parse(File.read("lib/landing_pages/programme_for_government.json"))
+
+    stub_publishing_api_has_lookups({})
+    SecureRandom.stubs(:uuid).returns("a-content-id")
+
+    PublishLandingPage.call(pfg_landing_page)
+
+    assert_publishing_api_put_content("a-content-id", pfg_landing_page)
+    assert_publishing_api_publish("a-content-id")
+  end
+
+  test "it uses the existing content id when publishing" do
+    pfg_landing_page = JSON.parse(File.read("lib/landing_pages/programme_for_government.json"))
+
+    stub_publishing_api_has_lookups("/programme-for-government" => "existing-content-id")
+
+    PublishLandingPage.call(pfg_landing_page)
+
+    assert_publishing_api_put_content("existing-content-id", pfg_landing_page)
+    assert_publishing_api_publish("existing-content-id")
+  end
+end


### PR DESCRIPTION
This is basically a copy of the PublishFinders code, including its tests.

The idea is that we'll publish some of these landing page content items just so that their routes are declared and point to the correct frontend (which is going to be frontend). The details and links of the content item will initially be added by the frontend based on hardcoded YAML files. Later, we'll work out a CMS for these content items, which may be Whitehall, or may be something else entirely (e.g. a third party CMS like Sanity of Contentful [other CMSs are available])

Currently draft, as it's not clear what base paths we'll want to reserve just yet.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️