### PR TITLE
Add UI for retagging content

### DIFF
--- a/app/controllers/admin/retagging_controller.rb
+++ b/app/controllers/admin/retagging_controller.rb
@@ -14,6 +14,8 @@ class Admin::RetaggingController < Admin::BaseController
       sanitized_errors = updater.errors.map { |err| sanitize(err) }
       flash[:alert] = "Errors with CSV input: <br>#{sanitized_errors.join('<br>')}".html_safe
       render :index
+    else
+      @docs_to_update = updater.summarise_changes
     end
   end
 

--- a/app/controllers/admin/retagging_controller.rb
+++ b/app/controllers/admin/retagging_controller.rb
@@ -1,0 +1,14 @@
+class Admin::RetaggingController < Admin::BaseController
+  # TODO: replicate or reuse DataHygiene::BulkOrganisationUpdater
+  # include ReshuffleMode # TODO: don't allow retagging while a reshuffle is in progress
+
+  before_action :enforce_permissions!
+
+  def index; end
+
+private
+
+  def enforce_permissions!
+    enforce_permission!(:administer, :retag_content)
+  end
+end

--- a/app/controllers/admin/retagging_controller.rb
+++ b/app/controllers/admin/retagging_controller.rb
@@ -1,10 +1,21 @@
 class Admin::RetaggingController < Admin::BaseController
-  # TODO: replicate or reuse DataHygiene::BulkOrganisationUpdater
+  include ActionView::Helpers::SanitizeHelper
   # include ReshuffleMode # TODO: don't allow retagging while a reshuffle is in progress
 
   before_action :enforce_permissions!
 
   def index; end
+
+  def preview
+    updater = DataHygiene::BulkOrganisationUpdater.new(params[:csv_input])
+    updater.validate
+
+    if updater.errors.any?
+      sanitized_errors = updater.errors.map { |err| sanitize(err) }
+      flash[:alert] = "Errors with CSV input: <br>#{sanitized_errors.join('<br>')}".html_safe
+      render :index
+    end
+  end
 
 private
 

--- a/app/controllers/admin/retagging_controller.rb
+++ b/app/controllers/admin/retagging_controller.rb
@@ -11,17 +11,34 @@ class Admin::RetaggingController < Admin::BaseController
     updater.validate
 
     if updater.errors.any?
-      sanitized_errors = updater.errors.map { |err| sanitize(err) }
-      flash[:alert] = "Errors with CSV input: <br>#{sanitized_errors.join('<br>')}".html_safe
+      set_flash_alert(updater.errors)
       render :index
     else
       @docs_to_update = updater.summarise_changes
     end
   end
 
+  def publish
+    updater = DataHygiene::BulkOrganisationUpdater.new(params[:csv_input])
+    updater.validate
+
+    if updater.errors.any?
+      set_flash_alert(updater.errors)
+    else
+      updater.call
+      flash[:notice] = "Retagging in progress."
+    end
+    redirect_to(admin_retagging_index_path)
+  end
+
 private
 
   def enforce_permissions!
     enforce_permission!(:administer, :retag_content)
+  end
+
+  def set_flash_alert(errors)
+    sanitized_errors = errors.map { |err| sanitize(err) }
+    flash[:alert] = "Errors with CSV input: <br>#{sanitized_errors.join('<br>')}".html_safe
   end
 end

--- a/app/helpers/admin/url_helper.rb
+++ b/app/helpers/admin/url_helper.rb
@@ -82,6 +82,12 @@ module Admin::UrlHelper
     end
   end
 
+  def admin_retag_content_link
+    if can?(:administer, :retag_content)
+      admin_link "Retag content", admin_retagging_index_path
+    end
+  end
+
 private
 
   def active_link_class(path_matcher)

--- a/app/views/admin/more/index.html.erb
+++ b/app/views/admin/more/index.html.erb
@@ -20,6 +20,7 @@
         admin_world_location_news_link,
         admin_worldwide_organisations_link,
         admin_republish_content_link,
