### PR TITLE
 Create editionable topical events

### DIFF
--- a/app/controllers/admin/editionable_topical_events_controller.rb
+++ b/app/controllers/admin/editionable_topical_events_controller.rb
@@ -1,0 +1,7 @@
+class Admin::EditionableTopicalEventsController < Admin::EditionsController
+private
+
+  def edition_class
+    EditionableTopicalEvent
+  end
+end

--- a/app/controllers/admin/new_document_controller.rb
+++ b/app/controllers/admin/new_document_controller.rb
@@ -24,6 +24,7 @@ private
       publication: new_admin_publication_path,
       speech: new_admin_speech_path,
       statistical_data_set: new_admin_statistical_data_set_path,
+      editionable_topical_event: new_admin_editionable_topical_event_path,
       worldwide_organisation: new_admin_worldwide_organisation_path,
       landing_page: new_admin_landing_page_path,
     }

--- a/app/helpers/admin/new_document_helper.rb
+++ b/app/helpers/admin/new_document_helper.rb
@@ -10,6 +10,7 @@ module Admin::NewDocumentHelper
     CaseStudy,
     StatisticalDataSet,
     CallForEvidence,
+    EditionableTopicalEvent,
     WorldwideOrganisation,
     LandingPage,
   ].freeze
@@ -43,6 +44,7 @@ private
       publication: "Use this for standalone government documents, white papers, strategy documents, and reports.",
       speech: "Use this for speeches by ministers or other named spokespeople, and ministerial statements to Parliament.",
       statistical_data_set: "Use this for data that you publish monthly or more often without analysis.",
+      editionable_topical_event: "Use this to create new Topical Events",
       worldwide_organisation: "Use this to create a new worldwide organisation page. Do not create a worldwide organisation unless you have permission from your managing editor or GOV.UK department lead.",
       landing_page: "EXPERIMENTAL Use this to create landing pages.",
     }

--- a/app/helpers/admin/new_document_helper.rb
+++ b/app/helpers/admin/new_document_helper.rb
@@ -20,7 +20,7 @@ module Admin::NewDocumentHelper
       .select { |edition_type| can?(:create, edition_type) }
       .map do |edition_type|
       title_value = edition_type.name.underscore
-      title_label = title_value.humanize
+      title_label = title_value.gsub("editionable_", "").humanize
       {
         value: title_value,
         text: title_label,

--- a/app/helpers/admin/republishing_helper.rb
+++ b/app/helpers/admin/republishing_helper.rb
@@ -89,6 +89,7 @@ module Admin::RepublishingHelper
       CorporateInformationPage
       DetailedGuide
       DocumentCollection
+      EditionableTopicalEvent
       WorldwideOrganisation
       FatalityNotice
       LandingPage

--- a/app/models/editionable_topical_event.rb
+++ b/app/models/editionable_topical_event.rb
@@ -1,0 +1,5 @@
+class EditionableTopicalEvent < Edition
+  def display_type_key
+    "editionable_topical_event"
+  end
+end

--- a/app/models/editionable_topical_event.rb
+++ b/app/models/editionable_topical_event.rb
@@ -2,4 +2,8 @@ class EditionableTopicalEvent < Edition
   def display_type_key
     "editionable_topical_event"
   end
+
+  def self.format_name
+    "topical event"
+  end
 end

--- a/app/views/admin/editionable_topical_events/_form.html.erb
+++ b/app/views/admin/editionable_topical_events/_form.html.erb
@@ -1,0 +1,3 @@
+<%= standard_edition_form(edition) do |form| %>
+
+<% end %>

--- a/config/features.rb
+++ b/config/features.rb
@@ -24,4 +24,5 @@ Flipflop.configure do
   feature :govspeak_visual_editor, description: "Enables a visual editor for Govspeak fields", default: false
   feature :override_government, description: "Enables GDS Editors and Admins to override the government associated with a document", default: false
   feature :show_link_to_content_block_manager, description: "Shows link to Content Block Manager from Whitehall editor", default: Whitehall.integration_or_staging?
+  feature :editionable_topical_events, description: "Enables edtionable topical events", default: false
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -163,6 +163,8 @@ Whitehall::Application.routes.draw do
       end
       resources :operational_fields, except: [:show]
 
+      resources :editionable_topical_events, path: "editionable-topical-events", except: [:index]
+
       resources :topical_events, path: "topical-events" do
         resource :topical_event_about_pages, path: "about"
         resources :topical_event_featurings, path: "featurings" do

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -18,7 +18,7 @@ module DocumentHelper
     create(:organisation) if Organisation.count.zero?
     visit admin_root_path
     find("li.app-c-sub-navigation__list-item a", text: "New document").click
-    page.choose(options[:type].humanize)
+    page.choose(options[:type].gsub("editionable_", "").humanize)
     click_button("Next")
 
     if options[:locale]

--- a/lib/whitehall/authority/enforcer.rb
+++ b/lib/whitehall/authority/enforcer.rb
@@ -48,5 +48,6 @@ module Whitehall::Authority
     "Organisation" => Rules::OrganisationRules,
     "Government" => Rules::GovernmentRules,
     "StatisticsAnnouncement" => Rules::StatisticsAnnouncementRules,
+    "EditionableTopicalEvent" => Rules::EditionableTopicalEventRules,
   }.freeze
 end

