### PR TITLE
Move `stub_request_for_schema` to a helper

### DIFF
--- a/lib/engines/content_object_store/test/integration/content_block/editions_test.rb
+++ b/lib/engines/content_object_store/test/integration/content_block/editions_test.rb
@@ -5,6 +5,7 @@ class ContentObjectStore::ContentBlock::EditionsTest < ActionDispatch::Integrati
   include Capybara::DSL
   extend Minitest::Spec::DSL
   include ContentObjectStore::Engine.routes.url_helpers
+  include ContentObjectStore::IntegrationTestHelpers
 
   before do
     login_as_admin
@@ -183,12 +184,6 @@ class ContentObjectStore::ContentBlock::EditionsTest < ActionDispatch::Integrati
       end
     end
   end
-end
-
-def stub_request_for_schema(block_type)
-  schema = stub(id: "content_block_type", fields: %w[foo bar], name: "schema", body: {}, block_type:)
-  ContentObjectStore::ContentBlock::Schema.stubs(:find_by_block_type).with(block_type).returns(schema)
-  schema
 end
 
 def renders_errors(&block)

--- a/lib/engines/content_object_store/test/integration/content_block/workflow_test.rb
+++ b/lib/engines/content_object_store/test/integration/content_block/workflow_test.rb
@@ -6,6 +6,7 @@ class ContentObjectStore::ContentBlock::WorkflowTest < ActionDispatch::Integrati
   extend Minitest::Spec::DSL
   include SidekiqTestHelpers
   include ContentObjectStore::Engine.routes.url_helpers
+  include ContentObjectStore::IntegrationTestHelpers
 
   let(:details) do
     {
@@ -174,11 +175,6 @@ def assert_edition_is_published(&block)
 
     assert_equal "published", new_edition.state
   end
-end
-
-def stub_request_for_schema(block_type)
-  schema = stub(id: "content_block_type", fields: %w[foo bar], name: "schema", body: {}, block_type:)
-  ContentObjectStore::ContentBlock::Schema.stubs(:find_by_block_type).with(block_type).returns(schema)
 end
 
 def update_params(edition_id:, organisation_id:)

--- a/lib/engines/content_object_store/test/support/integration_test_helpers.rb
+++ b/lib/engines/content_object_store/test/support/integration_test_helpers.rb
@@ -1,0 +1,7 @@
+module ContentObjectStore::IntegrationTestHelpers
+  def stub_request_for_schema(block_type)
+    schema = stub(id: "content_block_type", fields: %w[foo bar], name: "schema", body: {}, block_type:)
+    ContentObjectStore::ContentBlock::Schema.stubs(:find_by_block_type).with(block_type).returns(schema)
+    schema
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -27,6 +27,7 @@ if ENV["USE_I18N_COVERAGE"]
 end
 
 Dir[Rails.root.join("test/support/*.rb")].sort.each { |f| require f }
+Dir[Rails.root.join("lib/engines/**/test/support/*.rb")].sort.each { |f| require f }
 
 Whitehall::Application.load_tasks if Rake::Task.tasks.empty?
 


### PR DESCRIPTION
We were getting flaky tests when using `stub_request_for_schema` in two places because the helper function was defined in two files, but the implementation was slightly different. This unifies the behaviour, returning the stub schema in both places, whilst also moving the helper code to a module, which we include when we need it.