### PR TITLE
Read TAXONOMY_CACHE_REDIS_URL in Redis Cache Adapter if set

### DIFF
--- a/lib/taxonomy/redis_cache_adapter.rb
+++ b/lib/taxonomy/redis_cache_adapter.rb
@@ -4,6 +4,7 @@ module Taxonomy
     WORLD_TAXONS_CACHE_KEY = "world_taxonomy_taxons".freeze
 
     def initialize(redis_client: Redis.new(
+      url: ENV.fetch("TAXONOMY_CACHE_REDIS_URL", ENV["REDIS_URL"]),
       reconnect_attempts: 4,
       reconnect_delay: 15,
       reconnect_delay_max: 60,

--- a/test/functional/admin/emergency_banner_controller_test.rb
+++ b/test/functional/admin/emergency_banner_controller_test.rb
@@ -203,14 +203,4 @@ class Admin::EmergencyBannerControllerTest < ActionController::TestCase
       end
     end
   end
-
-  def mock_env(partial_env_hash)
-    old_env = ENV.to_hash
-    ENV.update partial_env_hash
-    begin
-      yield
-    ensure
-      ENV.replace old_env
-    end
-  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -96,6 +96,16 @@ class ActiveSupport::TestCase
     assert_output(/^(?!#{regex}).*$/, &block)
   end
 
+  def mock_env(partial_env_hash)
+    old_env = ENV.to_hash
+    ENV.update partial_env_hash
+    begin
+      yield
+    ensure
+      ENV.replace old_env
+    end
+  end
+
   def count_queries
     count = 0
     subscriber = ActiveSupport::Notifications.subscribe("sql.active_record") do |*_args|

--- a/test/unit/lib/taxonomy/redis_cache_adapter_test.rb
+++ b/test/unit/lib/taxonomy/redis_cache_adapter_test.rb
@@ -16,6 +16,35 @@ class Taxonomy::RedisCacheAdapterTest < ActiveSupport::TestCase
     @publishing_api_adapter ||= stub
   end
 
+  test "uses TAXONOMY_CACHE_REDIS_URL value for Redis Client if it has been set" do
+    mock_env("TAXONOMY_CACHE_REDIS_URL" => "redis://taxonomy-cache") do
+      Redis.expects(:new).with(
+        url: "redis://taxonomy-cache",
+        reconnect_attempts: 4,
+        reconnect_delay: 15,
+        reconnect_delay_max: 60,
+      )
+
+      Taxonomy::RedisCacheAdapter.new(adapter: publishing_api_adapter)
+    end
+  end
+
+  test "uses the default REDIS_URL for Redis Client if TAXONOMY_CACHE_REDIS_URL has not been set" do
+    mock_env({
+      "TAXONOMY_CACHE_REDIS_URL" => nil,
+      "REDIS_URL" => "redis://my-redis-url",
+    }) do
+      Redis.expects(:new).with(
+        url: "redis://my-redis-url",
+        reconnect_attempts: 4,
+        reconnect_delay: 15,
+        reconnect_delay_max: 60,
+      )
+
+      Taxonomy::RedisCacheAdapter.new(adapter: publishing_api_adapter)
+    end
+  end
+
   test "#rebuild_caches" do
     published_taxons = { "baz" => "qux" }
     publishing_api_adapter.stubs(:taxon_data).returns(published_taxons)


### PR DESCRIPTION
[Trello card](https://trello.com/c/zkDNXi7x/1400-create-new-redis-instance-for-whitehall-admin-integration)

## Changes in this PR

Updates the Redis Cache Adapter used by the Taxonomy Cache to point to the new environment variable we've currently only added to Integration (as of [this commit](https://github.com/alphagov/govuk-helm-charts/commit/501163523cee534667548ab9b288060d2f595ae4)), which points to a separate database for Whitehall's newly-provisioned own Redis DB.

For environments that don't have this variable set yet (i.e. Staging and Production) we fallback on the default `REDIS_URL`.

This is temporary - once we've moved all environments over to the new URL we can remove this default.

## Next steps

Once this is merged, we'll need to run [the rake task](https://github.com/alphagov/whitehall/blob/d82a16d532d4673e007fa8310434fd390a9a38b0/lib/tasks/taxonomy.rake#L2-L6) for rebuilding the Taxonomy Cache on Integration.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
