### PR TITLE
Content modelling/612 remove cancelled draft editions

### DIFF
--- a/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/editions_controller.rb
+++ b/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/editions_controller.rb
@@ -24,6 +24,12 @@ class ContentBlockManager::ContentBlock::EditionsController < ContentBlockManage
     render "content_block_manager/content_block/editions/new"
   end
 
+  def destroy
+    edition_to_delete = ContentBlockManager::ContentBlock::Edition.find(params[:id])
+    ContentBlockManager::DeleteEditionService.new.call(edition_to_delete)
+    redirect_to params[:redirect_path] || content_block_manager.content_block_manager_root_path
+  end
+
 private
 
   def block_type_param

--- a/lib/engines/content_block_manager/app/services/content_block_manager/delete_edition_service.rb
+++ b/lib/engines/content_block_manager/app/services/content_block_manager/delete_edition_service.rb
@@ -1,0 +1,23 @@
+module ContentBlockManager
+  class DeleteEditionService
+    def call(content_block_edition)
+      if content_block_edition.draft?
+        document = content_block_edition.document
+        document.with_lock do
+          content_block_edition.destroy!
+          if document_has_no_more_editions?(document)
+            document.destroy!
+          end
+        end
+      else
+        raise ArgumentError, "Could not delete Content Block Edition #{content_block_edition.id} because it is not in draft"
+      end
+    end
+
+  private
+
+    def document_has_no_more_editions?(document)
+      document.editions.count.zero?
+    end
+  end
+end

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/review.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/review.html.erb
@@ -20,14 +20,21 @@
   <div class="govuk-grid-column-full">
     <%= form_with(url: content_block_manager.content_block_manager_content_block_workflow_path(@content_block_edition, step: ContentBlockManager::ContentBlock::Editions::WorkflowController::NEW_BLOCK_STEPS[:review]), method: :put) do %>
       <div class="govuk-button-group govuk-!-margin-bottom-6">
-        <%= render "govuk_publishing_components/components/button", {
-          text: "Accept and publish",
-          name: "accept_and_publish",
-          value: "Accept and publish",
-          type: "submit",
-        } %>
-        <%= link_to("Cancel", content_block_manager.content_block_manager_content_block_documents_path, class: "govuk-link") %>
+        <div>
+          <%= render "govuk_publishing_components/components/button", {
+            text: "Accept and publish",
+            name: "accept_and_publish",
+            value: "Accept and publish",
+            type: "submit",
+          } %>
+      <% end %>
+        </div>
+        <div>
+          <%= render partial: "content_block_manager/content_block/shared/cancel_delete_button",
+                     locals: {
+                       url:  content_block_manager.content_block_manager_content_block_edition_path(@content_block_edition),
+                     } %>
+          </div>
       </div>
-    <% end %>
   </div>
 </div>

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/review_links.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/review_links.html.erb
@@ -24,23 +24,29 @@
   <div class="govuk-grid-column-two-thirds">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">
-        <%= form_with(
-              url: content_block_manager.content_block_manager_content_block_workflow_path(
-                edition_id: @content_block_edition.id,
-                step: ContentBlockManager::ContentBlock::Editions::WorkflowController::UPDATE_BLOCK_STEPS[:review_links],
-              ),
-              method: :put,
-            ) do %>
-          <div class="govuk-button-group govuk-!-margin-bottom-6">
-            <%= render "govuk_publishing_components/components/button", {
-              text: "Save and continue",
-              name: "save_and_continue",
-              value: "Save and continue",
-              type: "submit",
-            } %>
-            <%= link_to("Cancel", content_block_manager.content_block_manager_content_block_documents_path, class: "govuk-link") %>
+          <div class="govuk-button-group">
+          <%= form_with(
+                url: content_block_manager.content_block_manager_content_block_workflow_path(
+                  edition_id: @content_block_edition.id,
+                  step: ContentBlockManager::ContentBlock::Editions::WorkflowController::UPDATE_BLOCK_STEPS[:review_links],
+                ),
+                method: :put,
+              ) do %>
+              <%= render "govuk_publishing_components/components/button", {
+                text: "Save and continue",
+                name: "save_and_continue",
+                value: "Save and continue",
+                type: "submit",
+              } %>
+            <% end %>
+            <%= render partial: "content_block_manager/content_block/shared/cancel_delete_button",
+                       locals: {
+                         url: content_block_manager.content_block_manager_content_block_edition_path(
+                           @content_block_edition,
+                           redirect_path: content_block_manager.content_block_manager_content_block_document_path(@content_block_edition.document),
+                         ),
+                       } %>
           </div>
