### PR TITLE
Link to draft host document for content block preview

### DIFF
--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/host_editions_table_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/host_editions_table_component.rb
@@ -52,8 +52,16 @@ private
     end
   end
 
+  def content_link_text(content_item)
+    sanitize [
+      content_item.title,
+      tag.span("(opens in new tab)", class: "govuk-visually-hidden"),
+    ].join(" ")
+  end
+
   def content_link(content_item)
-    link_to(content_item.title, frontend_path(content_item), class: "govuk-link")
+    link_to(content_link_text(content_item),
+            frontend_path(content_item), class: "govuk-link", target: "_blank", rel: "noopener")
   end
 
   def organisation_link(content_item)

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/host_editions_table_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/host_editions_table_component.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 class ContentBlockManager::ContentBlock::Document::Show::HostEditionsTableComponent < ViewComponent::Base
-  def initialize(caption:, host_content_items:)
+  def initialize(caption:, host_content_items:, is_preview: false)
     @caption = caption
     @host_content_items = host_content_items
+    @is_preview = is_preview
   end
 
 private
@@ -43,8 +44,16 @@ private
     @users ||= User.where(uid: host_content_items.map(&:last_edited_by_editor_id))
   end
 
+  def frontend_path(content_item)
+    if @is_preview
+      Plek.external_url_for("draft-origin") + content_item.base_path
+    else
+      Plek.external_url_for("government-frontend") + content_item.base_path
+    end
+  end
+
   def content_link(content_item)
-    link_to(content_item.title, Plek.website_root + content_item.base_path, class: "govuk-link")
+    link_to(content_item.title, frontend_path(content_item), class: "govuk-link")
   end
 
   def organisation_link(content_item)

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/review_links.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/review_links.html.erb
@@ -13,6 +13,7 @@
   <div class="govuk-grid-column-full">
     <%= render(
           ContentBlockManager::ContentBlock::Document::Show::HostEditionsTableComponent.new(
+            is_preview: true,
             caption: "Content it appears in",
             host_content_items: @host_content_items,
             ),

--- a/lib/engines/content_block_manager/features/edit_object.feature
+++ b/lib/engines/content_block_manager/features/edit_object.feature
@@ -97,3 +97,8 @@ Feature: Edit a content object
     And I visit the Content Block Manager home page
     Then I should still see the live edition on the homepage
 
+  Scenario: GDS editor can preview a host document
+    When I revisit the edit page
+    And I fill out the form
+    Then I am shown where the changes will take place
+    And the host documents link to the draft content store

--- a/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
@@ -420,6 +420,7 @@ When(/^dependent content exists for a content block$/) do
       "content_id" => SecureRandom.uuid,
       "last_edited_by_editor_id" => SecureRandom.uuid,
       "last_edited_at" => 2.days.ago.to_s,
+      "host_content_id" => "abc12345",
       "primary_publishing_organisation" => {
         "content_id" => SecureRandom.uuid,
         "title" => "Organisation #{i}",
@@ -451,6 +452,16 @@ Then(/^I am shown where the changes will take place$/) do
     assert_text item["title"]
     break if item == @dependent_content.last
   end
+end
+
+And("the host documents link to the draft content store") do
+  @dependent_content.each do |item|
+    expect(page).to have_selector("a.govuk-link[href='#{Plek.external_url_for('draft-origin') + item['base_path']}']", text: item["title"])
+  end
+end
+
+When("I click on the first host document") do
+  click_on @dependent_content.first["title"]
 end
 
 When(/^I save and continue$/) do

--- a/lib/engines/content_block_manager/test/components/content_block/document/show/host_editions_table_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/document/show/host_editions_table_component_test.rb
@@ -58,8 +58,12 @@ class ContentBlockManager::ContentBlock::Document::Show::HostEditionsTableCompon
 
       assert_selector "tbody .govuk-table__row", count: 1
 
-      assert_selector "tbody .govuk-table__cell", text: host_content_item.title
-      assert_selector "a[href='#{Plek.external_url_for('government-frontend') + host_content_item.base_path}']", text: host_content_item.title
+      assert_selector ".govuk-link" do |link|
+        assert_equal "#{host_content_item.title} (opens in new tab)", link.text
+        assert_equal Plek.external_url_for("government-frontend") + host_content_item.base_path, link[:href]
+        assert_equal "noopener", link[:rel]
+        assert_equal "_blank", link[:target]
+      end
       assert_selector "tbody .govuk-table__cell", text: host_content_item.document_type.humanize
       assert_selector "tbody .govuk-table__cell", text: "1.2m"
       assert_selector "tbody .govuk-table__cell", text: host_content_item.publishing_organisation["title"]

--- a/lib/engines/content_block_manager/test/components/content_block/document/show/host_editions_table_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/document/show/host_editions_table_component_test.rb
@@ -59,6 +59,7 @@ class ContentBlockManager::ContentBlock::Document::Show::HostEditionsTableCompon
       assert_selector "tbody .govuk-table__row", count: 1
 
       assert_selector "tbody .govuk-table__cell", text: host_content_item.title
+      assert_selector "a[href='#{Plek.external_url_for('government-frontend') + host_content_item.base_path}']", text: host_content_item.title
       assert_selector "tbody .govuk-table__cell", text: host_content_item.document_type.humanize
       assert_selector "tbody .govuk-table__cell", text: "1.2m"
       assert_selector "tbody .govuk-table__cell", text: host_content_item.publishing_organisation["title"]
@@ -150,6 +151,20 @@ class ContentBlockManager::ContentBlock::Document::Show::HostEditionsTableCompon
         )
 
         assert_selector "tbody .govuk-table__cell", text: "Not set"
+      end
+    end
+
+    context "when previewing" do
+      it "returns the draft content store link" do
+        render_inline(
+          described_class.new(
+            is_preview: true,
+            caption:,
+            host_content_items:,
+          ),
+        )
+
+        assert_selector "a[href='#{Plek.external_url_for('draft-origin') + host_content_item.base_path}']", text: host_content_item.title
       end
     end
   end


### PR DESCRIPTION
![Screenshot 2024-11-05 at 11 17 02](https://github.com/user-attachments/assets/a2bf2bc4-9178-48a6-b46d-17956a027281)

This PR includes two changes:
1. Link to draft host document for content block preview
We would like to link to the draft store so that users can see the changes they've just made to the block in host documents. 
As the table component is also used on the 'view' page I am passing in a boolean to determine whether to show draft or live frontend.

2. Open links in new tab
Although opening a new tab is not ideal for accessibility, in this case we think it is the preferred behaviour - opening a new tab can be recommended if a user is in the middle of a for or would lose context of what they are working on if not taken to a new tab. In the case of these host documents, if the user is previewing changes they will be in the middle of the form, if they are just viewing the content block it could be confusing to be taken to gov.uk and out of Content Block Manager.
There is precedent across Whitehall GDS for opening in new tabs when needed, and the mitigation is to include a message for screen readers declaring that the link opens in a new tab. We can test how this approach works for our users and change if needed.



----

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
