### PR TITLE
Send `update_type` of `major` for Content Blocks

### DIFF
--- a/lib/engines/content_block_manager/app/lib/content_block_manager/publishable.rb
+++ b/lib/engines/content_block_manager/app/lib/content_block_manager/publishable.rb
@@ -86,6 +86,7 @@ module ContentBlockManager
         content_id_alias:,
         details:,
         links:,
+        update_type: "major",
       })
     end
 

--- a/lib/engines/content_block_manager/test/integration/content_block/workflow_test.rb
+++ b/lib/engines/content_block_manager/test/integration/content_block/workflow_test.rb
@@ -151,6 +151,7 @@ def assert_edition_is_published(&block)
       links: {
         primary_publishing_organisation: [organisation.content_id],
       },
+      update_type: "major",
     },
   ]
   publishing_api_mock.expect :publish, fake_publish_content_response, [

--- a/lib/engines/content_block_manager/test/unit/app/lib/content_block_manager/publishable_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/lib/content_block_manager/publishable_test.rb
@@ -35,6 +35,7 @@ class ContentBlockManager::PublishableTest < ActiveSupport::TestCase
               content_block_edition.lead_organisation.content_id,
             ],
           },
+          update_type: "major",
         },
       )
 

--- a/lib/engines/content_block_manager/test/unit/app/services/create_edition_service_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/services/create_edition_service_test.rb
@@ -106,6 +106,7 @@ def assert_draft_created_in_publishing_api(content_id:, content_id_alias:, &bloc
           organisation.content_id,
         ],
       },
+      update_type: "major",
     },
   )
 

--- a/lib/engines/content_block_manager/test/unit/app/services/publish_edition_service_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/services/publish_edition_service_test.rb
@@ -59,6 +59,7 @@ class ContentBlockManager::PublishEditionServiceTest < ActiveSupport::TestCase
           links: {
             primary_publishing_organisation: [@organisation.content_id],
           },
+          update_type: "major",
         },
       ]
       publishing_api_mock.expect :publish, fake_publish_content_response, [


### PR DESCRIPTION
Going forward, we will give users the option to choose if the update is a major or minor one, but for now, let’s set it to `major` each time, as this is creating a bunch of noise in the logs.