### PR TITLE
(678) Allow sorting on dependent content

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -243,7 +243,7 @@ GEM
       et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
     fuzzy_match (2.1.0)
-    gds-api-adapters (97.1.0)
+    gds-api-adapters (97.3.0)
       addressable
       link_header
       null_logger

--- a/lib/engines/content_block_manager/app/assets/stylesheets/content_block_manager/application.scss
+++ b/lib/engines/content_block_manager/app/assets/stylesheets/content_block_manager/application.scss
@@ -1,2 +1,3 @@
 @import "components/filter-options-component";
+@import "components/host-editions-table-component";
 @import "components/timeline-component";

--- a/lib/engines/content_block_manager/app/assets/stylesheets/content_block_manager/components/_host-editions-table-component.scss
+++ b/lib/engines/content_block_manager/app/assets/stylesheets/content_block_manager/components/_host-editions-table-component.scss
@@ -1,0 +1,63 @@
+.app-c-host-editions-table {
+  .govuk-table__header {
+    .app-table__sort-link {
+      display: inline-block;
+      position: relative;
+      padding-right: $sort-link-arrow-size;
+      color: $govuk-link-colour;
+      text-decoration: none;
+      @include govuk-link-style-no-visited-state;
+    }
+
+    .app-table__sort-link:focus {
+      @include govuk-focused-text;
+    }
+
+    .app-table__sort-link::after {
+      content: "";
+      position: absolute;
+      top: 5px;
+      right: 0;
+      @include govuk-shape-arrow($direction: up, $base: $sort-link-arrow-size-small, $display: block);
+    }
+
+    .app-table__sort-link::before {
+      content: "";
+      position: absolute;
+      top: 13px;
+      right: 0;
+      @include govuk-shape-arrow($direction: down, $base: $sort-link-arrow-size-small, $display: block);
+    }
+  }
+
+  .govuk-table__header--active {
+    .app-table__sort-link {
+      padding-right: govuk-spacing(4);
+    }
+
+    .app-table__sort-link--ascending::before,
+    .app-table__sort-link--descending::before {
+      content: none;
+    }
+
+    .app-table__sort-link--ascending::after {
+      content: "";
+      position: absolute;
+      top: $sort-link-arrow-spacing;
+      right: 0;
+      margin-left: govuk-spacing(1);
+
+      @include govuk-shape-arrow($direction: up, $base: $sort-link-arrow-size, $display: inline-block);
+    }
+
+    .app-table__sort-link--descending::after {
+      content: "";
+      position: absolute;
+      top: $sort-link-arrow-spacing;
+      right: 0;
+      margin-left: govuk-spacing(1);
+
+      @include govuk-shape-arrow($direction: down, $base: $sort-link-arrow-size, $display: inline-block);
+    }
+  }
+}

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/host_editions_table_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/host_editions_table_component.html.erb
@@ -2,25 +2,47 @@
 <!-- TODO: The prototype wants to show a counter beneath the title but
 before the table, the existing component doesn't support that so I've left
 it out for now-->
