### PR TITLE
Convert all tables to use UTF8MB4 charset

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -1,5 +1,5 @@
 default: &default
-  encoding: utf8
+  encoding: utf8mb4
   adapter: mysql2
   prepared_statements: true
   variables:

--- a/db/data_migration/2024121711524600_convert_text_columns_to_utf8mb4.rb
+++ b/db/data_migration/2024121711524600_convert_text_columns_to_utf8mb4.rb
@@ -1,0 +1,11 @@
+# Convert all tables to utf8mb4 in order to improve support for non-English languages.
+
+connection = ActiveRecord::Base.connection
+# Disable foreign key constraints because foreign keys using strings will prevent conversion due to a charset mismatch.
+connection.execute "SET foreign_key_checks = 0;"
+connection.tables.each do |table|
+  puts "START: Converting table #{table} to utf8mb4"
+  connection.execute "ALTER TABLE `#{table}` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
+  puts "END: Converted table #{table} to utf8mb4"
+end
+connection.execute "SET foreign_key_checks = 1;"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
-  create_table "assets", charset: "utf8mb3", force: :cascade do |t|
+  create_table "assets", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.string "variant", null: false
     t.datetime "created_at", null: false
@@ -23,7 +23,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["assetable_type", "assetable_id"], name: "index_assets_on_assetable"
   end
 
-  create_table "attachment_data", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+  create_table "attachment_data", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "carrierwave_file"
     t.string "content_type"
     t.integer "file_size"
@@ -34,13 +34,13 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["replaced_by_id"], name: "index_attachment_data_on_replaced_by_id"
   end
 
-  create_table "attachment_sources", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+  create_table "attachment_sources", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "attachment_id"
     t.string "url"
     t.index ["attachment_id"], name: "index_attachment_sources_on_attachment_id"
   end
 
-  create_table "attachments", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "attachments", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.string "title"
@@ -71,34 +71,34 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["ordering"], name: "index_attachments_on_ordering"
   end
 
-  create_table "call_for_evidence_participations", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+  create_table "call_for_evidence_participations", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "edition_id"
     t.string "link_url"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.string "email"
     t.integer "call_for_evidence_response_form_id"
-    t.text "postal_address"
+    t.text "postal_address", size: :medium
     t.index ["call_for_evidence_response_form_id"], name: "index_cfes_participations_on_cfes_response_form_id"
     t.index ["edition_id"], name: "index_call_for_evidence_participations_on_edition_id"
   end
 
-  create_table "call_for_evidence_response_form_data", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+  create_table "call_for_evidence_response_form_data", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "carrierwave_file"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
   end
 
-  create_table "call_for_evidence_response_forms", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+  create_table "call_for_evidence_response_forms", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "title"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.integer "call_for_evidence_response_form_data_id"
   end
 
-  create_table "call_for_evidence_responses", charset: "utf8mb3", force: :cascade do |t|
+  create_table "call_for_evidence_responses", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "edition_id"
-    t.text "summary"
+    t.text "summary", size: :medium
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.date "published_on"
@@ -107,34 +107,34 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["edition_id"], name: "index_call_for_evidence_responses_on_edition_id"
   end
 
-  create_table "consultation_participations", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+  create_table "consultation_participations", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "edition_id"
     t.string "link_url"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.string "email"
     t.integer "consultation_response_form_id"
-    t.text "postal_address"
+    t.text "postal_address", size: :medium
     t.index ["consultation_response_form_id"], name: "index_cons_participations_on_cons_response_form_id"
     t.index ["edition_id"], name: "index_consultation_participations_on_edition_id"
   end
 
-  create_table "consultation_response_form_data", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+  create_table "consultation_response_form_data", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "carrierwave_file"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
   end
 
-  create_table "consultation_response_forms", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+  create_table "consultation_response_forms", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "title"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.integer "consultation_response_form_data_id"
   end
 
-  create_table "consultation_responses", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+  create_table "consultation_responses", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "edition_id"
-    t.text "summary"
+    t.text "summary", size: :medium
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.date "published_on"
@@ -143,7 +143,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["edition_id"], name: "index_consultation_responses_on_edition_id"
   end
 
-  create_table "contact_number_translations", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "contact_number_translations", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "contact_number_id"
     t.string "locale"
     t.datetime "created_at", precision: nil, null: false
@@ -154,7 +154,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["locale"], name: "index_contact_number_translations_on_locale"
   end
 
-  create_table "contact_numbers", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "contact_numbers", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "contact_id"
     t.string "label"
     t.string "number"
