### PR TITLE
Use components for details items

### DIFF
--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/base_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/base_component.rb
@@ -1,0 +1,37 @@
+class ContentBlockManager::ContentBlockEdition::Details::Fields::BaseComponent < ViewComponent::Base
+  include ErrorsHelper
+
+  PARENT_CLASS = "content_block_manager_content_block_edition".freeze
+
+  def initialize(content_block_edition:, field:, label: nil, value: nil, id_suffix: nil)
+    @content_block_edition = content_block_edition
+    @field = field
+    @label = label
+    @value = value
+    @id_suffix = id_suffix
+  end
+
+private
+
+  attr_reader :content_block_edition, :field
+
+  def label
+    @label || field.humanize
+  end
+
+  def value
+    @value || content_block_edition.details&.fetch(field, nil)
+  end
+
+  def name
+    "content_block/edition[details[#{field}]]"
+  end
+
+  def id
+    "#{PARENT_CLASS}_details_#{@id_suffix || field}"
+  end
+
+  def error_items
+    errors_for(content_block_edition.errors, "details_#{@id_suffix || field}".to_sym)
+  end
+end

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/string_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/string_component.html.erb
@@ -1,0 +1,9 @@
+<%= render "govuk_publishing_components/components/input", {
+  label: {
+    text: label,
+  },
+  name:,
+  id:,
+  value:,
+  error_items:,
+} %>

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/string_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/string_component.rb
@@ -1,0 +1,2 @@
+class ContentBlockManager::ContentBlockEdition::Details::Fields::StringComponent < ContentBlockManager::ContentBlockEdition::Details::Fields::BaseComponent
+end

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/form_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/form_component.html.erb
@@ -1,0 +1,3 @@
+<% schema.fields.each do |attribute| %>
+  <%= render component_for_field(attribute) %>
+<% end %>

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/form_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/form_component.rb
@@ -1,0 +1,20 @@
+class ContentBlockManager::ContentBlockEdition::Details::FormComponent < ViewComponent::Base
+  def initialize(content_block_edition:, schema:)
+    @content_block_edition = content_block_edition
+    @schema = schema
+  end
+
+private
+
+  attr_reader :content_block_edition, :schema
+
+  def component_for_field(field)
+    format = @schema.body.dig("properties", field, "type")
+    if format == "string"
+      ContentBlockManager::ContentBlockEdition::Details::Fields::StringComponent.new(
+        content_block_edition:,
+        field:,
+      )
+    end
+  end
+end

--- a/lib/engines/content_block_manager/app/controllers/content_block_manager/base_controller.rb
+++ b/lib/engines/content_block_manager/app/controllers/content_block_manager/base_controller.rb
@@ -27,7 +27,7 @@ class ContentBlockManager::BaseController < Admin::BaseController
             "scheduled_publication(5i)",
             :title,
             document_attributes: %w[block_type],
-            details: @schema.fields,
+            details: @schema.permitted_params,
           )
           .merge!(creator: current_user)
   end

--- a/lib/engines/content_block_manager/app/models/content_block_manager/content_block/schema.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/content_block/schema.rb
@@ -29,6 +29,10 @@ module ContentBlockManager
         @body["properties"].keys
       end
 
+      def permitted_params
+        fields
+      end
+
       def block_type
         @block_type ||= id.delete_prefix("#{SCHEMA_PREFIX}_")
       end

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/shared/_form.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/shared/_form.html.erb
@@ -19,17 +19,12 @@
     error_items: errors_for(@form.content_block_edition.errors, "title".to_sym),
   } %>
 
