### PR TITLE
(656) Show pageviews on dependent content

### DIFF
--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/host_editions_table_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/host_editions_table_component.html.erb
@@ -13,6 +13,9 @@ it out for now-->
       text: "Document Type",
     },
     {
+      text: "Unique pageviews",
+    },
+    {
       text: "Publishing organisation",
     },
     {

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/host_editions_table_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/host_editions_table_component.rb
@@ -22,6 +22,9 @@ private
           text: content_item.document_type.humanize,
         },
         {
+          text: content_item.unique_pageviews ? number_to_human(content_item.unique_pageviews) : nil,
+        },
+        {
           text: organisation_link(content_item),
         },
         {

--- a/lib/engines/content_block_manager/app/models/content_block_manager/host_content_item.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/host_content_item.rb
@@ -7,6 +7,7 @@ module ContentBlockManager
     :publishing_app,
     :last_edited_by_editor_id,
     :last_edited_at,
+    :unique_pageviews,
   )
 
     def last_edited_at

--- a/lib/engines/content_block_manager/app/services/content_block_manager/get_host_content_items.rb
+++ b/lib/engines/content_block_manager/app/services/content_block_manager/get_host_content_items.rb
@@ -24,6 +24,7 @@ module ContentBlockManager
           publishing_app: item["publishing_app"],
           last_edited_by_editor_id: item["last_edited_by_editor_id"],
           last_edited_at: item["last_edited_at"],
+          unique_pageviews: item["unique_pageviews"],
         )
       end
     end

--- a/lib/engines/content_block_manager/test/components/content_block/document/show/host_editions_table_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/document/show/host_editions_table_component_test.rb
@@ -16,6 +16,7 @@ class ContentBlockManager::ContentBlock::Document::Show::HostEditionsTableCompon
     }
   end
   let(:last_edited_by_editor_id) { user.uid }
+  let(:unique_pageviews) { 1_200_000 }
 
   let(:host_content_item) do
     ContentBlockManager::HostContentItem.new(
@@ -26,6 +27,7 @@ class ContentBlockManager::ContentBlock::Document::Show::HostEditionsTableCompon
       "last_edited_by_editor_id" => last_edited_by_editor_id,
       "last_edited_at" => Time.zone.now.to_s,
       "publishing_organisation" => publishing_organisation,
+      "unique_pageviews" => unique_pageviews,
     )
   end
   let(:host_content_items) { [host_content_item] }
@@ -58,6 +60,7 @@ class ContentBlockManager::ContentBlock::Document::Show::HostEditionsTableCompon
 
       assert_selector "tbody .govuk-table__cell", text: host_content_item.title
       assert_selector "tbody .govuk-table__cell", text: host_content_item.document_type.humanize
+      assert_selector "tbody .govuk-table__cell", text: "1.2 Million"
       assert_selector "tbody .govuk-table__cell", text: host_content_item.publishing_organisation["title"]
       assert_selector "tbody .govuk-table__cell", text: "#{time_ago_in_words(host_content_item.last_edited_at)} ago by #{user.name}"
       assert_link user.name, { href: "mailto:#{user.email}" }
@@ -133,6 +136,21 @@ class ContentBlockManager::ContentBlock::Document::Show::HostEditionsTableCompon
       let(:last_edited_by_editor_id) { SecureRandom.uuid }
 
       it_returns_unknown_user
+    end
+
+    context "when unique pageviews can't be found" do
+      let(:unique_pageviews) { nil }
+
+      it "displays not found" do
+        render_inline(
+          described_class.new(
+            caption:,
+            host_content_items:,
+          ),
+        )
+
+        assert_selector "tbody .govuk-table__cell", text: "Not set"
+      end
     end
   end
 end

--- a/lib/engines/content_block_manager/test/factories/host_content_item.rb
+++ b/lib/engines/content_block_manager/test/factories/host_content_item.rb
@@ -7,6 +7,7 @@ FactoryBot.define do
     publishing_app { "publishing_app" }
     last_edited_by_editor_id { SecureRandom.uuid }
     last_edited_at { 2.days.ago.to_s }
+    unique_pageviews { 123 }
 
     initialize_with do
       new(title:,
@@ -15,7 +16,8 @@ FactoryBot.define do
           publishing_organisation:,
           publishing_app:,
           last_edited_by_editor_id:,
-          last_edited_at:)
+          last_edited_at:,
+          unique_pageviews:)
     end
   end
 end

--- a/lib/engines/content_block_manager/test/unit/app/services/get_host_content_items_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/services/get_host_content_items_test.rb
@@ -19,6 +19,7 @@ class ContentBlockManager::GetHostContentItemsTest < ActiveSupport::TestCase
           "publishing_app" => "publisher",
           "last_edited_by_editor_id" => SecureRandom.uuid,
           "last_edited_at" => "2023-01-01T08:00:00.000Z",
+          "unique_pageviews" => 123,
           "primary_publishing_organisation" => {
             "content_id" => SecureRandom.uuid,
             "title" => "bar",
@@ -69,6 +70,7 @@ class ContentBlockManager::GetHostContentItemsTest < ActiveSupport::TestCase
       assert_equal result[0].publishing_app, response_body["results"][0]["publishing_app"]
       assert_equal result[0].last_edited_by_editor_id, response_body["results"][0]["last_edited_by_editor_id"]
       assert_equal result[0].last_edited_at, Time.zone.parse(response_body["results"][0]["last_edited_at"])
+      assert_equal result[0].unique_pageviews, response_body["results"][0]["unique_pageviews"]
 
       assert_equal result[0].publishing_organisation, expected_publishing_organisation
     end


### PR DESCRIPTION
Now Publishing API sends page views in with the Dependent Content payload (see https://github.com/alphagov/publishing-api/pull/2957), we can display this to users

## Screenshot

![image](https://github.com/user-attachments/assets/828a94ba-4c6b-4587-adcf-27959cff6be4)
