### PR TITLE
Stop validating change notes for draft editions

### DIFF
--- a/app/components/admin/editions/show/preview_component.html.erb
+++ b/app/components/admin/editions/show/preview_component.html.erb
@@ -6,7 +6,11 @@
     margin_bottom: 3,
   } %>
 
-  <% if versioning_completed %>
+  <% if edition.new_record? %>
+    <%= render "govuk_publishing_components/components/inset_text", {
+      text: "To see the changes and share a document preview link, save the document.",
+    } %>
+  <% else %>
     <p class="govuk-body">
       <%= preview_link(primary_locale_link_text, edition.public_url(draft: true)) %>
     </p>
@@ -55,9 +59,5 @@
         <% end %>
       <% end %>
     <% end %>
-  <% else %>
-    <%= render "govuk_publishing_components/components/inset_text", {
-      text: "To see the changes and share a document preview link, add a change note or mark the change type to minor.",
-    } %>
   <% end %>
 </section>

--- a/app/components/admin/editions/show/preview_component.rb
+++ b/app/components/admin/editions/show/preview_component.rb
@@ -15,10 +15,6 @@ private
 
   attr_reader :edition
 
-  def versioning_completed
-    @versioning_completed ||= edition.versioning_completed?
-  end
-
   def preview_link(link_text, href)
     link_to(link_text,
             href,

--- a/app/helpers/admin/editions_helper.rb
+++ b/app/helpers/admin/editions_helper.rb
@@ -131,7 +131,7 @@ module Admin::EditionsHelper
 
   def standard_edition_publishing_controls(form, edition)
     tag.div(class: "publishing-controls") do
-      if edition.change_note_required?
+      if edition.previous_edition.present?
         concat render("change_notes", form:, edition:)
       end
 

--- a/app/models/concerns/edition/publishing.rb
+++ b/app/models/concerns/edition/publishing.rb
@@ -38,9 +38,9 @@ module Edition::Publishing
   end
 
   def change_note_required?
-    return false if new_record?
+    return false if state == "draft"
 
-    pre_publication? && previous_edition.present?
+    previous_edition.present?
   end
 
   def change_note_present!

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -142,8 +142,6 @@ class Edition < ApplicationRecord
   end
 
   def versioning_completed?
-    return true unless change_note_required?
-
     change_note.present? || minor_change
   end
 

--- a/app/services/edition_publisher.rb
+++ b/app/services/edition_publisher.rb
@@ -8,12 +8,17 @@ class EditionPublisher < EditionService
   def failure_reasons
     return @failure_reasons if @failure_reasons
 
+    # Make sure edition is being validated as though it were published so that change note validation is enabled
+    old_state = edition.state
+    edition.state = :published
+
     reasons = []
     reasons << "This edition is invalid: #{edition.errors.full_messages.to_sentence}" unless edition.valid?
     reasons << "This edition contains links which violate linking guidelines" if govspeak_link_errors.any?
     reasons << "An edition that is #{edition.current_state} cannot be #{past_participle}" unless can_transition?
     reasons << "Scheduled editions cannot be published. This edition is scheduled for publication on #{edition.scheduled_publication}" if scheduled_for_publication?
 
+    edition.state = old_state
     @failure_reasons = reasons
   end
 

--- a/app/services/edition_scheduler.rb
+++ b/app/services/edition_scheduler.rb
@@ -10,6 +10,10 @@ class EditionScheduler < EditionService
   end
 
   def failure_reason
+    # Make sure edition is being validated as though it were scheduled so that change note validation is enabled
+    old_state = edition.state
+    edition.state = :scheduled
+
     @failure_reason ||= if !edition.valid?
                           "This edition is invalid: #{edition.errors.full_messages.to_sentence}"
                         elsif !can_transition?
@@ -21,6 +25,9 @@ class EditionScheduler < EditionService
                         elsif DataHygiene::GovspeakLinkValidator.new(edition.body).errors.any?
                           "This edition contains links which violate linking guidelines"
                         end
+
+    edition.state = old_state
+    @failure_reason
   end
 
 private

--- a/app/views/admin/editions/_standard_fields.html.erb
+++ b/app/views/admin/editions/_standard_fields.html.erb
@@ -106,7 +106,7 @@
     <% end %>
   </div>
 
-  <% if !edition.new_record? && @edition.versioning_completed? %>
+  <% unless edition.new_record? %>
     <%= render "govuk_publishing_components/components/inset_text", {
       } do %>
       <p class="govuk-body">

--- a/features/visual-editor.feature
+++ b/features/visual-editor.feature
@@ -11,7 +11,6 @@ Feature: Save edition content with visual editor
     When I fill in the required fields for publication "Publication with visual editor" in organisation "Visual ministry"
     And I save and go to document summary
     Then I should see the visual editor on subsequent edits of the publication
-    And I force publish the publication "Publication with visual editor"
 
   @javascript
   Scenario: I create a new publication and exit the visual editor experience

--- a/test/components/admin/editions/show/preview_component_test.rb
+++ b/test/components/admin/editions/show/preview_component_test.rb
@@ -60,14 +60,13 @@ class Admin::Editions::Show::PreviewComponentTest < ViewComponent::TestCase
     assert_selector ".govuk-details__summary-text", text: "Share document preview", count: 0
   end
 
-  test "does not render preview or sharable preview functionality and informs the user when versioning needs to be completed" do
-    edition = build(:publication, document: @document)
-    edition.stubs(:versioning_completed?).returns(false)
+  test "does not render preview or sharable preview functionality and informs the user when edition has not been saved" do
+    edition = build(:publication, document: @document, title: nil)
 
     render_inline(Admin::Editions::Show::PreviewComponent.new(edition:))
 
     assert_selector "a[href='#{edition.public_url(draft: true)}']", text: "Preview on website (opens in new tab)", count: 0
     assert_selector ".govuk-details__summary-text", text: "Share document preview", count: 0
-    assert_selector ".govuk-inset-text", text: "To see the changes and share a document preview link, add a change note or mark the change type to minor."
+    assert_selector ".govuk-inset-text", text: "To see the changes and share a document preview link, save the document."
   end
 end

--- a/test/functional/admin/edition_lead_images_controller_test.rb
+++ b/test/functional/admin/edition_lead_images_controller_test.rb
@@ -23,14 +23,14 @@ class Admin::EditionLeadImagesControllerTest < ActionController::TestCase
     image = build(:image)
     edition = create(:draft_case_study, images: [image], document: published_edition.document)
 
-    edition.change_note = nil
+    edition.title = nil
     edition.save!(validate: false)
 
     get :update, params: { edition_id: edition.id, id: image.id }
 
     assert_nil edition.reload.lead_image
     assert_redirected_to admin_edition_images_path(edition)
-    assert_equal "This edition is invalid: Change note cannot be blank", flash[:alert]
+    assert_equal "This edition is invalid: Title cannot be blank", flash[:alert]
   end
 
   test "PATCH :update does not update the lead image when edition's body contains the images markdown" do

--- a/test/functional/admin/generic_editions_controller_test.rb
+++ b/test/functional/admin/generic_editions_controller_test.rb
@@ -100,15 +100,4 @@ class Admin::GenericEditionsControllerTest < ActionController::TestCase
     get :show, params: { id: draft_edition }
     assert_select ".govuk-link", text: "Preview on website (opens in new tab)", href: draft_edition.public_url(draft: true)
   end
-
-  view_test "GET :show doesn't render preview link if publically visible, change note is blank and edition is a major version" do
-    published_edition = create(:published_edition)
-    draft_edition = create(:draft_edition, change_note: nil, minor_change: false, document: published_edition.document)
-    stub_publishing_api_expanded_links_with_taxons(draft_edition.content_id, [])
-
-    get :show, params: { id: draft_edition }
-
-    assert_select ".govuk-link", text: "Preview on website (opens in new tab)", href: draft_edition.public_url(draft: true), count: 0
-    assert_select ".govuk-inset-text", text: "To see the changes and share a document preview link, add a change note or mark the change type to minor."
-  end
 end

--- a/test/unit/app/models/attachment_data_visibility_test.rb
+++ b/test/unit/app/models/attachment_data_visibility_test.rb
@@ -177,6 +177,7 @@ class AttachmentDataVisibilityTest < ActiveSupport::TestCase
 
             before do
               new_edition.reload
+              new_edition.change_note = "Minor change"
             end
 
             it "is not deleted" do
@@ -410,6 +411,7 @@ class AttachmentDataVisibilityTest < ActiveSupport::TestCase
 
             before do
               new_edition.reload
+              new_edition.change_note = "Major change"
             end
 
             it "is not deleted" do

--- a/test/unit/app/models/edition/publishing_test.rb
+++ b/test/unit/app/models/edition/publishing_test.rb
@@ -7,28 +7,28 @@ class Edition::PublishingChangeNoteTest < ActiveSupport::TestCase
     assert edition.valid?
   end
 
-  test "a draft is invalid without change note once saved if a published edition already exists" do
+  test "a draft is valid without change note once saved if a published edition already exists" do
     published_edition = create(:published_edition)
     edition = create(:draft_edition, change_note: nil, minor_change: false, document: published_edition.document)
-    assert_not edition.valid?
+    assert edition.valid?
   end
 
   test "a submitted edition is invalid without change note once saved if a published edition already exists" do
     published_edition = create(:published_edition)
-    edition = create(:submitted_edition, change_note: nil, minor_change: false, document: published_edition.document)
+    edition = build(:submitted_edition, change_note: nil, minor_change: false, document: published_edition.document)
     assert_not edition.valid?
   end
 
   test "a rejected edition is invalid without change note once saved if a published edition already exists" do
     published_edition = create(:published_edition)
-    edition = create(:rejected_edition, change_note: nil, minor_change: false, document: published_edition.document)
+    edition = build(:rejected_edition, change_note: nil, minor_change: false, document: published_edition.document)
     assert_not edition.valid?
   end
 
-  test "a draft is invalid without change note once saved if an unpublished edition already exists" do
+  test "a draft is valid without change note once saved if an unpublished edition already exists" do
     unpublished_edition = create(:unpublished_edition)
     edition = create(:draft_edition, change_note: nil, minor_change: false, document: unpublished_edition.document)
-    assert_not edition.valid?
+    assert edition.valid?
   end
 
   test "is valid without change note if no published edition already exists" do

--- a/test/unit/app/models/edition_test.rb
+++ b/test/unit/app/models/edition_test.rb
@@ -928,13 +928,6 @@ class EditionTest < ActiveSupport::TestCase
     end
   end
 
-  test "#versioning_completed? returns true if change note is not required" do
-    edition = build(:edition, change_note: nil, minor_change: false)
-    edition.stubs(:change_note_required?).returns(false)
-
-    assert edition.versioning_completed?
-  end
-
   test "#versioning_completed? returns true when a change note is present" do
     edition = build(:edition, change_note: "This is a change.", minor_change: false)
     edition.stubs(:change_note_required?).returns(true)

--- a/test/unit/app/services/edition_force_publisher_test.rb
+++ b/test/unit/app/services/edition_force_publisher_test.rb
@@ -16,6 +16,8 @@ class EditionForcePublisherTest < ActiveSupport::TestCase
   test "#perform! deletes any unpublishings for the edition" do
     unpublishing = create(:unpublishing)
     edition = unpublishing.edition
+    edition.change_note = "Major change"
+    edition.save!
 
     EditionForcePublisher.new(edition).perform!
 


### PR DESCRIPTION
We only want to make sure that editions have a change note at the point that they are submitted for publication (or force published/scheduled).

Validating change notes for draft editions could cause bugs. For example, if the user replaced an attachment before adding a change note to the edition, the replacement silently failed, leaving the old attachment live.

We therefore change the validation logic to only validate non-draft editions.

Unfortunately this required us to temporarily update the state of the editions in the edition publisher and scheduler services. Those services trigger the edition validation before the state is updated, so the validation occurs as if the editions are still drafts, which isn't logical behaviour.

Trello: https://trello.com/c/31CtEP8h - note that this is how we fix the bug, even if it looks unrelated
