### PR TITLE
content-modelling/ show only one edit action for content blocks

### DIFF
--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/summary_list_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/summary_list_component.rb
@@ -9,6 +9,7 @@ private
 
   def items
     [
+      edit_item,
       title_item,
       *details_items,
       organisation_item,
@@ -18,6 +19,13 @@ private
       state_item,
       scheduled_item,
     ].compact
+  end
+
+  def edit_item
+    {
+      field: "#{content_block_document.block_type.humanize} details",
+      edit: edit_action,
+    }
   end
 
   def embed_code_item
@@ -35,7 +43,6 @@ private
     {
       field: "Title",
       value: content_block_document.title,
-      edit: edit_action,
     }
   end
 
@@ -43,7 +50,6 @@ private
     {
       field: "Lead organisation",
       value: content_block_document.latest_edition.lead_organisation,
-      edit: edit_action,
     }
   end
 
@@ -51,7 +57,6 @@ private
     {
       field: "Instructions to publishers",
       value: content_block_document.latest_edition.instructions_to_publishers.presence || "None",
-      edit: edit_action,
     }
   end
 
@@ -60,7 +65,6 @@ private
       {
         field: key.humanize,
         value:,
-        edit: edit_action,
       }
     end
   end
@@ -95,7 +99,7 @@ private
   def edit_action
     {
       href: helpers.content_block_manager.new_content_block_manager_content_block_document_edition_path(content_block_document),
-      link_text: "Change",
+      link_text: "Edit",
     }
   end
 end

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/show/confirm_summary_list_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/show/confirm_summary_list_component.rb
@@ -9,12 +9,20 @@ private
 
   def items
     [
+      edit_item,
       *details_items,
       organisation_item,
       instructions_item,
       confirm_item,
       date_item,
     ]
+  end
+
+  def edit_item
+    {
+      field: "#{content_block_edition.document.block_type.humanize} details",
+      edit: edit_action,
+    }
   end
 
   def details_items
@@ -51,6 +59,13 @@ private
     {
       field: "Publish date",
       value: I18n.l(content_block_edition.created_at.to_date, format: :long_ordinal),
+    }
+  end
+
+  def edit_action
+    {
+      href: helpers.content_block_manager.content_block_manager_content_block_workflow_path(id: content_block_edition.id, step: ContentBlockManager::ContentBlock::Editions::WorkflowController::NEW_BLOCK_STEPS[:edit_draft]),
+      link_text: "Edit",
     }
   end
 end

--- a/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/editions/workflow_controller.rb
+++ b/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/editions/workflow_controller.rb
@@ -1,6 +1,7 @@
 class ContentBlockManager::ContentBlock::Editions::WorkflowController < ContentBlockManager::BaseController
   NEW_BLOCK_STEPS = {
     review: "review",
+    edit_draft: "edit_draft",
   }.freeze
 
   UPDATE_BLOCK_STEPS = {
@@ -18,6 +19,8 @@ class ContentBlockManager::ContentBlock::Editions::WorkflowController < ContentB
     @schema = ContentBlockManager::ContentBlock::Schema.find_by_block_type(@content_block_edition.document.block_type)
 
     case step
+    when NEW_BLOCK_STEPS[:edit_draft]
+      edit_draft
     when UPDATE_BLOCK_STEPS[:review_links]
       review_links
     when UPDATE_BLOCK_STEPS[:schedule_publishing]
@@ -45,6 +48,16 @@ class ContentBlockManager::ContentBlock::Editions::WorkflowController < ContentB
   end
 
 private
+
+  def edit_draft
+    @content_block_edition = ContentBlockManager::ContentBlock::Edition.find(params[:id])
+    @form = ContentBlockManager::ContentBlock::EditionForm.for(
+      content_block_edition: @content_block_edition,
+      schema: @schema,
+    )
+
+    render "content_block_manager/content_block/editions/new"
+  end
 
   def review
     @content_block_edition = ContentBlockManager::ContentBlock::Edition.find(params[:id])

--- a/lib/engines/content_block_manager/app/forms/content_block_manager/content_block/edition_form.rb
+++ b/lib/engines/content_block_manager/app/forms/content_block_manager/content_block/edition_form.rb
@@ -7,7 +7,7 @@ class ContentBlockManager::ContentBlock::EditionForm
   attr_reader :content_block_edition, :schema
 
   def self.for(content_block_edition:, schema:)
-    content_block_edition.document&.id ? Update.new(content_block_edition:, schema:) : Create.new(content_block_edition:, schema:)
+    content_block_edition.document&.latest_edition_id ? Update.new(content_block_edition:, schema:) : Create.new(content_block_edition:, schema:)
   end
 
   def initialize(content_block_edition:, schema:)

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/documents/show.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/documents/show.html.erb
@@ -6,11 +6,16 @@
   } %>
 <% end %>
 