+        admin_retag_content_link,
       ],
     } %>
   </div>

--- a/app/views/admin/republishing/index.html.erb
+++ b/app/views/admin/republishing/index.html.erb
@@ -4,28 +4,23 @@
 
 <div class="govuk-grid-row">
   <section class="govuk-grid-column-two-thirds">
-    <details class="govuk-details">
-      <summary class="govuk-details__summary">
-        <span class="govuk-details__summary-text">
-          Guidance on republishing content
-        </span>
-      </summary>
-      <div class="govuk-details__text">
-        <p class="govuk-body">
-          Sometimes it may be necessary to republish content to the Publishing API. This will refresh the content on the website.
-        </p>
+    <%= render "govuk_publishing_components/components/details", {
+      title: "Guidance on republishing content",
+    } do %>
+      <p class="govuk-body">
+        Sometimes it may be necessary to republish content to the Publishing API. This will refresh the content on the website.
+      </p>
 
-        <p class="govuk-body">
-          For example, if we make an update to govspeak and a publishing application pre-renders that content prior to its submission to Publishing API, that would require us to re-render and save new HTML for content.
-        </p>
+      <p class="govuk-body">
+        For example, if we make an update to govspeak and a publishing application pre-renders that content prior to its submission to Publishing API, that would require us to re-render and save new HTML for content.
+      </p>
 
-        <p class="govuk-body">
-          The following actions will allow you to republish content that was originally published in this application.
-          Any linked editions will also be republished through dependency resolution.
-          Try to pick the republishing task most focused to the scope of what you need to republish to avoid unnecessary server load.
-        </p>
-      </div>
-    </details>
+      <p class="govuk-body">
+        The following actions will allow you to republish content that was originally published in this application.
+        Any linked editions will also be republished through dependency resolution.
+        Try to pick the republishing task most focused to the scope of what you need to republish to avoid unnecessary server load.
+      </p>
+    <% end %>
 
     <h2 class="govuk-heading-m">Individual pages</h2>
 

--- a/app/views/admin/retagging/index.html.erb
+++ b/app/views/admin/retagging/index.html.erb
@@ -8,12 +8,13 @@
       This is to be used for machinery of government changes.
     </p>
 
-    <%= form_with(url: "#", method: :post) do %>
+    <%= form_with(url: admin_retagging_preview_path, method: :post) do %>
       <%= render "govuk_publishing_components/components/textarea", {
         label: {
           text: "Paste the CSV contents, as per the guidance below.",
         },
         name: "csv_input",
+        value: "#{params[:csv_input]}",
       } %>
       <p class="govuk-body">
         <%= render "govuk_publishing_components/components/button", {

--- a/app/views/admin/retagging/index.html.erb
+++ b/app/views/admin/retagging/index.html.erb
@@ -1,0 +1,64 @@
+<% content_for :page_title, "Retag content" %>
+<% content_for :title, "Retag content" %>
+<% content_for :title_margin_bottom, 6 %>
+
+<div class="govuk-grid-row">
+  <section class="govuk-grid-column-two-thirds">
+    <p class="govuk-body">
+      This is to be used for machinery of government changes.
+    </p>
+
+    <%= form_with(url: "#", method: :post) do %>
+      <%= render "govuk_publishing_components/components/textarea", {
+        label: {
+          text: "Paste the CSV contents, as per the guidance below.",
+        },
+        name: "csv_input",
+      } %>
+      <p class="govuk-body">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Preview changes",
+        } %>
+      </p>
+    <% end %>
+  </section>
+</div>
+
+<div class="govuk-grid-row">
+  <section class="govuk-grid-column-two-thirds">
+    <h2 class="govuk-heading-m">Guidance</h2>
+
+    <%= render "govuk_publishing_components/components/table", {
+      head: [
+        {
+          text: "Slug",
+        },
+        {
+          text: "Document type",
+        },
+        {
+          text: "New lead organisations",
+        },
+        {
+          text: "New supporting organisations",
+        },
+      ],
+      rows: [
+        [
+          {
+            text: "The slug of the document.",
+          },
+          {
+            text: "The type of the document, for example DetailedGuide. This is used when more than one document is matched by the Slug.",
+          },
+          {
+            text: "The slugs of the new leading organisations (separated by a comma). These will replace any existing organisations.",
+          },
+          {
+            text: "The slugs of the new supporting organisations (separated by a comma). These will replace any existing organisations.",
+          },
+        ],
+      ],
+    } %>
+  </section>
+</div>