-        <% end %>
       </div>
     </div>
 

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/schedule_publishing.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/schedule_publishing.html.erb
@@ -89,16 +89,26 @@
           },
         ],
       } %>
-      <div class="govuk-button-group govuk-!-margin-bottom-6">
-        <%= render "govuk_publishing_components/components/button", {
-          text: "Accept and publish",
-          name: "accept_and_publish",
-          value: "Accept and publish",
-          type: "submit",
-        } %>
-        <%= link_to("Cancel", content_block_manager.content_block_manager_content_block_documents_path, class: "govuk-link") %>
-      </div>
-    <% end %>
 
+      <div class="govuk-button-group">
+        <div>
+          <%= render "govuk_publishing_components/components/button", {
+            text: "Accept and publish",
+            name: "accept_and_publish",
+            value: "Accept and publish",
+            type: "submit",
+          } %>
+      <% end %>
+        </div>
+        <div>
+          <%= render partial: "content_block_manager/content_block/shared/cancel_delete_button",
+                     locals: {
+                       url: content_block_manager.content_block_manager_content_block_edition_path(
+                         @content_block_edition,
+                         redirect_path: content_block_manager.content_block_manager_content_block_document_path(@content_block_edition.document),
+                       ),
+                     } %>
+        </div>
+      </div>
   </div>
 </div>

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/shared/_cancel_delete_button.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/shared/_cancel_delete_button.erb
@@ -1,0 +1,9 @@
+<%= form_with url: url, method: :patch do %>
+  <%= render "govuk_publishing_components/components/button", {
+    text: "Cancel",
+    name: "_method",
+    value: "delete",
+    type: "submit",
+    secondary_solid: true,
+  } %>
+<% end %>

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/shared/_form.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/shared/_form.html.erb
@@ -52,6 +52,10 @@
       value: "Save and continue",
       type: "submit",
     } %>
-    <%= link_to("Cancel", @form.back_path, class: "govuk-link") %>
+    <%= render "govuk_publishing_components/components/button", {
+      text: "Cancel",
+      href: @form.back_path,
+      secondary_solid: true,
+    } %>
   </div>
 <% end %>

--- a/lib/engines/content_block_manager/config/routes.rb
+++ b/lib/engines/content_block_manager/config/routes.rb
@@ -9,7 +9,7 @@ ContentBlockManager::Engine.routes.draw do
         end
         resources :editions, only: %i[new create]
       end
-      resources :editions, only: %i[new create], path_names: { new: ":block_type/new" } do
+      resources :editions, only: %i[new create destroy], path_names: { new: ":block_type/new" } do
         member do
           resources :workflow, only: %i[show update], controller: "editions/workflow", param: :step
         end

--- a/lib/engines/content_block_manager/features/create_object.feature
+++ b/lib/engines/content_block_manager/features/create_object.feature
@@ -52,6 +52,18 @@ Feature: Create a content object
       | my email address | xxxxx           | Somewhere  | Ministry of Example |
     Then I should see a message that the "email_address" field is an invalid "email"
 
+  Scenario: GDS editor cancels the creation of an object
+    When I visit the Content Block Manager home page
+    And I click to create an object
+    When I click on the "email_address" schema
+    When I complete the form with the following fields:
+      | title            | email_address   | department | organisation |
+      | my email address | foo@example.com | Somewhere  | Ministry of Example |
+    And I click cancel
+    Then I am taken back to Content Block Manager home page
+    And no draft Content Block Edition has been created
+    And no draft Content Block Document has been created
+
   Scenario: Draft documents are not listed
     When I visit the Content Block Manager home page
     And I click to create an object

--- a/lib/engines/content_block_manager/features/edit_object.feature
+++ b/lib/engines/content_block_manager/features/edit_object.feature
@@ -29,6 +29,30 @@ Feature: Edit a content object
     And I should be taken back to the document page
     And I should see 2 publish events on the timeline
 
