### PR TITLE
Content modelling/735 homepage date filter

### DIFF
--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/index/date_filter_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/index/date_filter_component.html.erb
@@ -1,0 +1,50 @@
+<%= render("components/datetime_fields", {
+  heading_size: "s",
+  field_name: "last_updated_from",
+  prefix: "last_updated_from",
+  date_heading: "From",
+  date_only: true,
+  year: {
+    id: "last_updated_from_1i",
+    name: "last_updated_from[1i]",
+    label: "Year",
+    width: 4,
+  },
+  month: {
+    id: "last_updated_from_2i",
+    name: "last_updated_from[2i]",
+    label: "Month",
+    width: 2,
+  },
+  day: {
+    id: "last_updated_from_3i",
+    name: "last_updated_from[3i]",
+    label: "Day",
+    width: 2,
+  },
+}) %>
+<%= render("components/datetime_fields", {
+  heading_size: "s",
+  field_name: "last_updated_to",
+  prefix: "last_updated_to",
+  date_heading: "To",
+  date_only: true,
+  year: {
+    id: "last_updated_to_1i",
+    name: "last_updated_to[1i]",
+    label: "Year",
+    width: 4,
+  },
+  month: {
+    id: "last_updated_to_2i",
+    name: "last_updated_to[2i]",
+    label: "Month",
+    width: 2,
+  },
+  day: {
+    id: "last_updated_to_3i",
+    name: "last_updated_to[3i]",
+    label: "Day",
+    width: 2,
+  },
+}) %>

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/index/date_filter_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/index/date_filter_component.html.erb
@@ -9,18 +9,21 @@
     name: "last_updated_from[1i]",
     label: "Year",
     width: 4,
+    value: date_value(:last_updated_from, "1i"),
   },
   month: {
     id: "last_updated_from_2i",
     name: "last_updated_from[2i]",
     label: "Month",
     width: 2,
+    value: date_value(:last_updated_from, "2i"),
   },
   day: {
     id: "last_updated_from_3i",
     name: "last_updated_from[3i]",
     label: "Day",
     width: 2,
+    value: date_value(:last_updated_from, "3i"),
   },
 }) %>
 <%= render("components/datetime_fields", {
@@ -34,17 +37,20 @@
     name: "last_updated_to[1i]",
     label: "Year",
     width: 4,
+    value: date_value(:last_updated_to, "1i"),
   },
   month: {
     id: "last_updated_to_2i",
     name: "last_updated_to[2i]",
     label: "Month",
     width: 2,
+    value: date_value(:last_updated_to, "2i"),
   },
   day: {
     id: "last_updated_to_3i",
     name: "last_updated_to[3i]",
     label: "Day",
     width: 2,
+    value: date_value(:last_updated_to, "3i"),
   },
 }) %>

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/index/date_filter_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/index/date_filter_component.html.erb
@@ -4,6 +4,7 @@
   prefix: "last_updated_from",
   date_heading: "From",
   date_only: true,
+  error_items: helpers.errors_for(@errors, "last_updated_from"),
   year: {
     id: "last_updated_from_1i",
     name: "last_updated_from[1i]",
@@ -32,6 +33,7 @@
   prefix: "last_updated_to",
   date_heading: "To",
   date_only: true,
+  error_items: helpers.errors_for(@errors, "last_updated_to"),
   year: {
     id: "last_updated_to_1i",
     name: "last_updated_to[1i]",

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/index/date_filter_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/index/date_filter_component.rb
@@ -1,3 +1,13 @@
 class ContentBlockManager::ContentBlock::Document::Index::DateFilterComponent < ViewComponent::Base
-  def initialize; end
+  def initialize(filters: nil)
+    @filters = filters
+  end
+
+private
+
+  attr_reader :filters
+
+  def date_value(date, date_part)
+    filters&.dig(date, date_part)
+  end
 end

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/index/date_filter_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/index/date_filter_component.rb
@@ -1,0 +1,3 @@
+class ContentBlockManager::ContentBlock::Document::Index::DateFilterComponent < ViewComponent::Base
+  def initialize; end
+end

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/index/date_filter_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/index/date_filter_component.rb
@@ -1,6 +1,7 @@
 class ContentBlockManager::ContentBlock::Document::Index::DateFilterComponent < ViewComponent::Base
-  def initialize(filters: nil)
+  def initialize(filters: nil, errors: nil)
     @filters = filters
+    @errors = errors
   end
 
 private

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/index/filter_options_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/index/filter_options_component.html.erb
@@ -62,7 +62,7 @@
         },
         content: {
           html: (
-            render(ContentBlockManager::ContentBlock::Document::Index::DateFilterComponent.new)
+            render(ContentBlockManager::ContentBlock::Document::Index::DateFilterComponent.new(filters: @filters))
           ),
         },
         expanded: true,

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/index/filter_options_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/index/filter_options_component.html.erb
@@ -62,7 +62,7 @@
         },
         content: {
           html: (
-            render(ContentBlockManager::ContentBlock::Document::Index::DateFilterComponent.new(filters: @filters))
+            render(ContentBlockManager::ContentBlock::Document::Index::DateFilterComponent.new(filters: @filters, errors: @errors))
           ),
         },
         expanded: true,

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/index/filter_options_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/index/filter_options_component.html.erb
@@ -56,6 +56,17 @@
         },
         expanded: true,
       },
