### PR TITLE
Fix double tracking for some events

### DIFF
--- a/app/assets/javascripts/admin/analytics-modules/ga4-button-setup.js
+++ b/app/assets/javascripts/admin/analytics-modules/ga4-button-setup.js
@@ -24,6 +24,9 @@ window.GOVUK.analyticsGa4.analyticsModules =
             Object.assign(event, JSON.parse(button.dataset.ga4Event))
           }
           button.dataset.ga4Event = JSON.stringify(event)
+          button.dataset.module =
+            (button.dataset.module || '') + ' ga4-event-tracker'
+          GOVUK.modules.start(button)
         })
       })
     }

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -22,7 +22,7 @@
 
   <%= render partial: "shared/header" %>
 
-  <div class="govuk-width-container" data-module="ga4-event-tracker ga4-paste-tracker">
+  <div class="govuk-width-container" data-module="ga4-paste-tracker">
     <%= render "shared/phase_banner", {
       show_feedback_banner: t("admin.feedback.show_banner"),
     } %>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

- Remove `ga4-event-tracker` from width container
  - It was causing double tracking to occur for all components that have tracking built in
- When setting up a button form tracking, add the `ga4-event-tracker` and initialise it
  - This ensures the button is tracked without affecting other elements on the page

- Accompanying this PR is an update to the `govuk_publishing_components` documentation.
  - https://github.com/alphagov/govuk_publishing_components/pull/4377

- https://trello.com/c/Mt7YXtIc/3040-bugs-double-tracking-in-some-events