@@ -163,15 +163,15 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["contact_id"], name: "index_contact_numbers_on_contact_id"
   end
 
-  create_table "contact_translations", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "contact_translations", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "contact_id"
     t.string "locale"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.string "title"
-    t.text "comments"
+    t.text "comments", size: :medium
     t.string "recipient"
-    t.text "street_address"
+    t.text "street_address", size: :medium
     t.string "locality"
     t.string "region"
     t.string "email"
@@ -180,7 +180,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["locale"], name: "index_contact_translations_on_locale"
   end
 
-  create_table "contacts", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "contacts", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "contactable_id"
     t.string "contactable_type"
     t.string "postal_code"
@@ -191,7 +191,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["contactable_id", "contactable_type"], name: "index_contacts_on_contactable_id_and_contactable_type"
   end
 
-  create_table "content_block_documents", charset: "utf8mb3", force: :cascade do |t|
+  create_table "content_block_documents", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "content_id"
     t.string "sluggable_string"
     t.string "block_type"
@@ -205,7 +205,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["live_edition_id"], name: "index_content_block_documents_on_live_edition_id"
   end
 
-  create_table "content_block_edition_authors", charset: "utf8mb3", force: :cascade do |t|
+  create_table "content_block_edition_authors", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "edition_id", null: false
     t.datetime "created_at", precision: nil, null: false
@@ -214,7 +214,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["user_id"], name: "index_content_block_edition_authors_on_user_id"
   end
 
-  create_table "content_block_edition_organisations", charset: "utf8mb3", force: :cascade do |t|
+  create_table "content_block_edition_organisations", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "content_block_edition_id", null: false
     t.integer "organisation_id", null: false
     t.datetime "created_at", precision: nil, null: false
@@ -223,7 +223,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["organisation_id"], name: "index_content_block_edition_organisations_on_organisation_id"
   end
 
-  create_table "content_block_editions", charset: "utf8mb3", force: :cascade do |t|
+  create_table "content_block_editions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.json "details", null: false
     t.bigint "document_id", null: false
     t.datetime "created_at", precision: nil, null: false
@@ -231,7 +231,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.bigint "user_id"
     t.string "state", default: "draft", null: false
     t.datetime "scheduled_publication", precision: nil
-    t.text "instructions_to_publishers"
+    t.text "instructions_to_publishers", size: :medium
     t.string "title", default: "", null: false
     t.text "internal_change_note"
     t.text "change_note"
@@ -240,24 +240,24 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["user_id"], name: "index_content_block_editions_on_user_id"
   end
 
-  create_table "content_block_versions", charset: "utf8mb3", force: :cascade do |t|
+  create_table "content_block_versions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "item_type", null: false
     t.integer "item_id", null: false
     t.integer "event", null: false
     t.string "whodunnit"
     t.datetime "created_at", precision: nil, null: false
-    t.text "state"
+    t.text "state", size: :medium
     t.json "field_diffs"
     t.index ["item_id"], name: "index_content_block_versions_on_item_id"
     t.index ["item_type"], name: "index_content_block_versions_on_item_type"
   end
 
-  create_table "data_migration_records", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+  create_table "data_migration_records", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "version"
     t.index ["version"], name: "index_data_migration_records_on_version", unique: true
   end
 
-  create_table "document_collection_group_memberships", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "document_collection_group_memberships", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "document_id"
     t.integer "document_collection_group_id"
     t.integer "ordering"
@@ -269,26 +269,26 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["non_whitehall_link_id"], name: "index_document_collection_non_whitehall_link"
   end
 
-  create_table "document_collection_groups", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "document_collection_groups", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "document_collection_id"
     t.string "heading"
-    t.text "body"
+    t.text "body", size: :medium
     t.integer "ordering"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.index ["document_collection_id", "ordering"], name: "index_dc_groups_on_dc_id_and_ordering"
   end
 
-  create_table "document_collection_non_whitehall_links", charset: "utf8mb3", force: :cascade do |t|
+  create_table "document_collection_non_whitehall_links", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "content_id", null: false
     t.string "title", null: false
-    t.text "base_path", null: false
+    t.text "base_path", size: :medium, null: false
     t.string "publishing_app", null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
   end
 
-  create_table "documents", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "documents", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.string "slug"
@@ -303,7 +303,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["slug", "document_type"], name: "index_documents_on_slug_and_document_type", unique: true
   end
 
-  create_table "edition_authors", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+  create_table "edition_authors", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "edition_id"
     t.integer "user_id"
     t.datetime "created_at", precision: nil
