### PR TITLE
Content modelling/814 allow nested fields in content block manager

### DIFF
--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/summary_list_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/summary_list_component.rb
@@ -1,4 +1,6 @@
 class ContentBlockManager::ContentBlock::Document::Show::SummaryListComponent < ViewComponent::Base
+  include ContentBlockManager::ContentBlock::EditionHelper
+
   def initialize(content_block_document:)
     @content_block_document = content_block_document
   end
@@ -59,12 +61,7 @@ private
   end
 
   def details_items
-    content_block_document.latest_edition.details.map do |key, value|
-      {
-        field: key.humanize,
-        value:,
-      }
-    end
+    summary_list_entries_for_details(content_block_document.latest_edition.details)
   end
 
   def status_item

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/array_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/array_component.html.erb
@@ -2,6 +2,8 @@
   legend_text: field.humanize,
   heading_level: 3,
   heading_size: "l",
+  id:,
+  error_message:,
 } do %>
   <% render "govuk_publishing_components/components/add_another", {
     fieldset_legend: field.humanize,

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/array_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/array_component.html.erb
@@ -1,0 +1,16 @@
+<%= render "govuk_publishing_components/components/fieldset", {
+  legend_text: field.humanize,
+  heading_level: 3,
+  heading_size: "l",
+} do %>
+  <% render "govuk_publishing_components/components/add_another", {
+    fieldset_legend: field.humanize,
+    add_button_text: "Add #{field.humanize.singularize}",
+    items: items.each_with_index.map do  |object, index|
+      {
+        fields: fields(object:, index:).html_safe,
+      }
+    end,
+    empty: fields(object: {}, index: 0).html_safe,
+  } %>
+<% end %>

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/array_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/array_component.rb
@@ -12,6 +12,14 @@ private
     content_block_edition.details&.fetch(field, []) || []
   end
 
+  def id
+    "#{PARENT_CLASS}_details_#{field}"
+  end
+
+  def error_message
+    error_items&.first&.fetch(:text)
+  end
+
   def fields(object:, index:)
     properties.map { |key|
       render ContentBlockManager::ContentBlockEdition::Details::Fields::StringComponent.new(

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/array_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/array_component.rb
@@ -1,0 +1,26 @@
+class ContentBlockManager::ContentBlockEdition::Details::Fields::ArrayComponent < ContentBlockManager::ContentBlockEdition::Details::Fields::BaseComponent
+  def initialize(content_block_edition:, field:, properties:)
+    @properties = properties
+    super(content_block_edition:, field:)
+  end
+
+private
+
+  attr_reader :content_block_edition, :properties
+
+  def items
+    content_block_edition.details&.fetch(field, []) || []
+  end
+
+  def fields(object:, index:)
+    properties.map { |key|
+      render ContentBlockManager::ContentBlockEdition::Details::Fields::StringComponent.new(
+        content_block_edition:,
+        label: key.humanize,
+        field: "[#{field}][][#{key}]",
+        value: object[key],
+        id_suffix: "#{field}_#{index}_#{key}",
+      )
+    }.join("")
+  end
+end

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/base_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/base_component.rb
@@ -1,0 +1,37 @@
+class ContentBlockManager::ContentBlockEdition::Details::Fields::BaseComponent < ViewComponent::Base
+  include ErrorsHelper
+
+  PARENT_CLASS = "content_block_manager_content_block_edition".freeze
+
+  def initialize(content_block_edition:, field:, label: nil, value: nil, id_suffix: nil)
+    @content_block_edition = content_block_edition
+    @field = field
+    @label = label
+    @value = value
+    @id_suffix = id_suffix
+  end
+
+private
+
+  attr_reader :content_block_edition, :field
+
+  def label
+    @label || field.humanize
+  end
+
+  def value
+    @value || content_block_edition.details&.fetch(field, nil)
+  end
+
+  def name
+    "content_block/edition[details[#{field}]]"
+  end
+
+  def id
+    "#{PARENT_CLASS}_details_#{@id_suffix || field}"
+  end
+
+  def error_items
+    errors_for(content_block_edition.errors, "details_#{@id_suffix || field}".to_sym)
+  end
+end

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/string_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/string_component.html.erb
@@ -1,0 +1,9 @@
+<%= render "govuk_publishing_components/components/input", {
+  label: {
+    text: label,
+  },
+  name:,
+  id:,
+  value:,
+  error_items:,
+} %>

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/string_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/string_component.rb
@@ -1,0 +1,2 @@
+class ContentBlockManager::ContentBlockEdition::Details::Fields::StringComponent < ContentBlockManager::ContentBlockEdition::Details::Fields::BaseComponent
+end

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/form_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/form_component.html.erb
@@ -1,0 +1,3 @@
+<% schema.fields.each do |attribute| %>
+  <%= render component_for_field(attribute) %>
+<% end %>

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/form_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/form_component.rb
@@ -1,0 +1,27 @@
+class ContentBlockManager::ContentBlockEdition::Details::FormComponent < ViewComponent::Base
+  def initialize(content_block_edition:, schema:)
+    @content_block_edition = content_block_edition
+    @schema = schema
+  end
+
+private
+
+  attr_reader :content_block_edition, :schema
+
+  def component_for_field(field)
+    format = @schema.body.dig("properties", field, "type")
+    case format
+    when "array"
+      ContentBlockManager::ContentBlockEdition::Details::Fields::ArrayComponent.new(
+        content_block_edition:,
+        field:,
+        properties: @schema.body.dig("properties", field, "items", "properties").keys,
+      )
+    else
+      ContentBlockManager::ContentBlockEdition::Details::Fields::StringComponent.new(
+        content_block_edition:,
+        field:,
+      )
+    end
+  end
+end

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/show/confirm_summary_list_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/show/confirm_summary_list_component.rb
@@ -33,11 +33,28 @@ private
   end
 
   def details_items
-    content_block_edition.details.map do |key, value|
-      {
-        field: "New #{key.humanize.downcase}",
-        value:,
-      }
+    content_block_edition.details.map { |key, value|
+      if value.is_a?(Array)
+        value.each.with_index(1).map do |items, i|
+          {
+            field: "New #{key.humanize.downcase.singularize} #{i}",
+            value: list_entry_for_items(items),
+          }
+        end
+      else
+        {
+          field: "New #{key.humanize.downcase}",
+          value:,
+        }
+      end
+    }.flatten
+  end
+
+  def list_entry_for_items(items)
+    tag.ul(class: "govuk-list") do
+      items.map do |embedded_key, embedded_value|
+        concat(tag.li("#{embedded_key.humanize}: #{embedded_value}"))
+      end
     end
   end
 

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/show/confirm_summary_list_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/show/confirm_summary_list_component.rb
@@ -1,4 +1,6 @@
 class ContentBlockManager::ContentBlockEdition::Show::ConfirmSummaryListComponent < ViewComponent::Base
+  include ContentBlockManager::ContentBlock::EditionHelper
+
   def initialize(content_block_edition:)
     @content_block_edition = content_block_edition
   end
@@ -33,21 +35,7 @@ private
   end
 
   def details_items
-    content_block_edition.details.map { |key, value|
-      if value.is_a?(Array)
-        value.each.with_index(1).map do |items, i|
-          {
-            field: "New #{key.humanize.downcase.singularize} #{i}",
-            value: list_entry_for_items(items),
-          }
-        end
-      else
-        {
-          field: "New #{key.humanize.downcase}",
-          value:,
-        }
-      end
-    }.flatten
+    summary_list_entries_for_details(content_block_edition.details, title_style: :confirm)
   end
 
   def list_entry_for_items(items)

--- a/lib/engines/content_block_manager/app/controllers/content_block_manager/base_controller.rb
+++ b/lib/engines/content_block_manager/app/controllers/content_block_manager/base_controller.rb
@@ -27,7 +27,7 @@ class ContentBlockManager::BaseController < Admin::BaseController
             "scheduled_publication(5i)",
             :title,
             document_attributes: %w[block_type],
-            details: @schema.fields,
+            details: @schema.permitted_params,
           )
           .merge!(creator: current_user)
   end

--- a/lib/engines/content_block_manager/app/helpers/content_block_manager/content_block/edition_helper.rb
+++ b/lib/engines/content_block_manager/app/helpers/content_block_manager/content_block/edition_helper.rb
@@ -1,0 +1,31 @@
+module ContentBlockManager
+  module ContentBlock
+    module EditionHelper
+      def summary_list_entries_for_details(details, title_style: :standard)
+        details.map { |key, value|
+          if value.is_a?(Array)
+            value.each.with_index(1).map do |items, i|
+              {
+                field: title_style == :confirm ? "New #{key.humanize.downcase.singularize} #{i}" : "#{key.humanize.singularize} #{i}",
+                value: list_entry_for_items(items),
+              }
+            end
+          else
+            {
+              field: title_style == :confirm ? "New #{key.humanize.downcase}" : key.humanize,
+              value:,
+            }
+          end
+        }.flatten
+      end
+
+      def list_entry_for_items(items)
+        tag.ul(class: "govuk-list") do
+          items.map do |embedded_key, embedded_value|
+            concat(tag.li("#{embedded_key.humanize}: #{embedded_value}"))
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engines/content_block_manager/app/models/content_block_manager/content_block/schema.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/content_block/schema.rb
@@ -29,6 +29,16 @@ module ContentBlockManager
         @body["properties"].keys
       end
 
+      def permitted_params
+        @body["properties"].map do |k, v|
+          if v["type"] == "array"
+            { k => v["items"]["properties"].keys }
+          else
+            k
+          end
+        end
+      end
+
       def block_type
         @block_type ||= id.delete_prefix("#{SCHEMA_PREFIX}_")
       end

--- a/lib/engines/content_block_manager/app/validators/content_block_manager/details_validator.rb
+++ b/lib/engines/content_block_manager/app/validators/content_block_manager/details_validator.rb
@@ -1,6 +1,8 @@
 class ContentBlockManager::DetailsValidator < ActiveModel::Validator
   attr_reader :edition
 
+  BASE_TRANSLATION_PATH = "activerecord.errors.models.content_block_manager/content_block/edition.attributes.details".freeze
+
   def validate(edition)
     @edition = edition
     errors = validate_with_schema(edition)
@@ -15,20 +17,31 @@ class ContentBlockManager::DetailsValidator < ActiveModel::Validator
 
   def add_blank_errors(error)
     missing_keys = error.dig("details", "missing_keys") || []
+    root_key = error["data_pointer"].delete_prefix("/").gsub("/", "_")
     missing_keys.each do |k|
-      edition.errors.add("details_#{k}", :blank)
+      error_key = ["details", root_key, k].compact_blank.join("_")
+      edition.errors.add(error_key, I18n.t("#{BASE_TRANSLATION_PATH}.blank", attribute: k.humanize))
     end
   end
 
   def add_format_errors(error)
     key = error["data_pointer"].delete_prefix("/")
-    edition.errors.add("details_#{key}", :invalid)
+    field = key.split("/").last
+    edition.errors.add("details_#{key}", I18n.t("#{BASE_TRANSLATION_PATH}.invalid", attribute: field.humanize))
   end
 
   def validate_with_schema(edition)
     # Fetch the details and remove any blank fields (JSONSchema classes an empty string as valid,
     # unless a specific format has been specified)
-    details = edition.details.compact_blank
+    details = (edition.details || {}).compact_blank.transform_values do |value|
+      if value.is_a?(Array)
+        value.map(&:compact_blank)
+      elsif value.is_a?(Hash)
+        value.compact_blank
+      else
+        value
+      end
+    end
     schemer = JSONSchemer.schema(edition.schema.body)
     schemer.validate(details)
   end

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/shared/_form.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/shared/_form.html.erb
@@ -19,17 +19,12 @@
     error_items: errors_for(@form.content_block_edition.errors, "title".to_sym),
   } %>
 
-  <% @form.attributes.each do |field, _value| %>
-    <%= render "govuk_publishing_components/components/input", {
-      label: {
-        text: field.humanize,
-      },
-      name: "content_block/edition[details[#{field}]]",
-      id: "#{parent_class}_details_#{field}",
-      value: @form.content_block_edition.details&.fetch(field, nil),
-      error_items: errors_for(@form.content_block_edition.errors, "details_#{field}".to_sym),
-    } %>
-  <% end %>
+  <%=
+    render ContentBlockManager::ContentBlockEdition::Details::FormComponent.new(
+      content_block_edition: @form.content_block_edition,
+      schema: @form.schema,
+    )
+  %>
 
   <%= render "components/autocomplete", {
     id: "#{parent_class}_lead_organisation",

--- a/lib/engines/content_block_manager/config/locales/en.yml
+++ b/lib/engines/content_block_manager/config/locales/en.yml
@@ -11,6 +11,9 @@ en:
           invalid: "Invalid %{attribute}"
           blank: "%{attribute} cannot be blank"
           attributes:
+            details:
+              blank: "%{attribute} cannot be blank"
+              invalid: "Invalid %{attribute}"
             schedule_publishing:
               blank: "Select publish date"
             scheduled_publication:

--- a/lib/engines/content_block_manager/test/components/content_block/document/index/summary_card_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/document/index/summary_card_component_test.rb
@@ -68,4 +68,25 @@ class ContentBlockManager::ContentBlock::Document::Index::SummaryCardComponentTe
       assert_selector ".govuk-summary-list__value", text: "instructions"
     end
   end
+
+  describe "when the content block contains nested content" do
+    it "shows a list of keys and values for each embedded item" do
+      content_block_document.latest_edition.details = { "facts" => [
+        { "interesting_fact" => "value 1 of fact", "another_interesting_fact" => "another value 1 of fact" },
+        { "interesting_fact" => "value 2 of fact", "another_interesting_fact" => "another value 2 of fact" },
+      ] }
+
+      render_inline(ContentBlockManager::ContentBlock::Document::Index::SummaryCardComponent.new(content_block_document:))
+
+      page.find ".govuk-summary-list__row", text: "Fact 1" do
+        assert_selector "li", text: "Interesting fact: value 1 of fact"
+        assert_selector "li", text: "Another interesting fact: another value 1 of fact"
+      end
+
+      page.find ".govuk-summary-list__row", text: "Fact 2" do
+        assert_selector "li", text: "Interesting fact: value 2 of fact"
+        assert_selector "li", text: "Another interesting fact: another value 2 of fact"
+      end
+    end
+  end
 end

--- a/lib/engines/content_block_manager/test/components/content_block/document/show/summary_list_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/document/show/summary_list_component_test.rb
@@ -75,4 +75,25 @@ class ContentBlockManager::ContentBlock::Document::Show::SummaryListComponentTes
       assert_selector ".govuk-summary-list__value", text: "instructions"
     end
   end
+
+  describe "when the content block contains nested content" do
+    it "shows a list of keys and values for each embedded item" do
+      content_block_document.latest_edition.details = { "facts" => [
+        { "interesting_fact" => "value 1 of fact", "another_interesting_fact" => "another value 1 of fact" },
+        { "interesting_fact" => "value 2 of fact", "another_interesting_fact" => "another value 2 of fact" },
+      ] }
+
+      render_inline(ContentBlockManager::ContentBlock::Document::Show::SummaryListComponent.new(content_block_document:))
+
+      page.find ".govuk-summary-list__row", text: "Fact 1" do
+        assert_selector "li", text: "Interesting fact: value 1 of fact"
+        assert_selector "li", text: "Another interesting fact: another value 1 of fact"
+      end
+
+      page.find ".govuk-summary-list__row", text: "Fact 2" do
+        assert_selector "li", text: "Interesting fact: value 2 of fact"
+        assert_selector "li", text: "Another interesting fact: another value 2 of fact"
+      end
+    end
+  end
 end

--- a/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/array_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/array_component_test.rb
@@ -1,0 +1,50 @@
+require "test_helper"
+
+class ContentBlockManager::ContentBlockEdition::Details::Fields::ArrayComponentTest < ViewComponent::TestCase
+  extend Minitest::Spec::DSL
+
+  let(:content_block_edition) { build(:content_block_edition) }
+  let(:properties) { %w[foo bar] }
+
+  it "renders fields when there are no items" do
+    render_inline(
+      ContentBlockManager::ContentBlockEdition::Details::Fields::ArrayComponent.new(
+        content_block_edition:,
+        field: "my_array",
+        properties:,
+      ),
+    )
+
+    properties.each do |property|
+      expected_name = "content_block/edition[details[[my_array][][#{property}]]]"
+      expected_id = "#{ContentBlockManager::ContentBlockEdition::Details::Fields::BaseComponent::PARENT_CLASS}_details_my_array_0_#{property}"
+
+      assert_selector "label", text: property.humanize
+      assert_selector "input[type=\"text\"][name=\"#{expected_name}\"][id=\"#{expected_id}\"]"
+    end
+  end
+
+  it "renders fields when there is data present" do
+    content_block_edition.details = {
+      "my_array" => [
+        { "foo" => "Foo 1", "bar" => "Bar 2" },
+        { "foo" => "Foo 2", "bar" => "Bar 2" },
+      ],
+    }
+
+    render_inline(
+      ContentBlockManager::ContentBlockEdition::Details::Fields::ArrayComponent.new(
+        content_block_edition:,
+        field: "my_array",
+        properties:,
+      ),
+    )
+
+    content_block_edition.details["my_array"].each_with_index do |item, index|
+      item.each do |property, value|
+        expected_id = "#{ContentBlockManager::ContentBlockEdition::Details::Fields::BaseComponent::PARENT_CLASS}_details_my_array_#{index}_#{property}"
+        assert_selector "input[type=\"text\"][id=\"#{expected_id}\"][value=\"#{value}\"]"
+      end
+    end
+  end
+end

--- a/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/array_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/array_component_test.rb
@@ -15,6 +15,8 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::ArrayComponentT
       ),
     )
 
