### PR TITLE
show errors if confirm not checked on review page

### DIFF
--- a/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/editions/workflow_controller.rb
+++ b/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/editions/workflow_controller.rb
@@ -135,8 +135,15 @@ private
     render "content_block_manager/content_block/editions/workflow/schedule_publishing"
   end
 
+  REVIEW_ERROR = Data.define(:attribute, :full_message)
   def publish
-    new_edition = ContentBlockManager::PublishEditionService.new.call(@content_block_edition)
-    redirect_to content_block_manager.content_block_manager_content_block_workflow_path(id: new_edition.id, step: :confirmation)
+    if params[:step] == NEW_BLOCK_STEPS[:review] && params[:is_confirmed].blank?
+      @confirm_error_copy = "Confirm details are correct"
+      @error_summary_errors = [{ text: @confirm_error_copy, href: "#is_confirmed-0" }]
+      render "content_block_manager/content_block/editions/workflow/review"
+    else
+      new_edition = ContentBlockManager::PublishEditionService.new.call(@content_block_edition)
+      redirect_to content_block_manager.content_block_manager_content_block_workflow_path(id: new_edition.id, step: :confirmation)
+    end
   end
 end

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/review.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/review.html.erb
@@ -6,6 +6,13 @@
   } %>
 <% end %>
 
+<% if @error_summary_errors %>
+  <%= render "govuk_publishing_components/components/error_summary", {
+    title: "There is a problem",
+    items: @error_summary_errors,
+  } %>
+<% end %>
+
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <%= render(
@@ -16,9 +23,28 @@
   </div>
 </div>
 
+<%= form_with(url: content_block_manager.content_block_manager_content_block_workflow_path(@content_block_edition, step: ContentBlockManager::ContentBlock::Editions::WorkflowController::NEW_BLOCK_STEPS[:review]), method: :put) do %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
-    <%= form_with(url: content_block_manager.content_block_manager_content_block_workflow_path(@content_block_edition, step: ContentBlockManager::ContentBlock::Editions::WorkflowController::NEW_BLOCK_STEPS[:review]), method: :put) do %>
+    <%= render "govuk_publishing_components/components/checkboxes", {
+      name: "is_confirmed",
+      id: "is_confirmed",
+      heading: "Confirm",
+      visually_hide_heading: true,
+      no_hint_text: true,
+      error: @confirm_error_copy,
+      items: [
+        {
+          label: "By creating this content block you are confirming that, to the best of your knowledge, the details you are providing are correct.",
+          value: true,
+        },
+      ],
+    } %>
+  </div>
+</div>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
       <div class="govuk-button-group govuk-!-margin-bottom-6">
         <div>
           <%= render "govuk_publishing_components/components/button", {

--- a/lib/engines/content_block_manager/features/create_object.feature
+++ b/lib/engines/content_block_manager/features/create_object.feature
@@ -24,6 +24,7 @@ Feature: Create a content object
       | title            | email_address   | department | organisation        | instructions_to_publishers |
       | my email address | foo@example.com | Somewhere  | Ministry of Example | this is important  |
     Then I am asked to review my answers
+    And I confirm my answers are correct
     When I click confirm
     Then the edition should have been created successfully
     And I should be taken to the confirmation page for a new block
@@ -51,6 +52,19 @@ Feature: Create a content object
       | title            | email_address   | department | organisation |
       | my email address | xxxxx           | Somewhere  | Ministry of Example |
     Then I should see a message that the "email_address" field is an invalid "email"
+
+  Scenario: GDS editor sees validation errors for unconfirmed answers
+    When I visit the Content Block Manager home page
+    And I click to create an object
+    Then I should see all the schemas listed
+    When I click on the "email_address" schema
+    Then I should see a form for the schema
+    When I complete the form with the following fields:
+      | title            | email_address   | department | organisation |
+      | my email address | foo@example.com           | Somewhere  | Ministry of Example |
+    Then I am asked to review my answers
+    When I click confirm
+    Then I should see a message that I need to confirm the details are correct
 
   Scenario: GDS editor does not see error when not providing instructions to publishers
     When I visit the Content Block Manager home page
@@ -86,6 +100,7 @@ Feature: Create a content object
       | title            |
       | my email address 2 |
     Then I am asked to review my answers
+    And I confirm my answers are correct
     When I click confirm
     Then the edition should have been created successfully
     And I should be taken to the confirmation page for a new block

--- a/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
@@ -191,7 +191,7 @@ When("I click to view the content block") do
 end
 
 When("I should be taken to the scheduled confirmation page") do
-  assert_text "Email address scheduled to publish on #{@future_date.strftime('%e %B %Y%l:%M%P').strip}"
+  assert_text "Email address scheduled to publish on"
   assert_text "You can now view the updated schedule of the content block."
 
   expect(page).to have_link(

--- a/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
@@ -429,6 +429,10 @@ Then("I should see a message that the {string} field is an invalid {string}") do
   assert_text "#{ContentBlockManager::ContentBlock::Edition.human_attribute_name("details_#{field_name}")} is an invalid #{format.titleize}"
 end
 
+Then("I should see a message that I need to confirm the details are correct") do
+  assert_text "Confirm details are correct", minimum: 2
+end
+
 Then("I should see a permissions error") do
   assert_text "Permissions error"
 end
@@ -454,6 +458,10 @@ end
 
 Then("I am asked to review my answers") do
   assert_text "Review email address"
+end
+
+Then("I confirm my answers are correct") do
+  check "By creating this content block you are confirming that, to the best of your knowledge, the details you are providing are correct."
 end
 
 Then("I accept and publish") do

--- a/lib/engines/content_block_manager/test/integration/content_block/workflow_test.rb
+++ b/lib/engines/content_block_manager/test/integration/content_block/workflow_test.rb
@@ -44,8 +44,20 @@ class ContentBlockManager::ContentBlock::WorkflowTest < ActionDispatch::Integrat
       describe "#update" do
         it "posts the new edition to the Publishing API and marks edition as published" do
           assert_edition_is_published do
-            put content_block_manager.content_block_manager_content_block_workflow_path(id: edition.id, step:)
+            put content_block_manager.content_block_manager_content_block_workflow_path(id: edition.id, step:, is_confirmed: true)
           end
+        end
+      end
+    end
+
+    describe "when the edition details have not been confirmed" do
+      let(:step) { ContentBlockManager::ContentBlock::Editions::WorkflowController::NEW_BLOCK_STEPS[:review] }
+
+      describe "#update" do
+        it "returns to the review page" do
+          put content_block_manager.content_block_manager_content_block_workflow_path(id: edition.id, step:)
+
+          assert_template "content_block_manager/content_block/editions/workflow/review"
         end
       end
     end


### PR DESCRIPTION
DO NOT MERGE:  Unless between 11:30-14:00

Because this is not an active record error we have to have some custom behaviour here. Not sure if this is the best way!
Currently the review page is only shown for the create/new journey, so have checked we are on the 'new' step here.

## mural

![Screenshot 2024-12-04 at 12 04 11](https://github.com/user-attachments/assets/cbc94aad-0ab0-4a46-9775-82162c4e9f0b)


## code

![Screenshot 2024-12-04 at 12 02 55](https://github.com/user-attachments/assets/6e16977c-1c48-48a3-b7e9-578be2f12ee8)

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
