### PR TITLE
Allow setting of base path of landing_pages

### DIFF
--- a/app/controllers/admin/edition_slug_controller.rb
+++ b/app/controllers/admin/edition_slug_controller.rb
@@ -7,7 +7,7 @@ class Admin::EditionSlugController < Admin::BaseController
   def edit_slug; end
 
   def update_slug
-    if DataHygiene::DocumentReslugger.new(@document, @published_edition, current_user, params.dig("document", "slug")).run!
+    if reslugger_class.new(@document, @published_edition, current_user, params.dig("document", "slug")).run!
       flash[:notice] = "Slug updated successfully"
       redirect_to admin_edition_path(@published_edition)
     else
@@ -16,6 +16,12 @@ class Admin::EditionSlugController < Admin::BaseController
   end
 
 private
+
+  def reslugger_class
+    return DataHygiene::LandingPageRepather if @document.document_type == "LandingPage"
+
+    DataHygiene::DocumentReslugger
+  end
 
   def find_edition
     @edition = Edition.find(params[:id])

--- a/lib/data_hygiene/landing_page_repather.rb
+++ b/lib/data_hygiene/landing_page_repather.rb
@@ -1,0 +1,38 @@
+module DataHygiene
+  # Repoints a landing page document to new_base_path.
+  #
+  # This has to be slightly different than doing it for a normal edition because
+  # landing_page documents have a base_path in the slug field, and that has to have
+  # slightly different validations. It also currently doesn't appear in the Whitehall
+  # search index, so override search index calls to no-ops.
+  #
+  # When run, the following happens:
+  #
+  #  - changes the documents new_base_path
+  #  - republishes the document to Publishing API (automatically handles the redirect)
+  #
+  class LandingPageRepather < DocumentReslugger
+  private
+
+    def remove_from_search_index; end
+
+    def add_to_search_index; end
+
+    def add_errors_if_invalid
+      document.errors.add(:slug, "is blank") and return if new_slug.blank?
+
+      document.errors.add(:slug, "must be unique") and return if new_slug_is_a_duplicate
+
+      document.errors.add(:slug, "must start with a slash") unless new_slug.starts_with?("/")
+    end
+
+    def create_editorial_remark
+      published_edition.editorial_remarks.create!(
+        body: "Updated document base path to #{document.slug}",
+        author: current_user,
+        created_at: Time.zone.now,
+        updated_at: Time.zone.now,
+      )
+    end
+  end
+end

--- a/test/unit/lib/data_hygiene/landing_page_repather_test.rb
+++ b/test/unit/lib/data_hygiene/landing_page_repather_test.rb
@@ -1,0 +1,16 @@
+require "test_helper"
+
+class LandingPageRepatherTest < ActiveSupport::TestCase
+  setup do
+    stub_any_publishing_api_call
+    @user = create(:user)
+    @document = create(:document, slug: "/old/path", document_type: "landing_page")
+    @published_edition = create(:searchable_edition, :published)
+  end
+
+  test "returns false and the adds an error to the document when new_slug does not start with a slash" do
+    repather = DataHygiene::LandingPageRepather.new(@document, @published_edition, @user, "invalid-slug")
+    assert_equal false, repather.run!
+    assert_equal @document.errors.full_messages, ["Slug must start with a slash"]
+  end
+end


### PR DESCRIPTION
- Landing pages' documents' slugs are actually base paths, so they _must_ start with a / - other slugs must not. So we create a specialist repathing class that subclasses DocumentReslugger and overrides the errors and editorial remark, then allow the edition slugger UI to use that. The UI will still refer to slugs, but people using the UI will understand that at the moment.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

https://trello.com/c/U0Z4s3OW/113-investigate-changing-slugs-in-whitehall
