### PR TITLE
Fix yaml-editor for new documents (again)

### DIFF
--- a/app/assets/javascripts/components/yaml-editor.js
+++ b/app/assets/javascripts/components/yaml-editor.js
@@ -35,13 +35,13 @@ window.GOVUK.Modules = window.GOVUK.Modules || {}
       '.app-c-govspeak-editor__preview-button-wrapper'
     )
     const textArea = innerContainer?.querySelector('#edition_body')
-    const value = textArea?.value
-    if (!value) {
+    if (!textArea) {
       console.warn(
         'YamlEditor: DOM structure did not match expectations, falling back to doing nothing'
       )
       return
     }
+    const value = textArea.value
 
     const monacoHostDiv = document.createElement('div')
     monacoHostDiv.style.width = '100%'


### PR DESCRIPTION
The check for the querySelector chain should be that we found a textArea, not that we found a textArea and it has a truthy value.

The empty string is falsey in JavaScript land, so checking !value incorrectly meant we got the "DOM structure did not match" warning.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
