### PR TITLE
Have CompoundBlock extract subblocks

### DIFF
--- a/app/models/landing_page/block_factory.rb
+++ b/app/models/landing_page/block_factory.rb
@@ -5,16 +5,14 @@ class LandingPage::BlockFactory
 
   def self.build(block, images)
     case block.with_indifferent_access
-    in { type: "box", box_content: { blocks: } }
-      LandingPage::CompoundBlock.new(block, images, "box_content", blocks)
-    in { type: "card", card_content: { blocks: } }
-      LandingPage::CompoundBlock.new(block, images, "card_content", blocks)
-    in { type: "featured", featured_content: { blocks: } }
-      LandingPage::FeaturedBlock.new(block, images, blocks)
-    in { type: "hero", hero_content: { blocks: } }
-      LandingPage::HeroBlock.new(block, images, blocks)
+    in { type: "box" }
+      LandingPage::CompoundBlock.new(block, images, "box_content")
+    in { type: "card" }
+      LandingPage::CompoundBlock.new(block, images, "card_content")
+    in { type: "featured" }
+      LandingPage::FeaturedBlock.new(block, images)
     in { type: "hero" }
-      LandingPage::HeroBlock.new(block, images, nil)
+      LandingPage::HeroBlock.new(block, images)
     in { type: "image" }
       LandingPage::ImageBlock.new(block, images)
     in { type: String, blocks: Array }

--- a/app/models/landing_page/compound_block.rb
+++ b/app/models/landing_page/compound_block.rb
@@ -22,9 +22,10 @@ class LandingPage::CompoundBlock < LandingPage::BaseBlock
     content_blocks.each { |b| errors.merge!(b.errors) if b.invalid? }
   end
 
-  def initialize(source, images, content_block_key, content_blocks)
+  def initialize(source, images, content_block_key)
     super(source, images)
     @content_block_key = content_block_key
+    content_blocks = source.dig(content_block_key, "blocks")
     @content_blocks = LandingPage::BlockFactory.build_all(content_blocks, images)
   end
 

--- a/app/models/landing_page/featured_block.rb
+++ b/app/models/landing_page/featured_block.rb
@@ -2,8 +2,8 @@ class LandingPage::FeaturedBlock < LandingPage::CompoundBlock
   include ActiveModel::API
   include LandingPageImageBlock
 
-  def initialize(source, images, content_blocks)
-    super(source, images, "featured_content", content_blocks)
+  def initialize(source, images)
+    super(source, images, "featured_content")
 
     image_sources = @source.dig("image", "sources") || {}
     @desktop_image = find_image(image_sources["desktop"])

--- a/app/models/landing_page/hero_block.rb
+++ b/app/models/landing_page/hero_block.rb
@@ -19,8 +19,8 @@ class LandingPage::HeroBlock < LandingPage::CompoundBlock
     record.errors.add(attr, "is of the wrong image kind: #{actual_kind}") if actual_kind != expected_kind
   end
 
-  def initialize(source, images, content_blocks)
-    super(source, images, "hero_content", content_blocks)
+  def initialize(source, images)
+    super(source, images, "hero_content")
 
     image_sources = @source.dig("image", "sources") || {}
     @desktop_image = find_image(image_sources["desktop"])

--- a/test/unit/app/models/landing_page/compound_block_test.rb
+++ b/test/unit/app/models/landing_page/compound_block_test.rb
@@ -16,7 +16,6 @@ class CompoundBlockTest < ActiveSupport::TestCase
       @valid_block_config,
       EMPTY_IMAGES,
       "compound_block_content",
-      @valid_content_blocks,
     )
     assert subject.valid?
   end
@@ -26,7 +25,6 @@ class CompoundBlockTest < ActiveSupport::TestCase
       @valid_block_config,
       EMPTY_IMAGES,
       "compound_block_content",
-      @valid_content_blocks,
     )
     expected_result = {
       "type" => "some-compound-block",
@@ -39,10 +37,9 @@ class CompoundBlockTest < ActiveSupport::TestCase
 
   test "valid when missing content blocks" do
     subject = LandingPage::CompoundBlock.new(
-      @valid_block_config,
+      @valid_block_config.except("compound_block_content"),
       EMPTY_IMAGES,
       "compound_block_content",
-      nil,
     )
     assert subject.valid?
   end
@@ -52,7 +49,6 @@ class CompoundBlockTest < ActiveSupport::TestCase
       @valid_block_config.except("compound_block_content"),
       EMPTY_IMAGES,
       "compound_block_content",
-      nil,
     )
     assert_equal({ "type" => "some-compound-block" }, subject.present_for_publishing_api)
   end
