### PR TITLE
(699) Update view page

### DIFF
--- a/lib/engines/content_block_manager/app/assets/stylesheets/content_block_manager/application.scss
+++ b/lib/engines/content_block_manager/app/assets/stylesheets/content_block_manager/application.scss
@@ -4,3 +4,4 @@
 @import "components/timeline-component";
 
 @import "views/content_block_manager_header";
+@import "views/content_block_manager_show";

--- a/lib/engines/content_block_manager/app/assets/stylesheets/content_block_manager/components/_timeline-component.scss
+++ b/lib/engines/content_block_manager/app/assets/stylesheets/content_block_manager/components/_timeline-component.scss
@@ -62,7 +62,8 @@
 
 .timeline__latest {
   @include govuk-font($size: 19, $weight: bold);
-  background: #ffdd00;
+  color: govuk-colour("white");
+  background: govuk-colour("blue");
   padding: 0.25rem 0.5rem;
   font-size: 1rem !important;
   line-height: 1.25 !important;

--- a/lib/engines/content_block_manager/app/assets/stylesheets/content_block_manager/views/_content_block_manager_show.scss
+++ b/lib/engines/content_block_manager/app/assets/stylesheets/content_block_manager/views/_content_block_manager_show.scss
@@ -1,0 +1,8 @@
+.support-request-wrapper {
+  display: flex;
+
+  .govuk-button--secondary {
+    margin-left: auto;
+    margin-top: govuk-spacing(6);
+  }
+}

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/index/summary_card_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/index/summary_card_component.rb
@@ -16,7 +16,7 @@ private
       title_item,
       *details_items,
       organisation_item,
-      last_updated_item,
+      status_item,
       (instructions_item if content_block_document.latest_edition.instructions_to_publishers.present?),
       embed_code_item,
     ].compact

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/document_timeline_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/document_timeline_component.html.erb
@@ -1,4 +1,4 @@
-<h2 class="govuk-heading-l">Previous updates</h2>
+<h2 class="govuk-heading-l">Change history</h2>
 
 <div class="timeline">
   <% items.each_with_index do |item, i| %>

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/document_timeline_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/document_timeline_component.rb
@@ -12,7 +12,7 @@ private
     content_block_versions.reject { |version| version.state.nil? }.map do |version|
       {
         title: title(version),
-        byline: User.find_by_id(version.whodunnit)&.name || "unknown user",
+        byline: User.find_by_id(version.whodunnit)&.then { |user| helpers.linked_author(user, { class: "govuk-link" }) } || "unknown user",
         date: time_html(version.created_at),
       }
     end

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/host_editions_table_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/host_editions_table_component.html.erb
@@ -13,7 +13,7 @@ it out for now-->
         sort_direction: sort_direction("title"),
       },
       {
-        text: "Document Type",
+        text: "Type",
         href: sort_link("document_type"),
         sort_direction: sort_direction("document_type"),
       },
@@ -23,17 +23,17 @@ it out for now-->
         sort_direction: sort_direction("instances"),
       },
       {
-        text: "Unique pageviews",
+        text: "Views (30 days)",
         href: sort_link("unique_pageviews"),
         sort_direction: sort_direction("unique_pageviews"),
       },
       {
-        text: "Publishing organisation",
+        text: "Lead organisation",
         href: sort_link("primary_publishing_organisation_title"),
         sort_direction: sort_direction("primary_publishing_organisation_title"),
       },
       {
-        text: "Updated",
+        text: "Last updated",
         href: sort_link("last_edited_at"),
         sort_direction: sort_direction("last_edited_at"),
       },

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/summary_list_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/summary_list_component.rb
@@ -14,10 +14,8 @@ private
       *details_items,
       organisation_item,
       instructions_item,
-      last_updated_item,
+      status_item,
       embed_code_item,
-      state_item,
-      scheduled_item,
     ].compact
   end
 
@@ -69,31 +67,26 @@ private
     end
   end
 
