### PR TITLE
Fix validation context for filename uniqueness

### DIFF
--- a/app/models/file_attachment.rb
+++ b/app/models/file_attachment.rb
@@ -20,7 +20,7 @@ class FileAttachment < Attachment
 
   accepts_nested_attributes_for :attachment_data, reject_if: ->(attributes) { attributes[:file].blank? && attributes[:file_cache].blank? }
 
-  validate :filename_is_unique
+  validate :filename_is_unique, on: :user_input
 
   def filename_changed?
     previous_attachment_data_id = attachment_data_id_was

--- a/test/unit/app/models/file_attachment_test.rb
+++ b/test/unit/app/models/file_attachment_test.rb
@@ -29,7 +29,7 @@ class FileAttachmentTest < ActiveSupport::TestCase
     attachable = create(:policy_group, attachments: [build(:file_attachment, file: file_fixture("whitepaper.pdf"))])
     duplicate  = build(:file_attachment, file: file_fixture("whitepaper.pdf"), attachable:)
 
-    assert_not duplicate.valid?
+    assert_not duplicate.valid?(:user_input)
     assert_match %r{This policy group already has a file called "whitepaper.pdf"}, duplicate.errors[:base].first
   end
 


### PR DESCRIPTION
In 70752791cd0939180a5436de264d7d90f0ecc110, the decision was made to scope attachment validations to user submissions on attachment models only:

> This updates the Attachment model to scope the AttachmentValidator so
> that it's only part of the model validations when a user creates or
> updates an attachment.

This was to prevent an issue whereby invalid attachments would be 'shed' when creating new editions. We only want the validations to run when editing the attachments themselves.

The 'shedding' bug hasn't returned, but we do have a new one: when creating a new edition on a document that has multiple attachments of the same filename, we hit this validation error: 'Validation failed: This `<document type>` already has a file called "`<filename>`"'.

The fix was to only call the validation methods when making an edit to an attachment, not to its associated document. It looks as though the filename uniqueness validation check was accidentally missed from the commit above.

Trello: https://trello.com/c/FJuN46qU/3217-unable-to-create-new-edition-in-whitehall-validation-error

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
