### PR TITLE
Create a maintenance page for Whitehall

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,7 @@ class ApplicationController < ActionController::Base
 
   before_action :set_current_user
   before_action :set_authenticated_user_header
+  before_action :check_maintenance_mode
 
   rescue_from Notifications::Client::BadRequestError, with: :notify_bad_request
 
@@ -26,6 +27,12 @@ private
   def set_authenticated_user_header
     if current_user && GdsApi::GovukHeaders.headers[:x_govuk_authenticated_user].nil?
       GdsApi::GovukHeaders.set_header(:x_govuk_authenticated_user, current_user.uid)
+    end
+  end
+
+  def check_maintenance_mode
+    if Flipflop.maintenance_mode?
+      render "admin/errors/down_for_maintenance", status: :service_unavailable
     end
   end
 

--- a/app/views/admin/errors/down_for_maintenance.html.erb
+++ b/app/views/admin/errors/down_for_maintenance.html.erb
@@ -1,0 +1,9 @@
+<% content_for :page_title, "Down for maintenance" %>
+<% content_for :title, "Down for maintenance" %>
+<% content_for :title_margin_bottom, 6 %>
+
+<div class="govuk-grid-row govuk-!-margin-bottom-0">
+  <div class="govuk-grid-column-two-thirds">
+    <p class="govuk-body">Whitehall is currently down for maintenance. We'll be back soon.</p>
+  </div>
+</div>

--- a/config/features.rb
+++ b/config/features.rb
@@ -21,6 +21,7 @@ Flipflop.configure do
   # feature :world_domination,
   #   default: true,
   #   description: "Take over the world."
+  feature :maintenance_mode, description: "Put Whitehall into maintenance mode for planned downtime", default: false
   feature :delete_review_reminders, description: "Enables deletion of review reminders", default: false
   feature :govspeak_visual_editor, description: "Enables a visual editor for Govspeak fields", default: false
   feature :override_government, description: "Enables GDS Editors and Admins to override the government associated with a document", default: false

--- a/test/functional/admin/base_controller_test.rb
+++ b/test/functional/admin/base_controller_test.rb
@@ -147,6 +147,18 @@ class Admin::BaseControllerTest < ActionController::TestCase
     assert_not_current_item("/government/admin/organisations/my-test-org/features")
   end
 
+  view_test "dashboard page is inaccessible when maintenance mode is enabled" do
+    test_strategy = Flipflop::FeatureSet.current.test!
+    test_strategy.switch!(:maintenance_mode, true)
+    login_as :gds_editor
+    @controller = Admin::DashboardController.new
+    get :index
+
+    assert_response :service_unavailable
+    assert_template "admin/errors/down_for_maintenance"
+    test_strategy.switch!(:maintenance_mode, false)
+  end
+
 private
 
   def assert_not_current_item(path)


### PR DESCRIPTION
We sometimes need periods of planned downtime when maintaining Whitehall, for example when performing long running database migrations.

This commit adds a basic maintenance page that can be toggled on and off using a feature flag

Trello: https://trello.com/c/otYKhOEa
