### PR TITLE
schedule draft Content Block Editions to be deleted

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -17,3 +17,5 @@
       class: CheckAllOrganisationsLinksWorker
     LinkCheckerDeleteOldDataWorker:
       cron: '30 3 * * *' # Runs at 3:30 a.m every day
+    DeleteDraftContentBlocksWorker:
+      cron: '0 3 * * *' # Runs at 3:00 a.m every day

--- a/lib/engines/content_block_manager/app/workers/content_block_manager/delete_draft_content_blocks_worker.rb
+++ b/lib/engines/content_block_manager/app/workers/content_block_manager/delete_draft_content_blocks_worker.rb
@@ -1,0 +1,17 @@
+require "sidekiq/api"
+
+module ContentBlockManager
+  class DeleteDraftContentBlocksWorker < WorkerBase
+    sidekiq_options queue: :content_block_publishing
+
+    def perform
+      draft_content_editions = ContentBlockManager::ContentBlock::Edition.draft.where("created_at < ?", 60.days.ago).limit(100)
+      puts "Starting to delete #{draft_content_editions.count} draft Content Blocks"
+      draft_content_editions.each do |draft_content_edition|
+        puts "Deleting draft Content Block Edition #{draft_content_edition.id}"
+        ContentBlockManager::DeleteEditionService.new.call(draft_content_edition)
+      end
+      puts "Finished deleting draft Content Blocks"
+    end
+  end
+end

--- a/lib/engines/content_block_manager/test/unit/app/workers/delete_draft_content_blocks_worker_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/workers/delete_draft_content_blocks_worker_test.rb
@@ -1,0 +1,49 @@
+require "test_helper"
+
+class ContentBlockManager::DeleteDraftContentBlocksWorkerTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+  include SidekiqTestHelpers
+
+  # Suppress noisy Sidekiq logging in the test output
+  setup do
+    Sidekiq.configure_client do |cfg|
+      cfg.logger.level = ::Logger::WARN
+    end
+  end
+
+  describe "#perform" do
+    it "deletes draft content block editions older than 60 days" do
+      document = create(:content_block_document, :email_address)
+      _published_editions = create_list(:content_block_edition, 2, :email_address, document:, state: :published)
+      _drafts_younger_than_61_days = create_list(:content_block_edition, 2, :email_address, document:, state: :draft, created_at: 60.days.ago)
+      draft_editions_older_than_61_days = create_list(:content_block_edition, 2, :email_address, document:, state: :draft, created_at: 61.days.ago)
+
+      delete_service_mock = Minitest::Mock.new
+      ContentBlockManager::DeleteEditionService.expects(:new).returns(delete_service_mock).at_least_once
+      delete_service_mock.expect :call, nil, [draft_editions_older_than_61_days[0]]
+      delete_service_mock.expect :call, nil, [draft_editions_older_than_61_days[1]]
+
+      ContentBlockManager::DeleteDraftContentBlocksWorker.new.perform
+      delete_service_mock.verify
+    end
+
+    it "will take the first 100 drafts to delete" do
+      ar_mock = mock
+      ContentBlockManager::ContentBlock::Edition.expects(:draft).returns(ar_mock)
+      ar_mock.stubs(:where).with("created_at < ?", 60.days.ago).returns(ar_mock)
+      ar_mock.expects(:limit).with(100).returns([])
+
+      ContentBlockManager::DeleteDraftContentBlocksWorker.new.perform
+    end
+
+    it "returns without consequence if there are no draft editions" do
+      document = create(:content_block_document, :email_address)
+      create_list(:content_block_edition, 2, :email_address, document:, state: :published)
+
+      ContentBlockManager::DeleteEditionService.expects(:new).never
+      ContentBlockManager::DeleteEditionService.any_instance.expects(:call).never
+
+      ContentBlockManager::DeleteDraftContentBlocksWorker.new.perform
+    end
+  end
+end


### PR DESCRIPTION
We don't currently have any UX for using Content
Blocks in a draft state, but they are
automatically created if a user hits 'save and
continue' on the new form page - this schedules a
Sidekiq job to delete any Blocks that are hanging
around from people abandoning the form without
pressing 'cancel' (e.g. by closing the browser
window) and that are older than two months (so we
avoid deleting any in progress blocks).

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
