### PR TITLE
Add .atom additional path to topical event finder

### DIFF
--- a/lib/finders/topical_events.json
+++ b/lib/finders/topical_events.json
@@ -51,6 +51,10 @@
      {
        "type": "exact",
        "path": "/government/topical-events.json"
+     },
+     {
+       "type": "exact",
+       "path": "/government/topical-events.atom"
      }
    ]
 }


### PR DESCRIPTION
- Ultimately we probably want to retire the topical event finder, but while a produce decision is looked over, we should fix the missing atom feed route.

https://trello.com/c/O4pScXAZ/41-broken-atom-feed-on-topical-events-finder

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
