### PR TITLE
Send `last_edited_by_editor_id` to Publishing API

### DIFF
--- a/app/presenters/publishing_api/base_item_presenter.rb
+++ b/app/presenters/publishing_api/base_item_presenter.rb
@@ -18,7 +18,7 @@ module PublishingApi
         publishing_app: Whitehall::PublishingApp::WHITEHALL,
         redirects: [],
         update_type:,
-      }
+      }.merge(PayloadBuilder::LastEditedByEditorId.for(item))
     end
   end
 end

--- a/app/presenters/publishing_api/payload_builder/last_edited_by_editor_id.rb
+++ b/app/presenters/publishing_api/payload_builder/last_edited_by_editor_id.rb
@@ -1,0 +1,13 @@
+module PublishingApi
+  module PayloadBuilder
+    class LastEditedByEditorId
+      def self.for(item)
+        last_author = item.respond_to?(:last_author) ? item.last_author : nil
+
+        return {} if last_author.nil? || last_author.uid.blank?
+
+        { last_edited_by_editor_id: last_author.uid }
+      end
+    end
+  end
+end

--- a/test/unit/app/presenters/publishing_api/base_item_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/base_item_presenter_test.rb
@@ -2,19 +2,43 @@ require "test_helper"
 
 module PublishingApi
   class BaseItemPresenterTest < ActiveSupport::TestCase
-    test "it returns the base set of attributes needed by all documents sent to the publishing API" do
-      stubbed_item = stub(title: "A title")
+    extend Minitest::Spec::DSL
 
-      presenter = PublishingApi::BaseItemPresenter.new(stubbed_item, update_type: "major", locale: "fr")
-      expected_hash = {
-        title: stubbed_item.title,
-        locale: "fr",
-        publishing_app: Whitehall::PublishingApp::WHITEHALL,
-        redirects: [],
-        update_type: "major",
-      }
+    describe ".base_attributes" do
+      let(:presenter) { PublishingApi::BaseItemPresenter.new(stubbed_item, update_type: "major", locale: "fr") }
+      let(:expected_hash) do
+        {
+          title: stubbed_item.title,
+          locale: "fr",
+          publishing_app: Whitehall::PublishingApp::WHITEHALL,
+          redirects: [],
+          update_type: "major",
+        }
+      end
 
-      assert_equal presenter.base_attributes, expected_hash
+      context "when the item does not respond to last_author" do
+        let(:stubbed_item) { stub(title: "A title") }
+        let(:last_edited_by_editor_id) { nil }
+
+        it "returns the base set of attributes needed by all documents sent to the publishing API" do
+          assert_equal presenter.base_attributes, expected_hash
+        end
+      end
+
+      context "when the item responds to last_author" do
+        let(:last_edited_by_editor_id) { SecureRandom.uuid }
+        let(:last_author) { stub(uid: last_edited_by_editor_id) }
+        let(:stubbed_item) { stub(title: "A title", last_author:) }
+        let(:updated_expected_hash) do
+          expected_hash.merge(
+            last_edited_by_editor_id:,
+          )
+        end
+
+        it "returns the base set of attributes needed by all documents sent to the publishing API" do
+          assert_equal presenter.base_attributes, updated_expected_hash
+        end
+      end
     end
   end
 end

--- a/test/unit/app/presenters/publishing_api/payload_builder/last_edited_by_editor_id_test.rb
+++ b/test/unit/app/presenters/publishing_api/payload_builder/last_edited_by_editor_id_test.rb
@@ -1,0 +1,48 @@
+require "test_helper"
+
+module PublishingApi
+  module PayloadBuilder
+    class LastEditedByEditorIdTest < ActiveSupport::TestCase
+      extend Minitest::Spec::DSL
+
+      it "returns the UUID of the last author if present" do
+        last_author = stub(uid: SecureRandom.uuid)
+        item = stub(last_author:)
+
+        assert_equal(
+          { last_edited_by_editor_id: last_author.uid },
+          LastEditedByEditorId.for(item),
+        )
+      end
+
+      it "returns an empty hash if a last author is not present" do
+        item = stub(last_author: nil)
+
+        assert_equal(
+          {},
+          LastEditedByEditorId.for(item),
+        )
+      end
+
+      it "returns an empty hash if the last author uid is nil" do
+        last_author = stub(uid: nil)
+        item = stub(last_author:)
+
+        assert_equal(
+          {},
+          LastEditedByEditorId.for(item),
+        )
+      end
+
+      it "returns an empty hash if the item does not respond to `last_author`" do
+        item = stub
+        item.stubs(:respond_to?).with(:last_author).returns(false)
+
+        assert_equal(
+          {},
+          LastEditedByEditorId.for(item),
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a new field that will allow us to identify the last person who has edited an Edition within the Publishing API.

Rather than adding the field to each individual Edition Presenter, I've added a PayloadBuilder class that fetches the ID from the `last_author` attribute if it exists, and is not nil. 

This DRYs up the presenters, which were getting to be a bit repetitive, and also gives us the flexibility to get users from other attributes for other types of item, if we choose to in the future.