@@ -60,10 +56,9 @@ class CompoundBlockTest < ActiveSupport::TestCase
   test "invalid when content blocks are invalid" do
     invalid_blocks_config = [{ "invalid" => "because I do not have a type" }]
     subject = LandingPage::CompoundBlock.new(
-      @valid_block_config,
+      @valid_block_config.merge("compound_block_content" => { "blocks" => invalid_blocks_config }),
       EMPTY_IMAGES,
       "compound_block_content",
-      invalid_blocks_config,
     )
     assert subject.invalid?
     assert_equal ["Type can't be blank"], subject.errors.to_a

--- a/test/unit/app/models/landing_page/hero_block_test.rb
+++ b/test/unit/app/models/landing_page/hero_block_test.rb
@@ -22,12 +22,12 @@ class HeroBlockTest < ActiveSupport::TestCase
   end
 
   test "valid when given correct params" do
-    subject = LandingPage::HeroBlock.new(@valid_hero_block_config, @valid_hero_block_images, @valid_hero_content_blocks)
+    subject = LandingPage::HeroBlock.new(@valid_hero_block_config, @valid_hero_block_images)
     assert subject.valid?
   end
 
   test "presents hero blocks to publishing api" do
-    subject = LandingPage::HeroBlock.new(@valid_hero_block_config, @valid_hero_block_images, @valid_hero_content_blocks)
+    subject = LandingPage::HeroBlock.new(@valid_hero_block_config, @valid_hero_block_images)
     expected_result = {
       "type" => "hero",
       "image" => {
@@ -49,7 +49,7 @@ class HeroBlockTest < ActiveSupport::TestCase
   end
 
   test "invalid when missing images" do
-    subject = LandingPage::HeroBlock.new(@valid_hero_block_config.except("image"), @valid_hero_block_images, @valid_hero_content_blocks)
+    subject = LandingPage::HeroBlock.new(@valid_hero_block_config.except("image"), @valid_hero_block_images)
     assert subject.invalid?
     assert_equal [
       "Desktop image can't be blank",
@@ -60,7 +60,7 @@ class HeroBlockTest < ActiveSupport::TestCase
 
   test "invalid when image expressions are not found" do
     no_images = []
-    subject = LandingPage::HeroBlock.new(@valid_hero_block_config, no_images, @valid_hero_content_blocks)
+    subject = LandingPage::HeroBlock.new(@valid_hero_block_config, no_images)
     assert subject.invalid?
     assert_equal [
       "Desktop image can't be blank",
@@ -70,13 +70,16 @@ class HeroBlockTest < ActiveSupport::TestCase
   end
 
   test "valid when missing hero content blocks" do
-    subject = LandingPage::HeroBlock.new(@valid_hero_block_config, @valid_hero_block_images, nil)
+    subject = LandingPage::HeroBlock.new(@valid_hero_block_config.except("hero_content"), @valid_hero_block_images)
     subject.valid?
   end
 
   test "invalid when hero content blocks are invalid" do
     invalid_blocks_config = [{ "invalid" => "because I do not have a type" }]
-    subject = LandingPage::HeroBlock.new(@valid_hero_block_config, @valid_hero_block_images, invalid_blocks_config)
+    subject = LandingPage::HeroBlock.new(
+      @valid_hero_block_config.merge("hero_content" => { "blocks" => invalid_blocks_config }),
+      @valid_hero_block_images,
+    )
     assert subject.invalid?
     assert_equal ["Type can't be blank"], subject.errors.to_a
   end


### PR DESCRIPTION
... instead of doing it with pattern matching in BlockFactory.

We want these to be optional in most cases, but putting them in the patterns means we only use the correct block type if they're present. Instead, we just use type: in the pattern, and have the blocks take care of finding their config inside source.

This cleans up the following piece of tech debt: https://trello.com/c/zfUEbZdo/224-simplify-compound-block-models-in-whitehall

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
