### PR TITLE
Content modelling/659 Preview Host Documents via iFrame

### DIFF
--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/host_editions_table_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/host_editions_table_component.rb
@@ -3,12 +3,13 @@
 class ContentBlockManager::ContentBlock::Document::Show::HostEditionsTableComponent < ViewComponent::Base
   TABLE_ID = "host_editions"
 
-  def initialize(caption:, host_content_items:, is_preview: false, current_page: nil, order: nil)
+  def initialize(caption:, host_content_items:, content_block_edition:, is_preview: false, current_page: nil, order: nil)
     @caption = caption
     @host_content_items = host_content_items
     @is_preview = is_preview
     @current_page = current_page.presence || 1
     @order = order.presence || ContentBlockManager::GetHostContentItems::DEFAULT_ORDER
+    @content_block_edition = content_block_edition
   end
 
   def current_page
@@ -25,7 +26,7 @@ class ContentBlockManager::ContentBlock::Document::Show::HostEditionsTableCompon
 
 private
 
-  attr_reader :caption, :host_content_items, :order
+  attr_reader :caption, :host_content_items, :order, :content_block_edition
 
   def rows
     return [] unless host_content_items
@@ -81,7 +82,7 @@ private
 
   def frontend_path(content_item)
     if @is_preview
-      Plek.external_url_for("draft-origin") + content_item.base_path
+      helpers.content_block_manager.content_block_manager_content_block_host_content_preview_path(id: content_block_edition.id, host_content_id: content_item.host_content_id)
     else
       Plek.website_root + content_item.base_path
     end

--- a/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/editions/host_content_controller.rb
+++ b/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/editions/host_content_controller.rb
@@ -1,6 +1,7 @@
 class ContentBlockManager::ContentBlock::Editions::HostContentController < ContentBlockManager::BaseController
   def preview
     host_content_id = params[:host_content_id]
-    @preview_content = ContentBlockManager::GetPreviewContent.new(content_id: host_content_id).preview_content
+    content_block_edition = ContentBlockManager::ContentBlock::Edition.find(params[:id])
+    @preview_content = ContentBlockManager::GetPreviewContent.new(content_id: host_content_id, content_block_edition:).preview_content
   end
 end

--- a/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/editions/host_content_controller.rb
+++ b/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/editions/host_content_controller.rb
@@ -2,6 +2,6 @@ class ContentBlockManager::ContentBlock::Editions::HostContentController < Conte
   def preview
     host_content_id = params[:host_content_id]
     content_block_edition = ContentBlockManager::ContentBlock::Edition.find(params[:id])
-    @preview_content = ContentBlockManager::GetPreviewContent.new(content_id: host_content_id, content_block_edition:).preview_content
+    @preview_content = ContentBlockManager::GetPreviewContent.for_content_id(content_id: host_content_id, content_block_edition:)
   end
 end

--- a/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/editions/host_content_controller.rb
+++ b/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/editions/host_content_controller.rb
@@ -1,0 +1,6 @@
+class ContentBlockManager::ContentBlock::Editions::HostContentController < ContentBlockManager::BaseController
+  def preview
+    host_content_id = params[:host_content_id]
+    @preview_content = ContentBlockManager::GetPreviewContent.new(content_id: host_content_id).preview_content
+  end
+end

--- a/lib/engines/content_block_manager/app/models/content_block_manager/host_content_item.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/host_content_item.rb
@@ -9,6 +9,7 @@ module ContentBlockManager
     :last_edited_at,
     :unique_pageviews,
     :instances,
+    :host_content_id,
   )
 
     def last_edited_at

--- a/lib/engines/content_block_manager/app/models/content_block_manager/preview_content.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/preview_content.rb
@@ -1,0 +1,4 @@
+module ContentBlockManager
+  class PreviewContent < Data.define(:title, :html)
+  end
+end

--- a/lib/engines/content_block_manager/app/services/content_block_manager/get_host_content_items.rb
+++ b/lib/engines/content_block_manager/app/services/content_block_manager/get_host_content_items.rb
@@ -30,6 +30,7 @@ module ContentBlockManager
           last_edited_at: item["last_edited_at"],
           unique_pageviews: item["unique_pageviews"],
           instances: item["instances"],
+          host_content_id: item["host_content_id"],
         )
       end
 

