### PR TITLE
Add copy to homepage header

### DIFF
--- a/lib/engines/content_block_manager/app/assets/stylesheets/content_block_manager/views/_content_block_manager_header.scss
+++ b/lib/engines/content_block_manager/app/assets/stylesheets/content_block_manager/views/_content_block_manager_header.scss
@@ -4,7 +4,7 @@
 
   &--column-right {
     display: flex;
-    align-self: center;
+    align-self: flex-start;
     justify-content: flex-end;
   }
 }

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/documents/index.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/documents/index.html.erb
@@ -12,9 +12,11 @@
 
 <div class="govuk-grid-row content-block-manager-header">
     <div class="govuk-grid-column-one-half">
-      <h1 class="gem-c-title__text govuk-heading-xl">
+      <h1 class="govuk-heading-xl content-block-manager-header--heading">
         Content Block Manager
       </h1>
+
+      <p class="govuk-body">Create, edit and use standardised content across GOV.UK</p>
     </div>
     <div class="govuk-grid-column-one-half content-block-manager-header--column-right">
       <div>


### PR DESCRIPTION
Trello card: https://trello.com/c/WnDhkF18/824-add-copy-to-homepage-heading

This will help users know where they are and what the purpose of the system is. The copy is the same as that in Signon.

## Screenshot

![image](https://github.com/user-attachments/assets/b45052d9-e3b2-4293-8668-c497781abe6f)
