### PR TITLE
(656) Change number presentation

### DIFF
--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/host_editions_table_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/host_editions_table_component.rb
@@ -22,7 +22,7 @@ private
           text: content_item.document_type.humanize,
         },
         {
-          text: content_item.unique_pageviews ? number_to_human(content_item.unique_pageviews) : nil,
+          text: content_item.unique_pageviews ? number_to_human(content_item.unique_pageviews, format: "%n%u", precision: 3, significant: true, units: { thousand: "k", million: "m", billion: "b" }) : nil,
         },
         {
           text: organisation_link(content_item),

--- a/lib/engines/content_block_manager/test/components/content_block/document/show/host_editions_table_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/document/show/host_editions_table_component_test.rb
@@ -60,7 +60,7 @@ class ContentBlockManager::ContentBlock::Document::Show::HostEditionsTableCompon
 
       assert_selector "tbody .govuk-table__cell", text: host_content_item.title
       assert_selector "tbody .govuk-table__cell", text: host_content_item.document_type.humanize
-      assert_selector "tbody .govuk-table__cell", text: "1.2 Million"
+      assert_selector "tbody .govuk-table__cell", text: "1.2m"
       assert_selector "tbody .govuk-table__cell", text: host_content_item.publishing_organisation["title"]
       assert_selector "tbody .govuk-table__cell", text: "#{time_ago_in_words(host_content_item.last_edited_at)} ago by #{user.name}"
       assert_link user.name, { href: "mailto:#{user.email}" }


### PR DESCRIPTION
This makes the numbers more in line with how they are presented elsewhere, as well as using shortened forms instead of “Thousand, Million” etc

# Screenshots

## Before

![image](https://github.com/user-attachments/assets/e817901c-a501-4258-a39d-1c7c531318d9)

## After

![image](https://github.com/user-attachments/assets/92f697af-74df-498a-a196-a140ccc8dbfc)
