### PR TITLE
Delete review dates

### DIFF
--- a/app/components/admin/editions/show/sidebar_actions_component.rb
+++ b/app/components/admin/editions/show/sidebar_actions_component.rb
@@ -182,6 +182,9 @@ private
         href:,
         secondary_quiet: true,
       })
+      if Flipflop.delete_review_reminders? && review_reminder.present?
+        actions << link_to("Delete review date", confirm_destroy_admin_document_review_reminder_path(@edition.document, @edition.document.review_reminder), class: "govuk-link gem-link--destructive govuk-link--no-visited-state")
+      end
     end
   end
 

--- a/app/views/admin/review_reminders/_form.html.erb
+++ b/app/views/admin/review_reminders/_form.html.erb
@@ -47,9 +47,6 @@
       text: "Save",
     } %>
 
-    <% if Flipflop.delete_review_reminders? && review_reminder.persisted? %>
-      <%= link_to("Delete", confirm_destroy_admin_document_review_reminder_path(document, review_reminder), class: "govuk-link gem-link--destructive govuk-link--no-visited-state") %>
-    <% end %>
     <%= link_to("Cancel", admin_edition_path(@document.latest_edition), class: "govuk-link govuk-link--no-visited-state") %>
   </div>
 <% end %>

--- a/app/views/admin/review_reminders/confirm_destroy.html.erb
+++ b/app/views/admin/review_reminders/confirm_destroy.html.erb
@@ -5,6 +5,7 @@
 
 <div class="govuk-grid-row">
   <section class="govuk-grid-column-two-thirds">
+    <p class="govuk-body"><span class="govuk-!-font-weight-bold">Review date:</span> <%= @review_reminder.review_at.strftime("%-d %B %Y") %></p>
     <%= form_tag admin_document_review_reminder_path(@document, @review_reminder), method: :delete do %>
       <p class="govuk-body govuk-!-margin-bottom-7">Are you sure you want to delete this review reminder?</p>
 

--- a/app/views/admin/review_reminders/confirm_destroy.html.erb
+++ b/app/views/admin/review_reminders/confirm_destroy.html.erb
@@ -14,7 +14,7 @@
           destructive: true,
         } %>
 
-        <%= link_to("Cancel", edit_admin_document_review_reminder_path(@document, @review_reminder), class: "govuk-link govuk-link--no-visited-state") %>
+        <%= link_to("Cancel", admin_edition_path(@document.latest_edition), class: "govuk-link govuk-link--no-visited-state") %>
       </div>
     <% end %>
   </section>

--- a/features/review_reminder.feature
+++ b/features/review_reminder.feature
@@ -29,5 +29,6 @@ Feature: Review reminders
     And The delete review reminder feature flag is "enabled"
     And a review reminder exists for "Standard Beard Lengths" with the date "2032-1-1"
     When I click the link "Delete review date" on the edition summary page for "Standard Beard Lengths"
-    And I delete the review date
+    Then I should see the review date of "1 January 2032" on the deletion confirmation page
+    When I delete the review date
     Then I should not see a review date on the edition summary page

--- a/features/review_reminder.feature
+++ b/features/review_reminder.feature
@@ -28,6 +28,6 @@ Feature: Review reminders
     Given a published publication "Standard Beard Lengths" with a PDF attachment
     And The delete review reminder feature flag is "enabled"
     And a review reminder exists for "Standard Beard Lengths" with the date "2032-1-1"
-    When I click the button "Edit review date" on the edition summary page for "Standard Beard Lengths"
+    When I click the link "Delete review date" on the edition summary page for "Standard Beard Lengths"
     And I delete the review date
     Then I should not see a review date on the edition summary page

--- a/features/step_definitions/review_reminder_steps.rb
+++ b/features/step_definitions/review_reminder_steps.rb
@@ -35,6 +35,12 @@ When(/^I click the button "([^"]*)" on the edition summary page for "([^"]*)"$/)
   click_on label
 end
 
+When(/^I click the link "([^"]*)" on the edition summary page for "([^"]*)"$/) do |label, title|
+  edition = Edition.find_by!(title:)
+  visit admin_edition_path(edition)
+  click_link label
+end
+
 And(/^a review reminder exists for "([^"]*)" with the date "([^"]*)"$/) do |title, date|
   edition = Edition.find_by!(title:)
   create(:review_reminder, document: edition.document, review_at: date)
@@ -57,6 +63,5 @@ When(/^I filter by review overdue$/) do
 end
 
 And(/^I delete the review date$/) do
-  click_link "Delete"
   click_button "Delete"
 end

--- a/features/step_definitions/review_reminder_steps.rb
+++ b/features/step_definitions/review_reminder_steps.rb
@@ -24,6 +24,10 @@ Then(/^I should see the review date of "([^"]*)" on the edition summary page$/) 
   assert_selector ".app-view-summary__section .govuk-summary-list__row:nth-child(5) .govuk-summary-list__value", text: date
 end
 
+Then(/^I should see the review date of "([^"]*)" on the deletion confirmation page$/) do |date|
+  assert_selector ".govuk-body", text: "Review date: #{date}"
+end
+
 Then(/^I should not see a review date on the edition summary page$/) do
   assert_selector ".app-view-summary__section .govuk-summary-list__row:nth-child(5) .govuk-summary-list__key", text: "Review date"
   assert_selector ".app-view-summary__section .govuk-summary-list__row:nth-child(5) .govuk-summary-list__value", text: "Not set"

--- a/test/components/admin/editions/show/sidebar_actions_component_test.rb
+++ b/test/components/admin/editions/show/sidebar_actions_component_test.rb
@@ -26,6 +26,23 @@ class Admin::Editions::Show::SidebarActionsComponentTest < ViewComponent::TestCa
     assert_selector "a[href='https://www.test.gov.uk/government/generic-editions/#{edition.title}']", text: "View on website (opens in new tab)"
   end
 
+  test "actions for published edition with review date" do
+    @test_strategy ||= Flipflop::FeatureSet.current.test!
+    @test_strategy.switch!(:delete_review_reminders, true)
+    current_user = build_stubbed(:user)
+    edition = create(:published_edition)
+    create(:review_reminder, :reminder_due, document: edition.document)
+    render_inline(Admin::Editions::Show::SidebarActionsComponent.new(edition:, current_user:))
+
+    assert_selector "li", count: 5
+    assert_selector "button", text: "Create new edition"
+    assert_selector "a", text: "Edit review date"
+    assert_selector "a", text: "Delete review date"
+    assert_selector "a", text: "View data about page"
+    assert_selector "a[href='https://www.test.gov.uk/government/generic-editions/#{edition.title}']", text: "View on website (opens in new tab)"
+    @test_strategy.switch!(:delete_review_reminders, false)
+  end
+
   test "actions for published edition for non-english document" do
     current_user = build_stubbed(:user)
     edition = create(:non_english_published_edition)


### PR DESCRIPTION
Two changes here based on updated designs:

1. Move delete review reminder link from the edit review reminder form on to the edition summary page. It is now located on the edition summary actions sidebar
2. Add a reminder of the review date to the deletion confirmation screen

Trello: https://trello.com/c/qSHlTlQx

## Screenshots

Delete link in sidebar
![Screenshot 2024-12-18 at 14 51 27](https://github.com/user-attachments/assets/059cba19-9c6f-4d0b-8e7a-9229b93b3615)

Review date reminder
![Screenshot 2024-12-18 at 14 18 24](https://github.com/user-attachments/assets/bea8144a-7a7f-44d9-8716-9b9dd976c50e)

