### PR TITLE
Content modelling/748 add review page to the reschedule journey

### DIFF
--- a/lib/engines/content_block_manager/app/controllers/content_block_manager/base_controller.rb
+++ b/lib/engines/content_block_manager/app/controllers/content_block_manager/base_controller.rb
@@ -49,4 +49,15 @@ class ContentBlockManager::BaseController < Admin::BaseController
   def prepend_views
     prepend_view_path Rails.root.join("lib/engines/content_block_manager/app/views")
   end
+
+  def validate_scheduled_edition
+    if params[:schedule_publishing].blank?
+      @content_block_edition.errors.add(:schedule_publishing, "cannot be blank")
+      raise ActiveRecord::RecordInvalid, @content_block_edition
+    elsif params[:schedule_publishing] == "schedule"
+      @content_block_edition.assign_attributes(scheduled_publication_params)
+      @content_block_edition.assign_attributes(state: "scheduled")
+      raise ActiveRecord::RecordInvalid unless @content_block_edition.valid?
+    end
+  end
 end

--- a/lib/engines/content_block_manager/app/controllers/content_block_manager/base_controller.rb
+++ b/lib/engines/content_block_manager/app/controllers/content_block_manager/base_controller.rb
@@ -60,4 +60,16 @@ class ContentBlockManager::BaseController < Admin::BaseController
       raise ActiveRecord::RecordInvalid unless @content_block_edition.valid?
     end
   end
+
+  def review_update_url
+    schedule_publishing = params[:schedule_publishing]
+    scheduled_at = scheduled_publication_params.to_h
+
+    content_block_manager.content_block_manager_content_block_workflow_path(
+      @content_block_edition,
+      step: ContentBlockManager::ContentBlock::Editions::WorkflowController::UPDATE_BLOCK_STEPS[:review_update],
+      schedule_publishing:,
+      scheduled_at:,
+    )
+  end
 end

--- a/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/documents/schedule_controller.rb
+++ b/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/documents/schedule_controller.rb
@@ -9,18 +9,11 @@ class ContentBlockManager::ContentBlock::Documents::ScheduleController < Content
   def update
     document = ContentBlockManager::ContentBlock::Document.find(params[:document_id])
     @content_block_edition = document.latest_edition
-    validate_update
-  end
+    validate_scheduled_edition
 
-private
+    @url = review_update_url
 
-  def validate_update
-    if params[:schedule_publishing].blank?
-      @content_block_edition.errors.add(:schedule_publishing, "cannot be blank")
-      raise ActiveRecord::RecordInvalid, @content_block_edition
-    else
-      schedule_or_publish
-    end
+    render "content_block_manager/content_block/editions/workflow/review"
   rescue ActiveRecord::RecordInvalid
     render "content_block_manager/content_block/documents/schedule/edit"
   end

--- a/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/editions/workflow_controller.rb
+++ b/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/editions/workflow_controller.rb
@@ -96,21 +96,10 @@ private
     )
   end
 
-  def validate_scheduled_edition
-    @content_block_edition.assign_attributes(scheduled_publication_params)
-    @content_block_edition.assign_attributes(state: "scheduled")
-    raise ActiveRecord::RecordInvalid unless @content_block_edition.valid?
-  end
-
   def review_update
     @content_block_edition = ContentBlockManager::ContentBlock::Edition.find(params[:id])
 
-    if params[:schedule_publishing].blank?
-      @content_block_edition.errors.add(:schedule_publishing, "cannot be blank")
-      raise ActiveRecord::RecordInvalid, @content_block_edition
-    elsif params[:schedule_publishing] == "schedule"
-      validate_scheduled_edition
-    end
+    validate_scheduled_edition
 
     @url = review_update_url
 

--- a/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/editions/workflow_controller.rb
+++ b/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/editions/workflow_controller.rb
@@ -84,18 +84,6 @@ private
     )
   end
 
-  def review_update_url
-    schedule_publishing = params[:schedule_publishing]
-    scheduled_at = scheduled_publication_params.to_h
-
-    content_block_manager.content_block_manager_content_block_workflow_path(
-      @content_block_edition,
-      step: ContentBlockManager::ContentBlock::Editions::WorkflowController::UPDATE_BLOCK_STEPS[:review_update],
-      schedule_publishing:,
-      scheduled_at:,
-    )
-  end
-
   def review_update
     @content_block_edition = ContentBlockManager::ContentBlock::Edition.find(params[:id])
 

