### PR TITLE
Fix Homepage layout

### DIFF
--- a/lib/engines/content_block_manager/app/assets/javascripts/content_block_manager/modules/copy-embed-code.js
+++ b/lib/engines/content_block_manager/app/assets/javascripts/content_block_manager/modules/copy-embed-code.js
@@ -13,6 +13,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {}
     dd.append(this.copyLink)
 
     this.module.append(dd)
+    this.module.classList.remove('govuk-summary-list__row--no-actions')
   }
 
   CopyEmbedCode.prototype.createLink = function () {

--- a/lib/engines/content_block_manager/spec/content_block_manager/copy-code.spec.js
+++ b/lib/engines/content_block_manager/spec/content_block_manager/copy-code.spec.js
@@ -29,6 +29,12 @@ describe('GOVUK.Modules.CopyEmbedCode', function () {
     expect(copyLink.textContent).toBe('Copy code')
   })
 
+  it('should remove the .govuk-summary-list__row--no-actions class', function () {
+    expect(fixture.classList).not.toContain(
+      'govuk-summary-list__row--no-actions'
+    )
+  })
+
   it('should create and populate a textarea', function () {
     window.GOVUK.triggerEvent(copyLink, 'click')
 


### PR DESCRIPTION
When the Javascript added the Copy code link, the `govuk-summary-list__row--no-actions` class remained in place, which left an unsightly gap on the right hand side. This updates the JS to remove the class once we have appended the action element, meaning the gap is no longer there!

## Screenshots

### Before

![image](https://github.com/user-attachments/assets/d2f49dc5-6224-49f1-9a81-c220801b7b16)

### After

![image](https://github.com/user-attachments/assets/84544927-23fd-4aee-9dd4-f09c5eb69c2e)