### PR TITLE
add page title to Content Block Manager home page

### DIFF
--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/documents/index.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/documents/index.html.erb
@@ -1,6 +1,8 @@
 
 <% content_for :title_margin_bottom, 6 %>
 
+<% content_for :page_title, "Home" %>
+
 <% if @error_summary_errors %>
   <%= render "govuk_publishing_components/components/error_summary", {
     title: "There is a problem",

--- a/lib/engines/content_block_manager/features/content_block_manager.feature
+++ b/lib/engines/content_block_manager/features/content_block_manager.feature
@@ -3,6 +3,7 @@ Feature: Content block manager
   Scenario: Correct layout is used
     Given I am a GDS admin
     When I visit the Content Block Manager home page
+    Then I should see the object store's home page title
     Then I should see the object store's title in the header
     And I should see the object store's navigation
     And I should see the object store's phase banner

--- a/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
@@ -788,6 +788,10 @@ Then(/^I should see the object store's title in the header$/) do
   expect(page).to have_selector(".govuk-header__product-name", text: "Content Block Manager")
 end
 
+Then(/^I should see the object store's home page title$/) do
+  expect(page).to have_title "Home - GOV.UK Content Block Manager"
+end
+
 And(/^I should see the object store's navigation$/) do
   expect(page).to have_selector("a.govuk-header__link[href='#{content_block_manager.content_block_manager_root_path}']", text: "Dashboard")
 end


### PR DESCRIPTION
This sets the beginning of the page title - the
second half, the ` - GOV.UK Content Block Manager`
is set by the shared layout publishing component
[1] so it can't be changed.

Although the page title is Content Block Manager
I've gone with Search as the title, because that
is the main action taken on this page, and it
would be strange to have Content Block Manager
repeated twice.

[1]https://github.com/alphagov/govuk_publishing_components/blob/main/app/views/govuk_publishing_components/components/_layout_for_admin.html.erb

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
