### PR TITLE
Support reverting "foreign language only" mode by choosing English

### DIFF
--- a/app/models/concerns/edition/translatable.rb
+++ b/app/models/concerns/edition/translatable.rb
@@ -73,7 +73,7 @@ private
   end
 
   def remove_other_translations_if_primary_locale_changed
-    return unless saved_change_to_primary_locale?
+    return unless saved_change_to_primary_locale? && translations.count == 2
 
     translations.each do |translation|
       translation.destroy! unless translation.locale.to_s == primary_locale

--- a/app/models/concerns/edition/translatable.rb
+++ b/app/models/concerns/edition/translatable.rb
@@ -25,7 +25,7 @@ module Edition::Translatable
       on: :update,
     )
     before_validation(
-      :remove_other_translations_if_primary_locale_no_longer_english,
+      :remove_other_translations_if_primary_locale_changed,
       on: :update,
     )
 
@@ -72,9 +72,11 @@ private
     end
   end
 
-  def remove_other_translations_if_primary_locale_no_longer_english
-    if translations.count > 1 && translations.first.locale != :en
-      translations[1..].each(&:destroy)
+  def remove_other_translations_if_primary_locale_changed
+    return unless saved_change_to_primary_locale?
+
+    translations.each do |translation|
+      translation.destroy! unless translation.locale.to_s == primary_locale
     end
   end
 

--- a/app/views/admin/editions/_locale_fields.html.erb
+++ b/app/views/admin/editions/_locale_fields.html.erb
@@ -1,4 +1,10 @@
 <div class="govuk-!-margin-bottom-8 app-view-edit-edition__locale-field js-locale-switcher-selector <%= "app-view-edit-edition__locale-field--hidden" unless edition.locale_can_be_changed? %>">
+  <%
+    locale_options = options_for_locales(Locale.non_english)
+    if form.object.primary_locale != "en"
+      locale_options = [%w[English en]] + locale_options
+    end
+  %>
   <%= render "govuk_publishing_components/components/checkboxes", {
     name: "edition[create_foreign_language_only]",
     id: "edition_create_foreign_language_only",
@@ -19,7 +25,7 @@
           heading_size: "m",
           include_blank: true,
           errors: errors_for(edition.errors, :primary_locale),
-          options: options_for_locales(Locale.non_english).map do |language, value|
+          options: locale_options.map do |language, value|
             {
               text: language,
               value: value,

--- a/features/translated-content.feature
+++ b/features/translated-content.feature
@@ -26,3 +26,21 @@ Feature: Providing translated content from gov.uk/government
     And the organisation "Wales Office" is translated into Welsh and has a contact "Wales Office, Cardiff"
     When I add a welsh translation "Cysylltwch â ni" to the "Wales Office, Cardiff" contact
     Then I should see on the admin organisation contacts page that "Wales Office, Cardiff" has a welsh translation "Cysylltwch â ni"
+
+  Scenario: No English option on 'foreign language only' list
+    Given I am a GDS editor
+    When I start creating a document where the locale can be changed
+    Then I should see a "Foreign language only" checkbox
+    And English should not appear on the list of language choices
+
+  Scenario: Switching back to English from a foreign language
+    Given I am a GDS editor
+    When I create a foreign language only document
+    And I return to the edit screen
+    Then the foreign language only box should be checked
+    And English should appear as an option on the list of languages
+    And if I change the language to English
+    Then the edition should return to being an English language only document
+    And the foreign translation should be deleted
+    When I return to the edit screen
+    Then the foreign language only box should be unchecked

--- a/test/unit/app/models/edition/translatable_test.rb
+++ b/test/unit/app/models/edition/translatable_test.rb
@@ -113,4 +113,18 @@ class Edition::TranslatableTest < ActiveSupport::TestCase
     assert world_news_story.available_in_locale?(:fr)
     assert_not world_news_story.available_in_locale?(:en)
   end
+
+  test "changing primary locale of document that has lots of translations updates the primary locale of the translation but does not delete translations" do
+    world_news_story = create(
+      :news_article_world_news_story,
+      primary_locale: "en",
+    )
+    world_news_story.translations.create!(locale: "cy")
+    world_news_story.translations.create!(locale: "fr")
+    world_news_story.update!(primary_locale: "fr")
+    world_news_story.save!
+
+    assert_equal "fr", world_news_story.reload.primary_locale
+    assert_equal %i[en cy fr], world_news_story.reload.translations.map(&:locale)
+  end
 end


### PR DESCRIPTION
This has been successfully tested on Integration 👍 

We had a [support ticket on Zendesk](https://govuk.zendesk.com/agent/#/tickets/5956584) recently: a user created an English document, then accidentally set it to "Foreign language only" mode when trying to add a Welsh translation. The English version became unavailable, and they were unable to switch back to English mode - the document was stuck in "foreign language only" mode.

Whitehall has [three varying levels of support](https://docs.google.com/document/d/1ma5gzJU8EUl3Yo6J6z3XzkEdpqUVLPLPEoSPff9ZduE/edit) for languages:

1. No support (e.g. for Calls for Evidence)
2. Foreign language only (can change primary locale to something other than English, but not provide any other translations)
3. Translatable (can add any number of translations, but not change the primary locale to anything other than English)

There therefore never should be a situation where a publisher has a document with a non-English primary locale AND any translations. Therefore we shouldn't be breaking any existing workflows by triggering the deletion of non-English translations under these circumstances.

NB, I did consider not adding a "English" option to the list of languages, and instead figure out the user's intention from the absence of the checked "foreign language only" checkbox. But this felt rather unsafe - all it would take is for a developer to rename that checkbox and then the absence check would always return `true` and we could find ourselves in a place where non-English documents get mistakenly converted to English ones. See #9569 for the approach if interested.

Trello: https://trello.com/c/5B60uybX/3062-unable-to-uncheck-the-create-a-foreign-language-only-box