### PR TITLE
SPIKE: display `controller_name` in title

### DIFF
--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -14,7 +14,7 @@
 <%= render "govuk_publishing_components/components/layout_for_admin",
            product_name:,
            environment: environment,
-           browser_title: ("Error: " if yield(:error_summary).present?).to_s + sanitized_title do %>
+           browser_title: controller_name do %>
 
   <div data-module="ga4-page-view-tracking" data-attributes='<%= track_analytics_data_on_load(sanitized_title) %>'></div>
 


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Display the controller name in the page title so its eligibility as a form of categorisation for tracking can be evaluated.

https://trello.com/c/R2kwIDVF/3137-spike-decide-on-page-grouping-categorisation-for-analytics