### PR TITLE
Present editionable topical events

### DIFF
--- a/app/models/editionable_topical_event.rb
+++ b/app/models/editionable_topical_event.rb
@@ -3,6 +3,14 @@ class EditionableTopicalEvent < Edition
     "editionable_topical_event"
   end
 
+  def publishing_api_presenter
+    PublishingApi::EditionableTopicalEventPresenter
+  end
+
+  def base_path
+    "/government/editionable-topical-events/#{slug}"
+  end
+
   def self.format_name
     "topical event"
   end

--- a/app/presenters/publishing_api/editionable_topical_event_presenter.rb
+++ b/app/presenters/publishing_api/editionable_topical_event_presenter.rb
@@ -1,0 +1,40 @@
+module PublishingApi
+  class EditionableTopicalEventPresenter
+    include Rails.application.routes.url_helpers
+    include ActionView::Helpers::UrlHelper
+
+    attr_accessor :item, :update_type, :state
+
+    def initialize(item, update_type: nil, state: "published")
+      self.item = item
+      self.update_type = update_type || "major"
+      self.state = state
+    end
+
+    delegate :content_id, to: :item
+
+    def content
+      content = BaseItemPresenter.new(
+        item,
+        update_type:,
+      ).base_attributes
+
+      content.merge!(
+        details:,
+        document_type: item.class.name.underscore,
+        public_updated_at: item.updated_at,
+        rendering_app: Whitehall::RenderingApp::COLLECTIONS_FRONTEND,
+        schema_name: "topical_event",
+      )
+      content.merge!(PayloadBuilder::PolymorphicPath.for(item))
+    end
+
+    def links
+      {}
+    end
+
+    def details
+      {}
+    end
+  end
+end

--- a/test/unit/app/presenters/publishing_api/editionable_topical_event_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/editionable_topical_event_presenter_test.rb
@@ -1,0 +1,43 @@
+require "test_helper"
+
+class PublishingApi::EditionableTopicalEventPresenterTest < ActiveSupport::TestCase
+  def present(...)
+    PublishingApi::EditionableTopicalEventPresenter.new(...)
+  end
+
+  test "presents a Topical Event ready for adding to the publishing API" do
+    topical_event = create(:editionable_topical_event)
+
+    public_path = topical_event.public_path
+
+    expected_hash = {
+      base_path: public_path,
+      title: topical_event.title,
+      schema_name: "topical_event",
+      document_type: "editionable_topical_event",
+      locale: "en",
+      publishing_app: Whitehall::PublishingApp::WHITEHALL,
+      rendering_app: Whitehall::RenderingApp::COLLECTIONS_FRONTEND,
+      public_updated_at: topical_event.updated_at,
+      routes: [{ path: public_path, type: "exact" }],
+      redirects: [],
+      details: {},
+      update_type: "major",
+    }
+
+    expected_links = {}
+
+    presented_item = present(topical_event)
+
+    assert_equal expected_hash, presented_item.content
+    assert_equal "major", presented_item.update_type
+    assert_equal topical_event.content_id, presented_item.content_id
+
+    # TODO: uncomment the below assertion when the editionable_topical_event model is
+    # finished and all content can be added to this presenter.
+    # assert_valid_against_publisher_schema(presented_item.content, "topical_event")
+
+    assert_equal expected_links, presented_item.links
+    assert_valid_against_links_schema({ links: presented_item.links }, "topical_event")
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/o734OE2P/8-editionablise-a-new-content-type


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
