### PR TITLE
Simplify Whitehall rake tasks for re-enqueuing scheduled publishing jobs

### DIFF
--- a/lib/tasks/scheduled_publishing.rake
+++ b/lib/tasks/scheduled_publishing.rake
@@ -30,21 +30,5 @@ namespace :publishing do
       Consultation.open.or(Consultation.upcoming)
         .find_each(&:schedule_republishing_workers)
     end
-
-    desc "Finds editions that were meant to be published between 23:00 yesterday and 01:00 today - helps debug failed publications owing to British Summer Time"
-    task around_midnight: :environment do
-      yesterday = Date.yesterday
-      today = Time.zone.today
-
-      time_from = Time.zone.local(yesterday.year, yesterday.month, yesterday.day, 23, 0, 0)
-      time_to = Time.zone.local(today.year, today.month, today.day, 0, 0, 0)
-
-      editions = Edition.where("scheduled_publication between ? and ?", time_from, time_to)
-
-      puts "Document Id, Edition Id, Slug, Type"
-      editions.each do |edition|
-        puts "#{edition.document.id}, #{edition.id}, #{edition.slug}, #{edition.type}"
-      end
-    end
   end
 end

--- a/lib/tasks/scheduled_publishing.rake
+++ b/lib/tasks/scheduled_publishing.rake
@@ -57,19 +57,6 @@ namespace :publishing do
       puts "---"
     end
 
-    desc "Queues missing jobs for any scheduled editions (including overdue ones)"
-    task queue_missing_jobs: :environment do
-      queued_ids      = ScheduledPublishingWorker.queued_edition_ids
-      missing_jobs    = Edition.scheduled.reject { |edition| queued_ids.include?(edition.id) }
-      puts "#{Edition.scheduled.count} editions scheduled for publication, of which #{missing_jobs.size} do not have a job."
-
-      puts "Queueing missing jobs..."
-      missing_jobs.each do |edition|
-        ScheduledPublishingWorker.queue(edition)
-        puts "#{edition.id} queued"
-      end
-    end
-
     desc "Clears all jobs then requeues all scheduled editions (intended for use after a db restore)"
     task requeue_all_jobs: :environment do
       ScheduledPublishingWorker.dequeue_all

--- a/lib/tasks/scheduled_publishing.rake
+++ b/lib/tasks/scheduled_publishing.rake
@@ -90,22 +90,4 @@ namespace :publishing do
       end
     end
   end
-
-  namespace :overdue do
-    desc "List scheduled editions overdue for publication by more than one minute"
-    task list: :environment do
-      puts sprintf("%6s  %-25s  %s", "ID", "Scheduled date", "Title")
-      Edition.due_for_publication(1.minute).each do |edition|
-        puts sprintf("%6s  %-25s  %s", edition.id, edition.scheduled_publication.to_s, edition.title)
-      end
-    end
-
-    desc "Publishes scheduled editions overdue for publication by more than one minute"
-    task publish: :environment do
-      Edition.due_for_publication(1.minute).each do |edition|
-        puts "Publishing overdue scheduled edition #{edition.id}"
-        ScheduledPublishingWorker.new.perform(edition.id)
-      end
-    end
-  end
 end


### PR DESCRIPTION
(And fix republishing of Call for Evidence docs).

See commits for details.

Trello: https://trello.com/c/LVRPfx6V/3222-closed-consultation-still-showing-as-open-advice-on-content

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