+  Scenario: GDS editor cancels the creation of an object when reviewing links
+    When I visit the Content Block Manager home page
+    When I click to view the document
+    When I click the first change link
+    Then I should see the edit form
+    When I fill out the form
+    Then I am shown where the changes will take place
+    And I click cancel
+    Then I should be taken back to the document page
+    And no draft Content Block Edition has been created
+
+  Scenario: GDS editor cancels the creation of an object before publishing
+    When I visit the Content Block Manager home page
+    When I click to view the document
+    When I click the first change link
+    Then I should see the edit form
+    When I fill out the form
+    Then I am shown where the changes will take place
+    When I save and continue
+    Then I am asked when I want to publish the change
+    And I click cancel
+    Then I should be taken back to the document page
+    And no draft Content Block Edition has been created
+
   Scenario: GDS editor sees validation errors for missing fields
     And a schema "email_address" exists with the following fields:
     | field         | type   | format | required |

--- a/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
@@ -33,6 +33,10 @@ When("I click to create an object") do
   click_link "Create new object"
 end
 
+When("I click cancel") do
+  click_button "Cancel"
+end
+
 Then("I should see all the schemas listed") do
   @schemas.values.each do |schema|
     expect(page).to have_content(schema.name)
@@ -157,6 +161,18 @@ end
 
 When("I visit the Content Block Manager home page") do
   visit content_block_manager.content_block_manager_root_path
+end
+
+Then("I am taken back to Content Block Manager home page") do
+  assert_equal current_path, content_block_manager.content_block_manager_root_path
+end
+
+And("no draft Content Block Edition has been created") do
+  assert_equal 0, ContentBlockManager::ContentBlock::Edition.where(state: "draft").count
+end
+
+And("no draft Content Block Document has been created") do
+  assert_equal 0, ContentBlockManager::ContentBlock::Document.count
 end
 
 Then("I should see the details for all documents") do

--- a/lib/engines/content_block_manager/test/unit/app/services/delete_edition_service_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/services/delete_edition_service_test.rb
@@ -1,0 +1,48 @@
+require "test_helper"
+
+class ContentBlockManager::DeleteEditionServiceTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
+  describe "#call" do
+    let(:document) { create(:content_block_document, :email_address) }
+    let!(:draft_edition) { create(:content_block_edition, :email_address, document:, state: :draft) }
+
+    describe "when there is only one draft edition on a document" do
+      it "deletes the draft edition and its document" do
+        assert_changes -> { ContentBlockManager::ContentBlock::Document.count }, from: 1, to: 0 do
+          assert_changes -> { ContentBlockManager::ContentBlock::Edition.count }, from: 1, to: 0 do
+            ContentBlockManager::DeleteEditionService.new.call(draft_edition)
+          end
+        end
+      end
+    end
+
+    describe "when the edition is not a draft" do
+      let!(:scheduled_edition) { create(:content_block_edition, :email_address, document:, state: :published) }
+
+      it "does not delete the edition or document" do
+        assert_no_changes -> { ContentBlockManager::ContentBlock::Document.count } do
+          assert_no_changes -> { ContentBlockManager::ContentBlock::Edition.count } do
+            assert_raises(ArgumentError) do
+              ContentBlockManager::DeleteEditionService.new.call(scheduled_edition)
+            end
+          end
+        end
+      end
+    end
+
+    describe "when there is more than one draft edition on a document" do
+      let!(:other_edition) { create(:content_block_edition, :email_address, document:, state: :draft) }
+
+      it "only deletes the given edition" do
+        assert_no_changes -> { ContentBlockManager::ContentBlock::Document.count } do
+          assert_no_changes -> { ContentBlockManager::ContentBlock::Edition.exists?(other_edition.id) } do
+            assert_changes -> { ContentBlockManager::ContentBlock::Edition.exists?(draft_edition.id) }, from: true, to: false do
+              ContentBlockManager::DeleteEditionService.new.call(draft_edition)
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
When a user clicks 'cancel' on any page in the Content Block forms
Then any new draft Editions created by that form should be destroyed
And any orphaned Documents

Creating New Content Block (review page)
![Screenshot 2024-10-14 at 15 04 01](https://github.com/user-attachments/assets/f54e792c-7c7f-4e84-ab9c-0e94b1db417c)

Reviewing links for existing Content Block (review_links page)
![Screenshot 2024-10-14 at 14 58 19](https://github.com/user-attachments/assets/37795155-e6ac-404f-92ba-ab17530d87ea)

Schedule or Publish new Edition for existing Content Block (schedule_publishing page)
![Screenshot 2024-10-14 at 14 58 30](https://github.com/user-attachments/assets/84157f03-2fc9-4594-b4e0-88c73dd1dec0)


------

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