-<%= render(
-      ContentBlockManager::ContentBlock::Document::Show::SummaryListComponent.new(
-        content_block_document: @content_block_document,
-      ),
-    ) %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h2 class="govuk-heading-m">Details</h2>
+    <%= render(
+          ContentBlockManager::ContentBlock::Document::Show::SummaryListComponent.new(
+            content_block_document: @content_block_document,
+          ),
+        ) %>
+  </div>
+</div>
 
 <div class="govuk-grid-row govuk-!-padding-top-8">
   <div class="govuk-grid-column-full">

--- a/lib/engines/content_block_manager/features/create_object.feature
+++ b/lib/engines/content_block_manager/features/create_object.feature
@@ -72,6 +72,23 @@ Feature: Create a content object
     And no draft Content Block Edition has been created
     And no draft Content Block Document has been created
 
+  Scenario: GDS editor edits answers during creation of an object
+    When I visit the Content Block Manager home page
+    And I click to create an object
+    When I click on the "email_address" schema
+    When I complete the form with the following fields:
+      | title            | email_address   | department | organisation |
+      | my email address | foo@example.com | Somewhere  | Ministry of Example |
+    Then I am asked to check my answers
+    When I click the first edit link
+    And I complete the form with the following fields:
+      | title            |
+      | my email address 2 |
+    Then I am asked to check my answers
+    When I accept and publish
+    Then the edition should have been created successfully
+    And I should be taken to the confirmation page
+
   Scenario: Draft documents are not listed
     When I visit the Content Block Manager home page
     And I click to create an object

--- a/lib/engines/content_block_manager/features/edit_object.feature
+++ b/lib/engines/content_block_manager/features/edit_object.feature
@@ -13,7 +13,7 @@ Feature: Edit a content object
     Then I should see the details for all documents
     When I click to view the document
     Then I should see the details for the email address content block
-    When I click the first change link
+    When I click the first edit link
     Then I should see the edit form
     And I should see a back link to the document page
     When I fill out the form
@@ -33,7 +33,7 @@ Feature: Edit a content object
   Scenario: GDS editor cancels the creation of an object when reviewing links
     When I visit the Content Block Manager home page
     When I click to view the document
-    When I click the first change link
+    When I click the first edit link
     Then I should see the edit form
     When I fill out the form
     Then I am shown where the changes will take place
@@ -44,7 +44,7 @@ Feature: Edit a content object
   Scenario: GDS editor cancels the creation of an object before publishing
     When I visit the Content Block Manager home page
     When I click to view the document
-    When I click the first change link
+    When I click the first edit link
     Then I should see the edit form
     When I fill out the form
     Then I am shown where the changes will take place
@@ -61,7 +61,7 @@ Feature: Edit a content object
     And an email address content block has been created
     When I visit the Content Block Manager home page
     When I click to view the document
-    When I click the first change link
+    When I click the first edit link
     And I set all fields to blank
     Then I should see errors for the required fields
 
@@ -72,7 +72,7 @@ Feature: Edit a content object
     And an email address content block has been created
     When I visit the Content Block Manager home page
     When I click to view the document
