### PR TITLE
(613) Publish to draft content store when creating a draft

### DIFF
--- a/lib/engines/content_object_store/app/lib/content_object_store/publishable.rb
+++ b/lib/engines/content_object_store/app/lib/content_object_store/publishable.rb
@@ -41,6 +41,28 @@ module ContentObjectStore
       end
     end
 
+    def create_draft_edition(schema)
+      raise ArgumentError, "Local database changes not given" unless block_given?
+
+      ActiveRecord::Base.transaction do
+        content_block_edition = yield
+        content_id = content_block_edition.document.content_id
+        organisation_id = content_block_edition.lead_organisation.content_id
+
+        create_publishing_api_edition(
+          content_id:,
+          schema_id: schema.id,
+          title: content_block_edition.title,
+          details: content_block_edition.details.to_h,
+          links: {
+            primary_publishing_organisation: [
+              organisation_id,
+            ],
+          },
+        )
+      end
+    end
+
     def update_content_block_document(new_content_block_edition:, update_document_params:)
       # Updates to a Document should never change its block type
       update_document_params.delete(:block_type)

--- a/lib/engines/content_object_store/app/lib/content_object_store/publishable.rb
+++ b/lib/engines/content_object_store/app/lib/content_object_store/publishable.rb
@@ -2,7 +2,7 @@ module ContentObjectStore
   module Publishable
     class PublishingFailureError < StandardError; end
 
-    def publish_with_rollback(schema:, title:, details:)
+    def publish_with_rollback(schema)
       raise ArgumentError, "Local database changes not given" unless block_given?
 
       ActiveRecord::Base.transaction do