--- a/lib/engines/content_block_manager/app/services/content_block_manager/get_preview_content.rb
+++ b/lib/engines/content_block_manager/app/services/content_block_manager/get_preview_content.rb
@@ -4,19 +4,20 @@ require "uri"
 
 module ContentBlockManager
   class GetPreviewContent
+    def self.for_content_id(content_id:, content_block_edition:)
+      new(content_id:, content_block_edition:).for_content_id
+    end
+
+    def for_content_id
+      ContentBlockManager::PreviewContent.new(title: content_item["title"], html:)
+    end
+
+  private
+
     def initialize(content_id:, content_block_edition:)
       @content_id = content_id
       @content_block_edition = content_block_edition
     end
-
-    def preview_content
-      {
-        title: content_item["title"],
-        html:,
-      }
-    end
-
-  private
 
     def html
       @html ||= preview_html
@@ -50,8 +51,9 @@ module ContentBlockManager
     end
 
     def replace_blocks(nokogiri_html)
+      @preview_content_block_render ||= @content_block_edition.render
       content_block_spans(nokogiri_html).each do |span|
-        span.replace @content_block_edition.render
+        span.replace @preview_content_block_render
       end
     end
 
@@ -59,7 +61,7 @@ module ContentBlockManager
 
     def style_blocks(nokogiri_html)
       content_block_spans(nokogiri_html).each do |span|
-        span["style"] = "background-color: yellow;"
+        span["style"] = BLOCK_STYLE
       end
     end
 

--- a/lib/engines/content_block_manager/app/services/content_block_manager/get_preview_content.rb
+++ b/lib/engines/content_block_manager/app/services/content_block_manager/get_preview_content.rb
@@ -40,7 +40,7 @@ module ContentBlockManager
 
     def preview_html
       uri = URI(frontend_path)
-      nokogiri_html = Nokogiri::HTML.parse(Net::HTTP.get(uri))
+      nokogiri_html = html_snapshot_from_frontend(uri)
       replace_existing_content_blocks(nokogiri_html)
     end
 
@@ -67,6 +67,17 @@ module ContentBlockManager
 
     def content_block_spans(nokogiri_html)
       nokogiri_html.css("span[data-content-id=\"#{@content_block_edition.document.content_id}\"]")
+    end
+
+    ERROR_HTML = "<html><body><p>Preview not found</p></body></html>".freeze
+
+    def html_snapshot_from_frontend(uri)
+      begin
+        raw_html = Net::HTTP.get(uri)
+      rescue StandardError
+        raw_html = ERROR_HTML
+      end
+      Nokogiri::HTML.parse(raw_html)
     end
   end
 end

--- a/lib/engines/content_block_manager/app/services/content_block_manager/get_preview_content.rb
+++ b/lib/engines/content_block_manager/app/services/content_block_manager/get_preview_content.rb
@@ -44,13 +44,26 @@ module ContentBlockManager
     end
 
     def replace_existing_content_blocks(nokogiri_html)
-      existing_content_block_spans(nokogiri_html).each do |span|
-        span.replace @content_block_edition.render
-      end
+      replace_blocks(nokogiri_html)
+      style_blocks(nokogiri_html)
       nokogiri_html
     end
 
-    def existing_content_block_spans(nokogiri_html)
+    def replace_blocks(nokogiri_html)
+      content_block_spans(nokogiri_html).each do |span|
+        span.replace @content_block_edition.render
+      end
+    end
+
+    BLOCK_STYLE = "background-color: yellow;".freeze
+
+    def style_blocks(nokogiri_html)
+      content_block_spans(nokogiri_html).each do |span|
+        span["style"] = "background-color: yellow;"
+      end
+    end
+
+    def content_block_spans(nokogiri_html)
       nokogiri_html.css("span[data-content-id=\"#{@content_block_edition.document.content_id}\"]")
     end
   end

--- a/lib/engines/content_block_manager/app/services/content_block_manager/get_preview_content.rb
+++ b/lib/engines/content_block_manager/app/services/content_block_manager/get_preview_content.rb
@@ -1,0 +1,40 @@
+require "net/http"
+require "json"
+require "uri"
+
+module ContentBlockManager
+  class GetPreviewContent
+    def initialize(content_id:)
+      @content_id = content_id
+    end
+
+    def preview_content
+      {
+        title: content_item["title"],
+        html:,
+      }
+    end
+
+  private
+
+    def content_item
+      @content_item ||= begin
+        response = Services.publishing_api.get_content(@content_id)
+        response.parsed_content
+      end
+    end
+
+    def frontend_base_path
+      Rails.env.development? ? Plek.external_url_for("government-frontend") : Plek.website_root
+    end
+
+    def frontend_path
+      frontend_base_path + content_item["base_path"]
+    end
+
+    def html
+      uri = URI(frontend_path)
+      @html ||= Nokogiri::HTML.parse(Net::HTTP.get(uri))
+    end
+  end
+end