@@ -312,14 +312,14 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["user_id"], name: "index_edition_authors_on_user_id"
   end
 
-  create_table "edition_dependencies", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+  create_table "edition_dependencies", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "edition_id"
     t.integer "dependable_id"
     t.string "dependable_type"
     t.index ["dependable_id", "dependable_type", "edition_id"], name: "index_edition_dependencies_on_dependable_and_edition", unique: true
   end
 
-  create_table "edition_lead_images", charset: "utf8mb3", force: :cascade do |t|
+  create_table "edition_lead_images", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "edition_id"
     t.integer "image_id"
     t.datetime "created_at", null: false
@@ -327,7 +327,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["edition_id"], name: "index_lead_image_on_edition_id", unique: true
   end
 
-  create_table "edition_organisations", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "edition_organisations", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "edition_id"
     t.integer "organisation_id"
     t.datetime "created_at", precision: nil
@@ -338,7 +338,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["organisation_id"], name: "index_edition_organisations_on_organisation_id"
   end
 
-  create_table "edition_policies", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+  create_table "edition_policies", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "edition_id"
     t.string "policy_content_id"
     t.datetime "created_at", precision: nil
@@ -347,7 +347,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["policy_content_id"], name: "index_edition_policies_on_policy_content_id"
   end
 
-  create_table "edition_relations", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "edition_relations", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "edition_id", null: false
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
@@ -356,40 +356,40 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["edition_id"], name: "index_edition_relations_on_edition_id"
   end
 
-  create_table "edition_role_appointments", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+  create_table "edition_role_appointments", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "edition_id"
     t.integer "role_appointment_id"
     t.index ["edition_id"], name: "index_edition_role_appointments_on_edition_id"
     t.index ["role_appointment_id"], name: "index_edition_role_appointments_on_role_appointment_id"
   end
 
-  create_table "edition_roles", id: false, charset: "utf8mb3", force: :cascade do |t|
+  create_table "edition_roles", id: false, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "edition_id", null: false
     t.bigint "role_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "edition_statistical_data_sets", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+  create_table "edition_statistical_data_sets", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "edition_id"
     t.integer "document_id"
     t.index ["document_id"], name: "index_edition_statistical_data_sets_on_document_id"
     t.index ["edition_id"], name: "index_edition_statistical_data_sets_on_edition_id"
   end
 
-  create_table "edition_translations", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "edition_translations", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "edition_id"
     t.string "locale"
     t.string "title"
-    t.text "summary"
-    t.text "body", size: :medium
+    t.text "summary", size: :medium
+    t.text "body", size: :long
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.index ["edition_id"], name: "index_edition_translations_on_edition_id"
     t.index ["locale"], name: "index_edition_translations_on_locale"
   end
 
-  create_table "edition_world_locations", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "edition_world_locations", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "edition_id"
     t.integer "world_location_id"
     t.datetime "created_at", precision: nil
@@ -399,7 +399,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["world_location_id"], name: "index_edition_world_locations_on_world_location_id"
   end
 
-  create_table "edition_worldwide_organisations", charset: "utf8mb3", force: :cascade do |t|
+  create_table "edition_worldwide_organisations", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "edition_id"
     t.integer "document_id"
     t.datetime "created_at", null: false
@@ -408,7 +408,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["edition_id"], name: "index_edition_worldwide_organisations_on_edition_id"
   end
 
-  create_table "editions", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "editions", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.integer "lock_version", default: 0
@@ -422,7 +422,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.datetime "first_published_at", precision: nil
     t.integer "speech_type_id"
     t.boolean "stub", default: false
-    t.text "change_note"
+    t.text "change_note", size: :medium
     t.boolean "force_published"
     t.boolean "minor_change", default: false
     t.integer "publication_type_id"
@@ -438,7 +438,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.integer "published_major_version"
     t.integer "published_minor_version"
     t.integer "operational_field_id"
-    t.text "roll_call_introduction"
+    t.text "roll_call_introduction", size: :medium
     t.integer "news_article_type_id"
     t.boolean "relevant_to_local_government", default: false
     t.string "person_override"
@@ -479,8 +479,8 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["updated_at"], name: "index_editions_on_updated_at"
   end
 
-  create_table "editorial_remarks", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
-    t.text "body"
+  create_table "editorial_remarks", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.text "body", size: :medium
     t.integer "edition_id"
     t.integer "author_id"
     t.datetime "created_at", precision: nil
