### PR TITLE
Change CaseStudyPresenter to use Frontend rendering app

### DIFF
--- a/app/presenters/publishing_api/case_study_presenter.rb
+++ b/app/presenters/publishing_api/case_study_presenter.rb
@@ -22,7 +22,7 @@ module PublishingApi
           details:,
           document_type:,
           public_updated_at: item.public_timestamp || item.updated_at,
-          rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
+          rendering_app: Whitehall::RenderingApp::FRONTEND,
           schema_name: "case_study",
           auth_bypass_ids: [item.auth_bypass_id],
         )

--- a/test/unit/app/presenters/publishing_api/case_study_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/case_study_presenter_test.rb
@@ -23,7 +23,7 @@ class PublishingApi::CaseStudyPresenterTest < ActiveSupport::TestCase
       locale: "en",
       public_updated_at: case_study.public_timestamp,
       publishing_app: Whitehall::PublishingApp::WHITEHALL,
-      rendering_app: "government-frontend",
+      rendering_app: "frontend",
       routes: [
         { path: public_path, type: "exact" },
       ],


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Ticket: https://trello.com/c/ybpXwp34/368-move-document-type-casestudy-from-government-frontend-to-frontend

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