--- a/lib/engines/content_block_manager/app/services/content_block_manager/get_preview_content.rb
+++ b/lib/engines/content_block_manager/app/services/content_block_manager/get_preview_content.rb
@@ -4,8 +4,9 @@ require "uri"
 
 module ContentBlockManager
   class GetPreviewContent
-    def initialize(content_id:)
+    def initialize(content_id:, content_block_edition:)
       @content_id = content_id
+      @content_block_edition = content_block_edition
     end
 
     def preview_content
@@ -16,6 +17,10 @@ module ContentBlockManager
     end
 
   private
+
+    def html
+      @html ||= preview_html
+    end
 
     def content_item
       @content_item ||= begin
@@ -32,9 +37,21 @@ module ContentBlockManager
       frontend_base_path + content_item["base_path"]
     end
 
-    def html
+    def preview_html
       uri = URI(frontend_path)
-      @html ||= Nokogiri::HTML.parse(Net::HTTP.get(uri))
+      nokogiri_html = Nokogiri::HTML.parse(Net::HTTP.get(uri))
+      replace_existing_content_blocks(nokogiri_html)
+    end
+
+    def replace_existing_content_blocks(nokogiri_html)
+      existing_content_block_spans(nokogiri_html).each do |span|
+        span.replace @content_block_edition.render
+      end
+      nokogiri_html
+    end
+
+    def existing_content_block_spans(nokogiri_html)
+      nokogiri_html.css("span[data-content-id=\"#{@content_block_edition.document.content_id}\"]")
     end
   end
 end

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/documents/show.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/documents/show.html.erb
@@ -25,6 +25,7 @@
         host_content_items: @host_content_items,
         current_page: @page,
         order: @order,
+        content_block_edition: @content_block_document.latest_edition,
       ),
     ) %>
   </div>

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/host_content/preview.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/host_content/preview.html.erb
@@ -1,0 +1,16 @@
+<% content_for :page_title, "Preview content block in host document" %>
+<% content_for :context, "Preview content block" %>
+<% content_for :title, @preview_content[:title] %>
+<% content_for :title_margin_bottom, 0 %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds govuk-body govuk-!-margin-bottom-0">
+    <p><strong>Document title: </strong><%= @preview_content[:title] %></p>
+  </div>
+</div>
+<hr class="govuk-section-break govuk-!-margin-bottom-8 govuk-section-break--visible">
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <iframe id="preview" style="width:100%;height:80vh;" srcdoc="<%= @preview_content[:html] %>"></iframe>
+  </div>
+</div>

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/host_content/preview.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/host_content/preview.html.erb
@@ -1,16 +1,16 @@
 <% content_for :page_title, "Preview content block in host document" %>
 <% content_for :context, "Preview content block" %>
-<% content_for :title, @preview_content[:title] %>
+<% content_for :title, @preview_content.title %>
 <% content_for :title_margin_bottom, 0 %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds govuk-body govuk-!-margin-bottom-0">
-    <p><strong>Document title: </strong><%= @preview_content[:title] %></p>
+    <p><strong>Document title: </strong><%= @preview_content.title %></p>
   </div>
 </div>
 <hr class="govuk-section-break govuk-!-margin-bottom-8 govuk-section-break--visible">
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <iframe id="preview" style="width:100%;height:80vh;" srcdoc="<%= @preview_content[:html] %>"></iframe>
+    <iframe id="preview" style="width:100%;height:80vh;" srcdoc="<%= @preview_content.html %>"></iframe>
   </div>
 </div>

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/review_links.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/review_links.html.erb
@@ -18,6 +18,7 @@
             host_content_items: @host_content_items,
             current_page: @page,
             order: @order,
+            content_block_edition: @content_block_edition,
             ),
           ) %>
   </div>

--- a/lib/engines/content_block_manager/config/routes.rb
+++ b/lib/engines/content_block_manager/config/routes.rb
@@ -12,6 +12,9 @@ ContentBlockManager::Engine.routes.draw do
       resources :editions, only: %i[new create destroy], path_names: { new: ":block_type/new" } do
         member do
           resources :workflow, only: %i[show update], controller: "editions/workflow", param: :step