--- a/lib/engines/content_block_manager/features/reschedule_object.feature
+++ b/lib/engines/content_block_manager/features/reschedule_object.feature
@@ -1,0 +1,46 @@
+Feature: Schedule a content object
+  Background:
+    Given I am a GDS admin
+    And the organisation "Ministry of Example" exists
+    And a schema "email_address" exists with the following fields:
+      | field         | type   | format | required |
+      | email_address | string | email  | true     |
+    And an email address content block has been created
+
+  @disable-sidekiq-test-mode
+  Scenario: GDS Editor immediately publishes a scheduled content object
+    When I am updating a content block
+    Then I am asked when I want to publish the change
+    And I schedule the change for 7 days in the future
+    When I review and confirm my answers are correct
+    When I click to view the content block
+    And I click to edit the schedule
+    And I choose to publish the change now
+    And I save and continue
+    When I click to view the content block
+    Then the published state of the object should be shown
+    And there should be no jobs scheduled
+
+  @disable-sidekiq-test-mode
+  Scenario: GDS Editor reschedules a content object
+    When I am updating a content block
+    Then I am asked when I want to publish the change
+    And I schedule the change for 7 days in the future
+    When I review and confirm my answers are correct
+    When I click to view the content block
+    And I click to edit the schedule
+    And I schedule the change for 5 days in the future
+    When I click to view the content block
+    Then I should see the scheduled date on the object
+    And there should only be one job scheduled
+
+  @disable-sidekiq-test-mode
+  Scenario: GDS Editor tries to reschedule a content object without choosing to schedule
+    When I am updating a content block
+    Then I am asked when I want to publish the change
+    And I schedule the change for 7 days in the future
+    When I review and confirm my answers are correct
+    When I click to view the content block
+    And I click to edit the schedule
+    And I save and continue
+    Then I see the error message "Schedule publishing cannot be blank"

--- a/lib/engines/content_block_manager/features/reschedule_object.feature
+++ b/lib/engines/content_block_manager/features/reschedule_object.feature
@@ -17,6 +17,7 @@ Feature: Schedule a content object
     And I click to edit the schedule
     And I choose to publish the change now
     And I save and continue
+    When I review and confirm my answers are correct
     When I click to view the content block
     Then the published state of the object should be shown
     And there should be no jobs scheduled
@@ -30,6 +31,7 @@ Feature: Schedule a content object
     When I click to view the content block
     And I click to edit the schedule
     And I schedule the change for 5 days in the future
+    When I review and confirm my answers are correct
     When I click to view the content block
     Then I should see the scheduled date on the object
     And there should only be one job scheduled

--- a/lib/engines/content_block_manager/features/schedule_object.feature
+++ b/lib/engines/content_block_manager/features/schedule_object.feature
@@ -19,57 +19,6 @@ Feature: Schedule a content object
     And I should see the scheduled event on the timeline
 
   @disable-sidekiq-test-mode
-  Scenario: GDS Editor immediately publishes a scheduled content object
-    When I am updating a content block
-    Then I am asked when I want to publish the change
-    And I schedule the change for 7 days in the future
-    When I review and confirm my answers are correct
-    When I click to view the content block
-    And I click to edit the schedule
-    And I choose to publish the change now
-    And I save and continue
-    When I click to view the content block
-    Then the published state of the object should be shown
-    And there should be no jobs scheduled
-
-  @disable-sidekiq-test-mode
-  Scenario: GDS Editor reschedules a content object
-    When I am updating a content block
-    Then I am asked when I want to publish the change
-    And I schedule the change for 7 days in the future
-    When I review and confirm my answers are correct
-    When I click to view the content block
-    And I click to edit the schedule
-    And I schedule the change for 5 days in the future
-    When I click to view the content block
-    Then I should see the scheduled date on the object
-    And there should only be one job scheduled
-
-  @disable-sidekiq-test-mode
-  Scenario: GDS Editor tries to reschedule a content object without choosing to schedule
-    When I am updating a content block
-    Then I am asked when I want to publish the change
-    And I schedule the change for 7 days in the future
-    When I review and confirm my answers are correct
-    When I click to view the content block
-    And I click to edit the schedule
-    And I save and continue
-    Then I see the error message "Schedule publishing cannot be blank"
-
-  @disable-sidekiq-test-mode
-  Scenario: GDS Editor tries to reschedule a content object with an invalid date
-    When I am updating a content block
-    Then I am asked when I want to publish the change
-    And I schedule the change for 7 days in the future
-    When I review and confirm my answers are correct
-    When I click to view the content block
-    And I click to edit the schedule
-    When I choose to schedule the change
-    And I enter an invalid date
-    And I save and continue
-    Then I see the errors informing me the date is invalid
-
-  @disable-sidekiq-test-mode
   Scenario: GDS Editor publishes a new version of a previously scheduled content object
     When I am updating a content block
     Then I am asked when I want to publish the change
@@ -80,18 +29,6 @@ Feature: Schedule a content object
     And I save and continue
     When I review and confirm my answers are correct
     Then there should be no jobs scheduled
-
-  @disable-sidekiq-test-mode
-  Scenario: GDS Editor schedules a new version of a previously scheduled content block
-    When I am updating a content block
-    Then I am asked when I want to publish the change
-    And I schedule the change for 7 days in the future
-    When I review and confirm my answers are correct
-    When I click to view the content block
-    And I click to edit the schedule
-    And I schedule the change for 5 days in the future
-    When I click to view the content block
-    Then there should only be one job scheduled
 
   Scenario: A scheduled content object is published
     When I am updating a content block


### PR DESCRIPTION
Can be merged once this approved: https://github.com/alphagov/whitehall/pull/9735 

Adds the `review` page to the rescheduling journey, with some refactoring along the way.

![Screenshot 2024-12-17 at 15 20 42](https://github.com/user-attachments/assets/cb0804da-125c-4b55-b552-1ca9ed6015ad)


---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
