### PR TITLE
GA4: Remove `section` parameter and `action` parameter from buttons

### DIFF
--- a/app/assets/javascripts/admin/analytics-modules/ga4-button-setup.js
+++ b/app/assets/javascripts/admin/analytics-modules/ga4-button-setup.js
@@ -18,7 +18,6 @@ window.GOVUK.analyticsGa4.analyticsModules =
             event_name: 'navigation',
             type: 'button',
             text: button.textContent,
-            action: button.textContent,
             method: 'primary_click'
           }
           if (button.dataset.ga4Event) {

--- a/app/assets/javascripts/admin/analytics-modules/ga4-button-setup.js
+++ b/app/assets/javascripts/admin/analytics-modules/ga4-button-setup.js
@@ -18,7 +18,6 @@ window.GOVUK.analyticsGa4.analyticsModules =
             event_name: 'navigation',
             type: 'button',
             text: button.textContent,
-            section: document.title.split(' - ')[0].replace('Error: ', ''),
             action: button.textContent,
             method: 'primary_click'
           }

--- a/app/assets/javascripts/admin/analytics-modules/ga4-form-setup.js
+++ b/app/assets/javascripts/admin/analytics-modules/ga4-form-setup.js
@@ -15,7 +15,6 @@ window.GOVUK.analyticsGa4.analyticsModules =
         )
         moduleElement.dataset.ga4Form = JSON.stringify({
           event_name: 'form_response',
-          section: document.title.split(' - ')[0].replace('Error: ', ''),
           action: submitButton.textContent.toLowerCase()
         })
       })

--- a/app/assets/javascripts/admin/analytics-modules/ga4-link-setup.js
+++ b/app/assets/javascripts/admin/analytics-modules/ga4-link-setup.js
@@ -15,7 +15,6 @@ window.GOVUK.analyticsGa4.analyticsModules =
           const event = {
             event_name: 'navigation',
             type: link.role === 'button' ? 'button' : 'generic_link',
-            section: document.title.split(' - ')[0].replace('Error: ', ''),
             method: 'primary_click'
           }
           if (link.dataset.ga4Event) {

--- a/app/assets/javascripts/admin/analytics-modules/ga4-visual-editor-event-handlers.js
+++ b/app/assets/javascripts/admin/analytics-modules/ga4-visual-editor-event-handlers.js
@@ -9,7 +9,6 @@ window.GOVUK.analyticsGa4.analyticsModules =
       event_name: 'select_content',
       type: 'select',
       text: selectText,
-      section: document.title.split(' - ')[0].replace('Error: ', ''),
       action: selectText,
       tool_name: 'Visual Editor'
     }
@@ -22,7 +21,6 @@ window.GOVUK.analyticsGa4.analyticsModules =
       text: buttonText,
       external: 'false',
       method: 'primary click',
-      section: document.title.split(' - ')[0].replace('Error: ', ''),
       action: 'select',
       tool_name: 'Visual Editor'
     }

--- a/app/assets/javascripts/admin/analytics-modules/ga4-visual-editor-event-handlers.js
+++ b/app/assets/javascripts/admin/analytics-modules/ga4-visual-editor-event-handlers.js
@@ -9,7 +9,6 @@ window.GOVUK.analyticsGa4.analyticsModules =
       event_name: 'select_content',
       type: 'select',
       text: selectText,
-      action: selectText,
       tool_name: 'Visual Editor'
     }
   }
@@ -21,7 +20,6 @@ window.GOVUK.analyticsGa4.analyticsModules =
       text: buttonText,
       external: 'false',
       method: 'primary click',
-      action: 'select',
       tool_name: 'Visual Editor'
     }
   }

--- a/spec/javascripts/admin/analytics-modules/ga4-button-setup.spec.js
+++ b/spec/javascripts/admin/analytics-modules/ga4-button-setup.spec.js
@@ -18,7 +18,7 @@ describe('GOVUK.analyticsGa4.analyticsModules', function () {
     ga4ButtonSetup.init()
 
     expect(button.dataset.ga4Event).toEqual(
-      '{"event_name":"navigation","type":"button","text":"Button","section":"Title","action":"Button","method":"primary_click"}'
+      '{"event_name":"navigation","type":"button","text":"Button","method":"primary_click"}'
     )
   })
 
@@ -29,7 +29,7 @@ describe('GOVUK.analyticsGa4.analyticsModules', function () {
     ga4ButtonSetup.init()
 
     expect(button.dataset.ga4Event).toEqual(
-      '{"event_name":"navigation","type":"button","text":"Button","section":"Title","action":"Button","method":"primary_click"}'
+      '{"event_name":"navigation","type":"button","text":"Button","method":"primary_click"}'
     )
   })
 
