### PR TITLE
WIP - add tasks to publish history pages content object

### DIFF
--- a/app/services/publish_history_page.rb
+++ b/app/services/publish_history_page.rb
@@ -1,0 +1,61 @@
+class PublishHistoryPage
+  attr_reader :history_page_content_item, :content_id
+
+  def initialize(history_page_details)
+    @history_page_content_item = make_content_item(history_page_details)
+    @content_id = history_page_details[:content_it]
+  end
+
+  def self.call(history_page_details)
+    new(history_page_details).call
+  end
+
+  def call
+    send_to_publishing_api
+  end
+
+private
+
+  def make_content_item(details)
+    govspeak = Govspeak::Document.new(details[:govspeak])
+
+    {
+      base_path: details[:base_path],
+      title: details[:title],
+      description: details[:description],
+      locale: "en",
+      document_type: "history",
+      schema_name: "history",
+      publishing_app: "whitehall",
+      rendering_app: "frontend",
+      public_updated_at: Time.zone.now.iso8601,
+      update_type: "minor",
+      details: {
+        image: {
+          src: details[:image],
+          alt: details[:image_alt],
+        },
+        headers: extract_headers(govspeak),
+        body: govspeak.to_html,
+      },
+      routes: [
+        {
+          type: "exact",
+          path: details[:base_path],
+        },
+      ],
+    }
+  end
+
+  def extract_headers(govspeak)
+    govspeak.headers.select{ |h| h.level == 2 }.map { |h| { title: h.text, id: h.id } }
+  end
+
+  def send_to_publishing_api
+    Services.publishing_api.put_content(
+      content_id,
+      history_page_content_item,
+    )
+    Services.publishing_api.publish(content_id)
+  end
+end

