### PR TITLE
(622) Send a `content_id_alias` to the Publishing API when a content block is created

### DIFF
--- a/db/migrate/20241015123028_add_content_id_alias_to_content_block_documents.rb
+++ b/db/migrate/20241015123028_add_content_id_alias_to_content_block_documents.rb
@@ -1,0 +1,8 @@
+class AddContentIdAliasToContentBlockDocuments < ActiveRecord::Migration[7.1]
+  def change
+    change_table :content_block_documents, bulk: true do |t|
+      t.column :content_id_alias, :string
+      t.index :content_id_alias, unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_02_102908) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_15_123028) do
   create_table "assets", charset: "utf8mb3", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.string "variant", null: false
@@ -199,6 +199,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_02_102908) do
     t.datetime "updated_at", precision: nil
     t.integer "latest_edition_id"
     t.integer "live_edition_id"
+    t.string "content_id_alias"
+    t.index ["content_id_alias"], name: "index_content_block_documents_on_content_id_alias", unique: true
     t.index ["latest_edition_id"], name: "index_content_block_documents_on_latest_edition_id"
     t.index ["live_edition_id"], name: "index_content_block_documents_on_live_edition_id"
   end
@@ -226,9 +228,11 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_02_102908) do
     t.bigint "document_id", null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
+    t.bigint "user_id"
     t.string "state", default: "draft", null: false
     t.datetime "scheduled_publication", precision: nil
     t.index ["document_id"], name: "index_content_block_editions_on_document_id"
+    t.index ["user_id"], name: "index_content_block_editions_on_user_id"
   end
 
   create_table "content_block_versions", charset: "utf8mb3", force: :cascade do |t|
@@ -1291,7 +1295,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_02_102908) do
   add_foreign_key "content_block_editions", "content_block_documents", column: "document_id"
   add_foreign_key "documents", "editions", column: "latest_edition_id", on_update: :cascade, on_delete: :nullify
   add_foreign_key "documents", "editions", column: "live_edition_id", on_update: :cascade, on_delete: :nullify
-  add_foreign_key "editions", "governments"
+  add_foreign_key "editions", "governments", on_delete: :nullify
   add_foreign_key "link_checker_api_report_links", "link_checker_api_reports"
   add_foreign_key "related_mainstreams", "editions"
   add_foreign_key "statistics_announcements", "statistics_announcement_dates", column: "current_release_date_id", on_update: :cascade, on_delete: :nullify

--- a/lib/engines/content_block_manager/app/lib/content_block_manager/publishable.rb
+++ b/lib/engines/content_block_manager/app/lib/content_block_manager/publishable.rb
@@ -6,9 +6,11 @@ module ContentBlockManager
       document = content_block_edition.document
       schema = ContentBlockManager::ContentBlock::Schema.find_by_block_type(document.block_type)
       content_id = document.content_id
