### PR TITLE
Use `squish` when checking confirmation page

### DIFF
--- a/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
@@ -199,7 +199,11 @@ end
 When("I should be taken to the scheduled confirmation page") do
   content_block_edition = ContentBlockManager::ContentBlock::Edition.last
 
-  assert_text I18n.t("content_block_edition.confirmation_page.scheduled.banner", block_type: "Email address", date: I18n.l(content_block_edition.scheduled_publication, format: :long_ordinal))
+  assert_text I18n.t(
+    "content_block_edition.confirmation_page.scheduled.banner",
+    block_type: "Email address",
+    date: I18n.l(content_block_edition.scheduled_publication, format: :long_ordinal),
+  ).squish
   assert_text I18n.t("content_block_edition.confirmation_page.scheduled.detail")
 
   expect(page).to have_link(


### PR DESCRIPTION
The way dates are parsed is slightly different in the views and tests, leading to an additional space when the scheduled time is a single figure.

Calling [`.squish`](https://api.rubyonrails.org/classes/String.html#method-i-squish) removes any consecutive whitespaces, so we lose the additional space.