### PR TITLE
Have landing page extend document collection

### DIFF
--- a/app/models/landing_page.rb
+++ b/app/models/landing_page.rb
@@ -1,6 +1,4 @@
-class LandingPage < Edition
-  include Edition::Organisations
-
+class LandingPage < DocumentCollection
   skip_callback :validation, :before, :update_document_slug
   validates :base_path, presence: true
   validate :base_path_must_not_be_taken
@@ -8,6 +6,10 @@ class LandingPage < Edition
 
   def publishing_api_presenter
     PublishingApi::LandingPagePresenter
+  end
+
+  def locale_can_be_changed?
+    false
   end
 
   def rendering_app
@@ -28,6 +30,10 @@ private
     errors.add(:base_path, " is already taken") if Document.where(slug:).where.not(id: document.id).exists?
   end
 
+  def has_topic_level_notifications?
+    false
+  end
+
   def body_must_be_valid_yaml
     body_hash = YAML.load(body)
     if body_hash.keys != %w[blocks]
@@ -35,5 +41,11 @@ private
     end
   rescue StandardError => e
     errors.add(:body, "must be valid YAML: #{e.message}")
+  end
+
+private
+
+  def body_required?
+    true
   end
 end

--- a/app/models/landing_page.rb
+++ b/app/models/landing_page.rb
@@ -24,8 +24,6 @@ class LandingPage < DocumentCollection
     true
   end
 
-private
-
   def base_path_must_not_be_taken
     errors.add(:base_path, " is already taken") if Document.where(slug:).where.not(id: document.id).exists?
   end

--- a/app/presenters/publishing_api/landing_page_presenter.rb
+++ b/app/presenters/publishing_api/landing_page_presenter.rb
@@ -51,7 +51,7 @@ module PublishingApi
     def details
       body = YAML.load(item.body, permitted_classes: [Date])
       {
-        blocks: body.fetch(:blocks),
+        blocks: body.fetch("blocks"),
         collection_groups:,
       }
     end

--- a/app/presenters/publishing_api/landing_page_presenter.rb
+++ b/app/presenters/publishing_api/landing_page_presenter.rb
@@ -49,7 +49,25 @@ module PublishingApi
     attr_reader :item
 
     def details
-      YAML.load(item.body, permitted_classes: [Date])
+      body = YAML.load(item.body, permitted_classes: [Date])
+      {
+        blocks: body.fetch(:blocks),
+        collection_groups:,
+      }
+    end
+
+    def collection_groups
+      item.groups.map do |group|
+        {
+          title: group.heading,
+          body: govspeak_renderer.govspeak_to_html(group.body),
+          documents: group.content_ids,
+        }
+      end
+    end
+
+    def govspeak_renderer
+      @govspeak_renderer ||= Whitehall::GovspeakRenderer.new
     end
   end
 end

--- a/app/presenters/publishing_api/landing_page_presenter.rb
+++ b/app/presenters/publishing_api/landing_page_presenter.rb
@@ -35,7 +35,9 @@ module PublishingApi
     end
 
     def edition_links
-      PayloadBuilder::Links.for(item).extract(%i[organisations])
+      links = PayloadBuilder::Links.for(item).extract(%i[organisations])
+      links[:documents] = item.content_ids.uniq
+      links
     end
 
     def document_type

--- a/test/factories/landing_pages.rb
+++ b/test/factories/landing_pages.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
-  factory :landing_page, class: LandingPage, parent: :edition, traits: [:with_organisations] do
+  factory :landing_page, class: LandingPage, parent: :document_collection do
     title { "landing-page-title" }
     summary { "landing-page-summary" }
     body { "blocks:\n- type: govspeak\n  content: Hello!" }


### PR DESCRIPTION
The theory here is that often, landing pages effectively own collections of documents, and it's nice for those documents to be linked together in some way.

By extending document collection, we get some UI that allows us to add groups of documents, and publish them as links to the landing page.

Documents links ought to be reversed by publishing API, so the documents themselves should link back to the landing page.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
