### PR TITLE
Pin test workflows to run on Ubuntu 22.04

### DIFF
--- a/.github/workflows/cucumber.yml
+++ b/.github/workflows/cucumber.yml
@@ -4,7 +4,7 @@ on: workflow_call
 
 jobs:
   feature-test-matrix:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/minitest.yml
+++ b/.github/workflows/minitest.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   minitest-matrix:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Running these workflows on Ubuntu 24.04 caused test failures because the test couldn't load fixture files from the filesystem correctly.

It is unclear why this is, but I'm pinning the version to Ubuntu 22.04 for now until we can understand and fix the issue so that deployments are possible again.
