### PR TITLE
(782) Pull user details from Signon

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -248,7 +248,7 @@ GEM
       et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
     fuzzy_match (2.1.0)
-    gds-api-adapters (98.1.0)
+    gds-api-adapters (98.2.0)
       addressable
       link_header
       null_logger

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/host_editions_table_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/host_editions_table_component.rb
@@ -71,15 +71,6 @@ private
     helpers.content_block_manager.url_for(only_path: false, params: { order: param }, anchor: TABLE_ID)
   end
 
-  # TODO: Currently, we're only fetching Users from the local Whitehall database, which means
-  # content updated outside Whitehall with a `last_edited_by_editor_id` where the user
-  # does not have Whitehall access will show up as an unknown user. We are looking to
-  # fix this by possibly adding an endpoint to Signon, but this gets us part of the way
-  # there. Card for this work is here: https://trello.com/c/jVvs4nAP/640-get-author-information-from-signon
-  def users
-    @users ||= User.where(uid: host_content_items.map(&:last_edited_by_editor_id))
-  end
-
   def frontend_path(content_item)
     if @is_preview
       helpers.content_block_manager.content_block_manager_content_block_host_content_preview_path(id: content_block_edition.id, host_content_id: content_item.host_content_id)
@@ -122,8 +113,7 @@ private
   end
 
   def updated_field_for(content_item)
-    last_updated_by_user = content_item.last_edited_by_editor_id && users.find { |u| u.uid == content_item.last_edited_by_editor_id }
-    user_copy = last_updated_by_user ? mail_to(last_updated_by_user.email, last_updated_by_user.name, { class: "govuk-link" }) : "Unknown user"
+    user_copy = content_item.last_edited_by_editor ? mail_to(content_item.last_edited_by_editor.email, content_item.last_edited_by_editor.name, { class: "govuk-link" }) : "Unknown user"
     "#{time_ago_in_words(content_item.last_edited_at)} ago by #{user_copy}".html_safe
   end
 end

--- a/lib/engines/content_block_manager/app/models/content_block_manager/host_content_item.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/host_content_item.rb
@@ -5,6 +5,7 @@ module ContentBlockManager
     :document_type,
     :publishing_organisation,
     :publishing_app,
+    :last_edited_by_editor,
     :last_edited_by_editor_id,
     :last_edited_at,
     :unique_pageviews,

--- a/lib/engines/content_block_manager/app/models/content_block_manager/host_content_item.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/host_content_item.rb
@@ -6,7 +6,6 @@ module ContentBlockManager
     :publishing_organisation,
     :publishing_app,
     :last_edited_by_editor,
-    :last_edited_by_editor_id,
     :last_edited_at,
     :unique_pageviews,
     :instances,

--- a/lib/engines/content_block_manager/app/models/content_block_manager/host_content_item/editor.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/host_content_item/editor.rb
@@ -1,6 +1,16 @@
 module ContentBlockManager
   class HostContentItem
     class Editor < Data.define(:uid, :name, :email, :organisation)
+      def self.with_uuids(uuids)
+        Services.signon_api_client.get_users(uuids:).map do |user|
+          new(
+            uid: user["uid"],
+            name: user["name"],
+            email: user["email"],
+            organisation: ContentBlockManager::HostContentItem::Editor::Organisation.from_user_hash(user),
+          )
+        end
+      end
     end
   end
 end

--- a/lib/engines/content_block_manager/app/models/content_block_manager/host_content_item/editor.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/host_content_item/editor.rb
@@ -1,0 +1,6 @@
+module ContentBlockManager
+  class HostContentItem
+    class Editor < Data.define(:uid, :name, :email, :organisation)
+    end
+  end
+end

--- a/lib/engines/content_block_manager/app/models/content_block_manager/host_content_item/editor/organisation.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/host_content_item/editor/organisation.rb
@@ -1,0 +1,8 @@
+module ContentBlockManager
+  class HostContentItem
+    class Editor
+      class Organisation < Data.define(:content_id, :name, :slug)
+      end
+    end
+  end
+end

