### PR TITLE
Tidy PublishEditionService

### DIFF
--- a/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/editions/workflow_controller.rb
+++ b/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/editions/workflow_controller.rb
@@ -82,7 +82,7 @@ private
   end
 
   def publish
-    new_edition = ContentBlockManager::PublishEditionService.new(@schema).call(@content_block_edition)
+    new_edition = ContentBlockManager::PublishEditionService.new.call(@content_block_edition)
     redirect_to content_block_manager.content_block_manager_content_block_document_path(new_edition.document),
                 flash: { notice: "#{new_edition.block_type.humanize} created successfully" }
   end

--- a/lib/engines/content_block_manager/app/services/content_block_manager/publish_edition_service.rb
+++ b/lib/engines/content_block_manager/app/services/content_block_manager/publish_edition_service.rb
@@ -2,15 +2,8 @@ module ContentBlockManager
   class PublishEditionService
     include Publishable
 
-    def initialize(schema)
-      @schema = schema
-    end
-
     def call(edition)
-      publish_with_rollback(@schema) do
-        edition
-      end
-      edition
+      publish_with_rollback(edition)
     end
   end
 end

--- a/lib/engines/content_block_manager/app/workers/content_block_manager/schedule_publishing_worker.rb
+++ b/lib/engines/content_block_manager/app/workers/content_block_manager/schedule_publishing_worker.rb
@@ -46,12 +46,8 @@ module ContentBlockManager
       edition = ContentBlockManager::ContentBlock::Edition.find(edition_id)
       return if edition.published? || !edition.scheduled?
 
-      schema = ContentBlockManager::ContentBlock::Schema.find_by_block_type(edition.document.block_type)
-
       ContentBlockManager::ContentBlock::Edition::HasAuditTrail.acting_as(publishing_robot) do
-        ContentBlockManager::PublishEditionService.new(
-          schema,
-        ).call(edition)
+        ContentBlockManager::PublishEditionService.new.call(edition)
       end
     rescue ContentBlockManager::Publishable::PublishingFailureError => e
       raise SchedulingFailure, e.message

