### PR TITLE
Allow deletion of review reminders

### DIFF
--- a/app/controllers/admin/review_reminders_controller.rb
+++ b/app/controllers/admin/review_reminders_controller.rb
@@ -1,6 +1,6 @@
 class Admin::ReviewRemindersController < Admin::BaseController
   before_action :load_document
-  before_action :load_review_reminder, only: %i[edit update]
+  before_action :load_review_reminder, only: %i[edit update confirm_destroy destroy]
   before_action :build_review_reminder, only: %i[new create]
   before_action :enforce_permissions!
 
@@ -22,6 +22,13 @@ class Admin::ReviewRemindersController < Admin::BaseController
     else
       render :edit
     end
+  end
+
+  def confirm_destroy; end
+
+  def destroy
+    @review_reminder.destroy!
+    redirect_to admin_edition_path(@document.latest_edition), notice: "Review reminder deleted"
   end
 
 private

--- a/app/views/admin/review_reminders/_form.html.erb
+++ b/app/views/admin/review_reminders/_form.html.erb
@@ -47,6 +47,9 @@
       text: "Save",
     } %>
 
+    <% if Flipflop.delete_review_reminders? && review_reminder.persisted? %>
+      <%= link_to("Delete", confirm_destroy_admin_document_review_reminder_path(document, review_reminder), class: "govuk-link gem-link--destructive govuk-link--no-visited-state") %>
+    <% end %>
     <%= link_to("Cancel", admin_edition_path(@document.latest_edition), class: "govuk-link govuk-link--no-visited-state") %>
   </div>
 <% end %>

--- a/app/views/admin/review_reminders/confirm_destroy.html.erb
+++ b/app/views/admin/review_reminders/confirm_destroy.html.erb
@@ -1,0 +1,21 @@
+<% content_for :page_title, "Delete review reminder for #{@document.latest_edition.title}" %>
+<% content_for :title, "Delete review reminder" %>
+<% content_for :context, @document.latest_edition.title %>
+<% content_for :title_margin_bottom, 8 %>
+
+<div class="govuk-grid-row">
+  <section class="govuk-grid-column-two-thirds">
+    <%= form_tag admin_document_review_reminder_path(@document, @review_reminder), method: :delete do %>
+      <p class="govuk-body govuk-!-margin-bottom-7">Are you sure you want to delete this review reminder?</p>
+
+      <div class="govuk-button-group govuk-!-margin-bottom-6">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Delete",
+          destructive: true,
+        } %>
+
+        <%= link_to("Cancel", edit_admin_document_review_reminder_path(@document, @review_reminder), class: "govuk-link govuk-link--no-visited-state") %>
+      </div>
+    <% end %>
+  </section>
+</div>

--- a/config/features.rb
+++ b/config/features.rb
@@ -21,6 +21,7 @@ Flipflop.configure do
   # feature :world_domination,
   #   default: true,
   #   description: "Take over the world."
+  feature :delete_review_reminders, description: "Enables deletion of review reminders", default: false
   feature :govspeak_visual_editor, description: "Enables a visual editor for Govspeak fields", default: false
   feature :override_government, description: "Enables GDS Editors and Admins to override the government associated with a document", default: false
   feature :show_link_to_content_block_manager, description: "Shows link to Content Block Manager from Whitehall editor", default: Whitehall.integration_or_staging?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -77,7 +77,9 @@ Whitehall::Application.routes.draw do
       end
 
       resources :documents, only: [] do
-        resources :review_reminders, only: %i[new create edit update]
+        resources :review_reminders, only: %i[new create edit update destroy] do
+          get :confirm_destroy, on: :member
+        end
       end
 
       resources :authors, only: [:show]

--- a/features/review_reminder.feature
+++ b/features/review_reminder.feature
@@ -23,3 +23,11 @@ Feature: Review reminders
     When I click the button "Edit review date" on the edition summary page for "Standard Beard Lengths"
     And I update the review date to "2033-1-1"
     Then I should see the review date of "1 January 2033" on the edition summary page
