### PR TITLE
(700) Create rollup for view page and review page

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -310,7 +310,7 @@ GEM
     govuk_personalisation (1.1.0)
       plek (>= 1.9.0)
       rails (>= 6, < 9)
-    govuk_publishing_components (46.0.0)
+    govuk_publishing_components (46.1.0)
       chartkick
       govuk_app_config
       govuk_personalisation (>= 0.7.0)

--- a/lib/engines/content_block_manager/app/assets/stylesheets/content_block_manager/application.scss
+++ b/lib/engines/content_block_manager/app/assets/stylesheets/content_block_manager/application.scss
@@ -1,4 +1,5 @@
 @import "components/filter-options-component";
+@import "components/host-editions-rollup-component";
 @import "components/host-editions-table-component";
 @import "components/timeline-component";
 

--- a/lib/engines/content_block_manager/app/assets/stylesheets/content_block_manager/components/_host-editions-rollup-component.scss
+++ b/lib/engines/content_block_manager/app/assets/stylesheets/content_block_manager/components/_host-editions-rollup-component.scss
@@ -1,0 +1,31 @@
+.rollup-details {
+  background: govuk-colour("light-grey");
+  margin-bottom: govuk-spacing(8);
+
+  .govuk-grid-column-full {
+    padding: 0;
+  }
+
+  &__title {
+    @include govuk-visually-hidden;
+  }
+
+  &__rollup-metric {
+    .gem-c-glance-metric {
+      border: none;
+      margin: govuk-spacing(6);
+      padding: 0;
+
+      &__heading {
+        @include govuk-font(19, $weight: regular, $line-height: 1);
+
+        min-height: 1em;
+      }
+
+      &__context {
+        border: none;
+        min-height: 0;
+      }
+    }
+  }
+}

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/host_editions_rollup_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/host_editions_rollup_component.html.erb
@@ -1,0 +1,19 @@
+<div class="govuk-grid-row rollup-details">
+  <div class="govuk-grid-column-full">
+    <h2 class="rollup-details__title">Metrics</h2>
+    <% metrics.each do |name, value| %>
+      <div class="govuk-grid-column-one-quarter rollup-details__rollup-metric <%= name %>">
+        <%=
+          render(
+            "govuk_publishing_components/components/glance_metric",
+            name: name.to_s.titleize,
+            figure: value[:figure],
+            measurement_display_label: value[:display_label],
+            measurement_explicit_label: value[:explicit_label],
+            heading_level: 3,
+            )
+        %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/host_editions_rollup_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/host_editions_rollup_component.rb
@@ -1,0 +1,25 @@
+class ContentBlockManager::ContentBlock::Document::Show::HostEditionsRollupComponent < ViewComponent::Base
+  METRICS = %i[locations instances organisations views].freeze
+
+  def initialize(rollup:)
+    @rollup = rollup
+  end
+
+private
+
+  attr_reader :rollup
+
+  def metrics
+    METRICS.index_with do |metric|
+      abbreviate(rollup.send(metric))
+    end
+  end
+
+  def abbreviate(number)
+    {
+      figure: number_to_human(number, format: "%n"),
+      display_label: number_to_human(number, format: "%u", units: { unit: "", thousand: "k", million: "m", billion: "b" }),
+      explicit_label: number_to_human(number, format: "%u"),
+    }
+  end
+end

--- a/lib/engines/content_block_manager/app/models/content_block_manager/host_content_items.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/host_content_items.rb
@@ -1,9 +1,11 @@
 module ContentBlockManager
-  class HostContentItems < Data.define(:items, :total, :total_pages)
+  class HostContentItems < Data.define(:items, :total, :total_pages, :rollup)
     extend Forwardable
 
     ARRAY_METHODS = ([].methods - Object.methods)
 
     def_delegators :items, *ARRAY_METHODS
+
+    class Rollup < Data.define(:views, :locations, :instances, :organisations); end
   end
 end

