### PR TITLE
Change get_involved rendering app to Frontend

### DIFF
--- a/app/models/special_route.rb
+++ b/app/models/special_route.rb
@@ -14,7 +14,7 @@ class SpecialRoute
         content_id: "dbe329f1-359c-43f7-8944-580d4742aa91",
         title: "Get involved",
         description: "Find out how you can engage with government directly, and take part locally, nationally or internationally.",
-        rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
+        rendering_app: Whitehall::RenderingApp::FRONTEND,
         document_type: "get_involved",
         schema_name: "get_involved",
       },


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

Related PR to be merged
# https://github.com/alphagov/frontend/pull/4305

Trello card https://trello.com/c/mXj8oTI3/349-move-document-type-getinvolved-from-government-frontend-to-frontend
