### PR TITLE
fix link to frontend for live host documents

### DIFF
--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/host_editions_table_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/host_editions_table_component.rb
@@ -48,7 +48,7 @@ private
     if @is_preview
       Plek.external_url_for("draft-origin") + content_item.base_path
     else
-      Plek.external_url_for("government-frontend") + content_item.base_path
+      Plek.website_root + content_item.base_path
     end
   end
 

--- a/lib/engines/content_block_manager/test/components/content_block/document/show/host_editions_table_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/document/show/host_editions_table_component_test.rb
@@ -60,7 +60,7 @@ class ContentBlockManager::ContentBlock::Document::Show::HostEditionsTableCompon
 
       assert_selector ".govuk-link" do |link|
         assert_equal "#{host_content_item.title} (opens in new tab)", link.text
-        assert_equal Plek.external_url_for("government-frontend") + host_content_item.base_path, link[:href]
+        assert_equal Plek.website_root + host_content_item.base_path, link[:href]
         assert_equal "noopener", link[:rel]
         assert_equal "_blank", link[:target]
       end


### PR DESCRIPTION
although `government-frontend` works locally, it
does not work in other environments.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
