### PR TITLE
Prevent navigation events from being tracked on tab controls

### DIFF
--- a/app/assets/javascripts/admin/analytics-modules/ga4-link-setup.js
+++ b/app/assets/javascripts/admin/analytics-modules/ga4-link-setup.js
@@ -13,7 +13,10 @@ window.GOVUK.analyticsGa4.analyticsModules =
         const links = moduleElement.querySelectorAll('a')
         links.forEach((link) => {
           // Exclude links that serve as tab controls as they have their own event tracking
-          if (link.role === 'tab') {
+          // It would be preferable to use the role ARIA attribute to do this, but it's not present yet
+          // when this module is initialised because the tabs component adds the role.
+          // Component modules are initialised after analytics modules by GOV.UK Publishing components
+          if (link.classList.contains('govuk-tabs__tab')) {
             return
           }
           const event = {

--- a/spec/javascripts/admin/analytics-modules/ga4-link-setup.spec.js
+++ b/spec/javascripts/admin/analytics-modules/ga4-link-setup.spec.js
@@ -33,7 +33,7 @@ describe('GOVUK.analyticsGa4.analyticsModules.Ga4LinkSetup', function () {
   })
 
   it('excludes links that serve as tab controls', function () {
-    link.role = 'tab'
+    link.classList.add('govuk-tabs__tab')
 
     const Ga4LinkSetup = GOVUK.analyticsGa4.analyticsModules.Ga4LinkSetup
     Ga4LinkSetup.init()


### PR DESCRIPTION
It would be preferable to use the role ARIA attribute to do this, but it's not present yet when this module is initialised. This is because component modules are initialised after analytics and the tabs component is responsible for adding the role via javascript during its initialisation. Analytics modules are initialised before components by GOV.UK Publishing components.

Trello: https://trello.com/c/mVJGdWsZ