-<%= render "govuk_publishing_components/components/table", {
-  caption:,
-  caption_classes: "govuk-heading-l",
-  head: [
-    {
-      text: "Title",
-    },
-    {
-      text: "Document Type",
-    },
-    {
-      text: "Unique pageviews",
-    },
-    {
-      text: "Publishing organisation",
-    },
-    {
-      text: "Updated",
-    },
-  ],
-  rows:,
-} %>
+<div class="app-c-host-editions-table" id="<%= TABLE_ID %>">
+  <%= render "govuk_publishing_components/components/table", {
+    caption:,
+    caption_classes: "govuk-heading-l",
+    head: [
+      {
+        text: "Title",
+        href: sort_link("title"),
+        sort_direction: sort_direction("title"),
+      },
+      {
+        text: "Document Type",
+        href: sort_link("document_type"),
+        sort_direction: sort_direction("document_type"),
+      },
+      {
+        text: "Unique pageviews",
+        href: sort_link("unique_pageviews"),
+        sort_direction: sort_direction("unique_pageviews"),
+      },
+      {
+        text: "Publishing organisation",
+        href: sort_link("primary_publishing_organisation_title"),
+        sort_direction: sort_direction("primary_publishing_organisation_title"),
+      },
+      {
+        text: "Updated",
+        href: sort_link("last_edited_at"),
+        sort_direction: sort_direction("last_edited_at"),
+      },
+    ],
+    rows:,
+  } %>
+
+  <% if total_pages > 1 %>
+    <% Admin::PaginationHelper.pagination_hash(current_page:, total_pages:, path: base_pagination_path).tap do |hash| %>
+      <%= render "components/pagination", {
+        previous_href: hash[:previous_href],
+        next_href: hash[:next_href],
+        items: hash[:items],
+      } %>
+    <% end %>
+  <% end %>
+</div>

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/host_editions_table_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/host_editions_table_component.rb
@@ -1,15 +1,31 @@
 # frozen_string_literal: true
 
 class ContentBlockManager::ContentBlock::Document::Show::HostEditionsTableComponent < ViewComponent::Base
-  def initialize(caption:, host_content_items:, is_preview: false)
+  TABLE_ID = "host_editions"
+
+  def initialize(caption:, host_content_items:, is_preview: false, current_page: nil, order: nil)
     @caption = caption
     @host_content_items = host_content_items
     @is_preview = is_preview
+    @current_page = current_page.presence || 1
+    @order = order.presence || ContentBlockManager::GetHostContentItems::DEFAULT_ORDER
+  end
+
+  def current_page
+    @current_page.to_i
+  end
+
+  def total_pages
+    host_content_items.total_pages.to_i
+  end
+
+  def base_pagination_path
+    "#{request.url}##{TABLE_ID}"
   end
 
 private
 
-  attr_reader :caption, :host_content_items
+  attr_reader :caption, :host_content_items, :order
 
   def rows
     return [] unless host_content_items
@@ -33,6 +49,22 @@ private
         },
       ]
     end
+  end
+
+  def sort_direction(param)
+    case order
+    when param
+      "ascending"
+    when "-#{param}"
+      "descending"
+    end
+  end
+
+  def sort_link(param)
+    if sort_direction(param) == "ascending"
+      param = "-#{param}"
+    end
+    helpers.content_block_manager.url_for(only_path: false, params: { order: param }, anchor: TABLE_ID)
   end
 
   # TODO: Currently, we're only fetching Users from the local Whitehall database, which means

--- a/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/documents_controller.rb
+++ b/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/documents_controller.rb
@@ -15,9 +15,13 @@ class ContentBlockManager::ContentBlock::DocumentsController < ContentBlockManag
   def show
     @content_block_document = ContentBlockManager::ContentBlock::Document.find(params[:id])
     @content_block_versions = @content_block_document.versions
+    @order = params[:order]
+    @page = params[:page]
 
     @host_content_items = ContentBlockManager::GetHostContentItems.by_embedded_document(
       content_block_document: @content_block_document,
+      order: @order,
+      page: @page,
     )
   end
 

--- a/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/editions/workflow_controller.rb
+++ b/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/editions/workflow_controller.rb
@@ -68,8 +68,13 @@ private
 
   def review_links
     @content_block_document = @content_block_edition.document
+    @order = params[:order]
+    @page = params[:page]
+
     @host_content_items = ContentBlockManager::GetHostContentItems.by_embedded_document(
       content_block_document: @content_block_document,
+      order: @order,
+      page: @page,
     )
 
     render :review_links

