### PR TITLE
Add a new rake task to redirect some old unpublished statistics announcements

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -146,6 +146,42 @@ namespace :publishing_api do
     end
   end
 
+  desc "Manually redirect already unpublished Statistics Announcements"
+  # Statistics Announcements are not the same as other documents - once unpublished, they disappear for the user,
+  # meaning users are unable to set different redirects or reasons for the removed statistics announcement
+  task :redirect_unpublished_statistics_announcement, %i[slug alternative_url locale] => :environment do |_, args|
+    args.with_defaults(locale: "en")
+
+    results = StatisticsAnnouncement.unscoped.where(slug: args[:slug])
+    if results.empty?
+      puts "Could not find Statistics Announcement with slug #{args[:slug]}"
+      next
+    end
+    if results.count > 1
+      puts "More than one Statistics Announcement (including Unpublished) with slug #{args[:slug]}"
+      next
+    end
+    if results.first.publishing_state != "unpublished"
+      puts "Statistics Announcement with slug #{args[:slug]} is not unpublished"
+      next
+    end
+
+    puts "Updating redirect URL..."
+    statistics_announcement = results.first
+    statistics_announcement.redirect_url = args[:alternative_url].strip
+    statistics_announcement.save!
+
+    puts "Unpublishing from Publishing API..."
+    response = Services.publishing_api.unpublish(
+      statistics_announcement.content_id,
+      type: "redirect",
+      locale: args[:locale],
+      alternative_path: statistics_announcement.redirect_url,
+    )
+
+    puts response
+  end
+
   namespace :redirect_html_attachments do
     desc "Redirect HTML Attachments to a given URL (dry run)"
     task :by_content_id_dry_run, %i[content_id destination] => :environment do |_, args|

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -145,7 +145,7 @@ namespace :publishing_api do
         alternative_path: args[:alternative_path].strip,
       )
 
-      puts response
+      puts response.inspect
     end
   end
 
@@ -182,7 +182,7 @@ namespace :publishing_api do
       alternative_path: statistics_announcement.redirect_url,
     )
 
-    puts response
+    puts response.inspect
   end
 
   namespace :redirect_html_attachments do

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -133,7 +133,10 @@ namespace :publishing_api do
       args.with_defaults(locale: "en")
 
       document = Document.find_by(content_id: args[:content_id])
-      abort "Document with this content ID exists: #{document}" if document
+      if document
+        puts "Document with this content ID exists: #{document}"
+        next
+      end
 
       response = Services.publishing_api.unpublish(
         args[:content_id],

--- a/test/unit/lib/tasks/publishing_api_test.rb
+++ b/test/unit/lib/tasks/publishing_api_test.rb
@@ -142,6 +142,62 @@ class PublishingApiRake < ActiveSupport::TestCase
     end
   end
 
+  describe "redirect_unpublished_statistics_announcement" do
+    let(:task) { Rake::Task["publishing_api:redirect_unpublished_statistics_announcement"] }
+
+    test "does not redirect when there is no statistics announcement found" do
+      request = stub_any_publishing_api_unpublish
+
+      out, _err = capture_io { task.invoke("unknown-slug", "https://www.test.gov.uk/government/new") }
+
+      assert_not_requested request
+      assert_equal "Could not find Statistics Announcement with slug unknown-slug", out.strip
+    end
+
+    test "does not redirect when there are multiple statistics announcement found" do
+      sa1 = create(:unpublished_statistics_announcement, slug: "same-slug", redirect_url: "https://www.test.gov.uk/government/old")
+      sa2 = create(:unpublished_statistics_announcement, slug: "same-slug", redirect_url: "https://www.test.gov.uk/government/old")
+      request = stub_any_publishing_api_unpublish
+
+      out, _err = capture_io { task.invoke("same-slug", "https://www.test.gov.uk/government/new") }
+
+      assert_not_requested request
+      assert_equal "More than one Statistics Announcement (including Unpublished) with slug same-slug", out.strip
+      assert_equal sa1.reload.redirect_url, "https://www.test.gov.uk/government/old"
+      assert_equal sa2.reload.redirect_url, "https://www.test.gov.uk/government/old"
+    end
+
+    test "does not redirect when statistics announcement is not unpublished" do
+      statistics_announcement = create(:statistics_announcement, redirect_url: "https://www.test.gov.uk/government/old")
+      request = stub_any_publishing_api_unpublish
+
+      out, _err = capture_io { task.invoke(statistics_announcement.slug, "https://www.test.gov.uk/government/new") }
+
+      assert_not_requested request
+      assert_equal "Statistics Announcement with slug #{statistics_announcement.slug} is not unpublished", out.strip
+      assert_equal statistics_announcement.reload.redirect_url, "https://www.test.gov.uk/government/old"
+    end
+
+    test "redirects statistics announcement and updates the redirect_url" do
+      statistics_announcement = create(:unpublished_statistics_announcement, redirect_url: "https://www.test.gov.uk/government/old")
+
+      request = stub_publishing_api_unpublish(
+        statistics_announcement.content_id,
+        body: {
+          type: "redirect",
+          locale: "en",
+          alternative_path: "https://www.test.gov.uk/government/new",
+        },
+      )
+
+      out, _err = capture_io { task.invoke(statistics_announcement.slug, "https://www.test.gov.uk/government/new") }
+
+      assert_requested request
+      assert_includes out, "Unpublishing from Publishing API..."
+      assert_equal statistics_announcement.reload.redirect_url, "https://www.test.gov.uk/government/new"
+    end
+  end
+
   describe "redirect_html_attachments" do
     describe "#by_content_id" do
       let(:task) { Rake::Task["publishing_api:redirect_html_attachments:by_content_id"] }


### PR DESCRIPTION
Unfortunately Statistics Announcements behave differently to other Document Types.

Also changed aborts to next within this rake task file. The assertions within tests are skipped if abort is run in the rake task.

https://trello.com/c/VNP40fAr/3276-superseded-by-another-page-unpublish-content-request

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
