### PR TITLE
Add asset_manager_id to file attachments

### DIFF
--- a/app/models/file_attachment.rb
+++ b/app/models/file_attachment.rb
@@ -55,7 +55,7 @@ class FileAttachment < Attachment
       filename:,
       number_of_pages:,
       preview_url:,
-      asset_manager_id:,
+      assets:,
     }
   end
 
@@ -67,10 +67,15 @@ private
     nil
   end
 
-  def asset_manager_id
-    return unless csv? && attachable.is_a?(Edition) && attachment_data.all_asset_variants_uploaded?
+  def assets
+    return unless attachable.is_a?(Edition) && attachment_data.all_asset_variants_uploaded?
 
-    attachment_data.assets.first.asset_manager_id
+    attachment_data.assets.map do |asset|
+      {
+        asset_manager_id: asset.asset_manager_id,
+        filename: asset.filename,
+      }
+    end
   end
 
   def preview_url

--- a/app/models/file_attachment.rb
+++ b/app/models/file_attachment.rb
@@ -55,7 +55,7 @@ class FileAttachment < Attachment
       filename:,
       number_of_pages:,
       preview_url:,
-      attachment_data_id:,
+      asset_manager_id:,
     }
   end
 
@@ -67,10 +67,10 @@ private
     nil
   end
 
-  def attachment_data_id
+  def asset_manager_id
     return unless csv? && attachable.is_a?(Edition) && attachment_data.all_asset_variants_uploaded?
 
-    attachment_data.id
+    attachment_data.assets.first.asset_manager_id
   end
 
   def preview_url

--- a/app/models/file_attachment.rb
+++ b/app/models/file_attachment.rb
@@ -55,6 +55,7 @@ class FileAttachment < Attachment
       filename:,
       number_of_pages:,
       preview_url:,
+      attachment_data_id:,
     }
   end
 
@@ -64,6 +65,12 @@ private
     attachable.alternative_format_contact_email
   rescue NoMethodError
     nil
+  end
+
+  def attachment_data_id
+    return unless csv? && attachable.is_a?(Edition) && attachment_data.all_asset_variants_uploaded?
+
+    attachment_data.id
   end
 
   def preview_url

--- a/test/unit/app/models/attachment_test.rb
+++ b/test/unit/app/models/attachment_test.rb
@@ -8,7 +8,7 @@ class AttachmentTest < ActiveSupport::TestCase
 
     output = attachment.publishing_api_details
     assert_equal output.keys,
-                 %i[attachment_type id title url accessible alternative_format_contact_email content_type filename]
+                 %i[attachment_type id title url accessible alternative_format_contact_email content_type filename assets]
   end
 
   test ".publishing_api_details includes publication attachment details for " \

--- a/test/unit/app/models/file_attachment_test.rb
+++ b/test/unit/app/models/file_attachment_test.rb
@@ -69,9 +69,9 @@ class FileAttachmentTest < ActiveSupport::TestCase
     assert_equal Plek.asset_root + "/media/#{attachment.attachment_data.id}/sample.csv/preview", attachment.publishing_api_details_for_format[:preview_url]
   end
 
-  test "#asset_manager_id returns asset manager id if all_asset_variants_uploaded?" do
+  test "#assets returns assets list if all_asset_variants_uploaded?" do
     attachment = create(:csv_attachment, attachable: create(:edition))
-    assert_not_nil attachment.attachment_data.assets.first.asset_manager_id
-    assert_equal attachment.attachment_data.assets.first.asset_manager_id, attachment.publishing_api_details_for_format[:asset_manager_id]
+
+    assert_equal [{ "asset_manager_id": attachment.attachment_data.assets.first.asset_manager_id, "filename": attachment.attachment_data.assets.first.filename }], attachment.publishing_api_details_for_format[:assets]
   end
 end

--- a/test/unit/app/models/file_attachment_test.rb
+++ b/test/unit/app/models/file_attachment_test.rb
@@ -68,4 +68,9 @@ class FileAttachmentTest < ActiveSupport::TestCase
     attachment = create(:csv_attachment, attachable: create(:edition))
     assert_equal Plek.asset_root + "/media/#{attachment.attachment_data.id}/sample.csv/preview", attachment.publishing_api_details_for_format[:preview_url]
   end
+
+  test "return media attachment_data_id if all_asset_variants_uploaded?" do
+    attachment = create(:csv_attachment, attachable: create(:edition))
+    assert_equal attachment.attachment_data.id, attachment.publishing_api_details_for_format[:attachment_data_id]
+  end
 end

--- a/test/unit/app/models/file_attachment_test.rb
+++ b/test/unit/app/models/file_attachment_test.rb
@@ -69,8 +69,9 @@ class FileAttachmentTest < ActiveSupport::TestCase
     assert_equal Plek.asset_root + "/media/#{attachment.attachment_data.id}/sample.csv/preview", attachment.publishing_api_details_for_format[:preview_url]
   end
 
-  test "return media attachment_data_id if all_asset_variants_uploaded?" do
+  test "#asset_manager_id returns asset manager id if all_asset_variants_uploaded?" do
     attachment = create(:csv_attachment, attachable: create(:edition))
-    assert_equal attachment.attachment_data.id, attachment.publishing_api_details_for_format[:attachment_data_id]
+    assert_not_nil attachment.attachment_data.assets.first.asset_manager_id
+    assert_equal attachment.attachment_data.assets.first.asset_manager_id, attachment.publishing_api_details_for_format[:asset_manager_id]
   end
 end


### PR DESCRIPTION
This needs to follow on from https://github.com/alphagov/publishing-api/pull/2994

As described there, the lack of asset_manager_id in the data for file asset attachments in content store makes it hard to request the attachments on the server side. Instead, we have to redirect users to the assets, which has led to ugly workarounds like CSV previews being rendered by frontend but served on assets.publishing.service.gov.uk.

Adding asset_manager_id should allow the frontends to request attachments directly, using the API client:

    GdsApi.asset_manager.media(asset_manager_id, filename)

This should make it much more convenient to preview assets, or use them for other rendering purposes (e.g. showing a CSV as a line graph).

EDIT: This description has been updated by @unoduetre to not include details which are no longer relevant.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️