+    assert_selector "div.govuk-form-group##{ContentBlockManager::ContentBlockEdition::Details::Fields::BaseComponent::PARENT_CLASS}_details_my_array"
+
     properties.each do |property|
       expected_name = "content_block/edition[details[[my_array][][#{property}]]]"
       expected_id = "#{ContentBlockManager::ContentBlockEdition::Details::Fields::BaseComponent::PARENT_CLASS}_details_my_array_0_#{property}"
@@ -46,5 +48,20 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::ArrayComponentT
         assert_selector "input[type=\"text\"][id=\"#{expected_id}\"][value=\"#{value}\"]"
       end
     end
+  end
+
+  it "shows an error when an error is present" do
+    content_block_edition.errors.add(:details_my_array, "Some error goes here")
+
+    render_inline(
+      ContentBlockManager::ContentBlockEdition::Details::Fields::ArrayComponent.new(
+        content_block_edition:,
+        field: "my_array",
+        properties:,
+      ),
+    )
+
+    assert_selector "div.govuk-form-group--error##{ContentBlockManager::ContentBlockEdition::Details::Fields::BaseComponent::PARENT_CLASS}_details_my_array"
+    assert_selector ".govuk-error-message", text: "Some error goes here"
   end
 end

--- a/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/string_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/string_component_test.rb
@@ -1,0 +1,79 @@
+require "test_helper"
+
+class ContentBlockManager::ContentBlockEdition::Details::Fields::StringComponentTest < ViewComponent::TestCase
+  extend Minitest::Spec::DSL
+
+  let(:content_block_edition) { build(:content_block_edition, :email_address) }
+
+  it "should render an input field with default parameters" do
+    render_inline(
+      ContentBlockManager::ContentBlockEdition::Details::Fields::StringComponent.new(
+        content_block_edition:,
+        field: "email_address",
+      ),
+    )
+
+    expected_name = "content_block/edition[details[email_address]]"
+    expected_id = "#{ContentBlockManager::ContentBlockEdition::Details::Fields::BaseComponent::PARENT_CLASS}_details_email_address"
+
+    assert_selector "label", text: "Email address"
+    assert_selector "input[type=\"text\"][name=\"#{expected_name}\"][id=\"#{expected_id}\"]"
+  end
+
+  it "should show the value when present" do
+    content_block_edition.details = { "email_address": "example@example.com" }
+
+    render_inline(
+      ContentBlockManager::ContentBlockEdition::Details::Fields::StringComponent.new(
+        content_block_edition:,
+        field: "email_address",
+      ),
+    )
+
+    assert_selector 'input[value="example@example.com"]'
+  end
+
+  it "should show errors when present" do
+    content_block_edition.errors.add(:details_email_address, "Some error goes here")
+
+    render_inline(
+      ContentBlockManager::ContentBlockEdition::Details::Fields::StringComponent.new(
+        content_block_edition:,
+        field: "email_address",
+      ),
+    )
+
+    assert_selector ".govuk-form-group--error"
+    assert_selector ".govuk-error-message", text: "Some error goes here"
+    assert_selector "input.govuk-input--error"
+  end
+
+  it "should allow custom parameters" do
+    render_inline(
+      ContentBlockManager::ContentBlockEdition::Details::Fields::StringComponent.new(
+        content_block_edition:,
+        field: "embedded_thing[][something_else]",
+        label: "My Label",
+        id_suffix: "embedded_thing_0_something_else",
+      ),
+    )
+
+    expected_name = "content_block/edition[details[embedded_thing[][something_else]]]"
+    expected_id = "#{ContentBlockManager::ContentBlockEdition::Details::Fields::BaseComponent::PARENT_CLASS}_details_embedded_thing_0_something_else"
+
+    assert_selector "label", text: "My Label"
+    assert_selector "input[type=\"text\"][name=\"#{expected_name}\"][id=\"#{expected_id}\"]"
+  end
+
+  it "should allow a custom value" do
+    render_inline(
+      ContentBlockManager::ContentBlockEdition::Details::Fields::StringComponent.new(
+        content_block_edition:,
+        field: "email_address",
+        value: "some custom value",
+      ),
+    )
+
+    assert_selector 'input[value="some custom value"]'
+  end
+end