@@ -489,26 +489,26 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["edition_id"], name: "index_editorial_remarks_on_edition_id"
   end
 
-  create_table "fact_check_requests", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "fact_check_requests", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "edition_id"
     t.string "key"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.string "email_address"
-    t.text "comments"
-    t.text "instructions"
+    t.text "comments", size: :medium
+    t.text "instructions", size: :medium
     t.integer "requestor_id"
     t.index ["edition_id"], name: "index_fact_check_requests_on_edition_id"
     t.index ["key"], name: "index_fact_check_requests_on_key", unique: true
     t.index ["requestor_id"], name: "index_fact_check_requests_on_requestor_id"
   end
 
-  create_table "fatality_notice_casualties", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+  create_table "fatality_notice_casualties", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "fatality_notice_id"
-    t.text "personal_details"
+    t.text "personal_details", size: :medium
   end
 
-  create_table "feature_lists", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "feature_lists", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "featurable_id"
     t.string "featurable_type"
     t.string "locale"
@@ -517,7 +517,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["featurable_id", "featurable_type", "locale"], name: "featurable_lists_unique_locale_per_featurable", unique: true
   end
 
-  create_table "featured_image_data", charset: "utf8mb3", force: :cascade do |t|
+  create_table "featured_image_data", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "carrierwave_image"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -525,9 +525,9 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.integer "featured_imageable_id"
   end
 
-  create_table "featured_link_translations", charset: "utf8mb3", force: :cascade do |t|
-    t.text "url"
-    t.text "title"
+  create_table "featured_link_translations", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.text "url", size: :medium
+    t.text "title", size: :medium
     t.string "locale", null: false
     t.integer "featured_link_id", null: false
     t.datetime "created_at", null: false
@@ -536,14 +536,14 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["locale"], name: "index_on_locale"
   end
 
-  create_table "featured_links", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+  create_table "featured_links", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "linkable_id"
     t.string "linkable_type"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
   end
 
-  create_table "features", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "features", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "document_id"
     t.integer "feature_list_id"
     t.string "alt_text"
@@ -559,14 +559,14 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["ordering"], name: "index_features_on_ordering"
   end
 
-  create_table "flipflop_features", charset: "utf8mb3", force: :cascade do |t|
+  create_table "flipflop_features", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "key", null: false
     t.boolean "enabled", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "force_publication_attempts", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+  create_table "force_publication_attempts", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "import_id"
     t.integer "total_documents"
     t.integer "successful_documents"
@@ -579,7 +579,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["import_id"], name: "index_force_publication_attempts_on_import_id"
   end
 
-  create_table "governments", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+  create_table "governments", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "slug"
     t.string "name"
     t.date "start_date"
@@ -594,16 +594,16 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["start_date"], name: "index_governments_on_start_date"
   end
 
-  create_table "govspeak_contents", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+  create_table "govspeak_contents", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "html_attachment_id"
-    t.text "body", size: :medium
+    t.text "body", size: :long
     t.boolean "manually_numbered_headings"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.index ["html_attachment_id"], name: "index_govspeak_contents_on_html_attachment_id"
   end
 
-  create_table "group_memberships", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+  create_table "group_memberships", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "group_id"
     t.integer "person_id"
     t.datetime "created_at", precision: nil
@@ -612,18 +612,18 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["person_id"], name: "index_group_memberships_on_person_id"
   end
 
-  create_table "groups", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+  create_table "groups", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "organisation_id"
     t.string "name"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.string "slug"
-    t.text "description"
+    t.text "description", size: :medium
     t.index ["organisation_id"], name: "index_groups_on_organisation_id"
     t.index ["slug"], name: "index_groups_on_slug"
   end
 
-  create_table "historical_account_roles", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "historical_account_roles", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "role_id"
     t.integer "historical_account_id"
     t.datetime "created_at", precision: nil
@@ -632,14 +632,14 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["role_id"], name: "index_historical_account_roles_on_role_id"
   end
 
-  create_table "historical_accounts", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "historical_accounts", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "person_id"
-    t.text "summary"
-    t.text "body"
+    t.text "summary", size: :medium
+    t.text "body", size: :medium
     t.string "born"
     t.string "died"
-    t.text "major_acts"
-    t.text "interesting_facts"
+    t.text "major_acts", size: :medium
+    t.text "interesting_facts", size: :medium
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.string "political_party_ids"
@@ -647,7 +647,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["person_id"], name: "index_historical_accounts_on_person_id"
   end
 
