### PR TITLE
Make republishable_content_types less clever

### DIFF
--- a/app/helpers/admin/republishing_helper.rb
+++ b/app/helpers/admin/republishing_helper.rb
@@ -68,11 +68,23 @@ module Admin::RepublishingHelper
   end
 
   def republishable_content_types
-    editionable_content_types = Edition.descendants.select { |descendant|
-      descendant.descendants.count.zero?
-    }.map(&:to_s)
+    editionable_content_types = %w[
+      CallForEvidence
+      CaseStudy
+      Consultation
+      CorporateInformationPage
+      DetailedGuide
+      DocumentCollection
+      WorldwideOrganisation
+      FatalityNotice
+      LandingPage
+      NewsArticle
+      Publication
+      Speech
+      StatisticalDataSet
+    ]
 
-    [editionable_content_types, non_editionable_content_types].flatten.sort
+    [*editionable_content_types, *non_editionable_content_types].sort
   end
 
   def republishable_content_types_select_options
@@ -101,7 +113,22 @@ module Admin::RepublishingHelper
   end
 
   def non_editionable_content_types
-    ApplicationRecord.subclasses.select { |subclass| subclass.included_modules.include? PublishesToPublishingApi }.map(&:to_s)
+    %w[
+      Contact
+      Government
+      HistoricalAccount
+      OperationalField
+      Organisation
+      Person
+      PolicyGroup
+      Role
+      RoleAppointment
+      StatisticsAnnouncement
+      TakePartPage
+      TopicalEvent
+      TopicalEventAboutPage
+      WorldLocationNews
+    ]
   end
 
   def content_ids_string_to_array(content_ids_string)

--- a/test/unit/app/helpers/admin/republishing_helper_test.rb
+++ b/test/unit/app/helpers/admin/republishing_helper_test.rb
@@ -2,20 +2,26 @@ require "test_helper"
 
 class Admin::RepublishingHelperTest < ActionView::TestCase
   test "#republishable_content_types returns a sorted list combining valid document types and other publishable content types" do
-    # we need to eager load here to ensure we have all the models
     Rails.application.eager_load!
 
-    expected_content_types = omnipresent_content_types.sort
-    result_minus_test_types = republishable_content_types.reject { |type| content_types[:test_specific].include? type }
+    # Ignore "abstract" Edition descendants
+    unexpected_content_types = %w[Announcement GenericEdition Publicationesque SearchableEdition]
 
-    assert_equal expected_content_types, result_minus_test_types
+    expected_content_types = (
+      Edition.descendants.map(&:to_s) + non_editionable_content_types - unexpected_content_types
+    ).reject { _1.include?("Test::") }.sort
+
+    assert_equal expected_content_types, republishable_content_types
   end
 
   test "#non_editionable_content_types returns a list of non-editionable content types" do
-    # we need to eager load here to ensure we have all the models
     Rails.application.eager_load!
+    expected_non_editionable_models = ApplicationRecord.subclasses
+      .select { |subclass| subclass.included_modules.include? PublishesToPublishingApi }
+      .map(&:to_s)
+      .sort
 
-    assert_equal content_types[:omnipresent_non_editionable], non_editionable_content_types.sort
+    assert_equal expected_non_editionable_models, non_editionable_content_types.sort
   end
 
   test "#republishing_index_bulk_republishing_rows capitalises the first letter of the bulk content type" do
@@ -45,9 +51,6 @@ class Admin::RepublishingHelperTest < ActionView::TestCase
   end
 
   test "#republishable_content_types_select_options creates select options from republishable_content_types" do
-    # we need to eager load here to ensure we have all the models
-    Rails.application.eager_load!
-
     options = republishable_content_types_select_options
 
     assert_includes options, {
@@ -125,46 +128,4 @@ class Admin::RepublishingHelperTest < ActionView::TestCase
 
     assert_equal expected_rows, confirm_documents_by_content_ids_edition_rows([document_a, document_b])
   end
-end
-
-def omnipresent_content_types
-  content_types[:omnipresent_editionable].concat(content_types[:omnipresent_non_editionable])
-end
-
-def content_types
-  { omnipresent_editionable: %w[CallForEvidence
-                                CaseStudy
-                                Consultation
-                                CorporateInformationPage
-                                DetailedGuide
-                                DocumentCollection
-                                WorldwideOrganisation
-                                FatalityNotice
-                                LandingPage
-                                NewsArticle
-                                Publication
-                                Speech
-                                StatisticalDataSet],
-    omnipresent_non_editionable: %w[Contact
-                                    Government
-                                    HistoricalAccount
-                                    OperationalField
-                                    Organisation
-                                    Person
-                                    PolicyGroup
-                                    Role
-                                    RoleAppointment
-                                    StatisticsAnnouncement
-                                    TakePartPage
-                                    TopicalEvent
-                                    TopicalEventAboutPage
-                                    WorldLocationNews],
-    test_specific: %w[GenericEdition
-                      SearchableEdition
-                      Edition::AlternativeFormatProviderTest::EditionWithAlternativeFormat
-                      Edition::AppointmentTest::EditionWithAppointment
-                      Edition::WorldwideOrganisationTest::EditionWithWorldwideOrganisations
-                      Edition::ImagesTest::EditionWithImages
-                      Edition::StatisticalDataSetsTest::EditionWithStatisticalDataSets
-                      Edition::LimitedAccessTest::LimitedByDefaultEdition] }
 end


### PR DESCRIPTION
Using `Edition.descendants` makes some assumptions about the inheritance tree of Edition which might not always be true.

Specifically, at the moment the only classes that get published are leaf nodes in the tree - classes without any descendants. In another branch, I would like to make a new LandingPage class which inherits DocumentCollection. Both LandingPage and DocumentCollection should be publishable, so they should both appear in the republishable documents list.

I don't think there's a neat way to account for this, and we have to hardcode the lists of document types in the tests anyway, so I think it's probably fine to just... hardcode them in the production code.

This also removes the need for us to keep calling eager_load in the tests, which was a bit smelly because it indicates that the production code would give incorrect results if the classes in question hadn't been loaded for some reason.

I've also made non_editionable_content_types hardcode its list, even though the heuristic it's using seems to be more accurate / less likely to break with changes to the inheritance structure.

I've removed the non_editionable_content_types test, because with both sides hardcoded it's a bit meaningless.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
