### PR TITLE
Validate landing pages with active model

### DIFF
--- a/app/models/landing_page.rb
+++ b/app/models/landing_page.rb
@@ -7,7 +7,7 @@ class LandingPage < Edition
   validates :base_path, presence: true, format: { with: /\A\/.*\z/, message: "must start with a slash (/)" }
   validate :base_path_must_not_be_taken
   validate do
-    errors.merge!(landing_page_body.errors) unless landing_page_body.valid?
+    errors.merge!(landing_page_body.errors) if landing_page_body.invalid?
   end
 
   def publishing_api_presenter

--- a/app/models/landing_page.rb
+++ b/app/models/landing_page.rb
@@ -37,7 +37,7 @@ class LandingPage < Edition
     if @landing_page_body&.raw_body == body
       @landing_page_body
     else
-      @landing_page_body = LandingPage::Body.new(body)
+      @landing_page_body = LandingPage::Body.new(body, images)
     end
   end
 

--- a/app/models/landing_page.rb
+++ b/app/models/landing_page.rb
@@ -7,7 +7,10 @@ class LandingPage < Edition
   validates :base_path, presence: true, format: { with: /\A\/.*\z/, message: "must start with a slash (/)" }
   validate :base_path_must_not_be_taken
   validate do
-    errors.merge!(landing_page_body.errors) if landing_page_body.invalid?
+    if landing_page_body.invalid?
+      errors.add(:body, "contained errors")
+      errors.merge!(landing_page_body.errors)
+    end
   end
 
   def publishing_api_presenter

--- a/app/models/landing_page.rb
+++ b/app/models/landing_page.rb
@@ -6,7 +6,9 @@ class LandingPage < Edition
   skip_callback :validation, :before, :update_document_slug
   validates :base_path, presence: true, format: { with: /\A\/.*\z/, message: "must start with a slash (/)" }
   validate :base_path_must_not_be_taken
-  validate :body_must_be_valid_yaml
+  validate do
+    errors.merge!(landing_page_body.errors) unless landing_page_body.valid?
+  end
 
   def publishing_api_presenter
     PublishingApi::LandingPagePresenter
@@ -28,21 +30,17 @@ class LandingPage < Edition
     super + Whitehall.image_kinds.values.select { _1.permits?("hero") }
   end
 
+  def landing_page_body
+    if @landing_page_body&.raw_body == body
+      @landing_page_body
+    else
+      @landing_page_body = LandingPage::Body.new(body)
+    end
+  end
+
 private
 
   def base_path_must_not_be_taken
     errors.add(:base_path, " is already taken") if Document.where(slug:).where.not(id: document.id).exists?
-  end
-
-  def body_must_be_valid_yaml
-    body_hash = YAML.load(body)
-    unless body_hash.keys.include?("blocks")
-      errors.add(:body, "must contain a root element 'blocks:'")
-    end
-    if body_hash.key?("extends") && Document.find_by(slug: body_hash["extends"]).nil?
-      errors.add(:body, "extends #{body_hash.keys['extends']} but that document does not exist")
-    end
-  rescue StandardError => e
-    errors.add(:body, "must be valid YAML: #{e.message}")
   end
 end

--- a/app/models/landing_page/base_block.rb
+++ b/app/models/landing_page/base_block.rb
@@ -1,0 +1,16 @@
+class LandingPage::BaseBlock
+  include ActiveModel::API
+
+  attr_reader :type
+
+  validates :type, presence: true
+
+  def initialize(source)
+    @source = source
+    @type = @source["type"]
+  end
+
+  def present_for_publishing_api
+    @source
+  end
+end

--- a/app/models/landing_page/base_block.rb
+++ b/app/models/landing_page/base_block.rb
@@ -11,6 +11,8 @@ class LandingPage::BaseBlock
   end
 
   def present_for_publishing_api
+    raise "cannot present invalid block to publishing api - errors: #{errors.to_a}" if invalid?
+
     @source
   end
 end

--- a/app/models/landing_page/base_block.rb
+++ b/app/models/landing_page/base_block.rb
@@ -5,8 +5,9 @@ class LandingPage::BaseBlock
 
   validates :type, presence: true
 
-  def initialize(source)
+  def initialize(source, images)
     @source = source
+    @images = images
     @type = @source["type"]
   end
 

--- a/app/models/landing_page/base_block.rb
+++ b/app/models/landing_page/base_block.rb
@@ -1,7 +1,7 @@
 class LandingPage::BaseBlock
   include ActiveModel::API
 
-  attr_reader :type
+  attr_reader :type, :images
 
   validates :type, presence: true
 

--- a/app/models/landing_page/block_factory.rb
+++ b/app/models/landing_page/block_factory.rb
@@ -7,6 +7,8 @@ class LandingPage::BlockFactory
     case block.symbolize_keys
     in { type: "hero" }
       LandingPage::HeroBlock.new(block, images)
+    in { blocks: Array }
+      LandingPage::ParentBlock.new(block, images)
     else
       LandingPage::BaseBlock.new(block, images)
     end

--- a/app/models/landing_page/block_factory.rb
+++ b/app/models/landing_page/block_factory.rb
@@ -4,6 +4,11 @@ class LandingPage::BlockFactory
   end
 
   def self.build(block, images)
-    LandingPage::BaseBlock.new(block, images)
+    case block.symbolize_keys
+    in { type: "hero" }
+      LandingPage::HeroBlock.new(block, images)
+    else
+      LandingPage::BaseBlock.new(block, images)
+    end
   end
 end

--- a/app/models/landing_page/block_factory.rb
+++ b/app/models/landing_page/block_factory.rb
@@ -1,9 +1,9 @@
 class LandingPage::BlockFactory
-  def self.build_all(blocks)
-    (blocks || []).map { build(_1) }
+  def self.build_all(blocks, images)
+    (blocks || []).map { build(_1, images) }
   end
 
-  def self.build(block)
-    LandingPage::BaseBlock.new(block)
+  def self.build(block, images)
+    LandingPage::BaseBlock.new(block, images)
   end
 end

--- a/app/models/landing_page/block_factory.rb
+++ b/app/models/landing_page/block_factory.rb
@@ -1,0 +1,9 @@
+class LandingPage::BlockFactory
+  def self.build_all(blocks)
+    (blocks || []).map { build(_1) }
+  end
+
+  def self.build(block)
+    LandingPage::BaseBlock.new(block)
+  end
+end

--- a/app/models/landing_page/block_factory.rb
+++ b/app/models/landing_page/block_factory.rb
@@ -4,15 +4,15 @@ class LandingPage::BlockFactory
   end
 
   def self.build(block, images)
