### PR TITLE
Present editionable topical events summary

### DIFF
--- a/app/presenters/publishing_api/editionable_topical_event_presenter.rb
+++ b/app/presenters/publishing_api/editionable_topical_event_presenter.rb
@@ -16,10 +16,12 @@ module PublishingApi
     def content
       content = BaseItemPresenter.new(
         item,
+        title: item.title,
         update_type:,
       ).base_attributes
 
       content.merge!(
+        description: item.summary,
         details:,
         document_type: item.class.name.underscore,
         public_updated_at: item.updated_at,

--- a/test/factories/editionable_topical_events.rb
+++ b/test/factories/editionable_topical_events.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :editionable_topical_event, class: EditionableTopicalEvent, parent: :edition do
     title { "editionable-topical-event-title" }
+    summary { "Some basic info about the event" }
   end
 
   factory :draft_editionable_topical_event, parent: :editionable_topical_event, traits: [:draft]

--- a/test/unit/app/presenters/publishing_api/editionable_topical_event_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/editionable_topical_event_presenter_test.rb
@@ -13,6 +13,7 @@ class PublishingApi::EditionableTopicalEventPresenterTest < ActiveSupport::TestC
     expected_hash = {
       base_path: public_path,
       title: topical_event.title,
+      description: topical_event.summary,
       schema_name: "topical_event",
       document_type: "editionable_topical_event",
       locale: "en",


### PR DESCRIPTION
Trello: https://trello.com/c/o734OE2P/8-editionablise-a-new-content-type


Presents the summary of editionable topical events to the publishing api

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
