### PR TITLE
Remove default value for jobs url

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -9,7 +9,6 @@ class Organisation < ApplicationRecord
 
   date_attributes(:closed_at)
 
-  DEFAULT_JOBS_URL = "https://www.civilservicejobs.service.gov.uk/csr".freeze
   FEATURED_DOCUMENTS_DISPLAY_LIMIT = 6
 
   has_one :default_news_image, class_name: "FeaturedImageData", as: :featured_imageable, inverse_of: :featured_imageable
@@ -416,7 +415,7 @@ class Organisation < ApplicationRecord
   end
 
   def jobs_url
-    custom_jobs_url.presence || DEFAULT_JOBS_URL
+    custom_jobs_url.presence
   end
 
   def indexable_content

--- a/app/presenters/publishing_api/corporate_information_page_presenter.rb
+++ b/app/presenters/publishing_api/corporate_information_page_presenter.rb
@@ -153,6 +153,8 @@ module PublishingApi
       end
 
       def payload_for_jobs
+        return if organisation.jobs_url.blank?
+
         {
           title: "Jobs",
           url: organisation.jobs_url,

--- a/app/presenters/publishing_api/organisation_presenter.rb
+++ b/app/presenters/publishing_api/organisation_presenter.rb
@@ -201,10 +201,12 @@ module PublishingApi
         }
       end
 
-      cips << {
-        title: I18n.t("organisation.corporate_information.jobs"),
-        href: item.jobs_url,
-      }
+      if item.jobs_url.present?
+        cips << {
+          title: I18n.t("organisation.corporate_information.jobs"),
+          href: item.jobs_url,
+        }
+      end
 
       cips
     end

--- a/test/unit/app/models/organisation_test.rb
+++ b/test/unit/app/models/organisation_test.rb
@@ -929,12 +929,7 @@ class OrganisationTest < ActiveSupport::TestCase
     assert_equal [org_with_announcement], Organisation.with_statistics_announcements
   end
 
-  test "#jobs_url defaults to the default jobs url" do
-    organisation = build(:organisation)
-    assert_equal Organisation::DEFAULT_JOBS_URL, organisation.jobs_url
-  end
-
-  test "#jobs_url can be overridden" do
+  test "#jobs_url can be set" do
     organisation = build(:organisation, custom_jobs_url: "http://jobs.com/")
 
     assert organisation.valid?

--- a/test/unit/app/presenters/publishing_api/corporate_information_page_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/corporate_information_page_presenter_test.rb
@@ -275,10 +275,6 @@ module PublishingApi::CorporateInformationPagePresenterTest
       jobs = [
         @procurement_corporate_information_page.content_id,
         @recruitment_corporate_information_page.content_id,
-        {
-          title: "Jobs",
-          url: corporate_information_page.organisation.jobs_url,
-        },
       ]
 
       our_information = [

--- a/test/unit/app/presenters/publishing_api/organisation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/organisation_presenter_test.rb
@@ -64,12 +64,7 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
           crest: "single-identity",
         },
         foi_exempt: false,
-        ordered_corporate_information_pages: [
-          {
-            title: "Jobs",
-            href: "https://www.civilservicejobs.service.gov.uk/csr",
-          },
-        ],
+        ordered_corporate_information_pages: [],
         secondary_corporate_information_pages: "",
         ordered_featured_links: [],
         ordered_featured_documents: [],


### PR DESCRIPTION
By default organisation pages, except No 10, would have a link to civilservicejobs show up in the corporate info segment. We had a request to remove this from the DFT, as they do not publish jobs on that site. 

We have decided to make this section 'opt in', users will still be able to link to civilservicejobs by explicitly stating they want to when editing the Org's details - the 'Recruitment URL' value. This will make the 'Jobs' link reappear. 

**BEFORE** - with default jobs link
![Screenshot 2024-12-20 at 14 40 23](https://github.com/user-attachments/assets/d418db48-610e-4bbd-9875-63e147dc8bb8)

**AFTER** - no link given
![Screenshot 2024-12-20 at 13 50 30](https://github.com/user-attachments/assets/0595603e-411c-4b58-9870-7b8c42d31d62)



[Trello](https://trello.com/c/cS9RH4B6/3265-remove-default-civil-service-jobs-link-from-organisation-pages)
[Zendesk](https://govuk.zendesk.com/agent/tickets/5869890)