--- a/lib/engines/content_block_manager/app/models/content_block_manager/host_content_items.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/host_content_items.rb
@@ -1,0 +1,9 @@
+module ContentBlockManager
+  class HostContentItems < Data.define(:items, :total, :total_pages)
+    extend Forwardable
+
+    ARRAY_METHODS = ([].methods - Object.methods)
+
+    def_delegators :items, *ARRAY_METHODS
+  end
+end

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/documents/show.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/documents/show.html.erb
@@ -18,6 +18,8 @@
       ContentBlockManager::ContentBlock::Document::Show::HostEditionsTableComponent.new(
         caption: "Content appears in",
         host_content_items: @host_content_items,
+        current_page: @page,
+        order: @order,
       ),
     ) %>
   </div>

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/review_links.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/review_links.html.erb
@@ -16,6 +16,8 @@
             is_preview: true,
             caption: "Content it appears in",
             host_content_items: @host_content_items,
+            current_page: @page,
+            order: @order,
             ),
           ) %>
   </div>

--- a/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
@@ -428,7 +428,11 @@ When(/^dependent content exists for a content block$/) do
     }
   end
 
-  stub_publishing_api_has_embedded_content(content_id: anything, results: @dependent_content, total: @dependent_content.length)
+  stub_publishing_api_has_embedded_content_for_any_content_id(
+    results: @dependent_content,
+    total: @dependent_content.length,
+    order: ContentBlockManager::GetHostContentItems::DEFAULT_ORDER,
+  )
 end
 
 Then(/^I should see the dependent content listed$/) do

--- a/lib/engines/content_block_manager/features/support/stubs.rb
+++ b/lib/engines/content_block_manager/features/support/stubs.rb
@@ -1,3 +1,3 @@
 Before do
-  stub_publishing_api_has_embedded_content(content_id: anything, total: 0, results: [])
+  stub_publishing_api_has_embedded_content_for_any_content_id(total: 0, results: [], order: ContentBlockManager::GetHostContentItems::DEFAULT_ORDER)
 end

--- a/lib/engines/content_block_manager/test/factories/host_content_items.rb
+++ b/lib/engines/content_block_manager/test/factories/host_content_items.rb
@@ -1,0 +1,13 @@
+FactoryBot.define do
+  factory :host_content_items, class: "ContentBlockManager::HostContentItems" do
+    total_pages { 1 }
+    total { 10 }
+    items { build_list(:host_content_item, 10) }
+
+    initialize_with do
+      new(total_pages:,
+          total:,
+          items:)
+    end
+  end
+end

--- a/lib/engines/content_block_manager/test/integration/content_block/documents_test.rb
+++ b/lib/engines/content_block_manager/test/integration/content_block/documents_test.rb
@@ -133,4 +133,25 @@ class ContentBlockManager::ContentBlock::DocumentsTest < ActionDispatch::Integra
       assert_equal new_content_block_manager_content_block_edition_path(block_type:), path
     end
   end
+
+  describe "#show" do
+    let(:edition) { create(:content_block_edition, :email_address) }
+    let(:document) { edition.document }
+
+    it "returns information about the document" do
+      stub_publishing_api_has_embedded_content_for_any_content_id(
+        results: [],
+        total: 0,
+        order: ContentBlockManager::GetHostContentItems::DEFAULT_ORDER,
+      )
+
+      visit content_block_manager_content_block_document_path(document)
+
+      assert_text document.title
+    end
+
+    it_returns_embedded_content do
+      visit content_block_manager_content_block_document_path(document)
+    end
+  end
 end

--- a/lib/engines/content_block_manager/test/integration/content_block/workflow_test.rb
+++ b/lib/engines/content_block_manager/test/integration/content_block/workflow_test.rb
@@ -56,16 +56,8 @@ class ContentBlockManager::ContentBlock::WorkflowTest < ActionDispatch::Integrat
       let(:step) { ContentBlockManager::ContentBlock::Editions::WorkflowController::UPDATE_BLOCK_STEPS[:review_links] }
 
       describe "#show" do
-        it "shows host content items" do
-          host_content_items = build_list(:host_content_item, 2)
-          ContentBlockManager::GetHostContentItems.expects(:by_embedded_document)
-                                                 .with(content_block_document: document)
-                                                 .returns(host_content_items)
-
-          get content_block_manager.content_block_manager_content_block_workflow_path(id: edition.id, step:)
-
-          assert_template "content_block_manager/content_block/editions/workflow/review_links"
-          assert_equal host_content_items, assigns(:host_content_items)
+        it_returns_embedded_content do
+          visit content_block_manager.content_block_manager_content_block_workflow_path(id: edition.id, step:)
         end
       end
 

