### PR TITLE
Change the “can’t be blank” error suffix

### DIFF
--- a/app/controllers/admin/edition_access_limited_controller.rb
+++ b/app/controllers/admin/edition_access_limited_controller.rb
@@ -11,7 +11,7 @@ class Admin::EditionAccessLimitedController < Admin::BaseController
 
     if changed?
       if editorial_remark.blank?
-        @edition.errors.add(:editorial_remark, "can't be blank")
+        @edition.errors.add(:editorial_remark, t("errors.messages.blank"))
 
         render :edit
       else

--- a/app/models/concerns/edition/publishing.rb
+++ b/app/models/concerns/edition/publishing.rb
@@ -45,7 +45,7 @@ module Edition::Publishing
 
   def change_note_present!
     if change_note.blank? && !minor_change
-      errors.add(:change_note, "can't be blank")
+      errors.add(:change_note, :blank)
     end
   end
 

--- a/app/models/feature.rb
+++ b/app/models/feature.rb
@@ -63,6 +63,6 @@ private
   end
 
   def image_is_present
-    errors.add(:"image.file", "can't be blank") if image.blank?
+    errors.add(:"image.file", :blank) if image.blank?
   end
 end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -161,7 +161,7 @@ class Organisation < ApplicationRecord
   validates :alternative_format_contact_email,
             presence: {
               if: :requires_alternative_format?,
-              message: "can't be blank as there are editions which use this organisation as the alternative format provider",
+              message: "cannot be blank as there are editions which use this organisation as the alternative format provider",
             }
   validates :govuk_status, presence: true, inclusion: { in: %w[live joining exempt transitioning closed] }
   validates :govuk_closed_status, inclusion: { in: %w[no_longer_exists replaced split merged changed_name left_gov devolved] }, presence: true, if: :closed?

--- a/app/models/take_part_page.rb
+++ b/app/models/take_part_page.rb
@@ -71,6 +71,6 @@ protected
   end
 
   def image_is_present
-    errors.add(:"image.file", "can't be blank") if image.blank?
+    errors.add(:"image.file", :blank) if image.blank?
   end
 end

--- a/app/models/topical_event_featuring.rb
+++ b/app/models/topical_event_featuring.rb
@@ -50,6 +50,6 @@ class TopicalEventFeaturing < ApplicationRecord
   end
 
   def image_is_present
-    errors.add(:"image.file", "can't be blank") if image.blank?
+    errors.add(:"image.file", :blank) if image.blank?
   end
 end

--- a/app/views/components/docs/single_image_upload.yml
+++ b/app/views/components/docs/single_image_upload.yml
@@ -36,7 +36,7 @@ examples:
       id: single-image-upload-with-error
       name: single-image-upload-with-error
       error_items:
-        - text: Image can't be blank
+        - text: Image cannot be blank
   with_image_uploaded:
     data:
       id: single-image-upload-with-image

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -1,4 +1,7 @@
 en:
+  errors:
+    messages:
+      blank: "cannot be blank"
   activerecord:
     attributes:
       publication/nation_inapplicabilities:

--- a/lib/engines/content_block_manager/app/controllers/content_block_manager/base_controller.rb
+++ b/lib/engines/content_block_manager/app/controllers/content_block_manager/base_controller.rb
@@ -52,7 +52,7 @@ class ContentBlockManager::BaseController < Admin::BaseController
 
   def validate_scheduled_edition
     if params[:schedule_publishing].blank?
-      @content_block_edition.errors.add(:schedule_publishing, "cannot be blank")
+      @content_block_edition.errors.add(:schedule_publishing, t("errors.messages.blank"))
       raise ActiveRecord::RecordInvalid, @content_block_edition
     elsif params[:schedule_publishing] == "schedule"
       @content_block_edition.assign_attributes(scheduled_publication_params)

--- a/lib/engines/content_block_manager/app/validators/content_block_manager/details_validator.rb
+++ b/lib/engines/content_block_manager/app/validators/content_block_manager/details_validator.rb
@@ -16,7 +16,7 @@ class ContentBlockManager::DetailsValidator < ActiveModel::Validator
   def add_blank_errors(error)
     missing_keys = error.dig("details", "missing_keys") || []
     missing_keys.each do |k|
-      edition.errors.add("details_#{k}", :blank, message: "cannot be blank")
+      edition.errors.add("details_#{k}", :blank)
     end
   end
 

--- a/lib/engines/content_block_manager/app/validators/content_block_manager/organisation_validator.rb
+++ b/lib/engines/content_block_manager/app/validators/content_block_manager/organisation_validator.rb
@@ -4,7 +4,7 @@ class ContentBlockManager::OrganisationValidator < ActiveModel::Validator
   def validate(edition)
     @edition = edition
     if edition.edition_organisation.blank?
-      edition.errors.add("lead_organisation", :blank, message: "cannot be blank")
+      edition.errors.add("lead_organisation", :blank)
     end
   end
 end

--- a/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
@@ -425,7 +425,7 @@ def should_show_edit_form_for_email_address_content_block(document_title, email_
 end
 
 Then("I should see errors for the required fields") do
-  assert_text "Title can't be blank"
+  assert_text "Title cannot be blank"
 
   required_fields = @schema.body["required"]
   required_fields.each do |required_field|

--- a/lib/engines/content_block_manager/test/unit/app/models/content_block_edition_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/models/content_block_edition_test.rb
@@ -86,7 +86,7 @@ class ContentBlockManager::ContentBlockEditionTest < ActiveSupport::TestCase
     )
 
     assert_invalid content_block_edition
