### PR TITLE
content-modelling/ changing default configuration of search filters

### DIFF
--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/index/filter_options_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/index/filter_options_component.html.erb
@@ -20,7 +20,7 @@
             }
           ),
         },
-        expanded: @filters&.fetch(:keyword, nil).present?,
+        expanded: true,
       },
       {
         heading: {
@@ -39,7 +39,7 @@
             }
           ),
         },
-        expanded: @filters&.fetch(:block_type, nil).present?,
+        expanded: true,
       },
       {
         heading: {
@@ -55,7 +55,7 @@
             }
           ),
         },
-        expanded: @filters&.fetch(:lead_organisation, nil).present?,
+        expanded: true,
       },
     ],
   } %>

--- a/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/documents_controller.rb
+++ b/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/documents_controller.rb
@@ -46,6 +46,6 @@ private
   end
 
   def default_filters
-    { lead_organisation: current_user.organisation.try(:id) || "" }
+    { lead_organisation: "" }
   end
 end

--- a/lib/engines/content_block_manager/features/search_for_object.feature
+++ b/lib/engines/content_block_manager/features/search_for_object.feature
@@ -24,11 +24,11 @@ Feature: Search for a content object
 
   Scenario: GDS Editor can filter by organisation
     When I visit the Content Block Manager home page
-    Then my organisation is already selected as a filter
-    And I should see the details for all documents from my organisation
-    When I select the lead organisation "All organisations"
+    Then 'all organisations' is already selected as a filter
+    And "3" content blocks are returned in total
+    When I select the lead organisation "Department of Placeholder"
     And I click to view results
-    Then "3" content blocks are returned in total
+    Then I should see the details for all documents from my organisation
 
   Scenario: GDS Editor searches for a content object by keyword in instructions to publishers
     When I visit the Content Block Manager home page

--- a/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
@@ -271,8 +271,8 @@ Then("I should see the details for all documents") do
   end
 end
 
-Then("my organisation is already selected as a filter") do
-  expect(page).to have_field("Lead organisation", with: @user.organisation.id)
+Then("'all organisations' is already selected as a filter") do
+  expect(page).to have_field("Lead organisation", with: "")
 end
 
 Then("I should see the details for all documents from my organisation") do

--- a/lib/engines/content_block_manager/test/components/content_block/document/index/filter_options_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/document/index/filter_options_component_test.rb
@@ -18,13 +18,13 @@ class ContentBlockManager::ContentBlock::Document::Index::FilterOptionsComponent
     ContentBlockManager::ContentBlock::Schema.stubs(:valid_schemas).returns(%w[email_address postal_address])
   end
 
-  it "collapses all sections by default" do
+  it "expands all sections by default" do
     render_inline(
       ContentBlockManager::ContentBlock::Document::Index::FilterOptionsComponent.new(
         filters: {},
       ),
     )
-    assert_selector ".govuk-accordion__section--expanded", count: 0
+    assert_selector ".govuk-accordion__section--expanded", count: 3
   end
 
   it "adds value of keyword to text input from filter" do
@@ -34,7 +34,6 @@ class ContentBlockManager::ContentBlock::Document::Index::FilterOptionsComponent
       ),
     )
 
-    assert_selector ".govuk-accordion__section--expanded", count: 1
     assert_selector ".govuk-accordion__section--expanded", text: "Keyword"
     assert_selector "input[name='keyword'][value='ministry defense']"
   end
@@ -57,7 +56,6 @@ class ContentBlockManager::ContentBlock::Document::Index::FilterOptionsComponent
       ),
     )
 
-    assert_selector ".govuk-accordion__section--expanded", count: 1
     assert_selector ".govuk-accordion__section--expanded", text: "Content block type"
 
     assert_selector "input[type='checkbox'][name='block_type[]'][value='email_address'][checked]"
@@ -78,7 +76,6 @@ class ContentBlockManager::ContentBlock::Document::Index::FilterOptionsComponent
       ),
     )
 
-    assert_selector ".govuk-accordion__section--expanded", count: 1
     assert_selector ".govuk-accordion__section--expanded", text: "Lead organisation"
 
     assert_selector "select[name='lead_organisation']"

--- a/lib/engines/content_block_manager/test/integration/content_block/documents_test.rb
+++ b/lib/engines/content_block_manager/test/integration/content_block/documents_test.rb
@@ -55,10 +55,10 @@ class ContentBlockManager::ContentBlock::DocumentsTest < ActionDispatch::Integra
 
     describe "when no filter params are specified" do
       describe "when there are no session filters" do
-        it "adds the users organisation as the lead organisation by default" do
+        it "sets the filter to 'all organisations' by default" do
           visit content_block_manager.content_block_manager_content_block_documents_path
 
-          assert_current_path content_block_manager.content_block_manager_root_path({ lead_organisation: @organisation.id.to_s })
+          assert_current_path content_block_manager.content_block_manager_root_path({ lead_organisation: "" })
         end
       end
 
@@ -76,7 +76,7 @@ class ContentBlockManager::ContentBlock::DocumentsTest < ActionDispatch::Integra
         it "resets the filters when reset_fields is set" do
           visit content_block_manager.content_block_manager_content_block_documents_path({ reset_fields: true })
 
-          assert_current_path content_block_manager.content_block_manager_root_path({ lead_organisation: @organisation.id.to_s })
+          assert_current_path content_block_manager.content_block_manager_root_path({ lead_organisation: "" })
         end
       end
     end


### PR DESCRIPTION
Sneaking two small changes to the filters in one PR:

1. Set filters to be expanded by default. This came after user feedback that it was
frustrating that they were closed by default.

2. Filter Blocks by 'all organisations' as default. From user research that this would make more
sense, publishers may be looking at blocks not
from their organisations.

![Screenshot 2024-11-14 at 10 50 00](https://github.com/user-attachments/assets/28acb45f-ba87-4c0d-b278-d1480941f247)



---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