-    When I click the first change link
+    When I click the first edit link
     When I complete the form with the following fields:
     | title            | email_address   | organisation |
     | my email address | xxxxx           | Ministry of Example |

--- a/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
@@ -108,11 +108,11 @@ When("I complete the form with the following fields:") do |table|
   @instructions_to_publishers = fields.delete("instructions_to_publishers")
   @details = fields
 
-  fill_in "Title", with: @title
+  fill_in "Title", with: @title if @title.present?
 
-  select @organisation, from: "content_block/edition_lead_organisation"
+  select @organisation, from: "content_block/edition_lead_organisation" if @organisation.present?
 
-  fill_in "Instructions to publishers", with: @instructions_to_publishers
+  fill_in "Instructions to publishers", with: @instructions_to_publishers if @instructions_to_publishers.present?
 
   fields.keys.each do |k|
     fill_in "content_block_manager/content_block/edition_details_#{k}", with: @details[k]
@@ -138,9 +138,10 @@ Then("the edition should have been created successfully") do
   assert_not_nil edition
   assert_not_nil edition.document
 
-  assert_equal @title, edition.title
-  assert_equal @instructions_to_publishers, edition.instructions_to_publishers,
-               @details.keys.each do |k|
+  assert_equal @title, edition.title if @title.present?
+  assert_equal @instructions_to_publishers, edition.instructions_to_publishers if @instructions_to_publishers.present?
+
+  @details.keys.each do |k|
     assert_equal edition.details[k], @details[k]
   end
 end
@@ -315,6 +316,10 @@ end
 When("I click the first change link") do
   first_link = find("a[href='#{content_block_manager.new_content_block_manager_content_block_document_edition_path(@content_block.document)}']", match: :first)
   first_link.click
+end
+
+When("I click the first edit link") do
+  click_link "Edit"
 end
 
 Then("I should see the edit form") do

--- a/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
@@ -313,11 +313,6 @@ Then("I should see the details for the email address content block") do
   )
 end
 
-When("I click the first change link") do
-  first_link = find("a[href='#{content_block_manager.new_content_block_manager_content_block_document_edition_path(@content_block.document)}']", match: :first)
-  first_link.click
-end
-
 When("I click the first edit link") do
   click_link "Edit"
 end
@@ -359,7 +354,7 @@ end
 def should_show_summary_list_for_email_address_content_block(document_title, email_address, organisation, instructions_to_publishers = nil)
   expect(page).to have_selector(".govuk-summary-list__key", text: "Title")
   expect(page).to have_selector(".govuk-summary-list__value", text: document_title)
-  expect(page).to have_selector(".govuk-summary-list__actions", text: "Change")
+  expect(page).to have_selector(".govuk-summary-list__actions", text: "Edit")
   expect(page).to have_selector(".govuk-summary-list__key", text: "Email address")
   expect(page).to have_selector(".govuk-summary-list__value", text: email_address)
   expect(page).to have_selector(".govuk-summary-list__key", text: "Lead organisation")
