### PR TITLE
Maintenance banner

### DIFF
--- a/app/views/shared/_phase_banner.html.erb
+++ b/app/views/shared/_phase_banner.html.erb
@@ -2,6 +2,7 @@
 
 <% if t('admin.whats_new.show_banner') %>
   <%= render "govuk_publishing_components/components/phase_banner", {
+      id: "whats_new_banner",
       phase: "What's new",
       message: sanitize("Improvements to the editor workflow -
         #{
@@ -16,6 +17,7 @@
     } %>
 <% elsif show_feedback_banner %>
   <%= render "govuk_publishing_components/components/phase_banner", {
+      id: "feedback_banner",
       phase: "Feedback",
       message: mail_to(
         "publishing-service-feedback@digital.cabinet-office.gov.uk",
@@ -25,4 +27,12 @@
         },
       ),
     } %>
+<% end %>
+<% if t('admin.maintenance_banner.show_banner') %>
+  <%= render "govuk_publishing_components/components/phase_banner", {
+    id: "maintenance_banner",
+    phase: "Maintenance",
+    message: t("admin.maintenance_banner.message"),
+    disable_ga4: true,
+  } %>
 <% end %>

--- a/config/locales/en/admin/maintenance_banner.yml
+++ b/config/locales/en/admin/maintenance_banner.yml
@@ -1,0 +1,6 @@
+en:
+  admin:
+    maintenance_banner:
+      show_banner: true
+      message: |
+        Whitehall Publisher will be unavailable on 3 February from 8pm to 10pm for essential maintenance. Scheduled publishing may be delayed.

--- a/config/locales/en/admin/whats_new.yml
+++ b/config/locales/en/admin/whats_new.yml
@@ -1,7 +1,7 @@
 en:
   admin:
     feedback:
-      show_banner: true
+      show_banner: false
     whats_new:
       show_banner: false
       title: What’s new in Whitehall Publisher

--- a/test/integration/maintenance_banner_test.rb
+++ b/test/integration/maintenance_banner_test.rb
@@ -1,0 +1,15 @@
+require "test_helper"
+
+class MaintenanceBannerTest < ActionDispatch::IntegrationTest
+  test "uses the configuration value in the maintenance_banner.yml locale file to determine whether to render the banner" do
+    login_as create(:gds_editor)
+    get admin_root_path
+
+    if I18n.t("admin.maintenance_banner.show_banner")
+      assert_select "#maintenance_banner .govuk-phase-banner__content__tag", text: "Maintenance"
+      assert_select "#maintenance_banner .govuk-phase-banner__text", text: I18n.t("admin.maintenance_banner.message")
+    else
+      assert_select "#maintenance_banner", count: 0
+    end
+  end
+end

--- a/test/integration/whats_new_test.rb
+++ b/test/integration/whats_new_test.rb
@@ -25,9 +25,9 @@ class WhatsNewTest < ActionDispatch::IntegrationTest
     get admin_whats_new_path
 
     if I18n.t("admin.whats_new.show_banner") || I18n.t("admin.feedback.show_banner")
-      assert_select ".gem-c-phase-banner", count: 1
+      assert_select "#whats_new_banner.gem-c-phase-banner", count: 1
     else
-      assert_select ".gem-c-phase-banner", count: 0
+      assert_select "#whats_new_banner.gem-c-phase-banner", count: 0
     end
   end
 end


### PR DESCRIPTION
We want be able to switch a maintenance banner on to warn users of upcoming downtime.

Trello: https://trello.com/c/qjrtsn2Y