### PR TITLE
Content modelling/679 return the number of instances on a page

### DIFF
--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/host_editions_table_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/host_editions_table_component.html.erb
@@ -18,6 +18,11 @@ it out for now-->
         sort_direction: sort_direction("document_type"),
       },
       {
+        text: "Instances",
+        href: sort_link("instances"),
+        sort_direction: sort_direction("instances"),
+      },
+      {
         text: "Unique pageviews",
         href: sort_link("unique_pageviews"),
         sort_direction: sort_direction("unique_pageviews"),

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/host_editions_table_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/host_editions_table_component.rb
@@ -39,6 +39,9 @@ private
           text: content_item.document_type.humanize,
         },
         {
+          text: content_item.instances,
+        },
+        {
           text: content_item.unique_pageviews ? number_to_human(content_item.unique_pageviews, format: "%n%u", precision: 3, significant: true, units: { thousand: "k", million: "m", billion: "b" }) : nil,
         },
         {

--- a/lib/engines/content_block_manager/app/models/content_block_manager/host_content_item.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/host_content_item.rb
@@ -8,6 +8,7 @@ module ContentBlockManager
     :last_edited_by_editor_id,
     :last_edited_at,
     :unique_pageviews,
+    :instances,
   )
 
     def last_edited_at

--- a/lib/engines/content_block_manager/app/services/content_block_manager/get_host_content_items.rb
+++ b/lib/engines/content_block_manager/app/services/content_block_manager/get_host_content_items.rb
@@ -29,6 +29,7 @@ module ContentBlockManager
           last_edited_by_editor_id: item["last_edited_by_editor_id"],
           last_edited_at: item["last_edited_at"],
           unique_pageviews: item["unique_pageviews"],
+          instances: item["instances"],
         )
       end
 

--- a/lib/engines/content_block_manager/test/components/content_block/document/show/host_editions_table_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/document/show/host_editions_table_component_test.rb
@@ -28,6 +28,7 @@ class ContentBlockManager::ContentBlock::Document::Show::HostEditionsTableCompon
       "last_edited_at" => Time.zone.now.to_s,
       "publishing_organisation" => publishing_organisation,
       "unique_pageviews" => unique_pageviews,
+      "instances" => 1,
     )
   end
   let(:host_content_items) do
@@ -194,7 +195,7 @@ class ContentBlockManager::ContentBlock::Document::Show::HostEditionsTableCompon
           ),
         )
 
-        assert_selector "a.app-table__sort-link[href*='##{ContentBlockManager::ContentBlock::Document::Show::HostEditionsTableComponent::TABLE_ID}']", count: 5
+        assert_selector "a.app-table__sort-link[href*='##{ContentBlockManager::ContentBlock::Document::Show::HostEditionsTableComponent::TABLE_ID}']", count: 6
       end
 
       it "shows all the headers unordered by default" do
@@ -207,6 +208,7 @@ class ContentBlockManager::ContentBlock::Document::Show::HostEditionsTableCompon
 
         assert_selector "a.app-table__sort-link[href*='order=title']", text: "Title"
         assert_selector "a.app-table__sort-link[href*='order=document_type']", text: "Document Type"
+        assert_selector "a.app-table__sort-link[href*='order=instances']", text: "Instances"
         assert_selector "a.app-table__sort-link[href*='order=unique_pageviews']", text: "Unique pageviews"
         assert_selector "a.app-table__sort-link[href*='order=primary_publishing_organisation_title']", text: "Publishing organisation"
         assert_selector "a.app-table__sort-link[href*='order=last_edited_at']", text: "Updated"
@@ -214,7 +216,7 @@ class ContentBlockManager::ContentBlock::Document::Show::HostEditionsTableCompon
         assert_selector ".govuk-table__header--active a", text: "Unique pageviews"
       end
 
-      %w[title document_type unique_pageviews primary_publishing_organisation_title last_edited_at].each do |order|
+      %w[title document_type unique_pageviews primary_publishing_organisation_title last_edited_at instances].each do |order|
         it "shows the link as selected when #{order} is in ascending order" do
           render_inline(
             described_class.new(

--- a/lib/engines/content_block_manager/test/factories/host_content_item.rb
+++ b/lib/engines/content_block_manager/test/factories/host_content_item.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
     last_edited_by_editor_id { SecureRandom.uuid }
     last_edited_at { 2.days.ago.to_s }
     unique_pageviews { 123 }
+    instances { 1 }
 
     initialize_with do
       new(title:,
@@ -17,7 +18,8 @@ FactoryBot.define do
           publishing_app:,
           last_edited_by_editor_id:,
           last_edited_at:,
-          unique_pageviews:)
+          unique_pageviews:,
+          instances:)
     end
   end
 end

--- a/lib/engines/content_block_manager/test/unit/app/services/get_host_content_items_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/services/get_host_content_items_test.rb
@@ -21,6 +21,7 @@ class ContentBlockManager::GetHostContentItemsTest < ActiveSupport::TestCase
           "last_edited_by_editor_id" => SecureRandom.uuid,
           "last_edited_at" => "2023-01-01T08:00:00.000Z",
           "unique_pageviews" => 123,
+          "instances" => 1,
           "primary_publishing_organisation" => {
             "content_id" => SecureRandom.uuid,
             "title" => "bar",
@@ -108,6 +109,7 @@ class ContentBlockManager::GetHostContentItemsTest < ActiveSupport::TestCase
       assert_equal result[0].last_edited_by_editor_id, response_body["results"][0]["last_edited_by_editor_id"]
       assert_equal result[0].last_edited_at, Time.zone.parse(response_body["results"][0]["last_edited_at"])
       assert_equal result[0].unique_pageviews, response_body["results"][0]["unique_pageviews"]
+      assert_equal result[0].instances, response_body["results"][0]["instances"]
 
       assert_equal result[0].publishing_organisation, expected_publishing_organisation
     end


### PR DESCRIPTION
This follows on from https://github.com/alphagov/publishing-api/pull/2989 to return the number of times a block is used in a given document

# Screenshot

![image](https://github.com/user-attachments/assets/acd77ce1-4786-465d-a26b-15de9e9a798c)