+      {
+        heading: {
+          text: "Last updated date",
+        },
+        content: {
+          html: (
+            render(ContentBlockManager::ContentBlock::Document::Index::DateFilterComponent.new)
+          ),
+        },
+        expanded: true,
+      },
     ],
   } %>
 

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/index/filter_options_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/index/filter_options_component.rb
@@ -1,7 +1,8 @@
 class ContentBlockManager::ContentBlock::Document::Index::FilterOptionsComponent < ViewComponent::Base
   include ActionView::Helpers::RecordTagHelper
-  def initialize(filters:)
+  def initialize(filters:, errors: nil)
     @filters = filters
+    @errors = errors
   end
 
 private

--- a/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/documents_controller.rb
+++ b/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/documents_controller.rb
@@ -3,7 +3,12 @@ class ContentBlockManager::ContentBlock::DocumentsController < ContentBlockManag
     if params_filters.any?
       session[:content_block_filters] = params_filters
       @filters = params_filters
-      @content_block_documents = ContentBlockManager::ContentBlock::Document::DocumentFilter.new(@filters).paginated_documents
+      filter_result = ContentBlockManager::ContentBlock::Document::DocumentFilter.new(@filters)
+      @content_block_documents = filter_result.paginated_documents
+      unless filter_result.valid?
+        @errors = filter_result.errors
+        @error_summary_errors = @errors.map { |error| { text: error.full_message, href: "##{error.attribute}_3i" } }
+      end
       render :index
     elsif params[:reset_fields].blank? && session_filters.any?
       redirect_to content_block_manager.content_block_manager_root_path(session_filters)

--- a/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/documents_controller.rb
+++ b/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/documents_controller.rb
@@ -40,7 +40,7 @@ class ContentBlockManager::ContentBlock::DocumentsController < ContentBlockManag
 private
 
   def params_filters
-    params.slice(:keyword, :block_type, :lead_organisation, :page)
+    params.slice(:keyword, :block_type, :lead_organisation, :page, :last_updated_to, :last_updated_from)
           .permit!
           .to_h
   end

--- a/lib/engines/content_block_manager/app/models/content_block_manager/content_block/document.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/content_block/document.rb
@@ -3,6 +3,7 @@ module ContentBlockManager
     class Document < ApplicationRecord
       include Scopes::SearchableByKeyword
       include Scopes::SearchableByLeadOrganisation
+      include Scopes::SearchableByUpdatedDate
 
       extend FriendlyId
       friendly_id :title, use: :slugged, slug_column: :content_id_alias, routes: :default

--- a/lib/engines/content_block_manager/app/models/content_block_manager/content_block/document/document_filter.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/content_block/document/document_filter.rb
@@ -83,6 +83,7 @@ module ContentBlockManager
       documents = documents.with_lead_organisation(@filters[:lead_organisation]) if @filters[:lead_organisation].present?
       documents = documents.from_date(from_date) if valid? && from_date
       documents = documents.to_date(to_date) if valid? && to_date
+      documents = documents.distinct
       documents.order("content_block_editions.updated_at DESC")
     end
   end