--- a/lib/engines/content_block_manager/app/services/content_block_manager/get_host_content_items.rb
+++ b/lib/engines/content_block_manager/app/services/content_block_manager/get_host_content_items.rb
@@ -34,7 +34,21 @@ module ContentBlockManager
         )
       end
 
-      ContentBlockManager::HostContentItems.new(items, content_items["total"], content_items["total_pages"])
+      ContentBlockManager::HostContentItems.new(
+        items:,
+        total: content_items["total"],
+        total_pages: content_items["total_pages"],
+        rollup:,
+      )
+    end
+
+    def rollup
+      ContentBlockManager::HostContentItems::Rollup.new(
+        views: content_items["rollup"]["views"],
+        locations: content_items["rollup"]["locations"],
+        instances: content_items["rollup"]["instances"],
+        organisations: content_items["rollup"]["organisations"],
+      )
     end
 
   private

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/documents/show.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/documents/show.html.erb
@@ -6,6 +6,14 @@
   } %>
 <% end %>
 
+<%=
+  render(
+    ContentBlockManager::ContentBlock::Document::Show::HostEditionsRollupComponent.new(
+      rollup: @host_content_items.rollup,
+    ),
+  )
+%>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h2 class="govuk-heading-m">Details</h2>

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/review_links.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/review_links.html.erb
@@ -9,6 +9,14 @@
 
 <p class="govuk-body">The new <%= @content_block_document.block_type.humanize.downcase %> will appear on the following content after you publish the change.</p>
 
+<%=
+  render(
+    ContentBlockManager::ContentBlock::Document::Show::HostEditionsRollupComponent.new(
+      rollup: @host_content_items.rollup,
+      ),
+  )
+%>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <%= render(

--- a/lib/engines/content_block_manager/features/edit_object.feature
+++ b/lib/engines/content_block_manager/features/edit_object.feature
@@ -18,6 +18,7 @@ Feature: Edit a content object
     And I should see a back link to the document page
     When I fill out the form
     Then I am shown where the changes will take place
+    And I see the rollup data for the dependent content
     And I should see a back link to the edit page
     When I save and continue
     Then I am asked when I want to publish the change
@@ -37,6 +38,7 @@ Feature: Edit a content object
     Then I should see the edit form
     When I fill out the form
     Then I am shown where the changes will take place
+    And I see the rollup data for the dependent content
     And I click cancel
     Then I should be taken back to the document page
     And no draft Content Block Edition has been created
@@ -48,6 +50,7 @@ Feature: Edit a content object
     Then I should see the edit form
     When I fill out the form
     Then I am shown where the changes will take place
+    And I see the rollup data for the dependent content
     When I save and continue
     Then I am asked when I want to publish the change
     And I click cancel
@@ -101,5 +104,6 @@ Feature: Edit a content object
     When I revisit the edit page
     And I fill out the form
     Then I am shown where the changes will take place
+    And I see the rollup data for the dependent content
     When I click on the first host document
     Then the preview page opens in a new tab

--- a/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
@@ -456,7 +456,7 @@ When(/^dependent content exists for a content block$/) do
     results: @dependent_content,
     total: @dependent_content.length,
     order: ContentBlockManager::GetHostContentItems::DEFAULT_ORDER,
-    rollup: @rollup
+    rollup: @rollup,
   )
 end
 
@@ -469,7 +469,7 @@ Then(/^I should see the dependent content listed$/) do
   end
 end
 
-Then(/^I should see the rollup data for the dependent content$/) do
+Then(/^I (should )?see the rollup data for the dependent content$/) do |_should|
   @rollup.keys.each do |k|
     within ".rollup-details__rollup-metric.#{k}" do
       assert_text k.to_s.titleize

--- a/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
@@ -450,10 +450,13 @@ When(/^dependent content exists for a content block$/) do
     }
   end
 
+  @rollup = build(:rollup).to_h
+
   stub_publishing_api_has_embedded_content_for_any_content_id(
     results: @dependent_content,
     total: @dependent_content.length,
     order: ContentBlockManager::GetHostContentItems::DEFAULT_ORDER,
+    rollup: @rollup
   )
 end
 
