### PR TITLE
Enable monaco editor for new landing pages

### DIFF
--- a/app/assets/javascripts/components/yaml-editor.js
+++ b/app/assets/javascripts/components/yaml-editor.js
@@ -18,12 +18,12 @@ window.GOVUK.Modules = window.GOVUK.Modules || {}
       }
     }
     // NOTE: This is currently very specifically overriding the body field
-    //       in the edit edition form. If we actually wanted a YamlEditor,
+    //       in the edition form. If we actually wanted a YamlEditor,
     //       we would probably want it to be more general than this.
     //
     //       This should just be temporary code for the landing pages, while
     //       we work out a CMS though. So for now it's okay to be specific.
-    const form = this.module.querySelector('form#edit_edition')
+    const form = this.module.querySelector('form.edition-form')
     const outerContainer = form?.querySelector(
       '.app-c-govspeak-editor:has(#edition_body)'
     )


### PR DESCRIPTION
The form only has the id #edit_edition when we're editing an edition. It has #new_edition when we're creating a new edition. In either case, it has the .edition-form class, so let's use that for our selector instead:

https://github.com/alphagov/whitehall/blob/3bff7dd08ea39b71d5d63305a33b87394287d04a/app/helpers/admin/editions_helper.rb#L105

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