-  <% @form.attributes.each do |field, _value| %>
-    <%= render "govuk_publishing_components/components/input", {
-      label: {
-        text: field.humanize,
-      },
-      name: "content_block/edition[details[#{field}]]",
-      id: "#{parent_class}_details_#{field}",
-      value: @form.content_block_edition.details&.fetch(field, nil),
-      error_items: errors_for(@form.content_block_edition.errors, "details_#{field}".to_sym),
-    } %>
-  <% end %>
+  <%=
+    render ContentBlockManager::ContentBlockEdition::Details::FormComponent.new(
+      content_block_edition: @form.content_block_edition,
+      schema: @form.schema,
+    )
+  %>
 
   <%= render "components/autocomplete", {
     id: "#{parent_class}_lead_organisation",

--- a/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/string_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/string_component_test.rb
@@ -1,0 +1,79 @@
+require "test_helper"
+
+class ContentBlockManager::ContentBlockEdition::Details::Fields::StringComponentTest < ViewComponent::TestCase
+  extend Minitest::Spec::DSL
+
+  let(:content_block_edition) { build(:content_block_edition, :email_address) }
+
+  it "should render an input field with default parameters" do
+    render_inline(
+      ContentBlockManager::ContentBlockEdition::Details::Fields::StringComponent.new(
+        content_block_edition:,
+        field: "email_address",
+      ),
+    )
+
+    expected_name = "content_block/edition[details[email_address]]"
+    expected_id = "#{ContentBlockManager::ContentBlockEdition::Details::Fields::BaseComponent::PARENT_CLASS}_details_email_address"
+
+    assert_selector "label", text: "Email address"
+    assert_selector "input[type=\"text\"][name=\"#{expected_name}\"][id=\"#{expected_id}\"]"
+  end
+
+  it "should show the value when present" do
+    content_block_edition.details = { "email_address": "example@example.com" }
+
+    render_inline(
+      ContentBlockManager::ContentBlockEdition::Details::Fields::StringComponent.new(
+        content_block_edition:,
+        field: "email_address",
+      ),
+    )
+
+    assert_selector 'input[value="example@example.com"]'
+  end
+
+  it "should show errors when present" do
+    content_block_edition.errors.add(:details_email_address, "Some error goes here")
+
+    render_inline(
+      ContentBlockManager::ContentBlockEdition::Details::Fields::StringComponent.new(
+        content_block_edition:,
+        field: "email_address",
+      ),
+    )
+
+    assert_selector ".govuk-form-group--error"
+    assert_selector ".govuk-error-message", text: "Some error goes here"
+    assert_selector "input.govuk-input--error"
+  end
+
+  it "should allow custom parameters" do
+    render_inline(
+      ContentBlockManager::ContentBlockEdition::Details::Fields::StringComponent.new(
+        content_block_edition:,
+        field: "embedded_thing[][something_else]",
+        label: "My Label",
+        id_suffix: "embedded_thing_0_something_else",
+      ),
+    )
+
+    expected_name = "content_block/edition[details[embedded_thing[][something_else]]]"
+    expected_id = "#{ContentBlockManager::ContentBlockEdition::Details::Fields::BaseComponent::PARENT_CLASS}_details_embedded_thing_0_something_else"
+
+    assert_selector "label", text: "My Label"
+    assert_selector "input[type=\"text\"][name=\"#{expected_name}\"][id=\"#{expected_id}\"]"
+  end
+
+  it "should allow a custom value" do
+    render_inline(
+      ContentBlockManager::ContentBlockEdition::Details::Fields::StringComponent.new(
+        content_block_edition:,
+        field: "email_address",
+        value: "some custom value",
+      ),
+    )
+
+    assert_selector 'input[value="some custom value"]'
+  end
+end

--- a/lib/engines/content_block_manager/test/components/content_block/edition/details/form_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/details/form_component_test.rb
@@ -1,0 +1,49 @@
+require "test_helper"
+
+class ContentBlockManager::ContentBlockEdition::Details::FormComponentTest < ViewComponent::TestCase
+  extend Minitest::Spec::DSL
+
+  let(:body) do
+    {
+      "type" => "object",
+      "required" => %w[foo bar],
+      "additionalProperties" => false,
+      "properties" => {
+        "foo" => {
+          "type" => "string",
+        },
+        "bar" => {
+          "type" => "string",
+        },
+      },
+    }
+  end
+
+  let(:content_block_edition) { build(:content_block_edition) }
+  let(:schema) { build(:content_block_schema, body:) }
+
+  it "renders fields for each property" do
+    foo_stub = stub("string_component")
+    bar_stub = stub("string_component")
+
+    ContentBlockManager::ContentBlockEdition::Details::Fields::StringComponent.expects(:new).with(
+      content_block_edition:,
+      field: "foo",
+    ).returns(foo_stub)
+
+    ContentBlockManager::ContentBlockEdition::Details::Fields::StringComponent.expects(:new).with(
+      content_block_edition:,
+      field: "bar",
+    ).returns(bar_stub)
+
+    component = ContentBlockManager::ContentBlockEdition::Details::FormComponent.new(
+      content_block_edition:,
+      schema:,
+    )
+
+    component.expects(:render).with(foo_stub)
+    component.expects(:render).with(bar_stub)
+
+    render_inline(component)
+  end
+end

--- a/lib/engines/content_block_manager/test/support/integration_test_helpers.rb
+++ b/lib/engines/content_block_manager/test/support/integration_test_helpers.rb
@@ -11,6 +11,7 @@ module ContentBlockManager::IntegrationTestHelpers
         },
       },
       block_type:,
+      permitted_params: %i[foo bar],
     )
     ContentBlockManager::ContentBlock::Schema.stubs(:find_by_block_type).with(block_type).returns(schema)
     schema

--- a/lib/engines/content_block_manager/test/support/integration_test_helpers.rb
+++ b/lib/engines/content_block_manager/test/support/integration_test_helpers.rb
@@ -1,6 +1,17 @@
 module ContentBlockManager::IntegrationTestHelpers
   def stub_request_for_schema(block_type)
-    schema = stub(id: "content_block_type", fields: %w[foo bar], name: "schema", body: {}, block_type:)
+    schema = stub(
+      id: "content_block_type",
+      fields: %w[foo bar],
+      name: "schema",
+      body: {
+        "properties" => {
+          "foo" => { "type" => "string" },
+          "bar" => { "type" => "string" },
+        },
+      },
+      block_type:,
+    )
     ContentBlockManager::ContentBlock::Schema.stubs(:find_by_block_type).with(block_type).returns(schema)
     schema
   end

--- a/lib/engines/content_block_manager/test/unit/app/models/content_block_schema_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/models/content_block_schema_test.rb
@@ -22,6 +22,12 @@ class ContentBlockManager::SchemaTest < ActiveSupport::TestCase
     assert_equal schema.block_type, "email_address"
   end
 
+  describe ".permitted_params" do
+    it "returns permitted params" do
+      assert_equal schema.permitted_params, %w[foo bar]
+    end
+  end
+
   describe ".valid_schemas" do
     test "it returns the contents of the VALID_SCHEMA constant" do
       assert_equal ContentBlockManager::ContentBlock::Schema.valid_schemas, %w[


### PR DESCRIPTION
This was originally part of the draft PR https://github.com/alphagov/whitehall/pull/9815, but as we may not be using nested fields now, I've extracted the more useful code out of that feature, as it will still be helpful to have around.