-    assert content_block_edition.errors.full_messages.include?("Document block type can't be blank")
+    assert content_block_edition.errors.full_messages.include?("Document block type cannot be blank")
   end
 
   it "validates the presence of a document title" do
@@ -102,7 +102,7 @@ class ContentBlockManager::ContentBlockEditionTest < ActiveSupport::TestCase
     )
 
     assert_invalid content_block_edition
-    assert content_block_edition.errors.full_messages.include?("Title can't be blank")
+    assert content_block_edition.errors.full_messages.include?("Title cannot be blank")
   end
 
   it "adds a creator and first edition author for new records" do

--- a/test/components/admin/error_summary_component_test.rb
+++ b/test/components/admin/error_summary_component_test.rb
@@ -21,9 +21,9 @@ class Admin::ErrorSummaryComponentTest < ViewComponent::TestCase
 
     assert_equal page.all(".gem-c-error-summary__list-item").count, 3
     assert_equal page.all(".gem-c-error-summary__list-item a").count, 3
-    assert_equal first_link.text, "Title can't be blank"
+    assert_equal first_link.text, "Title cannot be blank"
     assert_equal first_link[:href], "#error_summary_test_object_title"
-    assert_equal second_link.text, "Date can't be blank"
+    assert_equal second_link.text, "Date cannot be blank"
     assert_equal second_link[:href], "#error_summary_test_object_date"
     assert_equal third_link.text, "Date is invalid"
     assert_equal third_link[:href], "#error_summary_test_object_date"
@@ -38,9 +38,9 @@ class Admin::ErrorSummaryComponentTest < ViewComponent::TestCase
 
     assert_equal page.all(".gem-c-error-summary__list-item").count, 3
     assert_equal page.all(".gem-c-error-summary__list-item a").count, 3
-    assert_equal first_link.text, "Title can't be blank"
+    assert_equal first_link.text, "Title cannot be blank"
     assert_equal first_link[:href], "#parent_class_title"
-    assert_equal second_link.text, "Date can't be blank"
+    assert_equal second_link.text, "Date cannot be blank"
     assert_equal second_link[:href], "#parent_class_date"
     assert_equal third_link.text, "Date is invalid"
     assert_equal third_link[:href], "#parent_class_date"
@@ -60,14 +60,14 @@ class Admin::ErrorSummaryComponentTest < ViewComponent::TestCase
     assert_equal first_link["data-module"], "ga4-auto-tracker"
     assert_equal first_link_data["event_name"], "form_error"
     assert_equal first_link_data["type"], "Editing Error Summary Test Object"
-    assert_equal first_link_data["text"], "Title can't be blank"
+    assert_equal first_link_data["text"], "Title cannot be blank"
     assert_equal first_link_data["section"], "Title"
     assert_equal first_link_data["action"], "error"
 
     assert_equal second_link["data-module"], "ga4-auto-tracker"
     assert_equal second_link_data["event_name"], "form_error"
     assert_equal second_link_data["type"], "Editing Error Summary Test Object"
-    assert_equal second_link_data["text"], "Date can't be blank"
+    assert_equal second_link_data["text"], "Date cannot be blank"
     assert_equal second_link_data["section"], "Date"
     assert_equal second_link_data["action"], "error"
 
@@ -97,9 +97,9 @@ class Admin::ErrorSummaryComponentTest < ViewComponent::TestCase
 
     assert_equal page.all(".gem-c-error-summary__list-item").count, 3
     assert_equal page.all(".gem-c-error-summary__list-item a").count, 3
-    assert_equal first_link.text, "Title can't be blank"
+    assert_equal first_link.text, "Title cannot be blank"
     assert_equal first_link[:href], "#error_summary_test_object_title"
-    assert_equal second_link.text, "Date can't be blank"
+    assert_equal second_link.text, "Date cannot be blank"
     assert_equal second_link[:href], "#error_summary_test_object_date"
     assert_equal third_link.text, "Date is invalid"
     assert_equal third_link[:href], "#error_summary_test_object_date"
@@ -114,9 +114,9 @@ class Admin::ErrorSummaryComponentTest < ViewComponent::TestCase
 
     assert_equal page.all(".gem-c-error-summary__list-item").count, 3
     assert_equal page.all(".gem-c-error-summary__list-item a").count, 3
-    assert_equal first_link.text, "Title can't be blank"
+    assert_equal first_link.text, "Title cannot be blank"
     assert_equal first_link[:href], "#error_summary_test_object_title"
-    assert_equal second_link.text, "Date can't be blank"
+    assert_equal second_link.text, "Date cannot be blank"
     assert_equal second_link[:href], "#error_summary_test_object_date"
     assert_equal third_link.text, "Date is invalid"
     assert_equal third_link[:href], "#error_summary_test_object_date"

--- a/test/functional/admin/bulk_republishing_controller_test.rb
+++ b/test/functional/admin/bulk_republishing_controller_test.rb
@@ -45,7 +45,7 @@ class Admin::BulkRepublishingControllerTest < ActionController::TestCase
 
     post :republish, params: { bulk_content_type: "all-published-organisation-about-us-pages", reason: "" }
 
-    assert_equal ["Reason can't be blank"], assigns(:republishing_event).errors.full_messages
+    assert_equal ["Reason cannot be blank"], assigns(:republishing_event).errors.full_messages
     assert_template "confirm"
   end
 
@@ -128,7 +128,7 @@ class Admin::BulkRepublishingControllerTest < ActionController::TestCase
 
     post :republish_by_type, params: { content_type: "organisation", reason: "" }
 
-    assert_equal ["Reason can't be blank"], assigns(:republishing_event).errors.full_messages
+    assert_equal ["Reason cannot be blank"], assigns(:republishing_event).errors.full_messages
     assert_template "confirm_by_type"
   end
 