--- a/lib/history_pages/10_downing_street.yaml
+++ b/lib/history_pages/10_downing_street.yaml
@@ -1,0 +1,295 @@
+:base_path: /government/history/10-downing-street
+:content_id: 14aa298f-03a8-4e76-96de-483efa3d001f
+:title: 10 Downing Street
+:description: 10 Downing Street, the locale of British prime ministers since 1735, vies with the White House as being the most important political building anywhere in the world in the modern era.
+:image:
+:image_alt: The front door of 10 Downing Street
+:govspeak: |
+  ## Introduction
+
+  ### by Sir Anthony Seldon
+
+  10 Downing Street, the locale of British prime ministers since 1735, vies with the White House as being the most important political building anywhere in the world in the modern era. Behind its black door have been taken the most important decisions affecting Britain for the last 275 years.
+
+  In the 20th century alone, the First and Second World Wars were directed from within it, as were the key decisions about the end of the empire, the building of the British nuclear bomb, the handling of economic crises from the Great Depression in 1929 to the great recession, and the building up of the welfare state.
+
+  Some of the most famous political figures of modern history have lived and worked in Number 10, including Robert Walpole, Pitt the Younger, Benjamin Disraeli, William Gladstone, David Lloyd George, Winston Churchill and Margaret Thatcher.
+
+  Number 10 has 3 overlapping functions. It is the official residence of the British Prime Minister: it is their office, and it is also the place where the Prime Minister has entertained guests from Her Late Majesty Queen Elizabeth II to presidents of the United States and other world leaders. The Prime Minister hosts countless receptions and events for a whole range of British and overseas guests, with charitable receptions high up the list.
+
+  The building is much larger than it appears from its frontage. The hall with the chequered floor immediately behind the front door lets on to a warren of rooms and staircases. The house in Downing Street was joined to a more spacious and elegant building behind it in the early 18th century. Number 10 has also spread itself out to the left of the front door, and has taken over much of 12 Downing Street, which is accessed by a corridor that runs through 11 Downing Street – the official residence of the Chancellor of the Exchequer.
+
+  ## Explore 10 Downing Street
+
+  Take a virtual tour inside 10 Downing Street and explore it’s most famous rooms and significant events at the [Google Cultural Institute](https://www.google.com/culturalinstitute/beta/u/0/partner/10-downing-street).
+
+  ## Origins and early inhabitants
+
+  The area around Downing Street was home to ancient Roman, Anglo-Saxon and Norman settlements, and was already a prestigious centre of government 1,000 years ago.
+
+  The Romans first came to Britain under the command of Julius Caesar in 55 BC. Making their capital at Londinium downriver, the Romans chose Thorney Island – a marshy piece of land lying between two branches of the river Tyburn that flowed from Hampstead Heath to the Thames – as the site for their early settlement.
+
+  These Roman settlements, and those of the Anglo-Saxons and Normans who supplanted them, were not very successful. The area was prone to plague and its inhabitants were very poor. A charter granted by the Mercian King Offa in the year 785 refers to “the terrible place called Thorney Island”. It took royal patronage to give the area prestige. King Canute (reigned 1017 to 1035) built a palace in the area, and Edward the Confessor (reigned 1042 to 1066) and William the Conqueror (reigned 1066 to 1087) maintained a royal presence there. The position of Westminster (as the area became known) as the centre of government and the church was solidified following the construction of the great abbey nearby, on Edward's orders.
+
+  Whitehall from St James’s Park – Hendrick Danckerts c.1675
+
+  The earliest building known to have stood on the site of Downing Street was the Axe brewery owned by the Abbey of Abingdon in the Middle Ages. By the early 1500s, it had fallen into disuse.
+
+  Henry VIII (reigned 1509 to 1547) developed Westminster's importance further by building an extravagant royal residence there.
+
+  Whitehall Palace was created when Henry VIII confiscated York House from Cardinal Wolsey in 1530 and extended the complex. Today's Downing Street is located on the edge of the Palace site.
+
+  The huge residence included tennis courts, a tiltyard for jousting, a bowling green, and a cockpit for bird fights. Stretching from St James's Park to the Thames, it was the official residence of Tudor and Stuart monarchs until it was destroyed by fire in 1698. It made the surrounding real estate some of the most important and valuable in London – and the natural home of power.
+
+  The first domestic house known to have been built on the site of Number 10 was a large building leased to Sir Thomas Knyvet in 1581 by Queen Elizabeth I (reigned 1558 to 1603). He was one of the Queen's favourites and was an MP for Thetford as well as a justice of the peace for Westminster. His claim to fame was the arrest of Guy Fawkes for his role in the gunpowder plot of 1605. He was knighted in 1604 by Elizabeth's successor, King James I (reigned 1603 to 1625), and the house was extended.
+
+  After the death of Sir Knyvet and his wife, the house passed to their niece, Elizabeth Hampden, who continued to live there for the next 40 years.
+
+  The middle of the 17th century was a period of political upheaval and Mrs Hampden's family was right in the middle of it. Her son, John Hampden, was one of the MPs who opposed King Charles I (reigned 1625 to 1649), and Oliver Cromwell, the Lord Protector, was Mrs Hampden's nephew.
+
+  Hampden House, as it was then known, gave Mrs Hampden a prime view of the tumultuous events during the Civil War and the Commonwealth and the early years of the Restoration.
+
+  The execution of Charles I in 1649 took place on a scaffold in front of Banqueting House in Whitehall, within earshot of the house. Mrs Hampden was still living there when King Charles II (reigned in Scotland from 1649 to 1685) was restored to the English throne in 1660.
+
+  The Parliamentary Commissioners, who took over Crown lands during the time of the Commonwealth, described the house in 1650:
+
+  > Built part of Bricke and part with Tymber and Flemish qalle and covered with Tyle, consistinge of a Large and spacious hall, wainscoted round, well lighted, and Paved with brick Pavements, two parls wherof one is Wainscoted round from the seelinge to ye floor, one Buttery, one seller, one Large kitchen well paved with stone and well fitted and Joynted and well fitted with dresser boards.
+  >
+  > And above stayres in the first story one large and spacious dyneinge Roome, Wainscoted round from the seelinge to the floore, well flored, Lighted and seeled, and fitted with a faire Chimney with a foote pace of paynted Tyle in the same. Also 6 more Roomes and 3 Closetts in the same flore all well lighted and seeled. And in the second story 4 garretts…
+
+  ## The emergence of Downing Street
+
+  George Downing gave his name to the most famous street in the world. It is unfortunate that he was such an unpleasant man. Able as a diplomat and a government administrator, he was miserly and at times brutal.
+
+  However, George Downing was responsible for the street, its name and the building we know today. A former diplomat at The Hague serving the Commonwealth, he changed allegiance with finesse. He traded enough secrets to gain a royal pardon in March 1660 and, by the Restoration in May 1660, to be rewarded with a knighthood.
+
+  Interested in power and money, he saw an opportunity to make his fortune in property. He had already gained the Crown interest in the land around Hampden House, but could not take possession as it was under lease to Knyvet's descendants. In 1682 he secured the leases to the property and employed Sir Christopher Wren to design the houses.
+
+  Between 1682 and 1684, existing properties were pulled down and in their place a cul-de-sac of 15 to 20 terraced houses was built along the north side of the new street, Downing Street. In order to maximise profit, the houses were cheaply built, with poor foundations for the boggy ground. Instead of neat brick façades, they had mortar lines drawn on to give the appearance of evenly spaced bricks. In the 20th Century, Prime Minister Winston Churchill wrote that Number 10 was:
+
+  > Shaky and lightly built by the profiteering contractor whose name they bear.
+
+  A rather important neighbour complained, however. The new houses were built directly behind a large and impressive house overlooking Horse Guards. Its occupier, the Countess of Lichfield, daughter of Charles II, was less than pleased with the emergence of the unwelcome terrace behind. She complained to her father, who wrote back with advice:
+
+  > I think that it is a very reasonable thing that other houses should not look into your house without your permission, and this note will be sufficient for Mr Surveyor to build up your wall as high as you please.
+
+  The original numbering of the Downing Street houses was completely different from what we see today. The sequence of numbers was haphazard, and the houses tended to be known by the name or title of their occupants. The current Number 10 started out life as Number 5, and was not renumbered until 1779.
+
+  The Downing Street house had several distinguished residents. The Countess of Yarmouth lived at Number 10 between 1688 and 1689, and was followed by Lord Lansdowne from 1692 to 1696 and the Earl of Grantham from 1699 to 1703. The last private resident of Downing's terrace was one Mr Chicken. Little is known about him except that he moved out in the early 1730s.
+
+  King George II presented both the house on Downing Street and the house overlooking Horse Guards to Sir Robert Walpole, who held the title First Lord of the Treasury and effectively served as the first Prime Minister. Walpole refused the property as a personal gift. Instead, he asked the king to make it available as an official residence to him and to future First Lords of the Treasury – starting the tradition that continues today. The brass letterbox on the black front door is still engraved with this title.
+
+  Walpole took up residence on 22 September 1735, once the townhouse on Downing Street and the house overlooking Horse Guards had been joined together and completely refurbished. Walpole employed architect William Kent – who had already worked on Walpole's Norfolk home, Houghton Hall – to undertake the work.
+
+  Kent carried out extensive work on the 2 houses, connecting them on 2 storeys. The main entrance now faced onto Downing Street rather than towards Horse Guards, and the Downing Street building became a passageway to the main house. At the back of the house, where the Walpoles lived, Kent created grand new rooms suitable for receiving important guests, and built an unusual, 3-sided staircase. It is still one of the most impressive features of the building.
+
+  Walpole used the ground floor for business, taking the largest room, on the north-west side of the house, as his study. This is now the Cabinet Room. Upstairs on the first floor, the Walpoles lived in the rooms facing onto Horse Guards Parade. Lady Walpole used today's White Drawing Room as her sitting room, and the present day Terracotta Room served as their dining room. The Walpoles were soon entertaining important guests in their smart house, including George II's wife Queen Caroline, politicians, writers and soldiers. Number 10 became – as it continues to be today – a place for politics and entertainment.
+
+  ## Pelham to Pitt
+
+  When Walpole left Downing Street in 1742, it was over 20 years before another First Lord of the Treasury moved in. His successors saw the house as a perk of the job, and Prime Ministers Henry Pelham (1743 to 1754) and the Duke of Newcastle (1757 to 1762) preferred to live in their own residences.
+
+  In 1763 George Grenville (1763 to 1765) took up residence but was sacked by King George III in 1765 for imposing stamp duty on the American colonies. The next Prime Minister to move into Downing Street was Lord North (1770 to 1782). He was very fond of the house and often entertained there. Visitors included the writer Samuel Johnson and Thomas Hansard, founder of the parliamentary reporting system that is still in use today. One guest, Clive of India, was so popular that furniture was made for him, which is still present today in the first floor anteroom and Terracotta Room.
+
+  During one memorable dinner party held by Lord North on 7 June 1780, civil unrest broke out in the street outside when angry Protestants unhappy with North's policy towards Roman Catholics rioted all over London, in what became known as the Gordon Riots. The Grenadier Guards held off a large mob, a situation that might have ended with bloodshed had North not gone outside to warn the protestors of the dangers of being shot, following which the crowd dispersed. North's dinner guests climbed to the top of the house to view the fires burning all over London.
+
+  Major improvements were made to the house during North's time, including the addition of many distinctive features: the black and white chequerboard floor in the entrance hall, the lamp above the front door and the famous lion's head door knocker.
+
+  Following the loss of the American colonies, North resigned and was followed by the Duke of Portland, who was Prime Minister for only 9 months in 1782.
+
+  ## Fall and rise of Number 10
+
+  At the turn of the 19th century, Downing Street had fallen on hard times. Although Number 10 continued to serve as the Prime Minister's office, it was not favoured as a home. Most prime ministers preferred to live in their own townhouses.
+
+  But by the 1820s, Downing Street had emerged as the centre of government. Prime Minister Viscount Goderich employed the brilliant, quirky architect Sir John Soane, designer of the [Bank of England](http://www.bankofengland.co.uk/), to make the house more suitable for its high-profile role. Soane created the wood-panelled State Dining Room and the Small Dining Room for elegant entertaining.
+
+  But this wasn't good enough for his successor, Lord Wellington, who only moved in while his own lavish home, [Apsley House](http://www.english-heritage.org.uk/daysout/properties/apsley-house/), was being refurbished. Later leaders such as Lord Melbourne and Viscount Palmerston used Number 10 only as an office and for Cabinet meetings. In 1828, Number 11 became the Chancellor of the Exchequer's official residence, but the surrounding area was becoming seedier, with brothels and gin parlours multiplying. Things became so bad that by 1839 there were plans to demolish Number 10 and the other buildings on the north side of Downing Street to make way for a remodelled Whitehall.
+
+  Security also became an issue. In 1842, Edward Drummond, secretary to Prime Minister Robert Peel (1841—1846), was murdered in Whitehall on his way back to his home in Downing Street by an assassin who mistook him for Peel. The prestige of Downing Street was reduced even further by the building of the magnificent new Foreign Office building at the end of the 1860s. George Gilbert Scott's creation, with a huge open court and elaborate state rooms, dwarfed Number 10 opposite. It even had its own Cabinet Room in which the Cabinet sometimes met, rather than at Number 10.
+
+  By the time Benjamin Disraeli became Prime Minister, the house was in poor shape. The living quarters had not been used for 30 years and Disraeli described it as “dingy and decaying”. It was time for modernisation.
+
+  The late 19th and early 20th century saw 10 Downing Street transformed from a humble terraced house into a grand residence with modern facilities – a home and office fit for the most powerful politician in the country. Disraeli persuaded the state to pay for renovation to the entrance halls and public rooms, though he paid for the refurbishment of the private rooms himself. His own first floor bedroom and dressing room were improved, and a bath with hot and cold water in the First Lord's Dressing Room was installed for the sum of £150.3s.6d.
+
+  When William Gladstone moved into the house for the first time in 1880, he insisted on redecorating, spending £1,555.5s.0d – an enormous sum for the time – on furniture. During his occupancy in 1884, electric lighting was fitted and the first telephones were installed.
+
+  The Marquess of Salisbury, who succeeded Gladstone on one occasion, was the last Prime Minister not to live at Number 10. Salisbury never liked the Cabinet Room, describing it as a “cramped close room”. Preferring to work in the larger Cabinet Room in the Foreign Office and live in Arlington Street, he offered Number 10 to his nephew, Arthur Balfour, who would later become Prime Minister himself. Balfour was the first inhabitant of Number 10 to bring a motor car to Downing Street.
+
+  Over the years, more and more changes and improvements were made to the house. When Prime Minister Ramsay MacDonald first entered the house, he wanted Number 10 to regain some of the grandeur it had during the times of Walpole and Pitt. Missing a proper library (or at least, one containing more than just Hansard reports), MacDonald set about creating one. He started the Prime Minister's Library, originally housed in the Cabinet Room. The custom of the Prime Minister and other ministers donating books to the library continues to this day. Central heating was installed in 1937 and work began to convert the labyrinth of rooms in the attic, which had formerly been used by servants, into a flat for the Prime Minister.
+
+  ## Number 10 at war
+
+  ### World War One
+
+  In 1912, Herbert Henry Asquith found himself at odds with Ulster and the Tory opposition following renewed attempts to introduce Irish Home Rule. This unrest and fierce opposition would continue, and civil war in Ireland was only averted with the outbreak of the First World War in August 1914.
+
+  The Cabinet Room at Number 10 was the nerve centre of Britain's war effort. Asquith's Cabinet included future Prime Ministers David Lloyd George and Winston Churchill, in their posts as Chancellor and First Lord of the Admiralty respectively. Asquith had been forced to take on the additional role of Secretary of State for War following the resignation of the incumbent in March 1914, but quickly appointed Lord Kitchener following the outbreak of war.
+
+  On 15 April 1916, Number 10 was the site of a meeting between General Haig, Commander-in-Chief of British forces in France, and the Cabinet to go over the detail of the planned Somme offensive, later known as the Battle of the Somme.
+
+  During a Cabinet split on 25 May 1915 (caused by public outcry at allegations the army had been under-supplied with shells and the failed offensive in the Dardanelles, for which Kitchener and Churchill respectively were blamed), Kitchener was stripped of his control over munitions and strategy, and Churchill lost his post as First Lord of the Admiralty. As a result of the split, Asquith formed a coalition government with the opposition Conservatives, whose leader was future Prime Minister, Andrew Bonar Law.
+
+  Asquith remained leader of the coalition until his resignation on 5 December 1916. After Andrew Bonar Law refused to form a government, David Lloyd George became leader of the coalition and Prime Minister on 7 December 1916.
+
+  Under Prime Minister Lloyd George the number of staff at Number 10 expanded and offices spilled out into the garden to cope with the demands of the administration of the war.
+
+  Lloyd George immediately formed his ‘War Cabinet’, whose members included Lord Curzon, Bonar Law and Arthur Henderson. In the first 235 days of its existence, the War Cabinet met 200 times.
+
+  This cabinet took total responsibility for the war, and on 3 occasions it sat as the Imperial War Cabinet when prime ministers from the Dominions attended. It provided a vigour previously lacking from the war effort.
+
+  Highly able young men were appointed to collect and collate data and to bypass slow moving government departments. These men were nicknamed the ‘Garden Suburb’ because they lived in huts at the end of gardens near to Downing Street. They were not liked by diehard civil servants, who they continually bypassed. However, the men from the Garden Suburb gave Lloyd George the one thing Asquith seemingly never had – up-to-date, meaningful statistics. Their work was invaluable, providing the War Cabinet with data on merchant ships sunk and UK farm production, issues essential to address if the country was not to be starved into defeat.
+
+  When armistice was finally declared on 11 November 1918, crowds thronged Downing Street chanting ‘LG’. Lloyd George made an appearance at one of the first floor windows to acknowledge them.
+
+  ### World War Two – Chamberlain
+
+  During the 1930s the world's eyes rested on Europe. With rising tensions between Germany and Czechoslovakia, the prime ministers of France and Britain did what they could in an attempt to avoid another war. On 12 September 1938, thousands gathered at Downing Street to listen to Hitler's speech on the final night of the Nuremberg Rally, convinced Britain stood on the brink of war.
+
+  As tension mounted further in Europe, Prime Minister Neville Chamberlain made several attempts to appease the situation, and Number 10 became the focus of international attention. On the morning of 29 September 1938, Chamberlain travelled to Germany for the final time as Prime Minister to hold talks with the French Prime Minister Édouard Daladier, Hitler, and Mussolini.
+
+  The Munich Agreement was signed and war – for now – had been averted. Before leaving for England, Chamberlain held a private meeting with Hitler where he obtained his signature on the famous “Peace in our Time” document, which declared that any future disputes between Britain and Germany would be settled peacefully.
+
+  Upon Chamberlain's return to Heston Airfield, he was mobbed by large crowds and gave the resounding “Peace in Our Time” speech, waving aloft the document signed by Hitler.
+
+  When he returned to Downing Street following a meeting with George VI, the Prime Minister found Downing Street and Number 10 itself packed with people. Chamberlain gave the speech a second time, from a first floor window of Number 10:
+
+  > My good friends, this is the second time there has come back from Germany to Downing Street peace with honour. I believe it is peace for our time. We thank you from the bottom of our hearts. Now I recommend you go home, and sleep quietly in your beds.
+
+  But over the following 12 months tension did not lift, and on 3 September 1939, Chamberlain broadcast to the nation from the Cabinet Room at Number 10, announcing that the country was now at war with Germany. Chamberlain resigned as Prime Minister on 10 May 1940 and advised King George VI to ask Winston Churchill to form a government.
+
+  When Winston Churchill replaced Chamberlain as Prime Minister, he and his wife moved into Downing Street's second-floor flat, where Churchill did much of his work.
+
+  He often dictated speeches, memos and letters to his secretary while lying propped up in bed in the morning or late in the evening, cigar in hand.
+
+  By October 1940, the intense bombing period known as the Blitz began. On 14 October, a huge bomb fell on Treasury Green near Downing Street, damaging the Number 10 kitchen and state rooms, and killing three Civil Servants doing Home Guard duty. Churchill was dining in the Garden Rooms when the air raid began. As he recalled in his memoir Their Finest Hour (1949):
+
+  > We were dining in the garden-room of Number 10 when the usual night raid began. The steel shutters had been closed. Several loud explosions occurred around us at no great distance, and presently a bomb fell, perhaps a hundred yards away, on the Horse Guards Parade, making a great deal of noise.
+  >
+  > Suddenly I had a providential impulse. The kitchen in Number 10 Downing Street is lofty and spacious, and looks out through a large plate-glass window about 25 feet high. The butler and parlour maid continued to serve the dinner with complete detachment, but I became acutely aware of this big window. I got up abruptly, went into the kitchen, told the butler to put the dinner on the hot plate in the dining-room, and ordered the cook and the other servants into the shelter, such as it was.
+  >
+  > I had been seated again at the table only about 3 minutes when a really loud crash, close at hand, and a violent shock showed that the house had been struck. My detective came into the room and said much damage had been done. The kitchen, the pantry and the offices on the Treasury were shattered.
+
+  Keeping Downing Street safe became the priority of the Prime Minister and the War Cabinet. Steel reinforcement was added to the Garden Rooms, and heavy metal shutters were fixed over windows as protection from bombing raids. The Garden Rooms included a small dining room, bedroom and a meeting area which were used by Churchill throughout the war. In reality, though, the steel reinforcement would not have protected him against a direct hit.
+
+  In October 1939, the Cabinet had moved out of Number 10 and into secret underground war rooms in the basement of the Office of Works opposite the Foreign Office, today's [Churchill War Rooms](http://www.iwm.org.uk/visits/churchill-war-rooms).
+
+  Following near misses by bombs, in 1940, Churchill and his wife moved out of Downing Street and into the Number 10 Annex above the war rooms. Furniture and valuables were removed from Number 10 and only the Garden Rooms, Cabinet Room and Private Secretaries' office remained in use.
+
+  Churchill disliked living in the Annex and, despite it being almost empty, he continued to use Number 10 for working and eating.
+
+  A reinforced shelter was constructed under the house for up to 6 people, for use by those working in the house. Even George VI sought shelter there when he dined with Churchill in the Garden Rooms. Although bombs caused further damage to Number 10, there were no direct hits to the house, allowing Churchill to continue to work and eat there right up until the end of the war.
+
+  As soon as war was over, Churchill and his wife moved back to Number 10, where he made his Victory in Europe (VE) Day broadcast, which was delivered from the Cabinet Room at 3pm on 8 May 1945.
+
+  ### Falklands Conflict – Margaret Thatcher
+
+  On 19 March 1982, the Argentinian flag was raised by a group of scrap metal merchants on the island of South Georgia, a British overseas territory and dependant of the Falkland Islands. There had been a lengthy dispute between Argentina and the United Kingdom over the sovereignty of the Islands and this action was seen as a precursor to the Argentinian invasion which would follow.
+
+  Argentine General Leopoldo Galtieri ordered the invasion of the Falklands to be brought forward to 2 April 1982, pre-empting any reinforcement of the United Kingdom's military presence in the area. Margaret Thatcher responded by sending a naval task force to recapture the islands, which set sail from Portsmouth on 5 April following a meeting of the Cabinet and the granting of a UN Resolution.
+
+  The Prime Minister stayed up all night in the Downing Street flat for the entire Falklands conflict. Margaret Thatcher's personal assistant, Cynthia Crawford, who moved into the flat at Number 10 to keep the Prime Minister company during the all-night vigils, recalls the 74 days of the conflict inside Number 10:
+
+  > She did not once change into her nightclothes in the flat for the duration of the war. We would sit in the flat listening to the BBC World Service for news of the task force. She couldn’t sleep because she wanted to be ready in case anything happened.
+  >
+  > She wanted to be able to go to any briefings with the naval commanders at any time without the fuss and bother of having to get dressed. She also wanted to know everything that was happening, every single detail, so she could keep on top of events. She had to know how the soldiers, sailors and airmen were getting on.
+  >
+  > She was so worried about them. It was awful when we heard any reports of our ships being hit. Her determination and powers of endurance were unbelievable. Denis was in the room next door. The 2 of us would sit in armchairs either side of a two-bar electric fire, listening to the radio.
+
+  Crawford recalls the Prime Minister leaving Downing Street at 8am each morning to attend military briefings for an update of events during the night and to discuss the next part of the campaign:
+
+  > I would take advantage of that and jump into bed at the flat so I could get some sleep. I'd tell the Downing Street switchboard to wake me when she was on her way back so I could be ready for work. We don't all have her energy.
+
+  The conflict ended with Argentinian surrender on 14 June 1982. Margaret Thatcher looked back on this period:
+
+  > When I became Prime Minister I never thought that I would have to order British troops into combat and I do not think I have ever lived so tensely or intensely as during the whole of that time.
+  >
+  > Margaret Thatcher – The Downing Street Years.
+
+  ## Restoration and modernisation
+
+  By the 1950s, the material state of 10 Downing Street had reached crisis point. Bomb damage had worsened existing structural problems: the building was suffering from subsidence, sloping walls, twisting door frames and an enormous annual repair bill.
+
+  The Ministry of Works carried out a survey in 1954 into the state of the structure. The report bounced from Winston Churchill (1951 to 1955) to Anthony Eden (1955 to 1957) to Harold Macmillan (1957 to 1963) as one Prime Minister followed the other. Finally, a committee set up by Macmillan concluded that drastic action was required before the building fell or burnt down.
+
+  The committee put forward a range of options, including the complete demolition of Number 10, 11 and 12 and their replacement with a new building. That idea was rejected and it was decided that Number 12 should be rebuilt, and Numbers 10 and 11 should be strengthened and their historic features preserved.
+
+  The architect Raymond Erith was selected to supervise the work, which was expected to take 2 years and cost £500,000. It ended up taking a year longer than planned and costing double the original estimate. The foundations proved to be so rotten that concrete underpinning was required on a massive scale.
+
+  Number 10 was completely gutted. Walls, floors and even the columns in the Cabinet Room and Pillared Room proved to be rotten and had to be replaced. New features were added too, including a room facing onto Downing Street and a veranda at Number 11 for the Chancellor.
+
+  It was also discovered that the familiar exterior façade was not black at all, but yellow. The blackened colour was a product of two centuries of severe pollution. To keep the familiar appearance, the newly cleaned yellow bricks were painted black to match their previous colour. Erith's work was completed in 1963, but not long afterwards, dry rot became apparent and further repairs had to be undertaken.
+
+  Margaret Thatcher (1979 to 1990) appointed architect Quinlan Terry to refurbish the state drawing rooms at the end of the 1980s. Two of the rooms, the White Drawing Room and Terracotta Room, gained ornate plasterwork ceilings. In the White Drawing Room, this included adding the national emblems of England, Northern Ireland, Scotland and Wales.
+
+  All the building work of the past few decades could have been ruined when a terrorist bomb exploded in 1991. An IRA mortar bomb was fired from a white transit van in Whitehall and exploded in the garden of Number 10, only a few metres away from where Prime Minister John Major (1990 to 1997) was chairing a Cabinet meeting to discuss the Gulf War.
+
+  Although no one was killed, it left a crater in the Number 10 gardens and blew in the windows of neighbouring houses. John Major and some of his staff moved into Admiralty Arch while damage caused by the bomb was repaired.
+
+  By 2006, it was clear that the Downing Street complex was no longer able to support the business of the Prime Minister's Office reliably. Independent surveys established that the building was no longer weather-tight, the heating system was failing, and the information and communications technology (ICT) network was at the limits of its operation. Power outages and water leaks were frequent occurrences and impacted significantly on the day-to-day operation of the Prime Minister's Office.
+
+  In addition to deterioration through age, pressures on the buildings had increased dramatically over recent years, through an increase in occupancy (stable at around 50 for many years) to around 170. In 2006, Prime Minister Tony Blair (1997 to 2007) authorised a new programme of improvements, with the building remaining operational throughout. Work was launched to address structural failure, renew the infrastructure, improve access and enhance the building's sustainability.
+
+  Structural issues were among the first to be tackled, and a phased exterior repair project was launched to address failing lead guttering, cracking brickwork and other structural issues. The distinctive black colourwash was also renewed, as it had faded away in many areas to reveal the yellow brickwork beneath. During the course of the works it was discovered that the façade of 11 Downing Street was unstable, and had to be secured using 225 stainless steel pins. All work was carried out in consultation with [English Heritage](http://www.english-heritage.org.uk/).
+
+  Other projects have been undertaken to renew the building's ageing infrastructure and to replace many of the building's key services, including heating, fire protection and electrical power distribution. Sustainability is a key feature of the programme and a 10% reduction in carbon emissions was achieved during 2011. Rainwater harvesting was introduced in 2009, providing a sustainable source of water for the garden. Accessibility for disabled visitors has been significantly improved through the introduction of ramps and modernisation of lifts. Many of the public areas of the building have also been restored, including the front entrance hall, the state and small dining rooms and the study.
+
+  An ongoing programme is in place to upgrade facilities to modern standards, and to ensure the preservation of this historic building for years to come.
+
+  ## A place of entertainment
+
+  Every week, Number 10 is the venue for official functions including meetings, receptions, lunches and dinners.
+
+  It is not only heads of state and official dignitaries who visit – functions are held for people from all areas of UK society, including notable achievers, public service employees and charity workers.
+
+  Receptions tend to be informal gatherings. Lunches and dinners are more formal events. The Small Dining Room will sit a maximum of 12, and the State Dining Room up to 65 around a large, U-shaped table. The dining table is laid with items from the state silver collection: a range of modern silverware pieces commissioned by the [Silver Trust](http://www.silvertrust.co.uk/) to promote modern British craftsmanship.
+
+  ## Installations at Number 10 timeline
+
+  Since 10 Downing Street became the official residence of the premier, the building has performed the dual role of both residence and place of work for Britain's Prime Ministers.
+
+  Number 10 has been upgraded – including new technology – throughout its history, to ensure both an acceptable standard of living for its residents and to keep the Prime Minister at the heart of decision making within government. Often, the prompt for new technology or an upgrade was the arrival of a new Prime Minister.
+
+  Here are some of the more notable developments across 3 centuries of history, from the arrival of hot running water to the first tweet:
+
+  ### Timeline
+
+  1877 – hot and cold running water installed. The living quarters were renovated for Benjamin Disraeli – including a bath.
+
+  1894 – installation of electric lighting and first telephones. Following Disraeli's departure William Gladstone redecorated the building and oversaw the installations.
+
+  1902 – first motor-car driven onto Downing Street. Arthur Balfour brought the first car and since then, Prime Ministers have looked to select British marques for their official car, with a procession of Wolseleys, Humbers, Rovers, Daimlers and Jaguars sweeping successive Prime Ministers into – and out of – Downing Street.
+
+  1937 – first central heating.
+
+  1963 – electrical and telephone systems were replaced. 1963 was a major period of renovation for the building.
+
+  1982 – the first direct hotline between No10 and Washington was established during Margaret Thatcher's first term of office.
+
+  1982 – first ‘micro-computer’ and microfilm reader installed.
+
+  1983 – wider roll-out of computers machines for Number 10 staff following a review of the building's needs.
+
+  1990s – first video conference. John Major used the technology from his study.
+
+  1996 – desktop PCs installed at all workstations.
+
+  1996 – [the launch of the first No10 website](http://web.archive.org/web/19970416130757/http://number-10.gov.uk/).
+
+  1998 – internet access became mainstreamed across Number 10 staff desktops.
+
+  2002 – dedicated video conferencing suite was installed. This followed the events of 9/11 and allowed the Prime Minister and his team to be in face to face contact with counterparts around the world in an instant.
+
+  2005 – a new e-mail account allowed the public to contact the Prime Minister directly.
+
+  2008 – Number 10's very own online TV station – Number10 TV
+
+  2008 – Number 10's first tweet – and there have been over 3,000 since.
+
+  ## Larry, Chief Mouser to the Cabinet Office
+
+  Larry has been in residence since 15 February 2011, he is the first cat at Number 10 to be bestowed with the official title Chief Mouser.
+
+  Larry was recruited from [Battersea Dogs & Cats Home](http://www.battersea.org.uk/) on recommendation for his mousing skills. He joined the Number 10 household and has made a significant impact.
+
+  Larry the cat
+

--- a/lib/tasks/publish_history_pages.rake
+++ b/lib/tasks/publish_history_pages.rake
@@ -1,0 +1,11 @@
+namespace :history_pages do
+  desc "Publish history pages to the publishing API"
+  task publish: :environment do
+    Dir[Rails.root.join("lib/history_pages/*.yaml")].each do |file_path|
+      puts "Publishing #{file_path}"
+
+      history_page_yaml = YAML.load(File.read(file_path))
+      PublishHistoryPage.call(history_page_yaml)
+    end
+  end
+end

--- a/test/unit/app/services/publish_history_page_test.rb
+++ b/test/unit/app/services/publish_history_page_test.rb
@@ -1,0 +1,17 @@
+require "test_helper"
+
+class PublishHistoryPageTest < ActiveSupport::TestCase
+  test "it uses the provided content id when publishing" do
+    ten_ds_page = YAML.load(File.read("lib/history_pages/10_downing_street.yaml"))
+
+    PublishHistoryPage.call(ten_ds_page.to_h)
+
+    assert_publishing_api_put_content("14aa298f-03a8-4e76-96de-483efa3d001f", ten_ds_page.history_page_content_item)
+    assert_publishing_api_publish("14aa298f-03a8-4e76-96de-483efa3d001f")
+  end
+
+  # TODO: Some reasonable tests:
+  # Did it extract the headers correctly?
+  # Is the HTML okayish?
+  # What are we going to do about the images?
+end


### PR DESCRIPTION
Currently, the history pages are published by government frontend - this can't simply be replaced with special routes in Publishing API because the contents of the page have to go into the content store to be searchable. The current solution is for them to be published directly from the frontend app, and it's a bit of a mess (there's ERB code in the body). We want to move rendering over to Frontend, but it would be better if we could make the content item a bit more rational, and publish them from an app (Whitehall) - This would also serve as a first step to it having a UI that content people can use to make edits (if it turns out that is necessary).

Unsolved problems:
- neither history nor generic schemas will allow this to work (ideally we'd want a header image and an array of in-page navigation links)
- how do we put images in (do we include them in the same file as the yaml, publish them as assets and then insert them as image govspeak tags?)

Related to:
https://trello.com/c/g3oNeSDH/199-move-document-type-history-from-government-frontend-to-frontend
https://trello.com/c/hJVUjqbs/1242-frontend-apps-publish-content-items-to-publishing-api

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
