### PR TITLE
Fix multiple replace asset bug

### DIFF
--- a/app/controllers/admin/case_studies_controller.rb
+++ b/app/controllers/admin/case_studies_controller.rb
@@ -6,7 +6,7 @@ class Admin::CaseStudiesController < Admin::EditionsController
   def update_image_display_option
     @edition.assign_attributes(image_display_option_params)
 
-    if updater.can_perform? && @edition.save_as(current_user)
+    if updater.can_perform? && @edition.save(user: current_user)
       @edition.update_lead_image
       updater.perform!
 

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -103,7 +103,7 @@ class Admin::EditionsController < Admin::BaseController
   def update
     @edition.assign_attributes(edition_params)
 
-    if updater.can_perform? && @edition.save_as(current_user)
+    if updater.can_perform? && @edition.save(user: current_user, context: Flipflop.remove_draft_change_note_validation? && :save_draft)
       updater.perform!
 
       if @edition.link_check_reports.last

--- a/app/models/concerns/edition/identifiable.rb
+++ b/app/models/concerns/edition/identifiable.rb
@@ -4,8 +4,8 @@ module Edition::Identifiable
   included do
     belongs_to :document, touch: true
     validates :document, presence: true
-    before_validation :ensure_presence_of_document, on: :create
-    before_validation :update_document_slug, on: :update
+    before_validation :ensure_presence_of_document, on: %i[create save_draft]
+    before_validation :update_document_slug, on: %i[update save_draft]
     before_validation :propagate_type_to_document
 
     scope :latest_edition, -> { joins(:document).where("editions.id = documents.latest_edition_id") }

--- a/app/models/concerns/edition/publishing.rb
+++ b/app/models/concerns/edition/publishing.rb
@@ -39,8 +39,11 @@ module Edition::Publishing
 
   def change_note_required?
     return false if new_record?
+    return false if previous_edition.blank?
+    # TODO: replace with except_on check for this in Rails 8
+    return false if validation_context == :save_draft
 
-    pre_publication? && previous_edition.present?
+    Edition::PRE_PUBLICATION_STATES.include?(state)
   end
 
   def change_note_present!

--- a/app/models/concerns/edition/workflow.rb
+++ b/app/models/concerns/edition/workflow.rb
@@ -100,13 +100,6 @@ module Edition::Workflow
     Edition::PRE_PUBLICATION_STATES.include?(state.to_s)
   end
 
-  def save_as(user)
-    if save
-      edition_authors.create!(user:)
-      recent_edition_openings.where(editor_id: user).delete_all
-    end
-  end
-
   def edition_has_no_unpublished_editions
     return unless document
 

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -124,6 +124,17 @@ class Edition < ApplicationRecord
     publicly_visible_and_available_in_english
   end
 
+  # rubocop:disable Rails/ActiveRecordOverride
+  def save(**options, &block)
+    saved = super
+    if saved && options.key?(:user)
+      edition_authors.create!(user: options[:user])
+      recent_edition_openings.where(editor_id: options[:user]).delete_all
+    end
+    saved
+  end
+  # rubocop:enable Rails/ActiveRecordOverride
+
   def creator
     edition_authors.first&.user
   end

--- a/app/services/draft_edition_updater.rb
+++ b/app/services/draft_edition_updater.rb
@@ -12,7 +12,7 @@ class DraftEditionUpdater < EditionService
       "A #{edition.state} edition may not be updated."
     elsif should_check_current_user_will_retain_access? && access_limit_excludes_current_user?
       "Access can only be limited by users belonging to an organisation tagged to the document"
-    elsif !edition.valid?
+    elsif !edition.valid?(Flipflop.remove_draft_change_note_validation? && :save_draft)
       "This edition is invalid: #{edition.errors.full_messages.to_sentence}"
     end
   end

--- a/app/services/draft_translation_updater.rb
+++ b/app/services/draft_translation_updater.rb
@@ -10,7 +10,7 @@ class DraftTranslationUpdater < EditionService
   def failure_reason
     if !edition.pre_publication?
       "A #{edition.state} edition may not be updated."
-    elsif !edition.valid?
+    elsif !edition.valid?(Flipflop.remove_draft_change_note_validation? && :save_draft)
       "This edition is invalid: #{edition.errors.full_messages.to_sentence}"
     end
   end

