### PR TITLE
(629) Update summary cards

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -2,6 +2,7 @@
 
 //= require govuk_publishing_components/dependencies
 //= require govuk_publishing_components/analytics-ga4
+//= require govuk_publishing_components/components/accordion
 //= require govuk_publishing_components/components/copy-to-clipboard
 //= require govuk_publishing_components/components/govspeak
 //= require govuk_publishing_components/components/reorderable-list

--- a/lib/engines/content_block_manager/app/assets/stylesheets/content_block_manager/application.scss
+++ b/lib/engines/content_block_manager/app/assets/stylesheets/content_block_manager/application.scss
@@ -1,1 +1,2 @@
+@import "components/filter-options-component";
 @import "components/timeline-component";

--- a/lib/engines/content_block_manager/app/assets/stylesheets/content_block_manager/components/_filter-options-component.scss
+++ b/lib/engines/content_block_manager/app/assets/stylesheets/content_block_manager/components/_filter-options-component.scss
@@ -1,0 +1,62 @@
+.app-c-content-block-manager-filter-options {
+  .govuk-accordion__section-toggle,
+  .govuk-accordion__controls .govuk-accordion-nav__chevron {
+    @include govuk-visually-hidden;
+  }
+
+  @mixin chevron($dir) {
+    &:before {
+      border-style: solid;
+      border-width: 0.2em 0.2em 0 0;
+      content: "";
+      display: inline-block;
+      height: 0.45em;
+      left: 0.15em;
+      position: relative;
+      vertical-align: top;
+      width: 0.45em;
+
+      @include govuk-responsive-margin(3, "right");
+
+      @if $dir == "down" {
+        top: 0.2em;
+        transform: rotate(135deg);
+      }
+
+      @if $dir == "up" {
+        top: 0.35em;
+        transform: rotate(-45deg);
+      }
+    }
+  }
+
+  .govuk-accordion__controls {
+    .govuk-accordion__show-all {
+      .govuk-accordion__show-all-text {
+        @include govuk-font($size: 19, $weight: bold);
+        color: govuk-colour("black");
+        @include chevron("down");
+      }
+
+      &[aria-expanded="true"] {
+        .govuk-accordion__show-all-text {
+          @include chevron("up");
+        }
+      }
+    }
+  }
+
+  .govuk-accordion__section-button {
+    .govuk-accordion__section-heading-text {
+      @include govuk-font($size: 19, $weight: bold);
+
+      @include chevron("down");
+    }
+
+    &[aria-expanded="true"] {
+      .govuk-accordion__section-heading-text {
+        @include chevron("up");
+      }
+    }
+  }
+}

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/index/filter_options_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/index/filter_options_component.html.erb
@@ -60,8 +60,15 @@
     ],
   } %>
 
