### PR TITLE
Add title to Content Block Editions, stage 1

### DIFF
--- a/db/migrate/20250106111536_add_title_to_content_block_editions.rb
+++ b/db/migrate/20250106111536_add_title_to_content_block_editions.rb
@@ -1,0 +1,13 @@
+class AddTitleToContentBlockEditions < ActiveRecord::Migration[7.1]
+  def up
+    change_table :content_block_editions, bulk: true do |t|
+      t.string "title", default: "", null: false
+    end
+  end
+
+  def down
+    change_table :content_block_editions, bulk: true do |t|
+      t.remove :title
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_12_20_143730) do
+ActiveRecord::Schema[7.1].define(version: 2025_01_06_111536) do
   create_table "assets", charset: "utf8mb3", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.string "variant", null: false
@@ -232,6 +232,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_12_20_143730) do
     t.string "state", default: "draft", null: false
     t.datetime "scheduled_publication", precision: nil
     t.text "instructions_to_publishers"
+    t.string "title", default: "", null: false
     t.index ["document_id"], name: "index_content_block_editions_on_document_id"
     t.index ["user_id"], name: "index_content_block_editions_on_user_id"
   end

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/show/confirm_summary_list_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/show/confirm_summary_list_component.rb
@@ -28,7 +28,7 @@ private
   def title_item
     {
       field: "Title",
-      value: content_block_edition.title,
+      value: content_block_edition.document_title,
     }
   end
 

--- a/lib/engines/content_block_manager/app/models/content_block_manager/content_block/edition.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/content_block/edition.rb
@@ -22,7 +22,7 @@ module ContentBlockManager
         ContentBlockTools::ContentBlock.new(
           document_type: "content_block_#{block_type}",
           content_id: document.content_id,
-          title:,
+          title: document_title,
           details:,
         ).render
       end

--- a/lib/engines/content_block_manager/app/models/content_block_manager/content_block/edition/documentable.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/content_block/edition/documentable.rb
@@ -11,8 +11,8 @@ module ContentBlockManager
       accepts_nested_attributes_for :document
     end
 
-    def title
-      document&.title || @title
+    def document_title
+      document&.title || @document_title
     end
 
     def block_type
@@ -24,7 +24,7 @@ module ContentBlockManager
         self.document = ContentBlock::Document.new(
           content_id: create_random_id,
           block_type: @block_type,
-          title: @title,
+          title: @document_title,
         )
       elsif document.new_record?
         document.content_id = create_random_id if document.content_id.blank?

--- a/lib/engines/content_block_manager/app/services/content_block_manager/create_edition_service.rb
+++ b/lib/engines/content_block_manager/app/services/content_block_manager/create_edition_service.rb
@@ -5,6 +5,7 @@ module ContentBlockManager
     end
 
     def call(edition_params, document_id: nil)
+      edition_params[:title] = edition_params[:document_attributes][:title]
       @new_edition = build_edition(edition_params, document_id)
       @new_edition.assign_attributes(edition_params)
       @new_edition.save!
@@ -17,6 +18,7 @@ module ContentBlockManager
       if document_id.nil?
         ContentBlockManager::ContentBlock::Edition.new(edition_params)
       else
