### PR TITLE
Fix argument call for DocumentListExportWorker

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -57,7 +57,7 @@ class Admin::EditionsController < Admin::BaseController
 
   def export
     if filter && filter.exportable?
-      DocumentListExportWorker.perform_async(params_filters_with_default_state, current_user.id)
+      DocumentListExportWorker.perform_async(params_filters_with_default_state.as_json, current_user.id)
       flash[:notice] = "The document list is being exported"
     else
       flash[:alert] = "The document list is too large for export"

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,1 +1,0 @@
-# Use Sidekiq strict args to force Sidekiq 6 deprecations to error ahead of upgrade to Sidekiq 7

--- a/test/functional/admin/editions_controller_test.rb
+++ b/test/functional/admin/editions_controller_test.rb
@@ -309,6 +309,25 @@ class Admin::EditionsControllerTest < ActionController::TestCase
     assert_response :forbidden
   end
 
+  test "passes raw JSON to the export worker" do
+    login_as :gds_editor
+    Admin::EditionFilter.any_instance.stubs(exportable?: true)
+
+    stub = proc do |params, _user_id|
+      assert_not params.instance_of?(ActiveSupport::HashWithIndifferentAccess)
+    end
+
+    DocumentListExportWorker.stub :perform_async, stub do
+      post :export,
+           params: {
+             include_last_author: true,
+             include_link_check_reports: true,
+             include_unpublishing: true,
+             state: "active",
+           }
+    end
+  end
+
   view_test "prevents oversized exports" do
     login_as :gds_editor
     Admin::EditionFilter.any_instance.stubs(exportable?: false)


### PR DESCRIPTION
Fixes a live issue where using the CSV exports feature causes a server error (see https://govuk.sentry.io/issues/6064299106/), which is a side-effect of the govuk_sidekiq upgrade in https://github.com/alphagov/whitehall/pull/9607. 

Trello: https://trello.com/c/t25764wU/3175-technical-fault-with-whitehall

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