-  create_table "home_page_list_items", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "home_page_list_items", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "home_page_list_id", null: false
     t.integer "item_id", null: false
     t.string "item_type", null: false
@@ -659,7 +659,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["item_id", "item_type"], name: "index_home_page_list_items_on_item_id_and_item_type"
   end
 
-  create_table "home_page_lists", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "home_page_lists", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "owner_id", null: false
     t.string "owner_type", null: false
     t.string "name"
@@ -668,40 +668,40 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["owner_id", "owner_type", "name"], name: "index_home_page_lists_on_owner_id_and_owner_type_and_name", unique: true
   end
 
-  create_table "image_data", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "image_data", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "carrierwave_image"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.string "image_kind", default: "default", null: false
   end
 
-  create_table "images", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "images", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "image_data_id"
     t.integer "edition_id"
     t.string "alt_text"
-    t.text "caption"
+    t.text "caption", size: :medium
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.index ["edition_id"], name: "index_images_on_edition_id"
     t.index ["image_data_id"], name: "index_images_on_image_data_id"
   end
 
-  create_table "link_checker_api_report_links", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+  create_table "link_checker_api_report_links", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "link_checker_api_report_id"
-    t.text "uri", null: false
+    t.text "uri", size: :medium, null: false
     t.string "status", null: false
     t.datetime "checked", precision: nil
-    t.text "check_warnings"
-    t.text "check_errors"
+    t.text "check_warnings", size: :medium
+    t.text "check_errors", size: :medium
     t.integer "ordering", null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
-    t.text "problem_summary"
-    t.text "suggested_fix"
+    t.text "problem_summary", size: :medium
+    t.text "suggested_fix", size: :medium
     t.index ["link_checker_api_report_id"], name: "index_link_checker_api_report_id"
   end
 
-  create_table "link_checker_api_reports", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+  create_table "link_checker_api_reports", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "batch_id"
     t.string "status", null: false
     t.string "link_reportable_type"
@@ -713,7 +713,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["link_reportable_type", "link_reportable_id"], name: "index_link_checker_api_reportable"
   end
 
-  create_table "nation_inapplicabilities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "nation_inapplicabilities", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "nation_id"
     t.integer "edition_id"
     t.datetime "created_at", precision: nil
@@ -723,7 +723,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["nation_id"], name: "index_nation_inapplicabilities_on_nation_id"
   end
 
-  create_table "offsite_links", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+  create_table "offsite_links", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "title"
     t.string "summary"
     t.string "url"
@@ -735,17 +735,17 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.datetime "updated_at", precision: nil, null: false
   end
 
-  create_table "operational_fields", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+  create_table "operational_fields", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
-    t.text "description"
+    t.text "description", size: :medium
     t.string "slug"
     t.string "content_id"
     t.index ["slug"], name: "index_operational_fields_on_slug"
   end
 
-  create_table "organisation_roles", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "organisation_roles", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "organisation_id"
     t.integer "role_id"
     t.datetime "created_at", precision: nil
@@ -755,17 +755,17 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["role_id"], name: "index_organisation_roles_on_role_id"
   end
 
-  create_table "organisation_supersedings", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+  create_table "organisation_supersedings", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "superseded_organisation_id"
     t.integer "superseding_organisation_id"
     t.index ["superseded_organisation_id"], name: "index_organisation_supersedings_on_superseded_organisation_id"
   end
 
-  create_table "organisation_translations", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "organisation_translations", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "organisation_id"
     t.string "locale"
     t.string "name"
-    t.text "logo_formatted_name"
+    t.text "logo_formatted_name", size: :medium
     t.string "acronym"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
@@ -774,7 +774,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["organisation_id"], name: "index_organisation_translations_on_organisation_id"
   end
 
-  create_table "organisational_relationships", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+  create_table "organisational_relationships", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "parent_organisation_id"
     t.integer "child_organisation_id"
     t.datetime "created_at", precision: nil
@@ -783,7 +783,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["parent_organisation_id"], name: "index_organisational_relationships_on_parent_organisation_id"
   end
 
-  create_table "organisations", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "organisations", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.string "slug", null: false
@@ -805,7 +805,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.boolean "foi_exempt", default: false, null: false
     t.string "organisation_chart_url"
     t.string "govuk_closed_status"
-    t.text "custom_jobs_url"
+    t.text "custom_jobs_url", size: :medium
     t.string "content_id"
     t.string "homepage_type", default: "news"
     t.boolean "political", default: false
@@ -816,7 +816,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["slug"], name: "index_organisations_on_slug", unique: true
   end
 
