### PR TITLE
Content modelling/748 review update

### DIFF
--- a/lib/engines/content_block_manager/app/controllers/concerns/can_schedule_or_publish.rb
+++ b/lib/engines/content_block_manager/app/controllers/concerns/can_schedule_or_publish.rb
@@ -3,7 +3,7 @@ module CanScheduleOrPublish
 
   def schedule_or_publish
     if params[:step] == ContentBlockManager::ContentBlock::Editions::WorkflowController::UPDATE_BLOCK_STEPS[:review_update] && params[:is_confirmed].blank?
-      @confirm_error_copy = "Confirm details are correct"
+      @confirm_error_copy = I18n.t("content_block_edition.review_page.errors.confirm")
       @error_summary_errors = [{ text: @confirm_error_copy, href: "#is_confirmed-0" }]
       render "content_block_manager/content_block/editions/workflow/review_update"
     else

--- a/lib/engines/content_block_manager/app/controllers/concerns/can_schedule_or_publish.rb
+++ b/lib/engines/content_block_manager/app/controllers/concerns/can_schedule_or_publish.rb
@@ -2,23 +2,17 @@ module CanScheduleOrPublish
   extend ActiveSupport::Concern
 
   def schedule_or_publish
-    if params[:step] == ContentBlockManager::ContentBlock::Editions::WorkflowController::UPDATE_BLOCK_STEPS[:review_update] && params[:is_confirmed].blank?
-      @confirm_error_copy = I18n.t("content_block_edition.review_page.errors.confirm")
-      @error_summary_errors = [{ text: @confirm_error_copy, href: "#is_confirmed-0" }]
-      render "content_block_manager/content_block/editions/workflow/review_update"
+    @schema = ContentBlockManager::ContentBlock::Schema.find_by_block_type(@content_block_edition.document.block_type)
+
+    if params[:schedule_publishing] == "schedule"
+      ContentBlockManager::ScheduleEditionService.new(@schema).call(@content_block_edition, scheduled_publication_params)
     else
-      @schema = ContentBlockManager::ContentBlock::Schema.find_by_block_type(@content_block_edition.document.block_type)
-
-      if params[:schedule_publishing] == "schedule"
-        ContentBlockManager::ScheduleEditionService.new(@schema).call(@content_block_edition, scheduled_publication_params)
-      else
-        publish and return
-      end
-
-      redirect_to content_block_manager.content_block_manager_content_block_workflow_path(id: @content_block_edition.id,
-                                                                                          step: :confirmation,
-                                                                                          is_scheduled: true)
+      publish and return
     end
+
+    redirect_to content_block_manager.content_block_manager_content_block_workflow_path(id: @content_block_edition.id,
+                                                                                        step: :confirmation,
+                                                                                        is_scheduled: true)
   end
 
   def publish

--- a/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/documents/schedule_controller.rb
+++ b/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/documents/schedule_controller.rb
@@ -9,6 +9,19 @@ class ContentBlockManager::ContentBlock::Documents::ScheduleController < Content
   def update
     document = ContentBlockManager::ContentBlock::Document.find(params[:document_id])
     @content_block_edition = document.latest_edition
-    schedule_or_publish("content_block_manager/content_block/documents/schedule/edit")
+    validate_update
+  end
+
+private
+
+  def validate_update
+    if params[:schedule_publishing].blank?
+      @content_block_edition.errors.add(:schedule_publishing, "cannot be blank")
+      raise ActiveRecord::RecordInvalid, @content_block_edition
+    else
+      schedule_or_publish
+    end
+  rescue ActiveRecord::RecordInvalid
+    render "content_block_manager/content_block/documents/schedule/edit"
   end
 end

--- a/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/editions/workflow_controller.rb
+++ b/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/editions/workflow_controller.rb
@@ -69,7 +69,13 @@ private
   def review
     @content_block_edition = ContentBlockManager::ContentBlock::Edition.find(params[:id])
 
+    @url = review_url
+
     render :review
+  end
+
+  def review_url
+    content_block_manager.content_block_manager_content_block_workflow_path(@content_block_edition, step: ContentBlockManager::ContentBlock::Editions::WorkflowController::NEW_BLOCK_STEPS[:review])
   end
 
   def confirmation
@@ -106,6 +112,7 @@ private
     if params[:step] == NEW_BLOCK_STEPS[:review] && params[:is_confirmed].blank?
       @confirm_error_copy = "Confirm details are correct"
       @error_summary_errors = [{ text: @confirm_error_copy, href: "#is_confirmed-0" }]
+      @url = review_url
       render "content_block_manager/content_block/editions/workflow/review"
     else
       new_edition = ContentBlockManager::PublishEditionService.new.call(@content_block_edition)

--- a/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/editions/workflow_controller.rb
+++ b/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/editions/workflow_controller.rb
@@ -144,7 +144,7 @@ private
 
   def publish
     if params[:step] == NEW_BLOCK_STEPS[:review] && params[:is_confirmed].blank?
