### PR TITLE
Stop validating uniqueness on attachment filenames

### DIFF
--- a/app/models/file_attachment.rb
+++ b/app/models/file_attachment.rb
@@ -20,8 +20,6 @@ class FileAttachment < Attachment
 
   accepts_nested_attributes_for :attachment_data, reject_if: ->(attributes) { attributes[:file].blank? && attributes[:file_cache].blank? }
 
-  validate :filename_is_unique
-
   def filename_changed?
     previous_attachment_data_id = attachment_data_id_was
     previous_attachment_data = AttachmentData.find(previous_attachment_data_id)
@@ -70,11 +68,5 @@ private
     return unless csv? && attachable.is_a?(Edition) && attachment_data.all_asset_variants_uploaded?
 
     Plek.asset_root + "/media/#{attachment_data.id}/#{filename}/preview"
-  end
-
-  def filename_is_unique
-    if attachable && attachable.attachments.any? { |a| a.file? && a != self && a.filename.downcase == filename.try(:downcase) }
-      errors.add(:base, message: "This #{attachable_model_name} already has a file called \"#{filename}\"")
-    end
   end
 end

--- a/test/unit/app/models/file_attachment_test.rb
+++ b/test/unit/app/models/file_attachment_test.rb
@@ -25,22 +25,6 @@ class FileAttachmentTest < ActiveSupport::TestCase
     assert_not attachment.html?
   end
 
-  test "should be invalid if an attachment already exists on the attachable with the same filename" do
-    attachable = create(:policy_group, attachments: [build(:file_attachment, file: file_fixture("whitepaper.pdf"))])
-    duplicate  = build(:file_attachment, file: file_fixture("whitepaper.pdf"), attachable:)
-
-    assert_not duplicate.valid?
-    assert_match %r{This policy group already has a file called "whitepaper.pdf"}, duplicate.errors[:base].first
-  end
-
-  test "unique filename check does not explode if file is not present" do
-    attachable = create(:policy_group, attachments: [build(:file_attachment)])
-    attachment = build(:file_attachment, attachable:, file: nil)
-
-    assert_not attachment.valid?
-    assert_match %r{can't be blank}, attachment.errors[:"attachment_data.file"].first
-  end
-
   test "update with empty nested attachment data attributes still works" do
     attachment = create(:file_attachment)
 


### PR DESCRIPTION
We've now had two support tickets relating to existing, published Whitehall documents that cannot be edited because the 'create draft edition' workflow fails to pass validation:
- https://govuk.zendesk.com/agent/tickets/5898727
- https://govuk.zendesk.com/agent/tickets/5978126

In these cases, documents had attachments that shared an identical filename, causing failures like "Validation failed: This publication already has a file called \"foo.pdf\"" when trying to create a draft edition.

It's surprisingly difficult to find a workaround for this; we can't just pass `validate: false` in the Rails console because of the convoluted edition superseding logic in Whitehall. We have no 'hook' to pass the validation override into.
The alternative is to delete one of the duplicate attachments, which is a developer task that is also quite a sensitive operation.

I've tracked the validation logic addition down to this PR from 2013: https://github.com/alphagov/whitehall/pull/1170

The linked pivotal tracker story explains the purpose:
> So that we can generate nice urls for attachments, e.g.
> (/publications/slug-for-pub/attachments/filename.pdf), we need
> to ensure all attachments on a given attachable are unique.

This reasoning no longer holds true, now that we're serving assets on the assets domain and not via Whitehall Frontend.

Note that there is a very similar validation rule enforcing uniqueness on IMAGE files, added in #7491. We're not touching that rule, which _does_ appear to still be needed, as images can be embedded in GovSpeak and thus it's important to be able to confidently refer to one single asset, no duplicates.

Trello: https://trello.com/c/FJuN46qU/3217-technical-fault-with-whitehall

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