@@ -370,7 +365,6 @@ def should_show_summary_list_for_email_address_content_block(document_title, ema
   end
   expect(page).to have_selector(".govuk-summary-list__key", text: "Last updated")
   expect(page).to have_selector(".govuk-summary-list__value", text: @user.name)
-  expect(page).to have_selector(".govuk-summary-list__actions", text: "Change")
 end
 
 def should_show_edit_form_for_email_address_content_block(document_title, email_address)

--- a/lib/engines/content_block_manager/test/components/content_block/document/show/summary_list_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/document/show/summary_list_component_test.rb
@@ -21,18 +21,20 @@ class ContentBlockManager::ContentBlock::Document::Show::SummaryListComponentTes
   it "renders a published content block correctly" do
     render_inline(ContentBlockManager::ContentBlock::Document::Show::SummaryListComponent.new(content_block_document:))
 
-    assert_selector ".govuk-summary-list__row", count: 8
+    assert_selector ".govuk-summary-list__row", count: 9
+    assert_selector ".govuk-summary-list__actions", count: 1
+
+    assert_selector ".govuk-summary-list__key", text: "Email address details"
+    assert_selector ".govuk-summary-list__actions", text: "Edit"
+
     assert_selector ".govuk-summary-list__key", text: "Title"
     assert_selector ".govuk-summary-list__value", text: content_block_document.title
-    assert_selector ".govuk-summary-list__actions", text: "Change"
 
     assert_selector ".govuk-summary-list__key", text: "Foo"
     assert_selector ".govuk-summary-list__value", text: "bar"
-    assert_selector ".govuk-summary-list__actions", text: "Change"
 
     assert_selector ".govuk-summary-list__key", text: "Something"
     assert_selector ".govuk-summary-list__value", text: "else"
-    assert_selector ".govuk-summary-list__actions", text: "Change"
 
     assert_selector ".govuk-summary-list__key", text: "Lead organisation"
     assert_selector ".govuk-summary-list__value", text: "Department for Example"
@@ -57,7 +59,7 @@ class ContentBlockManager::ContentBlock::Document::Show::SummaryListComponentTes
 
     render_inline(ContentBlockManager::ContentBlock::Document::Show::SummaryListComponent.new(content_block_document:))
 
-    assert_selector ".govuk-summary-list__row", count: 9
+    assert_selector ".govuk-summary-list__row", count: 10
 
     assert_selector ".govuk-summary-list__key", text: "Scheduled for publication at"
     assert_selector ".govuk-summary-list__value", text: I18n.l(content_block_edition.scheduled_publication, format: :long_ordinal)

--- a/lib/engines/content_block_manager/test/components/content_block/edition/show/confirm_summary_list_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/show/confirm_summary_list_component_test.rb
@@ -30,6 +30,8 @@ class ContentBlockManager::ContentBlockEdition::Show::ConfirmSummaryListComponen
                     content_block_edition:,
                   ))
 
+    assert_selector ".govuk-summary-list__key", text: "Email address details"
+    assert_selector ".govuk-summary-list__actions", text: "Edit"
     assert_selector ".govuk-summary-list__key", text: "New interesting fact"
     assert_selector ".govuk-summary-list__value", text: "value of fact"
     assert_selector ".govuk-summary-list__key", text: "Lead organisation"

--- a/lib/engines/content_block_manager/test/unit/app/forms/content_block_manager/content_block/edition_form_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/forms/content_block_manager/content_block/edition_form_test.rb
@@ -13,8 +13,8 @@ class ContentBlockManager::ContentBlock::EditionFormTest < ActiveSupport::TestCa
     )
   end
 
-  describe "when initialized for an edition with an existing document" do
-    let(:content_block_document) { build(:content_block_document, id: 123) }
+  describe "when initialized for an edition with an existing document and live edition" do
+    let(:content_block_document) { build(:content_block_document, :email_address, id: 123, latest_edition_id: "5b271577-3d3d-475d-986a-246d8c4063a3") }
     let(:content_block_edition) { build(:content_block_edition, :email_address, document: content_block_document) }
 
     let(:result) do


### PR DESCRIPTION
to match the agreed UI design

https://trello.com/c/HXLqncRg/648-update-check-your-answers-page
I'm keeping this scope to just the edit button and the existing check your answers page - as this PR has dragged on a bit I think any further content tweaks (e.g. to copy of button etc.) could be picked up later. [Based on designs currently in Figma](https://www.figma.com/design/F2Uq6Ju6fsSk1CEMjXm2va/Content-Modelling).

![Screenshot 2024-11-21 at 11 56 24](https://github.com/user-attachments/assets/3ff8dd6a-e42c-417c-a0a7-8c710aa0196a)

![Screenshot 2024-11-21 at 12 32 21](https://github.com/user-attachments/assets/d1a8778e-ffc2-4a92-b661-ed173d6bc368)



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
