### PR TITLE
Track all links and buttons in Whitehall as per agreed event schema

### DIFF
--- a/app/assets/javascripts/admin/analytics-modules/ga4-button-setup.js
+++ b/app/assets/javascripts/admin/analytics-modules/ga4-button-setup.js
@@ -13,7 +13,8 @@ window.GOVUK.analyticsGa4.analyticsModules =
         const buttons = moduleElement.querySelectorAll('button')
         buttons.forEach((button) => {
           const event = {
-            event_name: 'navigation',
+            event_name:
+              button.type === 'submit' ? 'navigation' : 'select_content',
             type: 'button',
             text: button.textContent
           }

--- a/app/assets/javascripts/admin/analytics-modules/ga4-button-setup.js
+++ b/app/assets/javascripts/admin/analytics-modules/ga4-button-setup.js
@@ -15,8 +15,7 @@ window.GOVUK.analyticsGa4.analyticsModules =
           const event = {
             event_name: 'navigation',
             type: 'button',
-            text: button.textContent,
-            method: 'primary_click'
+            text: button.textContent
           }
           if (button.dataset.ga4Event) {
             Object.assign(event, JSON.parse(button.dataset.ga4Event))

--- a/app/assets/javascripts/admin/analytics-modules/ga4-button-setup.js
+++ b/app/assets/javascripts/admin/analytics-modules/ga4-button-setup.js
@@ -10,9 +10,7 @@ window.GOVUK.analyticsGa4.analyticsModules =
         "[data-module~='ga4-button-setup']"
       )
       moduleElements.forEach(function (moduleElement) {
-        const buttons = moduleElement.querySelectorAll(
-          'button, [role="button"]'
-        )
+        const buttons = moduleElement.querySelectorAll('button')
         buttons.forEach((button) => {
           const event = {
             event_name: 'navigation',

--- a/app/assets/javascripts/admin/analytics-modules/ga4-link-setup.js
+++ b/app/assets/javascripts/admin/analytics-modules/ga4-link-setup.js
@@ -14,8 +14,7 @@ window.GOVUK.analyticsGa4.analyticsModules =
         links.forEach((link) => {
           const event = {
             event_name: 'navigation',
-            type: link.role === 'button' ? 'button' : 'generic_link',
-            method: 'primary_click'
+            type: link.role === 'button' ? 'button' : 'generic_link'
           }
           if (link.dataset.ga4Event) {
             Object.assign(event, JSON.parse(link.dataset.ga4Event))

--- a/app/assets/javascripts/admin/analytics-modules/ga4-link-setup.js
+++ b/app/assets/javascripts/admin/analytics-modules/ga4-link-setup.js
@@ -16,10 +16,10 @@ window.GOVUK.analyticsGa4.analyticsModules =
             event_name: 'navigation',
             type: link.role === 'button' ? 'button' : 'generic_link'
           }
-          if (link.dataset.ga4Event) {
-            Object.assign(event, JSON.parse(link.dataset.ga4Event))
+          if (link.dataset.ga4Link) {
+            Object.assign(event, JSON.parse(link.dataset.ga4Link))
           }
-          link.dataset.ga4Event = JSON.stringify(event)
+          link.dataset.ga4Link = JSON.stringify(event)
         })
       })
     }

--- a/app/assets/javascripts/admin/analytics-modules/ga4-link-setup.js
+++ b/app/assets/javascripts/admin/analytics-modules/ga4-link-setup.js
@@ -12,6 +12,10 @@ window.GOVUK.analyticsGa4.analyticsModules =
       moduleElements.forEach(function (moduleElement) {
         const links = moduleElement.querySelectorAll('a')
         links.forEach((link) => {
+          // Exclude links that serve as tab controls as they have their own event tracking
+          if (link.role === 'tab') {
+            return
+          }
           const event = {
             event_name: 'navigation',
             type: link.role === 'button' ? 'button' : 'generic_link'

--- a/app/components/admin/editions/show/sidebar_actions_component.html.erb
+++ b/app/components/admin/editions/show/sidebar_actions_component.html.erb
@@ -1,4 +1,4 @@
-<div class="app-view-summary__sidebar-actions" data-module="ga4-button-setup">
+<div class="app-view-summary__sidebar-actions">
   <%= render "govuk_publishing_components/components/list", {
     extra_spacing: true,
     items: actions,

--- a/app/helpers/admin/editions_helper.rb
+++ b/app/helpers/admin/editions_helper.rb
@@ -93,7 +93,7 @@ module Admin::EditionsHelper
   end
 
   def standard_edition_form(edition)
-    form_for form_url_for_edition(edition), as: :edition, html: { class: edition_form_classes(edition), multipart: true }, data: { module: "EditionForm LocaleSwitcher ga4-button-setup ga4-visual-editor-event-handlers", "rtl-locales": Locale.right_to_left.collect(&:to_param) } do |form|
+    form_for form_url_for_edition(edition), as: :edition, html: { class: edition_form_classes(edition), multipart: true }, data: { module: "EditionForm LocaleSwitcher ga4-visual-editor-event-handlers", "rtl-locales": Locale.right_to_left.collect(&:to_param) } do |form|
       concat render("standard_fields", form:, edition:)
       yield(form)
       concat render("settings_fields", form:, edition:)

--- a/app/views/admin/attachments/_form.html.erb
+++ b/app/views/admin/attachments/_form.html.erb
@@ -1,4 +1,4 @@
-<%= form_for attachment, url: [:admin, typecast_for_attachable_routing(attachable), attachment.becomes(Attachment)], as: :attachment, html: { :class => "app-view-attachments__form", data: { module: "LocaleSwitcher ga4-button-setup ga4-visual-editor-event-handlers", "rtl-locales": Locale.right_to_left.collect(&:to_param) }}, multipart: true do |form| %>
+<%= form_for attachment, url: [:admin, typecast_for_attachable_routing(attachable), attachment.becomes(Attachment)], as: :attachment, html: { :class => "app-view-attachments__form", data: { module: "LocaleSwitcher ga4-visual-editor-event-handlers", "rtl-locales": Locale.right_to_left.collect(&:to_param) }}, multipart: true do |form| %>
   <div class="govuk-!-margin-bottom-8 app-view-attachments__form-title js-locale-switcher-field">
     <%= render "govuk_publishing_components/components/input", {
       label: {

--- a/app/views/admin/new_document/index.html.erb
+++ b/app/views/admin/new_document/index.html.erb
@@ -3,7 +3,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_with url: admin_new_document_options_path, data: {
-      module: "ga4-form-setup ga4-form-tracker ga4-link-setup ga4-link-tracker",
+      module: "ga4-form-setup ga4-form-tracker",
     } do %>
       <%= render "govuk_publishing_components/components/radio", {
         heading: "New document",

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -22,7 +22,7 @@
 
   <%= render partial: "shared/header" %>
 
-  <div class="govuk-width-container" data-module="ga4-event-tracker ga4-paste-tracker">
+  <div class="govuk-width-container" data-module="ga4-event-tracker ga4-paste-tracker ga4-link-setup ga4-link-tracker ga4-button-setup">
     <%= render "shared/phase_banner", {
       show_feedback_banner: t("admin.feedback.show_banner"),
     } %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -28,7 +28,7 @@
   ],
 } %>
 
-<div class="govuk-width-container">
+<div class="govuk-width-container" data-module="ga4-link-setup ga4-link-tracker">
   <%= render "components/sub_navigation", {
     items: [
       sub_nav_item("New document", admin_new_document_path),

--- a/spec/javascripts/admin/analytics-modules/ga4-button-setup.spec.js
+++ b/spec/javascripts/admin/analytics-modules/ga4-button-setup.spec.js
@@ -45,18 +45,4 @@ describe('GOVUK.analyticsGa4.analyticsModules', function () {
       '{"event_name":"custom_event_name","type":"button","text":"Button","method":"primary_click"}'
     )
   })
-
-  it('adds ga4 event data to nodes with the button role', function () {
-    const link = document.createElement('a')
-    link.textContent = 'Link'
-    link.role = 'button'
-    button.replaceWith(link)
-
-    const ga4ButtonSetup = GOVUK.analyticsGa4.analyticsModules.Ga4ButtonSetup
-    ga4ButtonSetup.init()
-
-    expect(link.dataset.ga4Event).toEqual(
-      '{"event_name":"navigation","type":"button","text":"Link","method":"primary_click"}'
-    )
-  })
 })

--- a/spec/javascripts/admin/analytics-modules/ga4-button-setup.spec.js
+++ b/spec/javascripts/admin/analytics-modules/ga4-button-setup.spec.js
@@ -18,7 +18,7 @@ describe('GOVUK.analyticsGa4.analyticsModules', function () {
     ga4ButtonSetup.init()
 
     expect(button.dataset.ga4Event).toEqual(
-      '{"event_name":"navigation","type":"button","text":"Button"}'
+      '{"event_name":"select_content","type":"button","text":"Button"}'
     )
   })
 

--- a/spec/javascripts/admin/analytics-modules/ga4-button-setup.spec.js
+++ b/spec/javascripts/admin/analytics-modules/ga4-button-setup.spec.js
@@ -18,7 +18,7 @@ describe('GOVUK.analyticsGa4.analyticsModules', function () {
     ga4ButtonSetup.init()
 
     expect(button.dataset.ga4Event).toEqual(
-      '{"event_name":"navigation","type":"button","text":"Button","method":"primary_click"}'
+      '{"event_name":"navigation","type":"button","text":"Button"}'
     )
   })
 
@@ -29,7 +29,7 @@ describe('GOVUK.analyticsGa4.analyticsModules', function () {
     ga4ButtonSetup.init()
 
     expect(button.dataset.ga4Event).toEqual(
-      '{"event_name":"navigation","type":"button","text":"Button","method":"primary_click"}'
+      '{"event_name":"navigation","type":"button","text":"Button"}'
     )
   })
 
@@ -42,7 +42,7 @@ describe('GOVUK.analyticsGa4.analyticsModules', function () {
     ga4ButtonSetup.init()
 
     expect(button.dataset.ga4Event).toEqual(
-      '{"event_name":"custom_event_name","type":"button","text":"Button","method":"primary_click"}'
+      '{"event_name":"custom_event_name","type":"button","text":"Button"}'
     )
   })
 })

--- a/spec/javascripts/admin/analytics-modules/ga4-link-setup.spec.js
+++ b/spec/javascripts/admin/analytics-modules/ga4-link-setup.spec.js
@@ -17,7 +17,7 @@ describe('GOVUK.analyticsGa4.analyticsModules.Ga4LinkSetup', function () {
     Ga4LinkSetup.init()
 
     expect(link.dataset.ga4Event).toEqual(
-      '{"event_name":"navigation","type":"generic_link","method":"primary_click"}'
+      '{"event_name":"navigation","type":"generic_link"}'
     )
   })
 
@@ -28,7 +28,7 @@ describe('GOVUK.analyticsGa4.analyticsModules.Ga4LinkSetup', function () {
     Ga4LinkSetup.init()
 
     expect(link.dataset.ga4Event).toEqual(
-      '{"event_name":"navigation","type":"button","method":"primary_click"}'
+      '{"event_name":"navigation","type":"button"}'
     )
   })
 })

--- a/spec/javascripts/admin/analytics-modules/ga4-link-setup.spec.js
+++ b/spec/javascripts/admin/analytics-modules/ga4-link-setup.spec.js
@@ -16,7 +16,7 @@ describe('GOVUK.analyticsGa4.analyticsModules.Ga4LinkSetup', function () {
     const Ga4LinkSetup = GOVUK.analyticsGa4.analyticsModules.Ga4LinkSetup
     Ga4LinkSetup.init()
 
-    expect(link.dataset.ga4Event).toEqual(
+    expect(link.dataset.ga4Link).toEqual(
       '{"event_name":"navigation","type":"generic_link"}'
     )
   })
@@ -27,7 +27,7 @@ describe('GOVUK.analyticsGa4.analyticsModules.Ga4LinkSetup', function () {
     const Ga4LinkSetup = GOVUK.analyticsGa4.analyticsModules.Ga4LinkSetup
     Ga4LinkSetup.init()
 
-    expect(link.dataset.ga4Event).toEqual(
+    expect(link.dataset.ga4Link).toEqual(
       '{"event_name":"navigation","type":"button"}'
     )
   })

--- a/spec/javascripts/admin/analytics-modules/ga4-link-setup.spec.js
+++ b/spec/javascripts/admin/analytics-modules/ga4-link-setup.spec.js
@@ -31,4 +31,13 @@ describe('GOVUK.analyticsGa4.analyticsModules.Ga4LinkSetup', function () {
       '{"event_name":"navigation","type":"button"}'
     )
   })
+
+  it('excludes links that serve as tab controls', function () {
+    link.role = 'tab'
+
+    const Ga4LinkSetup = GOVUK.analyticsGa4.analyticsModules.Ga4LinkSetup
+    Ga4LinkSetup.init()
+
+    expect(link.dataset.ga4Link).toBeUndefined()
+  })
 })


### PR DESCRIPTION
There are a few things going on here:

We are preventing button tracking for elements that are not buttons but have the button role because there is a risk of duplicate events. Most non-button elements with the button role are links, and will therefore be tracked via the link tracker module. The link tracker module will send a link event type for links with the button role. We do not need to send additional events via button tracking for such elements.

There was a hardcoded "method" attribute which we unset, as we don't know whether it's actually a primary click or not. The link tracker from Publishing components does apply this attribute.

The link tracking setup was using the wrong data object, "event" instead of "link", so that's been fixed.

Finally we move the data module initialisation for links and buttons higher up the DOM tree so that tracking is applied globally(ish) 🎉 

