### PR TITLE
Content modelling/626 search by title

### DIFF
--- a/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/documents_controller.rb
+++ b/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/documents_controller.rb
@@ -1,6 +1,7 @@
 class ContentBlockManager::ContentBlock::DocumentsController < ContentBlockManager::BaseController
   def index
-    @content_block_documents = ContentBlockManager::ContentBlock::Document.live
+    @filters = params_filters
+    @content_block_documents = ContentBlockManager::ContentBlock::Document::DocumentFilter.new(@filters).documents
   end
 
   def show
@@ -22,5 +23,13 @@ class ContentBlockManager::ContentBlock::DocumentsController < ContentBlockManag
     else
       redirect_to content_block_manager.new_content_block_manager_content_block_document_path, flash: { error: "You must select a block type" }
     end
+  end
+
+private
+
+  def params_filters
+    params.slice(:title)
+          .permit!
+          .to_h
   end
 end

--- a/lib/engines/content_block_manager/app/models/content_block_manager/content_block/document.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/content_block/document.rb
@@ -1,6 +1,8 @@
 module ContentBlockManager
   module ContentBlock
     class Document < ApplicationRecord
+      include Scopes::SearchableByTitle
+
       extend FriendlyId
       friendly_id :title, use: :slugged, slug_column: :content_id_alias, routes: :default
 

--- a/lib/engines/content_block_manager/app/models/content_block_manager/content_block/document/document_filter.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/content_block/document/document_filter.rb
@@ -1,0 +1,14 @@
+module ContentBlockManager
+  class ContentBlock::Document::DocumentFilter
+    def initialize(filters = {})
+      @filters = filters
+    end
+
+    def documents
+      documents = ContentBlock::Document
+      documents = documents.live
+      documents = documents.with_title(@filters[:title]) if @filters[:title].present?
+      documents
+    end
+  end
+end

--- a/lib/engines/content_block_manager/app/models/content_block_manager/content_block/document/scopes/searchable_by_title.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/content_block/document/scopes/searchable_by_title.rb
@@ -1,0 +1,13 @@
+module ContentBlockManager
+  module ContentBlock::Document::Scopes::SearchableByTitle
+    extend ActiveSupport::Concern
+
+    included do
+      scope :with_title,
+            lambda { |*keywords|
+              pattern = "(#{keywords.map { |k| Regexp.escape(k) }.join('|')})"
+              where("title REGEXP :pattern", pattern:)
+            }
+    end
+  end
+end

--- a/lib/engines/content_block_manager/app/models/content_block_manager/content_block/document/scopes/searchable_by_title.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/content_block/document/scopes/searchable_by_title.rb
@@ -4,8 +4,13 @@ module ContentBlockManager
 
     included do
       scope :with_title,