--- a/app/views/admin/retagging/preview.html.erb
+++ b/app/views/admin/retagging/preview.html.erb
@@ -31,7 +31,7 @@
       end,
     } %>
 
-    <%= form_with(url: "#", method: :post) do %>
+    <%= form_with(url: admin_retagging_publish_path, method: :post) do %>
       <input type="hidden" name="csv_input" value="<%= params[:csv_input] %>">
       <p class="govuk-body">
         <%= render "govuk_publishing_components/components/button", {

--- a/app/views/admin/retagging/preview.html.erb
+++ b/app/views/admin/retagging/preview.html.erb
@@ -1,0 +1,43 @@
+<% content_for :page_title, "Retag content - preview changes" %>
+<% content_for :title, "Retag content - preview changes" %>
+<% content_for :title_margin_bottom, 6 %>
+
+<div class="govuk-grid-row">
+  <section class="govuk-grid-column-full-width">
+    <%= render "govuk_publishing_components/components/table", {
+      head: [
+        {
+          text: "Slug",
+        },
+        {
+          text: "Lead organisations",
+        },
+        {
+          text: "Supporting organisations",
+        },
+      ],
+      rows: @docs_to_update.map do |hash|
+        [
+          {
+            text: hash[:slug],
+          },
+          {
+            text: hash[:lead_orgs_summary],
+          },
+          {
+            text: hash[:supporting_orgs_summary],
+          },
+        ]
+      end,
+    } %>
+
+    <%= form_with(url: "#", method: :post) do %>
+      <input type="hidden" name="csv_input" value="<%= params[:csv_input] %>">
+      <p class="govuk-body">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Publish changes",
+        } %>
+      </p>
+    <% end %>
+  </section>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -76,9 +76,8 @@ Whitehall::Application.routes.draw do
         end
       end
 
-      scope :retagging do
-        root to: "retagging#index", as: :retagging_index, via: :get
-      end
+      get "/retagging" => "retagging#index", as: :retagging_index
+      post "/retagging" => "retagging#preview", as: :retagging_preview
 
       resources :documents, only: [] do
         resources :review_reminders, only: %i[new create edit update destroy] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -76,6 +76,10 @@ Whitehall::Application.routes.draw do
         end
       end
 
+      scope :retagging do
+        root to: "retagging#index", as: :retagging_index, via: :get
+      end
+
       resources :documents, only: [] do
         resources :review_reminders, only: %i[new create edit update destroy] do
           get :confirm_destroy, on: :member

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -78,6 +78,7 @@ Whitehall::Application.routes.draw do
 
       get "/retagging" => "retagging#index", as: :retagging_index
       post "/retagging" => "retagging#preview", as: :retagging_preview
+      post "/retagging/publish" => "retagging#publish", as: :retagging_publish
 
       resources :documents, only: [] do
         resources :review_reminders, only: %i[new create edit update destroy] do

--- a/features/retagging-content.feature
+++ b/features/retagging-content.feature
@@ -6,20 +6,6 @@ Feature: Retagging documents to different organisations
   Background:
     Given I am a GDS admin
 
-  Scenario: Dry run of the retagging - invalid data
-    Given the documents and organisations I am retagging contain errors
-    When I visit the retagging page
-    And I submit my CSV of documents to be retagged
-    Then I should be on the retagging page with my CSV input still present
-    And I should see a summary of retagging errors
-
-  Scenario: Dry run of the retagging - valid data
-    Given the documents and organisations I am retagging exist
-    When I visit the retagging page
-    And I submit my CSV of documents to be retagged
-    Then I can see a summary of the proposed changes
-    And my CSV input should be in a hidden field ready to confirm retagging
-
   Scenario: Full run of the retagging
     Given the documents and organisations I am retagging exist
     When I visit the retagging page