@@ -231,7 +231,7 @@ class Admin::BulkRepublishingControllerTest < ActionController::TestCase
 
     post :republish_documents_by_organisation, params: { organisation_slug: "an-existing-organisation", reason: "" }
 
-    assert_equal ["Reason can't be blank"], assigns(:republishing_event).errors.full_messages
+    assert_equal ["Reason cannot be blank"], assigns(:republishing_event).errors.full_messages
     assert_template "confirm_documents_by_organisation"
   end
 
@@ -360,7 +360,7 @@ class Admin::BulkRepublishingControllerTest < ActionController::TestCase
 
     post :republish_documents_by_content_ids, params: { content_ids: "abc-123, def-456", reason: "" }
 
-    assert_equal ["Reason can't be blank"], assigns(:republishing_event).errors.full_messages
+    assert_equal ["Reason cannot be blank"], assigns(:republishing_event).errors.full_messages
     assert_template "confirm_documents_by_content_ids"
   end
 

--- a/test/functional/admin/bulk_uploads_controller_test.rb
+++ b/test/functional/admin/bulk_uploads_controller_test.rb
@@ -64,7 +64,7 @@ class Admin::BulkUploadsControllerTest < ActionController::TestCase
 
   view_test "POST :upload_zip with no zip file requests that zip file be specified" do
     post_to_upload_zip(nil)
-    assert_select ".gem-c-error-summary__list-item", /file can't be blank/
+    assert_select ".gem-c-error-summary__list-item", /file cannot be blank/
   end
 
   view_test "POST :upload_zip prompts for metadata for each file in the zip" do

--- a/test/functional/admin/corporate_information_pages_controller_test.rb
+++ b/test/functional/admin/corporate_information_pages_controller_test.rb
@@ -50,7 +50,7 @@ class Admin::CorporateInformationPagesControllerTest < ActionController::TestCas
     post :create, params: { organisation_id: @organisation, edition: corporate_information_page_attributes(body: nil) }
     @organisation.reload
     assert_select "form[action='#{admin_organisation_corporate_information_pages_path(@organisation)}']"
-    assert_select ".govuk-error-summary a", text: "Body can't be blank", href: "#edition_body"
+    assert_select ".govuk-error-summary a", text: "Body cannot be blank", href: "#edition_body"
   end
 
   view_test "GET :edit should display form without type selector for existing corporate information page" do
@@ -83,7 +83,7 @@ class Admin::CorporateInformationPagesControllerTest < ActionController::TestCas
     corporate_information_page = create(:corporate_information_page, organisation: @organisation)
     new_attributes = { body: "", summary: "New summary" }
     put :update, params: { organisation_id: @organisation, id: corporate_information_page, edition: new_attributes }
-    assert_select ".govuk-error-summary a", text: "Body can't be blank", href: "#edition_body"
+    assert_select ".govuk-error-summary a", text: "Body cannot be blank", href: "#edition_body"
 
     assert_select "form[action='#{admin_organisation_corporate_information_page_path(@organisation, corporate_information_page)}']" do
       assert_select "textarea[name='edition[body]']", new_attributes[:body]

--- a/test/functional/admin/document_collections_controller_test.rb
+++ b/test/functional/admin/document_collections_controller_test.rb
@@ -62,7 +62,7 @@ class Admin::DocumentCollectionsControllerTest < ActionController::TestCase
     assert_response :success
     assert_equal 0, DocumentCollection.count
 
-    assert_select ".govuk-error-message", "Error: Title can't be blank"
+    assert_select ".govuk-error-message", "Error: Title cannot be blank"
   end
 
   view_test "GET #edit renders the edit form for the document collection" do
@@ -94,7 +94,7 @@ class Admin::DocumentCollectionsControllerTest < ActionController::TestCase
     assert_equal "old-title", document_collection.reload.title
 
     assert_select "form" do
-      assert_select ".govuk-error-message", "Error: Title can't be blank"
+      assert_select ".govuk-error-message", "Error: Title cannot be blank"
     end
   end
 

--- a/test/functional/admin/edition_access_limited_controller_test.rb
+++ b/test/functional/admin/edition_access_limited_controller_test.rb
@@ -143,7 +143,7 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
         }
 
     assert_template :edit
-    assert_equal ["Editorial remark can't be blank"], assigns(:edition).errors.full_messages
+    assert_equal ["Editorial remark cannot be blank"], assigns(:edition).errors.full_messages
     assert edition.reload.access_limited
   end
 

--- a/test/functional/admin/edition_lead_images_controller_test.rb
+++ b/test/functional/admin/edition_lead_images_controller_test.rb
@@ -30,7 +30,7 @@ class Admin::EditionLeadImagesControllerTest < ActionController::TestCase
 
     assert_nil edition.reload.lead_image
     assert_redirected_to admin_edition_images_path(edition)
-    assert_equal "This edition is invalid: Change note can't be blank", flash[:alert]
+    assert_equal "This edition is invalid: Change note cannot be blank", flash[:alert]
   end
 
   test "PATCH :update does not update the lead image when edition's body contains the images markdown" do

--- a/test/functional/admin/edition_workflow_controller_test.rb
+++ b/test/functional/admin/edition_workflow_controller_test.rb
@@ -169,7 +169,7 @@ class Admin::EditionWorkflowControllerTest < ActionController::TestCase
     post :submit, params: { id: draft_edition, lock_version: draft_edition.lock_version }
 
     assert_redirected_to admin_publication_path(draft_edition)
-    assert_equal "Unable to submit this edition because summary can't be blank. Please edit it and try again.", flash[:alert]
+    assert_equal "Unable to submit this edition because summary cannot be blank. Please edit it and try again.", flash[:alert]
   end
 
   test "submission error should read as a sentence when there are multiple validation errors" do
