### PR TITLE
Update organisation classes

### DIFF
--- a/app/models/organisation_brand_colour.rb
+++ b/app/models/organisation_brand_colour.rb
@@ -125,7 +125,7 @@ class OrganisationBrandColour
   TheOfficeOfTheLeaderOfTheHouseOfCommons = create!(
     id: 24,
     title: "Office of the Leader of the House of Commons",
-    class_name: "the-office-of-the-leader-of-the-house-of-commons",
+    class_name: "office-of-the-leader-of-the-house-of-commons",
   )
   UKExportFinance = create!(
     id: 25,
@@ -165,7 +165,7 @@ class OrganisationBrandColour
   DepartmentForScienceInnovationAndTechnology = create!(
     id: 32,
     title: "Department for Science, Innovation & Technology",
-    class_name: "department-for-science-innovation-and-technology",
+    class_name: "department-for-science-innovation-technology",
   )
   PrimeMinistersOffice10DowningStreet = create!(
     id: 33,


### PR DESCRIPTION
## What / Why

- Renames two classes in the Whitehall organisation colours model.
- These classes were renamed in `govuk-frontend`. They did not break when they were renamed, as we had '[middle man'/conversion classes in `govuk_publishing_components`](https://github.com/alphagov/govuk_publishing_components/blob/654637b8a9efffe97c3960f45ffaeec56c8465c0/app/assets/stylesheets/govuk_publishing_components/components/helpers/_brand-colours.scss#L19) that would redirect the old class names to the correct class name. However if we update the class in the model, we can then remove those conversion classes from `govuk_publishing_components`.
- These classes are used for the border colours on the [DSIT org page](https://www.gov.uk/government/organisations/department-for-science-innovation-and-technology) and [Office of the Leader of the House of Commons org page](https://www.gov.uk/government/organisations/the-office-of-the-leader-of-the-house-of-commons). 
- This change should be very safe, because:
    -  if you inspect element on those organisation pages, and rename the border classes (e.g. `brand--department-for-science-innovation-and-technology` becomes `brand--department-for-science-innovation-technology`) the border colours stay the same.
    - These new class names definitely exist in `govuk-frontend`. [See here](https://github.com/alphagov/govuk-frontend/blob/c53281daec9798dfc2e1d84643c09d96d5eccbea/packages/govuk-frontend/src/govuk/settings/_colours-organisations.scss#L101).
    - [We've done this before](https://github.com/alphagov/whitehall/pull/9379).
    - The old class names also still exist in the gem, so there's no time pressure to deploy this.
    - Worst case scenario, the border colours would turn black, but I can't see how this would happen.
- This change is a part of some technical debt cleanup as a result of https://github.com/alphagov/govuk_publishing_components/pull/4321