### PR TITLE
Use only `EMERGENCY_BANNER_REDIS_URL` environment variable

### DIFF
--- a/app/controllers/admin/emergency_banner_controller.rb
+++ b/app/controllers/admin/emergency_banner_controller.rb
@@ -64,7 +64,7 @@ private
 
   def redis_client
     Redis.new(
-      url: ENV.fetch("EMERGENCY_BANNER_REDIS_URL", ENV["REDIS_URL"]),
+      url: ENV["EMERGENCY_BANNER_REDIS_URL"],
       reconnect_attempts: 4,
       reconnect_delay: 15,
       reconnect_delay_max: 60,

--- a/test/functional/admin/emergency_banner_controller_test.rb
+++ b/test/functional/admin/emergency_banner_controller_test.rb
@@ -163,44 +163,4 @@ class Admin::EmergencyBannerControllerTest < ActionController::TestCase
       assert_equal expected_response, Redis.new.hgetall("emergency_banner").symbolize_keys
     end
   end
-
-  context "instantiating Redis" do
-    setup do
-      @mock_redis = Minitest::Mock.new
-      def @mock_redis.hgetall(*args); end
-      def @mock_redis.del(*args); end
-    end
-    context "when the EMERGENCY_BANNER_REDIS_URL environment variable has been set" do
-      view_test "uses that value as the URL for the Redis client" do
-        mock_env("EMERGENCY_BANNER_REDIS_URL" => "redis://emergency-banner") do
-          Redis.expects(:new).with(
-            url: "redis://emergency-banner",
-            reconnect_attempts: 4,
-            reconnect_delay: 15,
-            reconnect_delay_max: 60,
-          ).twice.returns(@mock_redis)
-
-          delete :destroy
-        end
-      end
-    end
-
-    context "when the EMERGENCY_BANNER_REDIS_URL environment variable has not been set" do
-      view_test "uses the default REDIS_URL as the URL for the Redis client" do
-        mock_env({
-          "EMERGENCY_BANNER_REDIS_URL" => nil,
-          "REDIS_URL" => "redis://my-redis-url",
-        }) do
-          Redis.expects(:new).with(
-            url: "redis://my-redis-url",
-            reconnect_attempts: 4,
-            reconnect_delay: 15,
-            reconnect_delay_max: 60,
-          ).twice.returns(@mock_redis)
-
-          delete :destroy
-        end
-      end
-    end
-  end
 end


### PR DESCRIPTION
In 93c708158530678f10fc5eb7bc2bb7af644554a4, we allowed this application to use either `EMERGENCY_BANNER_REDIS_URL` or `REDIS_URL`, as different environments were in differet states.

That is no longer the case, so we can remove the code to default to one over the other.

[Trello card](https://trello.com/c/2RF94Axr)