### PR TITLE
Ensure asset update happens at least once

### DIFF
--- a/app/sidekiq/asset_manager_create_asset_worker.rb
+++ b/app/sidekiq/asset_manager_create_asset_worker.rb
@@ -42,14 +42,16 @@ private
   end
 
   def enqueue_downstream_service_updates(assetable_id, assetable_type, attachable_model_class, attachable_model_id)
-    assetable = assetable_type.constantize.find(assetable_id)
-    assetable.republish_on_assets_ready if assetable.respond_to? :republish_on_assets_ready
-
     if attachable_model_class
       if attachable_model_class.constantize.ancestors.include?(Edition)
         PublishingApiDraftUpdateWorker.perform_async(attachable_model_class, attachable_model_id)
-      else
-        AssetManagerAttachmentMetadataWorker.perform_async(assetable_id)
+      end
+
+      AssetManagerAttachmentMetadataWorker.perform_async(assetable_id)
+    else
+      assetable = assetable_type.constantize.find(assetable_id)
+      if assetable.respond_to?(:republish_on_assets_ready)
+        assetable.republish_on_assets_ready
       end
     end
   end

--- a/test/integration/asset_manager_test.rb
+++ b/test/integration/asset_manager_test.rb
@@ -9,6 +9,7 @@ class AssetManagerIntegrationTest
       @edition = create(:draft_publication)
       @attachment = FactoryBot.build(:file_attachment_with_no_assets, file: file_fixture(@filename), attachable: @edition)
       @asset_manager_response = { "id" => "http://asset-manager/assets/asset_manager_id", "name" => @filename }
+      Services.asset_manager.stubs(:asset).returns(@asset_manager_response)
     end
 
     test "sends the attachment to Asset Manager" do


### PR DESCRIPTION
The `CreateAssetWorker` relies on the `DraftUpdaterWorker` successfully running in order to trigger a call to the `MetadataWorker` for editionable attachables. This happens due to the `AttachmentUpdater` service listening on the edition `draft_update` event.

However, if the edition is not valid, e.g. the attachment has been updated/replaced before saving the edition with a change note, then the `DraftUpdaterWorker` will not run, and the MetadataWorker will not be triggered. This means the state of the asset in Asset Manager will not be updated.

There are additional attempts that try to achieve the same result, that also fail:
- The `save_attachment` method in the `AttachmentsController` calls the `draft_updater`, which again fails, as above, because the edition is invalid, causing the `MetadataWorker` to not be enqueued.
- Although the `attachment_updater` in the `AttachmentsController` also triggers the MetadataWorker, it typically fails because the assets are not yet ready. There is currently no retry mechanism in place for this worker.

The current change ensures that the `MetadataWorker` runs after the asset has been created irrespective of whether or not the edition is valid. This ensures that we send an update to Asset Manager.

Related PRs for alternative solutions we considered (now closed): #9801 and #9806.


[Trello](https://trello.com/c/31CtEP8h/3249-fix-missing-replacement-causing-assets-to-be-live-when-they-should-not-be)