### PR TITLE
Update govuk_publishing_components to 48.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,7 +132,6 @@ GEM
       ssrf_filter (~> 1.0)
     carrierwave-i18n (3.0.0)
       carrierwave (>= 3.0.0, < 4)
-    chartkick (5.1.2)
     childprocess (5.0.0)
     chronic (0.10.2)
     climate_control (1.2.0)
@@ -310,8 +309,7 @@ GEM
     govuk_personalisation (1.1.0)
       plek (>= 1.9.0)
       rails (>= 6, < 9)
-    govuk_publishing_components (46.4.0)
-      chartkick
+    govuk_publishing_components (48.0.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/app/views/admin/governments/prepare_to_close.html.erb
+++ b/app/views/admin/governments/prepare_to_close.html.erb
@@ -9,7 +9,9 @@
     } %>
 
     <%= render "govuk_publishing_components/components/list", {
-      aria_label: "A list of active ministerial appointments.",
+      aria: {
+        label: "A list of active ministerial appointments.",
+      },
       visible_counters: true,
       extra_spacing: true,
       margin_bottom: 8,


### PR DESCRIPTION
## What

Updates `govuk_publishing_components` from `46.4.0` to `48.0.0`. 

<details>

<summary>How this was achieved</summary>

By running the following bundle update against whitehall-app in the Docker container: `govuk-docker exec whitehall-app bundle update --conservative govuk_publishing_components`

I initially looked to trigger a dependabot version bump of this dependency but encountered this message in the [dependancy graph updates view in GitHub](https://github.com/alphagov/whitehall/network/updates/200061/jobs)

> Errored with the message "Dependabot cannot open any more pull requests"

</details>

## Why 

Card 3317 will require `data_attributes` to be added to (flash) alert components to support GA4 tracking. While the documentation for these components describes `data_attributes` as a standard option (<sup>[1](https://components.publishing.service.gov.uk/component-guide/success_alert#standard-options) and [2](https://components.publishing.service.gov.uk/component-guide/error_alert#standard-options)</sup>), the component wrapper required to enable this was only added in version `48.0.0`.

## Checking the breaking changes

### Breaking changes in [47.0.0](https://github.com/alphagov/govuk_publishing_components/blob/main/CHANGELOG.md#4700)

The chart component was removed) in `47.0.0`, but a [search](https://github.com/search?q=repo%3Aalphagov%2Fwhitehall+govuk_publishing_components%2Fcomponents%2Fchart&type=code) shows there are no occurrences of `chart_helper` in the codebase

### Breaking changes in [48.0.0](https://github.com/alphagov/govuk_publishing_components/blob/main/CHANGELOG.md#4800)

1. The **Devolved Nations** component was changed, but a [search](https://github.com/search?q=repo%3Aalphagov%2Fwhitehall+govuk_publishing_components%2Fcomponents%2Fdevolved&type=code) shows this component does not seem to be used in the codebase
1. The **Intervention** component was changed, but a [search](https://github.com/search?q=repo%3Aalphagov%2Fwhitehall+govuk_publishing_components%2Fcomponents%2Fintervention&type=code) shows this component does not seem to be used in the codebase
1. The **List** component was changed and now accepts an `aria` hash option, rather than the `aria_label` string. A [search](https://github.com/search?q=repo%3Aalphagov%2Fwhitehall+govuk_publishing_components%2Fcomponents%2Flist+AND+aria_label&type=code) shows one usage, which has been updated in this PR
1. The **Search** component was changed to accept a `label_id`, rather than an `id`, option. A [search](https://github.com/search?q=repo%3Aalphagov%2Fwhitehall+govuk_publishing_components%2Fcomponents%2Fsearch+AND+id&type=code) shows `id` does not seem to be used on any search components in the application.
