### PR TITLE
Allow bulk republishing of World Locations

### DIFF
--- a/app/helpers/admin/republishing_helper.rb
+++ b/app/helpers/admin/republishing_helper.rb
@@ -162,6 +162,7 @@ module Admin::RepublishingHelper
       TakePartPage
       TopicalEvent
       TopicalEventAboutPage
+      WorldLocation
       WorldLocationNews
     ]
   end

--- a/app/models/world_location.rb
+++ b/app/models/world_location.rb
@@ -42,6 +42,8 @@ class WorldLocation < ApplicationRecord
 
   scope :ordered_by_name, -> { with_translations(I18n.default_locale).order("world_location_translations.name") }
 
+  include PublishesToPublishingApi
+
   def self.active
     where(active: true)
   end

--- a/app/presenters/publishing_api/world_location_presenter.rb
+++ b/app/presenters/publishing_api/world_location_presenter.rb
@@ -22,6 +22,8 @@ module PublishingApi
         document_type: item.class.name.underscore,
         public_updated_at: item.updated_at,
         schema_name: "world_location",
+        base_path: nil,
+        rendering_app: nil,
       )
       if item.international_delegation?
         content.merge!(PayloadBuilder::PolymorphicPath.for(item))

--- a/test/unit/app/presenters/publishing_api/world_location_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/world_location_presenter_test.rb
@@ -20,6 +20,8 @@ class PublishingApi::WorldLocationPresenterTest < ActiveSupport::TestCase
       details: {},
       analytics_identifier: "WL123",
       update_type: "major",
+      base_path: nil,
+      rendering_app: nil,
     }
     expected_links = {}
 


### PR DESCRIPTION
World Locations are not rendered on GOV.UK so do not have a rendering app or base path.

However, when first presented to Publishing API, they were rendered by Whitehall Frontend and had a base path.
    
In 865661ef5f7df596b590126cc9cb1069d0d39349, the name of the rendering app was removed from the presenter, but as no replacement value was provided (i.e. nil) we retained the value of Whitehall Frontend in Publishing API.
    
In 1166bb92d545e658bc1e893a44973d545e6b2e26, we removed the `PublisesToPublishingApi` from World Locations to stop them conflicting with World Location News which shared the same base path. This meant the World Locations could never be republished again.
    
Recently all published editions with a rendering app of Whitehall Frontend [were deleted](https://github.com/alphagov/publishing-api/pull/3025) from Publishing API, meaning the World Locations were also deleted.  We therefore need to republish all World Locations again.
    
Therefore adding a nil value to the rendering app, so they can be republished to Publishing API and the legacy Whitehall Frontend value overwritten, and adding a nil value to the base path so they do not conflict with the World Location News documents. Finally, reintroducing `PublishesToPublishingApi` so the world locations can be republished through the republishing user interface.

Depends on https://github.com/alphagov/publishing-api/pull/3061.

[Trello card](https://trello.com/c/6jD9m6Sl)