### PR TITLE
Do not validate a `Feature` when ending it

### DIFF
--- a/app/models/feature.rb
+++ b/app/models/feature.rb
@@ -42,7 +42,7 @@ class Feature < ApplicationRecord
 
   def end!
     self.ended_at = Time.zone.now
-    save!
+    save!(validate: false)
   end
 
   def locale

--- a/test/unit/app/models/feature_test.rb
+++ b/test/unit/app/models/feature_test.rb
@@ -33,4 +33,13 @@ class FeatureTest < ActiveSupport::TestCase
     assert feature.end!
     assert_equal Time.zone.now, feature.reload.ended_at
   end
+
+  test "#end! sets the ended_at timestamp and saves the model even if it otherwise fails to validate" do
+    feature = create(:feature, ended_at: nil)
+    feature.started_at = nil
+
+    assert_nothing_raised do
+      feature.end!
+    end
+  end
 end


### PR DESCRIPTION
We've had a report of a publisher being unable to unpublish a document because it has 'features' which do not validate. The feature in question is missing an image, which was added as a validation rule [11 months ago](https://github.com/alphagov/whitehall/blob/1c29bf277c69a0a134d44aa6a9f5c5a29cde63dc/app/models/feature.rb#L65-L66). The featuring predates the validation.

When we're calling `.end!` on a feature, we really shouldn't care whether or not the feature is valid, since it's literally being ended. There is precedent for that, e.g. in the code that triggers the `.end!` method, which already calls `.save!(validate: false)` on the edition itself:
https://github.com/alphagov/whitehall/blob/1dedd82dffa8680d2db4b741675fa68d2243fc3f/app/services/edition_unpublisher.rb#L25-L26

Trello: https://trello.com/c/LFCD7dMp/3011-superseded-by-another-page-unpublish-content-request

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