-    case block.symbolize_keys
-    in { type: "box", box_content: }
-      LandingPage::CompoundBlock.new(block, images, "box_content", box_content)
-    in { type: "card", card_content: }
-      LandingPage::CompoundBlock.new(block, images, "card_content", card_content)
-    in { type: "featured", featured_content: }
-      LandingPage::CompoundBlock.new(block, images, "featured_content", featured_content)
-    in { type: "hero", hero_content: }
-      LandingPage::HeroBlock.new(block, images, hero_content)
+    case block.with_indifferent_access
+    in { type: "box", box_content: { blocks: } }
+      LandingPage::CompoundBlock.new(block, images, "box_content", blocks)
+    in { type: "card", card_content: { blocks: } }
+      LandingPage::CompoundBlock.new(block, images, "card_content", blocks)
+    in { type: "featured", featured_content: { blocks: } }
+      LandingPage::CompoundBlock.new(block, images, "featured_content", blocks)
+    in { type: "hero", hero_content: { blocks: } }
+      LandingPage::HeroBlock.new(block, images, blocks)
     in { type: String, blocks: Array }
       LandingPage::ParentBlock.new(block, images)
     else

--- a/app/models/landing_page/block_factory.rb
+++ b/app/models/landing_page/block_factory.rb
@@ -5,9 +5,15 @@ class LandingPage::BlockFactory
 
   def self.build(block, images)
     case block.symbolize_keys
-    in { type: "hero" }
-      LandingPage::HeroBlock.new(block, images)
-    in { blocks: Array }
+    in { type: "box", box_content: }
+      LandingPage::CompoundBlock.new(block, images, "box_content", box_content)
+    in { type: "card", card_content: }
+      LandingPage::CompoundBlock.new(block, images, "card_content", card_content)
+    in { type: "featured", featured_content: }
+      LandingPage::CompoundBlock.new(block, images, "featured_content", featured_content)
+    in { type: "hero", hero_content: }
+      LandingPage::HeroBlock.new(block, images, hero_content)
+    in { type: String, blocks: Array }
       LandingPage::ParentBlock.new(block, images)
     else
       LandingPage::BaseBlock.new(block, images)

--- a/app/models/landing_page/body.rb
+++ b/app/models/landing_page/body.rb
@@ -1,0 +1,30 @@
+class LandingPage::Body
+  include ActiveModel::API
+
+  attr_reader :raw_body, :extends, :breadcrumbs, :navigation_groups, :blocks
+
+  validates :blocks, presence: true
+  validate :extends_a_document_which_exists
+
+  def initialize(raw_body)
+    @raw_body = raw_body
+
+    @yaml_errors = []
+    body = begin
+      YAML.load(@raw_body)
+    rescue StandardError => e
+      @yaml_errors << e
+      {}
+    end
+    @extends = body["extends"]
+    @breadcrumbs = body["breadcrumbs"]
+    @navigation_groups = body["navigation_groups"]
+    @blocks = body["blocks"]
+  end
+
+  def extends_a_document_which_exists
+    return unless extends.present?
+
+    errors.add(:body, "extends #{extends} but that document does not exist") unless Document.find_by(slug: extends)
+  end
+end

--- a/app/models/landing_page/body.rb
+++ b/app/models/landing_page/body.rb
@@ -5,6 +5,9 @@ class LandingPage::Body
 
   validates :blocks, presence: true
   validate :validate_extends_document_exists
+  validate do
+    blocks.each { |b| errors.merge!(b.errors) if b.invalid? }
+  end
 
   def initialize(raw_body)
     @raw_body = raw_body
@@ -20,14 +23,14 @@ class LandingPage::Body
     extend_body
     @breadcrumbs = body["breadcrumbs"]
     @navigation_groups = body["navigation_groups"]
-    @blocks = body["blocks"]
+    @blocks = LandingPage::BlockFactory.build_all(body["blocks"])
   end
 
   def present_for_publishing_api
     {
       breadcrumbs:,
       navigation_groups:,
-      blocks:,
+      blocks: blocks.map(&:present_for_publishing_api),
     }
   end
 

--- a/app/models/landing_page/body.rb
+++ b/app/models/landing_page/body.rb
@@ -7,18 +7,30 @@ class LandingPage::Body
   validate :validate_extends_document_exists
   validate do
     blocks.each { |b| errors.merge!(b.errors) if b.invalid? }
+
+    begin
+      YAML.load(@raw_body)
+    rescue StandardError => e
+      errors.add(:yaml, e.message)
+    end
   end
 
   def initialize(raw_body, images)
     @raw_body = raw_body
 
-    @yaml_errors = []
+    # Defaults if we can't load the body
+    @extends = nil
+    @blocks = []
+    @breadcrumbs = nil
+    @navigation_groups = nil
+
     @body = begin
       YAML.load(@raw_body)
-    rescue StandardError => e
-      @yaml_errors << e
-      {}
+    rescue StandardError
+      nil
     end
+    return if @body.nil?
+
     @extends = body["extends"]
     extend_body
     @breadcrumbs = body["breadcrumbs"]

--- a/app/models/landing_page/body.rb
+++ b/app/models/landing_page/body.rb
@@ -27,11 +27,13 @@ class LandingPage::Body
   end
 
   def present_for_publishing_api
-    {
+    return { "errors" => errors.to_a } if invalid?
+
+    body.merge({
       breadcrumbs:,
       navigation_groups:,
       blocks: blocks.map(&:present_for_publishing_api),
-    }
+    }).compact
   end
 
   def body_to_extend
@@ -59,6 +61,7 @@ class LandingPage::Body
   def extend_body
     return if body_to_extend.nil?
 
+    body.delete("extends")
     body.reverse_merge!(body_to_extend)
   end
 end

--- a/app/models/landing_page/body.rb
+++ b/app/models/landing_page/body.rb
@@ -39,7 +39,7 @@ class LandingPage::Body
   end
 
   def present_for_publishing_api