--- a/features/retagging-content.feature
+++ b/features/retagging-content.feature
@@ -1,0 +1,14 @@
+Feature: Retagging documents to different organisations
+  As an editor
+  I want to be able to retag published documents
+  So that they reflect changes to lead and supporting organisations
+
+  Background:
+    Given I am a GDS admin
+
+  Scenario: Dry run of the retagging - invalid data
+    Given the documents and organisations I am retagging contain errors
+    When I visit the retagging page
+    And I submit my CSV of documents to be retagged
+    Then I should be on the retagging page with my CSV input still present
+    And I should see a summary of retagging errors

--- a/features/retagging-content.feature
+++ b/features/retagging-content.feature
@@ -19,3 +19,14 @@ Feature: Retagging documents to different organisations
     And I submit my CSV of documents to be retagged
     Then I can see a summary of the proposed changes
     And my CSV input should be in a hidden field ready to confirm retagging
+
+  Scenario: Full run of the retagging
+    Given the documents and organisations I am retagging exist
+    When I visit the retagging page
+    And I submit my CSV of documents to be retagged
+    Then I can see a summary of the proposed changes
+    And my CSV input should be in a hidden field ready to confirm retagging
+    And when I click "Publish changes" on this retagging screen
+    Then I am redirected to the retagging index page
+    And I see a confirmation message that my documents are being retagged
+    And the changes should have been actioned

--- a/features/retagging-content.feature
+++ b/features/retagging-content.feature
@@ -12,3 +12,10 @@ Feature: Retagging documents to different organisations
     And I submit my CSV of documents to be retagged
     Then I should be on the retagging page with my CSV input still present
     And I should see a summary of retagging errors
+
+  Scenario: Dry run of the retagging - valid data
+    Given the documents and organisations I am retagging exist
+    When I visit the retagging page
+    And I submit my CSV of documents to be retagged
+    Then I can see a summary of the proposed changes
+    And my CSV input should be in a hidden field ready to confirm retagging

--- a/features/step_definitions/retagging_content_steps.rb
+++ b/features/step_definitions/retagging_content_steps.rb
@@ -19,10 +19,57 @@ Then("I should be on the retagging page with my CSV input still present") do
   expect(current_url).to eq(admin_retagging_index_url)
   expect(find_field("csv_input").value.gsub("\r\n", "\n")).to eq($csv_to_submit)
 end
-# rubocop:enable Style/GlobalVars
 
 Then("I should see a summary of retagging errors") do
   expect(page).to have_content("Errors with CSV input:")
   expect(page).to have_content("Document not found: made-up-slug")
   expect(page).to have_content("Organisation not found: government-digital-service")
 end
