### PR TITLE
Content modelling/612 fix sidekiq job

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -19,3 +19,4 @@
       cron: '30 3 * * *' # Runs at 3:30 a.m every day
     DeleteDraftContentBlocksWorker:
       cron: '0 3 * * *' # Runs at 3:00 a.m every day
+      class: ContentBlockManager::DeleteDraftContentBlocksWorker

--- a/lib/engines/content_block_manager/app/workers/content_block_manager/delete_draft_content_blocks_worker.rb
+++ b/lib/engines/content_block_manager/app/workers/content_block_manager/delete_draft_content_blocks_worker.rb
@@ -6,12 +6,12 @@ module ContentBlockManager
 
     def perform
       draft_content_editions = ContentBlockManager::ContentBlock::Edition.draft.where("created_at < ?", 60.days.ago).limit(100)
-      puts "Starting to delete #{draft_content_editions.count} draft Content Blocks"
+      logger.info("[delete-draft-content-blocks-debug] Starting to delete #{draft_content_editions.count} draft Content Blocks")
       draft_content_editions.each do |draft_content_edition|
-        puts "Deleting draft Content Block Edition #{draft_content_edition.id}"
+        logger.info("[delete-draft-content-blocks-debug] Deleting draft Content Block Edition #{draft_content_edition.id}")
         ContentBlockManager::DeleteEditionService.new.call(draft_content_edition)
       end
-      puts "Finished deleting draft Content Blocks"
+      logger.info("[delete-draft-content-blocks-debug] Finished deleting draft Content Blocks")
     end
   end
 end


### PR DESCRIPTION
This job was not able to run because it did not have the write class/engine name.
I've also corrected the logging level from `puts` to `log.info`.

This was run successfully on Staging and the logs are here https://kibana.logit.io/s/b8a10798-a30e-4611-9393-8843d2339dd2/goto/9b73ddcfc5935ff97b263213b602957d?security_tenant=global 

----
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