@@ -181,7 +181,7 @@ class Admin::EditionWorkflowControllerTest < ActionController::TestCase
     post :submit, params: { id: draft_edition, lock_version: draft_edition.lock_version }
 
     assert_redirected_to admin_publication_path(draft_edition)
-    assert_equal "Unable to submit this edition because title can't be blank, summary can't be blank, and alternative format provider can't be blank. Please edit it and try again.", flash[:alert]
+    assert_equal "Unable to submit this edition because title cannot be blank, summary cannot be blank, and alternative format provider cannot be blank. Please edit it and try again.", flash[:alert]
   end
 
   test "submit responds with 422 if missing a lock version" do

--- a/test/functional/admin/fact_check_requests_controller_test.rb
+++ b/test/functional/admin/fact_check_requests_controller_test.rb
@@ -250,7 +250,7 @@ class Admin::CreatingFactCheckRequestsControllerTest < ActionController::TestCas
     @attributes[:email_address] = ""
     post :create, params: { edition_id: @edition.id, fact_check_request: @attributes }
 
-    assert_equal "There was a problem: Email address can't be blank", flash[:alert]
+    assert_equal "There was a problem: Email address cannot be blank", flash[:alert]
   end
 
   test "redirect back to the edition preview if the fact checker's email address is missing" do

--- a/test/functional/admin/republishing_controller_test.rb
+++ b/test/functional/admin/republishing_controller_test.rb
@@ -77,7 +77,7 @@ class Admin::RepublishingControllerTest < ActionController::TestCase
 
     post :republish_page, params: { page_slug: "past-prime-ministers", reason: "" }
 
-    assert_equal ["Reason can't be blank"], assigns(:republishing_event).errors.full_messages
+    assert_equal ["Reason cannot be blank"], assigns(:republishing_event).errors.full_messages
     assert_template "confirm_page"
   end
 
@@ -203,7 +203,7 @@ class Admin::RepublishingControllerTest < ActionController::TestCase
 
     post :republish_organisation, params: { organisation_slug: "an-existing-organisation", reason: "" }
 
-    assert_equal ["Reason can't be blank"], assigns(:republishing_event).errors.full_messages
+    assert_equal ["Reason cannot be blank"], assigns(:republishing_event).errors.full_messages
     assert_template "confirm_organisation"
   end
 
@@ -307,7 +307,7 @@ class Admin::RepublishingControllerTest < ActionController::TestCase
 
     post :republish_person, params: { person_slug: "existing-person", reason: "" }
 
-    assert_equal ["Reason can't be blank"], assigns(:republishing_event).errors.full_messages
+    assert_equal ["Reason cannot be blank"], assigns(:republishing_event).errors.full_messages
     assert_template "confirm_person"
   end
 
@@ -411,7 +411,7 @@ class Admin::RepublishingControllerTest < ActionController::TestCase
 
     post :republish_role, params: { role_slug: "an-existing-role", reason: "" }
 
-    assert_equal ["Reason can't be blank"], assigns(:republishing_event).errors.full_messages
+    assert_equal ["Reason cannot be blank"], assigns(:republishing_event).errors.full_messages
     assert_template "confirm_role"
   end
 
@@ -515,7 +515,7 @@ class Admin::RepublishingControllerTest < ActionController::TestCase
 
     post :republish_document, params: { document_slug: "an-existing-document", reason: "" }
 
-    assert_equal ["Reason can't be blank"], assigns(:republishing_event).errors.full_messages
+    assert_equal ["Reason cannot be blank"], assigns(:republishing_event).errors.full_messages
     assert_template "confirm_document"
   end
 

--- a/test/functional/admin/role_appointments_controller_test.rb
+++ b/test/functional/admin/role_appointments_controller_test.rb
@@ -77,7 +77,7 @@ class Admin::RoleAppointmentsControllerTest < ActionController::TestCase
     _person = create(:person)
     post :create, params: { role_id: role.id, role_appointment: { started_at: 3.days.ago } }
     assert role.role_appointments.empty?
-    assert_select ".govuk-error-message", text: "Error: Person can't be blank"
+    assert_select ".govuk-error-message", text: "Error: Person cannot be blank"
   end
 
   test "create should curtail previous appointments if make_current is present" do

--- a/test/functional/admin/statistics_announcements_controller_test.rb
+++ b/test/functional/admin/statistics_announcements_controller_test.rb
@@ -99,7 +99,7 @@ class Admin::StatisticsAnnouncementsControllerTest < ActionController::TestCase
     post :create, params: { statistics_announcement: { title: "", summary: "Summary text" } }
 
     assert_response :success
-    assert_select "ul.govuk-error-summary__list a", text: "Title can't be blank"
+    assert_select "ul.govuk-error-summary__list a", text: "Title cannot be blank"
     assert_not StatisticsAnnouncement.any?
   end
 
@@ -189,7 +189,7 @@ class Admin::StatisticsAnnouncementsControllerTest < ActionController::TestCase
     put :update, params: { id: announcement.id, statistics_announcement: { title: "" } }
 
     assert_response :success
-    assert_select "ul.govuk-error-summary__list a", text: "Title can't be blank"
+    assert_select "ul.govuk-error-summary__list a", text: "Title cannot be blank"
   end
 
   test "PUT :update should update connected draft publication in Publishing API if announcement publication type has been changed" do

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -151,9 +151,9 @@ module AdminEditionControllerTestHelpers
                edition: attributes.merge(title: ""),
              }
 