+
+Given("the documents and organisations I am retagging exist") do
+  $csv_to_submit = <<~CSV
+    Slug,New lead organisations,New supporting organisations,Document type
+    /government/publications/linked-identifier-schemes-best-practice-guide,government-digital-service,geospatial-commission,Publication
+    /government/publications/search-engine-optimisation-for-publishers-best-practice-guide,government-digital-service,"cabinet-office, geospatial-commission",Publication
+  CSV
+
+  create(:organisation, slug: "government-digital-service")
+  create(:organisation, slug: "geospatial-commission")
+  co_org = create(:organisation, slug: "cabinet-office")
+  some_other_org = create(:organisation, slug: "some-other-org")
+
+  doc1 = create(:document, slug: "linked-identifier-schemes-best-practice-guide")
+  create(
+    :publication,
+    :published,
+    document: doc1,
+    lead_organisations: [some_other_org],
+    supporting_organisations: [],
+  )
+
+  doc2 = create(:document, slug: "search-engine-optimisation-for-publishers-best-practice-guide")
+  create(
+    :publication,
+    :published,
+    document: doc2,
+    lead_organisations: [co_org],
+    supporting_organisations: [some_other_org],
+  )
+end
+
+Then("I can see a summary of the proposed changes") do
+  expect(page).to have_content("Retag content - preview changes")
+  table_row = find(".govuk-table__body .govuk-table__row:first")
+  expect(table_row).to have_selector(".govuk-table__cell", text: "linked-identifier-schemes-best-practice-guide")
+  expect(table_row).to have_selector(".govuk-table__cell", text: "Added government-digital-service, Removed some-other-org. Result: government-digital-service")
+  expect(table_row).to have_selector(".govuk-table__cell", text: "Added geospatial-commission. Result: geospatial-commission")
+  table_row = find(".govuk-table__body .govuk-table__row:last")
+  expect(table_row).to have_selector(".govuk-table__cell", text: "search-engine-optimisation-for-publishers-best-practice-guide")
+  expect(table_row).to have_selector(".govuk-table__cell", text: "Added government-digital-service, Removed cabinet-office. Result: government-digital-service")
+  expect(table_row).to have_selector(".govuk-table__cell", text: "Added cabinet-office, geospatial-commission, Removed some-other-org. Result: cabinet-office, geospatial-commission")
+end
+
+And("my CSV input should be in a hidden field ready to confirm retagging") do
+  expect(find("[name=csv_input]", visible: false).value.gsub("\r\n", "\n")).to eq($csv_to_submit)
+end
+# rubocop:enable Style/GlobalVars

--- a/features/step_definitions/retagging_content_steps.rb
+++ b/features/step_definitions/retagging_content_steps.rb
@@ -1,31 +1,4 @@
 # rubocop:disable Style/GlobalVars
-Given("the documents and organisations I am retagging contain errors") do
-  $csv_to_submit = <<~CSV
-    Slug,New lead organisations,New supporting organisations,Document type
-    /made-up-slug,government-digital-service,geospatial-commission,Publication
-  CSV
-end
-
-When("I visit the retagging page") do
-  visit admin_retagging_index_path
-end
-
-When("I submit my CSV of documents to be retagged") do
-  fill_in "csv_input", with: $csv_to_submit
-  click_button "Preview changes"
-end
-
-Then("I should be on the retagging page with my CSV input still present") do
-  expect(current_url).to eq(admin_retagging_index_url)
-  expect(find_field("csv_input").value.gsub("\r\n", "\n")).to eq($csv_to_submit)
-end
-
-Then("I should see a summary of retagging errors") do
-  expect(page).to have_content("Errors with CSV input:")
-  expect(page).to have_content("Document not found: made-up-slug")
-  expect(page).to have_content("Organisation not found: government-digital-service")
-end
-
 Given("the documents and organisations I am retagging exist") do
   $csv_to_submit = <<~CSV
     Slug,New lead organisations,New supporting organisations,Document type
@@ -55,6 +28,15 @@ Given("the documents and organisations I am retagging exist") do
     lead_organisations: [co_org],
     supporting_organisations: [some_other_org],
   )
+end
+
+When("I visit the retagging page") do
+  visit admin_retagging_index_path
+end
+
+When("I submit my CSV of documents to be retagged") do
+  fill_in "csv_input", with: $csv_to_submit
+  click_button "Preview changes"
 end
 
 Then("I can see a summary of the proposed changes") do