+          resources :host_content, only: %i[preview], controller: "editions/host_content", param: :id do
+            get :preview, to: "editions/host_content#preview"
+          end
         end
       end
     end

--- a/lib/engines/content_block_manager/features/edit_object.feature
+++ b/lib/engines/content_block_manager/features/edit_object.feature
@@ -96,8 +96,10 @@ Feature: Edit a content object
     And I visit the Content Block Manager home page
     Then I should still see the live edition on the homepage
 
+  @javascript
   Scenario: GDS editor can preview a host document
     When I revisit the edit page
     And I fill out the form
     Then I am shown where the changes will take place
-    And the host documents link to the draft content store
+    When I click on the first host document
+    Then The preview page opens in a new tab

--- a/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
@@ -437,7 +437,7 @@ When(/^dependent content exists for a content block$/) do
     {
       "title" => "Content #{i}",
       "document_type" => "document",
-      "base_path" => "/",
+      "base_path" => "/host-content-path-#{i}",
       "content_id" => SecureRandom.uuid,
       "last_edited_by_editor_id" => SecureRandom.uuid,
       "last_edited_at" => 2.days.ago.to_s,
@@ -486,7 +486,40 @@ And("the host documents link to the draft content store") do
 end
 
 When("I click on the first host document") do
-  click_on @dependent_content.first["title"]
+  @current_host_document = @dependent_content.first
+  stub_request(
+    :get,
+    "#{Plek.find('publishing-api')}/v2/content/#{@current_host_document['host_content_id']}",
+  ).to_return(
+    status: 200,
+    body: {
+      details: {
+        body: "<p>title</p>",
+      },
+      title: @current_host_document["title"],
+      document_type: "news_story",
+      base_path: @current_host_document["base_path"],
+      publishing_app: "test",
+    }.to_json,
+  )
+
+  stub_request(
+    :get,
+    Plek.website_root + @current_host_document["base_path"],
+  ).to_return(
+    status: 200,
+    body: "<h1>#{@current_host_document['title']}</h1><p>iframe preview</p>",
+  )
+
+  click_on @current_host_document["title"]
+end
+
+Then("The preview page opens in a new tab") do
+  page.switch_to_window(page.windows.last)
+  assert_text "Preview content block"
+  within_frame "preview" do
+    assert_text @current_host_document["title"]
+  end
 end
 
 When(/^I save and continue$/) do

--- a/lib/engines/content_block_manager/test/components/content_block/document/show/host_editions_table_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/document/show/host_editions_table_component_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class ContentBlockManager::ContentBlock::Document::Show::HostEditionsTableComponentTest < ViewComponent::TestCase
   extend Minitest::Spec::DSL
-  include Rails.application.routes.url_helpers
+  include ContentBlockManager::Engine.routes.url_helpers
   include ActionView::Helpers::DateHelper
 
   let(:described_class) { ContentBlockManager::ContentBlock::Document::Show::HostEditionsTableComponent }
@@ -28,6 +28,7 @@ class ContentBlockManager::ContentBlock::Document::Show::HostEditionsTableCompon
       "last_edited_at" => Time.zone.now.to_s,
       "publishing_organisation" => publishing_organisation,
       "unique_pageviews" => unique_pageviews,
+      "host_content_id" => SecureRandom.uuid,
       "instances" => 1,
     )
   end
@@ -40,12 +41,17 @@ class ContentBlockManager::ContentBlock::Document::Show::HostEditionsTableCompon
     )
   end
 
+  let(:content_block_edition) do
+    build(:content_block_edition, :email_address, id: SecureRandom.uuid)
+  end
+
   def self.it_returns_unknown_user
     it "returns Unknown user" do
       render_inline(
         described_class.new(
           caption:,
           host_content_items:,
+          content_block_edition:,
         ),
       )
 
@@ -54,7 +60,7 @@ class ContentBlockManager::ContentBlock::Document::Show::HostEditionsTableCompon
   end
 
   around do |test|
-    with_request_url content_block_manager_path do
+    with_request_url content_block_manager_root_path do
       test.call
     end
   end
@@ -65,6 +71,7 @@ class ContentBlockManager::ContentBlock::Document::Show::HostEditionsTableCompon
         described_class.new(
           caption:,
           host_content_items:,
+          content_block_edition:,
         ),
       )
 