-  def last_updated_item
-    {
-      field: "Last updated",
-      value: last_updated_value,
-    }
+  def status_item
+    if content_block_document.latest_edition.state == "scheduled"
+      {
+        field: "Status",
+        value: scheduled_value,
+      }
+    else
+      {
+        field: "Status",
+        value: last_updated_value,
+      }
+    end
   end
 
   def last_updated_value
-    "#{time_ago_in_words(content_block_document.latest_edition.updated_at)} ago by #{content_block_document.latest_edition.creator.name}"
+    "Published #{time_ago_in_words(content_block_document.latest_edition.updated_at)} ago by #{content_block_document.latest_edition.creator.name}"
   end
 
-  def state_item
-    {
-      field: "State",
-      value: content_block_document.latest_edition.state.titleize,
-    }
-  end
-
-  def scheduled_item
-    if content_block_document.latest_edition.state == "scheduled"
-      {
-        field: "Scheduled for publication at",
-        value: I18n.l(content_block_document.latest_edition.scheduled_publication, format: :long_ordinal),
-      }
-    end
+  def scheduled_value
+    "Scheduled for publication at #{I18n.l(content_block_document.latest_edition.scheduled_publication, format: :long_ordinal)}"
   end
 
   def edit_action

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/documents/show.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/documents/show.html.erb
@@ -38,7 +38,7 @@
   <div class="govuk-grid-column-full">
     <%= render(
       ContentBlockManager::ContentBlock::Document::Show::HostEditionsTableComponent.new(
-        caption: "Content appears in",
+        caption: "List of locations",
         host_content_items: @host_content_items,
         current_page: @page,
         order: @order,

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/documents/show.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/documents/show.html.erb
@@ -1,5 +1,5 @@
-<% content_for :context, product_name %>
-<% content_for :title, "Manage #{add_indefinite_article @content_block_document.block_type.humanize}" %>
+<% content_for :context, "View #{@content_block_document.block_type.humanize.downcase}" %>
+<% content_for :title, @content_block_document.title %>
 <% content_for :back_link do %>
   <%= render "govuk_publishing_components/components/back_link", {
     href: content_block_manager.content_block_manager_content_block_documents_path,

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/documents/show.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/documents/show.html.erb
@@ -5,6 +5,15 @@
     href: content_block_manager.content_block_manager_content_block_documents_path,
   } %>
 <% end %>
+<% content_for :title_side do %>
+  <div class="support-request-wrapper">
+    <%= render "govuk_publishing_components/components/button", {
+      text: "Raise a support request",
+      href: support_url,
+      secondary_solid: true,
+    } %>
+  </div>
+<% end %>
 
 <%=
   render(

--- a/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
@@ -465,7 +465,7 @@ When(/^dependent content exists for a content block$/) do
 end
 
 Then(/^I should see the dependent content listed$/) do
-  assert_text "Content appears in"
+  assert_text "List of locations"
 
   @dependent_content.each do |item|
     assert_text item["title"]

--- a/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
@@ -367,7 +367,7 @@ def should_show_summary_list_for_email_address_content_block(document_title, ema
     expect(page).to have_selector(".govuk-summary-list__key", text: "Instructions to publishers")
     expect(page).to have_selector(".govuk-summary-list__value", text: instructions_to_publishers)
   end
-  expect(page).to have_selector(".govuk-summary-list__key", text: "Last updated")
+  expect(page).to have_selector(".govuk-summary-list__key", text: "Status")
   expect(page).to have_selector(".govuk-summary-list__value", text: @user.name)
 end
 
@@ -625,12 +625,12 @@ end
 
 Then("published state of the object is shown") do
   visit content_block_manager.content_block_manager_content_block_document_path(@content_block.document)
-  expect(page).to have_selector(".govuk-summary-list__key", text: "State")
+  expect(page).to have_selector(".govuk-summary-list__key", text: "Status")
   expect(page).to have_selector(".govuk-summary-list__value", text: "Published")
 end
 
 Then("I should see the scheduled date on the object") do
-  expect(page).to have_selector(".govuk-summary-list__key", text: "Scheduled for publication at")
+  expect(page).to have_selector(".govuk-summary-list__key", text: "Status")
   expect(page).to have_selector(".govuk-summary-list__value", text: I18n.l(@future_date, format: :long_ordinal).squish)
 end
 

--- a/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
@@ -308,7 +308,7 @@ When("I click to view the edition") do
 end
 
 Then("I should see the details for the email address content block") do
-  assert_text "Manage an Email address"
+  assert_text "View email address"
 
   should_show_summary_list_for_email_address_content_block(
     @content_block.document.title,

--- a/lib/engines/content_block_manager/test/components/content_block/document/index/summary_card_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/document/index/summary_card_component_test.rb
@@ -47,8 +47,8 @@ class ContentBlockManager::ContentBlock::Document::Index::SummaryCardComponentTe
     assert_no_selector ".govuk-summary-list__key", text: "Instructions to publishers"
     assert_no_selector ".govuk-summary-list__value", text: "None"
 
-    assert_selector ".govuk-summary-list__key", text: "Last updated"
-    assert_selector ".govuk-summary-list__value", text: "1 day ago by #{content_block_edition.creator.name}"
+    assert_selector ".govuk-summary-list__key", text: "Status"
+    assert_selector ".govuk-summary-list__value", text: "Published 1 day ago by #{content_block_edition.creator.name}"
 
     assert_selector ".govuk-summary-list__row[data-module='copy-embed-code']", text: "Embed code"
     assert_selector ".govuk-summary-list__row[data-embed-code='#{content_block_document.embed_code}']", text: "Embed code"

--- a/lib/engines/content_block_manager/test/components/content_block/document/show/document_timeline_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/document/show/document_timeline_component_test.rb
@@ -1,6 +1,10 @@
 require "test_helper"
 
 class ContentBlockManager::ContentBlock::Document::Show::DocumentTimelineComponentTest < ViewComponent::TestCase
+  include Rails.application.routes.url_helpers
+  include ActionView::Helpers::UrlHelper
+  include ApplicationHelper
+
   test "renders a timeline component with events in correct order" do
     @user = create(:user)
     @version_1 = create(
@@ -28,12 +32,12 @@ class ContentBlockManager::ContentBlock::Document::Show::DocumentTimelineCompone
     assert_selector ".timeline__item", count: 2
 
     assert_equal "Email address scheduled", page.all(".timeline__title")[0].text
-    assert_equal "by #{@user.name}", page.all(".timeline__byline")[0].text
+    assert_equal "by #{linked_author(@user, { class: 'govuk-link' })}", page.all(".timeline__byline")[0].native.inner_html
     assert_equal  I18n.l(@version_3.created_at, format: :long_ordinal),
                   page.all("time[datetime='#{@version_3.created_at.iso8601}']")[1].text
 
     assert_equal "Email address published", page.all(".timeline__title")[1].text
-    assert_equal "by #{@user.name}", page.all(".timeline__byline")[1].text
+    assert_equal "by #{linked_author(@user, { class: 'govuk-link' })}", page.all(".timeline__byline")[1].native.inner_html
     assert_equal  I18n.l(@version_2.created_at, format: :long_ordinal),
                   page.all("time[datetime='#{@version_2.created_at.iso8601}']")[1].text
   end

--- a/lib/engines/content_block_manager/test/components/content_block/document/show/host_editions_table_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/document/show/host_editions_table_component_test.rb
@@ -221,13 +221,13 @@ class ContentBlockManager::ContentBlock::Document::Show::HostEditionsTableCompon
         )
 
         assert_selector "a.app-table__sort-link[href*='order=title']", text: "Title"
-        assert_selector "a.app-table__sort-link[href*='order=document_type']", text: "Document Type"
+        assert_selector "a.app-table__sort-link[href*='order=document_type']", text: "Type"
         assert_selector "a.app-table__sort-link[href*='order=instances']", text: "Instances"
-        assert_selector "a.app-table__sort-link[href*='order=unique_pageviews']", text: "Unique pageviews"
-        assert_selector "a.app-table__sort-link[href*='order=primary_publishing_organisation_title']", text: "Publishing organisation"
-        assert_selector "a.app-table__sort-link[href*='order=last_edited_at']", text: "Updated"
+        assert_selector "a.app-table__sort-link[href*='order=unique_pageviews']", text: "Views (30 days)"
+        assert_selector "a.app-table__sort-link[href*='order=primary_publishing_organisation_title']", text: "Lead organisation"
+        assert_selector "a.app-table__sort-link[href*='order=last_edited_at']", text: "Last updated"
 
-        assert_selector ".govuk-table__header--active a", text: "Unique pageviews"
+        assert_selector ".govuk-table__header--active a", text: "Views (30 days)"
       end
 
       %w[title document_type unique_pageviews primary_publishing_organisation_title last_edited_at instances].each do |order|

--- a/lib/engines/content_block_manager/test/components/content_block/document/show/summary_list_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/document/show/summary_list_component_test.rb
@@ -21,7 +21,7 @@ class ContentBlockManager::ContentBlock::Document::Show::SummaryListComponentTes
   it "renders a published content block correctly" do
     render_inline(ContentBlockManager::ContentBlock::Document::Show::SummaryListComponent.new(content_block_document:))
 
-    assert_selector ".govuk-summary-list__row", count: 9
+    assert_selector ".govuk-summary-list__row", count: 8
     assert_selector ".govuk-summary-list__actions", count: 1
 
     assert_selector ".govuk-summary-list__key", text: "Email address details"
@@ -39,8 +39,8 @@ class ContentBlockManager::ContentBlock::Document::Show::SummaryListComponentTes
     assert_selector ".govuk-summary-list__key", text: "Lead organisation"
     assert_selector ".govuk-summary-list__value", text: "Department for Example"
 
-    assert_selector ".govuk-summary-list__key", text: "Last updated"
-    assert_selector ".govuk-summary-list__value", text: "1 day ago by #{content_block_edition.creator.name}"
+    assert_selector ".govuk-summary-list__key", text: "Status"
+    assert_selector ".govuk-summary-list__value", text: "Published 1 day ago by #{content_block_edition.creator.name}"
 
     assert_selector ".govuk-summary-list__key", text: "Instructions to publishers"
     assert_selector ".govuk-summary-list__value", text: "None"
@@ -49,9 +49,6 @@ class ContentBlockManager::ContentBlock::Document::Show::SummaryListComponentTes
     assert_selector ".govuk-summary-list__row[data-embed-code='#{content_block_document.embed_code}']", text: "Embed code"
     assert_selector ".govuk-summary-list__key", text: "Embed code"
     assert_selector ".govuk-summary-list__value", text: content_block_document.embed_code
-
-    assert_selector ".govuk-summary-list__key", text: "State"
-    assert_selector ".govuk-summary-list__value", text: content_block_edition.state.titleize
   end
 
   it "renders a scheduled content block correctly" do
@@ -59,10 +56,10 @@ class ContentBlockManager::ContentBlock::Document::Show::SummaryListComponentTes
 
     render_inline(ContentBlockManager::ContentBlock::Document::Show::SummaryListComponent.new(content_block_document:))
 
-    assert_selector ".govuk-summary-list__row", count: 10
+    assert_selector ".govuk-summary-list__row", count: 8
 
-    assert_selector ".govuk-summary-list__key", text: "Scheduled for publication at"
-    assert_selector ".govuk-summary-list__value", text: I18n.l(content_block_edition.scheduled_publication, format: :long_ordinal)
+    assert_selector ".govuk-summary-list__key", text: "Status"
+    assert_selector ".govuk-summary-list__value", text: "Scheduled for publication at #{I18n.l(content_block_edition.scheduled_publication, format: :long_ordinal)}"
   end
 
   describe "when there are instructions to publishers" do


### PR DESCRIPTION
This updates the view page to make some text tweaks, as well as allowing the schedule to be edited.

## Mural

![image](https://github.com/user-attachments/assets/ac00088a-5eaf-4cdd-97d6-1652d223adbf)

## Code

![image](https://github.com/user-attachments/assets/9113afd2-d8b9-42f5-9613-46ea42af545f)

Trello card: https://trello.com/c/nYOtTtr2/699-update-view-page
