### PR TITLE
Use presenter for confirmation text

### DIFF
--- a/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/editions/workflow_controller.rb
+++ b/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/editions/workflow_controller.rb
@@ -75,26 +75,9 @@ private
   def confirmation
     @content_block_edition = ContentBlockManager::ContentBlock::Edition.find(params[:id])
 
-    confirmation_copy
+    @confirmation_copy = ContentBlockManager::ConfirmationCopyPresenter.new(@content_block_edition)
 
     render :confirmation
-  end
-
-  def confirmation_copy
-    if params[:is_scheduled]
-      @panel_copy = "#{@content_block_edition.block_type.humanize} scheduled to publish on #{I18n.l(@content_block_edition.scheduled_publication, format: :long_ordinal)}"
-      @paragraph_copy = "You can now view the updated schedule of the content block."
-    elsif more_than_one_edition?
-      @panel_copy = "#{@content_block_edition.block_type.humanize} published"
-      @paragraph_copy = "You can now view the updated content block."
-    else
-      @panel_copy = "#{@content_block_edition.block_type.humanize} created"
-      @paragraph_copy = "You can now view the content block."
-    end
-  end
-
-  def more_than_one_edition?
-    @content_block_edition.document.editions.count > 1
   end
 
   def review_links

--- a/lib/engines/content_block_manager/app/presenters/content_block_manager/confirmation_copy_presenter.rb
+++ b/lib/engines/content_block_manager/app/presenters/content_block_manager/confirmation_copy_presenter.rb
@@ -1,0 +1,37 @@
+module ContentBlockManager
+  class ConfirmationCopyPresenter
+    def initialize(content_block_edition)
+      @content_block_edition = content_block_edition
+    end
+
+    def for_panel
+      I18n.t("content_block_edition.confirmation_page.#{state}.banner", block_type:, date:)
+    end
+
+    def for_paragraph
+      I18n.t("content_block_edition.confirmation_page.#{state}.detail")
+    end
+
+    def state
+      if content_block_edition.scheduled?
+        :scheduled
+      elsif content_block_edition.document.editions.count > 1
+        :updated
+      else
+        :created
+      end
+    end
+
+  private
+
+    attr_reader :content_block_edition
+
+    def date
+      I18n.l(content_block_edition.scheduled_publication, format: :long_ordinal) if content_block_edition.scheduled_publication
+    end
+
+    def block_type
+      content_block_edition.block_type.humanize
+    end
+  end
+end

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/confirmation.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/confirmation.html.erb
@@ -4,7 +4,7 @@
   <div class="govuk-grid-column-three-quarters">
     <div class="govuk-panel govuk-panel--confirmation">
       <h1 class="govuk-panel__title">
-        <%= @panel_copy %>
+        <%= @confirmation_copy.for_panel %>
       </h1>
     </div>
   </div>
@@ -13,7 +13,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-three-quarters govuk-body">
     <h2 class="govuk-heading-m">What happens next?</h2>
