### PR TITLE
(763) Fix mainstream preview bug within guide chapters

### DIFF
--- a/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/editions/host_content_controller.rb
+++ b/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/editions/host_content_controller.rb
@@ -2,6 +2,10 @@ class ContentBlockManager::ContentBlock::Editions::HostContentController < Conte
   def preview
     host_content_id = params[:host_content_id]
     @content_block_edition = ContentBlockManager::ContentBlock::Edition.find(params[:id])
-    @preview_content = ContentBlockManager::GetPreviewContent.for_content_id(content_id: host_content_id, content_block_edition: @content_block_edition)
+    @preview_content = ContentBlockManager::GetPreviewContent.for_content_id(
+      content_id: host_content_id,
+      content_block_edition: @content_block_edition,
+      base_path: params[:base_path],
+    )
   end
 end

--- a/lib/engines/content_block_manager/app/services/content_block_manager/get_preview_content.rb
+++ b/lib/engines/content_block_manager/app/services/content_block_manager/get_preview_content.rb
@@ -90,8 +90,13 @@ module ContentBlockManager
       nokogiri_html.css("span[data-content-id=\"#{@content_block_edition.document.content_id}\"]")
     end
 
+    def metadata
+      response = Services.publishing_api.get_host_content_item_for_content_id(@content_block_edition.document.content_id, @content_id)
+      response.parsed_content
+    end
+
     def instances_count
-      content_block_spans(html).length
+      metadata["instances"]
     end
 
     ERROR_HTML = "<html><body><p>Preview not found</p></body></html>".freeze

--- a/lib/engines/content_block_manager/app/services/content_block_manager/get_preview_content.rb
+++ b/lib/engines/content_block_manager/app/services/content_block_manager/get_preview_content.rb
@@ -6,8 +6,8 @@ module ContentBlockManager
   class GetPreviewContent
     include ContentBlockManager::Engine.routes.url_helpers
 
-    def self.for_content_id(content_id:, content_block_edition:)
-      new(content_id:, content_block_edition:).for_content_id
+    def self.for_content_id(content_id:, content_block_edition:, base_path: nil)
+      new(content_id:, content_block_edition:, base_path:).for_content_id
     end
 
     def for_content_id
@@ -16,9 +16,10 @@ module ContentBlockManager
 
   private
 
-    def initialize(content_id:, content_block_edition:)
+    def initialize(content_id:, content_block_edition:, base_path: nil)
       @content_id = content_id
       @content_block_edition = content_block_edition
+      @base_path = base_path
     end
 
     def html
@@ -36,8 +37,12 @@ module ContentBlockManager
       Rails.env.development? ? Plek.external_url_for("government-frontend") : Plek.website_root
     end
 
+    def base_path
+      @base_path || content_item["base_path"]
+    end
+
     def frontend_path
-      frontend_base_path + content_item["base_path"]
+      frontend_base_path + base_path
     end
 
     def preview_html

--- a/lib/engines/content_block_manager/app/services/content_block_manager/get_preview_content.rb
+++ b/lib/engines/content_block_manager/app/services/content_block_manager/get_preview_content.rb
@@ -4,6 +4,8 @@ require "uri"
 
 module ContentBlockManager
   class GetPreviewContent
+    include ContentBlockManager::Engine.routes.url_helpers
+
     def self.for_content_id(content_id:, content_block_edition:)
       new(content_id:, content_block_edition:).for_content_id
     end
@@ -41,8 +43,21 @@ module ContentBlockManager
     def preview_html
       uri = URI(frontend_path)
       nokogiri_html = html_snapshot_from_frontend(uri)
+      update_local_link_paths(nokogiri_html)
       add_draft_style(nokogiri_html)
       replace_existing_content_blocks(nokogiri_html)
+    end
+
+    def update_local_link_paths(nokogiri_html)
+      url = content_block_manager_content_block_host_content_preview_path(id: @content_block_edition.id, host_content_id: @content_id)
+      nokogiri_html.css("a").each do |link|
+        next if link[:href].start_with?("//") || link[:href].start_with?("http")
+
+        link[:href] = "#{url}?base_path=#{link[:href]}"
+        link[:target] = "_parent"
+      end
+
+      nokogiri_html
     end
 
     def replace_existing_content_blocks(nokogiri_html)

--- a/lib/engines/content_block_manager/features/edit_object.feature
+++ b/lib/engines/content_block_manager/features/edit_object.feature
@@ -108,3 +108,5 @@ Feature: Edit a content object
     And I see the rollup data for the dependent content
     When I click on the first host document
     Then the preview page opens in a new tab