--- a/app/services/edition_auth_bypass_updater.rb
+++ b/app/services/edition_auth_bypass_updater.rb
@@ -9,7 +9,7 @@ class EditionAuthBypassUpdater
 
   def call
     @edition.set_auth_bypass_id
-    @edition.save_as(@current_user)
+    @edition.save!(user: @current_user)
     @updater.perform!
 
     update_file_attachments(@edition)

--- a/config/features.rb
+++ b/config/features.rb
@@ -26,4 +26,5 @@ Flipflop.configure do
   feature :govspeak_visual_editor, description: "Enables a visual editor for Govspeak fields", default: false
   feature :override_government, description: "Enables GDS Editors and Admins to override the government associated with a document", default: false
   feature :show_link_to_content_block_manager, description: "Shows link to Content Block Manager from Whitehall editor", default: Whitehall.integration_or_staging?
+  feature :remove_draft_change_note_validation, description: "Remove the change note validation for editions in draft state", default: false
 end

--- a/test/integration/attachment_replacement_integration_test.rb
+++ b/test/integration/attachment_replacement_integration_test.rb
@@ -10,9 +10,11 @@ class AttachmentReplacementIntegrationTest < ActionDispatch::IntegrationTest
   describe "attachment replacement" do
     let(:managing_editor) { create(:managing_editor) }
     let(:filename) { "sample.csv" }
-    let(:asset_manager_id) { "asset_manager_id" }
     let(:replacement_filename) { "sample.rtf" }
+    let(:double_replacement_filename) { "sample.docx" }
+    let(:asset_manager_id) { "asset_manager_id" }
     let(:replacement_asset_manager_id) { "replacement-asset-id" }
+    let(:double_replacement_asset_manager_id) { "double-replacement-asset-id" }
     let(:variant) { Asset.variants[:original] }
     let(:attachment) { build(:csv_attachment, title: "attachment-title", attachable: edition) }
 
@@ -89,6 +91,71 @@ class AttachmentReplacementIntegrationTest < ActionDispatch::IntegrationTest
                   .at_least_once
                   .with(asset_manager_id, { "replacement_id" => replacement_asset_manager_id })
 
+          AssetManagerAttachmentMetadataWorker.drain
+        end
+      end
+
+      context "when new draft is created and attachment is replaced twice" do
+        before do
+
+          [
+           { id: replacement_asset_manager_id, filename: replacement_filename },
+           { id: double_replacement_asset_manager_id, filename: double_replacement_filename }].each do |item|
+            Services.asset_manager.expects(:create_asset).with { |args|
+              args[:file].path =~ /#{item[:filename]}/
+            }.returns("id" => "http://asset-manager/assets/#{item[:id]}", "name" => item[:filename])
+          end
+          stub_asset(double_replacement_asset_manager_id)
+
+          Sidekiq::Job.clear_all
+        end
+
+        it "updates replacement_id for attachment in Asset Manager" do
+          visit admin_news_article_path(edition)
+          click_button "Create new edition"
+          # choose "No – it’s a minor edit that does not change the meaning"
+          # click_button "Save"
+
+          AssetManagerCreateAssetWorker.drain
+          PublishingApiDraftUpdateWorker.drain
+          AssetManagerAttachmentMetadataWorker.drain
+
+          Services.asset_manager.expects(:update_asset)
+                  .times(3)
+                  .with(asset_manager_id, { "replacement_id" => replacement_asset_manager_id })
+          Services.asset_manager.expects(:update_asset)
+                  .times(3)
+                  .with(replacement_asset_manager_id, has_entry({ "draft" => true }))
+
+          click_link "Attachments 1"
+          within page.find("li", text: filename) do
+            click_link "Edit attachment"
+          end
+          attach_file "Replace file", path_to_attachment(replacement_filename)
+          click_button "Save"
+          assert_text "Attachment 'attachment-title' updated"
+
+          AssetManagerCreateAssetWorker.drain
+          PublishingApiDraftUpdateWorker.drain
+          AssetManagerAttachmentMetadataWorker.drain
+
+
+          Services.asset_manager.expects(:update_asset)
+                  .times(3)
+                  .with(replacement_asset_manager_id, { "replacement_id" => double_replacement_asset_manager_id })
+          Services.asset_manager.expects(:update_asset)
+                  .times(3)
+                  .with(double_replacement_asset_manager_id, has_entry({ "draft" => true }))
+
+          within page.find("li", text: replacement_filename) do
+            click_link "Edit attachment"
+          end
+          attach_file "Replace file", path_to_attachment(double_replacement_filename)
+          click_button "Save"
+          assert_text "Attachment 'attachment-title' updated"
+
+          AssetManagerCreateAssetWorker.drain
+          PublishingApiDraftUpdateWorker.drain
           AssetManagerAttachmentMetadataWorker.drain
         end
       end