-    <p><%= @paragraph_copy %> If you need any support or want to delete a content block you can raise a support request.
+    <p><%= @confirmation_copy.for_paragraph %> If you need any support or want to delete a content block you can raise a support request.
     </p>
     <div class="govuk-button-group">
       <%= render "govuk_publishing_components/components/button", {

--- a/lib/engines/content_block_manager/config/locales/en.yml
+++ b/lib/engines/content_block_manager/config/locales/en.yml
@@ -3,3 +3,14 @@ en:
     attributes:
       content_block_manager/content_block/edition/document:
         title: Title
+  content_block_edition:
+    confirmation_page:
+      scheduled:
+        banner: "%{block_type} scheduled to publish on %{date}"
+        detail: You can now view the updated schedule of the content block.
+      created:
+        banner: "%{block_type} created"
+        detail: You can now view the content block.
+      updated:
+        banner: "%{block_type} published"
+        detail: You can now view the updated content block.

--- a/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
@@ -151,12 +151,15 @@ Then("the edition should have been created successfully") do
 end
 
 And("I should be taken to the confirmation page for a published block") do
-  assert_text "Email address published"
-  assert_text "You can now view the updated content block. If you need any support or want to delete a content block you can raise a support request."
+  content_block_edition = ContentBlockManager::ContentBlock::Edition.last
+
+  assert_text I18n.t("content_block_edition.confirmation_page.updated.banner", block_type: "Email address")
+  assert_text I18n.t("content_block_edition.confirmation_page.updated.detail")
+
   expect(page).to have_link(
     "View content block",
     href: content_block_manager.content_block_manager_content_block_document_path(
-      ContentBlockManager::ContentBlock::Edition.last.document,
+      content_block_edition.document,
     ),
   )
 
@@ -171,13 +174,15 @@ def has_support_button
 end
 
 And("I should be taken to the confirmation page for a new block") do
-  assert_text "Email address created"
-  assert_text "You can now view the content block. If you need any support or want to delete a content block you can raise a support request."
+  content_block = ContentBlockManager::ContentBlock::Edition.last
+
+  assert_text I18n.t("content_block_edition.confirmation_page.created.banner", block_type: "Email address")
+  assert_text I18n.t("content_block_edition.confirmation_page.created.detail")
 
   expect(page).to have_link(
     "View content block",
     href: content_block_manager.content_block_manager_content_block_document_path(
-      ContentBlockManager::ContentBlock::Edition.last.document,
+      content_block.document,
     ),
   )
 
@@ -191,13 +196,15 @@ When("I click to view the content block") do
 end
 
 When("I should be taken to the scheduled confirmation page") do
-  assert_text "Email address scheduled to publish on"
-  assert_text "You can now view the updated schedule of the content block."
+  content_block_edition = ContentBlockManager::ContentBlock::Edition.last
+
+  assert_text I18n.t("content_block_edition.confirmation_page.scheduled.banner", block_type: "Email address", date: I18n.l(content_block_edition.scheduled_publication, format: :long_ordinal))
+  assert_text I18n.t("content_block_edition.confirmation_page.scheduled.detail")
 
   expect(page).to have_link(
     "View content block",
     href: content_block_manager.content_block_manager_content_block_document_path(
-      ContentBlockManager::ContentBlock::Edition.last.document,
+      content_block_edition.document,
     ),
   )
 

--- a/lib/engines/content_block_manager/test/unit/app/presenters/confirmation_copy_presenter_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/presenters/confirmation_copy_presenter_test.rb
@@ -1,0 +1,62 @@
+require "test_helper"
+
+class ContentBlockManager::ConfirmationCopyPresenterTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
+  let(:content_block_edition) { build(:content_block_edition, :email_address) }
+  let(:block_type) { content_block_edition.block_type.humanize }
+
+  let(:presenter) { ContentBlockManager::ConfirmationCopyPresenter.new(content_block_edition) }
+
+  context "when the content block is scheduled" do
+    let(:content_block_edition) { build(:content_block_edition, :email_address, scheduled_publication: Time.zone.now, state: :scheduled) }
+
+    describe "#for_panel" do
+      it "should return the scheduled text" do
+        assert_equal "#{block_type} scheduled to publish on #{I18n.l(content_block_edition.scheduled_publication, format: :long_ordinal)}", presenter.for_panel
+      end
+    end
+
+    describe "#for_paragraph" do
+      it "should return the scheduled text" do
+        assert_equal "You can now view the updated schedule of the content block.", presenter.for_paragraph
+      end
+    end
+  end
+
+  context "when there is more than one edition for the underlying document" do
+    let(:document) { content_block_edition.document }
+
+    before do
+      document.expects(:editions).returns(
+        build_list(:content_block_edition, 3, :email_address),
+      )
+    end
+
+    describe "#for_panel" do
+      it "should return the published text" do
+        assert_equal "#{block_type} published", presenter.for_panel
+      end
+    end
+
+    describe "#for_paragraph" do
+      it "should return the published text" do
+        assert_equal "You can now view the updated content block.", presenter.for_paragraph
+      end
+    end
+  end
+
+  context "when there is only one edition for the underlying document" do
+    describe "#for_panel" do
+      it "should return the created text" do
+        assert_equal "#{block_type} created", presenter.for_panel
+      end
+    end
+
+    describe "#for_paragraph" do
+      it "should return the created text" do
+        assert_equal "You can now view the content block.", presenter.for_paragraph
+      end
+    end
+  end
+end


### PR DESCRIPTION
As discussed in https://github.com/alphagov/whitehall/pull/9702#discussion_r1869942606 this adds a new presenter class to make the confirmation text a bit more testable