--- a/features/step_definitions/retagging_content_steps.rb
+++ b/features/step_definitions/retagging_content_steps.rb
@@ -1,0 +1,28 @@
+# rubocop:disable Style/GlobalVars
+Given("the documents and organisations I am retagging contain errors") do
+  $csv_to_submit = <<~CSV
+    Slug,New lead organisations,New supporting organisations,Document type
+    /made-up-slug,government-digital-service,geospatial-commission,Publication
+  CSV
+end
+
+When("I visit the retagging page") do
+  visit admin_retagging_index_path
+end
+
+When("I submit my CSV of documents to be retagged") do
+  fill_in "csv_input", with: $csv_to_submit
+  click_button "Preview changes"
+end
+
+Then("I should be on the retagging page with my CSV input still present") do
+  expect(current_url).to eq(admin_retagging_index_url)
+  expect(find_field("csv_input").value.gsub("\r\n", "\n")).to eq($csv_to_submit)
+end
+# rubocop:enable Style/GlobalVars
+
+Then("I should see a summary of retagging errors") do
+  expect(page).to have_content("Errors with CSV input:")
+  expect(page).to have_content("Document not found: made-up-slug")
+  expect(page).to have_content("Organisation not found: government-digital-service")
+end

--- a/features/step_definitions/retagging_content_steps.rb
+++ b/features/step_definitions/retagging_content_steps.rb
@@ -93,20 +93,8 @@ And("the changes should have been actioned") do
   expect(doc1.latest_edition.lead_organisations.map(&:slug)).to eq(%w[cabinet-office government-digital-service])
   expect(doc1.latest_edition.supporting_organisations.map(&:slug)).to eq(%w[geospatial-commission])
   expect(doc2.latest_edition.lead_organisations.map(&:slug)).to eq(%w[government-digital-service])
-  # The `.sort` below is needed as, without it, the response is
-  # `geospatial-commission, cabinet-office` despite the order specified in the CSV.
-  #
-  # This may not be desired behaviour but it has been the behaviour to date (in the rake task,
-  # which our new form replaces) so as far as we know, has not been an issue in the past.
-  # Just noting here for reference.
-  #
-  # NB, the `new_supporting_organisations` parameter in `BulkOrganisationUpdater`'s `update_edition`
-  # method DOES have the organisations coming through in the correct order, so it only seems to
-  # go out of order in the `edition.update(supporting_organisations: new_supporting_organisations)`
-  # call.
-  #
-  # NB, the same issue does not affect `lead_organisations`, presumably because the
-  # "edition_organisations" table has a `lead_ordering` integer to track the order. There is no
-  # equivalent ordering tracking for supporting organisations.
+  # The `.sort` below is needed as otherwise the response is `geospatial-commission, cabinet-office`
+  # despite the order specified in the CSV. It's an established rule of the Whitehall domain that we
+  # don't care about the order of supporting organisations.
   expect(doc2.latest_edition.supporting_organisations.map(&:slug).sort).to eq(%w[cabinet-office geospatial-commission])
 end

--- a/lib/tasks/data_hygiene.rake
+++ b/lib/tasks/data_hygiene.rake
@@ -15,7 +15,7 @@ namespace :data_hygiene do
 
   desc "Bulk update the organisations associated with documents."
   task :bulk_update_organisation, %i[csv_filename] => :environment do |_, args|
-    DataHygiene::BulkOrganisationUpdater.call(args[:csv_filename])
+    DataHygiene::BulkOrganisationUpdater.call(File.read(args[:csv_filename]))
   end
 
   desc "Move content from one role to another (DANGER!)."

--- a/lib/tasks/data_hygiene.rake
+++ b/lib/tasks/data_hygiene.rake
@@ -13,11 +13,6 @@ namespace :data_hygiene do
     end
   end
 
-  desc "Bulk update the organisations associated with documents."
-  task :bulk_update_organisation, %i[csv_filename] => :environment do |_, args|
-    DataHygiene::BulkOrganisationUpdater.call(File.read(args[:csv_filename]))
-  end
-
   desc "Move content from one role to another (DANGER!)."
   task :migrate_role_content, %i[old_role_appointment new_role_appointment] => :environment do |_task, args|
     old_role_app = RoleAppointment.find(args[:old_role_appointment])

--- a/lib/whitehall/authority/rules/miscellaneous_rules.rb
+++ b/lib/whitehall/authority/rules/miscellaneous_rules.rb
@@ -12,6 +12,10 @@ module Whitehall::Authority::Rules
       actor.gds_admin?
     end
 
