### PR TITLE
Increase maximum featured documents for No. 10 to 7

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -112,6 +112,12 @@ class Organisation < ApplicationRecord
 
   has_many :offsite_links, as: :parent
 
+  def featured_documents_display_limit
+    return 7 if slug == "prime-ministers-office-10-downing-street"
+
+    FEATURED_DOCUMENTS_DISPLAY_LIMIT
+  end
+
   # I'm trying to use a domain centric design rather than a persistence
   # centric design, so I do not want to expose a has_many :home_page_lists
   # and all that this implies. I really only want to expose a list of

--- a/app/presenters/publishing_api/organisation_presenter.rb
+++ b/app/presenters/publishing_api/organisation_presenter.rb
@@ -88,7 +88,7 @@ module PublishingApi
         ordered_corporate_information_pages: corporate_information_pages,
         secondary_corporate_information_pages:,
         ordered_featured_links: featured_links,
-        ordered_featured_documents: featured_documents(item, item.class::FEATURED_DOCUMENTS_DISPLAY_LIMIT),
+        ordered_featured_documents: featured_documents(item, item.featured_documents_display_limit),
         ordered_promotional_features: promotional_features,
         important_board_members:,
         organisation_featuring_priority:,

--- a/app/views/admin/organisations/features.html.erb
+++ b/app/views/admin/organisations/features.html.erb
@@ -32,7 +32,7 @@
       label: "Currently featured",
       content: render(Admin::CurrentlyFeaturedTabComponent.new(
         features: @feature_list.features.current,
-        maximum_featured_documents: @organisation.class::FEATURED_DOCUMENTS_DISPLAY_LIMIT,
+        maximum_featured_documents: @organisation.featured_documents_display_limit,
       )),
     },
     {

--- a/test/unit/app/presenters/publishing_api/organisation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/organisation_presenter_test.rb
@@ -127,6 +127,18 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
     assert_equal 6, present(organisation).content.dig(:details, :ordered_featured_documents).size
   end
 
+  test "caps number of featured documents at 7 for Number 10" do
+    features = (1..8).to_a.map do |i|
+      created_case_study = create(:published_case_study, title: "case-study-#{i}")
+      build(:feature, document: created_case_study.document, ordering: i)
+    end
+    organisation = create(:organisation, slug: "prime-ministers-office-10-downing-street")
+
+    create(:feature_list, featurable: organisation, features:)
+
+    assert_equal 7, present(organisation).content.dig(:details, :ordered_featured_documents).size
+  end
+
   test "presents an organisation’s custom logo" do
     organisation = create(
       :organisation_with_logo_and_assets,


### PR DESCRIPTION
https://trello.com/c/ey4KM89d/59-make-changes-to-no10-organisation-page

## Before
<img width="742" alt="Screenshot 2024-10-16 at 14 15 53" src="https://github.com/user-attachments/assets/6381e202-d848-42ac-bc75-a07bfc711e56">

## After
<img width="728" alt="Screenshot 2024-10-16 at 14 15 41" src="https://github.com/user-attachments/assets/11fc8c9d-8f5d-42df-ac20-d44652feb29f">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
