### PR TITLE
Content modelling/628 organisation by user

### DIFF
--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/index/filter_options_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/index/filter_options_component.html.erb
@@ -24,7 +24,7 @@
     name: "lead_organisation",
     label:  "Lead organisation",
     heading_size: "s",
-    include_blank: true,
+    include_blank: false,
     options: options_for_lead_organisation,
   } %>
 

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/index/filter_options_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/index/filter_options_component.rb
@@ -11,18 +11,30 @@ private
       {
         label: schema_name.humanize,
         value: schema_name,
-        checked: !@filters.nil? && @filters[:block_type]&.include?(schema_name),
+        checked: @filters.any? && @filters[:block_type]&.include?(schema_name),
+      }
+    end
+  end
+
+  def all_organisations_option
+    {
+      text: "All organisations",
+      value: "",
+      selected: @filters.none? || @filters[:lead_organisation]&.empty?,
+    }
+  end
+
+  def taggable_organisations_options
+    helpers.taggable_organisations_container.map do |name, id|
+      {
+        text: name,
+        value: id,
+        selected: @filters.any? && @filters[:lead_organisation] == id.to_s,
       }
     end
   end
 
   def options_for_lead_organisation
-    helpers.taggable_organisations_container.map do |name, id|
-      {
-        text: name,
-        value: id,
-        selected: !@filters.nil? && @filters[:lead_organisation] == id.to_s,
-      }
-    end
+    [all_organisations_option, taggable_organisations_options].flatten
   end
 end

--- a/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/documents_controller.rb
+++ b/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/documents_controller.rb
@@ -1,7 +1,15 @@
 class ContentBlockManager::ContentBlock::DocumentsController < ContentBlockManager::BaseController
   def index
-    @filters = params_filters
-    @content_block_documents = ContentBlockManager::ContentBlock::Document::DocumentFilter.new(@filters).documents
+    if params_filters.any?
+      session[:content_block_filters] = params_filters
+      @filters = params_filters
+      @content_block_documents = ContentBlockManager::ContentBlock::Document::DocumentFilter.new(@filters).documents
+      render :index
+    elsif session_filters.any?
+      redirect_to content_block_manager.content_block_manager_root_path(session_filters)
+    else
+      redirect_to content_block_manager.content_block_manager_root_path(default_filters)
+    end
   end
 
   def show
@@ -31,5 +39,13 @@ private
     params.slice(:keyword, :block_type, :lead_organisation)
           .permit!
           .to_h
+  end
+
+  def session_filters
+    (session[:content_block_filters] || {}).to_h
+  end
+
+  def default_filters
+    { lead_organisation: current_user.organisation.try(:id) || "" }
   end
 end

--- a/lib/engines/content_block_manager/features/search_for_object.feature
+++ b/lib/engines/content_block_manager/features/search_for_object.feature
@@ -1,50 +1,50 @@
 Feature: Search for a content object
   Background:
     Given the content block manager feature flag is enabled
-    Given I am a GDS admin
     And the organisation "Department of Placeholder" exists
+    And the organisation "Ministry of Example" exists
+    Given I am an admin in the organisation "Department of Placeholder"
     And a schema "email_address" exists with the following fields:
       | email_address |
     And a schema "postal_address" exists with the following fields:
       | an_address |
-    And an email address content block has been created
-    And an email address content block has been created with the following email address and title:
-      | title                  |  example search title |
-      | email_address          |  ministry@justice.com |
     And a "postal_address" type of content block has been created with fields:
+      | title |  "an address" |
       | an_address  | ABC123 |
       | organisation | Department of Placeholder |
+    And a "email_address" type of content block has been created with fields:
+      | title | example search title |
+      | email_address  | hello@example.com |
+      | organisation | Department of Placeholder |
+    And a "email_address" type of content block has been created with fields:
+      | title | ministry address |
+      | email_address  | ministry@example.com |
+      | organisation | Ministry of Example |
+    When I visit the Content Block Manager home page
+    Then my organisation is already selected as a filter
+    And I should see the details for all documents from my organisation
+    When I select the lead organisation ""
+    And I click to view results
+    Then "3" content blocks are returned
 
   Scenario: GDS Editor searches for a content object by keyword in title
-    When I visit the Content Block Manager home page
-    Then I should see the details for all documents
-    And "3" content blocks are returned
     When I enter the keyword "example search"
     And I click to view results
     Then I should see the content block with title "example search title" returned
     And "1" content blocks are returned
 
   Scenario: GDS Editor searches for a content object by keyword in details