--- a/lib/engines/content_block_manager/app/models/content_block_manager/content_block/document/document_filter.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/content_block/document/document_filter.rb
@@ -18,6 +18,30 @@ module ContentBlockManager
       Admin::EditionFilter::GOVUK_DESIGN_SYSTEM_PER_PAGE
     end
 
+    def is_date_present?(date_key)
+      @filters[date_key].present? && @filters[date_key].all? { |_, value| value.present? }
+    end
+
+    def from_date
+      @from_date ||= if is_date_present?(:last_updated_from)
+                       filter = @filters[:last_updated_from]
+                       year = filter["1i"].to_i
+                       month = filter["2i"].to_i
+                       day = filter["3i"].to_i
+                       Time.zone.local(year, month, day)
+                     end
+    end
+
+    def to_date
+      @to_date ||= if is_date_present?(:last_updated_to)
+                     filter = @filters[:last_updated_to]
+                     year = filter["1i"].to_i
+                     month = filter["2i"].to_i
+                     day = filter["3i"].to_i
+                     Time.zone.local(year, month, day).end_of_day
+                   end
+    end
+
     def unpaginated_documents
       documents = ContentBlock::Document
       documents = documents.live
@@ -25,6 +49,8 @@ module ContentBlockManager
       documents = documents.with_keyword(@filters[:keyword]) if @filters[:keyword].present?
       documents = documents.where(block_type: @filters[:block_type]) if @filters[:block_type].present?
       documents = documents.with_lead_organisation(@filters[:lead_organisation]) if @filters[:lead_organisation].present?
+      documents = documents.from_date(from_date) if from_date
+      documents = documents.to_date(to_date) if to_date
       documents.order("content_block_editions.updated_at DESC")
     end
   end

--- a/lib/engines/content_block_manager/app/models/content_block_manager/content_block/document/document_filter.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/content_block/document/document_filter.rb
@@ -1,5 +1,7 @@
 module ContentBlockManager
   class ContentBlock::Document::DocumentFilter
+    FILTER_ERROR = Data.define(:attribute, :full_message)
+
     def initialize(filters = {})
       @filters = filters
     end
@@ -8,7 +10,35 @@ module ContentBlockManager
       unpaginated_documents.page(page).per(default_page_size)
     end
 
+    def errors
+      @errors ||= begin
+        @errors = []
+        from = validate_date(:last_updated_from)
+        to = validate_date(:last_updated_to)
+
+        if @errors.empty? && to.present? && from.present? && from.after?(to)
+          @errors << FILTER_ERROR.new(attribute: "last_updated_from", full_message: I18n.t("content_block_document.index.errors.date.range.invalid"))
+        end
+
+        @errors
+      end
+    end
+
+    def valid?
+      errors.empty?
+    end
+
   private
+
+    def validate_date(key)
+      return unless is_date_present?(key)
+
+      date = date_from_filters(key)
+      Time.zone.local(date[:year], date[:month], date[:day])
+    rescue ArgumentError, TypeError, NoMethodError, RangeError
+      @errors << FILTER_ERROR.new(attribute: key.to_s, full_message: I18n.t("content_block_document.index.errors.date.invalid", attribute: key.to_s.humanize))
+      nil
+    end
 
     def page
       @filters[:page].presence || 1
@@ -19,26 +49,28 @@ module ContentBlockManager
     end
 
     def is_date_present?(date_key)
-      @filters[date_key].present? && @filters[date_key].all? { |_, value| value.present? }
+      @filters[date_key].present? && @filters[date_key].any? { |_, value| value.present? }
+    end
+
+    def date_from_filters(date_key)
+      filter = @filters[date_key]
+      year = filter["1i"].to_i
+      month = filter["2i"].to_i
+      day = filter["3i"].to_i
+      { year:, month:, day: }
     end
 
     def from_date
       @from_date ||= if is_date_present?(:last_updated_from)
-                       filter = @filters[:last_updated_from]
-                       year = filter["1i"].to_i
-                       month = filter["2i"].to_i
-                       day = filter["3i"].to_i
-                       Time.zone.local(year, month, day)
+                       date = date_from_filters(:last_updated_from)
+                       Time.zone.local(date[:year], date[:month], date[:day])
                      end
     end
 
     def to_date
       @to_date ||= if is_date_present?(:last_updated_to)