@@ -463,6 +466,17 @@ Then(/^I should see the dependent content listed$/) do
   @dependent_content.each do |item|
     assert_text item["title"]
     break if item == @dependent_content.last
+  end
+end
+
+Then(/^I should see the rollup data for the dependent content$/) do
+  @rollup.keys.each do |k|
+    within ".rollup-details__rollup-metric.#{k}" do
+      assert_text k.to_s.titleize
+      within ".gem-c-glance-metric__figure" do
+        assert_text @rollup[k]
+      end
+    end
   end
 end
 

--- a/lib/engines/content_block_manager/features/view_object.feature
+++ b/lib/engines/content_block_manager/features/view_object.feature
@@ -19,6 +19,7 @@ Feature: View a content object
     When I visit the Content Block Manager home page
     And I click to view the document
     Then I should see the dependent content listed
+    And I should see the rollup data for the dependent content
 
   @javascript
   Scenario: GDS Editor can copy embed code

--- a/lib/engines/content_block_manager/test/components/content_block/document/show/host_editions_rollup_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/document/show/host_editions_rollup_component_test.rb
@@ -1,0 +1,40 @@
+require "test_helper"
+
+class ContentBlockManager::ContentBlock::Document::Show::HostEditionsRollupComponentTest < ViewComponent::TestCase
+  extend Minitest::Spec::DSL
+
+  let(:described_class) { ContentBlockManager::ContentBlock::Document::Show::HostEditionsRollupComponent }
+
+  it "returns rolled up data with small numbers" do
+    rollup = build(:rollup, views: 12, locations: 2, instances: 3, organisations: 1)
+
+    render_inline(described_class.new(rollup:))
+
+    assert_selector ".rollup-details__rollup-metric.views .gem-c-glance-metric__heading", text: "Views"
+    assert_selector ".rollup-details__rollup-metric.views .gem-c-glance-metric__figure", text: "12"
+
+    assert_selector ".rollup-details__rollup-metric.locations .gem-c-glance-metric__heading", text: "Locations"
+    assert_selector ".rollup-details__rollup-metric.locations .gem-c-glance-metric__figure", text: "2"
+
+    assert_selector ".rollup-details__rollup-metric.instances .gem-c-glance-metric__heading", text: "Instances"
+    assert_selector ".rollup-details__rollup-metric.instances .gem-c-glance-metric__figure", text: "3"
+
+    assert_selector ".rollup-details__rollup-metric.organisations .gem-c-glance-metric__heading", text: "Organisations"
+    assert_selector ".rollup-details__rollup-metric.organisations .gem-c-glance-metric__figure", text: "1"
+  end
+
+  it "returns rolled up data with larger numbers" do
+    rollup = build(:rollup, views: 12_000_000, locations: 15_000)
+
+    render_inline(described_class.new(rollup:))
+
+    assert_selector ".rollup-details__rollup-metric.views .gem-c-glance-metric__heading", text: "Views"
+    assert_selector ".rollup-details__rollup-metric.views .gem-c-glance-metric__figure", text: "12"
+    assert_selector ".rollup-details__rollup-metric.views .gem-c-glance-metric__display-label", text: "m"
+    assert_selector ".rollup-details__rollup-metric.views .gem-c-glance-metric__explicit-label", text: "Million"
+
+    assert_selector ".rollup-details__rollup-metric.locations .gem-c-glance-metric__figure", text: "15"
+    assert_selector ".rollup-details__rollup-metric.locations .gem-c-glance-metric__display-label", text: "k"
+    assert_selector ".rollup-details__rollup-metric.locations .gem-c-glance-metric__explicit-label", text: "Thousand"
+  end
+end

--- a/lib/engines/content_block_manager/test/factories/host_content_items.rb
+++ b/lib/engines/content_block_manager/test/factories/host_content_items.rb
@@ -3,11 +3,27 @@ FactoryBot.define do
     total_pages { 1 }
     total { 10 }
     items { build_list(:host_content_item, 10) }
