### PR TITLE
Validate landing page base paths must start with /

### DIFF
--- a/app/models/landing_page.rb
+++ b/app/models/landing_page.rb
@@ -4,7 +4,7 @@ class LandingPage < Edition
   include Edition::Images
 
   skip_callback :validation, :before, :update_document_slug
-  validates :base_path, presence: true
+  validates :base_path, presence: true, format: { with: /\A\/.*\z/, message: "must start with a slash (/)" }
   validate :base_path_must_not_be_taken
   validate :body_must_be_valid_yaml
 

--- a/test/functional/admin/landing_pages_controller_test.rb
+++ b/test/functional/admin/landing_pages_controller_test.rb
@@ -47,7 +47,8 @@ class Admin::LandingPagesControllerTest < ActionController::TestCase
   end
 
   test "GET :edit fetches the supplied instance" do
-    page = create(:landing_page, organisations: [@organisation])
+    document = create(:document, slug: "/some-slug-starting-with-slash")
+    page = create(:landing_page, organisations: [@organisation], document:)
 
     get :edit, params: { id: page }
 
@@ -58,7 +59,8 @@ class Admin::LandingPagesControllerTest < ActionController::TestCase
 
   test "PUT :update changes the supplied instance with the supplied params" do
     attrs = attributes_for(:landing_page, title: "Hello there")
-    page = create(:landing_page, organisations: [@organisation], title: "Goodbye")
+    document = create(:document, slug: "/some-slug-starting-with-slash")
+    page = create(:landing_page, organisations: [@organisation], title: "Goodbye", document:)
 
     post :update, params: {
       id: page,
@@ -72,7 +74,8 @@ class Admin::LandingPagesControllerTest < ActionController::TestCase
 
   test "PUT :update doesn't save the new instance when the supplied params are invalid" do
     attrs = attributes_for(:landing_page, title: "")
-    page = create(:landing_page, organisations: [@organisation], title: "Goodbye")
+    document = create(:document, slug: "/some-slug-starting-with-slash")
+    page = create(:landing_page, organisations: [@organisation], title: "Goodbye", document:)
 
     post :update, params: { id: page, edition: attrs }
 

--- a/test/unit/app/models/landing_page_test.rb
+++ b/test/unit/app/models/landing_page_test.rb
@@ -20,6 +20,12 @@ class LandingPageTest < ActiveSupport::TestCase
     assert_equal :base_path, landing_page.errors.first.attribute
   end
 
+  test "landing-page is not valid if base_path does not start with a slash" do
+    document = build(:document, slug: "landing-page/test")
+    landing_page = build(:landing_page, document:, body: "blocks: []")
+    assert_not landing_page.valid?
+  end
+
   test "landing-page is valid if body is YAML with at least the blocks: element" do
     document = build(:document, slug: "/landing-page/test")
     landing_page = build(:landing_page, document:, body: "blocks:\nother:\n")


### PR DESCRIPTION
We're being a bit sneaky with landing pages, and setting base_path to be the entire user entered slug. Unlike with other editions, where the slug gets appended to /government/something, this lets the user set the whole base path.

Consequently, it's important that it starts with a slash, otherwise publishing API will reject it. As slugs can only be provided for landing pages when they're first created, leaving off the slash results in a situation the user can't recover from (the document is created with a bad slug, and there's no interface to change it).

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️