+    def can_for_retag_content?(_action)
+      actor.gds_admin?
+    end
+
     def can_for_emergency_banner?(_action)
       actor.gds_admin?
     end

--- a/test/functional/admin/retagging_controller_test.rb
+++ b/test/functional/admin/retagging_controller_test.rb
@@ -22,4 +22,16 @@ class Admin::RetaggingControllerTest < ActionController::TestCase
     get :index
     assert_response :forbidden
   end
+
+  test "Submitting a CSV with invalid data should show an error message" do
+    csv_to_submit = <<~CSV
+      Slug,New lead organisations,New supporting organisations,Document type
+      /made-up-slug,government-digital-service,geospatial-commission,Publication
+    CSV
+    post :preview, params: { csv_input: csv_to_submit }
+
+    assert_response :ok
+    assert_template :index
+    assert_equal flash[:alert], "Errors with CSV input: <br>Document not found: made-up-slug<br>Organisation not found: government-digital-service<br>Organisation not found: geospatial-commission"
+  end
 end

--- a/test/functional/admin/retagging_controller_test.rb
+++ b/test/functional/admin/retagging_controller_test.rb
@@ -10,7 +10,7 @@ class Admin::RetaggingControllerTest < ActionController::TestCase
   view_test "GDS Admin users should be able to GET :index and see a textarea for CSV input" do
     get :index
 
-    assert_select "form[action='#'][method='post']", count: 1
+    assert_select "form[action='/government/admin/retagging'][method='post']", count: 1
     assert_select "textarea[name='csv_input']", count: 1
 
     assert_response :ok

--- a/test/functional/admin/retagging_controller_test.rb
+++ b/test/functional/admin/retagging_controller_test.rb
@@ -1,0 +1,25 @@
+require "test_helper"
+
+class Admin::RetaggingControllerTest < ActionController::TestCase
+  setup do
+    login_as :gds_admin
+  end
+
+  should_be_an_admin_controller
+
+  view_test "GDS Admin users should be able to GET :index and see a textarea for CSV input" do
+    get :index
+
+    assert_select "form[action='#'][method='post']", count: 1
+    assert_select "textarea[name='csv_input']", count: 1
+
+    assert_response :ok
+  end
+
+  test "Non-GDS Admin users should not be able to GET :index" do
+    login_as :writer
+
+    get :index
+    assert_response :forbidden
+  end
+end


### PR DESCRIPTION
Adds UI for "bulk retagging documents" (as it is referred to in the [Support government changes](https://docs.publishing.service.gov.uk/manual/government-changes.html#bulk-retagging-documents) docs) to change their lead and supporting organisations. This UI replaces a rake task we had to run in the past, and removes our last CSV-dependent rake task (which has been [problematic since the introduction of Kubernetes](https://docs.publishing.service.gov.uk/manual/running-rake-tasks.html#working-with-csvs-on-kubernetes)).

Trello: https://trello.com/c/o9iYyNxf/623-add-ui-for-re-tagging-organisations-to-content-in-bulk


## Screenshots

Link added to the "More" page:
> ![Screenshot 2025-01-23 at 15 59 21](https://github.com/user-attachments/assets/54b0e839-9adb-4a31-bfc2-7dc897cd4136)

"Retag content" form:

> ![Screenshot 2025-01-23 at 15 59 34](https://github.com/user-attachments/assets/0fa2204c-3328-422d-9ba7-355751fa82e7)

Form with inputs filled in:

> ![Screenshot 2025-01-23 at 16 00 40](https://github.com/user-attachments/assets/482bd176-0c46-4724-a9eb-9f945411bab8)

Preview page / summary of changes:
> ![Screenshot 2025-01-23 at 16 00 52](https://github.com/user-attachments/assets/52342ae7-b7d5-4546-ba86-b7ec4b2cdf26)

Confirmation status:
> ![Screenshot 2025-01-23 at 16 01 03](https://github.com/user-attachments/assets/1ef20944-6ef2-4793-83bb-6900b228e56e)

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
