### PR TITLE
Refactoring: Reduce usages of sti_name to minimum

### DIFF
--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -8,10 +8,6 @@ class Announcement < Edition
   include Edition::WorldLocations
   include Edition::TopicalEvents
 
-  def self.sti_names
-    ([self] + descendants).map(&:sti_name)
-  end
-
   def self.published_with_eager_loading(ids)
     published.with_translations.includes([:document, { organisations: :translations }]).where(id: ids)
   end

--- a/app/models/concerns/edition/publishing.rb
+++ b/app/models/concerns/edition/publishing.rb
@@ -19,7 +19,7 @@ module Edition::Publishing
 
     def unpublished_as(slug)
       document = Document.at_slug(document_type, slug)
-      document && document.latest_edition && document.latest_edition.unpublishing
+      document&.latest_edition&.unpublishing
     end
   end
 

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -101,7 +101,7 @@ class Edition < ApplicationRecord
 
   def self.scheduled_for_publication_as(slug)
     document = Document.at_slug(document_type, slug)
-    document && document.scheduled_edition
+    document&.scheduled_edition
   end
 
   def skip_main_validation?

--- a/app/models/publicationesque.rb
+++ b/app/models/publicationesque.rb
@@ -16,10 +16,6 @@ class Publicationesque < Edition
 
   include ::Attachable
 
-  def self.sti_names
-    ([self] + descendants).map(&:sti_name)
-  end
-
   def self.published_with_eager_loading(ids)
     published.with_translations.includes([:document, { organisations: :translations }]).where(id: ids)
   end

--- a/test/unit/app/models/edition/identifiable_test.rb
+++ b/test/unit/app/models/edition/identifiable_test.rb
@@ -43,14 +43,6 @@ class Edition::IdentifiableTest < ActiveSupport::TestCase
     assert_equal publication.document.slug, news_article.document.slug
   end
 
-  test "should allow the same slug to be used for a news article and a speech" do
-    same_title = "same-title"
-    news_article = create(:news_article, title: same_title)
-    speech = create(:speech, title: same_title)
-
-    assert_equal news_article.document.slug, speech.document.slug
-  end
-
   test "should return the edition of the correct type when matching slugs for other types exist" do
     same_title = "same-title"
     news_article = create(:published_news_article, title: same_title)


### PR DESCRIPTION
`sti_names` methods don't seem to be used anywhere and can be removed.

within Edition::Identifiable:

* When edition is saved, the edition type should be propogated to the document type. Additionally the document_type on an Edition is being used in multiple places so is not easy to unpick. The published as class method is used to fetch document by slug based on the type of the subclass. So unfortunately we still need to use sti_name for this.
* The test however has 1 duplicate unecessary test, as we not only support News and Speeches sharing same slug, but all other document types too, which already has another test above covering that.

https://trello.com/c/EewW5W4A/3264-delete-selfstinames-methods

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
