### PR TITLE
Fix flaky content block updates test

### DIFF
--- a/features/admin-history-content-block-updates.feature
+++ b/features/admin-history-content-block-updates.feature
@@ -11,6 +11,7 @@ Feature: Showing content block updates in history
     Then I should see an entry for the content block "Some email address" on the current edition
 
   Scenario: Content block update exists for a previous edition
+    Given some time has passed
     When I force publish a new edition of the news article "Stubble to be Outlawed"
     And I am on the edit page for news article "Stubble to be Outlawed"
     And I click the "History" tab

--- a/features/step_definitions/time_steps.rb
+++ b/features/step_definitions/time_steps.rb
@@ -1,0 +1,3 @@
+Given(/^some time has passed$/) do
+  Timecop.travel rand(1.hour..1.week).from_now
+end


### PR DESCRIPTION
Because [`HostContentUpdateEvent#is_for_newer_edition?`][1] relies on the date the edition was superseded, sometimes the tests are too fast for their own good and everything happens at the same time (or within too small a window for Rails to notice), so the timeline entry shows up as on the current edition. This is extremely unlikely to happen in Real Life, so we add an artificial passage of time using Timecop to give a more realistic gap between when then first edition was created and when it was superseded. This should fix the flakiness we’ve seen.

[1]: https://github.com/alphagov/whitehall/blob/3971e93a2c7612d95e38c439c4bbf9752eaf5c2c/app/models/host_content_update_event.rb#L19