--- a/test/unit/app/helpers/admin/admin_govspeak_helper_test.rb
+++ b/test/unit/app/helpers/admin/admin_govspeak_helper_test.rb
@@ -74,7 +74,7 @@ class Admin::AdminGovspeakHelperTest < ActionView::TestCase
     writer = create(:writer)
     new_edition = publication.create_draft(writer)
     new_edition.change_note = "change-note"
-    new_edition.save_as(writer)
+    new_edition.save!(user: writer)
     new_edition.submit!
     publish(new_edition)
     html = govspeak_to_admin_html("this and [that](#{admin_publication_path(publication)})")

--- a/test/unit/app/helpers/govspeak_helper_link_rewriting_test.rb
+++ b/test/unit/app/helpers/govspeak_helper_link_rewriting_test.rb
@@ -99,7 +99,7 @@ private
     writer = create(:writer)
     new_draft = edition.create_draft(writer)
     new_draft.change_note = "change-note"
-    new_draft.save_as(writer)
+    new_draft.save!(user: writer)
     new_draft.submit!
     publish(new_draft)
     [edition, new_draft]
@@ -110,7 +110,7 @@ private
     writer = create(:writer)
     new_draft = edition.create_draft(writer)
     new_draft.change_note = "change-note"
-    new_draft.save_as(writer)
+    new_draft.save!(user: writer)
     [edition, new_draft]
   end
 end

--- a/test/unit/app/models/edition/active_editors_test.rb
+++ b/test/unit/app/models/edition/active_editors_test.rb
@@ -41,12 +41,12 @@ class Edition::ActiveEditorsTest < ActiveSupport::TestCase
     assert_equal [], edition.active_edition_openings
   end
 
-  test "#save_as removes all RecentEditionOpenings for the specified editor" do
+  test "#save with user option removes all RecentEditionOpenings for the specified editor" do
     user = create(:writer)
     edition = create(:edition)
     edition.open_for_editing_as(user)
     assert_difference "edition.recent_edition_openings.count", -1 do
-      edition.save_as(user)
+      edition.save(user: user)
     end
   end
 

--- a/test/unit/app/models/edition/identifiable_test.rb
+++ b/test/unit/app/models/edition/identifiable_test.rb
@@ -19,6 +19,12 @@ class Edition::IdentifiableTest < ActiveSupport::TestCase
     assert publication.document.content_id.present?
   end
 
+  test "should generate a content_id for the document of a new draft with the save_draft context" do
+    publication = build(:publication)
+    assert publication.valid?(:save_draft)
+    assert publication.document.content_id.present?
+  end
+
   test "should generate a content_id and slug on a document when present" do
     document = build(:document, content_id: nil, slug: nil)
     publication = build(:publication, document:)

--- a/test/unit/app/models/edition/publishing_test.rb
+++ b/test/unit/app/models/edition/publishing_test.rb
@@ -7,7 +7,15 @@ class Edition::PublishingChangeNoteTest < ActiveSupport::TestCase
     assert edition.valid?
   end
 
-  test "a draft is invalid without change note once saved if a published edition already exists" do
+  test "when validation context is save_draft a draft is valid without change note once saved if a published edition already exists" do
+    feature_flags.switch!(:remove_draft_change_note_validation, true)
+    published_edition = create(:published_edition)
+    edition = create(:draft_edition, change_note: nil, minor_change: false, document: published_edition.document)
+    assert edition.valid?(:save_draft)
+  end
+
+  test "when remove_draft_change_note_validation is false - a draft is invalid without change note once saved if a published edition already exists" do
+    feature_flags.switch!(:remove_draft_change_note_validation, false)
     published_edition = create(:published_edition)
     edition = create(:draft_edition, change_note: nil, minor_change: false, document: published_edition.document)
     assert_not edition.valid?