-  create_table "people", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "people", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "title"
     t.string "forename"
     t.string "surname"
@@ -829,17 +829,17 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["slug"], name: "index_people_on_slug", unique: true
   end
 
-  create_table "person_translations", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "person_translations", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "person_id"
     t.string "locale"
-    t.text "biography"
+    t.text "biography", size: :medium
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.index ["locale"], name: "index_person_translations_on_locale"
     t.index ["person_id"], name: "index_person_translations_on_person_id"
   end
 
-  create_table "policy_group_dependencies", charset: "utf8mb3", force: :cascade do |t|
+  create_table "policy_group_dependencies", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "policy_group_id"
     t.string "dependable_type"
     t.bigint "dependable_id"
@@ -850,21 +850,21 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["policy_group_id"], name: "index_policy_group_dependencies_on_policy_group_id"
   end
 
-  create_table "policy_groups", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "policy_groups", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "email"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.string "name"
-    t.text "description"
-    t.text "summary"
+    t.text "description", size: :medium
+    t.text "summary", size: :medium
     t.string "slug"
     t.string "content_id", null: false
     t.index ["slug"], name: "index_policy_groups_on_slug"
   end
 
-  create_table "promotional_feature_items", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "promotional_feature_items", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "promotional_feature_id"
-    t.text "summary"
+    t.text "summary", size: :medium
     t.string "image"
     t.string "image_alt_text"
     t.string "title"
@@ -876,7 +876,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["promotional_feature_id"], name: "index_promotional_feature_items_on_promotional_feature_id"
   end
 
-  create_table "promotional_feature_links", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "promotional_feature_links", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "promotional_feature_item_id"
     t.string "url"
     t.string "text"
@@ -885,7 +885,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["promotional_feature_item_id"], name: "index_promotional_feature_links_on_promotional_feature_item_id"
   end
 
-  create_table "promotional_features", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "promotional_features", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "organisation_id"
     t.string "title"
     t.datetime "created_at", precision: nil
@@ -894,14 +894,14 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["organisation_id"], name: "index_promotional_features_on_organisation_id"
   end
 
-  create_table "recent_edition_openings", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "recent_edition_openings", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "edition_id", null: false
     t.integer "editor_id", null: false
     t.datetime "created_at", precision: nil, null: false
     t.index ["edition_id", "editor_id"], name: "index_recent_edition_openings_on_edition_id_and_editor_id", unique: true
   end
 
-  create_table "related_mainstreams", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+  create_table "related_mainstreams", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "edition_id"
     t.string "content_id"
     t.boolean "additional", default: false
@@ -910,9 +910,9 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["edition_id"], name: "index_related_mainstreams_on_edition_id"
   end
 
-  create_table "republishing_events", charset: "utf8mb3", force: :cascade do |t|
-    t.text "action", null: false
-    t.text "reason", null: false
+  create_table "republishing_events", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.text "action", size: :medium, null: false
+    t.text "reason", size: :medium, null: false
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -925,7 +925,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["user_id"], name: "index_republishing_events_on_user_id"
   end
 
-  create_table "review_reminders", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "review_reminders", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "document_id"
     t.integer "creator_id"
     t.string "email_address"
@@ -938,7 +938,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["review_at", "reminder_sent_at"], name: "index_review_reminders_on_review_at_and_reminder_sent_at"
   end
 
-  create_table "role_appointments", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "role_appointments", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "role_id"
     t.integer "person_id"
     t.datetime "created_at", precision: nil
@@ -952,11 +952,11 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["role_id"], name: "index_role_appointments_on_role_id"
   end
 
-  create_table "role_translations", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "role_translations", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "role_id"
     t.string "locale"
     t.string "name"
-    t.text "responsibilities"
+    t.text "responsibilities", size: :medium
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.index ["locale"], name: "index_role_translations_on_locale"
@@ -964,7 +964,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["role_id"], name: "index_role_translations_on_role_id"
   end
 
-  create_table "roles", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "roles", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.string "type", null: false
@@ -984,18 +984,18 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["supports_historical_accounts"], name: "index_roles_on_supports_historical_accounts"
   end
 
-  create_table "sitewide_settings", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+  create_table "sitewide_settings", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "key"
-    t.text "description"
+    t.text "description", size: :medium
     t.boolean "on"
-    t.text "govspeak"
+    t.text "govspeak", size: :medium
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
   end
 
