### PR TITLE
add an endpoint for viewing Blocks by Content ID

### DIFF
--- a/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/documents_controller.rb
+++ b/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/documents_controller.rb
@@ -30,6 +30,16 @@ class ContentBlockManager::ContentBlock::DocumentsController < ContentBlockManag
     )
   end
 
+  def content_id
+    content_block_document = ContentBlockManager::ContentBlock::Document.where(content_id: params[:content_id]).first
+
+    if content_block_document.present?
+      redirect_to content_block_manager.content_block_manager_content_block_document_path(content_block_document)
+    else
+      raise ActiveRecord::RecordNotFound, "Could not find Content Block with Content ID #{params[:content_id]}"
+    end
+  end
+
   def new
     @schemas = ContentBlockManager::ContentBlock::Schema.all
   end

--- a/lib/engines/content_block_manager/config/routes.rb
+++ b/lib/engines/content_block_manager/config/routes.rb
@@ -3,6 +3,7 @@ ContentBlockManager::Engine.routes.draw do
     root to: "content_block/documents#index", via: :get
 
     namespace :content_block, path: "content-block" do
+      get "content-id/:content_id", to: "documents#content_id", as: :content_id
       resources :documents, only: %i[index show new], path_names: { new: "(:block_type)/new" }, path: "" do
         collection do
           post :new_document_options_redirect

--- a/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
@@ -297,6 +297,11 @@ When("I visit the Content Block Manager home page") do
   visit content_block_manager.content_block_manager_root_path
 end
 
+When("I visit a block's content ID endpoint") do
+  block = ContentBlockManager::ContentBlock::Document.last
+  visit content_block_manager.content_block_manager_content_block_content_id_path(block.content_id)
+end
+
 Then("I am taken back to Content Block Manager home page") do
   assert_equal current_path, content_block_manager.content_block_manager_root_path
 end

--- a/lib/engines/content_block_manager/features/view_object.feature
+++ b/lib/engines/content_block_manager/features/view_object.feature
@@ -14,6 +14,10 @@ Feature: View a content object
     And I should see the details for the email address content block
     And I should see 1 publish events on the timeline
 
+  Scenario: GDS Editor views a content object using the content ID
+    When I visit a block's content ID endpoint
+    And I should see the details for the email address content block
+
   Scenario: GDS Editor views dependent Content
     Given dependent content exists for a content block
     When I visit the Content Block Manager home page

--- a/lib/engines/content_block_manager/test/integration/content_block/documents_test.rb
+++ b/lib/engines/content_block_manager/test/integration/content_block/documents_test.rb
@@ -148,4 +148,11 @@ class ContentBlockManager::ContentBlock::DocumentsTest < ActionDispatch::Integra
       visit content_block_manager_content_block_document_path(document)
     end
   end
+
+  describe "#content_id" do
+    it "returns 404 if the document doesn't exist" do
+      visit content_block_manager_content_block_content_id_path("123")
+      assert_text "Could not find Content Block with Content ID 123"
+    end
+  end
 end


### PR DESCRIPTION
https://trello.com/c/76taF5IH/784-add-an-endpoint-to-view-a-content-block-by-content-id


We need to provide a way to view Content Blocks
via their Content ID, as this is the shared public
ID of a Block across different repos - this will
allow us to link to Blocks from Host Document's
history components.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