--- a/lib/engines/content_block_manager/test/components/content_block/edition/details/form_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/details/form_component_test.rb
@@ -1,0 +1,63 @@
+require "test_helper"
+
+class ContentBlockManager::ContentBlockEdition::Details::FormComponentTest < ViewComponent::TestCase
+  extend Minitest::Spec::DSL
+
+  let(:body) do
+    {
+      "type" => "object",
+      "required" => %w[foo bar],
+      "additionalProperties" => false,
+      "properties" => {
+        "foo" => {
+          "type" => "string",
+        },
+        "bar" => {
+          "type" => "array",
+          "items" => {
+            "type" => "object",
+            "required" => %w[item1 item2],
+            "additionalProperties" => false,
+            "properties" => {
+              "item1" => {
+                "type" => "string",
+              },
+              "item2" => {
+                "type" => "string",
+              },
+            },
+          },
+        },
+      },
+    }
+  end
+
+  let(:content_block_edition) { build(:content_block_edition) }
+  let(:schema) { build(:content_block_schema, body:) }
+
+  it "renders fields for each property" do
+    foo_stub = stub("string_component")
+    bar_stub = stub("array_component")
+
+    ContentBlockManager::ContentBlockEdition::Details::Fields::StringComponent.expects(:new).with(
+      content_block_edition:,
+      field: "foo",
+    ).returns(foo_stub)
+
+    ContentBlockManager::ContentBlockEdition::Details::Fields::ArrayComponent.expects(:new).with(
+      content_block_edition:,
+      field: "bar",
+      properties: %w[item1 item2],
+    ).returns(bar_stub)
+
+    component = ContentBlockManager::ContentBlockEdition::Details::FormComponent.new(
+      content_block_edition:,
+      schema:,
+    )
+
+    component.expects(:render).with(foo_stub)
+    component.expects(:render).with(bar_stub)
+
+    render_inline(component)
+  end
+end