+
+  Scenario: Deleting the review date for a published publication
+    Given a published publication "Standard Beard Lengths" with a PDF attachment
+    And The delete review reminder feature flag is "enabled"
+    And a review reminder exists for "Standard Beard Lengths" with the date "2032-1-1"
+    When I click the button "Edit review date" on the edition summary page for "Standard Beard Lengths"
+    And I delete the review date
+    Then I should not see a review date on the edition summary page

--- a/features/step_definitions/review_reminder_steps.rb
+++ b/features/step_definitions/review_reminder_steps.rb
@@ -1,3 +1,8 @@
+And(/^The delete review reminder feature flag is "(enabled|disabled)"$/) do |enabled|
+  @test_strategy ||= Flipflop::FeatureSet.current.test!
+  @test_strategy.switch!(:delete_review_reminders, enabled == "enabled")
+end
+
 And(/^I add a review date of "([^"]*)" and the email address "([^"]*)" on the edit page$/) do |date, email|
   click_link "Edit draft"
   check "Set a reminder to review this content after it has been published"
@@ -17,6 +22,11 @@ end
 Then(/^I should see the review date of "([^"]*)" on the edition summary page$/) do |date|
   assert_selector ".app-view-summary__section .govuk-summary-list__row:nth-child(5) .govuk-summary-list__key", text: "Review date"
   assert_selector ".app-view-summary__section .govuk-summary-list__row:nth-child(5) .govuk-summary-list__value", text: date
+end
+
+Then(/^I should not see a review date on the edition summary page$/) do
+  assert_selector ".app-view-summary__section .govuk-summary-list__row:nth-child(5) .govuk-summary-list__key", text: "Review date"
+  assert_selector ".app-view-summary__section .govuk-summary-list__row:nth-child(5) .govuk-summary-list__value", text: "Not set"
 end
 
 When(/^I click the button "([^"]*)" on the edition summary page for "([^"]*)"$/) do |label, title|
@@ -44,4 +54,9 @@ When(/^I filter by review overdue$/) do
   visit admin_editions_path
   check "Review overdue"
   click_on "Search"
+end
+
+And(/^I delete the review date$/) do
+  click_link "Delete"
+  click_button "Delete"
 end

--- a/test/functional/admin/review_reminders_controller_test.rb
+++ b/test/functional/admin/review_reminders_controller_test.rb
@@ -103,4 +103,22 @@ class Admin::ReviewRemindersControllerTest < ActionController::TestCase
     assert_equal assigns(:review_reminder).email_address, ""
     assert_template :edit
   end
+
+  test "GET to :confirm_destroy assigns the correct values and renders the correct template" do
+    review_reminder = create(:review_reminder, document: @document)
+
+    get :confirm_destroy, params: { document_id: @document, id: review_reminder }
+
+    assert_equal assigns(:document), @document
+    assert_equal assigns(:review_reminder), review_reminder
+    assert_template :confirm_destroy
+  end
+
+  test "DELETE to :destroy destroys the review reminder" do
+    review_reminder = create(:review_reminder, document: @document)
+
+    delete :destroy, params: { document_id: @document, id: review_reminder }
+
+    assert @document.reload.review_reminder.nil?
+  end
 end


### PR DESCRIPTION
Previously the only way to remove the review date from a document was to create a new edition and uncheck the set review date checkbox, then save the edition.

If the user publishes the new edition but neglects to remove the review reminder, they will receive another reminder even though they updated the content.

This commit makes it possible for the user to remove the reminder from the published edition without having to create another edition.

This feature has a feature flag applied so that we can merge and deploy without releasing.

## Screenshots

### Edit review reminder form (now includes delete link)
![Screenshot 2024-12-17 at 17 16 59](https://github.com/user-attachments/assets/11f0da7b-028a-4544-9d15-2c1a8de8a7c5)

### Confirm review reminder deletion
![Screenshot 2024-12-17 at 17 18 10](https://github.com/user-attachments/assets/dd67c306-8508-45bf-92dd-13de310da33a)

Trello: https://trello.com/c/qSHlTlQx
