### PR TITLE
(667) Fix back button on review links page

### DIFF
--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/review_links.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/review_links.html.erb
@@ -3,7 +3,7 @@
 <% content_for :title_margin_bottom, 4 %>
 <% content_for :back_link do %>
   <%= render "govuk_publishing_components/components/back_link", {
-    href: content_block_manager.new_content_block_manager_content_block_edition_path(@content_block_document.id),
+    href: content_block_manager.new_content_block_manager_content_block_document_edition_path(@content_block_document),
   } %>
 <% end %>
 

--- a/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
@@ -83,7 +83,7 @@ end
 Then("I should see a back link to the edit page") do
   expect(page).to have_link(
     "Back",
-    href: content_block_manager.new_content_block_manager_content_block_edition_path(@content_block.document),
+    href: content_block_manager.new_content_block_manager_content_block_document_edition_path(@content_block.document),
   )
 end
 


### PR DESCRIPTION
This should take the user back to the new edition path for a document. This will result in a new draft being created, but it’s fine as we’re deleting obsolete drafts now.