-        assert_select ".gem-c-error-message.govuk-error-message", text: "Error: Title can't be blank"
+        assert_select ".gem-c-error-message.govuk-error-message", text: "Error: Title cannot be blank"
         assert_equal attributes[:body], assigns(:edition).body, "the valid data should not have been lost"
-        assert_select ".govuk-error-summary a", text: "Title can't be blank", href: "#edition_title"
+        assert_select ".govuk-error-summary a", text: "Title cannot be blank", href: "#edition_title"
       end
 
       test "removes blank space from titles for new editions" do
@@ -305,7 +305,7 @@ module AdminEditionControllerTestHelpers
 
         assert_equal "A Title", edition.reload.title
         assert_template "editions/edit"
-        assert_select ".govuk-error-summary a", text: "Title can't be blank", href: "#edition_title"
+        assert_select ".govuk-error-summary a", text: "Title cannot be blank", href: "#edition_title"
       end
 
       test "update with a stale edition should render edit page with conflicting edition" do

--- a/test/support/tests_for_national_applicability.rb
+++ b/test/support/tests_for_national_applicability.rb
@@ -176,7 +176,7 @@ module TestsForNationalApplicability
 
       put :update, params: { id: edition, edition: attributes }
 
-      assert_page_has_error(/Title can't be blank/)
+      assert_page_has_error(/Title cannot be blank/)
 
       assert_nation_inapplicability_fields_exist
       assert_nation_inapplicability_fields_set_as(index: 0, checked: false)

--- a/test/unit/app/helpers/errors_helper_test.rb
+++ b/test/unit/app/helpers/errors_helper_test.rb
@@ -15,11 +15,11 @@ class ErrorsHelperTest < ActionView::TestCase
   end
 
   test "#errors_for_input returns errors for the attribute passed in" do
-    assert_equal errors_for_input(@object_with_errors.errors, :title), "Title can't be blank"
+    assert_equal errors_for_input(@object_with_errors.errors, :title), "Title cannot be blank"
   end
 
   test "#errors_for_input formats the error message when there are multiple errors on a field" do
-    assert_equal errors_for_input(@object_with_errors.errors, :date), "Date can't be blank<br>Date is invalid"
+    assert_equal errors_for_input(@object_with_errors.errors, :date), "Date cannot be blank<br>Date is invalid"
   end
 
   test "#errors_for_input does not return an empty string when object has unrelated error" do
@@ -31,11 +31,11 @@ class ErrorsHelperTest < ActionView::TestCase
   end
 
   test "#errors_for returns errors for the attribute passed in" do
-    assert_equal errors_for(@object_with_errors.errors, :title), [{ text: "Title can't be blank" }]
+    assert_equal errors_for(@object_with_errors.errors, :title), [{ text: "Title cannot be blank" }]
   end
 
   test "#errors_for formats the error message when there are multiple errors on a field" do
-    assert_equal errors_for(@object_with_errors.errors, :date), [{ text: "Date can't be blank" }, { text: "Date is invalid" }]
+    assert_equal errors_for(@object_with_errors.errors, :date), [{ text: "Date cannot be blank" }, { text: "Date is invalid" }]
   end
 
   test "#errors_for does not return an empty string when object has unrelated error" do

--- a/test/unit/app/models/asset_test.rb
+++ b/test/unit/app/models/asset_test.rb
@@ -10,21 +10,21 @@ class AssetTest < ActiveSupport::TestCase
     asset = Asset.new(assetable: @image_data, variant: @variant)
 
     assert_not asset.valid?
-    assert_equal asset.errors.messages[:asset_manager_id], ["can't be blank"]
+    assert_equal asset.errors.messages[:asset_manager_id], ["cannot be blank"]
   end
 
   test "should be invalid without an assetable" do
     asset = Asset.new(asset_manager_id: "asset_manager_id", variant: @variant)
 
     assert_not asset.valid?
-    assert_equal asset.errors.messages[:assetable], ["can't be blank"]
+    assert_equal asset.errors.messages[:assetable], ["cannot be blank"]
   end
 
   test "should be invalid without a variant" do
     asset = Asset.new(asset_manager_id: "asset_manager_id", assetable: @image_data)
 
     assert_not asset.valid?
-    assert_equal asset.errors.messages[:variant], ["can't be blank"]
+    assert_equal asset.errors.messages[:variant], ["cannot be blank"]
   end
 
   test "should be valid if all fields present" do

--- a/test/unit/app/models/call_for_evidence_test.rb
+++ b/test/unit/app/models/call_for_evidence_test.rb
@@ -58,7 +58,7 @@ class CallForEvidenceTest < ActiveSupport::TestCase
     edition = build(:call_for_evidence, external: true, external_url: nil)
 
     assert_not edition.valid?
-    assert_equal "can't be blank", edition.errors[:external_url].first
+    assert_equal "cannot be blank", edition.errors[:external_url].first
 
     edition.external_url = "bad.url"
     assert_not edition.valid?

--- a/test/unit/app/models/consultation_test.rb
+++ b/test/unit/app/models/consultation_test.rb
@@ -58,7 +58,7 @@ class ConsultationTest < ActiveSupport::TestCase
     edition = build(:consultation, external: true, external_url: nil)
 
     assert_not edition.valid?
-    assert_equal "can't be blank", edition.errors[:external_url].first
+    assert_equal "cannot be blank", edition.errors[:external_url].first
 
     edition.external_url = "bad.url"
     assert_not edition.valid?

--- a/test/unit/app/models/contact_test.rb
+++ b/test/unit/app/models/contact_test.rb
@@ -42,7 +42,7 @@ class ContactTest < ActiveSupport::TestCase
       country_id: country.id,
     )
     assert_not contact.valid?