+    When I click on a link within the frame
+    Then I should see the content of the linked page

--- a/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
@@ -1,4 +1,5 @@
 require_relative "../support/stubs"
+require_relative "../support/dependent_content"
 
 # Suppress noisy Sidekiq logging in the test output
 Sidekiq.configure_client do |cfg|
@@ -478,6 +479,7 @@ When(/^dependent content exists for a content block$/) do
       "last_edited_by_editor_id" => SecureRandom.uuid,
       "last_edited_at" => 2.days.ago.to_s,
       "host_content_id" => "abc12345",
+      "instances" => 1,
       "primary_publishing_organisation" => {
         "content_id" => SecureRandom.uuid,
         "title" => "Organisation #{i}",
@@ -494,6 +496,8 @@ When(/^dependent content exists for a content block$/) do
     order: ContentBlockManager::GetHostContentItems::DEFAULT_ORDER,
     rollup: @rollup,
   )
+
+  stub_publishing_api_has_embedded_content_details(@dependent_content.first)
 end
 
 Then(/^I should see the dependent content listed$/) do

--- a/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
@@ -558,7 +558,15 @@ When("I click on the first host document") do
     Plek.website_root + @current_host_document["base_path"],
   ).to_return(
     status: 200,
-    body: "<body><h1>#{@current_host_document['title']}</h1><p>iframe preview</p>#{@content_block.render}</body>",
+    body: "<body><h1>#{@current_host_document['title']}</h1><p>iframe preview <a href=\"/other-page\">Link to other page</a></p>#{@content_block.render}</body>",
+  )
+
+  stub_request(
+    :get,
+    "#{Plek.website_root}/other-page",
+  ).to_return(
+    status: 200,
+    body: "<body><h1>#{@current_host_document['title']}</h1><p>other page</p>#{@content_block.render}</body>",
   )
 
   click_on @current_host_document["title"]
@@ -571,6 +579,19 @@ Then("the preview page opens in a new tab") do
   assert_text "Email address: changed@example.com"
   within_frame "preview" do
     assert_text @current_host_document["title"]
+  end
+end
+
+When("I click on a link within the frame") do
+  within_frame "preview" do
+    click_on "Link to other page"
+  end
+end
+
+Then("I should see the content of the linked page") do
+  within_frame "preview" do
+    assert_text "other page"
+    assert_text "changed@example.com"
   end
 end
 

