### PR TITLE
Hide licence in footer

### DIFF
--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -74,6 +74,7 @@
   </div>
 
   <%= render "govuk_publishing_components/components/layout_footer", {
+    hide_licence: true,
     navigation: [
       {
         title: "Support and feedback",


### PR DESCRIPTION
Trello Card: https://trello.com/c/vaeRae01/730-remove-licence-details-from-footer

The licence details make sense on public-facing sites, but we don’t need them on the admin side. We’ve added a `hide_licence` option to the layout_footer component, so let’s use it here.

## Screenshot

### Before

![image](https://github.com/user-attachments/assets/d24f5c4e-afbe-465c-beb3-995d35e6973a)

### After

![image](https://github.com/user-attachments/assets/8c45a08d-cbcb-471f-b228-314849d0a7f6)