--- a/lib/whitehall/authority/rules/editionable_topical_event_rules.rb
+++ b/lib/whitehall/authority/rules/editionable_topical_event_rules.rb
@@ -1,0 +1,7 @@
+module Whitehall::Authority::Rules
+  EditionableTopicalEventRules = Struct.new(:actor, :subject) do
+    def can?(_action)
+      Flipflop.editionable_topical_events?
+    end
+  end
+end

--- a/test/factories/editionable_topical_events.rb
+++ b/test/factories/editionable_topical_events.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :editionable_topical_event, class: EditionableTopicalEvent, parent: :edition do
+    title { "editionable-topical-event-title" }
+  end
+
+  factory :draft_editionable_topical_event, parent: :editionable_topical_event, traits: [:draft]
+end

--- a/test/functional/admin/editionable_topical_events_controller_test.rb
+++ b/test/functional/admin/editionable_topical_events_controller_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+
+class Admin::EditionableTopicalEventsControllerTest < ActionController::TestCase
+  setup do
+    feature_flags.switch! :editionable_topical_events, true
+    login_as :writer
+  end
+
+  should_be_an_admin_controller
+
+  # should_allow_creating_of :editionable_topical_event
+  # should_allow_editing_of :editionable_topical_event
+
+  test "actions are forbidden when the editionable_topical_events feature flag is disabled" do
+    feature_flags.switch! :editionable_topical_events, false
+    topical_event = create(:editionable_topical_event)
+
+    get :show, params: { id: topical_event.id }
+
+    assert_response :forbidden
+  end
+end

--- a/test/functional/admin/new_document_controller_test.rb
+++ b/test/functional/admin/new_document_controller_test.rb
@@ -84,6 +84,22 @@ class Admin::NewDocumentControllerTest < ActionController::TestCase
     assert_equal flash[:alert], "Please select a new document option"
   end
 
+  view_test "GET #index renders Topical Event Edition when the editionable_topical_events feature flag is enabled" do
+    feature_flags.switch! :editionable_topical_events, true
+
+    get :index
+
+    assert_select ".govuk-radios__item input[type=radio][name=new_document_options][value=editionable_topical_event]", count: 1
+  end
+
+  view_test "GET #index does not render Topical Event Edition when the editionable_topical_events feature flag is not enabled" do
+    feature_flags.switch! :editionable_topical_events, false
+
+    get :index
+
+    refute_select ".govuk-radios__item input[type=radio][name=new_document_options][value=editionable_topical_event]"
+  end
+
 private
 
   def radio_button_values
@@ -106,6 +122,7 @@ private
       "publication": new_admin_publication_path,
       "speech": new_admin_speech_path,
       "statistical_data_set": new_admin_statistical_data_set_path,
+      "editionable_topical_event": new_admin_editionable_topical_event_path,
       "worldwide_organisation": new_admin_worldwide_organisation_path,
     }
   end


### PR DESCRIPTION
There's been [an RFC accepted](https://github.com/alphagov/govuk-rfcs/blob/main/rfc-177-edition-all-content.md) to editionablise all the remaining content types that are currently published by Whitehall. As part of a gift week project we're attempting to do that to topical events. We're unsure as to how far we'll get and will be liaising with the Whitehall Tech team to ensure we don't do anything too silly.

This sets up the core components needed for Topical events. We'll build on this until we're as close to feature parity as we can reasonably get in a week.

Trello: https://trello.com/c/o734OE2P/8-editionablise-a-new-content-type


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
