### PR TITLE
(707) Add Content Block guidance to Whitehall in non-production environments

### DIFF
--- a/app/helpers/admin/sidebar_helper.rb
+++ b/app/helpers/admin/sidebar_helper.rb
@@ -3,6 +3,7 @@ module Admin::SidebarHelper
     sidebar_content = []
     sidebar_content << render("admin/editions/govspeak_help", options)
     sidebar_content << render("admin/editions/style_guidance", options)
+    sidebar_content << render("admin/editions/content_block_guidance", options) if Flipflop.show_link_to_content_block_manager?
     raw sidebar_content.join("\n")
   end
 end

--- a/app/views/admin/editions/_content_block_guidance.html.erb
+++ b/app/views/admin/editions/_content_block_guidance.html.erb
@@ -1,0 +1,6 @@
+<h3 class="govuk-heading-m">Content block</h3>
+
+<p class="govuk-body">
+  To create, edit and use standardised content, go to the
+  <%= link_to "Content Block Manager (opens in new tab)", content_block_manager.content_block_manager_root_path, class: "govuk-link", target: "_blank", rel: "noopener" %>.
+</p>

--- a/config/features.rb
+++ b/config/features.rb
@@ -23,4 +23,5 @@ Flipflop.configure do
   #   description: "Take over the world."
   feature :govspeak_visual_editor, description: "Enables a visual editor for Govspeak fields", default: false
   feature :override_government, description: "Enables GDS Editors and Admins to override the government associated with a document", default: false
+  feature :show_link_to_content_block_manager, description: "Shows link to Content Block Manager from Whitehall editor", default: Whitehall.integration_or_staging?
 end

--- a/test/unit/app/helpers/admin/sidebar_helper_test.rb
+++ b/test/unit/app/helpers/admin/sidebar_helper_test.rb
@@ -1,0 +1,32 @@
+require "test_helper"
+
+class Admin::SidebarHelperTest < ActionView::TestCase
+  extend Minitest::Spec::DSL
+
+  before do
+    test_strategy = Flipflop::FeatureSet.current.test!
+    test_strategy.switch!(:show_link_to_content_block_manager, content_block_enabled)
+  end
+
+  context "when #show_link_to_content_block_manager? is false" do
+    let(:content_block_enabled) { false }
+
+    it "does not include content block guidance" do
+      result = simple_formatting_sidebar
+      assert_includes result, "Formatting"
+      assert_includes result, "Use plain English"
+      assert_not_includes result, "Content block"
+    end
+  end
+
+  context "when #show_link_to_content_block_manager? is true" do
+    let(:content_block_enabled) { true }
+
+    it "includes content block guidance" do
+      result = simple_formatting_sidebar
+      assert_includes result, "Formatting"
+      assert_includes result, "Use plain English"
+      assert_includes result, "Content block"
+    end
+  end
+end


### PR DESCRIPTION
To allow user testing of the "insert" journey for Content Modelling, we need to add a link to the Content Block Manager in the Guidance section of the sidebar when editing content. This is enabled by a feature flag, which is set to `true` by default in Staging/Integration.

## Screenshot

![image](https://github.com/user-attachments/assets/39404c6f-dad0-4253-aa65-33fa5d04a462)
