### PR TITLE
Content modelling/748 add review to edit

### DIFF
--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/show/confirm_summary_list_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/show/confirm_summary_list_component.rb
@@ -14,7 +14,8 @@ private
       *details_items,
       organisation_item,
       instructions_item,
-    ]
+      status_item,
+    ].compact
   end
 
   def edit_item
@@ -59,5 +60,18 @@ private
       href: helpers.content_block_manager.content_block_manager_content_block_workflow_path(id: content_block_edition.id, step: ContentBlockManager::ContentBlock::Editions::WorkflowController::NEW_BLOCK_STEPS[:edit_draft]),
       link_text: "Edit",
     }
+  end
+
+  def scheduled_value
+    I18n.l(content_block_edition.scheduled_publication, format: :long_ordinal)
+  end
+
+  def status_item
+    if content_block_edition.scheduled_publication
+      {
+        field: "Scheduled date and time",
+        value: scheduled_value,
+      }
+    end
   end
 end

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/show/confirm_summary_list_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/show/confirm_summary_list_component.rb
@@ -72,6 +72,11 @@ private
         field: "Scheduled date and time",
         value: scheduled_value,
       }
+    elsif content_block_edition.document.editions.count > 1
+      {
+        field: "Publish date",
+        value: I18n.l(Time.zone.today, format: :long_ordinal),
+      }
     end
   end
 end

--- a/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/editions/workflow_controller.rb
+++ b/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/editions/workflow_controller.rb
@@ -96,6 +96,12 @@ private
     )
   end
 
+  def validate_scheduled_edition
+    @content_block_edition.assign_attributes(scheduled_publication_params)
+    @content_block_edition.assign_attributes(state: "scheduled")
+    raise ActiveRecord::RecordInvalid unless @content_block_edition.valid?
+  end
+
   def review_update
     @content_block_edition = ContentBlockManager::ContentBlock::Edition.find(params[:id])
 
@@ -103,9 +109,7 @@ private
       @content_block_edition.errors.add(:schedule_publishing, "cannot be blank")
       raise ActiveRecord::RecordInvalid, @content_block_edition
     elsif params[:schedule_publishing] == "schedule"
-      @content_block_edition.update!(scheduled_publication_params)
-      @content_block_edition.schedule!
-      raise ActiveRecord::RecordInvalid, @content_block_edition if @content_block_edition.errors.any?
+      validate_scheduled_edition
     end
 
     @url = review_update_url

--- a/lib/engines/content_block_manager/features/edit_object.feature
+++ b/lib/engines/content_block_manager/features/edit_object.feature
@@ -44,7 +44,7 @@ Feature: Edit a content object
     Then I should be taken back to the document page
     And no draft Content Block Edition has been created
 
-  Scenario: GDS editor cancels the creation of an object before publishing
+  Scenario: GDS editor cancels the creation of an object before scheduling
     When I visit the Content Block Manager home page
     When I click to view the document
     When I click the first edit link
@@ -56,6 +56,18 @@ Feature: Edit a content object
     Then I am asked when I want to publish the change
     And I click cancel
     Then I should be taken back to the document page
+    And no draft Content Block Edition has been created
+
+  Scenario: GDS editor cancels the creation of an object before confirming answers
+    When I visit the Content Block Manager home page
+    When I click to view the document
+    When I click the first edit link
+    When I fill out the form
+    When I save and continue
+    When I choose to publish the change now
+    And I save and continue
+    And I click cancel
+    Then I am taken back to Content Block Manager home page
     And no draft Content Block Edition has been created
 
   Scenario: GDS editor sees validation errors for missing fields

--- a/lib/engines/content_block_manager/features/schedule_object.feature
+++ b/lib/engines/content_block_manager/features/schedule_object.feature
@@ -124,3 +124,11 @@ Feature: Schedule a content object
     And I enter a date in the past
     And I save and continue
     Then I see the errors informing me the date must be in the future
+
+  Scenario: GDS Editor cancels after scheduling a block
+    When I am updating a content block
+    Then I am asked when I want to publish the change
+    When I choose to schedule the change
+    And the block is scheduled and published
+    And I click cancel
+    Then I am taken back to Content Block Manager home page

--- a/lib/engines/content_block_manager/test/components/content_block/edition/show/confirm_summary_list_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/show/confirm_summary_list_component_test.rb
@@ -71,4 +71,34 @@ class ContentBlockManager::ContentBlockEdition::Show::ConfirmSummaryListComponen
       assert_selector ".govuk-summary-list__value", text: I18n.l(content_block_edition.scheduled_publication, format: :long_ordinal)
     end
   end
