### PR TITLE
Fix statistics announcement type mismatch validation

### DIFF
--- a/app/views/admin/statistics_announcement_publications/index.html.erb
+++ b/app/views/admin/statistics_announcement_publications/index.html.erb
@@ -6,6 +6,11 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
+    <%= render "govuk_publishing_components/components/inset_text", {
+      text: "The type of the document you are trying to connect must match the type of the statistics announcement. Only #{@statistics_announcement.publication_type.plural_name} documents will be shown.",
+      margin_bottom: 8,
+    } %>
+
     <%= form_with url: admin_statistics_announcement_publication_index_path(@statistics_announcement), method: :get do |_form| %>
       <%= render "govuk_publishing_components/components/search", {
         name: "title",

--- a/test/functional/admin/statistics_announcement_publications_controller_test.rb
+++ b/test/functional/admin/statistics_announcement_publications_controller_test.rb
@@ -69,7 +69,7 @@ class Admin::StatisticsAnnouncementPublicationsControllerTest < ActionController
 
     assert_response :success
     has_search_results_table
-    assert_select "ul.govuk-error-summary__list a", text: "Publication type does not match: must be statistics"
+    assert_select "ul.govuk-error-summary__list a", text: "Publication type does not match announcement type: must be 'Official Statistics'"
   end
 
 private

--- a/test/functional/admin/statistics_announcement_publications_controller_test.rb
+++ b/test/functional/admin/statistics_announcement_publications_controller_test.rb
@@ -25,6 +25,12 @@ class Admin::StatisticsAnnouncementPublicationsControllerTest < ActionController
     refute_select ".govuk-table"
   end
 
+  view_test "GET :index shows inset text" do
+    get :index, params: { statistics_announcement_id: @official_statistics_announcement }
+
+    assert_select ".govuk-inset-text", text: "The type of the document you are trying to connect must match the type of the statistics announcement. Only Official Statistics documents will be shown."
+  end
+
   test "GET :index with search value passes title and default params to filter" do
     default_filter_params_with_title = @default_filter_params.merge(title: @title)
 

--- a/test/unit/app/models/publication_test.rb
+++ b/test/unit/app/models/publication_test.rb
@@ -45,6 +45,14 @@ class PublicationTest < ActiveSupport::TestCase
     assert_equal accredited_official_publication.errors[:publication_type_id], ["does not match announcement type: must be '#{accredited_official_announcement.publication_type.singular_name}'"]
   end
 
+  test "it saves the announcement association" do
+    accredited_official_announcement = create(:statistics_announcement, publication_type_id: PublicationType::NationalStatistics.id)
+    accredited_official_publication = create(:draft_national_statistics, statistics_announcement_id: accredited_official_announcement.id)
+
+    assert_equal accredited_official_announcement.reload.publication.id, accredited_official_publication.id
+    assert_equal accredited_official_publication.statistics_announcement.id, accredited_official_announcement.id
+  end
+
   test "should build a draft copy of the existing publication" do
     published = create(
       :published_publication,

--- a/test/unit/app/models/publication_test.rb
+++ b/test/unit/app/models/publication_test.rb
@@ -24,6 +24,27 @@ class PublicationTest < ActiveSupport::TestCase
     assert publication.valid?
   end
 
+  test "(on create) is not valid if the publication type does not match the announcement type" do
+    accredited_official_announcement = create(:statistics_announcement, publication_type_id: PublicationType::NationalStatistics.id)
+    non_accredited_publication = build(:draft_statistics)
+
+    non_accredited_publication.statistics_announcement_id = accredited_official_announcement.id
+
+    assert_not non_accredited_publication.valid?
+    assert_equal non_accredited_publication.errors[:publication_type_id], ["does not match announcement type: must be '#{accredited_official_announcement.publication_type.singular_name}'"]
+  end
+
+  test "(on edit) is not valid if the publication type does not match the announcement type" do
+    # statistics_announcement_id not available, statistics_announcement already set
+    accredited_official_announcement = create(:statistics_announcement, publication_type_id: PublicationType::NationalStatistics.id)
+    accredited_official_publication = create(:draft_national_statistics, statistics_announcement_id: accredited_official_announcement.id)
+
+    accredited_official_publication.publication_type_id = PublicationType::OfficialStatistics.id
+
+    assert_not accredited_official_publication.valid?
+    assert_equal accredited_official_publication.errors[:publication_type_id], ["does not match announcement type: must be '#{accredited_official_announcement.publication_type.singular_name}'"]
+  end
+
   test "should build a draft copy of the existing publication" do
     published = create(
       :published_publication,

--- a/test/unit/app/models/statistics_announcement_test.rb
+++ b/test/unit/app/models/statistics_announcement_test.rb
@@ -92,14 +92,14 @@ class StatisticsAnnouncementTest < ActiveSupport::TestCase
 
     announcement.publication = national_statistics
     assert_not announcement.valid?
-    assert_equal ["type does not match: must be statistics"], announcement.errors[:publication]
+    assert_equal ["type does not match announcement type: must be 'Official Statistics'"], announcement.errors[:publication]
 
     announcement.publication_type_id = PublicationType::NationalStatistics.id
     assert announcement.valid?
 
     announcement.publication = policy_paper
     assert_not announcement.valid?
-    assert_equal ["type does not match: must be national statistics"], announcement.errors[:publication]
+    assert_equal ["type does not match announcement type: must be 'Accredited Official Statistics'"], announcement.errors[:publication]
   end
 
   test ".with_title_containing returns statistics announcements matching provided title" do


### PR DESCRIPTION
On the back of a few Zendesk tickets, we're improving how validation works for announcements and their associated publications. In the context of renaming "National Statistics" to "Accredited Official Statistics", the users were not setting the correct "publication type" either on the announcement or publication. The validation in the code was technically unfit for the models, causing the users to get a generic "Something went wrong" error. 

These changes ensure that: 
- Validation happens on publication so that when a new publication is created off of an announcement, it is validated for type match;
- Subsequent edits of the publication also validate the type match;
- The publication validation errors is also surfaced on the announcement for subsequent edits;
- The errors include a reference to what the label type is now (what the user sees);
- A bit of guidance text has been added to the "Connect a document" page.


Publication create document from announcement/edit page
![Screenshot 2024-10-02 at 11 47 19](https://github.com/user-attachments/assets/24803c26-ecc4-4293-903e-de1e18f234f5)

Announcement edit page
![Screenshot 2024-10-02 at 11 46 47](https://github.com/user-attachments/assets/b1e3ae8c-b6bc-4c69-9ef1-8cb486aefb1c)

Guidance text on search page
![Screenshot 2024-10-02 at 11 46 03](https://github.com/user-attachments/assets/4022e8d7-51c5-4e25-97cd-aea24b82a3a8)

I had a think about why the users were confused, and whether or not we may have missed some migration or something. Going through [Ryan's PRs on the original renaming work](https://trello.com/c/jkaJlgez/1501-update-whitehall-for-changes-to-national-stats), I think that is not the case, since the renaming was only a label change + republish. It's probably a lack of comms/guidance on the renaming. I've therefore raised [a ticket](https://trello.com/c/1fSoVVZu/11-improve-guidance-on-accredited-official-statistics) on the content board to further discuss guidance, and validate the copy of the current changes. 

[Trello](https://trello.com/c/a7naRYKH/2880-statistical-announcements-issue-saving-accredited-official-statistics-type)
[Content trello ticket](https://trello.com/c/1fSoVVZu/11-improve-guidance-on-accredited-official-statistics)
[Zendesk 1](https://govuk.zendesk.com/agent/tickets/5934093)
[Zendesk 2](https://govuk.zendesk.com/agent/tickets/5931376)