+    rollup { build(:rollup) }
 
     initialize_with do
       new(total_pages:,
           total:,
-          items:)
+          items:,
+          rollup:)
+    end
+  end
+
+  factory :rollup, class: "ContentBlockManager::HostContentItems::Rollup" do
+    views { Random.rand(0..10) }
+    locations { Random.rand(0..10) }
+    instances { Random.rand(0..10) }
+    organisations { Random.rand(0..10) }
+
+    initialize_with do
+      new(views:,
+          locations:,
+          instances:,
+          organisations:)
     end
   end
 end

--- a/lib/engines/content_block_manager/test/unit/app/models/host_content_items_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/models/host_content_items_test.rb
@@ -6,7 +6,8 @@ class ContentBlockManager::HostContentItemsTest < ActiveSupport::TestCase
   let(:items) { build_list(:host_content_item, 5) }
   let(:total) { 12 }
   let(:total_pages) { 2 }
-  let(:host_content_items) { build(:host_content_items, items:, total:, total_pages:) }
+  let(:rollup) { build(:rollup) }
+  let(:host_content_items) { build(:host_content_items, items:, total:, total_pages:, rollup:) }
 
   it "delegates array methods to items" do
     ([].methods - Object.methods).each do |method|

--- a/lib/engines/content_block_manager/test/unit/app/services/get_host_content_items_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/services/get_host_content_items_test.rb
@@ -9,11 +9,14 @@ class ContentBlockManager::GetHostContentItemsTest < ActiveSupport::TestCase
 
   let(:host_content_id) { SecureRandom.uuid }
 
+  let(:rollup) { build(:rollup) }
+
   let(:response_body) do
     {
       "content_id" => SecureRandom.uuid,
       "total" => 111,
       "total_pages" => 12,
+      "rollup" => rollup.to_h,
       "results" => [
         {
           "title" => "foo",
@@ -36,7 +39,7 @@ class ContentBlockManager::GetHostContentItemsTest < ActiveSupport::TestCase
   end
 
   setup do
-    stub_publishing_api_has_embedded_content(content_id: target_content_id, total: 111, total_pages: 12, results: response_body["results"], order: ContentBlockManager::GetHostContentItems::DEFAULT_ORDER)
+    stub_publishing_api_has_embedded_content(content_id: target_content_id, total: 111, total_pages: 12, results: response_body["results"], order: ContentBlockManager::GetHostContentItems::DEFAULT_ORDER, rollup: response_body["rollup"])
   end
 
   describe "#items" do
@@ -104,6 +107,11 @@ class ContentBlockManager::GetHostContentItemsTest < ActiveSupport::TestCase
 
       assert_equal result.total, response_body["total"]
       assert_equal result.total_pages, response_body["total_pages"]
+
+      assert_equal result.rollup.views, rollup.views
+      assert_equal result.rollup.locations, rollup.locations
+      assert_equal result.rollup.instances, rollup.instances
+      assert_equal result.rollup.organisations, rollup.organisations
 
       assert_equal result[0].title, response_body["results"][0]["title"]
       assert_equal result[0].base_path, response_body["results"][0]["base_path"]


### PR DESCRIPTION
This returns a "rollup" view of all the statistics for dependent content when viewing and reviewing content block changes using data from the Publishing API and the newly added `glance_metric` component.

## Screenshots

![Screenshot 2024-12-02 at 13-42-00 Manage an Email address - GOV UK Content Block Manager](https://github.com/user-attachments/assets/ee95015d-5fe4-4ce7-b8df-5376c6c9d181)

![Screenshot 2024-12-02 at 13-41-44 Where the change will appear - GOV UK Content Block Manager](https://github.com/user-attachments/assets/f5a57f26-f6fc-4f6c-9874-11d1d5afb65c)

Trello card: https://trello.com/c/eJTfFnFN/700-create-rollup-for-view-page-and-review-page
