### PR TITLE
Republish documents after updating access limits

### DIFF
--- a/app/controllers/admin/edition_access_limited_controller.rb
+++ b/app/controllers/admin/edition_access_limited_controller.rb
@@ -16,6 +16,7 @@ class Admin::EditionAccessLimitedController < Admin::BaseController
         render :edit
       else
         @edition.save!
+        PublishingApiDocumentRepublishingWorker.perform_async(@edition.document_id)
 
         EditorialRemark.create!(
           edition: @edition,

--- a/test/functional/admin/edition_access_limited_controller_test.rb
+++ b/test/functional/admin/edition_access_limited_controller_test.rb
@@ -64,6 +64,8 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
       supporting_organisations: [second_organisation],
     )
 
+    PublishingApiDocumentRepublishingWorker.expects(:perform_async).with(edition.document_id)
+
     editorial_remark = "Updating the organisations at the users request."
 
     put :update,


### PR DESCRIPTION
I was just burned by this not happening. I updated a bunch of editions to add number 10 to the access limited organisations, only to discover that number 10 still couldn't access them.

On inspection, I worked out that the access limits had been updated in Whitehall, but not content store.

Republishing the documents should ensure that they make it to the draft / live content stores any time their access limits are updated.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️