### PR TITLE
Fix hosts configuration for Whitehall

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -105,7 +105,7 @@ Rails.application.configure do
   # Enable DNS rebinding protection and other `Host` header attacks.
   config.hosts = [
     /whitehall-admin\..*\.gov.uk$/,
-    /^link-checker-api$/,
+    /^whitehall-admin$/,
   ]
 
   # Skip DNS rebinding protection for the default health check endpoint.


### PR DESCRIPTION
This was attempted to be fixed in #9542. An assumption was made that, because 403 errors were being seen in Link Checker API (https://govuk.sentry.io/issues/5982406876/events), then the request must be coming from Link Checker API, and that therefore that is the app that requires allow-listing.

That PR didn't work. We've since looked at the logs in Grafana and can find several entries like the following
https://kibana.logit.io/s/13d1a0b1-f54f-407b-a4e5-f53ba653fac3/app/discover#/doc/filebeat-*/filebeat-2024.10.25?id=j0NywpIBmKAqM5s1uiVd

It says:

```
kubernetes.labels.app_kubernetes_io/name: whitehall-admin

message: [ActionDispatch::HostAuthorization::DefaultResponseApp] Blocked hosts: whitehall-admin
```

In other words, it appears that the request to Whitehall comes 'internally' from the running Whitehall instance, rather than externally via a gov.uk domain, likely correlating with the link related cron tasks in sidekiq.yml that happen at 3:30/4am (coinciding with the spikes in errors we see in Sentry): https://github.com/alphagov/whitehall/blob/b5a9b32748cc86b042df0bab0a61fe2842c39f54/config/sidekiq.yml#L15-L19

The fix is to allow-list the internal name of the Whitehall app, as has been done in Release:
https://github.com/alphagov/release/pull/1589

Trello: https://trello.com/c/VvHwUqD8/3022-investigate-whitehall-403-responses-to-link-checker-api-callbacks

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