--- a/lib/engines/content_block_manager/features/support/dependent_content.rb
+++ b/lib/engines/content_block_manager/features/support/dependent_content.rb
@@ -1,0 +1,5 @@
+def stub_publishing_api_has_embedded_content_details(dependent_content)
+  url = %r{\A#{GdsApi::TestHelpers::PublishingApi::PUBLISHING_API_V2_ENDPOINT}/content/[0-9a-fA-F-]{36}/host-content/#{dependent_content['host_content_id']}}
+  stub_request(:get, url)
+    .to_return(body: dependent_content.to_json)
+end

--- a/lib/engines/content_block_manager/test/unit/app/services/get_preview_content_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/services/get_preview_content_test.rb
@@ -32,6 +32,15 @@ class ContentBlockManager::GetPreviewContentTest < ActiveSupport::TestCase
   let(:block_to_preview) do
     build(:content_block_edition, :email_address, document:, details: { "email_address" => "new@new.com" }, id: 1)
   end
+  let(:metadata_response) do
+    stub(:response, parsed_content: { "instances" => 2 })
+  end
+
+  before do
+    Services.publishing_api.expects(:get_host_content_item_for_content_id)
+            .with(block_to_preview.document.content_id, host_content_id)
+            .returns(metadata_response)
+  end
 
   describe "#for_content_id" do
     setup do
@@ -57,16 +66,12 @@ class ContentBlockManager::GetPreviewContentTest < ActiveSupport::TestCase
     it "returns the count of instances" do
       Net::HTTP.expects(:get).with(URI(Plek.website_root + host_base_path)).returns(fake_frontend_response)
 
-      expected_content = {
-        instances_count: 1,
-      }
-
       actual_content = ContentBlockManager::GetPreviewContent.for_content_id(
         content_id: host_content_id,
         content_block_edition: block_to_preview,
       )
 
-      assert_equal expected_content[:instances_count], actual_content.instances_count
+      assert_equal 2, actual_content.instances_count
     end
 
     it "returns the preview html" do

--- a/lib/engines/content_block_manager/test/unit/app/services/get_preview_content_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/services/get_preview_content_test.rb
@@ -2,6 +2,8 @@ require "test_helper"
 
 class ContentBlockManager::GetPreviewContentTest < ActiveSupport::TestCase
   extend Minitest::Spec::DSL
+  include ContentBlockManager::Engine.routes.url_helpers
+  include TextAssertions
 
   let(:described_class) { ContentBlockManager::GetPreviewContent }
   let(:host_content_id) { SecureRandom.uuid }
@@ -28,7 +30,7 @@ class ContentBlockManager::GetPreviewContentTest < ActiveSupport::TestCase
     build(:content_block_document, :email_address, content_id: preview_content_id)
   end
   let(:block_to_preview) do
-    build(:content_block_edition, :email_address, document:, details: { "email_address" => "new@new.com" })
+    build(:content_block_edition, :email_address, document:, details: { "email_address" => "new@new.com" }, id: 1)
   end
 
   describe "#for_content_id" do
@@ -98,6 +100,34 @@ class ContentBlockManager::GetPreviewContentTest < ActiveSupport::TestCase
 
       assert_equal expected_content[:title], actual_content.title
       assert_equal expected_content[:html].to_s, actual_content.html.to_s
+    end
+
+    it "updates any link paths" do
+      fake_frontend_response = "
+        <a href='/foo'>Internal link</a>
+        <a href='https://example.com'>External link</a>
+        <a href='//example.com'>Protocol relative link</a>
+      "
+      Net::HTTP.expects(:get).with(URI(Plek.website_root + host_base_path)).returns(fake_frontend_response)
+
+      actual_content = ContentBlockManager::GetPreviewContent.for_content_id(
+        content_id: host_content_id,
+        content_block_edition: block_to_preview,
+      )
+
+      url = content_block_manager_content_block_host_content_preview_path(id: block_to_preview.id, host_content_id:)
+
+      expected_content = Nokogiri::HTML.parse("
+        <html>
+          <body class=' draft'>
+            <a href='#{url}?base_path=/foo' target='_parent'>Internal link</a>
+            <a href='https://example.com'>External link</a>
+            <a href='//example.com'>Protocol relative link</a>
+          </body>
+        </html>
+      ").to_s
+
+      assert_equal_ignoring_whitespace actual_content.html.to_s, expected_content
     end
   end
 end

--- a/lib/engines/content_block_manager/test/unit/app/services/get_preview_content_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/services/get_preview_content_test.rb
@@ -129,5 +129,16 @@ class ContentBlockManager::GetPreviewContentTest < ActiveSupport::TestCase
 
       assert_equal_ignoring_whitespace actual_content.html.to_s, expected_content
     end
+
+    it "allows a base_path to be provided" do
+      base_path = "something/different"
+      Net::HTTP.expects(:get).with(URI(Plek.website_root + base_path)).returns("")
+
+      ContentBlockManager::GetPreviewContent.for_content_id(
+        content_id: host_content_id,
+        content_block_edition: block_to_preview,
+        base_path:,
+      )
+    end
   end
 end

--- a/test/support/text_assertions.rb
+++ b/test/support/text_assertions.rb
@@ -2,4 +2,11 @@ module TextAssertions
   def assert_string_includes(expected, actual)
     assert actual.include?(expected), "Expected \"#{actual}\" to include \"#{expected}\"."
   end
+
+  def assert_equal_ignoring_whitespace(expected, actual)
+    expected_without_whitespace = expected.gsub(/\s+/, "").strip
+    actual_without_whitespace = actual.gsub(/\s+/, "").strip
+
+    assert_equal expected_without_whitespace, actual_without_whitespace
+  end
 end


### PR DESCRIPTION
Trello card: https://trello.com/c/WZvzmuMI/763-bug-mainstream-preview-bug-within-guide-chapters

This fixes the issue when previewing content types with multiple pages by updating all relative links to link to the preview page with the path added as a query string, allowing any content to be parsed via the `GetPreviewContent` service.

Additionally, because we can't reliably get _all_ the instances within a document when parsing the content randomly, I've updated the call to `instances` to fetch the instance count via the Publishing API (PR here https://github.com/alphagov/publishing-api/pull/3030) rather than relying on the count on the current preview page.

~~This can't be merged until https://github.com/alphagov/publishing-api/pull/3030 is merged~~