### PR TITLE
Content modelling/630 pagination homepage

### DIFF
--- a/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/documents_controller.rb
+++ b/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/documents_controller.rb
@@ -3,7 +3,7 @@ class ContentBlockManager::ContentBlock::DocumentsController < ContentBlockManag
     if params_filters.any?
       session[:content_block_filters] = params_filters
       @filters = params_filters
-      @content_block_documents = ContentBlockManager::ContentBlock::Document::DocumentFilter.new(@filters).documents
+      @content_block_documents = ContentBlockManager::ContentBlock::Document::DocumentFilter.new(@filters).paginated_documents
       render :index
     elsif params[:reset_fields].blank? && session_filters.any?
       redirect_to content_block_manager.content_block_manager_root_path(session_filters)
@@ -36,7 +36,7 @@ class ContentBlockManager::ContentBlock::DocumentsController < ContentBlockManag
 private
 
   def params_filters
-    params.slice(:keyword, :block_type, :lead_organisation)
+    params.slice(:keyword, :block_type, :lead_organisation, :page)
           .permit!
           .to_h
   end

--- a/lib/engines/content_block_manager/app/models/content_block_manager/content_block/document/document_filter.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/content_block/document/document_filter.rb
@@ -4,7 +4,21 @@ module ContentBlockManager
       @filters = filters
     end
 
-    def documents
+    def paginated_documents
+      unpaginated_documents.page(page).per(default_page_size)
+    end
+
+  private
+
+    def page
+      @filters[:page].presence || 1
+    end
+
+    def default_page_size
+      Admin::EditionFilter::GOVUK_DESIGN_SYSTEM_PER_PAGE
+    end
+
+    def unpaginated_documents
       documents = ContentBlock::Document
       documents = documents.live
       documents = documents.joins(:latest_edition)

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/documents/index.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/documents/index.html.erb
@@ -30,7 +30,7 @@
           ) %>
   </div>
   <div class="govuk-grid-column-two-thirds">
-    <h2 class="govuk-heading-m"><%= pluralize(@content_block_documents.count, "result") %></h2>
+    <h2 class="govuk-heading-m"><%= pluralize(@content_block_documents.total_count, "result") %></h2>
     <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
     <p class="govuk-body"><strong>Sorted by last updated first</strong></p>
     <% @content_block_documents.each do |content_block_document| %>

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/documents/index.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/documents/index.html.erb
@@ -36,5 +36,7 @@
     <% @content_block_documents.each do |content_block_document| %>
       <%= render ContentBlockManager::ContentBlock::Document::Index::SummaryCardComponent.new(content_block_document:) %>
     <% end %>
+
+    <%= paginate(@content_block_documents, theme: "govuk_paginator") %>
   </div>
 </div>

--- a/lib/engines/content_block_manager/features/search_for_object.feature
+++ b/lib/engines/content_block_manager/features/search_for_object.feature
@@ -27,34 +27,34 @@ Feature: Search for a content object
     And I should see the details for all documents from my organisation
     When I select the lead organisation "All organisations"
     And I click to view results
-    Then "3" content blocks are returned
+    Then "3" content blocks are returned in total
 
   Scenario: GDS Editor searches for a content object by keyword in title
     When I visit the Content Block Manager home page
     And I enter the keyword "example search"
     And I click to view results
     Then I should see the content block with title "example search title" returned
-    And "1" content blocks are returned
+    And "1" content blocks are returned in total
 
   Scenario: GDS Editor searches for a content object by keyword in details
     When I visit the Content Block Manager home page
     And I enter the keyword "ABC123"
     And I click to view results
     Then I should see the content block with title "an address" returned
-    And "1" content blocks are returned
+    And "1" content blocks are returned in total
 
   Scenario: GDS Editor searches for a content object by block type
     When I visit the Content Block Manager home page
     And I select the lead organisation "All organisations"
     And I check the block type "Email address"
     And I click to view results
-    And "2" content blocks are returned
+    And "2" content blocks are returned in total
 
   Scenario: GDS Editor searches for a content object by lead organisation
     When I visit the Content Block Manager home page
     And I select the lead organisation "Ministry of Example"
     And I click to view results
-    And "1" content blocks are returned
+    And "1" content blocks are returned in total
 
   @javascript
   Scenario: GDS Editor can copy embed code
@@ -65,12 +65,17 @@ Feature: Search for a content object
     Then the embed code should be copied to my clipboard
 
   Scenario: GDS Editor can view more than one page
+    When 1 content blocks of type email_address have been created with the fields:
+      | title | page 2 edition |
+      | email_address  | ministry@example.com |
+      | organisation | Ministry of Example |
     When 15 content blocks of type email_address have been created with the fields:
-      | title | ministry address |
+      | title | page 1 edition |
       | email_address  | ministry@example.com |
       | organisation | Ministry of Example |
     When I visit the Content Block Manager home page
     And I select the lead organisation "Ministry of Example"
     And I click to view results
