### PR TITLE
remove session storage of filters for Content Blocks

### DIFF
--- a/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/documents_controller.rb
+++ b/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/documents_controller.rb
@@ -1,7 +1,6 @@
 class ContentBlockManager::ContentBlock::DocumentsController < ContentBlockManager::BaseController
   def index
     if params_filters.any?
-      session[:content_block_filters] = params_filters
       @filters = params_filters
       filter_result = ContentBlockManager::ContentBlock::Document::DocumentFilter.new(@filters)
       @content_block_documents = filter_result.paginated_documents
@@ -10,8 +9,6 @@ class ContentBlockManager::ContentBlock::DocumentsController < ContentBlockManag
         @error_summary_errors = @errors.map { |error| { text: error.full_message, href: "##{error.attribute}_3i" } }
       end
       render :index
-    elsif params[:reset_fields].blank? && session_filters.any?
-      redirect_to content_block_manager.content_block_manager_root_path(session_filters)
     else
       redirect_to content_block_manager.content_block_manager_root_path(default_filters)
     end
@@ -58,10 +55,6 @@ private
     params.slice(:keyword, :block_type, :lead_organisation, :page, :last_updated_to, :last_updated_from)
           .permit!
           .to_h
-  end
-
-  def session_filters
-    (session[:content_block_filters] || {}).to_h
   end
 
   def default_filters

--- a/lib/engines/content_block_manager/test/integration/content_block/documents_test.rb
+++ b/lib/engines/content_block_manager/test/integration/content_block/documents_test.rb
@@ -54,30 +54,10 @@ class ContentBlockManager::ContentBlock::DocumentsTest < ActionDispatch::Integra
     end
 
     describe "when no filter params are specified" do
-      describe "when there are no session filters" do
-        it "sets the filter to 'all organisations' by default" do
-          visit content_block_manager.content_block_manager_content_block_documents_path
+      it "sets the filter to 'all organisations' by default" do
+        visit content_block_manager.content_block_manager_content_block_documents_path
 
-          assert_current_path content_block_manager.content_block_manager_root_path({ lead_organisation: "" })
-        end
-      end
-
-      describe "when there are session filters" do
-        before do
-          visit content_block_manager.content_block_manager_content_block_documents_path({ keyword: "something" })
-        end
-
-        it "adds them to the params by default the next time user visits" do
-          visit content_block_manager.content_block_manager_content_block_documents_path
-
-          assert_current_path content_block_manager.content_block_manager_root_path({ keyword: "something" })
-        end
-
-        it "resets the filters when reset_fields is set" do
-          visit content_block_manager.content_block_manager_content_block_documents_path({ reset_fields: true })
-
-          assert_current_path content_block_manager.content_block_manager_root_path({ lead_organisation: "" })
-        end
+        assert_current_path content_block_manager.content_block_manager_root_path({ lead_organisation: "" })
       end
     end
 


### PR DESCRIPTION
https://trello.com/c/tIA76IyO/825-remove-session-storage-of-search-filters

This was proving to be confusing for users and not
necessary.

--

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
