### PR TITLE
add phase banner for content block manager

### DIFF
--- a/lib/engines/content_block_manager/app/views/shared/_phase_banner.html.erb
+++ b/lib/engines/content_block_manager/app/views/shared/_phase_banner.html.erb
@@ -1,0 +1,13 @@
+<%= render "govuk_publishing_components/components/phase_banner", {
+    phase: "Alpha",
+    message: sanitize("This is a new service - your
+        #{
+      mail_to(
+        "govuk-publishing-content-modelling-team@digital.cabinet-office.gov.uk",
+        "feedback",
+        {
+          class: "govuk-link",
+        },
+        )
+    } will help us to improve it.", attributes: %w(class href)),
+  } %>

--- a/lib/engines/content_block_manager/features/content_block_manager.feature
+++ b/lib/engines/content_block_manager/features/content_block_manager.feature
@@ -5,3 +5,4 @@ Feature: Content block manager
     When I visit the Content Block Manager home page
     Then I should see the object store's title in the header
     And I should see the object store's navigation
+    And I should see the object store's phase banner

--- a/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
@@ -775,6 +775,11 @@ And(/^I should see the object store's navigation$/) do
   expect(page).to have_selector("a.govuk-header__link[href='#{content_block_manager.content_block_manager_root_path}']", text: "Dashboard")
 end
 
+And("I should see the object store's phase banner") do
+  expect(page).to have_selector(".govuk-tag", text: "Alpha")
+  expect(page).to have_link("feedback", href: "mailto:govuk-publishing-content-modelling-team@digital.cabinet-office.gov.uk")
+end
+
 Then(/^I should still see the live edition on the homepage$/) do
   within(".govuk-summary-card", text: @content_block.document.title) do
     @content_block.details.keys.each do |key|


### PR DESCRIPTION
https://trello.com/c/X0CBVUxT/773-allow-content-block-manager-to-have-a-phase-banner

<img width="892" alt="Screenshot 2024-12-19 at 14 16 40" src="https://github.com/user-attachments/assets/2094d016-c87b-4c64-aaf6-5ff2f0768212" />


Note: different style of tag than on Trello, but this looks like [the latest gds style ](https://design-system.service.gov.uk/components/phase-banner/)
---
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