--- a/lib/engines/content_block_manager/test/integration/content_block/workflow_test.rb
+++ b/lib/engines/content_block_manager/test/integration/content_block/workflow_test.rb
@@ -25,7 +25,7 @@ class ContentBlockManager::ContentBlock::WorkflowTest < ActionDispatch::Integrat
 
     stub_request_for_schema("email_address")
 
-    stub_publishing_api_has_embedded_content(content_id: @content_id, total: 0, results: [])
+    stub_publishing_api_has_embedded_content(content_id: @content_id, total: 0, results: [], order: ContentBlockManager::GetHostContentItems::DEFAULT_ORDER)
   end
 
   describe "when creating a new content block" do

--- a/lib/engines/content_block_manager/test/support/embedded_content_helpers.rb
+++ b/lib/engines/content_block_manager/test/support/embedded_content_helpers.rb
@@ -1,0 +1,128 @@
+class ActionDispatch::IntegrationTest
+  def self.it_returns_embedded_content(&block)
+    let(:host_content_items) do
+      10.times.map do |i|
+        {
+          "title" => "Content #{i}",
+          "document_type" => "document",
+          "base_path" => "/",
+          "content_id" => SecureRandom.uuid,
+          "last_edited_by_editor_id" => SecureRandom.uuid,
+          "last_edited_at" => 2.days.ago.to_s,
+          "host_content_id" => "abc12345",
+          "primary_publishing_organisation" => {
+            "content_id" => SecureRandom.uuid,
+            "title" => "Organisation #{i}",
+            "base_path" => "/organisation/#{i}",
+          },
+        }
+      end
+    end
+
+    before do
+      stub_publishing_api_has_embedded_content_for_any_content_id(
+        results: host_content_items,
+        total: host_content_items.length,
+        order: ContentBlockManager::GetHostContentItems::DEFAULT_ORDER,
+      )
+    end
+
+    it "returns host content items" do
+      instance_exec(&block)
+
+      host_content_items.each do |content_item|
+        assert_text content_item["title"]
+      end
+    end
+
+    it "supports pagination" do
+      pages = []
+      3.times do |i|
+        pages << host_content_items.map { |item| item.merge("title" => "#{item['title']} - Page #{i}") }
+      end
+
+      total = pages.length + host_content_items.length
+
+      stub_publishing_api_has_embedded_content_for_any_content_id(
+        results: host_content_items,
+        total:,
+        total_pages: 4,
+        order: ContentBlockManager::GetHostContentItems::DEFAULT_ORDER,
+      )
+
+      pages.each.with_index(2) do |page, i|
+        stub_publishing_api_has_embedded_content_for_any_content_id(
+          results: page,
+          total:,
+          total_pages: 4,
+          order: ContentBlockManager::GetHostContentItems::DEFAULT_ORDER,
+          page_number: i.to_s,
+        )
+      end
+
+      instance_exec(&block)
+      click_on "Next page"
+
+      pages.each do |page|
+        page.each do |item|
+          assert_text item["title"]
+        end
+
+        click_on "Next page" unless page == pages.last
+      end
+    end
+
+    it "supports sorting" do
+      sorted_by_asc = {}
+      sorted_by_desc = {}
+      sort_fields = %w[title document_type unique_pageviews primary_publishing_organisation_title last_edited_at]
+
+      sort_fields.each do |key|
+        sorted_by_asc[key] = host_content_items.map { |item| item.merge("title" => "#{item['title']} - Sorted by #{key} asc") }
+        sorted_by_desc[key] = host_content_items.map { |item| item.merge("title" => "#{item['title']} - Sorted by #{key} desc") }
+      end
+
+      sorted_by_asc.each do |key, items|
+        stub_publishing_api_has_embedded_content_for_any_content_id(
+          results: items,
+          total: items.count,
+          order: key,
+        )
+      end
+
+      sorted_by_desc.each do |key, items|
+        stub_publishing_api_has_embedded_content_for_any_content_id(
+          results: items,
+          total: items.count,
+          order: "-#{key}",
+        )
+      end
+
+      should_be_sorted_by = proc do |field, order|
+        hash_to_match = order == :asc ? sorted_by_asc : sorted_by_desc
+        hash_to_match[field].each do |item|
+          assert_text item["title"]
+        end
+      end
+
+      instance_exec(&block)
+
+      initial_sort = sort_fields.delete("unique_pageviews")
+
+      should_be_sorted_by.call(initial_sort, :desc)
+
+      find("a[href*='order=#{initial_sort}']").click
+      should_be_sorted_by.call(initial_sort, :asc)
+
+      sort_fields.each do |field|
+        within ".app-c-host-editions-table" do
+          find("a[href*='order=#{field}']").click
+          should_be_sorted_by.call(field, :asc)
+
+          find("a[href*='order=-#{field}']").click
+          should_be_sorted_by.call(field, :desc)
+        end
+      end
+    end
+  end
+end

