### PR TITLE
Allow compound blocks without child blocks

### DIFF
--- a/app/models/landing_page/compound_block.rb
+++ b/app/models/landing_page/compound_block.rb
@@ -18,7 +18,6 @@ class LandingPage::CompoundBlock < LandingPage::BaseBlock
 
   attr_reader :content_blocks, :content_block_key
 
-  validates :content_blocks, presence: true
   validate do
     content_blocks.each { |b| errors.merge!(b.errors) if b.invalid? }
   end
@@ -30,6 +29,10 @@ class LandingPage::CompoundBlock < LandingPage::BaseBlock
   end
 
   def present_for_publishing_api
-    super.merge({ content_block_key => { "blocks" => content_blocks.map(&:present_for_publishing_api) } })
+    if content_blocks.blank?
+      super
+    else
+      super.merge({ content_block_key => { "blocks" => content_blocks.map(&:present_for_publishing_api) } })
+    end
   end
 end

--- a/test/unit/app/models/landing_page/compound_block_test.rb
+++ b/test/unit/app/models/landing_page/compound_block_test.rb
@@ -37,15 +37,24 @@ class CompoundBlockTest < ActiveSupport::TestCase
     assert_equal(expected_result, subject.present_for_publishing_api)
   end
 
-  test "invalid when missing content blocks" do
+  test "valid when missing content blocks" do
     subject = LandingPage::CompoundBlock.new(
       @valid_block_config,
       EMPTY_IMAGES,
       "compound_block_content",
       nil,
     )
-    assert subject.invalid?
-    assert_equal ["Content blocks can't be blank"], subject.errors.to_a
+    assert subject.valid?
+  end
+
+  test "presents without missing content blocks" do
+    subject = LandingPage::CompoundBlock.new(
+      @valid_block_config.except("compound_block_content"),
+      EMPTY_IMAGES,
+      "compound_block_content",
+      nil,
+    )
+    assert_equal({ "type" => "some-compound-block" }, subject.present_for_publishing_api)
   end
 
   test "invalid when content blocks are invalid" do

--- a/test/unit/app/models/landing_page/featured_block_test.rb
+++ b/test/unit/app/models/landing_page/featured_block_test.rb
@@ -68,10 +68,9 @@ class FeaturedBlockTest < ActiveSupport::TestCase
     ], subject.errors.to_a
   end
 
-  test "invalid when missing featured content blocks" do
+  test "valid when missing featured content blocks" do
     subject = LandingPage::FeaturedBlock.new(@valid_featured_block_config, @valid_featured_images, nil)
-    assert subject.invalid?
-    assert_equal ["Content blocks can't be blank"], subject.errors.to_a
+    assert subject.valid?
   end
 
   test "invalid when featured content blocks are invalid" do

--- a/test/unit/app/models/landing_page/hero_block_test.rb
+++ b/test/unit/app/models/landing_page/hero_block_test.rb
@@ -69,10 +69,9 @@ class HeroBlockTest < ActiveSupport::TestCase
     ], subject.errors.to_a
   end
 
-  test "invalid when missing hero content blocks" do
+  test "valid when missing hero content blocks" do
     subject = LandingPage::HeroBlock.new(@valid_hero_block_config, @valid_hero_block_images, nil)
-    assert subject.invalid?
-    assert_equal ["Content blocks can't be blank"], subject.errors.to_a
+    subject.valid?
   end
 
   test "invalid when hero content blocks are invalid" do


### PR DESCRIPTION
This is useful in some cases, for example with hero blocks where we might only want the image and no content overlaid.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