@@ -42,7 +42,7 @@ describe('GOVUK.analyticsGa4.analyticsModules', function () {
     ga4ButtonSetup.init()
 
     expect(button.dataset.ga4Event).toEqual(
-      '{"event_name":"custom_event_name","type":"button","text":"Button","section":"Title","action":"Button","method":"primary_click"}'
+      '{"event_name":"custom_event_name","type":"button","text":"Button","method":"primary_click"}'
     )
   })
 
@@ -56,7 +56,7 @@ describe('GOVUK.analyticsGa4.analyticsModules', function () {
     ga4ButtonSetup.init()
 
     expect(link.dataset.ga4Event).toEqual(
-      '{"event_name":"navigation","type":"button","text":"Link","section":"Title","action":"Link","method":"primary_click"}'
+      '{"event_name":"navigation","type":"button","text":"Link","method":"primary_click"}'
     )
   })
 })

--- a/spec/javascripts/admin/analytics-modules/ga4-form-setup.spec.js
+++ b/spec/javascripts/admin/analytics-modules/ga4-form-setup.spec.js
@@ -18,7 +18,7 @@ describe('GOVUK.analyticsGa4.analyticsModules.Ga4FormSetup', function () {
     Ga4FormSetup.init()
 
     expect(container.dataset.ga4Form).toEqual(
-      '{"event_name":"form_response","section":"Title","action":"button"}'
+      '{"event_name":"form_response","action":"button"}'
     )
   })
 })

--- a/spec/javascripts/admin/analytics-modules/ga4-link-setup.spec.js
+++ b/spec/javascripts/admin/analytics-modules/ga4-link-setup.spec.js
@@ -17,7 +17,7 @@ describe('GOVUK.analyticsGa4.analyticsModules.Ga4LinkSetup', function () {
     Ga4LinkSetup.init()
 
     expect(link.dataset.ga4Event).toEqual(
-      '{"event_name":"navigation","type":"generic_link","section":"Title","method":"primary_click"}'
+      '{"event_name":"navigation","type":"generic_link","method":"primary_click"}'
     )
   })
 
@@ -28,7 +28,7 @@ describe('GOVUK.analyticsGa4.analyticsModules.Ga4LinkSetup', function () {
     Ga4LinkSetup.init()
 
     expect(link.dataset.ga4Event).toEqual(
-      '{"event_name":"navigation","type":"button","section":"Title","method":"primary_click"}'
+      '{"event_name":"navigation","type":"button","method":"primary_click"}'
     )
   })
 })

--- a/spec/javascripts/admin/analytics-modules/ga4-visual-editor-event-handlers.spec.js
+++ b/spec/javascripts/admin/analytics-modules/ga4-visual-editor-event-handlers.spec.js
@@ -1,6 +1,5 @@
 describe('GOVUK.analyticsGa4.analyticsModules.Ga4VisualEditorEventHandlers', function () {
   it('triggers ga4 tracking on visualEditorSelectChange event', function () {
-    document.title = 'Title - Text'
     const container = document.createElement('div')
     const select = document.createElement('select')
     container.setAttribute('data-module', 'ga4-visual-editor-event-handlers')
@@ -28,8 +27,6 @@ describe('GOVUK.analyticsGa4.analyticsModules.Ga4VisualEditorEventHandlers', fun
       event_name: 'select_content',
       type: 'select',
       text: 'DROPDOWN',
-      section: 'Title',
-      action: 'DROPDOWN',
       tool_name: 'Visual Editor'
     }
 
@@ -40,7 +37,6 @@ describe('GOVUK.analyticsGa4.analyticsModules.Ga4VisualEditorEventHandlers', fun
   })
 
   it('triggers ga4 tracking on visualEditorButtonClick event', function () {
-    document.title = 'Title - Text'
     const container = document.createElement('div')
     const button = document.createElement('button')
     container.setAttribute('data-module', 'ga4-visual-editor-event-handlers')
@@ -70,8 +66,6 @@ describe('GOVUK.analyticsGa4.analyticsModules.Ga4VisualEditorEventHandlers', fun
       text: 'BUTTON',
       external: 'false',
       method: 'primary click',
-      section: 'Title',
-      action: 'select',
       tool_name: 'Visual Editor'
     }
 


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What
- Remove section from all GA4 tracking
- Remove `action` from button tracking
- https://trello.com/c/2Cac4RaO/3121-update-parameters-for-button-tracking

## Why
- Their value has not been decided by PAs so should be set to `undefined` for the time being.