-    assert_equal ["can't be blank"], contact.errors[:street_address]
+    assert_equal ["cannot be blank"], contact.errors[:street_address]
   end
 
   test "should be invalid with only street address but no country" do
@@ -56,7 +56,7 @@ class ContactTest < ActiveSupport::TestCase
       country_id: "",
     )
     assert_not contact.valid?
-    assert_equal ["can't be blank"], contact.errors[:country_id]
+    assert_equal ["cannot be blank"], contact.errors[:country_id]
   end
 
   test "should be valid with only street address and country" do

--- a/test/unit/app/models/featured_image_data_test.rb
+++ b/test/unit/app/models/featured_image_data_test.rb
@@ -21,7 +21,7 @@ class FeaturedImageDataTest < ActiveSupport::TestCase
     topical_event_featuring_image_data = build(:featured_image_data, file: nil)
 
     assert_not topical_event_featuring_image_data.valid?
-    assert_includes topical_event_featuring_image_data.errors.map(&:full_message), "File can't be blank"
+    assert_includes topical_event_featuring_image_data.errors.map(&:full_message), "File cannot be blank"
   end
 
   test "accepts valid image uploads" do
@@ -100,7 +100,7 @@ class FeaturedImageDataTest < ActiveSupport::TestCase
     featured_image_data = build(:featured_image_data, featured_imageable: nil)
 
     assert_not featured_image_data.valid?
-    assert_equal featured_image_data.errors.messages[:featured_imageable], ["can't be blank"]
+    assert_equal featured_image_data.errors.messages[:featured_imageable], ["cannot be blank"]
   end
 
   test "#republish_on_assets_ready should republish organisation and associations if assets are ready" do

--- a/test/unit/app/models/file_attachment_test.rb
+++ b/test/unit/app/models/file_attachment_test.rb
@@ -38,7 +38,7 @@ class FileAttachmentTest < ActiveSupport::TestCase
     attachment = build(:file_attachment, attachable:, file: nil)
 
     assert_not attachment.valid?
-    assert_match %r{can't be blank}, attachment.errors[:"attachment_data.file"].first
+    assert_match %r{cannot be blank}, attachment.errors[:"attachment_data.file"].first
   end
 
   test "update with empty nested attachment data attributes still works" do

--- a/test/unit/app/models/landing_page/base_block_test.rb
+++ b/test/unit/app/models/landing_page/base_block_test.rb
@@ -9,12 +9,12 @@ class BaseBlockTest < ActiveSupport::TestCase
   test "invalid when missing type" do
     subject = LandingPage::BaseBlock.new({}, [])
     assert subject.invalid?
-    assert_equal ["Type can't be blank"], subject.errors.to_a
+    assert_equal ["Type cannot be blank"], subject.errors.to_a
   end
 
   test "raises error when presenting an invalid block to publishing api" do
     subject = LandingPage::BaseBlock.new({}, [])
     assert subject.invalid?
-    assert_raises(StandardError, match: /cannot present invalid block to publishing api.*Type can't be blank/) { subject.present_for_publishing_api }
+    assert_raises(StandardError, match: /cannot present invalid block to publishing api.*Type cannot be blank/) { subject.present_for_publishing_api }
   end
 end

--- a/test/unit/app/models/landing_page/body_test.rb
+++ b/test/unit/app/models/landing_page/body_test.rb
@@ -6,14 +6,14 @@ class LandingPageBodyTest < ActiveSupport::TestCase
   test "is invalid with empty YAML" do
     subject = LandingPage::Body.new("", EMPTY_IMAGES)
     assert subject.invalid?
-    assert_equal ["Blocks can't be blank"], subject.errors.to_a
+    assert_equal ["Blocks cannot be blank"], subject.errors.to_a
   end
 
   test "is invalid with badly formed YAML" do
     subject = LandingPage::Body.new("{", EMPTY_IMAGES)
     assert subject.invalid?
     errors = subject.errors.to_a
-    assert_equal "Blocks can't be blank", errors.first
+    assert_equal "Blocks cannot be blank", errors.first
     assert_match(/Yaml .* did not find expected node content/, errors.second)
   end
 
@@ -22,7 +22,7 @@ class LandingPageBodyTest < ActiveSupport::TestCase
       blocks: []
     YAML
     assert subject.invalid?
-    assert_equal ["Blocks can't be blank"], subject.errors.to_a
+    assert_equal ["Blocks cannot be blank"], subject.errors.to_a
   end
 
   test "is valid with a single unknown block in YAML" do
@@ -99,6 +99,6 @@ class LandingPageBodyTest < ActiveSupport::TestCase
       - error: no type
     YAML
     assert subject.invalid?
-    assert_equal ["Type can't be blank"], subject.errors.to_a
+    assert_equal ["Type cannot be blank"], subject.errors.to_a
   end
 end

--- a/test/unit/app/models/landing_page/compound_block_test.rb
+++ b/test/unit/app/models/landing_page/compound_block_test.rb
@@ -61,6 +61,6 @@ class CompoundBlockTest < ActiveSupport::TestCase
       "compound_block_content",
     )
     assert subject.invalid?
-    assert_equal ["Type can't be blank"], subject.errors.to_a
+    assert_equal ["Type cannot be blank"], subject.errors.to_a
   end
 end

--- a/test/unit/app/models/landing_page/featured_block_test.rb
+++ b/test/unit/app/models/landing_page/featured_block_test.rb
@@ -50,9 +50,9 @@ class FeaturedBlockTest < ActiveSupport::TestCase
     subject = LandingPage::FeaturedBlock.new(@valid_featured_block_config.except("image"), @valid_featured_images)
     assert subject.invalid?
     assert_equal [
-      "Desktop image can't be blank",
-      "Tablet image can't be blank",
-      "Mobile image can't be blank",
+      "Desktop image cannot be blank",
+      "Tablet image cannot be blank",
+      "Mobile image cannot be blank",
     ], subject.errors.to_a
   end
 
@@ -61,9 +61,9 @@ class FeaturedBlockTest < ActiveSupport::TestCase
     subject = LandingPage::FeaturedBlock.new(@valid_featured_block_config, no_images)
     assert subject.invalid?
     assert_equal [
-      "Desktop image can't be blank",
-      "Tablet image can't be blank",
-      "Mobile image can't be blank",
+      "Desktop image cannot be blank",
+      "Tablet image cannot be blank",
+      "Mobile image cannot be blank",
     ], subject.errors.to_a
   end
 
@@ -82,6 +82,6 @@ class FeaturedBlockTest < ActiveSupport::TestCase
       @valid_featured_images,
     )
     assert subject.invalid?
