### PR TITLE
Replace title component with heading

### DIFF
--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -54,12 +54,16 @@
       <% if yield(:title).present? %>
         <div class="govuk-grid-row">
           <div class="govuk-grid-column-<%= column_width %>">
-            <%= render "govuk_publishing_components/components/title", {
-              context: yield(:context),
-              title: yield(:title),
-              margin_top: 0,
-              margin_bottom: yield(:title_margin_bottom).present? ? yield(:title_margin_bottom).to_i : nil,
-            } %>
+            <%
+              heading_options = {
+                context: yield(:context),
+                text: yield(:title),
+                heading_level: 1,
+                font_size: "xl",
+              }
+              heading_options[:margin_bottom] = yield(:title_margin_bottom).to_i if yield(:title_margin_bottom).present?
+            %>
+            <%= render "govuk_publishing_components/components/heading", heading_options %>
           </div>
 
           <% if yield(:page_full_width).blank? %>

--- a/features/step_definitions/document_steps.rb
+++ b/features/step_definitions/document_steps.rb
@@ -143,7 +143,7 @@ Then("I should see {edition} in the list of published documents") do |edition|
 end
 
 Then(/^I should see the conflict between the (publication|policy|news article|consultation|speech) titles "([^"]*)" and "([^"]*)"$/) do |_document_type, new_title, latest_title|
-  expect(new_title).to eq(find(".gem-c-title__context").text)
+  expect(new_title).to eq(find(".govuk-caption-xl").text)
   expect(page).to have_selector(".conflict h2", text: latest_title)
 end
 


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

## What / why

- replaces one instance of the title component with the heading component
- this instance was using `margin_top: 0` which is an option we're removing from the title component
- instead use the heading component, which when configured like this should look exactly like the title component, but by default has no margin top
- hopefully therefore no visual changes

Related to this change: https://github.com/alphagov/govuk_publishing_components/pull/4508

Trello card: https://trello.com/c/Y0pDWbHw/390-move-some-shared-helper-options-into-component-wrapper