### PR TITLE
Add SFO brand colour option

### DIFF
--- a/app/models/organisation_brand_colour.rb
+++ b/app/models/organisation_brand_colour.rb
@@ -177,4 +177,9 @@ class OrganisationBrandColour
     title: "Ministry of Housing, Communities & Local Government",
     class_name: "ministry-of-housing-communities-local-government",
   )
+  SeriousFraudOffice = create!(
+    id: 35,
+    title: "Serious Fraud Office",
+    class_name: "serious-fraud-office",
+  )
 end


### PR DESCRIPTION
Introduced in https://github.com/alphagov/govuk-frontend/pull/5389

Trello: https://trello.com/c/HJ81fNUF/2988-add-brand-color-for-sfo

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
