### PR TITLE
Apply GA4 tracking to flash alerts

### DIFF
--- a/app/components/admin/flash_alert_component.rb
+++ b/app/components/admin/flash_alert_component.rb
@@ -2,4 +2,15 @@ class Admin::FlashAlertComponent < Admin::FlashMessageComponent
   def component_name
     "error_alert"
   end
+
+  def data_attributes
+    {
+      module: "ga4-auto-tracker",
+      "ga4-auto": {
+        event_name: "flash_message",
+        text: message,
+        action: "error",
+      }.to_json,
+    }
+  end
 end

--- a/app/components/admin/flash_message_component.html.erb
+++ b/app/components/admin/flash_message_component.html.erb
@@ -1,5 +1,8 @@
 <%=
 content_tag(:div) do
-  render "govuk_publishing_components/components/#{component_name}", { message: }
+  render "govuk_publishing_components/components/#{component_name}", {
+    message: message,
+    data_attributes: data_attributes,
+  }
 end
 %>

--- a/app/components/admin/flash_message_component.rb
+++ b/app/components/admin/flash_message_component.rb
@@ -11,4 +11,6 @@ class Admin::FlashMessageComponent < ViewComponent::Base
       @message
     end
   end
+
+  def data_attributes; end
 end


### PR DESCRIPTION
## What

Adds GA4 tracking to flash alerts via the [GA4 Auto Tracker](https://github.com/alphagov/govuk_publishing_components/blob/main/docs/analytics-ga4/trackers/ga4-auto-tracker.md).

### Expected datalayer

```javascript
event_data':{
    'event_name':'flash_message',
    'text':'<flash text>',
    'action':error
}
```

## Why 

We want to understand when users have disruptions in their journey. 

### Screen / data layer screenshots after change

<details>

<summary>Data attributes <strong>are</strong> present in flash alert</summary>

<img width="1081" alt="Screenshot of data attributes present in Flash alerts" src="https://github.com/user-attachments/assets/f3f0bf83-8a33-4d11-af71-e9c7bfb24e4c" />

</details>

<details>

<summary>Data attributes <strong>are not</strong> present in flash success</summary>

![Screenshot 2025-01-16 at 12 23 36](https://github.com/user-attachments/assets/bc606e19-6cbf-41e0-84be-d8a3cf3a0244)

</details>

## Performance Analyst review

Implementation has been tested by PAs in Integration who confirm the data is present as expected.