--- a/lib/engines/content_block_manager/test/unit/app/models/host_content_item_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/models/host_content_item_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class ContentBlockManager::SchemaTest < ActiveSupport::TestCase
+class ContentBlockManager::HostContentItemTest < ActiveSupport::TestCase
   extend Minitest::Spec::DSL
 
   describe "#last_edited_at" do

--- a/lib/engines/content_block_manager/test/unit/app/models/host_content_items_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/models/host_content_items_test.rb
@@ -1,0 +1,25 @@
+require "test_helper"
+
+class ContentBlockManager::HostContentItemsTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
+  let(:items) { build_list(:host_content_item, 5) }
+  let(:total) { 12 }
+  let(:total_pages) { 2 }
+  let(:host_content_items) { build(:host_content_items, items:, total:, total_pages:) }
+
+  it "delegates array methods to items" do
+    ([].methods - Object.methods).each do |method|
+      assert host_content_items.respond_to?(method)
+    end
+
+    host_content_items.each_with_index do |item, i|
+      assert_equal item, items[i]
+    end
+  end
+
+  it "returns page count values" do
+    assert_equal host_content_items.total, total
+    assert_equal host_content_items.total_pages, total_pages
+  end
+end

--- a/lib/engines/content_block_manager/test/unit/app/services/schedule_edition_service_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/services/schedule_edition_service_test.rb
@@ -15,7 +15,7 @@ class ContentBlockManager::ScheduleEditionServiceTest < ActiveSupport::TestCase
   end
 
   setup do
-    stub_publishing_api_has_embedded_content(content_id:, total: 0, results: [])
+    stub_publishing_api_has_embedded_content(content_id:, total: 0, results: [], order: ContentBlockManager::GetHostContentItems::DEFAULT_ORDER)
   end
 
   describe "#call" do
@@ -97,7 +97,7 @@ class ContentBlockManager::ScheduleEditionServiceTest < ActiveSupport::TestCase
           },
         ]
 
-      stub_publishing_api_has_embedded_content(content_id:, total: 0, results: dependent_content)
+      stub_publishing_api_has_embedded_content(content_id:, total: 0, results: dependent_content, order: ContentBlockManager::GetHostContentItems::DEFAULT_ORDER)
 
       ContentBlockManager::PublishIntentWorker.expects(:perform_async).with(
         "/host-document",


### PR DESCRIPTION
This allows sorting and pagination on dependent content, both on the view and review pages

## Screenshots

_Note: I temporarily changed the number of results per page to demonstrate the pagination_

![image](https://github.com/user-attachments/assets/3e39011c-204a-4a2d-856d-f2166774712d)

![image](https://github.com/user-attachments/assets/e07291d9-8961-4e8c-afab-ae0ac5e9abb8)