### PR TITLE
Allow Link Checker API to connect to host

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -105,6 +105,7 @@ Rails.application.configure do
   # Enable DNS rebinding protection and other `Host` header attacks.
   config.hosts = [
     /whitehall-admin\..*\.gov.uk$/,
+    /^link-checker-api$/,
   ]
 
   # Skip DNS rebinding protection for the default health check endpoint.


### PR DESCRIPTION
We're seeing Link Checker API client errors [in Sentry](https://govuk.sentry.io/issues/5982406876/events/67b8507af36b472ca5e2aed567258c6d/?project=202233&referrer=next-event) where it's failing to connect to Whitehall:

```
Faraday::ForbiddenError
the server responded with status 403 (Faraday::ForbiddenError)
```

We need to allow requests from Link Checker API.

Trello: https://trello.com/c/VvHwUqD8/3022-investigate-whitehall-403-responses-to-link-checker-api-callbacks

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