-                     filter = @filters[:last_updated_to]
-                     year = filter["1i"].to_i
-                     month = filter["2i"].to_i
-                     day = filter["3i"].to_i
-                     Time.zone.local(year, month, day).end_of_day
+                     date = date_from_filters(:last_updated_to)
+                     Time.zone.local(date[:year], date[:month], date[:day]).end_of_day
                    end
     end
 
@@ -49,8 +81,8 @@ module ContentBlockManager
       documents = documents.with_keyword(@filters[:keyword]) if @filters[:keyword].present?
       documents = documents.where(block_type: @filters[:block_type]) if @filters[:block_type].present?
       documents = documents.with_lead_organisation(@filters[:lead_organisation]) if @filters[:lead_organisation].present?
-      documents = documents.from_date(from_date) if from_date
-      documents = documents.to_date(to_date) if to_date
+      documents = documents.from_date(from_date) if valid? && from_date
+      documents = documents.to_date(to_date) if valid? && to_date
       documents.order("content_block_editions.updated_at DESC")
     end
   end

--- a/lib/engines/content_block_manager/app/models/content_block_manager/content_block/document/scopes/searchable_by_updated_date.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/content_block/document/scopes/searchable_by_updated_date.rb
@@ -1,0 +1,11 @@
+module ContentBlockManager
+  module ContentBlock::Document::Scopes::SearchableByUpdatedDate
+    extend ActiveSupport::Concern
+
+    included do
+      scope :latest_edition, -> { joins(:editions).where("content_block_documents.latest_edition_id = content_block_editions.id") }
+      scope :from_date, ->(date) { latest_edition.where("content_block_editions.updated_at >= ?", date) }
+      scope :to_date, ->(date) { latest_edition.where("content_block_editions.updated_at <= ?", date) }
+    end
+  end
+end

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/documents/index.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/documents/index.html.erb
@@ -1,6 +1,13 @@
 
 <% content_for :title_margin_bottom, 6 %>
 
+<% if @error_summary_errors %>
+  <%= render "govuk_publishing_components/components/error_summary", {
+    title: "There is a problem",
+    items: @error_summary_errors,
+  } %>
+<% end %>
+
 <div class="govuk-grid-row content-block-manager-header">
     <div class="govuk-grid-column-one-half">
       <h1 class="gem-c-title__text govuk-heading-xl">
@@ -29,6 +36,7 @@
     <%= render(
           ContentBlockManager::ContentBlock::Document::Index::FilterOptionsComponent.new(
             filters: @filters,
+            errors: @errors,
             ),
           ) %>
   </div>

--- a/lib/engines/content_block_manager/config/locales/en.yml
+++ b/lib/engines/content_block_manager/config/locales/en.yml
@@ -3,6 +3,13 @@ en:
     attributes:
       content_block_manager/content_block/edition/document:
         title: Title
+  content_block_document:
+    index:
+      errors:
+        date:
+          invalid: "%{attribute} is not a valid date"
+          range:
+            invalid: "From date must be before to date"
   content_block_edition:
     confirmation_page:
       scheduled:

--- a/lib/engines/content_block_manager/features/search_for_object.feature
+++ b/lib/engines/content_block_manager/features/search_for_object.feature
@@ -71,6 +71,12 @@ Feature: Search for a content object
     And I click to view results
     And "1" content blocks are returned in total
 
+  Scenario: GDS Editor sees errors when searching by invalid dates
+    When I visit the Content Block Manager home page
+    And I input invalid dates to filter by
+    And I click to view results
+    Then I should see a message that the filter dates are invalid
+
   @javascript
   Scenario: GDS Editor can copy embed code
     When I visit the Content Block Manager home page

--- a/lib/engines/content_block_manager/features/search_for_object.feature
+++ b/lib/engines/content_block_manager/features/search_for_object.feature
@@ -64,6 +64,13 @@ Feature: Search for a content object
     And I click to view results
     And "1" content blocks are returned in total
 
+  Scenario: GDS Editor searches for a content object by last updated date
+    When one of the content blocks was updated 2 days ago
+    When I visit the Content Block Manager home page
+    And I add a filter for blocks updated two days ago
+    And I click to view results
+    And "1" content blocks are returned in total
+
   @javascript
   Scenario: GDS Editor can copy embed code
     When I visit the Content Block Manager home page