+        # TODO: is this covered when adding title?
         ContentBlockManager::ContentBlock::Edition.new(
           document_id:,
           document_attributes: edition_params.delete(:document_attributes).except(:block_type).merge({ id: document_id }),

--- a/lib/engines/content_block_manager/app/services/content_block_manager/publish_edition_service.rb
+++ b/lib/engines/content_block_manager/app/services/content_block_manager/publish_edition_service.rb
@@ -20,7 +20,7 @@ module ContentBlockManager
         content_id:,
         content_id_alias:,
         schema_id: schema.id,
-        title: content_block_edition.title,
+        title: content_block_edition.document_title,
         details: content_block_edition.details,
         instructions_to_publishers: content_block_edition.instructions_to_publishers,
         links: {

--- a/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
@@ -143,7 +143,7 @@ Then("the edition should have been created successfully") do
   assert_not_nil edition
   assert_not_nil edition.document
 
-  assert_equal @title, edition.title if @title.present?
+  assert_equal @title, edition.document_title if @title.present?
   assert_equal @instructions_to_publishers, edition.instructions_to_publishers if @instructions_to_publishers.present?
 
   @details.keys.each do |k|

--- a/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
@@ -144,6 +144,7 @@ Then("the edition should have been created successfully") do
   assert_not_nil edition.document
 
   assert_equal @title, edition.document_title if @title.present?
+  assert_equal @title, edition.title if @title.present?
   assert_equal @instructions_to_publishers, edition.instructions_to_publishers if @instructions_to_publishers.present?
 
   @details.keys.each do |k|
@@ -386,6 +387,10 @@ Then("the edition should have been updated successfully") do
     "Ministry of Example",
     "new context information",
   )
+
+  # TODO: this can be removed once the summary list is referring to the Edition's title, not the Document title
+  edition = ContentBlockManager::ContentBlock::Edition.all.last
+  assert_equal "Changed title", edition.title
 end
 
 def should_show_summary_card_for_email_address_content_block(document_title, email_address)

--- a/lib/engines/content_block_manager/test/components/content_block/document/index/summary_card_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/document/index/summary_card_component_test.rb
@@ -24,7 +24,7 @@ class ContentBlockManager::ContentBlock::Document::Index::SummaryCardComponentTe
   it "renders a published content block as a summary card" do
     render_inline(ContentBlockManager::ContentBlock::Document::Index::SummaryCardComponent.new(content_block_document:))
 
-    assert_selector ".govuk-summary-card__title", text: content_block_edition.title
+    assert_selector ".govuk-summary-card__title", text: content_block_edition.document_title
     assert_selector ".govuk-summary-card__action", count: 1
     assert_selector ".govuk-summary-card__action .govuk-link[href='#{content_block_manager_content_block_document_path(content_block_document)}']"
 
@@ -33,7 +33,7 @@ class ContentBlockManager::ContentBlock::Document::Index::SummaryCardComponentTe
     assert_selector ".govuk-summary-list__row", count: 6
 
     assert_selector ".govuk-summary-list__key", text: "Title"
-    assert_selector ".govuk-summary-list__value", text: content_block_edition.title
+    assert_selector ".govuk-summary-list__value", text: content_block_edition.document_title
 
     assert_selector ".govuk-summary-list__key", text: "Foo"
     assert_selector ".govuk-summary-list__value", text: "bar"

--- a/lib/engines/content_block_manager/test/unit/app/models/content_block_edition_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/models/content_block_edition_test.rb
@@ -53,7 +53,7 @@ class ContentBlockManager::ContentBlockEditionTest < ActiveSupport::TestCase
     content_block_edition.reload
     document = content_block_edition.document
 
-    assert_equal document.title, content_block_edition.title
+    assert_equal document.title, content_block_edition.document_title
   end
 
   it "creates a document" do

--- a/lib/engines/content_block_manager/test/unit/app/services/create_edition_service_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/services/create_edition_service_test.rb
@@ -50,6 +50,7 @@ class ContentBlockManager::CreateEditionServiceTest < ActiveSupport::TestCase
       new_edition = new_document.editions.first
 
       assert_equal new_title, new_document.title
+      assert_equal new_title, new_edition.title
       assert_equal edition_params[:document_attributes][:block_type], new_document.block_type
       assert_equal edition_params[:details], new_edition.details
       assert_equal new_edition.document_id, new_document.id
@@ -70,6 +71,7 @@ class ContentBlockManager::CreateEditionServiceTest < ActiveSupport::TestCase
         new_edition = document.editions.last
 
         assert_equal new_title, document.title
+        assert_equal new_title, new_edition.title
         assert_equal edition_params[:details], new_edition.details
         assert_equal new_edition.document_id, document.id
         assert_equal new_edition.lead_organisation.id, organisation.id

--- a/lib/tasks/content_block_manager/move_titles_from_documents_to_editions.rake
+++ b/lib/tasks/content_block_manager/move_titles_from_documents_to_editions.rake
@@ -1,0 +1,32 @@
+desc "Moves the title from Content Block Documents to any Editions that do not have titles."
+task :move_titles_from_documents_to_editions, %i[confirmation_string] => :environment do |_, args|
+  document_count = 0
+  edition_count = 0
+  confirmation_string = args[:confirmation_string]
+  is_real = confirmation_string == "run_for_real"
+
+  ContentBlockManager::ContentBlock::Document.find_each do |document|
+    document_count += 1
+
+    document.editions.each do |edition|
+      document = edition.document
+      if edition.title.blank?
+        if is_real
+          edition.update!(title: document.title)
+        else
+          edition.assign_attributes(title: document.title)
+        end
+        edition_count += 1
+        puts "Edition title set to #{edition.title} for Edition #{edition.id}"
+      else
+        puts "Skipping Edition #{edition.id} because title already set"
+      end
+    end
+  end
+
+  if is_real
+    puts "Titles were changed from #{document_count} documents to #{edition_count} editions."
+  else
+    puts "This was a dry run. Titles would have been changed from #{document_count} documents to #{edition_count} editions."
+  end
+end

--- a/test/unit/lib/tasks/content_block_manager/move_titles_from_documents_to_editions_test.rb
+++ b/test/unit/lib/tasks/content_block_manager/move_titles_from_documents_to_editions_test.rb
@@ -1,0 +1,69 @@
+require "test_helper"
+require "rake"
+
+class MoveTitlesFromDocumentsToEditionsRake < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
+  teardown { task.reenable }
+
+  describe "#move_title_from_documents_to_editions" do
+    let(:task) { Rake::Task["move_titles_from_documents_to_editions"] }
+    let(:documents) { create_list(:content_block_document, 3, :email_address) }
+    let(:schemas) { build_list(:content_block_schema, 1, block_type: "email_address", body: { "properties" => {} }) }
+
+    def log_output
+      log_output = ""
+      documents.each do |document|
+        log_output += document.editions.collect { |edition|
+          "Edition title set to #{edition.document.title} for Edition #{edition.id}"
+        }.join("\\n")
+        log_output += "\\n"
+      end
+      log_output
+    end
+
+    before do
+      documents.each_with_index do |document, index|
+        document.update!(title: "document_title_#{index}")
+        create(:content_block_edition, document:)
+        create(:content_block_edition, document:)
+      end
+
+      ContentBlockManager::ContentBlock::Schema.stubs(:all).returns(schemas)
+    end
+
+    describe "default dry run feature" do
+      let(:dry_run_output) do
+        "This was a dry run. Titles would have been changed from 3 documents to 6 editions."
+      end
+
+      it "logs an ouput for the title changes that would be made" do
+        assert_output(/#{log_output}#{dry_run_output}/) { task.invoke("dry_run") }
+      end
+    end
+
+    describe "running for real" do
+      let(:confirmation_output) do
+        "Titles were changed from 3 documents to 6 editions."
+      end
+
+      it "updates edition titles to their document titles" do
+        assert_output(/#{log_output}#{confirmation_output}/) { task.invoke("run_for_real") }
+        ContentBlockManager::ContentBlock::Edition.find_each do |edition|
+          assert_equal edition.document.title, edition.title
+        end
+      end
+    end
+
+    describe "when title is already set" do
+      it "skips editions with titles" do
+        edition_with_title = create(:content_block_edition, document: documents.first)
+        edition_with_title.update!(title: "set title")
+        skipped_output = "Skipping Edition #{edition_with_title.id} because title already set"
+
+        assert_output(/#{skipped_output}/) { task.invoke("run_for_real") }
+        assert_equal "set title", edition_with_title.title
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/kGVJtSCJ/777-bug-block-title-is-saved-even-when-edit-form-is-abandoned 

We want to move a Content Block's `title` field from the `Document` to the `Edition` model - this is because the title should be versionable, as it can change with each update of a block. Having it belong to the Document is causing the bug described in Trello, and we lose the audit history of the title over a block's lifetime. 

To do this without affecting live data I'm suggesting three steps:

### step 1
PR1 (this PR):

* Add a `title` field to CB Editions table - not nullable, but default to an empty string?

* Temporarily rename the existing Edition `title` method to `document_title` so we can keep referring to it while the db gets populated.

* Rake task to populate Editions with string from their Document `title`

* When Edition is created via UI, ensure the Edition `title` is updated as well as document one.

### step 2

Run the rake task, which will mean all old Editions have a populated `title` field with whatever the current Document `title` is.  
NOTE: this will mean old Editions might have a 'wrong' title on them, e.g. they may have been saved originally with a different title, I don't think this matters at this point, as we have no way of knowing what the original title was? And we are not yet using the tool properly in production.

### step 3

PR2:

* Point Document’s `title` method to latest Edition

* Remove `title` column from Documents table

* Remove `title` from Document attributes setting in Create service



---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