+      content_id_alias = document.content_id_alias
 
       create_publishing_api_edition(
         content_id:,
+        content_id_alias:,
         schema_id: schema.id,
         title: content_block_edition.title,
         details: content_block_edition.details,
@@ -44,10 +46,12 @@ module ContentBlockManager
       ActiveRecord::Base.transaction do
         content_block_edition = yield
         content_id = content_block_edition.document.content_id
+        content_id_alias = content_block_edition.document.content_id_alias
         organisation_id = content_block_edition.lead_organisation.content_id
 
         create_publishing_api_edition(
           content_id:,
+          content_id_alias:,
           schema_id: schema.id,
           title: content_block_edition.title,
           details: content_block_edition.details.to_h,
@@ -70,12 +74,13 @@ module ContentBlockManager
 
   private
 
-    def create_publishing_api_edition(content_id:, schema_id:, title:, details:, links:)
+    def create_publishing_api_edition(content_id:, content_id_alias:, schema_id:, title:, details:, links:)
       Services.publishing_api.put_content(content_id, {
         schema_name: schema_id,
         document_type: schema_id,
         publishing_app: Whitehall::PublishingApp::WHITEHALL,
         title:,
+        content_id_alias:,
         details:,
         links:,
       })

--- a/lib/engines/content_block_manager/app/models/content_block_manager/content_block/document.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/content_block/document.rb
@@ -1,6 +1,9 @@
 module ContentBlockManager
   module ContentBlock
     class Document < ApplicationRecord
+      extend FriendlyId
+      friendly_id :title, use: :slugged, slug_column: :content_id_alias, routes: :default
+
       has_many :editions,
                -> { order(created_at: :asc, id: :asc) },
                inverse_of: :document

--- a/lib/engines/content_block_manager/test/integration/content_block/workflow_test.rb
+++ b/lib/engines/content_block_manager/test/integration/content_block/workflow_test.rb
@@ -151,6 +151,7 @@ def assert_edition_is_published(&block)
       document_type: "content_block_type",
       publishing_app: "whitehall",
       title: "Some Title",
+      content_id_alias: "some-title",
       details: {
         "foo" => "Foo text",
         "bar" => "Bar text",

--- a/lib/engines/content_block_manager/test/unit/app/lib/content_block_manager/publishable_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/lib/content_block_manager/publishable_test.rb
@@ -27,6 +27,7 @@ class ContentBlockManager::PublishableTest < ActiveSupport::TestCase
           document_type: schema.id,
           publishing_app: Whitehall::PublishingApp::WHITEHALL,
           title: content_block_edition.title,
+          content_id_alias: content_block_edition.document.content_id_alias,
           details: content_block_edition.details,
           links: {
             primary_publishing_organisation: [

--- a/lib/engines/content_block_manager/test/unit/app/models/content_block_document_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/models/content_block_document_test.rb
@@ -18,6 +18,7 @@ class ContentBlockManager::ContentBlockDocumentTest < ActiveSupport::TestCase
     assert_equal "email_address", content_block_document.block_type
     assert_equal Time.zone.local(2000, 12, 31, 23, 59, 59).utc, content_block_document.created_at
     assert_equal Time.zone.local(2000, 12, 31, 23, 59, 59).utc, content_block_document.updated_at
+    assert_equal "title", content_block_document.content_id_alias
   end
 
   it "does not allow the block type to be changed" do
@@ -80,6 +81,43 @@ class ContentBlockManager::ContentBlockDocumentTest < ActiveSupport::TestCase
       create(:content_block_document, :email_address, latest_edition_id: nil)
 
       assert_equal [document_with_latest_edition], ContentBlockManager::ContentBlock::Document.live
+    end
+  end
+
+  describe "friendly_id" do
+    it "generates a content_id_alias" do
+      content_block_document = create(
+        :content_block_document,
+        :email_address,
+        title: "This is a title",
+      )
+
+      assert_equal "this-is-a-title", content_block_document.content_id_alias
+    end
+
+    it "ensures content_id_aliases are unique" do
+      content_block_documents = create_list(
+        :content_block_document,
+        2,
+        :email_address,
+        title: "This is a title",
+      )
+
+      assert_equal "this-is-a-title", content_block_documents[0].content_id_alias
+      assert_equal "this-is-a-title--2", content_block_documents[1].content_id_alias
+    end
+
+    it "does not change the alias if the title changes" do
+      content_block_document = create(
+        :content_block_document,
+        :email_address,
+        title: "This is a title",
+      )
+
+      content_block_document.title = "Something else"
+      content_block_document.save!
+
+      assert_equal "this-is-a-title", content_block_document.content_id_alias
     end
   end
 end

--- a/lib/engines/content_block_manager/test/unit/app/services/create_edition_service_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/services/create_edition_service_test.rb
@@ -57,7 +57,7 @@ class ContentBlockManager::CreateEditionServiceTest < ActiveSupport::TestCase
     end
 
     it "sends the content block to the Publishing API as a draft" do
-      assert_draft_created_in_publishing_api(content_id) do
+      assert_draft_created_in_publishing_api(content_id:, content_id_alias: new_title.parameterize) do
         ContentBlockManager::CreateEditionService.new(schema).call(edition_params)
       end
     end
@@ -82,7 +82,7 @@ class ContentBlockManager::CreateEditionServiceTest < ActiveSupport::TestCase
       end
 
       it "sends the content block to the Publishing API as a draft" do
-        assert_draft_created_in_publishing_api(document.content_id) do
+        assert_draft_created_in_publishing_api(content_id: document.content_id, content_id_alias: document.content_id_alias) do
           ContentBlockManager::CreateEditionService.new(schema).call(edition_params, document_id: document.id)
         end
       end
@@ -90,7 +90,7 @@ class ContentBlockManager::CreateEditionServiceTest < ActiveSupport::TestCase
   end
 end
 
-def assert_draft_created_in_publishing_api(content_id, &block)
+def assert_draft_created_in_publishing_api(content_id:, content_id_alias:, &block)
   Services.publishing_api.expects(:put_content).with(
     content_id,
     {
@@ -98,6 +98,7 @@ def assert_draft_created_in_publishing_api(content_id, &block)
       document_type: schema.id,
       publishing_app: Whitehall::PublishingApp::WHITEHALL,
       title: new_title,
+      content_id_alias:,
       details: edition_params[:details],
       links: {
         primary_publishing_organisation: [

--- a/lib/engines/content_block_manager/test/unit/app/services/publish_edition_service_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/services/publish_edition_service_test.rb
@@ -42,6 +42,7 @@ class ContentBlockManager::PublishEditionServiceTest < ActiveSupport::TestCase
           document_type: schema.id,
           publishing_app: "whitehall",
           title: "Some Title",
+          content_id_alias: "some-title",
           details: {
             "foo" => "Foo text",
             "bar" => "Bar text",


### PR DESCRIPTION
Now https://github.com/alphagov/publishing-api/pull/2911 has been merged as part of the platform team's work towards making human-readable embed codes, we can now generate `content_id_alias` fields and send them to the Publishing API when creating an edition.

This uses the [Friendly ID](https://github.com/norman/friendly_id) gem, which is already used elsewhere in Whitehall to generate unique slugs from the titles of the blocks.