### PR TITLE
Add missing .atom paths to finders

### DIFF
--- a/lib/finders/case_studies.json
+++ b/lib/finders/case_studies.json
@@ -27,6 +27,10 @@
     {
       "type": "exact",
       "path": "/government/case-studies.json"
+    },
+    {
+      "type": "exact",
+      "path": "/government/case-studies.atom"
     }
   ]
 }

--- a/lib/finders/people.json
+++ b/lib/finders/people.json
@@ -27,6 +27,10 @@
     {
       "type": "exact",
       "path": "/government/people.json"
+    },
+    {
+      "type": "exact",
+      "path": "/government/people.atom"
     }
   ]
 }

--- a/lib/finders/statistical_data_sets.json
+++ b/lib/finders/statistical_data_sets.json
@@ -43,6 +43,10 @@
     {
       "type": "exact",
       "path": "/government/statistical-data-sets.json"
+    },
+    {
+      "type": "exact",
+      "path": "/government/statistical-data-sets.atom"
     }
   ]
 }

--- a/lib/finders/worldwide_organisations.json
+++ b/lib/finders/worldwide_organisations.json
@@ -25,6 +25,10 @@
     {
       "type": "exact",
       "path": "/world/organisations.json"
+    },
+    {
+      "type": "exact",
+      "path": "/world/organisations.atom"
     }
   ]
 }


### PR DESCRIPTION
- groups already has .atom, topical events had it added in a previous PR, add to the other 4.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
