### PR TITLE
(837) Populate scheduled_at date/time using model values

### DIFF
--- a/lib/engines/content_block_manager/app/components/content_block_manager/shared/schedule_publishing_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/shared/schedule_publishing_component.html.erb
@@ -8,11 +8,6 @@
 <% end %>
 
 <%
-  year_param = params.dig("scheduled_at", "scheduled_publication(1i)")
-  month_param = params.dig("scheduled_at", "scheduled_publication(2i)")
-  day_param = params.dig("scheduled_at", "scheduled_publication(3i)")
-  hour_param = params.dig("scheduled_at", "scheduled_publication(4i)")
-  minute_param =  params.dig("scheduled_at", "scheduled_publication(5i)")
   is_scheduled_param = params["schedule_publishing"]
 %>
 

--- a/lib/engines/content_block_manager/app/components/content_block_manager/shared/schedule_publishing_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/shared/schedule_publishing_component.rb
@@ -11,4 +11,24 @@ class ContentBlockManager::Shared::SchedulePublishingComponent < ViewComponent::
 private
 
   attr_reader :is_rescheduling, :content_block_edition, :params, :context, :back_link, :form_url
+
+  def year_param
+    content_block_edition.scheduled_publication&.year || params.dig("scheduled_at", "scheduled_publication(1i)")
+  end
+
+  def month_param
+    content_block_edition.scheduled_publication&.month || params.dig("scheduled_at", "scheduled_publication(2i)")
+  end
+
+  def day_param
+    content_block_edition.scheduled_publication&.day || params.dig("scheduled_at", "scheduled_publication(3i)")
+  end
+
+  def hour_param
+    content_block_edition.scheduled_publication&.hour || params.dig("scheduled_at", "scheduled_publication(4i)")
+  end
+
+  def minute_param
+    content_block_edition.scheduled_publication&.min || params.dig("scheduled_at", "scheduled_publication(5i)")
+  end
 end

--- a/lib/engines/content_block_manager/test/components/shared/schedule_publishing_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/shared/schedule_publishing_component_test.rb
@@ -52,4 +52,45 @@ class ContentBlockManager::Shared::SchedulePublishingComponentTest < ViewCompone
       )}']"
     end
   end
+
+  describe "when the content_block_edition already has a publish date set" do
+    let(:params) do
+      {
+        "scheduled_at" => {
+          "scheduled_publication(1i)" => "2022",
+          "scheduled_publication(2i)" => "2",
+          "scheduled_publication(3i)" => "3",
+          "scheduled_publication(4i)" => "1",
+          "scheduled_publication(5i)" => "2",
+        },
+      }
+    end
+
+    it "prepopulates the date fields" do
+      render_inline(component)
+
+      assert_selector "input[name='scheduled_at[scheduled_publication(1i)]'][value='#{params['scheduled_at']['scheduled_publication(1i)']}']"
+      assert_selector "input[name='scheduled_at[scheduled_publication(2i)]'][value='#{params['scheduled_at']['scheduled_publication(2i)']}']"
+      assert_selector "input[name='scheduled_at[scheduled_publication(3i)]'][value='#{params['scheduled_at']['scheduled_publication(3i)']}']"
+
+      assert_selector "select[name='scheduled_at[scheduled_publication(4i)]'] option[value='0#{params['scheduled_at']['scheduled_publication(4i)']}'][selected='selected']"
+      assert_selector "select[name='scheduled_at[scheduled_publication(5i)]'] option[value='0#{params['scheduled_at']['scheduled_publication(5i)']}'][selected='selected']"
+    end
+  end
+
+  describe "when the params have date attributes set" do
+    let(:scheduled_publication) { Time.zone.now + 1.month }
+    let(:content_block_edition) { create(:content_block_edition, :email_address, document: content_block_document, scheduled_publication:) }
+
+    it "prepopulates the date fields" do
+      render_inline(component)
+
+      assert_selector "input[name='scheduled_at[scheduled_publication(1i)]'][value='#{scheduled_publication.year}']"
+      assert_selector "input[name='scheduled_at[scheduled_publication(2i)]'][value='#{scheduled_publication.month}']"
+      assert_selector "input[name='scheduled_at[scheduled_publication(3i)]'][value='#{scheduled_publication.day}']"
+
+      assert_selector "select[name='scheduled_at[scheduled_publication(4i)]'] option[value='#{scheduled_publication.hour}'][selected='selected']"
+      assert_selector "select[name='scheduled_at[scheduled_publication(5i)]'] option[value='#{scheduled_publication.min}'][selected='selected']"
+    end
+  end
 end


### PR DESCRIPTION
Trello card: https://trello.com/c/aDIYdgfJ/837-bug-scheduled-publishing-form-does-not-populate-data-from-existing-block

Currently, when editing a schedule, the form values aren’t populated
with the currently set date. This could be confusing for a user. This
updates the component to first check if there is a datetime set for the
current model, if not, it falls back to the provided params.