@@ -91,6 +98,7 @@ class ContentBlockManager::ContentBlock::Document::Show::HostEditionsTableCompon
           described_class.new(
             caption:,
             host_content_items:,
+            content_block_edition:,
           ),
         )
         assert_no_selector "tbody .govuk-table__cell a", text: host_content_item.publishing_organisation["title"]
@@ -101,12 +109,13 @@ class ContentBlockManager::ContentBlock::Document::Show::HostEditionsTableCompon
       it "links to the organisation instead of printing the name" do
         organisation = create(:organisation, content_id: host_content_item.publishing_organisation["content_id"], name: host_content_item.publishing_organisation["title"])
 
-        expected_href = admin_organisation_path(organisation)
+        expected_href = Rails.application.routes.url_helpers.admin_organisation_path(organisation)
 
         render_inline(
           described_class.new(
             caption:,
             host_content_items:,
+            content_block_edition:,
           ),
         )
         assert_selector "tbody .govuk-table__cell a",
@@ -130,6 +139,7 @@ class ContentBlockManager::ContentBlock::Document::Show::HostEditionsTableCompon
           described_class.new(
             caption:,
             host_content_items:,
+            content_block_edition:,
           ),
         )
 
@@ -165,6 +175,7 @@ class ContentBlockManager::ContentBlock::Document::Show::HostEditionsTableCompon
           described_class.new(
             caption:,
             host_content_items:,
+            content_block_edition:,
           ),
         )
 
@@ -179,10 +190,11 @@ class ContentBlockManager::ContentBlock::Document::Show::HostEditionsTableCompon
             is_preview: true,
             caption:,
             host_content_items:,
+            content_block_edition:,
           ),
         )
 
-        assert_selector "a[href='#{Plek.external_url_for('draft-origin') + host_content_item.base_path}']", text: host_content_item.title
+        assert_selector "a[href='#{content_block_manager_content_block_host_content_preview_path(id: content_block_edition.id, host_content_id: host_content_item.host_content_id)}']", text: host_content_item.title
       end
     end
 
@@ -192,6 +204,7 @@ class ContentBlockManager::ContentBlock::Document::Show::HostEditionsTableCompon
           described_class.new(
             caption:,
             host_content_items:,
+            content_block_edition:,
           ),
         )
 
@@ -203,6 +216,7 @@ class ContentBlockManager::ContentBlock::Document::Show::HostEditionsTableCompon
           described_class.new(
             caption:,
             host_content_items:,
+            content_block_edition:,
           ),
         )
 
@@ -223,6 +237,7 @@ class ContentBlockManager::ContentBlock::Document::Show::HostEditionsTableCompon
               caption:,
               host_content_items:,
               order:,
+              content_block_edition:,
             ),
           )
 
@@ -235,6 +250,7 @@ class ContentBlockManager::ContentBlock::Document::Show::HostEditionsTableCompon
               caption:,
               host_content_items:,
               order: "-#{order}",
+              content_block_edition:,
             ),
           )
 
@@ -259,6 +275,7 @@ class ContentBlockManager::ContentBlock::Document::Show::HostEditionsTableCompon
             described_class.new(
               caption:,
               host_content_items:,
+              content_block_edition:,
             ),
           )
 
@@ -281,6 +298,7 @@ class ContentBlockManager::ContentBlock::Document::Show::HostEditionsTableCompon
             described_class.new(
               caption:,
               host_content_items:,
+              content_block_edition:,
             ),
           )
 
@@ -293,6 +311,7 @@ class ContentBlockManager::ContentBlock::Document::Show::HostEditionsTableCompon
             described_class.new(
               caption:,
               host_content_items:,
+              content_block_edition:,
             ),
           )
 
@@ -306,6 +325,7 @@ class ContentBlockManager::ContentBlock::Document::Show::HostEditionsTableCompon
               caption:,
               host_content_items:,
               current_page: 2,
+              content_block_edition:,
             ),
           )
 

--- a/lib/engines/content_block_manager/test/factories/host_content_item.rb
+++ b/lib/engines/content_block_manager/test/factories/host_content_item.rb
@@ -9,6 +9,7 @@ FactoryBot.define do
     last_edited_at { 2.days.ago.to_s }
     unique_pageviews { 123 }
     instances { 1 }
