### PR TITLE
Up limit to 6 for featured documents for Topical Event Pages

### DIFF
--- a/app/models/topical_event.rb
+++ b/app/models/topical_event.rb
@@ -29,6 +29,7 @@ class TopicalEvent < ApplicationRecord
   has_many :publications, through: :topical_event_memberships
   has_many :speeches, through: :topical_event_memberships
 
+  MAX_FEATURED_DOCUMENTS = 6
   has_many :features, inverse_of: :topical_event, dependent: :destroy
   has_many :offsite_links, as: :parent
   has_many :social_media_accounts, as: :socialable, dependent: :destroy

--- a/app/presenters/publishing_api/topical_event_presenter.rb
+++ b/app/presenters/publishing_api/topical_event_presenter.rb
@@ -63,7 +63,7 @@ module PublishingApi
       item
         .topical_event_featurings
         .includes(:image, edition: :document)
-        .limit(FeaturedLink::DEFAULT_SET_SIZE)
+        .limit(TopicalEvent::MAX_FEATURED_DOCUMENTS)
         .select { |feature| feature.image.all_asset_variants_uploaded? }
         .map do |feature|
           {

--- a/app/views/admin/topical_event_featurings/index.html.erb
+++ b/app/views/admin/topical_event_featurings/index.html.erb
@@ -32,7 +32,7 @@
       label: "Currently featured",
       content: render(Admin::CurrentlyFeaturedTabComponent.new(
         featurings: @topical_event_featurings,
-        maximum_featured_documents: 5,
+        maximum_featured_documents: TopicalEvent::MAX_FEATURED_DOCUMENTS,
       )),
     },
     {

--- a/test/unit/app/presenters/publishing_api/topical_event_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/topical_event_presenter_test.rb
@@ -155,11 +155,11 @@ class PublishingApi::TopicalEventPresenterTest < ActiveSupport::TestCase
 
   test "it limits the number of featured items" do
     topical_event = create(:topical_event, start_date: Time.zone.today)
-    create_list(:topical_event_featuring, FeaturedLink::DEFAULT_SET_SIZE + 1, topical_event:)
+    create_list(:topical_event_featuring, TopicalEvent::MAX_FEATURED_DOCUMENTS + 1, topical_event:)
 
     presenter = PublishingApi::TopicalEventPresenter.new(topical_event)
 
-    assert_equal FeaturedLink::DEFAULT_SET_SIZE, presenter.content.dig(:details, :ordered_featured_documents).length
+    assert_equal TopicalEvent::MAX_FEATURED_DOCUMENTS, presenter.content.dig(:details, :ordered_featured_documents).length
   end
 
   test "it ignores featured items if image variants are missing" do


### PR DESCRIPTION
Trello: https://trello.com/c/4dWCsqii/3057-featured-docs

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