-  <%= render "govuk_publishing_components/components/button", {
-    text: "View results",
-    margin_bottom: 4,
-  } %>
+  <div class="govuk-button-group">
+    <%= render "govuk_publishing_components/components/button", {
+      text: "View results",
+      margin_bottom: 4,
+    } %>
+
+    <%= link_to "Reset all fields",
+                helpers.content_block_manager.content_block_manager_root_path(reset_fields: true),
+                class: "govuk-link" %>
+  </div>
+
 <% end %>

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/index/filter_options_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/index/filter_options_component.html.erb
@@ -1,31 +1,63 @@
-<%= form_with url: helpers.content_block_manager.content_block_manager_content_block_documents_path, method: :get do %>
-  <%= render "govuk_publishing_components/components/input", {
-    label: {
-      text: "Keyword",
-      bold: true,
-    },
-    hint: 'For example, "driving standards"',
-    name: "keyword",
-    id: "keyword_filter",
-    value: !@filters.nil? && @filters[:keyword],
-  } %>
-
-  <%= render "govuk_publishing_components/components/checkboxes", {
-    heading: "Content block type",
-    heading_size: "s",
-    no_hint_text: true,
-    id: "block_type",
-    name: "block_type[]",
-    items: items_for_block_type,
-  } %>
-
-  <%= render "components/select_with_search", {
-    id: "lead_organisation",
-    name: "lead_organisation",
-    label:  "Lead organisation",
-    heading_size: "s",
-    include_blank: false,
-    options: options_for_lead_organisation,
+<%= form_with url: helpers.content_block_manager.content_block_manager_content_block_documents_path, method: :get, class: "app-c-content-block-manager-filter-options" do %>
+  <%= render "govuk_publishing_components/components/accordion", {
+    disable_ga4: true,
+    items: [
+      {
+        heading: {
+          text: "Search by keyword",
+        },
+        content: {
+          html: (
+            render "govuk_publishing_components/components/input", {
+              label: {
+                text: "Keyword",
+                bold: true,
+              },
+              hint: 'For example, "driving standards"',
+              name: "keyword",
+              id: "keyword_filter",
+              value: @filters.present? && @filters[:keyword],
+            }
+          ),
+        },
+        expanded: @filters&.fetch(:keyword, nil).present?,
+      },
+      {
+        heading: {
+          text: "Content block type",
+        },
+        content: {
+          html: (
+            render "govuk_publishing_components/components/checkboxes", {
+              heading: "Content block type",
+              visually_hide_heading: true,
+              heading_size: "s",
+              no_hint_text: true,
+              id: "block_type",
+              name: "block_type[]",
+              items: items_for_block_type,
+            }
+          ),
+        },
+        expanded: @filters&.fetch(:block_type, nil).present?,
+      },
+      {
+        heading: {
+          text: "Lead organisation",
+        },
+        content: {
+          html: (
+            render "components/select_with_search", {
+              id: "lead_organisation",
+              name: "lead_organisation",
+              include_blank: false,
+              options: options_for_lead_organisation,
+            }
+          ),
+        },
+        expanded: @filters&.fetch(:lead_organisation, nil).present?,
+      },
+    ],
   } %>
 
   <%= render "govuk_publishing_components/components/button", {

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/index/summary_card_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/index/summary_card_component.rb
@@ -11,6 +11,16 @@ private
     end
   end
 
+  def items
+    [
+      title_item,
+      *details_items,
+      organisation_item,
+      last_updated_item,
+      embed_code_item,
+    ]
+  end
+
   def title
     content_block_document.title
   end

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/summary_list_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/summary_list_component.rb
@@ -12,7 +12,7 @@ private
       title_item,
       *details_items,
       organisation_item,
-      creator_item,
+      last_updated_item,
       embed_code_item,
       state_item,
       scheduled_item,
@@ -56,11 +56,15 @@ private
     end
   end
 
-  def creator_item
+  def last_updated_item
     {
-      field: "Creator",
-      value: content_block_document.latest_edition.creator.name,
+      field: "Last updated",
+      value: last_updated_value,
     }
+  end
+
+  def last_updated_value
+    "#{time_ago_in_words(content_block_document.latest_edition.updated_at)} ago by #{content_block_document.latest_edition.creator.name}"
   end
 
   def state_item

--- a/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/documents_controller.rb
+++ b/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/documents_controller.rb
@@ -5,7 +5,7 @@ class ContentBlockManager::ContentBlock::DocumentsController < ContentBlockManag
       @filters = params_filters
       @content_block_documents = ContentBlockManager::ContentBlock::Document::DocumentFilter.new(@filters).documents
       render :index
-    elsif session_filters.any?
+    elsif params[:reset_fields].blank? && session_filters.any?
       redirect_to content_block_manager.content_block_manager_root_path(session_filters)
     else
       redirect_to content_block_manager.content_block_manager_root_path(default_filters)

--- a/lib/engines/content_block_manager/app/models/content_block_manager/content_block/document/document_filter.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/content_block/document/document_filter.rb
@@ -7,10 +7,11 @@ module ContentBlockManager
     def documents
       documents = ContentBlock::Document
       documents = documents.live
+      documents = documents.joins(:latest_edition)
       documents = documents.with_keyword(@filters[:keyword]) if @filters[:keyword].present?
       documents = documents.where(block_type: @filters[:block_type]) if @filters[:block_type].present?
       documents = documents.with_lead_organisation(@filters[:lead_organisation]) if @filters[:lead_organisation].present?
-      documents
+      documents.order("content_block_editions.updated_at DESC")
     end
   end
 end

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/documents/index.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/documents/index.html.erb
@@ -1,12 +1,23 @@
-<% content_for :context, product_name %>
-<% content_for :title, "All content blocks" %>
+<% content_for :title, product_name %>
+<% content_for :title_margin_bottom, 6 %>
 
 <div class="govuk-grid-row govuk-!-margin-bottom-8">
   <div class="govuk-grid-column-full">
-    <%= render "govuk_publishing_components/components/button", {
-      text: "Create new object",
-      href: content_block_manager.new_content_block_manager_content_block_document_path,
-    } %>
+    <p class="govuk-body govuk-!-margin-bottom-1">Create, edit and use modular content.</p>
+    <p class="govuk-body">If you need any support or want to delete a content block, you can raise a support request.</p>
+    <span class="govuk-!-margin-right-2">
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Create new object",
+        href: content_block_manager.new_content_block_manager_content_block_document_path,
+      } %>
+    </span>
+    <span>
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Raise a support request",
+        href: "https://govuk.zendesk.com",
+        secondary_solid: true,
+      } %>
+    </span>
   </div>
 </div>
 

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/documents/index.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/documents/index.html.erb
@@ -20,6 +20,8 @@
   </div>
   <div class="govuk-grid-column-two-thirds">
     <h2 class="govuk-heading-m"><%= pluralize(@content_block_documents.count, "result") %></h2>