--- a/lib/engines/content_block_manager/test/integration/content_block/workflow_test.rb
+++ b/lib/engines/content_block_manager/test/integration/content_block/workflow_test.rb
@@ -147,8 +147,8 @@ def assert_edition_is_published(&block)
   publishing_api_mock.expect :put_content, fake_put_content_response, [
     @content_id,
     {
-      schema_name: "content_block_type",
-      document_type: "content_block_type",
+      schema_name: document.block_type,
+      document_type: document.block_type,
       publishing_app: "whitehall",
       title: "Some Title",
       details: {

--- a/lib/engines/content_block_manager/test/unit/app/lib/content_block_manager/publishable_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/lib/content_block_manager/publishable_test.rb
@@ -7,19 +7,6 @@ class ContentBlockManager::PublishableTest < ActiveSupport::TestCase
     include ContentBlockManager::Publishable
   end
 
-  describe "#publish_with_rollback" do
-    it "raises an error if a block isn't passed since changes need to be made locally" do
-      anything = Object.new
-      test_instance = PublishableTestClass.new
-
-      assert_raises ArgumentError, "Local database changes not given" do
-        test_instance.publish_with_rollback(
-          schema: anything, title: anything, details: anything,
-        )
-      end
-    end
-  end
-
   describe "#create_draft_edition" do
     let(:schema) { build(:content_block_schema) }
     let(:content_block_edition) { build(:content_block_edition, :email_address) }

--- a/lib/engines/content_block_manager/test/unit/app/services/publish_edition_service_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/services/publish_edition_service_test.rb
@@ -5,29 +5,25 @@ class ContentBlockManager::PublishEditionServiceTest < ActiveSupport::TestCase
 
   describe "#call" do
     let(:content_id) { "49453854-d8fd-41da-ad4c-f99dbac601c3" }
-    let(:schema) { build(:content_block_schema, block_type: "content_block_type", body: { "properties" => { "foo" => "", "bar" => "" } }) }
     let(:document) { create(:content_block_document, :email_address, content_id:, title: "Some Title") }
     let(:edition) { create(:content_block_edition, document:, details: { "foo" => "Foo text", "bar" => "Bar text" }, organisation: @organisation) }
 
     setup do
-      ContentBlockManager::ContentBlock::Schema.stubs(:find_by_block_type)
-                                              .returns(schema)
       @organisation = create(:organisation)
     end
 
-    test "returns a ContentBlockEdition" do
-      result = ContentBlockManager::PublishEditionService.new(schema).call(edition)
+    it "returns a ContentBlockEdition" do
+      result = ContentBlockManager::PublishEditionService.new.call(edition)
       assert_instance_of ContentBlockManager::ContentBlock::Edition, result
     end
 
-    test "it publishes the Edition in Whitehall" do
-      ContentBlockManager::PublishEditionService.new(schema).call(edition)
-
+    it "publishes the Edition in Whitehall" do
+      ContentBlockManager::PublishEditionService.new.call(edition)
       assert_equal "published", edition.state
       assert_equal edition.id, document.live_edition_id
     end
 
-    test "it creates an Edition in the Publishing API" do
+    it "creates an Edition in the Publishing API" do
       fake_put_content_response = GdsApi::Response.new(
         stub("http_response", code: 200, body: {}),
       )
@@ -39,8 +35,8 @@ class ContentBlockManager::PublishEditionServiceTest < ActiveSupport::TestCase
       publishing_api_mock.expect :put_content, fake_put_content_response, [
         content_id,
         {
-          schema_name: schema.id,
-          document_type: schema.id,
+          schema_name: document.block_type,
+          document_type: document.block_type,
           publishing_app: "whitehall",
           title: "Some Title",
           details: {
@@ -58,7 +54,7 @@ class ContentBlockManager::PublishEditionServiceTest < ActiveSupport::TestCase
       ]
 
       Services.stub :publishing_api, publishing_api_mock do
-        ContentBlockManager::PublishEditionService.new(schema).call(edition)
+        ContentBlockManager::PublishEditionService.new.call(edition)
 
         publishing_api_mock.verify
         assert_equal "published", edition.state
@@ -66,7 +62,7 @@ class ContentBlockManager::PublishEditionServiceTest < ActiveSupport::TestCase
       end
     end
 
-    test "if the publishing API request fails, the Whitehall ContentBlockEdition and ContentBlockDocument are rolled back" do
+    it "rolls back the Whitehall ContentBlockEdition and ContentBlockDocument if the publishing API request fails" do
       exception = GdsApi::HTTPErrorResponse.new(
         422,
         "An internal error message",
@@ -79,14 +75,14 @@ class ContentBlockManager::PublishEditionServiceTest < ActiveSupport::TestCase
 
       Services.publishing_api.stub :put_content, raises_exception do
         assert_raises(GdsApi::HTTPErrorResponse) do
-          ContentBlockManager::PublishEditionService.new(schema).call(edition)
+          ContentBlockManager::PublishEditionService.new.call(edition)
         end
         assert_equal "draft", edition.state
         assert_nil document.live_edition_id
       end
     end
 
-    test "if the publish request fails, the latest draft is discarded and the database actions are rolled back" do
+    it "discards the latest draft if the publish request fails" do
       fake_put_content_response = GdsApi::Response.new(
         stub("http_response", code: 200, body: {}),
       )
@@ -112,7 +108,7 @@ class ContentBlockManager::PublishEditionServiceTest < ActiveSupport::TestCase
 
       Services.publishing_api.stub :publish, raises_exception do
         assert_raises(ContentBlockManager::PublishEditionService::PublishingFailureError, "Could not publish #{content_id} because: Some backend error") do
-          ContentBlockManager::PublishEditionService.new(schema).call(edition)
+          ContentBlockManager::PublishEditionService.new.call(edition)
           publishing_api_mock.verify
         end
         assert_equal "draft", edition.state

--- a/lib/engines/content_block_manager/test/unit/app/services/schedule_edition_service_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/services/schedule_edition_service_test.rb
@@ -75,9 +75,7 @@ class ContentBlockManager::ScheduleEditionServiceTest < ActiveSupport::TestCase
 
       edition.stub :update!, raises_exception do
         assert_raises(ArgumentError) do
-          ContentBlockManager::ScheduleEditionService
-            .new(schema)
-            .call(edition, scheduled_publication_params)
+          ContentBlockManager::ScheduleEditionService.new.call(edition, scheduled_publication_params)
         end
       end
     end

--- a/lib/engines/content_block_manager/test/unit/app/workers/schedule_publishing_worker_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/workers/schedule_publishing_worker_test.rb
@@ -1,6 +1,7 @@
 require "test_helper"
 
 class ContentBlockManager::SchedulePublishingWorkerTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
   include SidekiqTestHelpers
 
   # Suppress noisy Sidekiq logging in the test output
@@ -10,146 +11,153 @@ class ContentBlockManager::SchedulePublishingWorkerTest < ActiveSupport::TestCas
     end
   end
 
-  test "#perform publishes a scheduled edition" do
-    schema = build(:content_block_schema, block_type: "content_block_type", body: { "properties" => { "foo" => "", "bar" => "" } })
-    document = create(:content_block_document, :email_address)
-    edition = create(:content_block_edition, document:, state: "scheduled", scheduled_publication: Time.zone.now)
+  describe "#perform" do
+    it "publishes a scheduled edition" do
+      document = create(:content_block_document, :email_address)
+      edition = create(:content_block_edition, document:, state: "scheduled", scheduled_publication: Time.zone.now)
 
-    ContentBlockManager::ContentBlock::Schema.expects(:find_by_block_type).with("email_address").returns(schema)
-    publish_service_mock = Minitest::Mock.new
-    ContentBlockManager::PublishEditionService.expects(:new).with(schema).returns(publish_service_mock)
-    publish_service_mock.expect :call, nil, [edition]
+      publish_service_mock = Minitest::Mock.new
+      ContentBlockManager::PublishEditionService.expects(:new).returns(publish_service_mock)
+      publish_service_mock.expect :call, nil, [edition]
 
-    ContentBlockManager::SchedulePublishingWorker.new.perform(edition.id)
+      ContentBlockManager::SchedulePublishingWorker.new.perform(edition.id)
 
-    publish_service_mock.verify
-  end
+      publish_service_mock.verify
+    end
 
-  test "#perform raises an error if the edition cannot be published" do
-    schema = build(:content_block_schema, block_type: "content_block_type", body: { "properties" => { "foo" => "", "bar" => "" } })
-    document = create(:content_block_document, :email_address)
-    edition = create(:content_block_edition, document:, state: "scheduled", scheduled_publication: 7.days.since(Time.zone.now).to_date)
+    it "raises an error if the edition cannot be published" do
+      document = create(:content_block_document, :email_address)
+      edition = create(:content_block_edition, document:, state: "scheduled", scheduled_publication: 7.days.since(Time.zone.now).to_date)
 
-    ContentBlockManager::ContentBlock::Schema.expects(:find_by_block_type).with("email_address").returns(schema)
-    publish_service_mock = Minitest::Mock.new
+      publish_service_mock = Minitest::Mock.new
 
-    exception = ContentBlockManager::PublishEditionService::PublishingFailureError.new(
-      "Could not publish #{document.content_id} because: Some backend error",
-    )
+      exception = ContentBlockManager::PublishEditionService::PublishingFailureError.new(
+        "Could not publish #{document.content_id} because: Some backend error",
+      )
 
-    ContentBlockManager::PublishEditionService.any_instance.stubs(:call).raises(exception)
+      ContentBlockManager::PublishEditionService.any_instance.stubs(:call).raises(exception)
 
-    assert_raises(ContentBlockManager::SchedulePublishingWorker::SchedulingFailure, "Could not publish #{document.content_id} because: Some backend error") do
+      assert_raises(ContentBlockManager::SchedulePublishingWorker::SchedulingFailure, "Could not publish #{document.content_id} because: Some backend error") do
+        ContentBlockManager::SchedulePublishingWorker.new.perform(edition.id)
+      end
+      publish_service_mock.verify
+    end
+
+    it "returns without consequence if the edition is already published" do
+      document = create(:content_block_document, :email_address)
+      edition = create(:content_block_edition, document:, state: "published")
+
+      ContentBlockManager::PublishEditionService.expects(:new).never
+      ContentBlockManager::PublishEditionService.any_instance.expects(:call).never
+
       ContentBlockManager::SchedulePublishingWorker.new.perform(edition.id)
     end
-    publish_service_mock.verify
   end
 
-  test "#perform returns without consequence if the edition is already published" do
-    document = create(:content_block_document, :email_address)
-    edition = create(:content_block_edition, document:, state: "published")
+  describe ".queue" do
+    it "queues a job for a scheduled edition" do
+      document = create(:content_block_document, :email_address)
+      edition = create(
+        :content_block_edition,
+        document:, state: "scheduled",
+        scheduled_publication: 1.day.from_now
+      )
 
-    ContentBlockManager::ContentBlock::Schema.expects(:find_by_block_type).never
-    ContentBlockManager::PublishEditionService.expects(:new).never
-    ContentBlockManager::PublishEditionService.any_instance.expects(:call).never
-
-    ContentBlockManager::SchedulePublishingWorker.new.perform(edition.id)
-  end
-
-  test ".queue queues a job for a scheduled edition" do
-    document = create(:content_block_document, :email_address)
-    edition = create(
-      :content_block_edition,
-      document:, state: "scheduled",
-      scheduled_publication: 1.day.from_now
-    )
-
-    ContentBlockManager::SchedulePublishingWorker.queue(edition)
-
-    assert job = ContentBlockManager::SchedulePublishingWorker.jobs.last
-    assert_equal edition.id, job["args"].first
-    assert_equal edition.scheduled_publication.to_i, job["at"].to_i
-  end
-
-  test ".dequeue removes a job for a scheduled edition" do
-    document = create(:content_block_document, :email_address)
-    edition = create(
-      :content_block_edition,
-      document:,
-      state: "scheduled",
-      scheduled_publication: 1.day.from_now,
-    )
-
-    control_document = create(:content_block_document, :email_address)
-    control_edition = create(
-      :content_block_edition,
-      document: control_document,
-      state: "scheduled",
-      scheduled_publication: 1.day.from_now,
-    )
-
-    with_real_sidekiq do
       ContentBlockManager::SchedulePublishingWorker.queue(edition)
-      ContentBlockManager::SchedulePublishingWorker.queue(control_edition)
 
-      assert_equal 2, Sidekiq::ScheduledSet.new.size
-
-      ContentBlockManager::SchedulePublishingWorker.dequeue(edition)
-
-      assert_equal 1, Sidekiq::ScheduledSet.new.size
-
-      control_job = Sidekiq::ScheduledSet.new.first
-
-      assert_equal control_job["args"].first, control_edition.id
-      assert_equal control_job.at.to_i, control_edition.scheduled_publication.to_i
+      assert job = ContentBlockManager::SchedulePublishingWorker.jobs.last
+      assert_equal edition.id, job["args"].first
+      assert_equal edition.scheduled_publication.to_i, job["at"].to_i
     end
   end
 
-  test ".dequeue_all removes all content block publishing jobs" do
-    document_1 = create(:content_block_document, :email_address)
-    edition_1 = create(
-      :content_block_edition,
-      document: document_1,
-      state: "scheduled",
-      scheduled_publication: 1.day.from_now,
-    )
+  describe ".dequeue" do
+    it "removes a job for a scheduled edition" do
+      document = create(:content_block_document, :email_address)
+      edition = create(
+        :content_block_edition,
+        document:,
+        state: "scheduled",
+        scheduled_publication: 1.day.from_now,
+      )
 
-    document_2 = create(:content_block_document, :email_address)
-    edition_2 = create(
-      :content_block_edition,
-      document: document_2,
-      state: "scheduled",
-      scheduled_publication: 1.day.from_now,
-    )
+      control_document = create(:content_block_document, :email_address)
+      control_edition = create(
+        :content_block_edition,
+        document: control_document,
+        state: "scheduled",
+        scheduled_publication: 1.day.from_now,
+      )
 
-    with_real_sidekiq do
-      ContentBlockManager::SchedulePublishingWorker.queue(edition_1)
-      ContentBlockManager::SchedulePublishingWorker.queue(edition_2)
+      with_real_sidekiq do
+        ContentBlockManager::SchedulePublishingWorker.queue(edition)
+        ContentBlockManager::SchedulePublishingWorker.queue(control_edition)
 
-      assert_equal 2, Sidekiq::ScheduledSet.new.size
+        assert_equal 2, Sidekiq::ScheduledSet.new.size
 
-      ContentBlockManager::SchedulePublishingWorker.dequeue_all
+        ContentBlockManager::SchedulePublishingWorker.dequeue(edition)
 
-      assert_equal 0, Sidekiq::ScheduledSet.new.size
+        assert_equal 1, Sidekiq::ScheduledSet.new.size
+
+        control_job = Sidekiq::ScheduledSet.new.first
+
+        assert_equal control_job["args"].first, control_edition.id
+        assert_equal control_job.at.to_i, control_edition.scheduled_publication.to_i
+      end
     end
   end
 
-  test ".queue_size returns the number of queued ContentBlockPublishingWorker jobs" do
-    with_real_sidekiq do
-      ContentBlockManager::SchedulePublishingWorker.perform_at(1.day.from_now, "null")
-      assert_equal 1, ContentBlockManager::SchedulePublishingWorker.queue_size
+  describe ".dequeue_all" do
+    it "removes all content block publishing jobs" do
+      document_1 = create(:content_block_document, :email_address)
+      edition_1 = create(
+        :content_block_edition,
+        document: document_1,
+        state: "scheduled",
+        scheduled_publication: 1.day.from_now,
+      )
 
-      ContentBlockManager::SchedulePublishingWorker.perform_at(2.days.from_now, "null")
-      assert_equal 2, ContentBlockManager::SchedulePublishingWorker.queue_size
+      document_2 = create(:content_block_document, :email_address)
+      edition_2 = create(
+        :content_block_edition,
+        document: document_2,
+        state: "scheduled",
+        scheduled_publication: 1.day.from_now,
+      )
+
+      with_real_sidekiq do
+        ContentBlockManager::SchedulePublishingWorker.queue(edition_1)
+        ContentBlockManager::SchedulePublishingWorker.queue(edition_2)
+
+        assert_equal 2, Sidekiq::ScheduledSet.new.size
+
+        ContentBlockManager::SchedulePublishingWorker.dequeue_all
+
+        assert_equal 0, Sidekiq::ScheduledSet.new.size
+      end
     end
   end
 
-  test ".queued_edition_ids returns the edition ids of the currently queued jobs" do
-    with_real_sidekiq do
-      ContentBlockManager::SchedulePublishingWorker.perform_at(1.day.from_now, "3")
-      ContentBlockManager::SchedulePublishingWorker.perform_at(2.days.from_now, "6")
+  describe ".queue_size" do
+    it "returns the number of queued ContentBlockPublishingWorker jobs" do
+      with_real_sidekiq do
+        ContentBlockManager::SchedulePublishingWorker.perform_at(1.day.from_now, "null")
+        assert_equal 1, ContentBlockManager::SchedulePublishingWorker.queue_size
 
-      assert_same_elements %w[3 6], ContentBlockManager::SchedulePublishingWorker.queued_edition_ids
+        ContentBlockManager::SchedulePublishingWorker.perform_at(2.days.from_now, "null")
+        assert_equal 2, ContentBlockManager::SchedulePublishingWorker.queue_size
+      end
+    end
+  end
+
+  describe ".queued_edition_ids" do
+    it "returns the edition ids of the currently queued jobs" do
+      with_real_sidekiq do
+        ContentBlockManager::SchedulePublishingWorker.perform_at(1.day.from_now, "3")
+        ContentBlockManager::SchedulePublishingWorker.perform_at(2.days.from_now, "6")
+
+        assert_same_elements %w[3 6], ContentBlockManager::SchedulePublishingWorker.queued_edition_ids
+      end
     end
   end
 end


### PR DESCRIPTION
We don’t carry out any database actions in `publish_with_rollback` now, so the transaction and block are no longer needed. Additionally we can get the schema name from the document’s block type, so we no longer need to pass the schema into the service.