-    assert_equal ["Type can't be blank"], subject.errors.to_a
+    assert_equal ["Type cannot be blank"], subject.errors.to_a
   end
 end

--- a/test/unit/app/models/landing_page/hero_block_test.rb
+++ b/test/unit/app/models/landing_page/hero_block_test.rb
@@ -52,9 +52,9 @@ class HeroBlockTest < ActiveSupport::TestCase
     subject = LandingPage::HeroBlock.new(@valid_hero_block_config.except("image"), @valid_hero_block_images)
     assert subject.invalid?
     assert_equal [
-      "Desktop image can't be blank",
-      "Tablet image can't be blank",
-      "Mobile image can't be blank",
+      "Desktop image cannot be blank",
+      "Tablet image cannot be blank",
+      "Mobile image cannot be blank",
     ], subject.errors.to_a
   end
 
@@ -63,9 +63,9 @@ class HeroBlockTest < ActiveSupport::TestCase
     subject = LandingPage::HeroBlock.new(@valid_hero_block_config, no_images)
     assert subject.invalid?
     assert_equal [
-      "Desktop image can't be blank",
-      "Tablet image can't be blank",
-      "Mobile image can't be blank",
+      "Desktop image cannot be blank",
+      "Tablet image cannot be blank",
+      "Mobile image cannot be blank",
     ], subject.errors.to_a
   end
 
@@ -81,6 +81,6 @@ class HeroBlockTest < ActiveSupport::TestCase
       @valid_hero_block_images,
     )
     assert subject.invalid?
-    assert_equal ["Type can't be blank"], subject.errors.to_a
+    assert_equal ["Type cannot be blank"], subject.errors.to_a
   end
 end

--- a/test/unit/app/models/landing_page/image_block_test.rb
+++ b/test/unit/app/models/landing_page/image_block_test.rb
@@ -45,9 +45,9 @@ class ImageBlockTest < ActiveSupport::TestCase
     subject = LandingPage::ImageBlock.new(@valid_image_block_config.except("image"), @valid_landing_page_images)
     assert subject.invalid?
     assert_equal [
-      "Desktop image can't be blank",
-      "Tablet image can't be blank",
-      "Mobile image can't be blank",
+      "Desktop image cannot be blank",
+      "Tablet image cannot be blank",
+      "Mobile image cannot be blank",
     ], subject.errors.to_a
   end
 
@@ -56,9 +56,9 @@ class ImageBlockTest < ActiveSupport::TestCase
     subject = LandingPage::ImageBlock.new(@valid_image_block_config, no_images)
     assert subject.invalid?
     assert_equal [
-      "Desktop image can't be blank",
-      "Tablet image can't be blank",
-      "Mobile image can't be blank",
+      "Desktop image cannot be blank",
+      "Tablet image cannot be blank",
+      "Mobile image cannot be blank",
     ], subject.errors.to_a
   end
 end

--- a/test/unit/app/models/landing_page/parent_block_test.rb
+++ b/test/unit/app/models/landing_page/parent_block_test.rb
@@ -15,6 +15,6 @@ class ParentBlockTest < ActiveSupport::TestCase
       "blocks" => [{ "invalid" => "because I do not have a type" }],
     }, [])
     assert subject.invalid?
-    assert_equal ["Type can't be blank"], subject.errors.to_a
+    assert_equal ["Type cannot be blank"], subject.errors.to_a
   end
 end

--- a/test/unit/app/models/promotional_feature_link_test.rb
+++ b/test/unit/app/models/promotional_feature_link_test.rb
@@ -5,7 +5,7 @@ class PromotionalFeatureLinkTest < ActiveSupport::TestCase
     %w[url text promotional_feature_item].each do |attribute|
       link = build(:promotional_feature_link, attribute => nil)
       assert_not link.valid?
-      assert_includes link.errors[attribute], "can't be blank"
+      assert_includes link.errors[attribute], "cannot be blank"
     end
   end
 

--- a/test/unit/app/models/related_mainstream_test.rb
+++ b/test/unit/app/models/related_mainstream_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class RelatedMainstreamTest < ActiveSupport::TestCase
   test "raises an error if creating a record with a nil content_id" do
     detailed_guide = create(:detailed_guide)
-    assert_raises StandardError, match: "Validation failed: Content can't be blank" do
+    assert_raises StandardError, match: "Validation failed: Content cannot be blank" do
       RelatedMainstream.create!(edition_id: detailed_guide.id, content_id: nil)
     end
   end
@@ -19,7 +19,7 @@ class RelatedMainstreamTest < ActiveSupport::TestCase
   end
 
   test "raises an error if creating a record with a nil edition" do
