### PR TITLE
Content modelling/611 confirmation screen

### DIFF
--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/confirmation.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/confirmation.html.erb
@@ -1,0 +1,28 @@
+<% content_for :page_title, "Your content block is available for use" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-three-quarters">
+    <div class="govuk-panel govuk-panel--confirmation">
+      <h1 class="govuk-panel__title">
+        <%= @panel_copy %>
+      </h1>
+    </div>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-three-quarters govuk-body">
+    <h2 class="govuk-heading-m">What happens next</h2>
+    <p><%= @paragraph_copy %><br>
+    If you need any support or want to delete an instance you can
+      <a class="govuk-link--no-visited-state" href="<%= Plek.external_url_for("support") %>">raise a support request</a>
+    </p>
+    <%= render "govuk_publishing_components/components/button", {
+        text: "View content block",
+        name: "view",
+        value: "view",
+        href: content_block_manager.content_block_manager_content_block_document_path(@content_block_edition.document.id),
+        secondary_solid: true,
+    } %>
+  </div>
+</div>

--- a/lib/engines/content_block_manager/features/create_object.feature
+++ b/lib/engines/content_block_manager/features/create_object.feature
@@ -26,7 +26,7 @@ Feature: Create a content object
     Then I am asked to check my answers
     When I accept and publish
     Then the edition should have been created successfully
-    And I should be taken back to the document page
+    And I should be taken to the confirmation page
 
   Scenario: GDS editor sees validation errors when not selecting an object type
     When I visit the Content Block Manager home page

--- a/lib/engines/content_block_manager/features/edit_object.feature
+++ b/lib/engines/content_block_manager/features/edit_object.feature
@@ -25,6 +25,8 @@ Feature: Edit a content object
     And I should see a back link to the review page
     When I choose to publish the change now
     And I accept and publish
+    Then I should be taken to the confirmation page
+    When I click to view the content block
     Then the edition should have been updated successfully
     And I should be taken back to the document page
     And I should see 2 publish events on the timeline
@@ -86,6 +88,8 @@ Feature: Edit a content object
     When I make the changes
     And I choose to publish the change now
     And I accept and publish
+    Then I should be taken to the confirmation page
+    When I click to view the content block
     Then the edition should have been updated successfully
 
   Scenario: GDS editor still sees live edition when abandoning an edit

--- a/lib/engines/content_block_manager/features/schedule_object.feature
+++ b/lib/engines/content_block_manager/features/schedule_object.feature
@@ -12,8 +12,8 @@ Feature: Schedule a content object
     When I am updating a content block
     Then I am asked when I want to publish the change
     And I schedule the change for 7 days in the future
-    Then the edition should have been scheduled successfully
-    And I should be taken back to the document page
+    And I should be taken to the scheduled confirmation page
+    When I click to view the content block
     And I should see the scheduled date on the object
     And I should see the scheduled event on the timeline
 

--- a/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
@@ -119,8 +119,6 @@ When("I complete the form") do
 end
 
 Then("the edition should have been created successfully") do
-  assert_text "#{@schema.name} created successfully"
-
   edition = ContentBlockManager::ContentBlock::Edition.all.last
 
   assert_not_nil edition
@@ -130,6 +128,36 @@ Then("the edition should have been created successfully") do
   @details.keys.each do |k|
     assert_equal edition.details[k], @details[k]
   end
+end
+
+And("I should be taken to the confirmation page") do
+  assert_text "Your content block is available for use"
+  assert_text "Your content block has been published and is now available for use."
+
+  expect(page).to have_link(
+    "View content block",
+    href: content_block_manager.content_block_manager_content_block_document_path(
+      ContentBlockManager::ContentBlock::Edition.last.document,
+    ),
+  )
+end
+
+When("I click to view the content block") do
+  click_link href: content_block_manager.content_block_manager_content_block_document_path(
+    ContentBlockManager::ContentBlock::Edition.last.document,
+  )
+end
+
+When("I should be taken to the scheduled confirmation page") do
+  assert_text "Your content block is scheduled for change"
+  assert_text "Your content block has been edited and is now scheduled for change."
+
+  expect(page).to have_link(
+    "View content block",
+    href: content_block_manager.content_block_manager_content_block_document_path(
+      ContentBlockManager::ContentBlock::Edition.last.document,
+    ),
+  )
 end
 
 Then("I should be taken back to the document page") do

--- a/lib/engines/content_block_manager/test/integration/content_block/workflow_test.rb
+++ b/lib/engines/content_block_manager/test/integration/content_block/workflow_test.rb
@@ -117,8 +117,9 @@ class ContentBlockManager::ContentBlock::WorkflowTest < ActionDispatch::Integrat
               scheduled_at:,
             }
 
-            assert_redirected_to content_block_manager_content_block_document_path(document)
-            assert_equal "#{edition.block_type.humanize} scheduled successfully", flash[:notice]
+            assert_redirected_to content_block_manager.content_block_manager_content_block_workflow_path(id: edition.id,
+                                                                                                         step: :confirmation,
+                                                                                                         is_scheduled: true)
           end
         end
 


### PR DESCRIPTION
Add a confirmation page for creating/editing/scheduling content blocks

![Screenshot 2024-10-16 at 14 30 38](https://github.com/user-attachments/assets/3c10ec03-ded1-430b-987d-6ca3147939dd)

<img width="926" alt="Screenshot 2024-10-16 at 14 32 49" src="https://github.com/user-attachments/assets/d0de7cf2-aa6c-4cbc-a9e6-56d5fa5bdb42">


--
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
