### PR TITLE
Content modelling/719 review page

### DIFF
--- a/features/step_definitions/previously_published_steps.rb
+++ b/features/step_definitions/previously_published_steps.rb
@@ -10,6 +10,10 @@ And(/^I click save$/) do
   click_button "Save"
 end
 
+And(/^I click confirm$/) do
+  click_button "Confirm"
+end
+
 And(/^I select a previously published date in the future$/) do
   check "This document has previously been published on another website"
   within "#edition_previously_published" do

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/show/confirm_summary_list_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/show/confirm_summary_list_component.rb
@@ -14,8 +14,6 @@ private
       *details_items,
       organisation_item,
       instructions_item,
-      confirm_item,
-      date_item,
     ]
   end
 
@@ -53,20 +51,6 @@ private
     {
       field: "Instructions to publishers",
       value: content_block_edition.instructions_to_publishers.presence || "None",
-    }
-  end
-
-  def confirm_item
-    {
-      field: "Confirm",
-      value: "I confirm that I am happy for the content block to be changed on these pages.",
-    }
-  end
-
-  def date_item
-    {
-      field: "Publish date",
-      value: I18n.l(content_block_edition.created_at.to_date, format: :long_ordinal),
     }
   end
 

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/show/confirm_summary_list_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/show/confirm_summary_list_component.rb
@@ -10,6 +10,7 @@ private
   def items
     [
       edit_item,
+      title_item,
       *details_items,
       organisation_item,
       instructions_item,
@@ -22,6 +23,13 @@ private
     {
       field: "#{content_block_edition.document.block_type.humanize} details",
       edit: edit_action,
+    }
+  end
+
+  def title_item
+    {
+      field: "Title",
+      value: content_block_edition.title,
     }
   end
 

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/review.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/review.html.erb
@@ -1,5 +1,5 @@
 <% content_for :context, "Create a content block" %>
-<% content_for :title, "Check your answers" %>
+<% content_for :title, "Review #{@content_block_edition.block_type.humanize.downcase}" %>
 <% content_for :back_link do %>
   <%= render "govuk_publishing_components/components/back_link", {
     href: content_block_manager.content_block_manager_content_block_documents_path,

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/review.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/review.html.erb
@@ -1,4 +1,4 @@
-<% content_for :context, "Manage #{add_indefinite_article @content_block_edition.block_type.humanize.downcase}" %>
+<% content_for :context, "Create a content block" %>
 <% content_for :title, "Check your answers" %>
 <% content_for :back_link do %>
   <%= render "govuk_publishing_components/components/back_link", {

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/review.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/review.html.erb
@@ -22,9 +22,9 @@
       <div class="govuk-button-group govuk-!-margin-bottom-6">
         <div>
           <%= render "govuk_publishing_components/components/button", {
-            text: "Accept and publish",
-            name: "accept_and_publish",
-            value: "Accept and publish",
+            text: "Confirm",
+            name: "confirm",
+            value: "Confirm",
             type: "submit",
           } %>
       <% end %>

--- a/lib/engines/content_block_manager/features/create_object.feature
+++ b/lib/engines/content_block_manager/features/create_object.feature
@@ -24,7 +24,7 @@ Feature: Create a content object
       | title            | email_address   | department | organisation        | instructions_to_publishers |
       | my email address | foo@example.com | Somewhere  | Ministry of Example | this is important  |
     Then I am asked to review my answers
-    When I accept and publish
+    When I click confirm
     Then the edition should have been created successfully
     And I should be taken to the confirmation page
 
@@ -86,7 +86,7 @@ Feature: Create a content object
       | title            |
       | my email address 2 |
     Then I am asked to review my answers
-    When I accept and publish
+    When I click confirm
     Then the edition should have been created successfully
     And I should be taken to the confirmation page
 

--- a/lib/engines/content_block_manager/features/create_object.feature
+++ b/lib/engines/content_block_manager/features/create_object.feature
@@ -23,7 +23,7 @@ Feature: Create a content object
     When I complete the form with the following fields:
       | title            | email_address   | department | organisation        | instructions_to_publishers |
       | my email address | foo@example.com | Somewhere  | Ministry of Example | this is important  |
-    Then I am asked to check my answers
+    Then I am asked to review my answers
     When I accept and publish
     Then the edition should have been created successfully
     And I should be taken to the confirmation page
@@ -59,7 +59,7 @@ Feature: Create a content object
     When I complete the form with the following fields:
       | title            | email_address   | department | organisation        |
       | my email address | foo@example.com | Somewhere  | Ministry of Example |
-    Then I am asked to check my answers
+    Then I am asked to review my answers
 
   Scenario: GDS editor cancels the creation of an object
     When I visit the Content Block Manager home page
@@ -80,12 +80,12 @@ Feature: Create a content object
     When I complete the form with the following fields:
       | title            | email_address   | department | organisation |
       | my email address | foo@example.com | Somewhere  | Ministry of Example |
-    Then I am asked to check my answers
+    Then I am asked to review my answers
     When I click the first edit link
     And I complete the form with the following fields:
       | title            |
       | my email address 2 |
-    Then I am asked to check my answers
+    Then I am asked to review my answers
     When I accept and publish
     Then the edition should have been created successfully
     And I should be taken to the confirmation page

--- a/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
@@ -428,8 +428,8 @@ Then("I should see the scheduled event on the timeline") do
   expect(page).to have_selector(".timeline__byline", text: "by #{@user.name}")
 end
 
-Then("I am asked to check my answers") do
-  assert_text "Check your answers"
+Then("I am asked to review my answers") do
+  assert_text "Review email address"
 end
 
 Then("I accept and publish") do

--- a/lib/engines/content_block_manager/test/components/content_block/edition/show/confirm_summary_list_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/show/confirm_summary_list_component_test.rb
@@ -43,9 +43,5 @@ class ContentBlockManager::ContentBlockEdition::Show::ConfirmSummaryListComponen
     assert_selector ".govuk-summary-list__value", text: "Department for Example"
     assert_selector ".govuk-summary-list__key", text: "Instructions to publishers"
     assert_selector ".govuk-summary-list__value", text: "None"
-    assert_selector ".govuk-summary-list__key", text: "Confirm"
-    assert_selector ".govuk-summary-list__value", text: "I confirm that I am happy for the content block to be changed on these pages."
-    assert_selector ".govuk-summary-list__key", text: "Publish date"
-    assert_selector ".govuk-summary-list__value", text: I18n.l(content_block_edition.created_at.to_date, format: :long_ordinal)
   end
 end

--- a/lib/engines/content_block_manager/test/components/content_block/edition/show/confirm_summary_list_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/show/confirm_summary_list_component_test.rb
@@ -19,11 +19,14 @@ class ContentBlockManager::ContentBlockEdition::Show::ConfirmSummaryListComponen
   test "renders a summary list component with the edition details to confirm" do
     organisation = create(:organisation, name: "Department for Example")
 
+    content_block_document = create(:content_block_document, :email_address, title: "Some title")
+
     content_block_edition = create(
       :content_block_edition,
       :email_address,
       details: { "interesting_fact" => "value of fact" },
       organisation:,
+      document: content_block_document,
     )
 
     render_inline(ContentBlockManager::ContentBlockEdition::Show::ConfirmSummaryListComponent.new(
@@ -32,6 +35,8 @@ class ContentBlockManager::ContentBlockEdition::Show::ConfirmSummaryListComponen
 
     assert_selector ".govuk-summary-list__key", text: "Email address details"
     assert_selector ".govuk-summary-list__actions", text: "Edit"
+    assert_selector ".govuk-summary-list__key", text: "Title"
+    assert_selector ".govuk-summary-list__value", text: "Some title"
     assert_selector ".govuk-summary-list__key", text: "New interesting fact"
     assert_selector ".govuk-summary-list__value", text: "value of fact"
     assert_selector ".govuk-summary-list__key", text: "Lead organisation"


### PR DESCRIPTION
https://trello.com/c/dSGWZ38U/719-update-review-email-address-screen-as-part-of-the-create-journey

I've had to take out the checkbox confirmation, as it was causing issues in the edit flow (the create and edit share controller methods, but edit does not yet have the review screen, so requiring a confirmation was affecting it.)

## mural
![Screenshot 2024-12-04 at 09 58 29](https://github.com/user-attachments/assets/3b579c65-d6a7-4715-9539-5e31d72cacca)


## code

![Screenshot 2024-12-04 at 11 10 56](https://github.com/user-attachments/assets/57f60b07-d49f-4321-b40e-75be53b97133)


---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
