### PR TITLE
(801) Link to content block from Whitehall history

### DIFF
--- a/app/assets/stylesheets/admin/views/_host-content-update-event.scss
+++ b/app/assets/stylesheets/admin/views/_host-content-update-event.scss
@@ -3,13 +3,14 @@
     margin-bottom: govuk-spacing(4);
   }
 
-  &__detail {
+  &__detail,
+  &__link {
     margin-top: govuk-spacing(0);
     margin-bottom: govuk-spacing(0);
   }
 
   &__heading {
-    margin-bottom: govuk-spacing(1);
+    margin-bottom: govuk-spacing(0);
   }
 
   &__datetime {

--- a/app/components/admin/editions/host_content_update_event_component.html.erb
+++ b/app/components/admin/editions/host_content_update_event_component.html.erb
@@ -1,8 +1,12 @@
 <div class="app-view-editions-host-content-update-event-entry__list-item">
-  <h4 class="govuk-heading-s app-view-editions-host-content-update-event-entry__heading">Content Block Update</h4>
+  <h4 class="govuk-heading-s app-view-editions-host-content-update-event-entry__heading">Content block updated</h4>
 
-  <p class="govuk-body app-view-editions-host-content-update-event-entry__detail">
-    <%= activity %>
+  <p class="app-view-editions-host-content-update-event-entry__detail">
+    <%= block_type %>: <%= block_name %>
+  </p>
+
+  <p class="govuk-body app-view-editions-host-content-update-event-entry__link">
+    <%= link_to link_text, helpers.content_block_manager.content_block_manager_content_block_content_id_path(content_id: event.content_id), class: "govuk-link" %>
   </p>
 
   <p class="govuk-body-s app-view-editions-host-content-update-event-entry__datetime">

--- a/app/components/admin/editions/host_content_update_event_component.rb
+++ b/app/components/admin/editions/host_content_update_event_component.rb
@@ -9,8 +9,16 @@ private
 
   attr_reader :event
 
-  def activity
-    "#{event.content_title.strip} updated"
+  def block_type
+    event.document_type
+  end
+
+  def block_name
+    event.content_title.strip
+  end
+
+  def link_text
+    "[View#{tag.span(" #{block_name}", class: 'govuk-visually-hidden')} in Content Block Manager]".html_safe
   end
 
   def time

--- a/app/models/host_content_update_event.rb
+++ b/app/models/host_content_update_event.rb
@@ -1,4 +1,4 @@
-class HostContentUpdateEvent < Data.define(:author, :created_at, :content_id, :content_title)
+class HostContentUpdateEvent < Data.define(:author, :created_at, :content_id, :content_title, :document_type)
   def self.all_for_date_window(document:, from:, to:)
     events = Services.publishing_api.get_events_for_content_id(document.content_id, {
       action: "HostContentUpdateJob",
@@ -12,6 +12,7 @@ class HostContentUpdateEvent < Data.define(:author, :created_at, :content_id, :c
         created_at: Time.zone.parse(event["created_at"]),
         content_id: event["payload"]["source_block"]["content_id"],
         content_title: event["payload"]["source_block"]["title"],
+        document_type: humanize_document_type(event["payload"]["source_block"]["document_type"]),
       )
     end
   end
@@ -30,5 +31,9 @@ class HostContentUpdateEvent < Data.define(:author, :created_at, :content_id, :c
 
   def self.get_user_for_uuid(uuid)
     User.find_by(uid: uuid)
+  end
+
+  def self.humanize_document_type(document_type)
+    document_type.delete_prefix("content_block_").humanize
   end
 end

--- a/features/step_definitions/content_block_update_steps.rb
+++ b/features/step_definitions/content_block_update_steps.rb
@@ -7,7 +7,7 @@ Then(/^I should see an entry for the content block "([^"]*)" on the (current|pre
   selector = current_or_previous == "current" ? ".app-view-editions__current-edition-entries" : ".app-view-editions__previous-edition-entries"
 
   within selector do
-    assert_text "Content Block Update"
-    assert_text "#{content_block} updated"
+    assert_text "Content block updated"
+    assert_text content_block
   end
 end

--- a/test/components/admin/editions/host_content_update_event_component_test.rb
+++ b/test/components/admin/editions/host_content_update_event_component_test.rb
@@ -2,22 +2,26 @@ require "test_helper"
 
 class Admin::Editions::HostContentUpdateEventComponentTest < ViewComponent::TestCase
   extend Minitest::Spec::DSL
-  include Rails.application.routes.url_helpers
+  include ContentBlockManager::Engine.routes.url_helpers
 
   let(:created_at) { Time.zone.local(2020, 1, 1, 11, 11) }
   let(:content_title) { "Some content" }
+  let(:document_type) { "Email address" }
   let(:user) { build_stubbed(:user) }
 
   let(:host_content_update_event) do
-    build(:host_content_update_event, content_title:, created_at:, author: user)
+    build(:host_content_update_event, content_title:, created_at:, author: user, document_type:)
   end
 
   it "constructs output based on the entry when an actor is present" do
     render_inline(Admin::Editions::HostContentUpdateEventComponent.new(host_content_update_event))
 
-    assert_equal page.find("h4").text, "Content Block Update"
-    assert_equal page.all("p")[0].text.strip, "#{content_title} updated"
-    assert_equal page.all("p")[1].text.strip, "1 January 2020 11:11am by #{user.name}"
+    assert_equal page.find("h4").text, "Content block updated"
+    assert_equal page.all("p")[0].text.strip, "#{document_type}: #{content_title}"
+    assert_equal page.all("a")[0].native.inner_html, "[View<span class=\"govuk-visually-hidden\"> #{content_title}</span> in Content Block Manager]"
+    assert_equal page.all("a")[0].native["href"], content_block_manager_content_block_content_id_path(content_id: host_content_update_event.content_id)
+
+    assert_equal page.all("p")[2].text.strip, "1 January 2020 11:11am by #{user.name}"
   end
 
   describe "when an actor is not present" do
@@ -26,7 +30,7 @@ class Admin::Editions::HostContentUpdateEventComponentTest < ViewComponent::Test
     it "shows removed user when an actor is not present" do
       render_inline(Admin::Editions::HostContentUpdateEventComponent.new(host_content_update_event))
 
-      assert_equal page.all("p")[1].text.strip, "1 January 2020 11:11am by User (removed)"
+      assert_equal page.all("p")[2].text.strip, "1 January 2020 11:11am by User (removed)"
     end
   end
 end

--- a/test/factories/host_content_update_events.rb
+++ b/test/factories/host_content_update_events.rb
@@ -4,9 +4,10 @@ FactoryBot.define do
     created_at { Time.zone.now }
     content_id { SecureRandom.uuid }
     content_title { "Some title" }
+    document_type { "Some document type" }
 
     initialize_with do
-      new(author:, created_at:, content_id:, content_title:)
+      new(author:, created_at:, content_id:, content_title:, document_type:)
     end
   end
 end

--- a/test/unit/app/models/host_content_update_event_test.rb
+++ b/test/unit/app/models/host_content_update_event_test.rb
@@ -34,6 +34,7 @@ class HostContentUpdateEventTest < ActiveSupport::TestCase
                 "title" => "An exciting piece of content",
                 "content_id" => "ef224ae6-7a81-4c59-830b-e9884fe57ec8",
                 "updated_by_user_uid" => user.uid,
+                "document_type" => "content_block_email_address",
               },
             },
           },
@@ -53,6 +54,7 @@ class HostContentUpdateEventTest < ActiveSupport::TestCase
                 "title" => "Another exciting piece of content",
                 "content_id" => "5c5520ce-6677-4a76-bd6e-4515f46a804e",
                 "updated_by_user_uid" => nil,
+                "document_type" => "content_block_something_else",
               },
             },
           },