-      @confirm_error_copy = "Confirm details are correct"
+      @confirm_error_copy = I18n.t("content_block_edition.review_page.errors.confirm")
       @error_summary_errors = [{ text: @confirm_error_copy, href: "#is_confirmed-0" }]
       @url = review_url
       render "content_block_manager/content_block/editions/workflow/review"

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/review.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/review.html.erb
@@ -23,7 +23,7 @@
   </div>
 </div>
 
-<%= form_with(url: content_block_manager.content_block_manager_content_block_workflow_path(@content_block_edition, step: ContentBlockManager::ContentBlock::Editions::WorkflowController::NEW_BLOCK_STEPS[:review]), method: :put) do %>
+<%= form_with(url: @url, method: :put) do %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <%= render "govuk_publishing_components/components/checkboxes", {

--- a/lib/engines/content_block_manager/config/locales/en.yml
+++ b/lib/engines/content_block_manager/config/locales/en.yml
@@ -21,3 +21,6 @@ en:
       updated:
         banner: "%{block_type} published"
         detail: You can now view the updated content block.
+    review_page:
+      errors:
+        confirm: Confirm details are correct

--- a/lib/engines/content_block_manager/features/edit_object.feature
+++ b/lib/engines/content_block_manager/features/edit_object.feature
@@ -25,6 +25,7 @@ Feature: Edit a content object
     And I should see a back link to the review page
     When I choose to publish the change now
     And I save and continue
+    When I review and confirm my answers are correct
     Then I should be taken to the confirmation page for a published block
     When I click to view the content block
     Then the edition should have been updated successfully
@@ -81,16 +82,31 @@ Feature: Edit a content object
     | my email address | xxxxx           | Ministry of Example |
     Then I should see a message that the "email_address" field is an invalid "email"
 
+  Scenario: GDS editor sees validation errors for unconfirmed answers
+    When I visit the Content Block Manager home page
+    When I click to view the document
+    When I click the first edit link
+    When I fill out the form
+    Then I am shown where the changes will take place
+    When I save and continue
+    And I choose to publish the change now
+    When I save and continue
+    Then I am asked to review my answers
+    When I click confirm
+    Then I should see a message that I need to confirm the details are correct
+
   @enable-sidekiq-test-mode
   Scenario: GDS editor can override a previously scheduled object
     When I am updating a content block
     And I am asked when I want to publish the change
     And I schedule the change for 7 days in the future
+    When I review and confirm my answers are correct
     When I revisit the edit page
     Then I should see a warning telling me there is a scheduled change
     When I make the changes
     And I choose to publish the change now
     And I save and continue
+    When I review and confirm my answers are correct
     Then I should be taken to the confirmation page for a published block
     When I click to view the content block
     Then the edition should have been updated successfully

--- a/lib/engines/content_block_manager/features/schedule_object.feature
+++ b/lib/engines/content_block_manager/features/schedule_object.feature
@@ -12,6 +12,7 @@ Feature: Schedule a content object
     When I am updating a content block
     Then I am asked when I want to publish the change
     And I schedule the change for 7 days in the future
+    When I review and confirm my answers are correct
     And I should be taken to the scheduled confirmation page
     When I click to view the content block
     And I should see the scheduled date on the object
@@ -22,6 +23,7 @@ Feature: Schedule a content object
     When I am updating a content block
     Then I am asked when I want to publish the change
     And I schedule the change for 7 days in the future
+    When I review and confirm my answers are correct
     When I click to view the content block
     And I click to edit the schedule
     And I choose to publish the change now
@@ -35,6 +37,7 @@ Feature: Schedule a content object
     When I am updating a content block
     Then I am asked when I want to publish the change
     And I schedule the change for 7 days in the future
+    When I review and confirm my answers are correct
     When I click to view the content block
     And I click to edit the schedule
     And I schedule the change for 5 days in the future
@@ -43,13 +46,39 @@ Feature: Schedule a content object
     And there should only be one job scheduled
 
   @disable-sidekiq-test-mode
+  Scenario: GDS Editor tries to reschedule a content object without choosing to schedule
+    When I am updating a content block
+    Then I am asked when I want to publish the change
+    And I schedule the change for 7 days in the future
+    When I review and confirm my answers are correct
+    When I click to view the content block
+    And I click to edit the schedule
+    And I save and continue
+    Then I see the error message "Schedule publishing cannot be blank"
+
+  @disable-sidekiq-test-mode
+  Scenario: GDS Editor tries to reschedule a content object with an invalid date
+    When I am updating a content block
+    Then I am asked when I want to publish the change
+    And I schedule the change for 7 days in the future
+    When I review and confirm my answers are correct
+    When I click to view the content block
+    And I click to edit the schedule
+    When I choose to schedule the change
+    And I enter an invalid date
+    And I save and continue
+    Then I see the errors informing me the date is invalid
+
+  @disable-sidekiq-test-mode
   Scenario: GDS Editor publishes a new version of a previously scheduled content object
     When I am updating a content block
     Then I am asked when I want to publish the change
     And I schedule the change for 7 days in the future
+    When I review and confirm my answers are correct
     When I am updating a content block
     And I choose to publish the change now
     And I save and continue
+    When I review and confirm my answers are correct
     Then there should be no jobs scheduled
 
   @disable-sidekiq-test-mode
@@ -57,6 +86,7 @@ Feature: Schedule a content object
     When I am updating a content block
     Then I am asked when I want to publish the change
     And I schedule the change for 7 days in the future
+    When I review and confirm my answers are correct
     When I click to view the content block
     And I click to edit the schedule
     And I schedule the change for 5 days in the future
@@ -68,6 +98,7 @@ Feature: Schedule a content object
     Then I am asked when I want to publish the change
     When I choose to schedule the change
     And the block is scheduled and published
+    When I review and confirm my answers are correct
     Then the published state of the object should be shown
     And I should see the publish event on the timeline
 

--- a/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
@@ -437,6 +437,10 @@ Then("I see the errors informing me the date is invalid") do
   assert_text "Scheduled publication is not in the correct format", minimum: 2
 end
 
+Then("I see the error message {string}") do |text|
+  assert_text text, minimum: 2
+end
+
 Then("I see the errors informing me the date must be in the future") do
   assert_text "Scheduled publication date and time must be in the future", minimum: 2
 end
@@ -487,6 +491,12 @@ end
 
 Then("I accept and publish") do
   click_on "Accept and publish"
+end
+
+When("I review and confirm my answers are correct") do
+  assert_text "Review email address"
+  check "By creating this content block you are confirming that, to the best of your knowledge, the details you are providing are correct."
+  click_on "Confirm"
 end
 
 When(/^dependent content exists for a content block$/) do

--- a/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
@@ -450,7 +450,7 @@ Then("I should see a message that the {string} field is an invalid {string}") do
 end
 
 Then("I should see a message that I need to confirm the details are correct") do
-  assert_text "Confirm details are correct", minimum: 2
+  assert_text I18n.t("content_block_edition.review_page.errors.confirm"), minimum: 2
 end
 
 Then("I should see a message that the filter dates are invalid") do

--- a/lib/engines/content_block_manager/test/integration/content_block/workflow_test.rb
+++ b/lib/engines/content_block_manager/test/integration/content_block/workflow_test.rb
@@ -96,15 +96,27 @@ class ContentBlockManager::ContentBlock::WorkflowTest < ActionDispatch::Integrat
 
       describe "#update" do
         describe "when choosing to publish immediately" do
-          it "posts the new edition to the Publishing API and marks edition as published" do
-            assert_edition_is_published do
-              put content_block_manager.content_block_manager_content_block_workflow_path(id: edition.id, step:), params: { schedule_publishing: "now" }
-            end
+          it "shows the review page" do
+            scheduled_at = {
+              "scheduled_publication(1i)": "",
+              "scheduled_publication(2i)": "",
+              "scheduled_publication(3i)": "",
+              "scheduled_publication(4i)": "",
+              "scheduled_publication(5i)": "",
+            }
+
+            put content_block_manager.content_block_manager_content_block_workflow_path(id: edition.id, step:),
+                params: {
+                  schedule_publishing: "now",
+                  scheduled_at:,
+                }
+
+            assert_template "content_block_manager/content_block/editions/workflow/review"
           end
         end
 
         describe "when scheduling publication" do
-          it "schedules the edition and redirects" do
+          it "shows the review page" do
             scheduled_at = {
               "scheduled_publication(1i)": "2024",
               "scheduled_publication(2i)": "01",
@@ -112,16 +124,13 @@ class ContentBlockManager::ContentBlock::WorkflowTest < ActionDispatch::Integrat
               "scheduled_publication(4i)": "12",
               "scheduled_publication(5i)": "00",
             }
-            ContentBlockManager::ScheduleEditionService.any_instance.expects(:call).with(edition, ActionController::Parameters.new(scheduled_at).permit!)
 
             put content_block_manager.content_block_manager_content_block_workflow_path(id: edition.id, step:), params: {
               schedule_publishing: "schedule",
               scheduled_at:,
             }
 
-            assert_redirected_to content_block_manager.content_block_manager_content_block_workflow_path(id: edition.id,
-                                                                                                         step: :confirmation,
-                                                                                                         is_scheduled: true)
+            assert_template "content_block_manager/content_block/editions/workflow/review"
           end
         end
 


### PR DESCRIPTION
https://trello.com/c/uMVUEObq/748-add-review-email-address-screen-as-part-of-the-edit-journey

This PR is to include a `review` step after the user choose to publish/schedule an update to an existing Content Block.

This is a bit more complicated than it might seem, because we now need to validate the answers on the `schedule_publishing` page, and pass on the answers to the next method. We also need to change the behaviour  of the existing `can_schedule_or_publish` concern, which affects the 'edit schedule' flow.

I've tried to separate out validation into it's own methods as an attempt to start separating responsibilities.

------

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