--- a/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
@@ -445,6 +445,11 @@ Then("I should see a message that I need to confirm the details are correct") do
   assert_text "Confirm details are correct", minimum: 2
 end
 
+Then("I should see a message that the filter dates are invalid") do
+  expect(page).to have_selector("a[href='#last_updated_from_3i']"), text: "Last updated from is not a valid date"
+  expect(page).to have_selector("a[href='#last_updated_to_3i']"), text: "Last updated to is not a valid date"
+end
+
 Then("I should see a permissions error") do
   assert_text "Permissions error"
 end
@@ -677,6 +682,16 @@ When("I add a filter for blocks updated two days ago") do
   fill_in "last_updated_to_1i", with: date.year
   fill_in "last_updated_to_2i", with: date.month
   fill_in "last_updated_to_3i", with: date.day
+end
+
+When("I input invalid dates to filter by") do
+  fill_in "last_updated_from_1i", with: "1"
+  fill_in "last_updated_from_2i", with: "34"
+  fill_in "last_updated_from_3i", with: "56"
+
+  fill_in "last_updated_to_1i", with: "1"
+  fill_in "last_updated_to_2i", with: "67"
+  fill_in "last_updated_to_3i", with: "56"
 end
 
 When("I enter an invalid date") do

--- a/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
@@ -661,6 +661,24 @@ And(/^I schedule the change for (\d+) days in the future$/) do |number_of_days|
   click_on "Save and continue"
 end
 
+When("one of the content blocks was updated 2 days ago") do
+  content_block_document = ContentBlockManager::ContentBlock::Document.all.last
+  content_block_document.latest_edition.updated_at = 2.days.before(Time.zone.now)
+  content_block_document.latest_edition.save!
+end
+
+When("I add a filter for blocks updated two days ago") do
+  date = 2.days.before(Time.zone.now)
+
+  fill_in "last_updated_from_1i", with: date.year
+  fill_in "last_updated_from_2i", with: date.month
+  fill_in "last_updated_from_3i", with: date.day
+
+  fill_in "last_updated_to_1i", with: date.year
+  fill_in "last_updated_to_2i", with: date.month
+  fill_in "last_updated_to_3i", with: date.day
+end
+
 When("I enter an invalid date") do
   fill_in "Year", with: "01"
 end