--- a/lib/engines/content_block_manager/app/models/content_block_manager/host_content_item/editor/organisation.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/host_content_item/editor/organisation.rb
@@ -2,6 +2,15 @@ module ContentBlockManager
   class HostContentItem
     class Editor
       class Organisation < Data.define(:content_id, :name, :slug)
+        def self.from_user_hash(user)
+          if user["organisation"].present?
+            new(
+              content_id: user["organisation"]["content_id"],
+              name: user["organisation"]["name"],
+              slug: user["organisation"]["slug"],
+            )
+          end
+        end
       end
     end
   end

--- a/lib/engines/content_block_manager/app/services/content_block_manager/get_host_content_items.rb
+++ b/lib/engines/content_block_manager/app/services/content_block_manager/get_host_content_items.rb
@@ -26,6 +26,7 @@ module ContentBlockManager
           document_type: item["document_type"],
           publishing_organisation: item["primary_publishing_organisation"],
           publishing_app: item["publishing_app"],
+          last_edited_by_editor: editor_for_uid(item["last_edited_by_editor_id"]),
           last_edited_by_editor_id: item["last_edited_by_editor_id"],
           last_edited_at: item["last_edited_at"],
           unique_pageviews: item["unique_pageviews"],
@@ -60,6 +61,18 @@ module ContentBlockManager
         response = Services.publishing_api.get_host_content_for_content_id(@content_id, { page:, order: }.compact)
         response.parsed_content
       end
+    end
+
+    def editor_for_uid(uid)
+      editors.find { |editor| editor.uid == uid }
+    end
+
+    def editors
+      @editors ||= editor_uuids.present? ? ContentBlockManager::HostContentItem::Editor.with_uuids(editor_uuids) : []
+    end
+
+    def editor_uuids
+      content_items["results"].map { |c| c["last_edited_by_editor_id"] }.compact
     end
   end
 end

--- a/lib/engines/content_block_manager/app/services/content_block_manager/get_host_content_items.rb
+++ b/lib/engines/content_block_manager/app/services/content_block_manager/get_host_content_items.rb
@@ -27,7 +27,6 @@ module ContentBlockManager
           publishing_organisation: item["primary_publishing_organisation"],
           publishing_app: item["publishing_app"],
           last_edited_by_editor: editor_for_uid(item["last_edited_by_editor_id"]),
-          last_edited_by_editor_id: item["last_edited_by_editor_id"],
           last_edited_at: item["last_edited_at"],
           unique_pageviews: item["unique_pageviews"],
           instances: item["instances"],

--- a/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
@@ -533,6 +533,10 @@ When(/^dependent content exists for a content block$/) do
   )
 
   stub_publishing_api_has_embedded_content_details(@dependent_content.first)
+
+  stub_request(:get, "#{Plek.find('signon', external: true)}/api/users")
+    .with(query: { uuids: @dependent_content.map { |item| item["last_edited_by_editor_id"] } })
+    .to_return(body: [].to_json)
 end
 
 Then(/^I should see the dependent content listed$/) do

--- a/lib/engines/content_block_manager/test/components/content_block/document/show/host_editions_table_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/document/show/host_editions_table_component_test.rb
@@ -23,7 +23,6 @@ class ContentBlockManager::ContentBlock::Document::Show::HostEditionsTableCompon
       "base_path" => "/foo",
       "document_type" => "document_type",
       "publishing_app" => "publisher",
-      "last_edited_by_editor_id" => SecureRandom.uuid,
       "last_edited_by_editor" => last_edited_by_editor,
       "last_edited_at" => Time.zone.now.to_s,
       "publishing_organisation" => publishing_organisation,

--- a/lib/engines/content_block_manager/test/components/content_block/document/show/host_editions_table_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/document/show/host_editions_table_component_test.rb
@@ -6,7 +6,6 @@ class ContentBlockManager::ContentBlock::Document::Show::HostEditionsTableCompon
   include ActionView::Helpers::DateHelper
 
   let(:described_class) { ContentBlockManager::ContentBlock::Document::Show::HostEditionsTableComponent }