-    assert_raises StandardError, match: "Validation failed: Edition can't be blank" do
+    assert_raises StandardError, match: "Validation failed: Edition cannot be blank" do
       RelatedMainstream.create!(edition_id: nil, content_id: "5a2fea6a-360a-49ba-97b3-46d3612ec198")
     end
   end

--- a/test/unit/app/models/social_media_account_test.rb
+++ b/test/unit/app/models/social_media_account_test.rb
@@ -42,7 +42,7 @@ class SocialMediaAccountTest < ActiveSupport::TestCase
   test "should be invalid without a url" do
     account = build(:social_media_account, url: nil)
     assert_not account.valid?
-    assert_includes account.errors.full_messages, "Url can't be blank"
+    assert_includes account.errors.full_messages, "Url cannot be blank"
   end
 
   test "should be invalid with a malformed url" do
@@ -64,7 +64,7 @@ class SocialMediaAccountTest < ActiveSupport::TestCase
   test "should be invalid without a social media service" do
     account = build(:social_media_account, social_media_service_id: nil)
     assert_not account.valid?
-    assert_includes account.errors.full_messages, "Social media service can't be blank"
+    assert_includes account.errors.full_messages, "Social media service cannot be blank"
   end
 
   test "display_name is the title if present" do

--- a/test/unit/app/models/statistics_announcement_organisation_test.rb
+++ b/test/unit/app/models/statistics_announcement_organisation_test.rb
@@ -5,13 +5,13 @@ class StatisticsAnnouncementOrganisationTest < ActiveSupport::TestCase
     statistics_announcement_organisation = StatisticsAnnouncementOrganisation.new(organisation: build(:organisation))
 
     assert_not statistics_announcement_organisation.valid?
-    assert_includes statistics_announcement_organisation.errors[:statistics_announcement], "can't be blank"
+    assert_includes statistics_announcement_organisation.errors[:statistics_announcement], "cannot be blank"
   end
 
   test "should be invalid without an organisation" do
     statistics_announcement_organisation = StatisticsAnnouncementOrganisation.new(statistics_announcement: build(:statistics_announcement))
 
     assert_not statistics_announcement_organisation.valid?
-    assert_includes statistics_announcement_organisation.errors[:organisation], "can't be blank"
+    assert_includes statistics_announcement_organisation.errors[:organisation], "cannot be blank"
   end
 end

--- a/test/unit/app/models/worldwide_organisation_page_test.rb
+++ b/test/unit/app/models/worldwide_organisation_page_test.rb
@@ -42,7 +42,7 @@ class WorldwideOrganisationPageTest < ActiveSupport::TestCase
     page = build(:worldwide_organisation_page, edition: nil)
 
     assert_not page.valid?
-    assert page.errors[:edition].include?("can't be blank")
+    assert page.errors[:edition].include?("cannot be blank")
   end
 
   test "should not be valid when corporate information page type is `about us`" do

--- a/test/unit/app/services/edition_publisher_test.rb
+++ b/test/unit/app/services/edition_publisher_test.rb
@@ -48,7 +48,7 @@ class EditionPublisherTest < ActiveSupport::TestCase
 
     assert_not publisher.perform!
     assert_not edition.published?
-    assert_equal "This edition is invalid: Title can't be blank", publisher.failure_reason
+    assert_equal "This edition is invalid: Title cannot be blank", publisher.failure_reason
   end
 
   test "#perform! with a re-editioned document updates the version numbers" do

--- a/test/unit/app/services/edition_scheduler_test.rb
+++ b/test/unit/app/services/edition_scheduler_test.rb
@@ -28,7 +28,7 @@ class EditionSchedulerTest < ActiveSupport::TestCase
     scheduler = EditionScheduler.new(edition)
 
     assert_not scheduler.can_perform?
-    assert_equal "This edition is invalid: Title can't be blank", scheduler.failure_reason
+    assert_equal "This edition is invalid: Title cannot be blank", scheduler.failure_reason
   end
 
   test "an edition cannot be scheduled without a scheduled_publication timestamp" do

--- a/test/unit/lib/localised_model_test.rb
+++ b/test/unit/lib/localised_model_test.rb
@@ -46,7 +46,7 @@ class LocalisedModelTest < ActiveSupport::TestCase
     localised_model = LocalisedModel.new(model, :es)
 
     assert_not localised_model.valid?
-    assert_equal ["can't be blank"], localised_model.errors[:title]
+    assert_equal ["cannot be blank"], localised_model.errors[:title]
   end
 
   test "ActiveRecord has_many associations are localised" do
@@ -69,11 +69,11 @@ class LocalisedModelTest < ActiveSupport::TestCase
     model = create(:news_article)
     localised_model = LocalisedModel.new(model, :es)
     assert_not localised_model.update(title: "")
-    assert_equal ["can't be blank"], localised_model.errors[:title]
+    assert_equal ["cannot be blank"], localised_model.errors[:title]
 
     organisation = create(:organisation)
     localised_model = LocalisedModel.new(organisation, :fr)
     assert_not localised_model.update(name: "")
-    assert_equal ["can't be blank"], localised_model.errors[:name]
+    assert_equal ["cannot be blank"], localised_model.errors[:name]
   end
 end


### PR DESCRIPTION
Trello card: https://trello.com/c/khfU73qF/754-update-error-messaging-across-the-journey-in-design-and-code

This came up in a recent content review of Content Block Manager. GDS guidance is to avoid negative contractions like "can’t" and "don’t". From the [GDS Style guide][1]:

> Avoid negative contractions like can’t and don’t. Many users find them harder to read, or misread them as the opposite of what they say. Use cannot, instead of can’t.

[1]: https://www.gov.uk/guidance/style-guide/a-to-z#contractions