--- a/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
@@ -249,8 +249,9 @@ Given(/^([^"]*) content blocks of type ([^"]*) have been created with the fields
   (1..count.to_i).each do |_i|
     document = create(:content_block_document, block_type.to_sym, title:)
 
-    create(
+    editions = create_list(
       :content_block_edition,
+      3,
       block_type.to_sym,
       document:,
       organisation:,
@@ -258,6 +259,9 @@ Given(/^([^"]*) content blocks of type ([^"]*) have been created with the fields
       creator: @user,
       instructions_to_publishers:,
     )
+
+    document.latest_edition = editions.last
+    document.save!
   end
 end
 

--- a/lib/engines/content_block_manager/test/components/content_block/document/index/date_filter_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/document/index/date_filter_component_test.rb
@@ -5,12 +5,36 @@ class ContentBlockManager::ContentBlock::Document::Index::DateFilterComponentTes
 
   it "renders from and to dates" do
     render_inline(ContentBlockManager::ContentBlock::Document::Index::DateFilterComponent.new)
-    assert_selector "input[name='last_updated[from(1i)]']"
-    assert_selector "input[name='last_updated[from(2i)]']"
-    assert_selector "input[name='last_updated[from(3i)]']"
+    assert_selector "input[name='last_updated_from[1i]']"
+    assert_selector "input[name='last_updated_from[2i]']"
+    assert_selector "input[name='last_updated_from[3i]']"
 
-    assert_selector "input[name='last_updated[to(1i)]']"
-    assert_selector "input[name='last_updated[to(2i)]']"
-    assert_selector "input[name='last_updated[to(3i)]']"
+    assert_selector "input[name='last_updated_to[1i]']"
+    assert_selector "input[name='last_updated_to[2i]']"
+    assert_selector "input[name='last_updated_to[3i]']"
+  end
+
+  it "keeps the values from the filter params" do
+    filters = {
+      last_updated_from: {
+        "3i" => "1",
+        "2i" => "2",
+        "1i" => "2025",
+      },
+      last_updated_to: {
+        "3i" => "3",
+        "2i" => "4",
+        "1i" => "2026",
+      },
+    }
+    render_inline(ContentBlockManager::ContentBlock::Document::Index::DateFilterComponent.new(filters:))
+
+    assert_selector "input[name='last_updated_from[3i]'][value=1]"
+    assert_selector "input[name='last_updated_from[2i]'][value='2']"
+    assert_selector "input[name='last_updated_from[1i]'][value='2025']"
+
+    assert_selector "input[name='last_updated_to[3i]'][value='3']"
+    assert_selector "input[name='last_updated_to[2i]'][value='4']"
+    assert_selector "input[name='last_updated_to[1i]'][value='2026']"
   end
 end

--- a/lib/engines/content_block_manager/test/components/content_block/document/index/date_filter_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/document/index/date_filter_component_test.rb
@@ -37,4 +37,19 @@ class ContentBlockManager::ContentBlock::Document::Index::DateFilterComponentTes
     assert_selector "input[name='last_updated_to[2i]'][value='4']"
     assert_selector "input[name='last_updated_to[1i]'][value='2026']"
   end
+
+  it "renders errors if there are errors on the date filter" do
+    errors = [
+      ContentBlockManager::ContentBlock::Document::DocumentFilter::FILTER_ERROR.new(
+        attribute: "last_updated_from", full_message: "From date is not in the correct format",
+      ),
+      ContentBlockManager::ContentBlock::Document::DocumentFilter::FILTER_ERROR.new(
+        attribute: "last_updated_to", full_message: "To date is not in the correct format",
+      ),
+    ]
+    render_inline(ContentBlockManager::ContentBlock::Document::Index::DateFilterComponent.new(errors:))
+
+    assert_selector ".govuk-error-message", text: "From date is not in the correct format"
+    assert_selector ".govuk-error-message", text: "To date is not in the correct format"
+  end
 end

--- a/lib/engines/content_block_manager/test/components/content_block/document/index/date_filter_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/document/index/date_filter_component_test.rb
@@ -1,0 +1,16 @@
+require "test_helper"
+
+class ContentBlockManager::ContentBlock::Document::Index::DateFilterComponentTest < ViewComponent::TestCase
+  extend Minitest::Spec::DSL
+
+  it "renders from and to dates" do
+    render_inline(ContentBlockManager::ContentBlock::Document::Index::DateFilterComponent.new)
+    assert_selector "input[name='last_updated[from(1i)]']"
+    assert_selector "input[name='last_updated[from(2i)]']"
+    assert_selector "input[name='last_updated[from(3i)]']"
+
+    assert_selector "input[name='last_updated[to(1i)]']"
+    assert_selector "input[name='last_updated[to(2i)]']"
+    assert_selector "input[name='last_updated[to(3i)]']"
+  end
+end

--- a/lib/engines/content_block_manager/test/components/content_block/document/index/filter_options_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/document/index/filter_options_component_test.rb
@@ -82,15 +82,17 @@ class ContentBlockManager::ContentBlock::Document::Index::FilterOptionsComponent
     assert_selector "option[selected='selected'][value=2]"
   end
 
-  it "filters by last updated date" do
+  it "passes filters to Date component" do
+    filters = { lead_organisation: "2" }
+    date_component = ContentBlockManager::ContentBlock::Document::Index::DateFilterComponent.new(filters:)
+    ContentBlockManager::ContentBlock::Document::Index::DateFilterComponent.expects(:new).with(filters:).returns(date_component)
+
     render_inline(
       ContentBlockManager::ContentBlock::Document::Index::FilterOptionsComponent.new(
-        filters: { lead_organisation: "2" },
+        filters:,
       ),
     )
 
     assert_selector ".govuk-accordion__section--expanded", text: "Last updated date"
-    assert_selector "h3", text: "From"
-    assert_selector "h3", text: "To"
   end
 end

--- a/lib/engines/content_block_manager/test/components/content_block/document/index/filter_options_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/document/index/filter_options_component_test.rb
@@ -24,7 +24,7 @@ class ContentBlockManager::ContentBlock::Document::Index::FilterOptionsComponent
         filters: {},
       ),
     )
-    assert_selector ".govuk-accordion__section--expanded", count: 3
+    assert_selector ".govuk-accordion__section--expanded", count: 4
   end
 
   it "adds value of keyword to text input from filter" do
@@ -80,5 +80,17 @@ class ContentBlockManager::ContentBlock::Document::Index::FilterOptionsComponent
 
     assert_selector "select[name='lead_organisation']"
     assert_selector "option[selected='selected'][value=2]"
+  end
+
+  it "filters by last updated date" do
+    render_inline(
+      ContentBlockManager::ContentBlock::Document::Index::FilterOptionsComponent.new(
+        filters: { lead_organisation: "2" },
+      ),
+    )
+
+    assert_selector ".govuk-accordion__section--expanded", text: "Last updated date"
+    assert_selector "h3", text: "From"
+    assert_selector "h3", text: "To"
   end
 end

--- a/lib/engines/content_block_manager/test/components/content_block/document/index/filter_options_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/document/index/filter_options_component_test.rb
@@ -82,14 +82,21 @@ class ContentBlockManager::ContentBlock::Document::Index::FilterOptionsComponent
     assert_selector "option[selected='selected'][value=2]"
   end
 
-  it "passes filters to Date component" do
+  it "passes filters and errors to Date component" do
     filters = { lead_organisation: "2" }
-    date_component = ContentBlockManager::ContentBlock::Document::Index::DateFilterComponent.new(filters:)
-    ContentBlockManager::ContentBlock::Document::Index::DateFilterComponent.expects(:new).with(filters:).returns(date_component)
+    errors = [
+      ContentBlockManager::ContentBlock::Document::DocumentFilter::FILTER_ERROR.new(
+        attribute: "last_updated_from", full_message: "From date is not in the correct format",
+      ),
+    ]
+    date_component = ContentBlockManager::ContentBlock::Document::Index::DateFilterComponent.new(filters:, errors:)
+    ContentBlockManager::ContentBlock::Document::Index::DateFilterComponent.expects(:new).with(filters:, errors:)
+                                                                           .returns(date_component)
 
     render_inline(
       ContentBlockManager::ContentBlock::Document::Index::FilterOptionsComponent.new(
         filters:,
+        errors:,
       ),
     )
 

--- a/lib/engines/content_block_manager/test/unit/app/models/content_block_edition/document/document_filter_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/models/content_block_edition/document/document_filter_test.rb
@@ -9,6 +9,7 @@ class ContentBlockManager::DocumentFilterTest < ActiveSupport::TestCase
     before do
       ContentBlockManager::ContentBlock::Document.expects(:live).returns(document_scope_mock)
       document_scope_mock.expects(:joins).with(:latest_edition).returns(document_scope_mock)
+      document_scope_mock.expects(:distinct).returns(document_scope_mock)
       document_scope_mock.expects(:order).with("content_block_editions.updated_at DESC").returns(document_scope_mock)
       document_scope_mock.expects(:per).with(15).returns([])
     end

--- a/lib/engines/content_block_manager/test/unit/app/models/content_block_edition/document/document_filter_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/models/content_block_edition/document/document_filter_test.rb
@@ -71,5 +71,48 @@ class ContentBlockManager::DocumentFilterTest < ActiveSupport::TestCase
         ContentBlockManager::ContentBlock::Document::DocumentFilter.new({ page: 2 }).paginated_documents
       end
     end
+
+    describe "last updated dates" do
+      describe "when dates are missing" do
+        it "does not filter by date if one or more date element is missing" do
+          document_scope_mock.expects(:page).with(1).returns(document_scope_mock)
+
+          ContentBlockManager::ContentBlock::Document::DocumentFilter.new(
+            {
+              last_updated_from: { "3i" => "", "2i" => "2", "1i" => "2025" },
+              last_updated_to: { "3i" => "", "2i" => "", "1i" => ""  },
+            },
+          ).paginated_documents
+        end
+      end
+
+      describe "when dates are valid" do
+        it "filters using last updated from date" do
+          document_scope_mock.expects(:page).with(1).returns(document_scope_mock)
+
+          expected_date_time = Time.zone.local(2025, 2, 1)
+
+          document_scope_mock.expects(:from_date).with(expected_date_time).returns(document_scope_mock)
+          ContentBlockManager::ContentBlock::Document::DocumentFilter.new(
+            {
+              last_updated_from: { "3i" => "1", "2i" => "2", "1i" => "2025" },
+            },
+          ).paginated_documents
+        end
+
+        it "filters using last updated to date" do
+          document_scope_mock.expects(:page).with(1).returns(document_scope_mock)
+
+          expected_date_time = Time.zone.local(2026, 4, 3).end_of_day
+
+          document_scope_mock.expects(:to_date).with(expected_date_time).returns(document_scope_mock)
+          ContentBlockManager::ContentBlock::Document::DocumentFilter.new(
+            {
+              last_updated_to: { "3i" => "3", "2i" => "4", "1i" => "2026" },
+            },
+          ).paginated_documents
+        end
+      end
+    end
   end
 end

--- a/lib/engines/content_block_manager/test/unit/app/models/content_block_edition/document/scopes/searchable_by_updated_date_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/models/content_block_edition/document/scopes/searchable_by_updated_date_test.rb
@@ -1,0 +1,54 @@
+require "test_helper"
+
+class ContentBlockManager::SearchableByUpdatedDateTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
+  describe ".from_date" do
+    test "finds documents updated from and including this date" do
+      filter_date_time = 1.day.before(Time.zone.now)
+      matching_document_1 = create(:content_block_document, :email_address)
+      _old_edition_1 = create(:content_block_edition, :email_address, document: matching_document_1, updated_at: 4.days.before(Time.zone.now))
+      latest_edition_1 = create(:content_block_edition, :email_address, document: matching_document_1, updated_at: filter_date_time)
+      matching_document_1.latest_edition = latest_edition_1
+      matching_document_1.save!
+
+      matching_document_2 = create(:content_block_document, :email_address)
+      _old_edition_2 = create(:content_block_edition, :email_address, document: matching_document_2, updated_at: 12.days.before(Time.zone.now))
+      latest_edition_2 = create(:content_block_edition, :email_address, document: matching_document_2, updated_at: Time.zone.now)
+      matching_document_2.latest_edition = latest_edition_2
+      matching_document_2.save!
+
+      not_matching_document = create(:content_block_document, :email_address)
+      not_matching_edition = create(:content_block_edition, :email_address, document: not_matching_document, updated_at: 2.days.before(Time.zone.now))
+      not_matching_document.latest_edition = not_matching_edition
+      not_matching_document.save!
+
+      assert_equal [matching_document_1, matching_document_2], ContentBlockManager::ContentBlock::Document.from_date(filter_date_time)
+    end
+  end
+
+  describe ".to_date" do
+    test "finds documents updated up to and including this date" do
+      filter_date_time = 1.day.before(Time.zone.now)
+
+      matching_document_1 = create(:content_block_document, :email_address)
+      _old_edition_1 = create(:content_block_edition, :email_address, document: matching_document_1, updated_at: 4.days.before(Time.zone.now))
+      latest_edition_1 = create(:content_block_edition, :email_address, document: matching_document_1, updated_at: filter_date_time)
+      matching_document_1.latest_edition = latest_edition_1
+      matching_document_1.save!
+
+      matching_document_2 = create(:content_block_document, :email_address)
+      _old_edition_2 = create(:content_block_edition, :email_address, document: matching_document_2, updated_at: 2.days.before(Time.zone.now))
+      latest_edition_2 = create(:content_block_edition, :email_address, document: matching_document_2, updated_at: filter_date_time)
+      matching_document_2.latest_edition = latest_edition_2
+      matching_document_2.save!
+
+      not_matching_document = create(:content_block_document, :email_address)
+      not_matching_edition = create(:content_block_edition, :email_address, document: not_matching_document, updated_at: Time.zone.now)
+      not_matching_document.latest_edition = not_matching_edition
+      not_matching_document.save!
+
+      assert_equal [matching_document_1, matching_document_2], ContentBlockManager::ContentBlock::Document.to_date(filter_date_time)
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/auF0TsMT/735-update-homepage-add-last-updated-date-filter

![Screenshot 2024-11-29 at 13 00 59](https://github.com/user-attachments/assets/8f6e3e6d-32d1-447c-a703-04477a75de3a)


---
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