-  let(:user) { create(:user) }
   let(:caption) { "Some caption" }
   let(:publishing_organisation) do
     {
@@ -15,16 +14,17 @@ class ContentBlockManager::ContentBlock::Document::Show::HostEditionsTableCompon
       "base_path" => "/bar",
     }
   end
-  let(:last_edited_by_editor_id) { user.uid }
   let(:unique_pageviews) { 1_200_000 }
 
+  let(:last_edited_by_editor) { build(:host_content_item_editor) }
   let(:host_content_item) do
     ContentBlockManager::HostContentItem.new(
       "title" => "Some title",
       "base_path" => "/foo",
       "document_type" => "document_type",
       "publishing_app" => "publisher",
-      "last_edited_by_editor_id" => last_edited_by_editor_id,
+      "last_edited_by_editor_id" => SecureRandom.uuid,
+      "last_edited_by_editor" => last_edited_by_editor,
       "last_edited_at" => Time.zone.now.to_s,
       "publishing_organisation" => publishing_organisation,
       "unique_pageviews" => unique_pageviews,
@@ -88,8 +88,8 @@ class ContentBlockManager::ContentBlock::Document::Show::HostEditionsTableCompon
       assert_selector "tbody .govuk-table__cell", text: host_content_item.document_type.humanize
       assert_selector "tbody .govuk-table__cell", text: "1.2m"
       assert_selector "tbody .govuk-table__cell", text: host_content_item.publishing_organisation["title"]
-      assert_selector "tbody .govuk-table__cell", text: "#{time_ago_in_words(host_content_item.last_edited_at)} ago by #{user.name}"
-      assert_link user.name, { href: "mailto:#{user.email}" }
+      assert_selector "tbody .govuk-table__cell", text: "#{time_ago_in_words(host_content_item.last_edited_at)} ago by #{last_edited_by_editor.name}"
+      assert_link last_edited_by_editor.name, { href: "mailto:#{last_edited_by_editor.email}" }
     end
 
     context "when the organisation does NOT exist within Whitehall" do
@@ -147,22 +147,8 @@ class ContentBlockManager::ContentBlock::Document::Show::HostEditionsTableCompon
       end
     end
 
-    context "when last_edited_by_editor_id is nil" do
-      let(:last_edited_by_editor_id) { nil }
-
-      it_returns_unknown_user
-
-      context "and a user exists with a nil uuid" do
-        before do
-          create(:user, uid: nil)
-        end
-
-        it_returns_unknown_user
-      end
-    end
-
-    context "when last_edited_by_editor_id refers to a user id which is not present in Whitehall" do
-      let(:last_edited_by_editor_id) { SecureRandom.uuid }
+    context "when last_edited_by_editor is nil" do
+      let(:last_edited_by_editor) { nil }
 
       it_returns_unknown_user
     end

--- a/lib/engines/content_block_manager/test/factories/host_content_item.rb
+++ b/lib/engines/content_block_manager/test/factories/host_content_item.rb
@@ -6,7 +6,6 @@ FactoryBot.define do
     publishing_organisation { { name: "organisation", content_id: SecureRandom.uuid } }
     publishing_app { "publishing_app" }
     last_edited_by_editor { build(:host_content_item_editor) }
-    last_edited_by_editor_id { SecureRandom.uuid }
     last_edited_at { 2.days.ago.to_s }
     unique_pageviews { 123 }
     instances { 1 }
@@ -18,7 +17,6 @@ FactoryBot.define do
           document_type:,
           publishing_organisation:,
           publishing_app:,
-          last_edited_by_editor_id:,
           last_edited_by_editor:,
           last_edited_at:,
           unique_pageviews:,

--- a/lib/engines/content_block_manager/test/factories/host_content_item.rb
+++ b/lib/engines/content_block_manager/test/factories/host_content_item.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     document_type { "something" }
     publishing_organisation { { name: "organisation", content_id: SecureRandom.uuid } }
     publishing_app { "publishing_app" }
+    last_edited_by_editor { build(:host_content_item_editor) }
     last_edited_by_editor_id { SecureRandom.uuid }
     last_edited_at { 2.days.ago.to_s }
     unique_pageviews { 123 }
@@ -18,6 +19,7 @@ FactoryBot.define do
           publishing_organisation:,
           publishing_app:,
           last_edited_by_editor_id:,
+          last_edited_by_editor:,
           last_edited_at:,
           unique_pageviews:,
           host_content_id:,

--- a/lib/engines/content_block_manager/test/factories/host_content_item_editor.rb
+++ b/lib/engines/content_block_manager/test/factories/host_content_item_editor.rb
@@ -1,0 +1,17 @@
+FactoryBot.define do
+  factory :host_content_item_editor, class: "ContentBlockManager::HostContentItem::Editor" do
+    uid { SecureRandom.uuid }
+    sequence(:name) { |i| "Someone #{i}" }
+    sequence(:email) { |i| "someone-#{i}@example.com" }
+    organisation { build(:host_content_item_editor_organisation) }
+
+    initialize_with do
+      new(
+        uid:,
+        name:,
+        email:,
+        organisation:,
+      )
+    end
+  end
+end

--- a/lib/engines/content_block_manager/test/factories/host_content_item_editor_organisation.rb
+++ b/lib/engines/content_block_manager/test/factories/host_content_item_editor_organisation.rb
@@ -1,0 +1,15 @@
+FactoryBot.define do
+  factory :host_content_item_editor_organisation, class: "ContentBlockManager::HostContentItem::Editor::Organisation" do
+    content_id { SecureRandom.uuid }
+    sequence(:name) { |i| "organisation #{i}" }
+    sequence(:slug) { |i| "organisation-#{i}" }
+
+    initialize_with do
+      new(
+        content_id:,
+        name:,
+        slug:,
+      )
+    end
+  end
+end

--- a/lib/engines/content_block_manager/test/support/embedded_content_helpers.rb
+++ b/lib/engines/content_block_manager/test/support/embedded_content_helpers.rb
@@ -19,12 +19,16 @@ class ActionDispatch::IntegrationTest
       end
     end
 
+    let(:host_content_item_users) { build_list(:host_content_item_editor, 10) }
+
     before do
       stub_publishing_api_has_embedded_content_for_any_content_id(
         results: host_content_items,
         total: host_content_items.length,
         order: ContentBlockManager::GetHostContentItems::DEFAULT_ORDER,
       )
+
+      ContentBlockManager::HostContentItem::Editor.stubs(:with_uuids).with(host_content_items.map { |i| i["last_edited_by_editor_id"] }).returns(host_content_item_users)
     end
 
     it "returns host content items" do

--- a/lib/engines/content_block_manager/test/unit/app/models/host_content_item/editor_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/models/host_content_item/editor_test.rb
@@ -1,0 +1,57 @@
+require "test_helper"
+
+class ContentBlockManager::HostContentItem::EditorTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
+  describe ".with_uuids" do
+    let(:signon_api_stub) { stub }
+
+    before do
+      Services.expects(:signon_api_client).returns(signon_api_stub)
+    end
+
+    it "returns an empty array when no UUIDs are provided" do
+      signon_api_stub.expects(:get_users).with(uuids: []).returns([])
+
+      result = ContentBlockManager::HostContentItem::Editor.with_uuids([])
+
+      assert_equal [], result
+    end
+
+    it "fetches users for a given list of UUIDs" do
+      uuids = [SecureRandom.uuid, SecureRandom.uuid]
+      api_response = [
+        {
+          "uid" => uuids[0],
+          "name" => "Someone",
+          "email" => "someone@example.com",
+        },
+        {
+          "uid" => uuids[1],
+          "name" => "Someone else",
+          "email" => "someoneelse@example.com",
+          "organisation" => {
+            "content_id" => SecureRandom.uuid,
+            "name" => "Organisation",
+            "slug" => "organisation",
+          },
+        },
+      ]
+      signon_api_stub.expects(:get_users).with(uuids:).returns(api_response)
+
+      result = ContentBlockManager::HostContentItem::Editor.with_uuids(uuids)
+
+      assert_equal result[0].uid, api_response[0]["uid"]
+      assert_equal result[0].name, api_response[0]["name"]
+      assert_equal result[0].email, api_response[0]["email"]
+      assert_nil result[0].organisation
+
+      assert_equal result[1].uid, api_response[1]["uid"]
+      assert_equal result[1].name, api_response[1]["name"]
+      assert_equal result[1].email, api_response[1]["email"]
+      assert_equal result[1].organisation.content_id, api_response[1]["organisation"]["content_id"]
+      assert_equal result[1].organisation.name, api_response[1]["organisation"]["name"]
+      assert_equal result[1].organisation.slug, api_response[1]["organisation"]["slug"]
+    end
+  end
+end

--- a/lib/engines/content_block_manager/test/unit/app/services/get_host_content_items_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/services/get_host_content_items_test.rb
@@ -40,7 +40,7 @@ class ContentBlockManager::GetHostContentItemsTest < ActiveSupport::TestCase
     }
   end
 
