### PR TITLE
Hide what's new banner

### DIFF
--- a/config/locales/en/admin/whats_new.yml
+++ b/config/locales/en/admin/whats_new.yml
@@ -3,7 +3,7 @@ en:
     feedback:
       show_banner: true
     whats_new:
-      show_banner: true
+      show_banner: false
       title: What’s new in Whitehall Publisher
       summary: |
         Summary of updates from the GOV.UK publishing teams on Whitehall Publisher, the roadmap, and getting involved


### PR DESCRIPTION
## What
- Set `show_banner` to `false` for the what's new banner

## Why
- The what's new page hasn't been updated in months

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
