### PR TITLE
Remove dashboard filters for orphaned corporate info pages

### DIFF
--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,13 +1,9 @@
 class Admin::DashboardController < Admin::BaseController
   def index
     if current_user.organisation
-      @draft_documents = Edition.authored_by(current_user).where(state: "draft").includes(:translations, :versions).in_reverse_chronological_order.reject do |edition|
-        edition.respond_to?(:organisation) && edition.organisation.nil?
-      end
+      @draft_documents = Edition.authored_by(current_user).where(state: "draft").includes(:translations, :versions).in_reverse_chronological_order
 
-      @force_published_documents = current_user.organisation.editions.force_published.includes(:translations, :versions).in_reverse_chronological_order.limit(5).reject do |edition|
-        edition.respond_to?(:organisation) && edition.organisation.nil?
-      end
+      @force_published_documents = current_user.organisation.editions.force_published.includes(:translations, :versions).in_reverse_chronological_order.limit(5)
     end
   end
 end


### PR DESCRIPTION
These filters were added in 2439f413 to work around the fact that we had a number of orphaned corporate information pages in the Whitehall database.

We have since removed all of the orphaned corporate info pages. Unfortunately we did not use a data migration to do this so I can't link to the commit. I checked that there are none in existence any longer with the following query:

```
CorporateInformationPage.left_joins(:organisation).where(organisations: {id: nil}).count
=> nil
```

We also believe we have fixed the issue that was causing the orphaned pages to be created. I believe this was done during the move to make worldwide organisations editionable but there isn't really a specific commit to link to.

As a result of both the above, it should be safe to remove this code.

Trello: https://trello.com/c/USPBcvgg