-  let(:editors) { build_list(:host_content_item_editor, 1) }
+  let(:editor) { build(:host_content_item_editor, uid: last_edited_by_editor_id) }
 
   setup do
     stub_publishing_api_has_embedded_content(content_id: target_content_id, total: 111, total_pages: 12, results: response_body["results"], order: ContentBlockManager::GetHostContentItems::DEFAULT_ORDER, rollup: response_body["rollup"])
@@ -57,7 +57,7 @@ class ContentBlockManager::GetHostContentItemsTest < ActiveSupport::TestCase
 
     before do
       Services.expects(:publishing_api).returns(publishing_api_mock)
-      ContentBlockManager::HostContentItem::Editor.stubs(:with_uuids).returns(editors)
+      ContentBlockManager::HostContentItem::Editor.stubs(:with_uuids).returns([editor])
     end
 
     it "calls the Publishing API for the content which embeds the target" do
@@ -92,7 +92,7 @@ class ContentBlockManager::GetHostContentItemsTest < ActiveSupport::TestCase
 
     it "calls the editor finder with the correct argument" do
       publishing_api_mock.expects(:get_host_content_for_content_id).returns(fake_api_response)
-      ContentBlockManager::HostContentItem::Editor.expects(:with_uuids).with([last_edited_by_editor_id]).returns(editors)
+      ContentBlockManager::HostContentItem::Editor.expects(:with_uuids).with([last_edited_by_editor_id]).returns([editor])
 
       described_class.by_embedded_document(content_block_document: document)
     end
