### PR TITLE
(834) Don’t record drafts in version history

### DIFF
--- a/lib/engines/content_block_manager/app/models/content_block_manager/content_block/edition/has_audit_trail.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/content_block/edition/has_audit_trail.rb
@@ -25,9 +25,11 @@ module ContentBlockManager
     end
 
     def record_update
-      user = Current.user
-      state = try(:state)
-      versions.create!(event: "updated", user:, state:)
+      unless draft?
+        user = Current.user
+        state = try(:state)
+        versions.create!(event: "updated", user:, state:)
+      end
     end
   end
 end


### PR DESCRIPTION
Trello card: https://trello.com/c/nR5cfCe2/834-dont-show-draft-in-content-block-history-when-scheduling

When scheduling a content block, we see an additional entry in the version history to say a draft has been created like so:

![image](https://github.com/user-attachments/assets/0c91bbe6-6529-4944-93d7-82b1ade5f03b)

This is caused by the fact that we save the edition before scheduling, and then call `schedule!`, which triggers another event. It’s tricky to get round this double save issue as we need to dequeue any previously scheduled editions as well as update the document reference, so the easiest way to do this is to skip creating a version when a draft is updated.

I’ve also made some tweaks to the tests so we can be sure the number of versions is changed by the change to a model’s state.