@@ -67,11 +69,13 @@ class HostContentUpdateEventTest < ActiveSupport::TestCase
       assert_equal result.first.created_at, Time.zone.parse("2024-01-01T00:00:00.000Z")
       assert_equal result.first.content_id, "ef224ae6-7a81-4c59-830b-e9884fe57ec8"
       assert_equal result.first.content_title, "An exciting piece of content"
+      assert_equal result.first.document_type, "Email address"
 
       assert_nil result.second.author
       assert_equal result.second.created_at, Time.zone.parse("2023-12-01T00:00:00.000Z")
       assert_equal result.second.content_id, "5c5520ce-6677-4a76-bd6e-4515f46a804e"
       assert_equal result.second.content_title, "Another exciting piece of content"
+      assert_equal result.second.document_type, "Something else"
     end
   end
 


### PR DESCRIPTION
Trello card: https://trello.com/c/iYVwlbzT/801-link-to-content-block-from-whitehall-history

This updates the Whitehall history to show a bit more information about the content block that has been updated, as well as linking to the block in Content Block Manager

~~Needs https://github.com/alphagov/publishing-api/pull/3077 to be merged first~~

## Screenshot

![image](https://github.com/user-attachments/assets/d276e37c-b7b6-4a60-aea3-b943bfd566fd)
