### PR TITLE
content-modelling/fix: send schema ID not block type to Publishing API

### DIFF
--- a/lib/engines/content_block_manager/app/lib/content_block_manager/publishable.rb
+++ b/lib/engines/content_block_manager/app/lib/content_block_manager/publishable.rb
@@ -4,11 +4,12 @@ module ContentBlockManager
 
     def publish_with_rollback(content_block_edition)
       document = content_block_edition.document
+      schema = ContentBlockManager::ContentBlock::Schema.find_by_block_type(document.block_type)
       content_id = document.content_id
 
       create_publishing_api_edition(
         content_id:,
-        schema_id: document.block_type,
+        schema_id: schema.id,
         title: content_block_edition.title,
         details: content_block_edition.details,
         links: {

--- a/lib/engines/content_block_manager/test/integration/content_block/workflow_test.rb
+++ b/lib/engines/content_block_manager/test/integration/content_block/workflow_test.rb
@@ -147,8 +147,8 @@ def assert_edition_is_published(&block)
   publishing_api_mock.expect :put_content, fake_put_content_response, [
     @content_id,
     {
-      schema_name: document.block_type,
-      document_type: document.block_type,
+      schema_name: "content_block_type",
+      document_type: "content_block_type",
       publishing_app: "whitehall",
       title: "Some Title",
       details: {

--- a/lib/engines/content_block_manager/test/unit/app/services/publish_edition_service_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/services/publish_edition_service_test.rb
@@ -5,10 +5,13 @@ class ContentBlockManager::PublishEditionServiceTest < ActiveSupport::TestCase
 
   describe "#call" do
     let(:content_id) { "49453854-d8fd-41da-ad4c-f99dbac601c3" }
+    let(:schema) { build(:content_block_schema, block_type: "content_block_type", body: { "properties" => { "foo" => "", "bar" => "" } }) }
     let(:document) { create(:content_block_document, :email_address, content_id:, title: "Some Title") }
     let(:edition) { create(:content_block_edition, document:, details: { "foo" => "Foo text", "bar" => "Bar text" }, organisation: @organisation) }
 
     setup do
+      ContentBlockManager::ContentBlock::Schema.stubs(:find_by_block_type)
+                                               .returns(schema)
       @organisation = create(:organisation)
     end
 
@@ -35,8 +38,8 @@ class ContentBlockManager::PublishEditionServiceTest < ActiveSupport::TestCase
       publishing_api_mock.expect :put_content, fake_put_content_response, [
         content_id,
         {
-          schema_name: document.block_type,
-          document_type: document.block_type,
+          schema_name: schema.id,
+          document_type: schema.id,
           publishing_app: "whitehall",
           title: "Some Title",
           details: {


### PR DESCRIPTION
previously using `block_type` just sent `email_address` and was not recognised by the API, because we need to include
`content_block` in front of it. I thiink the ID was designed to be sent to the Publishing API and `block_type` is for internal use.