+
+  describe "when the content block is being updated and published immediately" do
+    it "shows a publish now row" do
+      organisation = create(:organisation, name: "Department for Example")
+
+      content_block_document = create(:content_block_document, :email_address, title: "Some title")
+
+      _previous_edition = create(
+        :content_block_edition,
+        :email_address,
+        organisation:,
+        document: content_block_document,
+      )
+
+      content_block_edition = create(
+        :content_block_edition,
+        :email_address,
+        details: { "interesting_fact" => "value of fact" },
+        organisation:,
+        document: content_block_document,
+      )
+
+      render_inline(ContentBlockManager::ContentBlockEdition::Show::ConfirmSummaryListComponent.new(
+                      content_block_edition:,
+                    ))
+
+      assert_selector ".govuk-summary-list__key", text: "Publish date"
+      assert_selector ".govuk-summary-list__value", text: I18n.l(Time.zone.today, format: :long_ordinal)
+    end
+  end
 end

--- a/lib/engines/content_block_manager/test/components/content_block/edition/show/confirm_summary_list_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/show/confirm_summary_list_component_test.rb
@@ -1,7 +1,8 @@
 require "test_helper"
 
 class ContentBlockManager::ContentBlockEdition::Show::ConfirmSummaryListComponentTest < ViewComponent::TestCase
-  test "it renders instructions to publishers" do
+  extend Minitest::Spec::DSL
+  it "it renders instructions to publishers" do
     content_block_edition = create(
       :content_block_edition,
       :email_address,
@@ -16,7 +17,7 @@ class ContentBlockManager::ContentBlockEdition::Show::ConfirmSummaryListComponen
     assert_selector ".govuk-summary-list__value", text: "some instructions"
   end
 
-  test "renders a summary list component with the edition details to confirm" do
+  it "renders a summary list component with the edition details to confirm" do
     organisation = create(:organisation, name: "Department for Example")
 
     content_block_document = create(:content_block_document, :email_address, title: "Some title")

--- a/lib/engines/content_block_manager/test/components/content_block/edition/show/confirm_summary_list_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/show/confirm_summary_list_component_test.rb
@@ -45,4 +45,30 @@ class ContentBlockManager::ContentBlockEdition::Show::ConfirmSummaryListComponen
     assert_selector ".govuk-summary-list__key", text: "Instructions to publishers"
     assert_selector ".govuk-summary-list__value", text: "None"
   end
+
+  describe "when the content block is scheduled" do
+    it "shows the scheduled date time" do
+      organisation = create(:organisation, name: "Department for Example")
+
+      content_block_document = create(:content_block_document, :email_address, title: "Some title")
+
+      content_block_edition = create(
+        :content_block_edition,
+        :email_address,
+        details: { "interesting_fact" => "value of fact" },
+        organisation:,
+        document: content_block_document,
+        scheduled_publication: 2.days.from_now,
+      )
+
+      content_block_edition.schedule!
+
+      render_inline(ContentBlockManager::ContentBlockEdition::Show::ConfirmSummaryListComponent.new(
+                      content_block_edition:,
+                    ))
+
+      assert_selector ".govuk-summary-list__key", text: "Scheduled date and time"
+      assert_selector ".govuk-summary-list__value", text: I18n.l(content_block_edition.scheduled_publication, format: :long_ordinal)
+    end
+  end
 end

--- a/lib/engines/content_block_manager/test/unit/app/models/content_block_edition/workflow_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/models/content_block_edition/workflow_test.rb
@@ -6,12 +6,6 @@ class ContentBlockManager::WorkflowTest < ActiveSupport::TestCase
     assert edition.draft?
   end
 
-  test "publishing a draft edition transitions it into the published state" do
-    edition = create(:content_block_edition, document: create(:content_block_document, block_type: "email_address"))
-    edition.publish!
-    assert edition.published?
-  end
-
   test "publishing a scheduled edition transitions it into the published state" do
     edition = create(:content_block_edition,
                      document: create(


### PR DESCRIPTION
https://trello.com/c/uMVUEObq/748-add-review-email-address-screen-as-part-of-the-edit-journey

* Adding the row to show either published date or scheduled date if present on the review page.
* Fixing the cancel process if users were to press cancel on this page during the edit flow.

![Screenshot 2024-12-11 at 16 54 22](https://github.com/user-attachments/assets/5410d16d-d6d5-4627-858c-25b83994063c)

![Screenshot 2024-12-11 at 16 54 00](https://github.com/user-attachments/assets/83791d8d-5613-4ca8-a0e0-e8523467ef48)

---



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
