### PR TITLE
Add Landing Pages to the list of edition classes

### DIFF
--- a/app/helpers/admin/edition_actions_helper.rb
+++ b/app/helpers/admin/edition_actions_helper.rb
@@ -159,6 +159,7 @@ private
   def type_options_container(user)
     Whitehall.edition_classes.map { |edition_type|
       next if edition_type == FatalityNotice && !user.can_handle_fatalities?
+      next if edition_type == LandingPage && !user.gds_admin?
 
       [edition_type.format_name.humanize.pluralize, edition_type.model_name.singular]
     }.compact

--- a/app/presenters/search_api_presenters.rb
+++ b/app/presenters/search_api_presenters.rb
@@ -16,7 +16,7 @@ module SearchApiPresenters
   end
 
   def self.searchable_classes_for_government_index
-    searchable_classes - [DetailedGuide]
+    searchable_classes - [DetailedGuide, LandingPage]
   end
 
   def self.searchable_classes

--- a/lib/whitehall.rb
+++ b/lib/whitehall.rb
@@ -172,7 +172,7 @@ module Whitehall
   end
 
   def self.edition_route_path_segments
-    %w[news speeches policies publications consultations priority detailed-guides case-studies statistical-data-sets fatalities collections supporting-pages calls-for-evidence worldwide-organisations]
+    %w[news speeches policies publications consultations priority detailed-guides case-studies statistical-data-sets fatalities collections supporting-pages calls-for-evidence worldwide-organisations landing-pages]
   end
 
   def self.analytics_format(format)

--- a/lib/whitehall.rb
+++ b/lib/whitehall.rb
@@ -162,6 +162,7 @@ module Whitehall
       DetailedGuide,
       DocumentCollection,
       FatalityNotice,
+      LandingPage,
       NewsArticle,
       Publication,
       Speech,

--- a/test/unit/app/helpers/admin/edition_actions_helper_test.rb
+++ b/test/unit/app/helpers/admin/edition_actions_helper_test.rb
@@ -45,4 +45,11 @@ class Admin::EditionActionsHelperTest < ActionView::TestCase
 
     assert_same_elements @editions + ["Fatality notices"], types
   end
+
+  test "#filter_edition_type_opt_groups should include landing pages when the user is an admin" do
+    filter_options = filter_edition_type_opt_groups(create(:gds_admin), nil)
+    types = filter_options[1].last.map { |type| type[:text] }
+
+    assert_same_elements @editions + ["Fatality notices", "Landing pages"], types
+  end
 end

--- a/test/unit/app/helpers/govspeak_helper_link_rewriting_test.rb
+++ b/test/unit/app/helpers/govspeak_helper_link_rewriting_test.rb
@@ -6,7 +6,12 @@ class GovspeakHelperLinkRewritingTest < ActionView::TestCase
 
   Whitehall.edition_classes.each do |edition_class|
     test "should rewrite absolute path to an admin page for a published #{edition_class} as link to its public page" do
-      edition = create("published_#{edition_class.name.underscore}")
+      document = if edition_class == LandingPage
+                   create(:document, slug: "/starts-with-slash")
+                 else
+                   create(:document)
+                 end
+      edition = create("published_#{edition_class.name.underscore}", document:)
       assert_rewrites_link(from: admin_edition_path(edition), to: edition.public_url)
     end
   end


### PR DESCRIPTION
This changes behaviour in a couple of ways:
1) It causes landing pages to show up in the "Document types" dropdown on the editions index page (which is my primary motivation for doing this)
2) It adds support for the `[internal admin link](/government/landing-pages/888)` style links for landing pages, which previously wouldn't have worked.

For the first use case, we remove landing pages for non-gds-admins, since other users can't do anything useful with landing pages.

The second use case isn't something I particularly care about, but there are tests for it so I had to make it work.

There's also a third side effect of adding LandingPage to the edition classes, which is that they would be sent to search-api somehow. I don't think we want or need that behaviour for landing pages, as we're already populating the search indexes via publishing-api. So I've excluded landing pages from that process.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