@@ -13,8 +13,8 @@ module ContentObjectStore
         create_publishing_api_edition(
           content_id:,
           schema_id: schema.id,
-          title:,
-          details: details.to_h,
+          title: content_block_edition.title,
+          details: content_block_edition.details,
           links: {
             primary_publishing_organisation: [
               organisation_id,

--- a/lib/engines/content_object_store/app/services/content_object_store/create_edition_service.rb
+++ b/lib/engines/content_object_store/app/services/content_object_store/create_edition_service.rb
@@ -7,9 +7,12 @@ module ContentObjectStore
     end
 
     def call(edition_params, document_id: nil)
-      @new_edition = build_edition(edition_params, document_id)
-      @new_edition.assign_attributes(edition_params)
-      @new_edition.save!
+      create_draft_edition(@schema) do
+        @new_edition = build_edition(edition_params, document_id)
+        @new_edition.assign_attributes(edition_params)
+        @new_edition.save!
+        @new_edition
+      end
       @new_edition
     end
 

--- a/lib/engines/content_object_store/app/services/content_object_store/publish_edition_service.rb
+++ b/lib/engines/content_object_store/app/services/content_object_store/publish_edition_service.rb
@@ -7,9 +7,7 @@ module ContentObjectStore
     end
 
     def call(edition)
-      title = edition.title
-      details = edition.details
-      publish_with_rollback(schema: @schema, title:, details:) do
+      publish_with_rollback(@schema) do
         edition
       end
       edition

--- a/lib/engines/content_object_store/test/factories/content_block_edition.rb
+++ b/lib/engines/content_object_store/test/factories/content_block_edition.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     schema { build(:content_block_schema) }
     creator
 
-    organisation { FactoryBot.create(:organisation) }
+    organisation { FactoryBot.build(:organisation) }
 
     document_id { nil }
 

--- a/lib/engines/content_object_store/test/unit/app/lib/content_object_store/publishable_test.rb
+++ b/lib/engines/content_object_store/test/unit/app/lib/content_object_store/publishable_test.rb
@@ -7,14 +7,51 @@ class ContentObjectStore::PublishableTest < ActiveSupport::TestCase
     include ContentObjectStore::Publishable
   end
 
-  test "it raises an error if a block isn't passed since changes need to be made locally" do
-    anything = Object.new
-    test_instance = PublishableTestClass.new
+  describe "#publish_with_rollback" do
+    it "raises an error if a block isn't passed since changes need to be made locally" do
+      anything = Object.new
+      test_instance = PublishableTestClass.new
 
-    assert_raises ArgumentError, "Local database changes not given" do
-      test_instance.publish_with_rollback(
-        schema: anything, title: anything, details: anything,
+      assert_raises ArgumentError, "Local database changes not given" do
+        test_instance.publish_with_rollback(
+          schema: anything, title: anything, details: anything,
+        )
+      end
+    end
+  end
+
+  describe "#create_draft_edition" do
+    let(:schema) { build(:content_block_schema) }
+    let(:content_block_edition) { build(:content_block_edition, :email_address) }
+
+    let(:publishable_test_instance) { PublishableTestClass.new }
+
+    it "raises an error if a block isn't passed since changes need to be made locally" do
+      assert_raises ArgumentError, "Local database changes not given" do
+        publishable_test_instance.create_draft_edition(schema)
+      end
+    end
+
+    it "creates a draft edition" do
+      Services.publishing_api.expects(:put_content).with(
+        content_block_edition.document.content_id,
+        {
+          schema_name: schema.id,
+          document_type: schema.id,
+          publishing_app: Whitehall::PublishingApp::WHITEHALL,
+          title: content_block_edition.title,
+          details: content_block_edition.details,
+          links: {
+            primary_publishing_organisation: [
+              content_block_edition.lead_organisation.content_id,
+            ],
+          },
+        },
       )
+
+      publishable_test_instance.create_draft_edition(schema) do
+        content_block_edition
+      end
     end
   end
 end

--- a/lib/engines/content_object_store/test/unit/app/services/create_edition_service_test.rb
+++ b/lib/engines/content_object_store/test/unit/app/services/create_edition_service_test.rb
@@ -4,8 +4,9 @@ class ContentObjectStore::CreateEditionServiceTest < ActiveSupport::TestCase
   extend Minitest::Spec::DSL
 
   describe "#call" do
+    let!(:organisation) { create(:organisation) }
+
     let(:content_id) { "49453854-d8fd-41da-ad4c-f99dbac601c3" }
-    let(:organisation) { create(:organisation) }
     let(:schema) { build(:content_block_schema, block_type: "content_block_type", body: { "properties" => { "foo" => "", "bar" => "" } }) }
     let(:new_title) { "New Title" }
     let(:edition_params) do
@@ -55,6 +56,12 @@ class ContentObjectStore::CreateEditionServiceTest < ActiveSupport::TestCase
       assert_equal new_edition.lead_organisation.id, organisation.id
     end
 
+    it "sends the content block to the Publishing API as a draft" do
+      assert_draft_created_in_publishing_api(content_id) do
+        ContentObjectStore::CreateEditionService.new(schema).call(edition_params)
+      end
+    end
+
     describe "when a document id is provided" do
       let(:document) { create(:content_block_document, :email_address) }
       let!(:previous_edition) { create(:content_block_edition, :email_address, document:) }
@@ -73,6 +80,32 @@ class ContentObjectStore::CreateEditionServiceTest < ActiveSupport::TestCase
         assert_equal new_edition.document_id, document.id
         assert_equal new_edition.lead_organisation.id, organisation.id
       end
+
+      it "sends the content block to the Publishing API as a draft" do
+        assert_draft_created_in_publishing_api(document.content_id) do
+          ContentObjectStore::CreateEditionService.new(schema).call(edition_params, document_id: document.id)
+        end
+      end
     end
   end
+end
+
+def assert_draft_created_in_publishing_api(content_id, &block)
+  Services.publishing_api.expects(:put_content).with(
+    content_id,
+    {
+      schema_name: schema.id,
+      document_type: schema.id,
+      publishing_app: Whitehall::PublishingApp::WHITEHALL,
+      title: new_title,
+      details: edition_params[:details],
+      links: {
+        primary_publishing_organisation: [
+          organisation.content_id,
+        ],
+      },
+    },
+  )
+
+  block.call
 end

--- a/lib/engines/content_object_store/test/unit/app/services/create_edition_service_test.rb
+++ b/lib/engines/content_object_store/test/unit/app/services/create_edition_service_test.rb
@@ -5,7 +5,7 @@ class ContentObjectStore::CreateEditionServiceTest < ActiveSupport::TestCase
 
   describe "#call" do
     let(:content_id) { "49453854-d8fd-41da-ad4c-f99dbac601c3" }
-    let(:organisation_id) { "f67b4350-35c2-46a8-babf-e39f5a4f2a7e" }
+    let(:organisation) { create(:organisation) }
     let(:schema) { build(:content_block_schema, block_type: "content_block_type", body: { "properties" => { "foo" => "", "bar" => "" } }) }
     let(:new_title) { "New Title" }
     let(:edition_params) do
@@ -19,7 +19,7 @@ class ContentObjectStore::CreateEditionServiceTest < ActiveSupport::TestCase
           "bar" => "Bar text",
         },
         creator: build(:user),
-        organisation_id:,
+        organisation_id: organisation.id.to_s,
       }
     end
 
@@ -52,6 +52,7 @@ class ContentObjectStore::CreateEditionServiceTest < ActiveSupport::TestCase
       assert_equal edition_params[:document_attributes][:block_type], new_document.block_type
       assert_equal edition_params[:details], new_edition.details
       assert_equal new_edition.document_id, new_document.id
+      assert_equal new_edition.lead_organisation.id, organisation.id
     end
 
     describe "when a document id is provided" do
@@ -70,6 +71,7 @@ class ContentObjectStore::CreateEditionServiceTest < ActiveSupport::TestCase
         assert_equal new_title, document.title
         assert_equal edition_params[:details], new_edition.details
         assert_equal new_edition.document_id, document.id
+        assert_equal new_edition.lead_organisation.id, organisation.id
       end
     end
   end


### PR DESCRIPTION
This updates the `CreateEditionService` to send an edition to the draft content store whenever a new edition is created. This will make previewing possible once we've decided how to handle it, as well as keep parity between what is in Whitehall and what is in the Publishing API.

We still have the issue of what happens if a user changes their mind and keeps something in draft, but I'm hoping that we can address this in this card - https://trello.com/c/fySdBC34/612-remove-draft-editions-on-cancellation