### PR TITLE
use new Content Block update type when publishing

### DIFF
--- a/lib/engines/content_block_manager/app/lib/content_block_manager/publishable.rb
+++ b/lib/engines/content_block_manager/app/lib/content_block_manager/publishable.rb
@@ -82,7 +82,7 @@ module ContentBlockManager
     end
 
     def publish_publishing_api_edition(content_id:)
-      Services.publishing_api.publish(content_id, "major")
+      Services.publishing_api.publish(content_id, "content_block")
     rescue GdsApi::HTTPErrorResponse => e
       raise PublishingFailureError, "Could not publish #{content_id} because: #{e.message}"
     end

--- a/lib/engines/content_block_manager/test/integration/content_block/workflow_test.rb
+++ b/lib/engines/content_block_manager/test/integration/content_block/workflow_test.rb
@@ -162,7 +162,7 @@ def assert_edition_is_published(&block)
   ]
   publishing_api_mock.expect :publish, fake_publish_content_response, [
     @content_id,
-    "major",
+    "content_block",
   ]
 
   Services.stub :publishing_api, publishing_api_mock do

--- a/lib/engines/content_block_manager/test/unit/app/services/publish_edition_service_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/services/publish_edition_service_test.rb
@@ -53,7 +53,7 @@ class ContentBlockManager::PublishEditionServiceTest < ActiveSupport::TestCase
       ]
       publishing_api_mock.expect :publish, fake_publish_content_response, [
         content_id,
-        "major",
+        "content_block",
       ]
 
       Services.stub :publishing_api, publishing_api_mock do


### PR DESCRIPTION
Once the work in this PR [1] is done to introduce
the new type we should be able to start using it
in Whitehall - we should not see any functionality change yet, but the new update types should be
being logged

[1] https://github.com/alphagov/publishing-api/pull/2904

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
