### PR TITLE
(680) Switch feature flag out for permissions check

### DIFF
--- a/config/features.rb
+++ b/config/features.rb
@@ -22,6 +22,5 @@ Flipflop.configure do
   #   default: true,
   #   description: "Take over the world."
   feature :govspeak_visual_editor, description: "Enables a visual editor for Govspeak fields", default: false
-  feature :content_block_manager, description: "Enables the object store for sharable content", default: Rails.env.development? || Whitehall.integration_or_staging?
   feature :override_government, description: "Enables GDS Editors and Admins to override the government associated with a document", default: false
 end

--- a/lib/engines/content_block_manager/app/controllers/content_block_manager/base_controller.rb
+++ b/lib/engines/content_block_manager/app/controllers/content_block_manager/base_controller.rb
@@ -1,8 +1,9 @@
 class ContentBlockManager::BaseController < Admin::BaseController
-  before_action :check_block_manager_feature_flag, :set_sentry_tags, :prepend_views
+  before_action :check_block_manager_permissions, :set_sentry_tags, :prepend_views
 
-  def check_block_manager_feature_flag
-    forbidden! unless Flipflop.content_block_manager?
+  def check_block_manager_permissions
+    # Temporarily disable production access for non-admin users
+    forbidden! unless Whitehall.integration_or_staging? || current_user.gds_admin?
   end
 
   def scheduled_publication_params

--- a/lib/engines/content_block_manager/features/content_block_manager.feature
+++ b/lib/engines/content_block_manager/features/content_block_manager.feature
@@ -1,7 +1,6 @@
 Feature: Content block manager
 
   Scenario: Correct layout is used
-    Given the content block manager feature flag is enabled
     Given I am a GDS admin
     When I visit the Content Block Manager home page
     Then I should see the object store's title in the header

--- a/lib/engines/content_block_manager/features/create_object.feature
+++ b/lib/engines/content_block_manager/features/create_object.feature
@@ -1,7 +1,6 @@
 Feature: Create a content object
 
   Background:
-    Given the content block manager feature flag is enabled
     Given I am a GDS admin
     And the organisation "Ministry of Example" exists
     And a schema "email_address" exists with the following fields:

--- a/lib/engines/content_block_manager/features/edit_object.feature
+++ b/lib/engines/content_block_manager/features/edit_object.feature
@@ -1,7 +1,6 @@
 Feature: Edit a content object
   Background:
-    Given the content block manager feature flag is enabled
-    And I am a GDS admin
+    Given I am a GDS admin
     And the organisation "Ministry of Example" exists
     And a schema "email_address" exists with the following fields:
       | field         | type   | format | required |

--- a/lib/engines/content_block_manager/features/object_store_feature_flag.feature
+++ b/lib/engines/content_block_manager/features/object_store_feature_flag.feature
@@ -1,9 +1,0 @@
-Feature: Create a content object when feature flag is disabled
-
-  Background:
-    Given the content block manager feature flag is disabled
-    Given I am a GDS admin
-
-  Scenario: GDS editor visits object store
-    When I visit the Content Block Manager home page
-    Then I should see a permissions error

--- a/lib/engines/content_block_manager/features/permissions.feature
+++ b/lib/engines/content_block_manager/features/permissions.feature
@@ -1,0 +1,17 @@
+Feature: Content Block Manager Permissions
+
+  Scenario: GDS editor cannot access the content block manager
+    Given I am a GDS editor
+    When I visit the Content Block Manager home page
+    Then I should see a permissions error
+
+  Scenario: GDS admin can access the content block manager
+    Given I am a GDS admin
+    When I visit the Content Block Manager home page
+    Then I should see the content block manager home page
+
+  Scenario: GDS editor can access the content block manager in non-production environments
+    Given I am in the staging or integration environment
+    And I am a GDS editor
+    When I visit the Content Block Manager home page
+    Then I should see the content block manager home page

--- a/lib/engines/content_block_manager/features/schedule_object.feature
+++ b/lib/engines/content_block_manager/features/schedule_object.feature
@@ -1,7 +1,6 @@
 Feature: Schedule a content object
   Background:
-    Given the content block manager feature flag is enabled
-    And I am a GDS admin
+    Given I am a GDS admin
     And the organisation "Ministry of Example" exists
     And a schema "email_address" exists with the following fields:
       | field         | type   | format | required |