--- a/test/unit/app/models/edition/workflow_test.rb
+++ b/test/unit/app/models/edition/workflow_test.rb
@@ -96,68 +96,50 @@ class Edition::WorkflowTest < ActiveSupport::TestCase
     assert edition.valid?
   end
 
-  test "#save_as saves the edition" do
+  test "#save with user option records the new creator if save succeeds" do
     edition = create(:publication)
-    edition.expects(:save)
-    edition.save_as(create(:user))
-  end
-
-  test "#save_as records the new creator if save succeeds" do
-    edition = create(:publication)
-    edition.stubs(:save).returns(true)
     user = create(:user)
-    edition.save_as(user)
+    edition.save!(user:)
     assert_equal 2, edition.edition_authors.count
     assert_equal user, edition.edition_authors.last.user
   end
 
-  test "#save_as does not record new creator if save fails" do
+  test "#save with user option does not record new creator if save fails" do
     edition = create(:publication)
-    edition.stubs(:save).returns(true)
     user = create(:user)
-    edition.save_as(user)
+    edition.save!(user:)
     assert_equal 2, edition.edition_authors.count
     assert_equal user, edition.edition_authors.last.user
   end
 
-  test "#save_as returns true if save succeeds" do
-    edition = create(:publication)
-    edition.stubs(:save).returns(true)
-    assert edition.save_as(create(:user))
-  end
-
-  test "#save_as updates the document slug if this is the first draft" do
+  test "#save with user option updates the document slug if this is the first draft" do
     edition = create(:submitted_publication, title: "First Title")
-    edition.save_as(user = create(:user))
+    user = create(:user)
+    edition.save!(user:)
 
     edition.title = "Second Title"
-    edition.save_as(user)
+    edition.save!(user:)
     publish(edition)
 
     assert_nil Publication.published_as("first-title")
     assert_equal edition, Publication.published_as("second-title")
   end
 
-  test "#save_as does not alter the slug if this edition has previously been published" do
+  test "#save with user option does not alter the slug if this edition has previously been published" do
     edition = create(:submitted_publication, title: "First Title")
-    edition.save_as(user = create(:user))
+    user = create(:user)
+    edition.save!(user:)
     publish(edition)
 
     new_draft = edition.create_draft(user)
     new_draft.title = "Second Title"
     new_draft.change_note = "change-note"
-    new_draft.save_as(user)
+    new_draft.save!(user:)
     new_draft.submit!
     publish(new_draft)
 
     assert_equal new_draft, Publication.published_as("first-title")
     assert_nil Publication.published_as("second-title")
-  end
-
-  test "#save_as returns false if save fails" do
-    edition = create(:publication)
-    edition.stubs(:save).returns(false)
-    assert_not edition.save_as(create(:user))
   end
 
   test "#supersede! on a depended-upon edition destroys its dependencies" do

--- a/test/unit/app/models/edition_test.rb
+++ b/test/unit/app/models/edition_test.rb
@@ -246,16 +246,16 @@ class EditionTest < ActiveSupport::TestCase
   test ".authored_by includes editions edited by given user" do
     publication = create(:publication)
     writer = create(:writer)
-    publication.save_as(writer)
+    publication.save!(user: writer)
     assert Edition.authored_by(writer).include?(publication)
   end
 
   test ".authored_by includes editions only once no matter how many edits a user has made" do
     publication = create(:publication)
     writer = create(:writer)
-    publication.save_as(writer)
-    publication.save_as(writer)
-    publication.save_as(writer)
+    publication.save!(user: writer)
+    publication.save!(user: writer)
+    publication.save!(user: writer)
     assert_equal 1, Edition.authored_by(writer).size
   end
 


### PR DESCRIPTION
[Trello](https://trello.com/c/31CtEP8h/3249-fix-missing-replacement-causing-assets-to-be-live-when-they-should-not-be)