### PR TITLE
Add deletion tests

### DIFF
--- a/test/unit/app/models/attachment_data_test.rb
+++ b/test/unit/app/models/attachment_data_test.rb
@@ -365,6 +365,29 @@ class AttachmentDataTest < ActiveSupport::TestCase
     assert_not attachment_data.deleted?
   end
 
+  test "#deleted? returns false for AttachmentData with multiple attachments, if draft off published has not been published yet" do
+    attachable = create(:published_news_article, :with_file_attachment)
+    new_attachable = attachable.reload.create_draft(create(:gds_editor))
+
+    assert_equal new_attachable.attachments.count, 1
+
+    attachment = new_attachable.attachments.first
+    attachment.destroy!
+
+    assert_not attachment.reload.attachment_data.deleted?
+  end
+
+  test "#deleted? returns true for AttachmentData with multiple attachments, if they are all on live attachables" do
+    attachable = create(:published_news_article, :with_file_attachment)
+    new_attachable = attachable.reload.create_draft(create(:gds_editor))
+    attachment = new_attachable.attachments.first
+    attachment.destroy!
+    new_attachable.update!(minor_change: true)
+    new_attachable.force_publish!
+
+    assert attachment.reload.attachment_data.deleted?
+  end
+
   test "#draft_attachment_for(user) returns the attachment with a draft edition" do
     user = build(:user)
     attachment_data = build(:attachment_data)


### PR DESCRIPTION
Adding one integration and some `AttachmentData` tests to cover the interesting case where the `deleted?` method returns false if the latest draft off a previously published edition (where we delete an `Attachment`) has not been published yet.
This is interesting because it blocks the update of Asset Manager until the edition is published. This ensures we can still surface the assets on the live edition until the new one gets published.

[Trello](https://trello.com/c/Dyev3Yav/2991-generate-list-of-assets-that-need-deleting)