+    host_content_id { SecureRandom.uuid }
 
     initialize_with do
       new(title:,
@@ -19,6 +20,7 @@ FactoryBot.define do
           last_edited_by_editor_id:,
           last_edited_at:,
           unique_pageviews:,
+          host_content_id:,
           instances:)
     end
   end

--- a/lib/engines/content_block_manager/test/factories/preview_content.rb
+++ b/lib/engines/content_block_manager/test/factories/preview_content.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :preview_content, class: "ContentBlockManager::PreviewContent" do
+    title { "Example Title" }
+    html { "<p>Example HTML</p>" }
+
+    initialize_with do
+      new(title:, html:)
+    end
+  end
+end

--- a/lib/engines/content_block_manager/test/unit/app/models/preview_content_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/models/preview_content_test.rb
@@ -1,0 +1,14 @@
+require "test_helper"
+
+class ContentBlockManager::PreviewContentTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
+  let(:title) { "Ministry of Example" }
+  let(:html) { "<p>Ministry of Example</p>" }
+  let(:preview_content) { build(:preview_content, title:, html:) }
+
+  it "returns title and html" do
+    assert_equal preview_content.title, title
+    assert_equal preview_content.html, html
+  end
+end

--- a/lib/engines/content_block_manager/test/unit/app/services/get_host_content_items_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/services/get_host_content_items_test.rb
@@ -7,6 +7,8 @@ class ContentBlockManager::GetHostContentItemsTest < ActiveSupport::TestCase
 
   let(:target_content_id) { SecureRandom.uuid }
 