-  create_table "social_media_account_translations", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
-    t.text "url"
-    t.text "title"
+  create_table "social_media_account_translations", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+    t.text "url", size: :medium
+    t.text "title", size: :medium
     t.string "locale", null: false
     t.integer "social_media_account_id", null: false
     t.datetime "created_at", null: false
@@ -1004,7 +1004,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["social_media_account_id"], name: "index_on_social_media_account"
   end
 
-  create_table "social_media_accounts", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "social_media_accounts", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "socialable_id"
     t.integer "social_media_service_id"
     t.datetime "created_at", precision: nil
@@ -1015,18 +1015,18 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["socialable_id"], name: "index_social_media_accounts_on_organisation_id"
   end
 
-  create_table "social_media_services", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "social_media_services", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
   end
 
-  create_table "statistics_announcement_dates", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+  create_table "statistics_announcement_dates", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "statistics_announcement_id"
     t.datetime "release_date", precision: nil
     t.integer "precision"
     t.boolean "confirmed"
-    t.text "change_note"
+    t.text "change_note", size: :medium
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.integer "creator_id"
@@ -1034,7 +1034,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["statistics_announcement_id", "created_at"], name: "statistics_announcement_release_date"
   end
 
-  create_table "statistics_announcement_organisations", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+  create_table "statistics_announcement_organisations", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "statistics_announcement_id"
     t.integer "organisation_id"
     t.datetime "created_at", precision: nil, null: false
@@ -1043,7 +1043,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["statistics_announcement_id", "organisation_id"], name: "index_on_statistics_announcement_id_and_organisation_id"
   end
 
-  create_table "statistics_announcement_topics", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+  create_table "statistics_announcement_topics", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "statistics_announcement_id"
     t.integer "topic_id"
     t.datetime "created_at", precision: nil, null: false
@@ -1052,17 +1052,17 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["topic_id"], name: "index_statistics_announcement_topics_on_topic_id"
   end
 
-  create_table "statistics_announcements", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+  create_table "statistics_announcements", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "title"
     t.string "slug"
-    t.text "summary"
+    t.text "summary", size: :medium
     t.integer "publication_type_id"
     t.integer "topic_id"
     t.integer "creator_id"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.integer "publication_id"
-    t.text "cancellation_reason"
+    t.text "cancellation_reason", size: :medium
     t.datetime "cancelled_at", precision: nil
     t.integer "cancelled_by_id"
     t.string "publishing_state", default: "published", null: false
@@ -1078,11 +1078,11 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["topic_id"], name: "index_statistics_announcements_on_topic_id"
   end
 
-  create_table "take_part_pages", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "take_part_pages", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "title", null: false
     t.string "slug", null: false
     t.string "summary", null: false
-    t.text "body", size: :medium, null: false
+    t.text "body", size: :long, null: false
     t.string "image_alt_text"
     t.integer "ordering", null: false
     t.datetime "created_at", precision: nil
@@ -1092,24 +1092,24 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["slug"], name: "index_take_part_pages_on_slug", unique: true
   end
 
-  create_table "topical_event_about_pages", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "topical_event_about_pages", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "topical_event_id"
     t.string "name"
-    t.text "summary"
-    t.text "body"
+    t.text "summary", size: :medium
+    t.text "body", size: :medium
     t.string "read_more_link_text"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.string "content_id"
   end
 
-  create_table "topical_event_featuring_image_data", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+  create_table "topical_event_featuring_image_data", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "carrierwave_image"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
   end
 
-  create_table "topical_event_featurings", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+  create_table "topical_event_featurings", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "edition_id"
     t.integer "topical_event_id"
     t.datetime "created_at", precision: nil
@@ -1124,7 +1124,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["topical_event_id"], name: "index_topical_event_feat_on_topical_event_id"
   end
 
-  create_table "topical_event_memberships", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "topical_event_memberships", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "topical_event_id"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
@@ -1134,7 +1134,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["topical_event_id"], name: "index_topical_event_memberships_on_topical_event_id"
   end
 
-  create_table "topical_event_organisations", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "topical_event_organisations", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "organisation_id", null: false
     t.integer "topical_event_id", null: false
     t.datetime "created_at", precision: nil
@@ -1147,26 +1147,26 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["topical_event_id"], name: "index_topical_event_org_on_topical_event_id"
   end
 
-  create_table "topical_events", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "topical_events", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
-    t.text "description"
+    t.text "description", size: :medium
     t.string "slug"
     t.string "state"
     t.string "logo_alt_text"
     t.date "start_date"
     t.date "end_date"
     t.string "content_id"