-    When I visit the Content Block Manager home page
-    Then I should see the details for all documents
-    And "3" content blocks are returned
-    When I enter the keyword "ministry justice"
+    When I enter the keyword "ABC123"
     And I click to view results
-    Then I should see the content block with title "example search title" returned
+    Then I should see the content block with title "an address" returned
     And "1" content blocks are returned
 
   Scenario: GDS Editor searches for a content object by block type
-    When I visit the Content Block Manager home page
-    Then I should see the details for all documents
-    And "3" content blocks are returned
     When I check the block type "Email address"
     And I click to view results
     And "2" content blocks are returned
 
   Scenario: GDS Editor searches for a content object by lead organisation
-    When I visit the Content Block Manager home page
-    Then I should see the details for all documents
-    And "3" content blocks are returned
-    When I select the lead organisation "Department of Placeholder"
+    When I select the lead organisation "Ministry of Example"
     And I click to view results
     And "1" content blocks are returned

--- a/lib/engines/content_block_manager/features/search_for_object.feature
+++ b/lib/engines/content_block_manager/features/search_for_object.feature
@@ -23,7 +23,7 @@ Feature: Search for a content object
     When I visit the Content Block Manager home page
     Then my organisation is already selected as a filter
     And I should see the details for all documents from my organisation
-    When I select the lead organisation ""
+    When I select the lead organisation "All organisations"
     And I click to view results
     Then "3" content blocks are returned
 

--- a/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
@@ -191,9 +191,13 @@ Given("a {string} type of content block has been created with fields:") do |bloc
   fields = table.rows_hash
   organisation_name = fields.delete("organisation")
   organisation = Organisation.where(name: organisation_name).first
+  title = fields.delete("title") || "title"
+  document = create(:content_block_document, block_type.to_sym, title:)
+
   create(
     :content_block_edition,
     block_type.to_sym,
+    document:,
     organisation:,
     details: fields,
     creator: @user,
@@ -248,6 +252,19 @@ Then("I should see the details for all documents") do
       document.title,
       document.latest_edition.details[:email_address],
     )
+  end
+end
+
+Then("my organisation is already selected as a filter") do
+  expect(page).to have_field("Lead organisation", with: @user.organisation.id)
+end
+
+Then("I should see the details for all documents from my organisation") do
+  ContentBlockManager::ContentBlock::Document.with_lead_organisation(@user.organisation.id).each do |document|
+    should_show_summary_card_for_email_address_content_block(
+      document.title,
+      document.latest_edition.details[:email_address],
+      )
   end
 end
 

--- a/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
@@ -264,7 +264,7 @@ Then("I should see the details for all documents from my organisation") do
     should_show_summary_card_for_email_address_content_block(
       document.title,
       document.latest_edition.details[:email_address],
-      )
+    )
   end
 end
 

--- a/lib/engines/content_block_manager/test/components/content_block/document/index/filter_options_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/document/index/filter_options_component_test.rb
@@ -29,6 +29,20 @@ class ContentBlockManager::ContentBlock::Document::Index::FilterOptionsComponent
     assert_selector "input[type='checkbox'][name='block_type[]'][value='postal_address']"
   end
 
+  test "returns organisations with an 'all organisations' option" do
+    helper_mock = mock
+    ContentBlockManager::ContentBlock::Document::Index::FilterOptionsComponent.any_instance.stubs(:helpers).returns(helper_mock)
+    helper_mock.stubs(:content_block_manager).returns(helper_mock)
+    helper_mock.stubs(:content_block_manager_content_block_documents_path).returns("path")
+    helper_mock.stubs(:taggable_organisations_container).returns(
+      [["Department of Placeholder", 1], ["Ministry of Example", 2]],
+    )
+    render_inline(ContentBlockManager::ContentBlock::Document::Index::FilterOptionsComponent.new(filters: {}))
+
+    assert_selector "select[name='lead_organisation']"
+    assert_selector "option[selected='selected'][value='']"
+  end
+
   test "selects organisation if selected in filters" do
     helper_mock = mock
     ContentBlockManager::ContentBlock::Document::Index::FilterOptionsComponent.any_instance.stubs(:helpers).returns(helper_mock)


### PR DESCRIPTION
* set the default organisation to the user's when viewing content blocks, and set the session params as in Whitehall
* also change the 'none' option to say 'All organisations'

![Screenshot 2024-10-28 at 16 59 21](https://github.com/user-attachments/assets/ed33759b-58b8-4d11-a2ff-2c8f978b33a3)

---


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