+    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+    <p class="govuk-body"><strong>Sorted by last updated first</strong></p>
     <% @content_block_documents.each do |content_block_document| %>
       <%= render ContentBlockManager::ContentBlock::Document::Index::SummaryCardComponent.new(content_block_document:) %>
     <% end %>

--- a/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
@@ -584,7 +584,9 @@ end
 
 Then(/^I should still see the live edition on the homepage$/) do
   within(".govuk-summary-card", text: @content_block.document.title) do
-    expect(page).to have_content("Published")
+    @content_block.details.keys.each do |key|
+      expect(page).to have_content(@content_block.details[key])
+    end
   end
 end
 

--- a/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
@@ -244,7 +244,7 @@ And("no draft Content Block Document has been created") do
 end
 
 Then("I should see the details for all documents") do
-  assert_text "All content blocks"
+  assert_text "Content Block Manager"
 
   ContentBlockManager::ContentBlock::Document.find_each do |document|
     should_show_summary_card_for_email_address_content_block(
@@ -595,7 +595,7 @@ Then(/^I should not see the draft document$/) do
 end
 
 Then("I should see the content block manager home page") do
-  expect(page).to have_content("All content blocks")
+  expect(page).to have_content("Content Block Manager")
 end
 
 When("I click to copy the embed code") do

--- a/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
@@ -340,7 +340,7 @@ def should_show_summary_list_for_email_address_content_block(document_title, ema
   expect(page).to have_selector(".govuk-summary-list__value", text: email_address)
   expect(page).to have_selector(".govuk-summary-list__key", text: "Lead organisation")
   expect(page).to have_selector(".govuk-summary-list__value", text: organisation)
-  expect(page).to have_selector(".govuk-summary-list__key", text: "Creator")
+  expect(page).to have_selector(".govuk-summary-list__key", text: "Last updated")
   expect(page).to have_selector(".govuk-summary-list__value", text: @user.name)
   expect(page).to have_selector(".govuk-summary-list__actions", text: "Change")
 end

--- a/lib/engines/content_block_manager/test/components/content_block/document/index/filter_options_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/document/index/filter_options_component_test.rb
@@ -9,6 +9,7 @@ class ContentBlockManager::ContentBlock::Document::Index::FilterOptionsComponent
     ContentBlockManager::ContentBlock::Document::Index::FilterOptionsComponent.any_instance.stubs(:helpers).returns(helper_mock)
     helper_mock.stubs(:content_block_manager).returns(helper_mock)
     helper_mock.stubs(:content_block_manager_content_block_documents_path).returns("path")
+    helper_mock.stubs(:content_block_manager_root_path).returns("path")
 
     helper_mock.stubs(:taggable_organisations_container).returns(
       [["Department of Placeholder", 1], ["Ministry of Example", 2]],

--- a/lib/engines/content_block_manager/test/components/content_block/document/index/filter_options_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/document/index/filter_options_component_test.rb
@@ -1,59 +1,84 @@
 require "test_helper"
 
 class ContentBlockManager::ContentBlock::Document::Index::FilterOptionsComponentTest < ViewComponent::TestCase
-  test "adds value of keyword to text input from filter" do
-    render_inline(ContentBlockManager::ContentBlock::Document::Index::FilterOptionsComponent.new(
-                    filters: { keyword: "ministry defense" },
-                  ))
+  extend Minitest::Spec::DSL
 
+  let(:helper_mock) { mock }
+
+  before do
+    ContentBlockManager::ContentBlock::Document::Index::FilterOptionsComponent.any_instance.stubs(:helpers).returns(helper_mock)
+    helper_mock.stubs(:content_block_manager).returns(helper_mock)
+    helper_mock.stubs(:content_block_manager_content_block_documents_path).returns("path")
+
+    helper_mock.stubs(:taggable_organisations_container).returns(
+      [["Department of Placeholder", 1], ["Ministry of Example", 2]],
+    )
+
+    ContentBlockManager::ContentBlock::Schema.stubs(:valid_schemas).returns(%w[email_address postal_address])
+  end
+
+  it "collapses all sections by default" do
+    render_inline(
+      ContentBlockManager::ContentBlock::Document::Index::FilterOptionsComponent.new(
+        filters: {},
+      ),
+    )
+    assert_selector ".govuk-accordion__section--expanded", count: 0
+  end
+
+  it "adds value of keyword to text input from filter" do
+    render_inline(
+      ContentBlockManager::ContentBlock::Document::Index::FilterOptionsComponent.new(
+        filters: { keyword: "ministry defense" },
+      ),
+    )
+
+    assert_selector ".govuk-accordion__section--expanded", count: 1
+    assert_selector ".govuk-accordion__section--expanded", text: "Keyword"
     assert_selector "input[name='keyword'][value='ministry defense']"
   end
 
-  test "renders checkbox items for all valid schemas" do
-    ContentBlockManager::ContentBlock::Schema.expects(:valid_schemas).returns(%w[email_address postal_address])
-    render_inline(ContentBlockManager::ContentBlock::Document::Index::FilterOptionsComponent.new(
-                    filters: {},
-                  ))
+  it "renders checkbox items for all valid schemas" do
+    render_inline(
+      ContentBlockManager::ContentBlock::Document::Index::FilterOptionsComponent.new(
+        filters: {},
+      ),
+    )
 
     assert_selector "input[type='checkbox'][name='block_type[]'][value='email_address']"
     assert_selector "input[type='checkbox'][name='block_type[]'][value='postal_address']"
   end
 
-  test "checks checkbox items if checked in filters" do
-    ContentBlockManager::ContentBlock::Schema.expects(:valid_schemas).returns(%w[email_address postal_address])
-    render_inline(ContentBlockManager::ContentBlock::Document::Index::FilterOptionsComponent.new(
-                    filters: { block_type: %w[email_address] },
-                  ))
+  it "checks checkbox items if checked in filters" do
+    render_inline(
+      ContentBlockManager::ContentBlock::Document::Index::FilterOptionsComponent.new(
+        filters: { block_type: %w[email_address] },
+      ),
+    )
+
+    assert_selector ".govuk-accordion__section--expanded", count: 1
+    assert_selector ".govuk-accordion__section--expanded", text: "Content block type"
 
     assert_selector "input[type='checkbox'][name='block_type[]'][value='email_address'][checked]"
     assert_selector "input[type='checkbox'][name='block_type[]'][value='postal_address']"
   end
 
-  test "returns organisations with an 'all organisations' option" do
-    helper_mock = mock
-    ContentBlockManager::ContentBlock::Document::Index::FilterOptionsComponent.any_instance.stubs(:helpers).returns(helper_mock)
-    helper_mock.stubs(:content_block_manager).returns(helper_mock)
-    helper_mock.stubs(:content_block_manager_content_block_documents_path).returns("path")
-    helper_mock.stubs(:taggable_organisations_container).returns(
-      [["Department of Placeholder", 1], ["Ministry of Example", 2]],
-    )
+  it "returns organisations with an 'all organisations' option" do
     render_inline(ContentBlockManager::ContentBlock::Document::Index::FilterOptionsComponent.new(filters: {}))
 
     assert_selector "select[name='lead_organisation']"
     assert_selector "option[selected='selected'][value='']"
   end
 
-  test "selects organisation if selected in filters" do
-    helper_mock = mock
-    ContentBlockManager::ContentBlock::Document::Index::FilterOptionsComponent.any_instance.stubs(:helpers).returns(helper_mock)
-    helper_mock.stubs(:content_block_manager).returns(helper_mock)
-    helper_mock.stubs(:content_block_manager_content_block_documents_path).returns("path")
-    helper_mock.stubs(:taggable_organisations_container).returns(
-      [["Department of Placeholder", 1], ["Ministry of Example", 2]],
+  it "selects organisation if selected in filters" do
+    render_inline(
+      ContentBlockManager::ContentBlock::Document::Index::FilterOptionsComponent.new(
+        filters: { lead_organisation: "2" },
+      ),
     )
-    render_inline(ContentBlockManager::ContentBlock::Document::Index::FilterOptionsComponent.new(
-                    filters: { lead_organisation: "2" },
-                  ))
+
+    assert_selector ".govuk-accordion__section--expanded", count: 1
+    assert_selector ".govuk-accordion__section--expanded", text: "Lead organisation"
 
     assert_selector "select[name='lead_organisation']"
     assert_selector "option[selected='selected'][value=2]"

--- a/lib/engines/content_block_manager/test/components/content_block/document/index/summary_card_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/document/index/summary_card_component_test.rb
@@ -15,6 +15,7 @@ class ContentBlockManager::ContentBlock::Document::Index::SummaryCardComponentTe
       organisation: build(:organisation),
       scheduled_publication: Time.zone.now,
       state: "published",
+      updated_at: 1.day.ago,
     )
   end
 
@@ -27,7 +28,7 @@ class ContentBlockManager::ContentBlock::Document::Index::SummaryCardComponentTe
     assert_selector ".govuk-summary-card__action", count: 1
     assert_selector ".govuk-summary-card__action .govuk-link[href='#{content_block_manager_content_block_document_path(content_block_document)}']"
 
-    assert_selector ".govuk-summary-list__row", count: 7
+    assert_selector ".govuk-summary-list__row", count: 6
 
     assert_selector ".govuk-summary-list__key", text: "Title"
     assert_selector ".govuk-summary-list__value", text: content_block_edition.title
@@ -41,26 +42,12 @@ class ContentBlockManager::ContentBlock::Document::Index::SummaryCardComponentTe
     assert_selector ".govuk-summary-list__key", text: "Lead organisation"
     assert_selector ".govuk-summary-list__value", text: content_block_edition.lead_organisation.name
 
-    assert_selector ".govuk-summary-list__key", text: "Creator"
-    assert_selector ".govuk-summary-list__value", text: content_block_edition.creator.name
+    assert_selector ".govuk-summary-list__key", text: "Last updated"
+    assert_selector ".govuk-summary-list__value", text: "1 day ago by #{content_block_edition.creator.name}"
 
     assert_selector ".govuk-summary-list__row[data-module='copy-embed-code']", text: "Embed code"
     assert_selector ".govuk-summary-list__row[data-embed-code='#{content_block_document.embed_code}']", text: "Embed code"
     assert_selector ".govuk-summary-list__key", text: "Embed code"
     assert_selector ".govuk-summary-list__value", text: content_block_document.embed_code
-
-    assert_selector ".govuk-summary-list__key", text: "State"
-    assert_selector ".govuk-summary-list__value", text: content_block_edition.state.titleize
-  end
-
-  it "renders a scheduled content block as a summary card" do
-    content_block_document.latest_edition.state = "scheduled"
-
-    render_inline(ContentBlockManager::ContentBlock::Document::Index::SummaryCardComponent.new(content_block_document:))
-
-    assert_selector ".govuk-summary-list__row", count: 8
-
-    assert_selector ".govuk-summary-list__key", text: "Scheduled for publication at"
-    assert_selector ".govuk-summary-list__value", text: I18n.l(content_block_edition.scheduled_publication, format: :long_ordinal)
   end
 end

--- a/lib/engines/content_block_manager/test/components/content_block/document/show/summary_list_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/document/show/summary_list_component_test.rb
@@ -13,6 +13,7 @@ class ContentBlockManager::ContentBlock::Document::Show::SummaryListComponentTes
       organisation:,
       scheduled_publication: Time.zone.now,
       state: "published",
+      updated_at: 1.day.ago,
     )
   end
   let(:content_block_document) { content_block_edition.document }
@@ -36,8 +37,8 @@ class ContentBlockManager::ContentBlock::Document::Show::SummaryListComponentTes
     assert_selector ".govuk-summary-list__key", text: "Lead organisation"
     assert_selector ".govuk-summary-list__value", text: "Department for Example"
 
-    assert_selector ".govuk-summary-list__key", text: "Creator"
-    assert_selector ".govuk-summary-list__value", text: content_block_edition.creator.name
+    assert_selector ".govuk-summary-list__key", text: "Last updated"
+    assert_selector ".govuk-summary-list__value", text: "1 day ago by #{content_block_edition.creator.name}"
 
     assert_selector ".govuk-summary-list__row[data-module='copy-embed-code']", text: "Embed code"
     assert_selector ".govuk-summary-list__row[data-embed-code='#{content_block_document.embed_code}']", text: "Embed code"

--- a/lib/engines/content_block_manager/test/integration/content_block/documents_test.rb
+++ b/lib/engines/content_block_manager/test/integration/content_block/documents_test.rb
@@ -49,7 +49,9 @@ class ContentBlockManager::ContentBlock::DocumentsTest < ActionDispatch::Integra
       document_mock = mock
 
       ContentBlockManager::ContentBlock::Document.expects(:live).returns(document_mock)
-      document_mock.expects(:with_lead_organisation).with(@organisation.id.to_s).returns([document_with_latest_edition])
+      document_mock.expects(:joins).with(:latest_edition).returns(document_mock)
+      document_mock.expects(:with_lead_organisation).with(@organisation.id.to_s).returns(document_mock)
+      document_mock.expects(:order).with("content_block_editions.updated_at DESC").returns([document_with_latest_edition])
 
       visit content_block_manager.content_block_manager_content_block_documents_path
 

--- a/lib/engines/content_block_manager/test/integration/content_block/documents_test.rb
+++ b/lib/engines/content_block_manager/test/integration/content_block/documents_test.rb
@@ -69,11 +69,20 @@ class ContentBlockManager::ContentBlock::DocumentsTest < ActionDispatch::Integra
       end
 
       describe "when there are session filters" do
-        it "adds them to the params by default the next time user visits" do
+        before do
           visit content_block_manager.content_block_manager_content_block_documents_path({ keyword: "something" })
+        end
+
+        it "adds them to the params by default the next time user visits" do
           visit content_block_manager.content_block_manager_content_block_documents_path
 
           assert_current_path content_block_manager.content_block_manager_root_path({ keyword: "something" })
+        end
+
+        it "resets the filters when reset_fields is set" do
+          visit content_block_manager.content_block_manager_content_block_documents_path({ reset_fields: true })
+
+          assert_current_path content_block_manager.content_block_manager_root_path({ lead_organisation: @organisation.id.to_s })
         end
       end
     end

--- a/lib/engines/content_block_manager/test/unit/app/models/content_block_edition/document/document_filter_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/models/content_block_edition/document/document_filter_test.rb
@@ -4,10 +4,16 @@ class ContentBlockManager::DocumentFilterTest < ActiveSupport::TestCase
   extend Minitest::Spec::DSL
 
   describe "documents" do
+    let(:document_scope_mock) { mock }
+
+    before do
+      ContentBlockManager::ContentBlock::Document.expects(:live).returns(document_scope_mock)
+      document_scope_mock.expects(:joins).with(:latest_edition).returns(document_scope_mock)
+      document_scope_mock.expects(:order).with("content_block_editions.updated_at DESC")
+    end
+
     describe "when no filters are given" do
       it "returns live documents" do
-        document_scope_mock = mock
-        ContentBlockManager::ContentBlock::Document.expects(:live).returns(document_scope_mock)
         document_scope_mock.expects(:with_keyword).never
         document_scope_mock.expects(:where).never
         document_scope_mock.expects(:with_lead_organisation).never
@@ -18,38 +24,30 @@ class ContentBlockManager::DocumentFilterTest < ActiveSupport::TestCase
 
     describe "when a keyword filter is given" do
       it "returns live documents with keyword" do
-        document_scope_mock = mock
-        ContentBlockManager::ContentBlock::Document.expects(:live).returns(document_scope_mock)
-        document_scope_mock.expects(:with_keyword).with("ministry of example").returns([])
+        document_scope_mock.expects(:with_keyword).with("ministry of example").returns(document_scope_mock)
         ContentBlockManager::ContentBlock::Document::DocumentFilter.new({ keyword: "ministry of example" }).documents
       end
     end
 
     describe "when a block type is given" do
       it "returns live documents of the type given" do
-        document_scope_mock = mock
-        ContentBlockManager::ContentBlock::Document.expects(:live).returns(document_scope_mock)
-        document_scope_mock.expects(:where).with(block_type: %w[email_address]).returns([])
+        document_scope_mock.expects(:where).with(block_type: %w[email_address]).returns(document_scope_mock)
         ContentBlockManager::ContentBlock::Document::DocumentFilter.new({ block_type: %w[email_address] }).documents
       end
     end
 
     describe "when a lead organisation id is given" do
       it "returns live documents with lead org given" do
-        document_scope_mock = mock
-        ContentBlockManager::ContentBlock::Document.expects(:live).returns(document_scope_mock)
-        document_scope_mock.expects(:with_lead_organisation).with("123").returns([])
+        document_scope_mock.expects(:with_lead_organisation).with("123").returns(document_scope_mock)
         ContentBlockManager::ContentBlock::Document::DocumentFilter.new({ lead_organisation: "123" }).documents
       end
     end
 
     describe "when block types, keyword and organisation is given" do
       it "returns live documents with the filters given" do
-        document_scope_mock = mock
-        ContentBlockManager::ContentBlock::Document.expects(:live).returns(document_scope_mock)
         document_scope_mock.expects(:with_keyword).with("ministry of example").returns(document_scope_mock)
         document_scope_mock.expects(:where).with(block_type: %w[email_address]).returns(document_scope_mock)
-        document_scope_mock.expects(:with_lead_organisation).with("123").returns([])
+        document_scope_mock.expects(:with_lead_organisation).with("123").returns(document_scope_mock)
         ContentBlockManager::ContentBlock::Document::DocumentFilter.new(
           { block_type: %w[email_address], keyword: "ministry of example", lead_organisation: "123" },
         ).documents


### PR DESCRIPTION
This updates the summary cards on the homepage, as well as some tweaks to the copy.

## Screenshot

![image](https://github.com/user-attachments/assets/8577fa6b-da6b-46f2-bbec-5d983bbf90a5)