+    Then I should see the content block with title "page 1 edition" returned
     And I click on page 2
-    Then "1" content blocks are returned
+    Then I should see the content block with title "page 2 edition" returned

--- a/lib/engines/content_block_manager/features/search_for_object.feature
+++ b/lib/engines/content_block_manager/features/search_for_object.feature
@@ -63,3 +63,14 @@ Feature: Search for a content object
     And I click to view results
     And I click to copy the embed code for the content block "ministry address"
     Then the embed code should be copied to my clipboard
+
+  Scenario: GDS Editor can view more than one page
+    When 15 content blocks of type email_address have been created with the fields:
+      | title | ministry address |
+      | email_address  | ministry@example.com |
+      | organisation | Ministry of Example |
+    When I visit the Content Block Manager home page
+    And I select the lead organisation "Ministry of Example"
+    And I click to view results
+    And I click on page 2
+    Then "1" content blocks are returned

--- a/lib/engines/content_block_manager/features/search_for_object.feature
+++ b/lib/engines/content_block_manager/features/search_for_object.feature
@@ -8,15 +8,15 @@ Feature: Search for a content object
       | email_address |
     And a schema "postal_address" exists with the following fields:
       | an_address |
-    And a "postal_address" type of content block has been created with fields:
+    And 1 content blocks of type postal_address have been created with the fields:
       | title |  "an address" |
       | an_address  | ABC123 |
       | organisation | Department of Placeholder |
-    And a "email_address" type of content block has been created with fields:
+    And 1 content blocks of type email_address have been created with the fields:
       | title | example search title |
       | email_address  | hello@example.com |
       | organisation | Department of Placeholder |
-    And a "email_address" type of content block has been created with fields:
+    And 1 content blocks of type email_address have been created with the fields:
       | title | ministry address |
       | email_address  | ministry@example.com |
       | organisation | Ministry of Example |

--- a/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
@@ -286,7 +286,7 @@ Then("I should see the content block with title {string} returned") do |title|
   expect(page).to have_selector(".govuk-summary-card__title", text: title)
 end
 
-Then("{string} content blocks are returned") do |count|
+Then("{string} content blocks are returned in total") do |count|
   assert_text "#{count} #{'result'.pluralize(count.to_i)}"
 end
 

--- a/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
@@ -36,6 +36,14 @@ When("I click cancel") do
   click_button "Cancel"
 end
 