--- a/lib/engines/content_block_manager/features/search_for_object.feature
+++ b/lib/engines/content_block_manager/features/search_for_object.feature
@@ -1,9 +1,9 @@
 Feature: Search for a content object
   Background:
-    Given the content block manager feature flag is enabled
+    Given I am in the staging or integration environment
     And the organisation "Department of Placeholder" exists
     And the organisation "Ministry of Example" exists
-    Given I am an admin in the organisation "Department of Placeholder"
+    And I am an admin in the organisation "Department of Placeholder"
     And a schema "email_address" exists with the following fields:
       | email_address |
     And a schema "postal_address" exists with the following fields:

--- a/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
@@ -5,9 +5,8 @@ Sidekiq.configure_client do |cfg|
   cfg.logger.level = ::Logger::WARN
 end
 
-Given(/^the content block manager feature flag is (enabled|disabled)$/) do |enabled|
-  @test_strategy ||= Flipflop::FeatureSet.current.test!
-  @test_strategy.switch!(:content_block_manager, enabled == "enabled")
+Given("I am in the staging or integration environment") do
+  Whitehall.stubs(:integration_or_staging?).returns(true)
 end
 
 Given("a schema {string} exists with the following fields:") do |block_type, table|
@@ -591,4 +590,8 @@ end
 
 Then(/^I should not see the draft document$/) do
   expect(page).not_to have_content(@title)
+end
+
+Then("I should see the content block manager home page") do
+  expect(page).to have_content("All content blocks")
 end

--- a/lib/engines/content_block_manager/features/view_object.feature
+++ b/lib/engines/content_block_manager/features/view_object.feature
@@ -1,6 +1,5 @@
 Feature: View a content object
   Background:
-    Given the content block manager feature flag is enabled
     Given I am a GDS admin
     And the organisation "Ministry of Example" exists
     And a schema "email_address" exists with the following fields:

--- a/lib/engines/content_block_manager/test/integration/base_test.rb
+++ b/lib/engines/content_block_manager/test/integration/base_test.rb
@@ -8,7 +8,6 @@ end
 
 class ContentBlockManager::BaseTest < ActionDispatch::IntegrationTest
   setup do
-    feature_flags.switch!(:content_block_manager, true)
     login_as_admin
 
     @controller = TestController.new

--- a/lib/engines/content_block_manager/test/integration/content_block/documents_test.rb
+++ b/lib/engines/content_block_manager/test/integration/content_block/documents_test.rb
@@ -9,10 +9,8 @@ class ContentBlockManager::ContentBlock::DocumentsTest < ActionDispatch::Integra
   setup do
     logout
     @organisation = create(:organisation)
-    user = create(:user, organisation: @organisation)
+    user = create(:gds_admin, organisation: @organisation)
     login_as(user)
-
-    feature_flags.switch!(:content_block_manager, true)
   end
 
   describe "#index" do

--- a/lib/engines/content_block_manager/test/integration/content_block/editions_test.rb
+++ b/lib/engines/content_block_manager/test/integration/content_block/editions_test.rb
@@ -9,7 +9,6 @@ class ContentBlockManager::ContentBlock::EditionsTest < ActionDispatch::Integrat
 
   before do
     login_as_admin
-    feature_flags.switch!(:content_block_manager, true)
   end
 
   describe "#new" do

--- a/lib/engines/content_block_manager/test/integration/content_block/workflow_test.rb
+++ b/lib/engines/content_block_manager/test/integration/content_block/workflow_test.rb
@@ -25,8 +25,6 @@ class ContentBlockManager::ContentBlock::WorkflowTest < ActionDispatch::Integrat
 
     stub_request_for_schema("email_address")
 
-    feature_flags.switch!(:content_block_manager, true)
-
     stub_publishing_api_has_embedded_content(content_id: @content_id, total: 0, results: [])
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -272,7 +272,7 @@ class ActionDispatch::IntegrationTest
   end
 
   def login_as_admin
-    login_as(create(:user, name: "admin-name", email: "admin@example.com"))
+    login_as(create(:gds_admin, name: "admin-name", email: "admin@example.com"))
   end
 
   def logout


### PR DESCRIPTION
This removes the Flipflop feature flag check for a simple check of if the environment is staging or integration OR if the user is a GDS admin. Eventually we’ll allow access to all users, so there’s no point adding a new permission, but we do want to control access in production until we’re ready for launch.

I’ve also updated the `login_as_admin` helper, so the user we log in as is actually a GDS admin.
