### PR TITLE
Ensure worldwide org office contacts are unpublished effectively

### DIFF
--- a/test/factories/worldwide_offices.rb
+++ b/test/factories/worldwide_offices.rb
@@ -2,10 +2,11 @@ FactoryBot.define do
   factory :worldwide_office do
     transient do
       title { "Contact title" }
+      translated_into { nil }
     end
     sequence(:slug) { |index| "worldwide-office-#{index}" }
     content_id { SecureRandom.uuid }
-    contact { create :contact_with_country, title: }
+    contact { create :contact_with_country, title:, translated_into: }
     edition { create :worldwide_organisation }
     worldwide_office_type_id { WorldwideOfficeType.all.sample.id }
   end

--- a/test/factories/worldwide_organisations.rb
+++ b/test/factories/worldwide_organisations.rb
@@ -23,6 +23,12 @@ FactoryBot.define do
       end
     end
 
+    trait(:with_translated_main_office) do
+      after :create do |organisation, _evaluator|
+        FactoryBot.create(:worldwide_office, edition: organisation, translated_into: :fr)
+      end
+    end
+
     trait(:with_home_page_offices) do
       after :create do |organisation, _evaluator|
         worldwide_office = create(:worldwide_office, edition: organisation)

--- a/test/unit/app/services/service_listeners/publishing_api_associated_documents_test.rb
+++ b/test/unit/app/services/service_listeners/publishing_api_associated_documents_test.rb
@@ -481,6 +481,29 @@ module ServiceListeners
         call(worldwide_organisation)
       end
 
+      test "for an worldwide organisation that has been unpublished publishes a gone unpublishing for all the office contact translations" do
+        worldwide_organisation = create(:unpublished_worldwide_organisation, :with_translated_main_office, translated_into: :fr)
+        office = worldwide_organisation.main_office
+
+        PublishingApiGoneWorker.any_instance.expects(:perform).with(
+          office.contact.content_id,
+          nil,
+          nil,
+          "en",
+          false,
+        )
+
+        PublishingApiGoneWorker.any_instance.expects(:perform).with(
+          office.contact.content_id,
+          nil,
+          nil,
+          "fr",
+          false,
+        )
+
+        call(worldwide_organisation)
+      end
+
       test "for an worldwide organisation that has been consolidated publishes a redirect to the alternative url" do
         worldwide_organisation = create(:unpublished_worldwide_organisation_consolidated, :with_main_office, :with_page)
         office = worldwide_organisation.main_office
@@ -493,9 +516,10 @@ module ServiceListeners
           false,
         )
 
-        PublishingApiRedirectWorker.any_instance.expects(:perform).with(
+        PublishingApiGoneWorker.any_instance.expects(:perform).with(
           office.contact.content_id,
-          "/government/another/page",
+          nil,
+          nil,
           "en",
           false,
         )
@@ -533,9 +557,10 @@ module ServiceListeners
           false,
         )
 
-        PublishingApiRedirectWorker.any_instance.expects(:perform).with(
+        PublishingApiGoneWorker.any_instance.expects(:perform).with(
           office.contact.content_id,
-          "/government/another/page",
+          nil,
+          nil,
           "en",
           false,
         )
@@ -569,9 +594,10 @@ module ServiceListeners
           false,
         )
 
-        PublishingApiRedirectWorker.any_instance.expects(:perform).with(
+        PublishingApiGoneWorker.any_instance.expects(:perform).with(
           office.contact.content_id,
-          external_url,
+          nil,
+          nil,
           "en",
           false,
         )
@@ -610,9 +636,10 @@ module ServiceListeners
           false,
         )
 
-        PublishingApiRedirectWorker.any_instance.expects(:perform).with(
+        PublishingApiGoneWorker.any_instance.expects(:perform).with(
           office.contact.content_id,
-          worldwide_organisation.search_link,
+          nil,
+          nil,
           "en",
           false,
         )


### PR DESCRIPTION
Contacts should be unpublished without a redirect, as they do not have a base path. We therefore invoke the gone worker instead of the redirect worker where the content item does not response to the base_path method.

This was preventing the unpublishing of a world organisation.

I'd desperately love to refactor that associated document handling stuff but it'll take a while, so leaving it alone for now and just throwing another conditional at the problem 😢 

One thing I can't understand - this resulted in a user facing error because the Publishing API unpublishing request returned a 500 response. However, that should have failed in a Sidekiq job. Are we not calling our Sidekiq jobs correctly? 🤔 

Trello: https://trello.com/c/U4QZKdQ7