@@ -120,7 +120,7 @@ class ContentBlockManager::GetHostContentItemsTest < ActiveSupport::TestCase
       assert_equal result[0].base_path, response_body["results"][0]["base_path"]
       assert_equal result[0].document_type, response_body["results"][0]["document_type"]
       assert_equal result[0].publishing_app, response_body["results"][0]["publishing_app"]
-      assert_equal result[0].last_edited_by_editor_id, response_body["results"][0]["last_edited_by_editor_id"]
+      assert_equal result[0].last_edited_by_editor, editor
       assert_equal result[0].last_edited_at, Time.zone.parse(response_body["results"][0]["last_edited_at"])
       assert_equal result[0].unique_pageviews, response_body["results"][0]["unique_pageviews"]
       assert_equal result[0].instances, response_body["results"][0]["instances"]

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -33,4 +33,11 @@ module Services
       bearer_token: ENV["RUMMAGER_BEARER_TOKEN"] || "example",
     )
   end
+
+  def self.signon_api_client
+    GdsApi::SignonApi.new(
+      Plek.find("signon", external: true),
+      bearer_token: ENV.fetch("SIGNON_API_BEARER_TOKEN", "example"),
+    )
+  end
 end


### PR DESCRIPTION
Trello card: https://trello.com/c/i5WgITxE/782-pull-user-details-from-signon

Now there is a new API endpoint for Signon (see https://github.com/alphagov/signon/pull/3426) we are able to fetch users directly from Signon without having to rely on the Whitehall database.