### PR TITLE
Support hero blocks without content

### DIFF
--- a/app/models/landing_page/block_factory.rb
+++ b/app/models/landing_page/block_factory.rb
@@ -13,6 +13,8 @@ class LandingPage::BlockFactory
       LandingPage::FeaturedBlock.new(block, images, blocks)
     in { type: "hero", hero_content: { blocks: } }
       LandingPage::HeroBlock.new(block, images, blocks)
+    in { type: "hero" }
+      LandingPage::HeroBlock.new(block, images, nil)
     in { type: "image" }
       LandingPage::ImageBlock.new(block, images)
     in { type: String, blocks: Array }

--- a/test/unit/app/models/landing_page/block_factory_test.rb
+++ b/test/unit/app/models/landing_page/block_factory_test.rb
@@ -7,6 +7,27 @@ class BlockFactoryTest < ActiveSupport::TestCase
     assert_instance_of LandingPage::BaseBlock, block
   end
 
+  test "#build builds hero blocks with content" do
+    images = []
+    config = {
+      "type" => "hero",
+      "image" => {},
+      "hero_content" => { "blocks" => [{ "type" => "some-type" }] },
+    }
+    block = LandingPage::BlockFactory.build(config, images)
+    assert_instance_of LandingPage::HeroBlock, block
+  end
+
+  test "#build builds hero blocks without content" do
+    images = []
+    config = {
+      "type" => "hero",
+      "image" => {},
+    }
+    block = LandingPage::BlockFactory.build(config, images)
+    assert_instance_of LandingPage::HeroBlock, block
+  end
+
   test "#build_all builds blocks" do
     images = []
     blocks = LandingPage::BlockFactory.build_all([{ "type" => "some-type" }, { "type" => "some-type" }], images)


### PR DESCRIPTION
Previously the pattern in BlockFactory would only match hero blocks if they had content. For now, adding another pattern for blocks without content, but this could be refactored more nicely in future I think.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
