### PR TITLE
(746) Update preview email address screen in the edit journey

### DIFF
--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/host_editions_table_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/host_editions_table_component.html.erb
@@ -18,14 +18,14 @@ it out for now-->
         sort_direction: sort_direction("document_type"),
       },
       {
-        text: "Instances",
-        href: sort_link("instances"),
-        sort_direction: sort_direction("instances"),
-      },
-      {
         text: "Views (30 days)",
         href: sort_link("unique_pageviews"),
         sort_direction: sort_direction("unique_pageviews"),
+      },
+      {
+        text: "Instances",
+        href: sort_link("instances"),
+        sort_direction: sort_direction("instances"),
       },
       {
         text: "Lead organisation",

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/host_editions_table_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/host_editions_table_component.rb
@@ -40,10 +40,10 @@ private
           text: content_item.document_type.humanize,
         },
         {
-          text: content_item.instances,
+          text: content_item.unique_pageviews ? number_to_human(content_item.unique_pageviews, format: "%n%u", precision: 3, significant: true, units: { thousand: "k", million: "m", billion: "b" }) : 0,
         },
         {
-          text: content_item.unique_pageviews ? number_to_human(content_item.unique_pageviews, format: "%n%u", precision: 3, significant: true, units: { thousand: "k", million: "m", billion: "b" }) : nil,
+          text: content_item.instances,
         },
         {
           text: organisation_link(content_item),

--- a/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/editions/workflow_controller.rb
+++ b/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/editions/workflow_controller.rb
@@ -47,6 +47,11 @@ class ContentBlockManager::ContentBlock::Editions::WorkflowController < ContentB
     end
   end
 
+  def context
+    "Edit content block"
+  end
+  helper_method :context
+
 private
 
   def edit_draft

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/review_links.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/review_links.html.erb
@@ -24,7 +24,7 @@
     <%= render(
           ContentBlockManager::ContentBlock::Document::Show::HostEditionsTableComponent.new(
             is_preview: true,
-            caption: "Content it appears in",
+            caption: "List of locations",
             host_content_items: @host_content_items,
             current_page: @page,
             order: @order,

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/review_links.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/review_links.html.erb
@@ -7,7 +7,9 @@
   } %>
 <% end %>
 
-<p class="govuk-body">The new <%= @content_block_document.block_type.humanize.downcase %> will appear on the following content after you publish the change.</p>
+<p class="govuk-body">
+  The list does not include content in PDF or beyond <a href="https://gov.uk" class="govuk-link">GOV.UK</a>.
+</p>
 
 <%=
   render(

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/review_links.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/review_links.html.erb
@@ -1,4 +1,4 @@
-<% content_for :context, "Manage #{add_indefinite_article @content_block_document.block_type.humanize}" %>
+<% content_for :context, context %>
 <% content_for :title, "Where the change will appear" %>
 <% content_for :title_margin_bottom, 4 %>
 <% content_for :back_link do %>

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/review_links.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/review_links.html.erb
@@ -1,5 +1,5 @@
 <% content_for :context, context %>
-<% content_for :title, "Where the change will appear" %>
+<% content_for :title, "Preview #{@content_block_document.block_type.humanize.downcase}" %>
 <% content_for :title_margin_bottom, 4 %>
 <% content_for :back_link do %>
   <%= render "govuk_publishing_components/components/back_link", {

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/schedule_publishing.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/schedule_publishing.html.erb
@@ -1,4 +1,4 @@
-<% content_for :context, "Manage #{add_indefinite_article @content_block_edition.document.block_type.humanize}" %>
+<% content_for :context, context %>
 <% content_for :title, "When do you want to publish the change?" %>
 <% content_for :title_margin_bottom, 4 %>
 <% content_for :back_link do %>

--- a/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
@@ -489,7 +489,7 @@ Then(/^I should see an error prompting me to choose an object type$/) do
 end
 
 Then(/^I am shown where the changes will take place$/) do
-  expect(page).to have_selector("h1", text: "Where the change will appear")
+  expect(page).to have_selector("h1", text: "Preview email address")
 
   @dependent_content.each do |item|
     assert_text item["title"]

--- a/lib/engines/content_block_manager/test/components/content_block/document/show/host_editions_table_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/document/show/host_editions_table_component_test.rb
@@ -170,7 +170,7 @@ class ContentBlockManager::ContentBlock::Document::Show::HostEditionsTableCompon
     context "when unique pageviews can't be found" do
       let(:unique_pageviews) { nil }
 
-      it "displays not found" do
+      it "displays a zero" do
         render_inline(
           described_class.new(
             caption:,
@@ -179,7 +179,7 @@ class ContentBlockManager::ContentBlock::Document::Show::HostEditionsTableCompon
           ),
         )
 
-        assert_selector "tbody .govuk-table__cell", text: "Not set"
+        assert_selector "tbody .govuk-table__cell", text: "0"
       end
     end
 


### PR DESCRIPTION
This makes a bunch of minor copy changes to the preview section of the Content Modelling edit journey

## Screenshot

![image](https://github.com/user-attachments/assets/11c78447-2790-4c65-9b8a-ef5299381d87)