--- a/lib/engines/content_block_manager/test/support/integration_test_helpers.rb
+++ b/lib/engines/content_block_manager/test/support/integration_test_helpers.rb
@@ -1,6 +1,13 @@
 module ContentBlockManager::IntegrationTestHelpers
   def stub_request_for_schema(block_type)
-    schema = stub(id: "content_block_type", fields: %w[foo bar], name: "schema", body: {}, block_type:)
+    schema = stub(
+      id: "content_block_type",
+      fields: %w[foo bar],
+      name: "schema",
+      body: {},
+      block_type:,
+      permitted_params: %i[foo bar],
+    )
     ContentBlockManager::ContentBlock::Schema.stubs(:find_by_block_type).with(block_type).returns(schema)
     schema
   end

--- a/lib/engines/content_block_manager/test/unit/app/models/content_block_schema_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/models/content_block_schema_test.rb
@@ -22,6 +22,35 @@ class ContentBlockManager::SchemaTest < ActiveSupport::TestCase
     assert_equal schema.block_type, "email_address"
   end
 
+  describe ".permitted_params" do
+    it "returns permitted params" do
+      assert_equal schema.permitted_params, %w[foo bar]
+    end
+
+    describe "when the body includes an array" do
+      let(:body) do
+        {
+          "properties" => {
+            "foo" => {},
+            "bar" => {
+              "type" => "array",
+              "items" => {
+                "properties" => {
+                  "item1" => {},
+                  "item2" => {},
+                },
+              },
+            },
+          },
+        }
+      end
+
+      it "returns permitted params including an array's properties" do
+        assert_equal schema.permitted_params, ["foo", { "bar" => %w[item1 item2] }]
+      end
+    end
+  end
+
   describe ".valid_schemas" do
     test "it returns the contents of the VALID_SCHEMA constant" do
       assert_equal ContentBlockManager::ContentBlock::Schema.valid_schemas, %w[

--- a/lib/engines/content_block_manager/test/unit/app/validators/details_validator_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/validators/details_validator_test.rb
@@ -3,59 +3,159 @@ require "test_helper"
 class ContentBlockManager::DetailsValidatorTest < ActiveSupport::TestCase
   extend Minitest::Spec::DSL
 
-  let(:body) do
-    {
-      "type" => "object",
-      "required" => %w[foo bar],
-      "additionalProperties" => false,
-      "properties" => {
-        "foo" => {
-          "type" => "string",
-          "format" => "email",
-        },
-        "bar" => {
-          "type" => "string",
-          "format" => "date",
-        },
-      },
-    }
-  end
-
   let(:schema) { build(:content_block_schema, body:) }
 
-  test "it validates the presence of fields" do
-    content_block_edition = build(
-      :content_block_edition,
-      :email_address,
-      details: {
-        foo: "",
-        bar: "",
-      },
-      schema:,
-    )
+  describe "with a non-nested schema" do
+    let(:body) do
+      {
+        "type" => "object",
+        "required" => %w[foo bar],
+        "additionalProperties" => false,
+        "properties" => {
+          "foo" => {
+            "type" => "string",
+            "format" => "email",
+          },
+          "bar" => {
+            "type" => "string",
+            "format" => "date",
+          },
+        },
+      }
+    end
 
-    assert_equal content_block_edition.valid?, false
-    assert_equal content_block_edition.errors.full_messages, [
-      I18n.t("activerecord.errors.models.content_block_manager/content_block/edition.blank", attribute: "Foo"),
-      I18n.t("activerecord.errors.models.content_block_manager/content_block/edition.blank", attribute: "Bar"),
-    ]
+    it "validates the presence of fields" do
+      content_block_edition = build(
+        :content_block_edition,
+        :email_address,
+        details: {
+          foo: "",
+          bar: "",
+        },
+        schema:,
+      )
+
+      assert_equal content_block_edition.valid?, false
+      assert_equal content_block_edition.errors.messages, {
+        details_foo: [I18n.t("#{ContentBlockManager::DetailsValidator::BASE_TRANSLATION_PATH}.blank", attribute: "Foo")],
+        details_bar: [I18n.t("#{ContentBlockManager::DetailsValidator::BASE_TRANSLATION_PATH}.blank", attribute: "Bar")],
+      }
+      assert_equal content_block_edition.errors.full_messages, [
+        I18n.t("#{ContentBlockManager::DetailsValidator::BASE_TRANSLATION_PATH}.blank", attribute: "Foo"),
+        I18n.t("#{ContentBlockManager::DetailsValidator::BASE_TRANSLATION_PATH}.blank", attribute: "Bar"),
+      ]
+    end
+
+    it "validates the format of fields" do
+      content_block_edition = build(
+        :content_block_edition,
+        :email_address,
+        details: {
+          foo: "dddd",
+          bar: "ffff",
+        },
+        schema:,
+      )
+
+      assert_equal content_block_edition.valid?, false
+      assert_equal content_block_edition.errors.messages, {
+        details_foo: [I18n.t("#{ContentBlockManager::DetailsValidator::BASE_TRANSLATION_PATH}.invalid", attribute: "Foo")],
+        details_bar: [I18n.t("#{ContentBlockManager::DetailsValidator::BASE_TRANSLATION_PATH}.invalid", attribute: "Bar")],
+      }
+      assert_equal content_block_edition.errors.full_messages, [
+        I18n.t("#{ContentBlockManager::DetailsValidator::BASE_TRANSLATION_PATH}.invalid", attribute: "Foo"),
+        I18n.t("#{ContentBlockManager::DetailsValidator::BASE_TRANSLATION_PATH}.invalid", attribute: "Bar"),
+      ]
+    end
   end
 
-  test "it validates the format of fields" do
-    content_block_edition = build(
-      :content_block_edition,
-      :email_address,
-      details: {
-        foo: "dddd",
-        bar: "ffff",
-      },
-      schema:,
-    )
+  describe "with a nested schema" do
+    let(:body) do
+      {
+        "type" => "object",
+        "required" => %w[my_array],
+        "additionalProperties" => false,
+        "properties" => {
+          "my_array" => {
+            "type" => "array",
+            "items" => {
+              "type" => "object",
+              "required" => %w[foo bar],
+              "additionalProperties" => false,
+              "properties" => {
+                "foo" => {
+                  "type" => "string",
+                  "format" => "email",
+                },
+                "bar" => {
+                  "type" => "string",
+                  "format" => "date",
+                },
+              },
+            },
+          },
+        },
+      }
+    end
 
-    assert_equal content_block_edition.valid?, false
-    assert_equal content_block_edition.errors.full_messages, [
-      I18n.t("activerecord.errors.models.content_block_manager/content_block/edition.invalid", attribute: "Foo"),
-      I18n.t("activerecord.errors.models.content_block_manager/content_block/edition.invalid", attribute: "Bar"),
-    ]
+    it "validates the presence of an array" do
+      content_block_edition = build(
+        :content_block_edition,
+        :email_address,
+        details: {
+          my_array: [],
+        },
+        schema:,
+      )
+
+      assert_equal content_block_edition.valid?, false
+      assert_equal content_block_edition.errors.full_messages, [
+        I18n.t("#{ContentBlockManager::DetailsValidator::BASE_TRANSLATION_PATH}.blank", attribute: "My array"),
+      ]
+    end
+
+    it "validates the presence of fields in an array" do
+      content_block_edition = build(
+        :content_block_edition,
+        :email_address,
+        details: {
+          my_array: [
+            foo: "",
+            bar: "",
+          ],
+        },
+        schema:,
+      )
+
+      assert_equal content_block_edition.valid?, false
+      assert_equal content_block_edition.errors.messages, {
+        details_my_array_0_foo: [I18n.t("#{ContentBlockManager::DetailsValidator::BASE_TRANSLATION_PATH}.blank", attribute: "Foo")],
+        details_my_array_0_bar: [I18n.t("#{ContentBlockManager::DetailsValidator::BASE_TRANSLATION_PATH}.blank", attribute: "Bar")],
+      }
+      assert_equal content_block_edition.errors.full_messages, [
+        I18n.t("#{ContentBlockManager::DetailsValidator::BASE_TRANSLATION_PATH}.blank", attribute: "Foo"),
+        I18n.t("#{ContentBlockManager::DetailsValidator::BASE_TRANSLATION_PATH}.blank", attribute: "Bar"),
+      ]
+    end
+
+    it "validates the format of fields in an array" do
+      content_block_edition = build(
+        :content_block_edition,
+        :email_address,
+        details: {
+          my_array: [
+            foo: "dddd",
+            bar: "ffff",
+          ],
+        },
+        schema:,
+      )
+
+      assert_equal content_block_edition.valid?, false
+      assert_equal content_block_edition.errors.full_messages, [
+        I18n.t("#{ContentBlockManager::DetailsValidator::BASE_TRANSLATION_PATH}.invalid", attribute: "Foo"),
+        I18n.t("#{ContentBlockManager::DetailsValidator::BASE_TRANSLATION_PATH}.invalid", attribute: "Bar"),
+      ]
+    end
   end
 end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
