### PR TITLE
Allow file attachments on Case Studies

### DIFF
--- a/app/models/case_study.rb
+++ b/app/models/case_study.rb
@@ -1,6 +1,7 @@
 class CaseStudy < Edition
   include Edition::Searchable
 
+  include ::Attachable
   include Edition::Images
   include Edition::FactCheckable
   include Edition::CustomLeadImage

--- a/test/unit/app/helpers/admin/tabbed_nav_helper_test.rb
+++ b/test/unit/app/helpers/admin/tabbed_nav_helper_test.rb
@@ -160,7 +160,7 @@ class Admin::TabbedNavHelperTest < ActionView::TestCase
   end
 
   test "#secondary_navigation_tabs_items for persisted editions which do not allow attachments" do
-    %i[case_study fatality_notice speech].each do |type|
+    %i[fatality_notice speech].each do |type|
       edition = build_stubbed(type)
 
       expected_output = [

--- a/test/unit/app/models/case_study_test.rb
+++ b/test/unit/app/models/case_study_test.rb
@@ -4,6 +4,8 @@ class CaseStudyTest < ActiveSupport::TestCase
   include ActionDispatch::TestProcess
 
   should_allow_image_attachments
+  should_be_attachable
+  should_allow_inline_attachments
   should_have_custom_lead_image
   should_protect_against_xss_and_content_attacks_on :case_study, :body
 


### PR DESCRIPTION
This brings them into line with News Stories and Detailed Guides. We can't see a reason why Case Studies should not be allowed file attachments, and it has caused issues for publishers in at least one case: https://govuk.zendesk.com/agent/tickets/5595072

Before:

> ![Screenshot 2024-10-17 at 13 39 58](https://github.com/user-attachments/assets/b8e0621b-d820-459c-a740-464b92441375)

After:

> ![Screenshot 2024-10-17 at 13 40 03](https://github.com/user-attachments/assets/7b8a3087-9bd3-4b31-b9cf-c5b9fc2545c0)

Trello: https://trello.com/c/uJccMA6o/2844-allow-non-html-attachments-for-case-studies

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

