### PR TITLE
Fix mocha deprecation warning

### DIFF
--- a/test/functional/admin/attachments_controller_test.rb
+++ b/test/functional/admin/attachments_controller_test.rb
@@ -163,6 +163,7 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
 
     Whitehall::PublishingApi
       .expects(:save_draft)
+      .with(instance_of(FileAttachment))
       .never
 
     post :create, params: { edition_id: @edition.id, type: "file", attachment: }


### PR DESCRIPTION
Since mocha was upgraded to v2.6.1 in #9677, we've been seeing the following deprecation warning (e.g. in [this build][1]):

    Mocha deprecation warning at app/services/service_listeners/publishing_api_pusher.rb:16:in `push':
    The expectation defined at test/functional/admin/attachments_controller_test.rb:165:in
    `block in <class:AttachmentsControllerTest>' does not allow invocations, but
    Whitehall::PublishingApi.save_draft(#<Consultation:0xd4300>) was invoked.
    This invocation will cause the test to fail fast in a future version of Mocha.

And indeed the test does fail as follows in #9712 where an attempt is made to upgrade mocha to v2.7.0 (e.g. in [this build][2]):

    Admin::AttachmentsControllerTest#test_POST_:create_for_a_FileAttachnment_doesnt_update_the_publishing_api
    [app/services/service_listeners/publishing_api_pusher.rb:16]:
    unexpected invocation: Whitehall::PublishingApi.save_draft(#<Consultation:0xd8018>)
    unsatisfied expectations:
    - expected never, invoked once: Whitehall::PublishingApi.save_draft(any_parameters)
    - expected exactly once, invoked never: Whitehall::PublishingApi.save_draft(#<Consultation:0xd7d70>) satisfied expectations: ...

The test has 2 expectations on `Whitehall::PublishingApi.save_draft`:

    Whitehall::PublishingApi.expects(:save_draft).with(@edition)
    Whitehall::PublishingApi.expects(:save_draft).never

The latter was introduced in [this commit][3] when the test was first added. The former was added in [this later commit][4] when a call to `Whitehall::PublishingApi.save_draft` was added for the edition (as opposed to the attachment).

The name of the test above the failing test ("POST :create for an HtmlAttachment updates the publishing api") and the name of the failing test itself (""POST :create for a FileAttachnment doesnt update the publishing api"") suggest that the idea is that `Whitehall::PublishingApi.save_draft` should be called for an `HtmlAttachment` but not for a `FileAttachment` and this seems to be confirmed by the note & the diff of [the eariler commit][3].

So I think the correct fix is to change the 2nd expectation to be more specific about the arguments to `Whitehall::PublishingApi.save_draft` a bit like the 2nd expectation in the test above, i.e.

    Whitehall::PublishingApi.expects(:save_draft).with(@edition)
    Whitehall::PublishingApi.expects(:save_draft).with(instance_of(FileAttachment)).never

Testing a negative like this is always a bit brittle and it might be better/necessary to include matchers for the optional `update_type_override` positional argument and/or the optional `bulk_publishing` keyword argument.

Unfortunately I don't have the development environment set up locally and I suspect the CI build won't run if I open this as a PR, because I'm not in the alphagov organisation. So I haven't been able to test the fix and I may have got this completely wrong! However, hopefully this will be enough for someone to take it forward and get it merged.

[1]: https://github.com/alphagov/whitehall/actions/runs/12085657880/job/33703340154#step:10:59
[2]: https://github.com/alphagov/whitehall/actions/runs/12232782283/job/34118535539?pr=9712#step:10:46
[3]: https://github.com/alphagov/whitehall/commit/7127e1cedc74c23ebbdfd532926ad13fa2d74a82#diff-01a2146be4a23b6cf601a9f3e5174eac63bb35560bc4f19fecdd9190516cdd01R134-R136
[4]: https://github.com/alphagov/whitehall/commit/ed680dc2f172bbd28113f57be2fd1bce7bcfd106#diff-01a2146be4a23b6cf601a9f3e5174eac63bb35560bc4f19fecdd9190516cdd01R154-R157