-    return { "errors" => errors.to_a } if invalid?
+    raise "cannot present invalid body to publishing api - errors: #{errors.to_a}" if invalid?
 
     body.merge({
       breadcrumbs:,

--- a/app/models/landing_page/body.rb
+++ b/app/models/landing_page/body.rb
@@ -9,7 +9,7 @@ class LandingPage::Body
     blocks.each { |b| errors.merge!(b.errors) if b.invalid? }
   end
 
-  def initialize(raw_body)
+  def initialize(raw_body, images)
     @raw_body = raw_body
 
     @yaml_errors = []
@@ -23,7 +23,7 @@ class LandingPage::Body
     extend_body
     @breadcrumbs = body["breadcrumbs"]
     @navigation_groups = body["navigation_groups"]
-    @blocks = LandingPage::BlockFactory.build_all(body["blocks"])
+    @blocks = LandingPage::BlockFactory.build_all(body["blocks"], images)
   end
 
   def present_for_publishing_api

--- a/app/models/landing_page/body.rb
+++ b/app/models/landing_page/body.rb
@@ -53,7 +53,7 @@ class LandingPage::Body
   def validate_extends_document_exists
     return unless extends.present? && body_to_extend.nil?
 
-    errors.add(:body, "extends #{extends} but that document does not exist, or does not have a YAML body")
+    errors.add(:extends, "from #{extends} but that document does not exist, or does not have a YAML body")
   end
 
   def extend_body

--- a/app/models/landing_page/compound_block.rb
+++ b/app/models/landing_page/compound_block.rb
@@ -1,0 +1,20 @@
+class LandingPage::CompoundBlock < LandingPage::BaseBlock
+  include ActiveModel::API
+
+  attr_reader :content_blocks, :content_block_key
+
+  validates :content_blocks, presence: true
+  validate do
+    content_blocks.each { |b| errors.merge!(b.errors) if b.invalid? }
+  end
+
+  def initialize(source, images, content_block_key, content_blocks)
+    super(source, images)
+    @content_block_key = content_block_key
+    @content_blocks = LandingPage::BlockFactory.build_all(content_blocks, images)
+  end
+
+  def present_for_publishing_api
+    super.merge({ content_block_key => { "blocks" => content_blocks.map(&:present_for_publishing_api) } })
+  end
+end

--- a/app/models/landing_page/compound_block.rb
+++ b/app/models/landing_page/compound_block.rb
@@ -1,3 +1,18 @@
+# Compound blocks are blocks which have some of their own configuration,
+# alongside a list of child blocks. For example:
+#
+# - type: hero
+#   image: ...
+#   hero_content:
+#     blocks:
+#       - type: govspeak
+#         content: some text
+#
+# hero blocks are Compound blocks because they have their own config (image) as
+# well as children (hero_content -> blocks).
+#
+# Compound blocks have an extra key above the blocks (hero_content, featured_content, card_content etc.)
+# This is referred to here as the "content_block_key"
 class LandingPage::CompoundBlock < LandingPage::BaseBlock
   include ActiveModel::API
 

--- a/app/models/landing_page/hero_block.rb
+++ b/app/models/landing_page/hero_block.rb
@@ -18,6 +18,9 @@ class LandingPage::HeroBlock < LandingPage::BaseBlock
     actual_kind = value.image_data.image_kind
     record.errors.add(attr, "is of the wrong image kind: #{actual_kind}") if actual_kind != expected_kind
   end
+  validate do
+    hero_content_blocks.each { |b| errors.merge!(b.errors) if b.invalid? }
+  end
 
   def initialize(source, images)
     super
@@ -32,14 +35,14 @@ class LandingPage::HeroBlock < LandingPage::BaseBlock
   def present_for_publishing_api
     return { "errors" => errors.to_a } if invalid?
 
-    @source.merge({
+    super.merge({
       "image" => {
         # NOTE: alt text is always blank for hero images, as they are decorative
         "alt" => "",
         "sources" => present_image_sources,
       },
       "hero_content" => {
-        "blocks" => @hero_content_blocks.map(&:present_for_publishing_api),
+        "blocks" => hero_content_blocks.map(&:present_for_publishing_api),
       },
     })
   end

--- a/app/models/landing_page/hero_block.rb
+++ b/app/models/landing_page/hero_block.rb
@@ -1,0 +1,65 @@
+class LandingPage::HeroBlock < LandingPage::BaseBlock
+  include ActiveModel::API
+
+  IMAGE_PATTERN = /^\[Image:\s*(.*?)\s*\]/
+  EXPECTED_IMAGE_KINDS = {
+    desktop_image: "hero_desktop",
+    tablet_image: "hero_tablet",
+    mobile_image: "hero_mobile",
+  }.freeze
+
+  attr_reader :desktop_image, :tablet_image, :mobile_image, :hero_content_blocks
+
+  validates :desktop_image, :tablet_image, :mobile_image, :hero_content_blocks, presence: true
+  validates_each :desktop_image, :tablet_image, :mobile_image do |record, attr, value|
+    next if value.blank?
+
+    expected_kind = EXPECTED_IMAGE_KINDS.fetch(attr)
+    actual_kind = value.image_data.image_kind
+    record.errors.add(attr, "is of the wrong image kind: #{actual_kind}") if actual_kind != expected_kind
+  end
+
+  def initialize(source, images)
+    super
+    @hero_content_blocks = LandingPage::BlockFactory.build_all(source.dig("hero_content", "blocks"), images)
+
+    image_sources = @source.dig("image", "sources") || {}
+    @desktop_image = find_image(image_sources["desktop"])
+    @tablet_image = find_image(image_sources["tablet"])
+    @mobile_image = find_image(image_sources["mobile"])
+  end
+
+  def present_for_publishing_api
+    return { "errors" => errors.to_a } if invalid?
+
+    @source.merge({
+      "image" => {
+        # NOTE: alt text is always blank for hero images, as they are decorative
+        "alt" => "",
+        "sources" => present_image_sources,
+      },
+      "hero_content" => {
+        "blocks" => @hero_content_blocks.map(&:present_for_publishing_api),
+      },
+    })
+  end
+
+  def present_image_sources
+    {
+      "desktop" => desktop_image.url(:hero_desktop_1x),
+      "desktop_2x" => desktop_image.url(:hero_desktop_2x),
+      "tablet" => tablet_image.url(:hero_tablet_1x),
+      "tablet_2x" => tablet_image.url(:hero_tablet_2x),
+      "mobile" => mobile_image.url(:hero_mobile_1x),
+      "mobile_2x" => mobile_image.url(:hero_mobile_2x),
+    }
+  end
+
+  def find_image(image_expression)
+    match = IMAGE_PATTERN.match(image_expression)
+    return if match.nil?
+
+    image_id = match.captures.first
+    images.find { _1.filename == image_id }
+  end
+end

--- a/app/models/landing_page/parent_block.rb
+++ b/app/models/landing_page/parent_block.rb
@@ -1,0 +1,17 @@
+class LandingPage::ParentBlock < LandingPage::BaseBlock
+  attr_reader :blocks
+
+  validate do
+    blocks.each { |b| errors.merge!(b.errors) if b.invalid? }
+  end
+
+  def initialize(source, images)
+    super(source, images)
+
+    @blocks = LandingPage::BlockFactory.build_all(source["blocks"], images)
+  end
+
+  def present_for_publishing_api
+    super.merge("blocks" => blocks.map(&:present_for_publishing_api))
+  end
+end

--- a/app/presenters/publishing_api/landing_page_presenter.rb
+++ b/app/presenters/publishing_api/landing_page_presenter.rb
@@ -49,80 +49,9 @@ module PublishingApi
     attr_reader :item
 
     def details
-      body = item.landing_page_body.present_for_publishing_api
-
-      recursively_expand_images(body.deep_symbolize_keys)
-    end
-
-    def recursively_expand_images(input)
-      case input
-      in { type: "hero", image: { sources: { desktop:, tablet:, mobile: } }, **rest }
-        {
-          type: "hero",
-          image: present_hero_image(desktop, tablet, mobile),
-          **recursively_expand_images(rest),
-        }
-      in Hash => h
-        h.transform_values { recursively_expand_images(_1) }
-      in Array => a
-        a.map { recursively_expand_images(_1) }
-      else
-        input
-      end
-    end
-
-    def present_hero_image(desktop, tablet, mobile)
-      images = find_images(desktop, tablet, mobile)
-      return { errors: ["Some image expressions weren't correctly formatted, or images could not be found"] } if images.any?(&:nil?)
-
-      image_data = images.map(&:image_data)
-      desktop_image_kind, tablet_image_kind, mobile_image_kind = image_data.map(&:image_kind)
-      errors = [
-        ("Some image variants hadn't finished uploading" unless image_data.all?(&:all_asset_variants_uploaded?)),
-        ("Desktop image is of the wrong image kind: #{desktop_image_kind}" unless desktop_image_kind == "hero_desktop"),
-        ("Tablet image is of the wrong image kind: #{tablet_image_kind}" unless tablet_image_kind == "hero_tablet"),
-        ("Mobile image is of the wrong image kind: #{mobile_image_kind}" unless mobile_image_kind == "hero_mobile"),
-      ].compact
-      return { errors: } unless errors.empty?
-
-      desktop_image, tablet_image, mobile_image = images
-
-      {
-        alt: present_alt_text(images),
-        sources: {
-          desktop: desktop_image.url(:hero_desktop_1x),
-          desktop_2x: desktop_image.url(:hero_desktop_2x),
-          tablet: tablet_image.url(:hero_tablet_1x),
-          tablet_2x: tablet_image.url(:hero_tablet_2x),
-          mobile: mobile_image.url(:hero_mobile_1x),
-          mobile_2x: mobile_image.url(:hero_mobile_2x),
-        },
-      }
-    end
-
-    def find_images(*image_expressions)
-      image_expressions.map do |image_expression|
-        match = IMAGE_PATTERN.match(image_expression)
-        if match.nil?
-          nil
-        else
-          image_id = match.captures.first
-          item.images.find { _1.filename == image_id }
-        end
-      end
-    end
-
-    def present_alt_text(images)
-      unique_alt_text = images.map(&:alt_text).compact.uniq
-      case unique_alt_text
-      in []
-        nil
-      in [alt_text]
-        alt_text
-      in Array
-        warn("Different images had different alt text, using the first option")
-        unique_alt_text.first
-      end
+      item.landing_page_body
+        .present_for_publishing_api
+        &.merge(PayloadBuilder::Attachments.for(item))
     end
   end
 end

--- a/app/presenters/publishing_api/landing_page_presenter.rb
+++ b/app/presenters/publishing_api/landing_page_presenter.rb
@@ -49,14 +49,7 @@ module PublishingApi
     attr_reader :item
 
     def details
-      body = YAML.load(item.body, permitted_classes: [Date])
-              .merge(PayloadBuilder::Attachments.for(item))
-      extends_slug = body.delete("extends")
-      if extends_slug
-        extends = Document.find_by(slug: extends_slug).latest_edition
-        extends_body = YAML.safe_load(extends.body, permitted_classes: [Date])
-        body.reverse_merge!(extends_body)
-      end
+      body = item.landing_page_body.present_for_publishing_api
 
       recursively_expand_images(body.deep_symbolize_keys)
     end

--- a/test/factories/image_data.rb
+++ b/test/factories/image_data.rb
@@ -38,7 +38,7 @@ FactoryBot.define do
       # Defining this method is a bit of a hack, but with FactoryBot created model,
       # the file_url method just returns nil, which makes it less useful for testing
       def image_data.file_url(variant)
-        "http://asset-manager/#{assets.find_by(variant:).asset_manager_id}"
+        "http://asset-manager/#{variant}"
       end
     end
   end

--- a/test/functional/admin/landing_pages_controller_test.rb
+++ b/test/functional/admin/landing_pages_controller_test.rb
@@ -18,7 +18,8 @@ class Admin::LandingPagesControllerTest < ActionController::TestCase
   end
 
   test "POST :create saves a new instance with the supplied valid params" do
-    landing_page_attrs = attributes_for(:landing_page, title: "Hello there", summary: "Landing page summary", body: "blocks:")
+    body = "blocks: [{ type: some-type }]"
+    landing_page_attrs = attributes_for(:landing_page, title: "Hello there", summary: "Landing page summary", body:)
                              .merge(
                                lead_organisation_ids: [@organisation.id],
                                document_attributes: {
@@ -31,7 +32,7 @@ class Admin::LandingPagesControllerTest < ActionController::TestCase
     assert assigns(:edition).persisted?
     assert_equal "Hello there", assigns(:edition).title
     assert_equal "Landing page summary", assigns(:edition).summary
-    assert_equal "blocks:", assigns(:edition).body
+    assert_equal body, assigns(:edition).body
     assert_equal "/landing-page/test", assigns(:edition).base_path
     assert_redirected_to admin_landing_page_path(assigns(:edition))
   end

--- a/test/unit/app/models/landing_page/base_block_test.rb
+++ b/test/unit/app/models/landing_page/base_block_test.rb
@@ -15,6 +15,6 @@ class BaseBlockTest < ActiveSupport::TestCase
   test "raises error when presenting an invalid block to publishing api" do
     subject = LandingPage::BaseBlock.new({}, [])
     assert subject.invalid?
-    assert_raises(StandardError, match: /Type can't be blank/) { subject.present_for_publishing_api }
+    assert_raises(StandardError, match: /cannot present invalid block to publishing api.*Type can't be blank/) { subject.present_for_publishing_api }
   end
 end

--- a/test/unit/app/models/landing_page/base_block_test.rb
+++ b/test/unit/app/models/landing_page/base_block_test.rb
@@ -11,4 +11,10 @@ class BaseBlockTest < ActiveSupport::TestCase
     assert subject.invalid?
     assert_equal ["Type can't be blank"], subject.errors.to_a
   end
+
+  test "raises error when presenting an invalid block to publishing api" do
+    subject = LandingPage::BaseBlock.new({}, [])
+    assert subject.invalid?
+    assert_raises(StandardError, match: /Type can't be blank/) { subject.present_for_publishing_api }
+  end
 end

--- a/test/unit/app/models/landing_page/base_block_test.rb
+++ b/test/unit/app/models/landing_page/base_block_test.rb
@@ -2,12 +2,12 @@ require "test_helper"
 
 class BaseBlockTest < ActiveSupport::TestCase
   test "valid when given correct params" do
-    subject = LandingPage::BaseBlock.new("type" => "some-type")
+    subject = LandingPage::BaseBlock.new({ "type" => "some-type" }, [])
     assert subject.valid?
   end
 
   test "invalid when missing type" do
-    subject = LandingPage::BaseBlock.new({})
+    subject = LandingPage::BaseBlock.new({}, [])
     assert subject.invalid?
     assert_equal ["Type can't be blank"], subject.errors.to_a
   end

--- a/test/unit/app/models/landing_page/base_block_test.rb
+++ b/test/unit/app/models/landing_page/base_block_test.rb
@@ -1,0 +1,14 @@
+require "test_helper"
+
+class BaseBlockTest < ActiveSupport::TestCase
+  test "valid when given correct params" do
+    subject = LandingPage::BaseBlock.new("type" => "some-type")
+    assert subject.valid?
+  end
+
+  test "invalid when missing type" do
+    subject = LandingPage::BaseBlock.new({})
+    assert subject.invalid?
+    assert_equal ["Type can't be blank"], subject.errors.to_a
+  end
+end

--- a/test/unit/app/models/landing_page/block_factory_test.rb
+++ b/test/unit/app/models/landing_page/block_factory_test.rb
@@ -2,12 +2,14 @@ require "test_helper"
 
 class BlockFactoryTest < ActiveSupport::TestCase
   test "#build builds a block" do
-    block = LandingPage::BlockFactory.build({ "type" => "some-type" })
+    images = []
+    block = LandingPage::BlockFactory.build({ "type" => "some-type" }, images)
     assert_instance_of LandingPage::BaseBlock, block
   end
 
   test "#build_all builds blocks" do
-    blocks = LandingPage::BlockFactory.build_all([{ "type" => "some-type" }, { "type" => "some-type" }])
+    images = []
+    blocks = LandingPage::BlockFactory.build_all([{ "type" => "some-type" }, { "type" => "some-type" }], images)
     assert_equal 2, blocks.length
     assert_instance_of LandingPage::BaseBlock, blocks.first
     assert_instance_of LandingPage::BaseBlock, blocks.second

--- a/test/unit/app/models/landing_page/block_factory_test.rb
+++ b/test/unit/app/models/landing_page/block_factory_test.rb
@@ -1,0 +1,15 @@
+require "test_helper"
+
+class BlockFactoryTest < ActiveSupport::TestCase
+  test "#build builds a block" do
+    block = LandingPage::BlockFactory.build({ "type" => "some-type" })
+    assert_instance_of LandingPage::BaseBlock, block
+  end
+
+  test "#build_all builds blocks" do
+    blocks = LandingPage::BlockFactory.build_all([{ "type" => "some-type" }, { "type" => "some-type" }])
+    assert_equal 2, blocks.length
+    assert_instance_of LandingPage::BaseBlock, blocks.first
+    assert_instance_of LandingPage::BaseBlock, blocks.second
+  end
+end

--- a/test/unit/app/models/landing_page/body_test.rb
+++ b/test/unit/app/models/landing_page/body_test.rb
@@ -9,6 +9,14 @@ class LandingPageBodyTest < ActiveSupport::TestCase
     assert_equal ["Blocks can't be blank"], subject.errors.to_a
   end
 
+  test "is invalid with badly formed YAML" do
+    subject = LandingPage::Body.new("{", EMPTY_IMAGES)
+    assert subject.invalid?
+    errors = subject.errors.to_a
+    assert_equal "Blocks can't be blank", errors.first
+    assert_match(/Yaml .* did not find expected node content/, errors.second)
+  end
+
   test "is invalid with empty blocks" do
     subject = LandingPage::Body.new(<<~YAML, EMPTY_IMAGES)
       blocks: []
@@ -81,7 +89,7 @@ class LandingPageBodyTest < ActiveSupport::TestCase
     YAML
     assert subject.invalid?
     assert_equal [
-      "Body extends /some-document-which-does-not-exist but that document does not exist, or does not have a YAML body",
+      "Extends from /some-document-which-does-not-exist but that document does not exist, or does not have a YAML body",
     ], subject.errors.to_a
   end
 

--- a/test/unit/app/models/landing_page/body_test.rb
+++ b/test/unit/app/models/landing_page/body_test.rb
@@ -1,14 +1,16 @@
 require "test_helper"
 
 class LandingPageBodyTest < ActiveSupport::TestCase
+  EMPTY_IMAGES = [].freeze
+
   test "is invalid with empty YAML" do
-    subject = LandingPage::Body.new("")
+    subject = LandingPage::Body.new("", EMPTY_IMAGES)
     assert subject.invalid?
     assert_equal ["Blocks can't be blank"], subject.errors.to_a
   end
 
   test "is invalid with empty blocks" do
-    subject = LandingPage::Body.new(<<~YAML)
+    subject = LandingPage::Body.new(<<~YAML, EMPTY_IMAGES)
       blocks: []
     YAML
     assert subject.invalid?
@@ -16,7 +18,7 @@ class LandingPageBodyTest < ActiveSupport::TestCase
   end
 
   test "is valid with a single unknown block in YAML" do
-    subject = LandingPage::Body.new(<<~YAML)
+    subject = LandingPage::Body.new(<<~YAML, EMPTY_IMAGES)
       blocks:
       - type: unknown
     YAML
@@ -24,7 +26,7 @@ class LandingPageBodyTest < ActiveSupport::TestCase
   end
 
   test "is valid with all parameters provided" do
-    subject = LandingPage::Body.new(<<~YAML)
+    subject = LandingPage::Body.new(<<~YAML, EMPTY_IMAGES)
       navigation_groups: []
       breadcrumbs: []
       blocks:
@@ -44,7 +46,7 @@ class LandingPageBodyTest < ActiveSupport::TestCase
   end
 
   test "presents to publishing-api" do
-    subject = LandingPage::Body.new(<<~YAML)
+    subject = LandingPage::Body.new(<<~YAML, EMPTY_IMAGES)
       navigation_groups: []
       breadcrumbs: []
       blocks:
@@ -62,7 +64,7 @@ class LandingPageBodyTest < ActiveSupport::TestCase
 
   test "extends a document which does exist" do
     edition = create(:edition, body: "navigation_groups: []")
-    subject = LandingPage::Body.new(<<~YAML)
+    subject = LandingPage::Body.new(<<~YAML, EMPTY_IMAGES)
       extends: #{edition.slug}
       blocks:
       - type: unknown
@@ -72,7 +74,7 @@ class LandingPageBodyTest < ActiveSupport::TestCase
   end
 
   test "is invalid when extending a document which does not exist" do
-    subject = LandingPage::Body.new(<<~YAML)
+    subject = LandingPage::Body.new(<<~YAML, EMPTY_IMAGES)
       extends: /some-document-which-does-not-exist
       blocks:
       - type: unknown
@@ -84,7 +86,7 @@ class LandingPageBodyTest < ActiveSupport::TestCase
   end
 
   test "is invalid when given invalid blocks" do
-    subject = LandingPage::Body.new(<<~YAML)
+    subject = LandingPage::Body.new(<<~YAML, EMPTY_IMAGES)
       blocks:
       - error: no type
     YAML

--- a/test/unit/app/models/landing_page/body_test.rb
+++ b/test/unit/app/models/landing_page/body_test.rb
@@ -1,0 +1,85 @@
+require "test_helper"
+
+class LandingPageBodyTest < ActiveSupport::TestCase
+  test "is invalid with empty YAML" do
+    subject = LandingPage::Body.new("")
+    assert subject.invalid?
+    assert_equal ["Blocks can't be blank"], subject.errors.to_a
+  end
+
+  test "is invalid with empty blocks" do
+    subject = LandingPage::Body.new(<<~YAML)
+      blocks: []
+    YAML
+    assert subject.invalid?
+    assert_equal ["Blocks can't be blank"], subject.errors.to_a
+  end
+
+  test "is valid with a single unknown block in YAML" do
+    subject = LandingPage::Body.new(<<~YAML)
+      blocks:
+      - type: unknown
+    YAML
+    assert subject.valid?
+  end
+
+  test "is valid with all parameters provided" do
+    subject = LandingPage::Body.new(<<~YAML)
+      navigation_groups: []
+      breadcrumbs: []
+      blocks:
+      - type: unknown
+    YAML
+    assert subject.valid?
+    assert_equal [], subject.navigation_groups
+    assert_equal [], subject.breadcrumbs
+    assert_equal 1, subject.blocks.length
+    assert_equal({
+      navigation_groups: [],
+      breadcrumbs: [],
+      blocks: [
+        { type: "unknown" },
+      ],
+    }, subject.present_for_publishing_api.deep_symbolize_keys)
+  end
+
+  test "presents to publishing-api" do
+    subject = LandingPage::Body.new(<<~YAML)
+      navigation_groups: []
+      breadcrumbs: []
+      blocks:
+      - type: unknown
+    YAML
+    result = subject.present_for_publishing_api
+    assert_equal({
+      navigation_groups: [],
+      breadcrumbs: [],
+      blocks: [
+        { type: "unknown" },
+      ],
+    }, result.deep_symbolize_keys)
+  end
+
+  test "extends a document which does exist" do
+    edition = create(:edition, body: "navigation_groups: []")
+    subject = LandingPage::Body.new(<<~YAML)
+      extends: #{edition.slug}
+      blocks:
+      - type: unknown
+    YAML
+    assert subject.valid?
+    assert_equal [], subject.navigation_groups
+  end
+
+  test "is invalid when extending a document which does not exist" do
+    subject = LandingPage::Body.new(<<~YAML)
+      extends: /some-document-which-does-not-exist
+      blocks:
+      - type: unknown
+    YAML
+    assert subject.invalid?
+    assert_equal [
+      "Body extends /some-document-which-does-not-exist but that document does not exist, or does not have a YAML body",
+    ], subject.errors.to_a
+  end
+end

--- a/test/unit/app/models/landing_page/body_test.rb
+++ b/test/unit/app/models/landing_page/body_test.rb
@@ -82,4 +82,13 @@ class LandingPageBodyTest < ActiveSupport::TestCase
       "Body extends /some-document-which-does-not-exist but that document does not exist, or does not have a YAML body",
     ], subject.errors.to_a
   end
+
+  test "is invalid when given invalid blocks" do
+    subject = LandingPage::Body.new(<<~YAML)
+      blocks:
+      - error: no type
+    YAML
+    assert subject.invalid?
+    assert_equal ["Type can't be blank"], subject.errors.to_a
+  end
 end

--- a/test/unit/app/models/landing_page/compound_block_test.rb
+++ b/test/unit/app/models/landing_page/compound_block_test.rb
@@ -1,0 +1,62 @@
+require "test_helper"
+
+class CompoundBlockTest < ActiveSupport::TestCase
+  EMPTY_IMAGES = [].freeze
+
+  setup do
+    @valid_content_blocks = [{ "type" => "some-block-type" }]
+    @valid_block_config = {
+      "type" => "some-compound-block",
+      "compound_block_content" => { "blocks" => @valid_content_blocks },
+    }
+  end
+
+  test "valid when given correct params" do
+    subject = LandingPage::CompoundBlock.new(
+      @valid_block_config,
+      EMPTY_IMAGES,
+      "compound_block_content",
+      @valid_content_blocks,
+    )
+    assert subject.valid?
+  end
+
+  test "presents compound blocks to publishing api" do
+    subject = LandingPage::CompoundBlock.new(
+      @valid_block_config,
+      EMPTY_IMAGES,
+      "compound_block_content",
+      @valid_content_blocks,
+    )
+    expected_result = {
+      "type" => "some-compound-block",
+      "compound_block_content" => {
+        "blocks" => [{ "type" => "some-block-type" }],
+      },
+    }
+    assert_equal(expected_result, subject.present_for_publishing_api)
+  end
+
+  test "invalid when missing content blocks" do
+    subject = LandingPage::CompoundBlock.new(
+      @valid_block_config,
+      EMPTY_IMAGES,
+      "compound_block_content",
+      nil,
+    )
+    assert subject.invalid?
+    assert_equal ["Content blocks can't be blank"], subject.errors.to_a
+  end
+
+  test "invalid when content blocks are invalid" do
+    invalid_blocks_config = [{ "invalid" => "because I do not have a type" }]
+    subject = LandingPage::CompoundBlock.new(
+      @valid_block_config,
+      EMPTY_IMAGES,
+      "compound_block_content",
+      invalid_blocks_config,
+    )
+    assert subject.invalid?
+    assert_equal ["Type can't be blank"], subject.errors.to_a
+  end
+end

--- a/test/unit/app/models/landing_page/hero_block_test.rb
+++ b/test/unit/app/models/landing_page/hero_block_test.rb
@@ -1,25 +1,19 @@
 require "test_helper"
 
 class HeroBlockTest < ActiveSupport::TestCase
-  StubImage = Data.define(:filename) do
-    def url(version)
-      "https://example.com/#{version}/#{filename}"
-    end
-  end
-
   setup do
     @valid_hero_block_images = [
-      StubImage.new("desktop.jpg"),
-      StubImage.new("tablet.jpg"),
-      StubImage.new("mobile.jpg"),
+      build(:image, image_data: build(:hero_image_data, image_kind: "hero_desktop", file: upload_fixture("hero_image_desktop_2x.png", "image/png"))),
+      build(:image, image_data: build(:hero_image_data, image_kind: "hero_tablet", file: upload_fixture("hero_image_tablet_2x.png", "image/png"))),
+      build(:image, image_data: build(:hero_image_data, image_kind: "hero_mobile", file: upload_fixture("hero_image_mobile_2x.png", "image/png"))),
     ]
     @valid_hero_block_config = {
       "type" => "hero",
       "image" => {
         "sources" => {
-          "desktop" => "[Image: desktop.jpg]",
-          "tablet" => "[Image: tablet.jpg]",
-          "mobile" => "[Image: mobile.jpg]",
+          "desktop" => "[Image: hero_image_desktop_2x.png]",
+          "tablet" => "[Image: hero_image_tablet_2x.png]",
+          "mobile" => "[Image: hero_image_mobile_2x.png]",
         },
       },
       "hero_content" => {
@@ -40,12 +34,12 @@ class HeroBlockTest < ActiveSupport::TestCase
       "image" => {
         "alt" => "",
         "sources" => {
-          "desktop" => "https://example.com/hero_desktop_1x/desktop.jpg",
-          "desktop_2x" => "https://example.com/hero_desktop_2x/desktop.jpg",
-          "tablet" => "https://example.com/hero_tablet_1x/tablet.jpg",
-          "tablet_2x" => "https://example.com/hero_tablet_2x/tablet.jpg",
-          "mobile" => "https://example.com/hero_mobile_1x/mobile.jpg",
-          "mobile_2x" => "https://example.com/hero_mobile_2x/mobile.jpg",
+          "desktop" => "http://asset-manager/hero_desktop_1x",
+          "desktop_2x" => "http://asset-manager/hero_desktop_2x",
+          "tablet" => "http://asset-manager/hero_tablet_1x",
+          "tablet_2x" => "http://asset-manager/hero_tablet_2x",
+          "mobile" => "http://asset-manager/hero_mobile_1x",
+          "mobile_2x" => "http://asset-manager/hero_mobile_2x",
         },
       },
       "hero_content" => {
@@ -80,5 +74,13 @@ class HeroBlockTest < ActiveSupport::TestCase
     subject = LandingPage::HeroBlock.new(@valid_hero_block_config.except("hero_content"), @valid_hero_block_images)
     assert subject.invalid?
     assert_equal ["Hero content blocks can't be blank"], subject.errors.to_a
+  end
+
+  test "invalid when hero content blocks are invalid" do
+    invalid_blocks_config = { "blocks" => [{ "invalid" => "because I do not have a type" }] }
+    block_config = @valid_hero_block_config.merge("hero_content" => invalid_blocks_config)
+    subject = LandingPage::HeroBlock.new(block_config, @valid_hero_block_images)
+    assert subject.invalid?
+    assert_equal ["Type can't be blank"], subject.errors.to_a
   end
 end

--- a/test/unit/app/models/landing_page/hero_block_test.rb
+++ b/test/unit/app/models/landing_page/hero_block_test.rb
@@ -1,0 +1,84 @@
+require "test_helper"
+
+class HeroBlockTest < ActiveSupport::TestCase
+  StubImage = Data.define(:filename) do
+    def url(version)
+      "https://example.com/#{version}/#{filename}"
+    end
+  end
+
+  setup do
+    @valid_hero_block_images = [
+      StubImage.new("desktop.jpg"),
+      StubImage.new("tablet.jpg"),
+      StubImage.new("mobile.jpg"),
+    ]
+    @valid_hero_block_config = {
+      "type" => "hero",
+      "image" => {
+        "sources" => {
+          "desktop" => "[Image: desktop.jpg]",
+          "tablet" => "[Image: tablet.jpg]",
+          "mobile" => "[Image: mobile.jpg]",
+        },
+      },
+      "hero_content" => {
+        "blocks" => [{ "type" => "some-block-type" }],
+      },
+    }
+  end
+
+  test "valid when given correct params" do
+    subject = LandingPage::HeroBlock.new(@valid_hero_block_config, @valid_hero_block_images)
+    assert subject.valid?
+  end
+
+  test "presents hero blocks to publishing api" do
+    subject = LandingPage::HeroBlock.new(@valid_hero_block_config, @valid_hero_block_images)
+    expected_result = {
+      "type" => "hero",
+      "image" => {
+        "alt" => "",
+        "sources" => {
+          "desktop" => "https://example.com/hero_desktop_1x/desktop.jpg",
+          "desktop_2x" => "https://example.com/hero_desktop_2x/desktop.jpg",
+          "tablet" => "https://example.com/hero_tablet_1x/tablet.jpg",
+          "tablet_2x" => "https://example.com/hero_tablet_2x/tablet.jpg",
+          "mobile" => "https://example.com/hero_mobile_1x/mobile.jpg",
+          "mobile_2x" => "https://example.com/hero_mobile_2x/mobile.jpg",
+        },
+      },
+      "hero_content" => {
+        "blocks" => [{ "type" => "some-block-type" }],
+      },
+    }
+    assert_equal(expected_result, subject.present_for_publishing_api)
+  end
+
+  test "invalid when missing images" do
+    subject = LandingPage::HeroBlock.new(@valid_hero_block_config.except("image"), @valid_hero_block_images)
+    assert subject.invalid?
+    assert_equal [
+      "Desktop image can't be blank",
+      "Tablet image can't be blank",
+      "Mobile image can't be blank",
+    ], subject.errors.to_a
+  end
+
+  test "invalid when image expressions are not found" do
+    no_images = []
+    subject = LandingPage::HeroBlock.new(@valid_hero_block_config, no_images)
+    assert subject.invalid?
+    assert_equal [
+      "Desktop image can't be blank",
+      "Tablet image can't be blank",
+      "Mobile image can't be blank",
+    ], subject.errors.to_a
+  end
+
+  test "invalid when missing hero content blocks" do
+    subject = LandingPage::HeroBlock.new(@valid_hero_block_config.except("hero_content"), @valid_hero_block_images)
+    assert subject.invalid?
+    assert_equal ["Hero content blocks can't be blank"], subject.errors.to_a
+  end
+end

--- a/test/unit/app/models/landing_page/parent_block_test.rb
+++ b/test/unit/app/models/landing_page/parent_block_test.rb
@@ -1,0 +1,20 @@
+require "test_helper"
+
+class ParentBlockTest < ActiveSupport::TestCase
+  test "valid when given correct params" do
+    subject = LandingPage::ParentBlock.new({
+      "type" => "some-parent-type",
+      "blocks" => [],
+    }, [])
+    assert subject.valid?
+  end
+
+  test "invalid when child blocks are invalid" do
+    subject = LandingPage::ParentBlock.new({
+      "type" => "some-parent-type",
+      "blocks" => [{ "invalid" => "because I do not have a type" }],
+    }, [])
+    assert subject.invalid?
+    assert_equal ["Type can't be blank"], subject.errors.to_a
+  end
+end

--- a/test/unit/app/models/landing_page_test.rb
+++ b/test/unit/app/models/landing_page_test.rb
@@ -26,9 +26,9 @@ class LandingPageTest < ActiveSupport::TestCase
     assert_not landing_page.valid?
   end
 
-  test "landing-page is valid if body is YAML with at least the blocks: element" do
+  test "landing-page is valid if body is YAML with at least one block" do
     document = build(:document, slug: "/landing-page/test")
-    landing_page = build(:landing_page, document:, body: "blocks:\nother:\n")
+    landing_page = build(:landing_page, document:, body: "blocks: [{ type: some-type }]\nother:\n")
     assert landing_page.valid?
   end
 
@@ -39,11 +39,11 @@ class LandingPageTest < ActiveSupport::TestCase
     assert_equal :body, landing_page.errors.first.attribute
   end
 
-  test "landing-page is valid if includes the extends: and the extends element is valud" do
-    create(:document, slug: "/homepage")
+  test "landing-page is valid if includes the extends: and the extends element is valid" do
+    create(:landing_page, document: create(:document, slug: "/homepage"), body: "blocks: [{ type: some-type }]")
 
     document = build(:document, slug: "/landing-page/test")
-    landing_page = build(:landing_page, document:, body: "extends: /homepage\nblocks:")
+    landing_page = build(:landing_page, document:, body: "extends: /homepage\nblocks: [{ type: some-type }]")
     assert landing_page.valid?
   end
 

--- a/test/unit/app/presenters/publishing_api/landing_page_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/landing_page_presenter_test.rb
@@ -169,12 +169,12 @@ class PublishingApi::LandingPagePresenterTest < ActiveSupport::TestCase
           type: "hero",
           image: {
             sources: {
-              desktop_2x: "http://asset-manager/asset_manager_id_hero_desktop_2x",
-              desktop: "http://asset-manager/asset_manager_id_hero_desktop_1x",
-              tablet_2x: "http://asset-manager/asset_manager_id_hero_tablet_2x",
-              tablet: "http://asset-manager/asset_manager_id_hero_tablet_1x",
-              mobile_2x: "http://asset-manager/asset_manager_id_hero_mobile_2x",
-              mobile: "http://asset-manager/asset_manager_id_hero_mobile_1x",
+              desktop_2x: "http://asset-manager/hero_desktop_2x",
+              desktop: "http://asset-manager/hero_desktop_1x",
+              tablet_2x: "http://asset-manager/hero_tablet_2x",
+              tablet: "http://asset-manager/hero_tablet_1x",
+              mobile_2x: "http://asset-manager/hero_mobile_2x",
+              mobile: "http://asset-manager/hero_mobile_1x",
             }
           },
           hero_content: {
@@ -187,12 +187,12 @@ class PublishingApi::LandingPagePresenterTest < ActiveSupport::TestCase
             type: "hero",
             image: {
               sources: {
-                desktop_2x: "http://asset-manager/asset_manager_id_hero_desktop_2x",
-                desktop: "http://asset-manager/asset_manager_id_hero_desktop_1x",
-                tablet_2x: "http://asset-manager/asset_manager_id_hero_tablet_2x",
-                tablet: "http://asset-manager/asset_manager_id_hero_tablet_1x",
-                mobile_2x: "http://asset-manager/asset_manager_id_hero_mobile_2x",
-                mobile: "http://asset-manager/asset_manager_id_hero_mobile_1x",
+                desktop_2x: "http://asset-manager/hero_desktop_2x",
+                desktop: "http://asset-manager/hero_desktop_1x",
+                tablet_2x: "http://asset-manager/hero_tablet_2x",
+                tablet: "http://asset-manager/hero_tablet_1x",
+                mobile_2x: "http://asset-manager/hero_mobile_2x",
+                mobile: "http://asset-manager/hero_mobile_1x",
               }
             },
             hero_content: {
@@ -204,7 +204,7 @@ class PublishingApi::LandingPagePresenterTest < ActiveSupport::TestCase
     end
   end
 
-  test "it presents errors if files are not found" do
+  test "raises errors if files are not found" do
     body = <<~YAML
       blocks:
       - type: hero
@@ -230,18 +230,8 @@ class PublishingApi::LandingPagePresenterTest < ActiveSupport::TestCase
     )
 
     presented_landing_page = PublishingApi::LandingPagePresenter.new(landing_page)
-    presented_content = I18n.with_locale("en") { presented_landing_page.content }
-    details = presented_content[:details].deep_symbolize_keys
-
-    assert_pattern do
-      details =>
-        {
-          errors: [
-            "Desktop image can't be blank",
-            "Tablet image can't be blank",
-            "Mobile image can't be blank",
-          ],
-        }
+    assert_raises(StandardError, match: /cannot present invalid body/) do
+      I18n.with_locale("en") { presented_landing_page.content }
     end
   end
 
@@ -275,18 +265,8 @@ class PublishingApi::LandingPagePresenterTest < ActiveSupport::TestCase
     )
 
     presented_landing_page = PublishingApi::LandingPagePresenter.new(landing_page)
-    presented_content = I18n.with_locale("en") { presented_landing_page.content }
-    details = presented_content[:details].deep_symbolize_keys
-
-    assert_pattern do
-      details =>
-      {
-        errors: [
-          "Desktop image is of the wrong image kind: hero_mobile",
-          "Tablet image is of the wrong image kind: hero_desktop",
-          "Mobile image is of the wrong image kind: hero_tablet",
-        ],
-      }
+    assert_raises(StandardError, match: /cannot present invalid body/) do
+      I18n.with_locale("en") { presented_landing_page.content }
     end
   end
 end

--- a/test/unit/app/presenters/publishing_api/landing_page_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/landing_page_presenter_test.rb
@@ -79,8 +79,7 @@ class PublishingApi::LandingPagePresenterTest < ActiveSupport::TestCase
 
   test "it presents attachments" do
     attachment = @landing_page.attachments.first
-    assert_equal @presented_content.dig(:details, :attachments, 0, :id),
-                 attachment.id.to_s
+    assert_equal attachment.id.to_s, @presented_content.dig(:details, :attachments, 0, :id)
   end
 
   test "it merges its data with a document using extends:" do
@@ -214,9 +213,12 @@ class PublishingApi::LandingPagePresenterTest < ActiveSupport::TestCase
             desktop: "[Image: non-existent-file.jpg]"
             tablet: "[Image: non-existent-file.jpg]"
             mobile: "[Image: non-existent-file.jpg]"
+        hero_content:
+          blocks:
+          - type: some-block-type
     YAML
 
-    landing_page = create(
+    landing_page = build(
       :landing_page,
       document: create(:document, id: 12_346, slug: "/landing-page/with-images"),
       body:,
@@ -234,13 +236,10 @@ class PublishingApi::LandingPagePresenterTest < ActiveSupport::TestCase
     assert_pattern do
       details =>
         {
-          blocks: [
-            {
-              type: "hero",
-              image: {
-                errors: ["Some image expressions weren't correctly formatted, or images could not be found"],
-              }
-            },
+          errors: [
+            "Desktop image can't be blank",
+            "Tablet image can't be blank",
+            "Mobile image can't be blank",
           ],
         }
     end
@@ -255,9 +254,12 @@ class PublishingApi::LandingPagePresenterTest < ActiveSupport::TestCase
             desktop: "[Image: hero_image_mobile_2x.png]" # NOTE - using mobile image for desktop field
             tablet: "[Image: hero_image_desktop_2x.png]" # NOTE - using desktop image for tablet field
             mobile: "[Image: hero_image_tablet_2x.png]" # NOTE - using tablet image for desktop field
+        hero_content:
+          blocks:
+          - type: some-block-type
     YAML
 
-    landing_page = create(
+    landing_page = build(
       :landing_page,
       document: create(:document, id: 12_346, slug: "/landing-page/with-images"),
       body:,
@@ -279,17 +281,10 @@ class PublishingApi::LandingPagePresenterTest < ActiveSupport::TestCase
     assert_pattern do
       details =>
       {
-        blocks: [
-          {
-            type: "hero",
-            image: {
-               errors: [
-                 "Desktop image is of the wrong image kind: hero_mobile",
-                 "Tablet image is of the wrong image kind: hero_desktop",
-                 "Mobile image is of the wrong image kind: hero_tablet",
-               ],
-            }
-          },
+        errors: [
+          "Desktop image is of the wrong image kind: hero_mobile",
+          "Tablet image is of the wrong image kind: hero_desktop",
+          "Mobile image is of the wrong image kind: hero_tablet",
         ],
       }
     end


### PR DESCRIPTION
## What

At the moment, if you attempt to save a landing page which has YAML in a format that frontend won't accept, it will be submitted to publishing-api with the errors. Most of the time, this will result in a 500 error from frontend when the page is loaded.

This PR processes the YAML into a tree of ActiveModel classes, which validate that various properties hold.

It doesn't fully validate the format of every block - any unknown block types will be passed through as-is. It does add validation for hero blocks though, which are a very common source of errors.

These models can also be used to present the YAML to publishing-api, which significantly simplifies the landing page presenter, and should make it much easier to add other kinds of block which need processing (like images and featured images).

## Screenshots

<img width="1193" alt="image" src="https://github.com/user-attachments/assets/ca7456e6-2c15-4b44-ba1d-f6d2d614164a">


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