-    t.text "summary"
+    t.text "summary", size: :medium
     t.index ["slug"], name: "index_topical_events_on_slug"
   end
 
-  create_table "unpublishings", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "unpublishings", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "edition_id"
     t.integer "unpublishing_reason_id"
-    t.text "explanation"
-    t.text "alternative_url"
+    t.text "explanation", size: :medium
+    t.text "alternative_url", size: :medium
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.string "document_type"
@@ -1178,20 +1178,20 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["unpublishing_reason_id"], name: "index_unpublishings_on_unpublishing_reason_id"
   end
 
-  create_table "user_world_locations", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "user_world_locations", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.integer "world_location_id"
     t.index ["user_id", "world_location_id"], name: "index_user_world_locations_on_user_id_and_world_location_id", unique: true
   end
 
-  create_table "users", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "users", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.string "email"
     t.string "uid"
     t.integer "version"
-    t.text "permissions"
+    t.text "permissions", size: :medium
     t.boolean "remotely_signed_out", default: false
     t.string "organisation_slug"
     t.boolean "disabled", default: false
@@ -1199,25 +1199,25 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["organisation_slug"], name: "index_users_on_organisation_slug"
   end
 
-  create_table "versions", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "versions", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "item_type", null: false
     t.integer "item_id", null: false
     t.string "event", null: false
     t.string "whodunnit"
-    t.text "object"
+    t.text "object", size: :medium
     t.datetime "created_at", precision: nil
-    t.text "state"
+    t.text "state", size: :medium
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
-  create_table "world_location_news", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "world_location_news", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "world_location_id"
     t.string "content_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "world_location_news_translations", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+  create_table "world_location_news_translations", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "world_location_news_id"
     t.string "locale"
     t.string "title"
@@ -1226,7 +1226,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "world_location_translations", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "world_location_translations", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "world_location_id"
     t.string "locale"
     t.string "name"
@@ -1236,7 +1236,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["world_location_id"], name: "index_world_location_translations_on_world_location_id"
   end
 
-  create_table "world_locations", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "world_locations", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.string "slug"
@@ -1250,38 +1250,38 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["world_location_type"], name: "index_world_locations_on_world_location_type"
   end
 
-  create_table "worldwide_office_worldwide_services", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+  create_table "worldwide_office_worldwide_services", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "worldwide_office_id", null: false
     t.integer "worldwide_service_id", null: false
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
   end
 
-  create_table "worldwide_offices", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+  create_table "worldwide_offices", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.integer "worldwide_office_type_id", null: false
     t.string "slug"
-    t.text "access_and_opening_times"
+    t.text "access_and_opening_times", size: :medium
     t.string "content_id"
     t.integer "edition_id"
     t.index ["edition_id"], name: "index_worldwide_offices_on_edition_id"
     t.index ["slug"], name: "index_worldwide_offices_on_slug"
   end
 
-  create_table "worldwide_organisation_page_translations", charset: "utf8mb3", force: :cascade do |t|
+  create_table "worldwide_organisation_page_translations", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.bigint "worldwide_organisation_page_id", null: false
     t.string "locale", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "title"
-    t.text "summary"
-    t.text "body"
+    t.text "summary", size: :medium
+    t.text "body", size: :medium
     t.index ["locale"], name: "index_worldwide_organisation_page_translations_on_locale"
     t.index ["worldwide_organisation_page_id"], name: "index_bbd0fc4436b2d97c8b36796e9089468751fc0f2e"
   end
 
-  create_table "worldwide_organisation_pages", charset: "utf8mb3", force: :cascade do |t|
+  create_table "worldwide_organisation_pages", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.integer "corporate_information_page_type_id", null: false
     t.integer "edition_id", null: false
     t.datetime "created_at", null: false
@@ -1290,7 +1290,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_29_095918) do
     t.index ["edition_id"], name: "index_worldwide_organisation_pages_on_edition_id"
   end
 
-  create_table "worldwide_services", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+  create_table "worldwide_services", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", default: "", null: false
     t.integer "service_type_id", null: false
     t.datetime "created_at", precision: nil


### PR DESCRIPTION
We have seen an increasing number of errors recently relating to publishers attempting to use 4 byte characters in Whitehall. This commit adds a data migration which will convert all of the tables to use the UTF8MB4 charset. This uses a data migration because it is not subject to the 15 minute limit for schema migrations applied in the kubernetes configuration.

The migration will need to be run out of hours as the tables will need to be locked during conversion.

Trello: https://trello.com/c/aTlLraLX