+  let(:host_content_id) { SecureRandom.uuid }
+
   let(:response_body) do
     {
       "content_id" => SecureRandom.uuid,
@@ -22,6 +24,7 @@ class ContentBlockManager::GetHostContentItemsTest < ActiveSupport::TestCase
           "last_edited_at" => "2023-01-01T08:00:00.000Z",
           "unique_pageviews" => 123,
           "instances" => 1,
+          "host_content_id" => host_content_id,
           "primary_publishing_organisation" => {
             "content_id" => SecureRandom.uuid,
             "title" => "bar",
@@ -110,6 +113,7 @@ class ContentBlockManager::GetHostContentItemsTest < ActiveSupport::TestCase
       assert_equal result[0].last_edited_at, Time.zone.parse(response_body["results"][0]["last_edited_at"])
       assert_equal result[0].unique_pageviews, response_body["results"][0]["unique_pageviews"]
       assert_equal result[0].instances, response_body["results"][0]["instances"]
+      assert_equal result[0].host_content_id, response_body["results"][0]["host_content_id"]
 
       assert_equal result[0].publishing_organisation, expected_publishing_organisation
     end

--- a/lib/engines/content_block_manager/test/unit/app/services/get_preview_content_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/services/get_preview_content_test.rb
@@ -1,0 +1,32 @@
+require "test_helper"
+
+class ContentBlockManager::GetPreviewContentTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
+  let(:described_class) { ContentBlockManager::GetPreviewContent }
+  let(:host_content_id) { "64570503-7a7f-4fca-80c1-e6dce7278419" }
+  let(:host_title) { "Test" }
+  let(:host_base_path) { "/test" }
+  let(:uri_mock) { mock }
+  let(:fake_frontend_response) do
+    "<!DOCTYPE html><body><p>test</p></body>"
+  end
+
+  describe "#preview_content" do
+    setup do
+      stub_publishing_api_has_item(content_id: host_content_id, title: host_title, base_path: host_base_path)
+    end
+
+    it "returns the title and raw frontend HTML for a document" do
+      Net::HTTP.expects(:get).with(URI(Plek.website_root + host_base_path)).returns(fake_frontend_response)
+      Nokogiri::HTML.expects(:parse).with(fake_frontend_response).returns(fake_frontend_response)
+
+      expected_content = {
+        title: host_title,
+        html: fake_frontend_response,
+      }
+
+      assert_equal expected_content, ContentBlockManager::GetPreviewContent.new(content_id: host_content_id).preview_content
+    end
+  end
+end

--- a/lib/engines/content_block_manager/test/unit/app/services/get_preview_content_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/services/get_preview_content_test.rb
@@ -42,13 +42,13 @@ class ContentBlockManager::GetPreviewContentTest < ActiveSupport::TestCase
         html: Nokogiri::HTML.parse(expected_html),
       }
 
-      actual_content = ContentBlockManager::GetPreviewContent.new(
+      actual_content = ContentBlockManager::GetPreviewContent.for_content_id(
         content_id: host_content_id,
         content_block_edition: block_to_preview,
-      ).preview_content
+      )
 
-      assert_equal expected_content[:title], actual_content[:title]
-      assert_equal expected_content[:html].to_s, actual_content[:html].to_s
+      assert_equal expected_content[:title], actual_content.title
+      assert_equal expected_content[:html].to_s, actual_content.html.to_s
     end
   end
 end

--- a/lib/engines/content_block_manager/test/unit/app/services/get_preview_content_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/services/get_preview_content_test.rb
@@ -21,6 +21,9 @@ class ContentBlockManager::GetPreviewContentTest < ActiveSupport::TestCase
   let(:expected_html) do
     "<body><p>test</p>#{block_render_with_style}</body>"
   end
+  let(:error_html) do
+    "<html><body><p>Preview not found</p></body></html>"
+  end
   let(:document) do
     build(:content_block_document, :email_address, content_id: preview_content_id)
   end
@@ -28,18 +31,36 @@ class ContentBlockManager::GetPreviewContentTest < ActiveSupport::TestCase
     build(:content_block_edition, :email_address, document:, details: { "email_address" => "new@new.com" })
   end
 
-  describe "#preview_content" do
+  describe "#for_content_id" do
     setup do
       stub_publishing_api_has_item(content_id: host_content_id, title: host_title, base_path: host_base_path)
+      block_to_preview.expects(:render).returns(block_render)
     end
 
     it "returns the title and preview HTML for a document" do
       Net::HTTP.expects(:get).with(URI(Plek.website_root + host_base_path)).returns(fake_frontend_response)
-      block_to_preview.expects(:render).returns(block_render)
 
       expected_content = {
         title: host_title,
         html: Nokogiri::HTML.parse(expected_html),
+      }
+
+      actual_content = ContentBlockManager::GetPreviewContent.for_content_id(
+        content_id: host_content_id,
+        content_block_edition: block_to_preview,
+      )
+
+      assert_equal expected_content[:title], actual_content.title
+      assert_equal expected_content[:html].to_s, actual_content.html.to_s
+    end
+
+    it "shows an error template when the request to the frontend throws an error" do
+      exception = StandardError.new("Something went wrong")
+      Net::HTTP.expects(:get).with(URI(Plek.website_root + host_base_path)).raises(exception)
+
+      expected_content = {
+        title: host_title,
+        html: Nokogiri::HTML.parse(error_html),
       }
 
       actual_content = ContentBlockManager::GetPreviewContent.for_content_id(

--- a/lib/engines/content_block_manager/test/unit/app/services/get_preview_content_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/services/get_preview_content_test.rb
@@ -15,8 +15,11 @@ class ContentBlockManager::GetPreviewContentTest < ActiveSupport::TestCase
   let(:block_render) do
     "<span class=\"content-embed content-embed__content_block_email_address\" data-content-block=\"\" data-document-type=\"content_block_email_address\" data-content-id=\"#{preview_content_id}\">new@new.com</span>"
   end
+  let(:block_render_with_style) do
+    "<span class=\"content-embed content-embed__content_block_email_address\" data-content-block=\"\" data-document-type=\"content_block_email_address\" data-content-id=\"#{preview_content_id}\" style=\"background-color: yellow;\">new@new.com</span>"
+  end
   let(:expected_html) do
-    "<body><p>test</p>#{block_render}</body>"
+    "<body><p>test</p>#{block_render_with_style}</body>"
   end
   let(:document) do
     build(:content_block_document, :email_address, content_id: preview_content_id)


### PR DESCRIPTION
https://trello.com/c/e2rpWPUT/659-spike-preview-host-documents

We would like users to be able to click through from the edit journey to view a preview of the Host Document with the new Content Block content within it.
This PR suggests the first stage of enabling it via an iframe embedding the HTML from the gov.uk frontend of the Host Document. 
We have come to this solution of using an iframe after extensive chats and found this to be the least bad option.
https://docs.google.com/document/d/19Nla6imjblR4XK_VI7t1lpob8Jmng2ZqRfpmsSnVuVQ/edit?tab=t.0#heading=h.s3ee1ypp6ehg


![Screenshot 2024-11-25 at 11 49 32](https://github.com/user-attachments/assets/0fbcce0c-d68b-4945-9f1a-d521ff2dba11)





⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