-            lambda { |*keywords|
-              pattern = "(#{keywords.map { |k| Regexp.escape(k) }.join('|')})"
+            lambda { |keywords|
+              split_keywords = keywords.split
+              pattern = ""
+              split_keywords.map do |k|
+                escaped_word = Regexp.escape(k)
+                pattern += "(?=.*#{escaped_word})"
+              end
               where("title REGEXP :pattern", pattern:)
             }
     end

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/documents/_filter_options.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/documents/_filter_options.html.erb
@@ -1,0 +1,17 @@
+<%= form_with url: content_block_manager.content_block_manager_content_block_documents_path, method: :get do %>
+    <%= render "govuk_publishing_components/components/input", {
+      label: {
+        text: "Title",
+        bold: true,
+      },
+      hint: 'For example, "driving standards"',
+      name: "title",
+      id: "title_filter",
+      value: !@filters.nil? && @filters[:title],
+    } %>
+
+  <%= render "govuk_publishing_components/components/button", {
+    text: "View results",
+    margin_bottom: 4,
+  } %>
+<% end %>

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/documents/index.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/documents/index.html.erb
@@ -11,9 +11,13 @@
 </div>
 
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
-  <% @content_block_documents.each do |content_block_document| %>
-    <%= render ContentBlockManager::ContentBlock::Document::Index::SummaryCardComponent.new(content_block_document:) %>
-  <% end %>
+  <div class="govuk-grid-column-one-third">
+    <%= render "filter_options" %>
+  </div>
+  <div class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-m"><%= pluralize(@content_block_documents.count, "result") %></h2>
+    <% @content_block_documents.each do |content_block_document| %>
+      <%= render ContentBlockManager::ContentBlock::Document::Index::SummaryCardComponent.new(content_block_document:) %>
+    <% end %>
   </div>
 </div>

--- a/lib/engines/content_block_manager/features/search_for_object.feature
+++ b/lib/engines/content_block_manager/features/search_for_object.feature
@@ -1,0 +1,18 @@
+Feature: Search for a content object
+  Background:
+    Given the content block manager feature flag is enabled
+    Given I am a GDS admin
+    And the organisation "Ministry of Example" exists
+    And a schema "email_address" exists with the following fields:
+      | email_address |
+    And an email address content block has been created
+    And an email address content block has been created with the title "example search title"
+
+  Scenario: GDS Editor searches for a content object by keyword in title
+    When I visit the Content Block Manager home page
+    Then I should see the details for all documents
+    And "2" content blocks are returned
+    When I enter the title "example search"
+    And I click to view results
+    Then I should see the content block with title "example search title" returned
+    And "1" content blocks are returned

--- a/lib/engines/content_block_manager/test/unit/app/models/content_block_edition/document/document_filter_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/models/content_block_edition/document/document_filter_test.rb
@@ -1,0 +1,26 @@
+require "test_helper"
+
+class ContentBlockManager::DocumentFilterTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
+  describe "documents" do
+    describe "when no filters are given" do
+      it "returns live documents" do
+        document_scope_mock = mock
+        ContentBlockManager::ContentBlock::Document.expects(:live).returns(document_scope_mock)
+        document_scope_mock.expects(:with_title).never
+
+        ContentBlockManager::ContentBlock::Document::DocumentFilter.new({}).documents
+      end
+    end
+
+    describe "when a title filter is given" do
+      it "returns live documents with keyword in title" do
+        document_scope_mock = mock
+        ContentBlockManager::ContentBlock::Document.expects(:live).returns(document_scope_mock)
+        document_scope_mock.expects(:with_title).returns([])
+        ContentBlockManager::ContentBlock::Document::DocumentFilter.new({ title: "ministry of example" }).documents
+      end
+    end
+  end
+end

--- a/lib/engines/content_block_manager/test/unit/app/models/content_block_edition/document/scopes/searchable_by_title_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/models/content_block_edition/document/scopes/searchable_by_title_test.rb
@@ -10,5 +10,12 @@ class ContentBlockManager::SearchableByTitleTest < ActiveSupport::TestCase
       _document_without_first_keyword = create(:content_block_document, :email_address, title: "this document is about muppets")
       assert_equal [document_with_first_keyword], ContentBlockManager::ContentBlock::Document.with_title("klingons")
     end
+
+    test "should find documents with title containing keywords not in order" do
+      document_with_first_keyword = create(:content_block_document, :email_address, title: "klingons and such")
+      _edition_with_first_keyword = create(:content_block_edition, :email_address, document: document_with_first_keyword)
+      _document_without_first_keyword = create(:content_block_document, :email_address, title: "muppets and such")
+      assert_equal [document_with_first_keyword], ContentBlockManager::ContentBlock::Document.with_title("such klingons")
+    end
   end
 end

--- a/lib/engines/content_block_manager/test/unit/app/models/content_block_edition/document/scopes/searchable_by_title_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/models/content_block_edition/document/scopes/searchable_by_title_test.rb
@@ -1,0 +1,14 @@
+require "test_helper"
+
+class ContentBlockManager::SearchableByTitleTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
+  describe ".with_title" do
+    test "should find documents with title containing keyword" do
+      document_with_first_keyword = create(:content_block_document, :email_address, title: "klingons and such")
+      _edition_with_first_keyword = create(:content_block_edition, :email_address, document: document_with_first_keyword)
+      _document_without_first_keyword = create(:content_block_document, :email_address, title: "this document is about muppets")
+      assert_equal [document_with_first_keyword], ContentBlockManager::ContentBlock::Document.with_title("klingons")
+    end
+  end
+end


### PR DESCRIPTION
As an editor
When I enter keywords from a block title
Then I should see the relevant blocks

![Screenshot 2024-10-18 at 15 37 10](https://github.com/user-attachments/assets/c098fca0-cb41-4c9e-b22e-13bded62aa97)


--- 

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