+Then(/^I click on page ([^"]*)$/) do |page_number|
+  click_link page_number
+end
+
+When("I click on page ") do
+  click_button "Cancel"
+end
+
 When("I click to view results") do
   click_button "View results"
 end
@@ -190,21 +198,24 @@ Given("an email address content block has been created") do
   @content_blocks.push(@content_block)
 end
 
-Given("a {string} type of content block has been created with fields:") do |block_type, table|
+Given(/^([^"]*) content blocks of type ([^"]*) have been created with the fields:$/) do |count, block_type, table|
   fields = table.rows_hash
   organisation_name = fields.delete("organisation")
   organisation = Organisation.where(name: organisation_name).first
   title = fields.delete("title") || "title"
-  document = create(:content_block_document, block_type.to_sym, title:)
 
-  create(
-    :content_block_edition,
-    block_type.to_sym,
-    document:,
-    organisation:,
-    details: fields,
-    creator: @user,
-  )
+  (1..count.to_i).each do |_i|
+    document = create(:content_block_document, block_type.to_sym, title:)
+
+    create(
+      :content_block_edition,
+      block_type.to_sym,
+      document:,
+      organisation:,
+      details: fields,
+      creator: @user,
+    )
+  end
 end
 
 Given("an email address content block has been created with the following email address and title:") do |table|

--- a/lib/engines/content_block_manager/test/integration/content_block/documents_test.rb
+++ b/lib/engines/content_block_manager/test/integration/content_block/documents_test.rb
@@ -38,22 +38,16 @@ class ContentBlockManager::ContentBlock::DocumentsTest < ActionDispatch::Integra
     end
 
     it "only returns documents with a latest edition" do
-      document_with_latest_edition = build(:content_block_document, :email_address, id: 123)
-      document_with_latest_edition.latest_edition = build(
+      document_with_latest_edition = create(:content_block_document, :email_address)
+      document_with_latest_edition.latest_edition = create(
         :content_block_edition,
         :email_address,
         details: { "email_address" => "live_edition@example.com" },
         document_id: document_with_latest_edition.id,
       )
-      document_without_latest_edition = build(:content_block_document, :email_address, title: "no latest edition")
-      document_mock = mock
+      document_without_latest_edition = create(:content_block_document, :email_address, title: "no latest edition")
 
-      ContentBlockManager::ContentBlock::Document.expects(:live).returns(document_mock)
-      document_mock.expects(:joins).with(:latest_edition).returns(document_mock)
-      document_mock.expects(:with_lead_organisation).with(@organisation.id.to_s).returns(document_mock)
-      document_mock.expects(:order).with("content_block_editions.updated_at DESC").returns([document_with_latest_edition])
-
-      visit content_block_manager.content_block_manager_content_block_documents_path
+      visit content_block_manager.content_block_manager_content_block_documents_path({ lead_organisation: "" })
 
       assert_text document_with_latest_edition.latest_edition.details["email_address"]
       assert_no_text document_without_latest_edition.title

--- a/lib/engines/content_block_manager/test/unit/app/models/content_block_edition/document/document_filter_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/models/content_block_edition/document/document_filter_test.rb
@@ -3,54 +3,72 @@ require "test_helper"
 class ContentBlockManager::DocumentFilterTest < ActiveSupport::TestCase
   extend Minitest::Spec::DSL
 
-  describe "documents" do
+  describe "paginated_documents" do
     let(:document_scope_mock) { mock }
 
     before do
       ContentBlockManager::ContentBlock::Document.expects(:live).returns(document_scope_mock)
       document_scope_mock.expects(:joins).with(:latest_edition).returns(document_scope_mock)
-      document_scope_mock.expects(:order).with("content_block_editions.updated_at DESC")
+      document_scope_mock.expects(:order).with("content_block_editions.updated_at DESC").returns(document_scope_mock)
+      document_scope_mock.expects(:per).with(15).returns([])
     end
 
     describe "when no filters are given" do
       it "returns live documents" do
+        document_scope_mock.expects(:page).with(1).returns(document_scope_mock)
+
         document_scope_mock.expects(:with_keyword).never
         document_scope_mock.expects(:where).never
         document_scope_mock.expects(:with_lead_organisation).never
 
-        ContentBlockManager::ContentBlock::Document::DocumentFilter.new({}).documents
+        ContentBlockManager::ContentBlock::Document::DocumentFilter.new({}).paginated_documents
       end
     end
 
     describe "when a keyword filter is given" do
       it "returns live documents with keyword" do
+        document_scope_mock.expects(:page).with(1).returns(document_scope_mock)
+
         document_scope_mock.expects(:with_keyword).with("ministry of example").returns(document_scope_mock)
-        ContentBlockManager::ContentBlock::Document::DocumentFilter.new({ keyword: "ministry of example" }).documents
+        ContentBlockManager::ContentBlock::Document::DocumentFilter.new({ keyword: "ministry of example" }).paginated_documents
       end
     end
 
     describe "when a block type is given" do
       it "returns live documents of the type given" do
+        document_scope_mock.expects(:page).with(1).returns(document_scope_mock)
+
         document_scope_mock.expects(:where).with(block_type: %w[email_address]).returns(document_scope_mock)
-        ContentBlockManager::ContentBlock::Document::DocumentFilter.new({ block_type: %w[email_address] }).documents
+        ContentBlockManager::ContentBlock::Document::DocumentFilter.new({ block_type: %w[email_address] }).paginated_documents
       end
     end
 
     describe "when a lead organisation id is given" do
       it "returns live documents with lead org given" do
+        document_scope_mock.expects(:page).with(1).returns(document_scope_mock)
+
         document_scope_mock.expects(:with_lead_organisation).with("123").returns(document_scope_mock)
-        ContentBlockManager::ContentBlock::Document::DocumentFilter.new({ lead_organisation: "123" }).documents
+        ContentBlockManager::ContentBlock::Document::DocumentFilter.new({ lead_organisation: "123" }).paginated_documents
       end
     end
 
     describe "when block types, keyword and organisation is given" do
       it "returns live documents with the filters given" do
+        document_scope_mock.expects(:page).with(1).returns(document_scope_mock)
+
         document_scope_mock.expects(:with_keyword).with("ministry of example").returns(document_scope_mock)
         document_scope_mock.expects(:where).with(block_type: %w[email_address]).returns(document_scope_mock)
         document_scope_mock.expects(:with_lead_organisation).with("123").returns(document_scope_mock)
         ContentBlockManager::ContentBlock::Document::DocumentFilter.new(
           { block_type: %w[email_address], keyword: "ministry of example", lead_organisation: "123" },
-        ).documents
+        ).paginated_documents
+      end
+    end
+
+    describe "when a page is given" do
+      it "passes the page to the query" do
+        document_scope_mock.expects(:page).with(2).returns(document_scope_mock)
+        ContentBlockManager::ContentBlock::Document::DocumentFilter.new({ page: 2 }).paginated_documents
       end
     end
   end


### PR DESCRIPTION
Paginate search results of Content Blocks - using existing pagination component from Whitehall.

https://trello.com/c/o2rm0o7t/630-add-pagination-homepage


![Screenshot 2024-11-13 at 16 09 17](https://github.com/user-attachments/assets/bdffb940-2ec0-4414-b3ca-b764d3ac3b90)

![Screenshot 2024-11-13 at 16 09 30](https://github.com/user-attachments/assets/f7d63ae6-8b05-48b4-9c02-bbff6c455a9d)



---
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
