### PR TITLE
(828) Add internal and external change notes when editing blocks

### DIFF
--- a/db/migrate/20250121102923_add_internal_change_note_to_content_block_editions.rb
+++ b/db/migrate/20250121102923_add_internal_change_note_to_content_block_editions.rb
@@ -1,0 +1,5 @@
+class AddInternalChangeNoteToContentBlockEditions < ActiveRecord::Migration[7.1]
+  def change
+    add_column :content_block_editions, :internal_change_note, :string
+  end
+end

--- a/db/migrate/20250122155447_add_change_note_and_major_change_to_content_block_editions.rb
+++ b/db/migrate/20250122155447_add_change_note_and_major_change_to_content_block_editions.rb
@@ -1,0 +1,15 @@
+class AddChangeNoteAndMajorChangeToContentBlockEditions < ActiveRecord::Migration[7.1]
+  def up
+    change_table :content_block_editions, bulk: true do |t|
+      t.string "change_note"
+      t.boolean "major_change"
+    end
+  end
+
+  def down
+    change_table :content_block_editions, bulk: true do |t|
+      t.remove "change_note"
+      t.remove "major_change"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_01_08_102234) do
+ActiveRecord::Schema[7.1].define(version: 2025_01_21_102923) do
   create_table "assets", charset: "utf8mb3", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.string "variant", null: false
@@ -233,6 +233,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_01_08_102234) do
     t.datetime "scheduled_publication", precision: nil
     t.text "instructions_to_publishers"
     t.string "title", default: "", null: false
+    t.string "internal_change_note"
     t.index ["document_id"], name: "index_content_block_editions_on_document_id"
     t.index ["user_id"], name: "index_content_block_editions_on_user_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_01_21_102923) do
+ActiveRecord::Schema[7.1].define(version: 2025_01_22_155447) do
   create_table "assets", charset: "utf8mb3", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.string "variant", null: false
@@ -234,6 +234,8 @@ ActiveRecord::Schema[7.1].define(version: 2025_01_21_102923) do
     t.text "instructions_to_publishers"
     t.string "title", default: "", null: false
     t.string "internal_change_note"
+    t.string "change_note"
+    t.boolean "major_change"
     t.index ["document_id"], name: "index_content_block_editions_on_document_id"
     t.index ["user_id"], name: "index_content_block_editions_on_user_id"
   end

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/show/confirm_summary_list_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/show/confirm_summary_list_component.rb
@@ -57,7 +57,7 @@ private
 
   def edit_action
     {
-      href: helpers.content_block_manager.content_block_manager_content_block_workflow_path(id: content_block_edition.id, step: ContentBlockManager::ContentBlock::Editions::WorkflowController::NEW_BLOCK_STEPS[:edit_draft]),
+      href: helpers.content_block_manager.content_block_manager_content_block_workflow_path(id: content_block_edition.id, step: :edit_draft),
       link_text: "Edit",
     }
   end

--- a/lib/engines/content_block_manager/app/controllers/concerns/can_schedule_or_publish.rb
+++ b/lib/engines/content_block_manager/app/controllers/concerns/can_schedule_or_publish.rb
@@ -77,7 +77,7 @@ module CanScheduleOrPublish
   def review_update_url
     content_block_manager.content_block_manager_content_block_workflow_path(
       @content_block_edition,
-      step: ContentBlockManager::ContentBlock::Editions::WorkflowController::UPDATE_BLOCK_STEPS[:review_update],
+      step: :review,
     )
   end
 

--- a/lib/engines/content_block_manager/app/controllers/concerns/workflow/show_methods.rb
+++ b/lib/engines/content_block_manager/app/controllers/concerns/workflow/show_methods.rb
@@ -5,7 +5,9 @@ module Workflow::ShowMethods
     edit_draft: :edit_draft,
     review_links: :review_links,
     schedule_publishing: :schedule_publishing,
+    internal_note: :internal_note,
     review: :review,
+    review_update: :review_update,
     confirmation: :confirmation,
   }.freeze
 
@@ -39,8 +41,31 @@ module Workflow::ShowMethods
     render :schedule_publishing
   end
 
+  def internal_note
+    @content_block_document = @content_block_edition.document
+    @back_path = content_block_manager.content_block_manager_content_block_workflow_path(
+      @content_block_edition,
+      step: :schedule_publishing,
+    )
+
+    render :internal_note
+  end
+
+  def review_update
+    @content_block_edition = ContentBlockManager::ContentBlock::Edition.find(params[:id])
+
+    @url = review_update_url
+    @back_path = content_block_manager.content_block_manager_content_block_workflow_path(
+      @content_block_edition,
+      step: :internal_note,
+    )
+
+    render :review
+  end
+
   def review
     @content_block_edition = ContentBlockManager::ContentBlock::Edition.find(params[:id])
+    @back_path = content_block_manager.content_block_manager_content_block_documents_path
 
     @url = review_url
 

--- a/lib/engines/content_block_manager/app/controllers/concerns/workflow/show_methods.rb
+++ b/lib/engines/content_block_manager/app/controllers/concerns/workflow/show_methods.rb
@@ -1,0 +1,57 @@
+module Workflow::ShowMethods
+  extend ActiveSupport::Concern
+
+  SHOW_ACTIONS = {
+    edit_draft: :edit_draft,
+    review_links: :review_links,
+    schedule_publishing: :schedule_publishing,
+    review: :review,
+    confirmation: :confirmation,
+  }.freeze
+
+  def edit_draft
+    @content_block_edition = ContentBlockManager::ContentBlock::Edition.find(params[:id])
+    @form = ContentBlockManager::ContentBlock::EditionForm.for(
+      content_block_edition: @content_block_edition,
+      schema: @schema,
+    )
+
+    render "content_block_manager/content_block/editions/new"
+  end
+
+  def review_links
+    @content_block_document = @content_block_edition.document
+    @order = params[:order]
+    @page = params[:page]
+
+    @host_content_items = ContentBlockManager::HostContentItem.for_document(
+      @content_block_document,
+      order: @order,
+      page: @page,
+    )
+
+    render :review_links
+  end
+
+  def schedule_publishing
+    @content_block_document = @content_block_edition.document
+
+    render :schedule_publishing
+  end
+
+  def review
+    @content_block_edition = ContentBlockManager::ContentBlock::Edition.find(params[:id])
+
+    @url = review_url
+
+    render :review
+  end
+
+  def confirmation
+    @content_block_edition = ContentBlockManager::ContentBlock::Edition.find(params[:id])
+
+    @confirmation_copy = ContentBlockManager::ConfirmationCopyPresenter.new(@content_block_edition)
+
+    render :confirmation
+  end
+end

--- a/lib/engines/content_block_manager/app/controllers/concerns/workflow/show_methods.rb
+++ b/lib/engines/content_block_manager/app/controllers/concerns/workflow/show_methods.rb
@@ -6,6 +6,7 @@ module Workflow::ShowMethods
     review_links: :review_links,
     schedule_publishing: :schedule_publishing,
     internal_note: :internal_note,
+    change_note: :change_note,
     review: :review,
     review_update: :review_update,
     confirmation: :confirmation,
@@ -51,13 +52,23 @@ module Workflow::ShowMethods
     render :internal_note
   end
 
+  def change_note
+    @content_block_document = @content_block_edition.document
+    @back_path = content_block_manager.content_block_manager_content_block_workflow_path(
+      @content_block_edition,
+      step: :internal_note,
+    )
+
+    render :change_note
+  end
+
   def review_update
     @content_block_edition = ContentBlockManager::ContentBlock::Edition.find(params[:id])
 
     @url = review_update_url
     @back_path = content_block_manager.content_block_manager_content_block_workflow_path(
       @content_block_edition,
-      step: :internal_note,
+      step: :change_note,
     )
 
     render :review

--- a/lib/engines/content_block_manager/app/controllers/concerns/workflow/update_methods.rb
+++ b/lib/engines/content_block_manager/app/controllers/concerns/workflow/update_methods.rb
@@ -6,6 +6,7 @@ module Workflow::UpdateMethods
   UPDATE_ACTIONS = {
     review_links: :redirect_to_schedule,
     schedule_publishing: :validate_schedule,
+    internal_note: :update_internal_note,
     review_update: :validate_review_page,
     review: :validate_review_page,
   }.freeze
@@ -22,9 +23,21 @@ module Workflow::UpdateMethods
 
     validate_scheduled_edition
 
-    redirect_to content_block_manager.content_block_manager_content_block_workflow_path(@content_block_edition, step: :review)
+    redirect_to content_block_manager.content_block_manager_content_block_workflow_path(
+      id: @content_block_edition.id,
+      step: :internal_note,
+    )
   rescue ActiveRecord::RecordInvalid
     render "content_block_manager/content_block/editions/workflow/schedule_publishing"
+  end
+
+  def update_internal_note
+    @content_block_edition.update!(internal_change_note: edition_params[:internal_change_note])
+
+    redirect_to content_block_manager.content_block_manager_content_block_workflow_path(
+      id: @content_block_edition.id,
+      step: :review_update,
+    )
   end
 
   def validate_review_page

--- a/lib/engines/content_block_manager/app/controllers/concerns/workflow/update_methods.rb
+++ b/lib/engines/content_block_manager/app/controllers/concerns/workflow/update_methods.rb
@@ -1,0 +1,50 @@
+module Workflow::UpdateMethods
+  extend ActiveSupport::Concern
+
+  REVIEW_ERROR = Data.define(:attribute, :full_message)
+
+  UPDATE_ACTIONS = {
+    review_links: :redirect_to_schedule,
+    schedule_publishing: :validate_schedule,
+    review_update: :validate_review_page,
+    review: :validate_review_page,
+  }.freeze
+
+  def redirect_to_schedule
+    redirect_to content_block_manager.content_block_manager_content_block_workflow_path(
+      id: @content_block_edition.id,
+      step: :schedule_publishing,
+    )
+  end
+
+  def validate_schedule
+    @content_block_edition = ContentBlockManager::ContentBlock::Edition.find(params[:id])
+
+    validate_scheduled_edition
+
+    redirect_to content_block_manager.content_block_manager_content_block_workflow_path(@content_block_edition, step: :review)
+  rescue ActiveRecord::RecordInvalid
+    render "content_block_manager/content_block/editions/workflow/schedule_publishing"
+  end
+
+  def validate_review_page
+    if params[:is_confirmed].blank?
+      @confirm_error_copy = I18n.t("content_block_edition.review_page.errors.confirm")
+      @error_summary_errors = [{ text: @confirm_error_copy, href: "#is_confirmed-0" }]
+      @url = on_review_page? ? review_url : review_update_url
+      render "content_block_manager/content_block/editions/workflow/review"
+    else
+      schedule_or_publish
+    end
+  end
+
+private
+
+  def on_review_page?
+    params[:step] == :review
+  end
+
+  def on_review_update_page?
+    params[:step] == :review_update
+  end
+end

--- a/lib/engines/content_block_manager/app/controllers/concerns/workflow/update_methods.rb
+++ b/lib/engines/content_block_manager/app/controllers/concerns/workflow/update_methods.rb
@@ -7,6 +7,7 @@ module Workflow::UpdateMethods
     review_links: :redirect_to_schedule,
     schedule_publishing: :validate_schedule,
     internal_note: :update_internal_note,
+    change_note: :update_change_note,
     review_update: :validate_review_page,
     review: :validate_review_page,
   }.freeze
@@ -36,8 +37,20 @@ module Workflow::UpdateMethods
 
     redirect_to content_block_manager.content_block_manager_content_block_workflow_path(
       id: @content_block_edition.id,
+      step: :change_note,
+    )
+  end
+
+  def update_change_note
+    @content_block_edition.assign_attributes(change_note: edition_params[:change_note], major_change: edition_params[:major_change])
+    @content_block_edition.save!(context: :change_note)
+
+    redirect_to content_block_manager.content_block_manager_content_block_workflow_path(
+      id: @content_block_edition.id,
       step: :review_update,
     )
+  rescue ActiveRecord::RecordInvalid
+    render :change_note
   end
 
   def validate_review_page

--- a/lib/engines/content_block_manager/app/controllers/content_block_manager/base_controller.rb
+++ b/lib/engines/content_block_manager/app/controllers/content_block_manager/base_controller.rb
@@ -27,6 +27,8 @@ class ContentBlockManager::BaseController < Admin::BaseController
             "scheduled_publication(5i)",
             :title,
             :internal_change_note,
+            :change_note,
+            :major_change,
             document_attributes: %w[block_type],
             details: @schema.permitted_params,
           )

--- a/lib/engines/content_block_manager/app/controllers/content_block_manager/base_controller.rb
+++ b/lib/engines/content_block_manager/app/controllers/content_block_manager/base_controller.rb
@@ -26,6 +26,7 @@ class ContentBlockManager::BaseController < Admin::BaseController
             "scheduled_publication(4i)",
             "scheduled_publication(5i)",
             :title,
+            :internal_change_note,
             document_attributes: %w[block_type],
             details: @schema.permitted_params,
           )

--- a/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/documents/schedule_controller.rb
+++ b/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/documents/schedule_controller.rb
@@ -16,7 +16,7 @@ class ContentBlockManager::ContentBlock::Documents::ScheduleController < Content
 
     validate_scheduled_edition
 
-    redirect_to content_block_manager.content_block_manager_content_block_workflow_path(@content_block_edition, step: :review_update)
+    redirect_to content_block_manager.content_block_manager_content_block_workflow_path(@content_block_edition, step: :review)
   rescue ActiveRecord::RecordInvalid
     render "content_block_manager/content_block/documents/schedule/edit"
   end

--- a/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/editions/workflow_controller.rb
+++ b/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/editions/workflow_controller.rb
@@ -1,56 +1,31 @@
 class ContentBlockManager::ContentBlock::Editions::WorkflowController < ContentBlockManager::BaseController
   include CanScheduleOrPublish
-
-  NEW_BLOCK_STEPS = {
-    review: "review",
-    edit_draft: "edit_draft",
-  }.freeze
-
-  UPDATE_BLOCK_STEPS = {
-    review_links: "review_links",
-    schedule_publishing: "schedule_publishing",
-    review_update: "review_update",
-  }.freeze
-
-  SHARED_STEPS = {
-    confirmation: "confirmation",
-  }.freeze
+  include Workflow::ShowMethods
+  include Workflow::UpdateMethods
 
   def show
-    step = params[:step]
-    @content_block_edition = ContentBlockManager::ContentBlock::Edition.find(params[:id])
-    @schema = ContentBlockManager::ContentBlock::Schema.find_by_block_type(@content_block_edition.document.block_type)
+    step = params[:step].to_sym
+    action = SHOW_ACTIONS[step]
 
-    case step
-    when NEW_BLOCK_STEPS[:edit_draft]
-      edit_draft
-    when UPDATE_BLOCK_STEPS[:review_links]
-      review_links
-    when UPDATE_BLOCK_STEPS[:schedule_publishing]
-      schedule_publishing
-    when NEW_BLOCK_STEPS[:review]
-      review
-    when UPDATE_BLOCK_STEPS[:review_update]
-      review_update
-    when SHARED_STEPS[:confirmation]
-      confirmation
+    if action
+      @content_block_edition = ContentBlockManager::ContentBlock::Edition.find(params[:id])
+      @schema = ContentBlockManager::ContentBlock::Schema.find_by_block_type(@content_block_edition.document.block_type)
+      send(action)
+    else
+      raise ActionController::RoutingError, "Step #{step} does not exist"
     end
   end
 
   def update
-    step = params[:step]
-    @content_block_edition = ContentBlockManager::ContentBlock::Edition.find(params[:id])
-    @schema = ContentBlockManager::ContentBlock::Schema.find_by_block_type(@content_block_edition.document.block_type)
+    step = params[:step].to_sym
+    action = UPDATE_ACTIONS[step]
 
-    case step
-    when UPDATE_BLOCK_STEPS[:review_links]
-      redirect_to content_block_manager.content_block_manager_content_block_workflow_path(id: @content_block_edition.id, step: :schedule_publishing)
-    when UPDATE_BLOCK_STEPS[:schedule_publishing]
-      validate_schedule
-    when UPDATE_BLOCK_STEPS[:review_update]
-      validate_review_page("review_update")
-    when NEW_BLOCK_STEPS[:review]
-      validate_review_page("review")
+    if action
+      @content_block_edition = ContentBlockManager::ContentBlock::Edition.find(params[:id])
+      @schema = ContentBlockManager::ContentBlock::Schema.find_by_block_type(@content_block_edition.document.block_type)
+      send(action)
+    else
+      raise ActionController::RoutingError, "Step #{step} does not exist"
     end
   end
 
@@ -61,89 +36,10 @@ class ContentBlockManager::ContentBlock::Editions::WorkflowController < ContentB
 
 private
 
-  def edit_draft
-    @content_block_edition = ContentBlockManager::ContentBlock::Edition.find(params[:id])
-    @form = ContentBlockManager::ContentBlock::EditionForm.for(
-      content_block_edition: @content_block_edition,
-      schema: @schema,
-    )
-
-    render "content_block_manager/content_block/editions/new"
-  end
-
-  def review
-    @content_block_edition = ContentBlockManager::ContentBlock::Edition.find(params[:id])
-
-    @url = review_url
-
-    render :review
-  end
-
   def review_url
     content_block_manager.content_block_manager_content_block_workflow_path(
       @content_block_edition,
-      step: ContentBlockManager::ContentBlock::Editions::WorkflowController::NEW_BLOCK_STEPS[:review],
+      step: :review,
     )
-  end
-
-  def validate_schedule
-    @content_block_edition = ContentBlockManager::ContentBlock::Edition.find(params[:id])
-
-    validate_scheduled_edition
-
-    redirect_to content_block_manager.content_block_manager_content_block_workflow_path(@content_block_edition, step: :review_update)
-  rescue ActiveRecord::RecordInvalid
-    render "content_block_manager/content_block/editions/workflow/schedule_publishing"
-  end
-
-  def review_update
-    @content_block_edition = ContentBlockManager::ContentBlock::Edition.find(params[:id])
-
-    @url = review_update_url
-
-    render :review
-  rescue ActiveRecord::RecordInvalid
-    render :schedule_publishing
-  end
-
-  def confirmation
-    @content_block_edition = ContentBlockManager::ContentBlock::Edition.find(params[:id])
-
-    @confirmation_copy = ContentBlockManager::ConfirmationCopyPresenter.new(@content_block_edition)
-
-    render :confirmation
-  end
-
-  def review_links
-    @content_block_document = @content_block_edition.document
-    @order = params[:order]
-    @page = params[:page]
-
-    @host_content_items = ContentBlockManager::HostContentItem.for_document(
-      @content_block_document,
-      order: @order,
-      page: @page,
-    )
-
-    render :review_links
-  end
-
-  def schedule_publishing
-    @content_block_document = @content_block_edition.document
-
-    render :schedule_publishing
-  end
-
-  REVIEW_ERROR = Data.define(:attribute, :full_message)
-
-  def validate_review_page(step)
-    if (step == NEW_BLOCK_STEPS[:review] || step == UPDATE_BLOCK_STEPS[:review_update]) && params[:is_confirmed].blank?
-      @confirm_error_copy = I18n.t("content_block_edition.review_page.errors.confirm")
-      @error_summary_errors = [{ text: @confirm_error_copy, href: "#is_confirmed-0" }]
-      @url = step == NEW_BLOCK_STEPS[:review] ? review_url : review_update_url
-      render "content_block_manager/content_block/editions/workflow/review"
-    else
-      schedule_or_publish
-    end
   end
 end

--- a/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/editions_controller.rb
+++ b/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/editions_controller.rb
@@ -19,7 +19,7 @@ class ContentBlockManager::ContentBlock::EditionsController < ContentBlockManage
   def create
     @schema = ContentBlockManager::ContentBlock::Schema.find_by_block_type(block_type_param)
     new_edition = ContentBlockManager::CreateEditionService.new(@schema).call(edition_params, document_id: params[:document_id])
-    step = params[:document_id] ? ContentBlockManager::ContentBlock::Editions::WorkflowController::UPDATE_BLOCK_STEPS[:review_links] : ContentBlockManager::ContentBlock::Editions::WorkflowController::NEW_BLOCK_STEPS[:review]
+    step = params[:document_id] ? :review_links : :review
     redirect_to content_block_manager.content_block_manager_content_block_workflow_path(id: new_edition.id, step:)
   rescue ActiveRecord::RecordInvalid => e
     @form = ContentBlockManager::ContentBlock::EditionForm.for(content_block_edition: e.record, schema: @schema)

--- a/lib/engines/content_block_manager/app/models/content_block_manager/content_block/edition.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/content_block/edition.rb
@@ -2,6 +2,8 @@ module ContentBlockManager
   module ContentBlock
     class Edition < ApplicationRecord
       validates :title, presence: true
+      validates :change_note, presence: true, if: :major_change?, on: :change_note
+      validates :major_change, inclusion: [true, false], on: :change_note
 
       include Documentable
       include HasAuditTrail

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/change_note.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/change_note.html.erb
@@ -1,0 +1,67 @@
+<% content_for :context, context %>
+<% content_for :title, "Do users have to know the content has changed?" %>
+<% content_for :title_margin_bottom, 4 %>
+<% content_for :back_link do %>
+  <%= render "govuk_publishing_components/components/back_link", {
+    href: @back_path,
+  } %>
+<% end %>
+
+<% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @content_block_edition)) %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with url: content_block_manager.content_block_manager_content_block_workflow_path(
+      @content_block_edition,
+      step: :change_note,
+      ), method: :put do %>
+
+      <%= render "govuk_publishing_components/components/radio", {
+        name: "content_block/edition[major_change]",
+        id: "content_block_manager_content_block_edition_major_change",
+        error_items: errors_for(@content_block_edition.errors, :major_change),
+        items: [
+          {
+            value: "1",
+            checked: @content_block_edition.major_change === true,
+            text: "Yes - information has been added, updated or removed",
+            hint_text: "A change note will be published on the page and emailed to users subscribed to email alerts. The 'last updated' date will change.",
+            bold: true,
+            conditional: render("govuk_publishing_components/components/textarea", {
+              label: {
+                text: "Describe the edit for users",
+              },
+              name: "content_block/edition[change_note]",
+              id: "content_block_manager_content_block_edition_change_note",
+              error_items: errors_for(@content_block_edition.errors, :change_note),
+              value: @content_block_edition.change_note,
+              hint: (tag.p('Tell users what has changed, where and why. Write in full sentences, leading with the most important words. For example, "College A has been removed from the registered sponsors list because its licence has been suspended."', class: "govuk-!-margin-bottom-0 govuk-!-margin-top-0") +
+                link_to("Guidance about change notes (opens in a new tab)", "https://www.gov.uk/guidance/content-design/writing-for-gov-uk#change-notes", target: "_blank", class: "govuk-link", rel: "noopener")).html_safe,
+            }),
+          },
+          {
+            value: "0",
+            checked: @content_block_edition.major_change === false,
+            text: "No - it's a minor edit that does not change the meaning",
+            hint_text: "This includes fixing a typo or broken link, a style change or similar. Users signed up to email alerts will not get notified and the 'last updated' date will not change.",
+            bold: true,
+          },
+        ],
+      } %>
+
+      <div class="govuk-button-group govuk-!-margin-bottom-6">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Save and continue",
+          name: "save_and_continue",
+          value: "Save and continue",
+          type: "submit",
+        } %>
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Cancel",
+          href: @back_path,
+          secondary_solid: true,
+        } %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/internal_note.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/internal_note.html.erb
@@ -1,0 +1,40 @@
+<% content_for :context, context %>
+<% content_for :title, "Add internal change note" %>
+<% content_for :title_margin_bottom, 4 %>
+<% content_for :back_link do %>
+  <%= render "govuk_publishing_components/components/back_link", {
+    href: @back_path,
+  } %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with url: content_block_manager.content_block_manager_content_block_workflow_path(
+      @content_block_edition,
+      step: :internal_note,
+      ), method: :put do %>
+      <%= render "govuk_publishing_components/components/textarea", {
+        label: {
+          text: "Describe the change for internal users",
+        },
+        name: "content_block/edition[internal_change_note]",
+        id: "content_block_manager_content_block_edition_title",
+        value: @content_block_edition.internal_change_note,
+      } %>
+
+      <div class="govuk-button-group govuk-!-margin-bottom-6">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Save and continue",
+          name: "save_and_continue",
+          value: "Save and continue",
+          type: "submit",
+        } %>
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Cancel",
+          href: @back_path,
+          secondary_solid: true,
+        } %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/review.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/review.html.erb
@@ -2,7 +2,7 @@
 <% content_for :title, "Review #{@content_block_edition.block_type.humanize.downcase}" %>
 <% content_for :back_link do %>
   <%= render "govuk_publishing_components/components/back_link", {
-    href: content_block_manager.content_block_manager_content_block_documents_path,
+    href: @back_path,
   } %>
 <% end %>
 

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/review_links.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/review_links.html.erb
@@ -42,7 +42,7 @@
           <%= form_with(
                 url: content_block_manager.content_block_manager_content_block_workflow_path(
                   edition_id: @content_block_edition.id,
-                  step: ContentBlockManager::ContentBlock::Editions::WorkflowController::UPDATE_BLOCK_STEPS[:review_links],
+                  step: :review_links,
                 ),
                 method: :put,
               ) do %>

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/schedule_publishing.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/schedule_publishing.html.erb
@@ -5,11 +5,11 @@
       context:,
       back_link: content_block_manager.content_block_manager_content_block_workflow_path(
         @content_block_edition,
-        step: ContentBlockManager::ContentBlock::Editions::WorkflowController::UPDATE_BLOCK_STEPS[:review_links],
+        step: :review_links,
       ),
       form_url: content_block_manager.content_block_manager_content_block_workflow_path(
         @content_block_edition,
-        step: ContentBlockManager::ContentBlock::Editions::WorkflowController::UPDATE_BLOCK_STEPS[:schedule_publishing],
+        step: :schedule_publishing,
       ),
       is_rescheduling: false,
     )

--- a/lib/engines/content_block_manager/config/locales/en.yml
+++ b/lib/engines/content_block_manager/config/locales/en.yml
@@ -13,6 +13,8 @@ en:
           attributes:
             schedule_publishing:
               blank: "Select publish date"
+            major_change:
+              inclusion: "Select if users have to know the content has changed"
             scheduled_publication:
               blank: "Scheduled publication date and time cannot be blank"
               invalid_date: "Invalid scheduled publication date and time"

--- a/lib/engines/content_block_manager/features/edit_object.feature
+++ b/lib/engines/content_block_manager/features/edit_object.feature
@@ -24,8 +24,11 @@ Feature: Edit a content object
     Then I should be on the "internal_note" step
     And I should see a back link to the "schedule_publishing" step
     When I add an internal note
-    Then I should be on the "review" step
+    Then I should be on the "change_note" step
     And I should see a back link to the "internal_note" step
+    When I add a change note
+    Then I should be on the "review" step
+    And I should see a back link to the "change_note" step
     When I review and confirm my answers are correct
     Then I should be taken to the confirmation page for a published block
     When I click to view the content block
@@ -60,6 +63,7 @@ Feature: Edit a content object
     And I continue after reviewing the links
     When I choose to publish the change now
     And I add an internal note
+    And I add a change note
     When I click cancel
     Then I am taken back to Content Block Manager home page
     And no draft Content Block Edition has been created
@@ -96,6 +100,7 @@ Feature: Edit a content object
     And I continue after reviewing the links
     And I choose to publish the change now
     And I add an internal note
+    And I add a change note
     Then I am asked to review my answers
     When I click publish without confirming my details
     Then I should see a message that I need to confirm the details are correct
@@ -105,12 +110,14 @@ Feature: Edit a content object
     When I am updating a content block
     And I schedule the change for 7 days in the future
     And I add an internal note
+    And I add a change note
     When I review and confirm my answers are correct
     When I revisit the edit page
     Then I should see a warning telling me there is a scheduled change
     When I make the changes
     And I choose to publish the change now
     And I add an internal note
+    And I add a change note
     When I review and confirm my answers are correct
     Then I should be taken to the confirmation page for a published block
     When I click to view the content block

--- a/lib/engines/content_block_manager/features/edit_object.feature
+++ b/lib/engines/content_block_manager/features/edit_object.feature
@@ -10,21 +10,19 @@ Feature: Edit a content object
 
   Scenario: GDS Editor edits a content object
     When I visit the Content Block Manager home page
-    Then I should see the details for all documents
-    When I click to view the document
-    Then I should see the details for the email address content block
-    When I click the first edit link
-    Then I should see the edit form
+    And I click to view the document
+    And I click the first edit link
+    Then I should be on the "edit" step
     And I should see a back link to the document page
     When I fill out the form
-    Then I am shown where the changes will take place
-    And I see the rollup data for the dependent content
-    And I should see a back link to the edit page
-    When I save and continue
-    Then I am asked when I want to publish the change
-    And I should see a back link to the review page
+    Then I should be on the "review_links" step
+    And I should see a back link to the "edit" step
+    When I continue after reviewing the links
+    Then I should be on the "schedule_publishing" step
+    And I should see a back link to the "review_links" step
     When I choose to publish the change now
-    And I save and continue
+    Then I should be on the "review" step
+    And I should see a back link to the "schedule_publishing" step
     When I review and confirm my answers are correct
     Then I should be taken to the confirmation page for a published block
     When I click to view the content block
@@ -36,36 +34,28 @@ Feature: Edit a content object
     When I visit the Content Block Manager home page
     When I click to view the document
     When I click the first edit link
-    Then I should see the edit form
     When I fill out the form
-    Then I am shown where the changes will take place
-    And I see the rollup data for the dependent content
     And I click cancel
     Then I should be taken back to the document page
     And no draft Content Block Edition has been created
 
   Scenario: GDS editor cancels the creation of an object before scheduling
     When I visit the Content Block Manager home page
-    When I click to view the document
+    And I click to view the document
     When I click the first edit link
-    Then I should see the edit form
-    When I fill out the form
-    Then I am shown where the changes will take place
-    And I see the rollup data for the dependent content
-    When I save and continue
-    Then I am asked when I want to publish the change
-    And I click cancel
+    And I fill out the form
+    And I continue after reviewing the links
+    When I click cancel
     Then I should be taken back to the document page
     And no draft Content Block Edition has been created
 
   Scenario: GDS editor cancels the creation of an object before confirming answers
     When I visit the Content Block Manager home page
-    When I click to view the document
+    And I click to view the document
     When I click the first edit link
-    When I fill out the form
-    When I save and continue
+    And I fill out the form
+    And I continue after reviewing the links
     When I choose to publish the change now
-    And I save and continue
     And I click cancel
     Then I am taken back to Content Block Manager home page
     And no draft Content Block Edition has been created

--- a/lib/engines/content_block_manager/features/edit_object.feature
+++ b/lib/engines/content_block_manager/features/edit_object.feature
@@ -21,8 +21,11 @@ Feature: Edit a content object
     Then I should be on the "schedule_publishing" step
     And I should see a back link to the "review_links" step
     When I choose to publish the change now
-    Then I should be on the "review" step
+    Then I should be on the "internal_note" step
     And I should see a back link to the "schedule_publishing" step
+    When I add an internal note
+    Then I should be on the "review" step
+    And I should see a back link to the "internal_note" step
     When I review and confirm my answers are correct
     Then I should be taken to the confirmation page for a published block
     When I click to view the content block
@@ -56,7 +59,8 @@ Feature: Edit a content object
     And I fill out the form
     And I continue after reviewing the links
     When I choose to publish the change now
-    And I click cancel
+    And I add an internal note
+    When I click cancel
     Then I am taken back to Content Block Manager home page
     And no draft Content Block Edition has been created
 
@@ -89,10 +93,9 @@ Feature: Edit a content object
     When I click to view the document
     When I click the first edit link
     When I fill out the form
-    Then I am shown where the changes will take place
-    When I save and continue
+    And I continue after reviewing the links
     And I choose to publish the change now
-    When I save and continue
+    And I add an internal note
     Then I am asked to review my answers
     When I click publish without confirming my details
     Then I should see a message that I need to confirm the details are correct
@@ -100,14 +103,14 @@ Feature: Edit a content object
   @enable-sidekiq-test-mode
   Scenario: GDS editor can override a previously scheduled object
     When I am updating a content block
-    And I am asked when I want to publish the change
     And I schedule the change for 7 days in the future
+    And I add an internal note
     When I review and confirm my answers are correct
     When I revisit the edit page
     Then I should see a warning telling me there is a scheduled change
     When I make the changes
     And I choose to publish the change now
-    And I save and continue
+    And I add an internal note
     When I review and confirm my answers are correct
     Then I should be taken to the confirmation page for a published block
     When I click to view the content block
@@ -122,8 +125,6 @@ Feature: Edit a content object
   Scenario: GDS editor can preview a host document
     When I revisit the edit page
     And I save and continue
-    Then I am shown where the changes will take place
-    And I see the rollup data for the dependent content
     When I click on the first host document
     Then the preview page opens in a new tab
     When I click on a link within the frame

--- a/lib/engines/content_block_manager/features/reschedule_object.feature
+++ b/lib/engines/content_block_manager/features/reschedule_object.feature
@@ -11,6 +11,7 @@ Feature: Schedule a content object
   Scenario: GDS Editor immediately publishes a scheduled content object
     When I am updating a content block
     And I schedule the change for 7 days in the future
+    And I add an internal note
     When I review and confirm my answers are correct
     When I click to view the content block
     And I click to edit the schedule
@@ -24,6 +25,7 @@ Feature: Schedule a content object
   Scenario: GDS Editor reschedules a content object
     When I am updating a content block
     And I schedule the change for 7 days in the future
+    And I add an internal note
     When I review and confirm my answers are correct
     When I click to view the content block
     And I click to edit the schedule
@@ -37,6 +39,7 @@ Feature: Schedule a content object
   Scenario: GDS Editor tries to reschedule a content object without choosing to schedule
     When I am updating a content block
     And I schedule the change for 7 days in the future
+    And I add an internal note
     When I review and confirm my answers are correct
     When I click to view the content block
     And I click to edit the schedule
@@ -47,6 +50,7 @@ Feature: Schedule a content object
   Scenario: GDS editor cancels the rescheduling of an object
     When I am updating a content block
     And I schedule the change for 7 days in the future
+    And I add an internal note
     When I review and confirm my answers are correct
     When I click to view the content block
     And I click to edit the schedule
@@ -58,6 +62,7 @@ Feature: Schedule a content object
   Scenario: GDS editor cancels the rescheduling of an object on the confirmation page
     When I am updating a content block
     And I schedule the change for 7 days in the future
+    And I add an internal note
     When I review and confirm my answers are correct
     When I click to view the content block
     And I click to edit the schedule

--- a/lib/engines/content_block_manager/features/reschedule_object.feature
+++ b/lib/engines/content_block_manager/features/reschedule_object.feature
@@ -10,13 +10,11 @@ Feature: Schedule a content object
   @disable-sidekiq-test-mode
   Scenario: GDS Editor immediately publishes a scheduled content object
     When I am updating a content block
-    Then I am asked when I want to publish the change
     And I schedule the change for 7 days in the future
     When I review and confirm my answers are correct
     When I click to view the content block
     And I click to edit the schedule
     And I choose to publish the change now
-    And I save and continue
     When I review and confirm my answers are correct
     When I click to view the content block
     Then the published state of the object should be shown
@@ -25,7 +23,6 @@ Feature: Schedule a content object
   @disable-sidekiq-test-mode
   Scenario: GDS Editor reschedules a content object
     When I am updating a content block
-    Then I am asked when I want to publish the change
     And I schedule the change for 7 days in the future
     When I review and confirm my answers are correct
     When I click to view the content block
@@ -39,7 +36,6 @@ Feature: Schedule a content object
   @disable-sidekiq-test-mode
   Scenario: GDS Editor tries to reschedule a content object without choosing to schedule
     When I am updating a content block
-    Then I am asked when I want to publish the change
     And I schedule the change for 7 days in the future
     When I review and confirm my answers are correct
     When I click to view the content block
@@ -50,7 +46,6 @@ Feature: Schedule a content object
   @disable-sidekiq-test-mode
   Scenario: GDS editor cancels the rescheduling of an object
     When I am updating a content block
-    Then I am asked when I want to publish the change
     And I schedule the change for 7 days in the future
     When I review and confirm my answers are correct
     When I click to view the content block
@@ -62,7 +57,6 @@ Feature: Schedule a content object
   @disable-sidekiq-test-mode
   Scenario: GDS editor cancels the rescheduling of an object on the confirmation page
     When I am updating a content block
-    Then I am asked when I want to publish the change
     And I schedule the change for 7 days in the future
     When I review and confirm my answers are correct
     When I click to view the content block

--- a/lib/engines/content_block_manager/features/reschedule_object.feature
+++ b/lib/engines/content_block_manager/features/reschedule_object.feature
@@ -12,6 +12,7 @@ Feature: Schedule a content object
     When I am updating a content block
     And I schedule the change for 7 days in the future
     And I add an internal note
+    And I add a change note
     When I review and confirm my answers are correct
     When I click to view the content block
     And I click to edit the schedule
@@ -26,6 +27,7 @@ Feature: Schedule a content object
     When I am updating a content block
     And I schedule the change for 7 days in the future
     And I add an internal note
+    And I add a change note
     When I review and confirm my answers are correct
     When I click to view the content block
     And I click to edit the schedule
@@ -40,6 +42,7 @@ Feature: Schedule a content object
     When I am updating a content block
     And I schedule the change for 7 days in the future
     And I add an internal note
+    And I add a change note
     When I review and confirm my answers are correct
     When I click to view the content block
     And I click to edit the schedule
@@ -51,6 +54,7 @@ Feature: Schedule a content object
     When I am updating a content block
     And I schedule the change for 7 days in the future
     And I add an internal note
+    And I add a change note
     When I review and confirm my answers are correct
     When I click to view the content block
     And I click to edit the schedule
@@ -63,6 +67,7 @@ Feature: Schedule a content object
     When I am updating a content block
     And I schedule the change for 7 days in the future
     And I add an internal note
+    And I add a change note
     When I review and confirm my answers are correct
     When I click to view the content block
     And I click to edit the schedule

--- a/lib/engines/content_block_manager/features/schedule_object.feature
+++ b/lib/engines/content_block_manager/features/schedule_object.feature
@@ -11,6 +11,7 @@ Feature: Schedule a content object
   Scenario: GDS Editor schedules a content object
     When I am updating a content block
     And I schedule the change for 7 days in the future
+    And I add an internal note
     When I review and confirm my answers are correct
     And I should be taken to the scheduled confirmation page
     When I click to view the content block
@@ -21,6 +22,7 @@ Feature: Schedule a content object
   Scenario: GDS Editor publishes a new version of a previously scheduled content object
     When I am updating a content block
     And I schedule the change for 7 days in the future
+    And I add an internal note
     When I review and confirm my answers are correct
     When I am updating a content block
     And I choose to publish the change now
@@ -32,6 +34,7 @@ Feature: Schedule a content object
     When I am updating a content block
     When I choose to schedule the change
     And the block is scheduled and published
+    And I add an internal note
     When I review and confirm my answers are correct
     Then the published state of the object should be shown
     And I should see the publish event on the timeline
@@ -60,5 +63,6 @@ Feature: Schedule a content object
     When I am updating a content block
     When I choose to schedule the change
     And the block is scheduled and published
+    And I add an internal note
     And I click cancel
     Then I am taken back to Content Block Manager home page

--- a/lib/engines/content_block_manager/features/schedule_object.feature
+++ b/lib/engines/content_block_manager/features/schedule_object.feature
@@ -12,6 +12,7 @@ Feature: Schedule a content object
     When I am updating a content block
     And I schedule the change for 7 days in the future
     And I add an internal note
+    And I add a change note
     When I review and confirm my answers are correct
     And I should be taken to the scheduled confirmation page
     When I click to view the content block
@@ -23,10 +24,12 @@ Feature: Schedule a content object
     When I am updating a content block
     And I schedule the change for 7 days in the future
     And I add an internal note
+    And I add a change note
     When I review and confirm my answers are correct
     When I am updating a content block
     And I choose to publish the change now
     And I save and continue
+    And I add a change note
     When I review and confirm my answers are correct
     Then there should be no jobs scheduled
 
@@ -35,6 +38,7 @@ Feature: Schedule a content object
     When I choose to schedule the change
     And the block is scheduled and published
     And I add an internal note
+    And I add a change note
     When I review and confirm my answers are correct
     Then the published state of the object should be shown
     And I should see the publish event on the timeline
@@ -64,5 +68,6 @@ Feature: Schedule a content object
     When I choose to schedule the change
     And the block is scheduled and published
     And I add an internal note
+    And I add a change note
     And I click cancel
     Then I am taken back to Content Block Manager home page

--- a/lib/engines/content_block_manager/features/schedule_object.feature
+++ b/lib/engines/content_block_manager/features/schedule_object.feature
@@ -10,7 +10,6 @@ Feature: Schedule a content object
   @enable-sidekiq-test-mode
   Scenario: GDS Editor schedules a content object
     When I am updating a content block
-    Then I am asked when I want to publish the change
     And I schedule the change for 7 days in the future
     When I review and confirm my answers are correct
     And I should be taken to the scheduled confirmation page
@@ -21,7 +20,6 @@ Feature: Schedule a content object
   @disable-sidekiq-test-mode
   Scenario: GDS Editor publishes a new version of a previously scheduled content object
     When I am updating a content block
-    Then I am asked when I want to publish the change
     And I schedule the change for 7 days in the future
     When I review and confirm my answers are correct
     When I am updating a content block
@@ -32,7 +30,6 @@ Feature: Schedule a content object
 
   Scenario: A scheduled content object is published
     When I am updating a content block
-    Then I am asked when I want to publish the change
     When I choose to schedule the change
     And the block is scheduled and published
     When I review and confirm my answers are correct
@@ -41,14 +38,12 @@ Feature: Schedule a content object
 
   Scenario: GDS Editor does not provide date for scheduling
     When I am updating a content block
-    Then I am asked when I want to publish the change
     When I choose to schedule the change
     And I save and continue
     Then I see the errors prompting me to provide a date and time
 
   Scenario: GDS Editor does not provide a valid date for scheduling
     When I am updating a content block
-    Then I am asked when I want to publish the change
     When I choose to schedule the change
     And I enter an invalid date
     And I save and continue
@@ -56,7 +51,6 @@ Feature: Schedule a content object
 
   Scenario: GDS Editor provides a date in the past for scheduling
     When I am updating a content block
-    Then I am asked when I want to publish the change
     When I choose to schedule the change
     And I enter a date in the past
     And I save and continue
@@ -64,7 +58,6 @@ Feature: Schedule a content object
 
   Scenario: GDS Editor cancels after scheduling a block
     When I am updating a content block
-    Then I am asked when I want to publish the change
     When I choose to schedule the change
     And the block is scheduled and published
     And I click cancel

--- a/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
@@ -747,6 +747,12 @@ When("I continue after reviewing the links") do
   click_save_and_continue
 end
 
+When(/^I add a change note$/) do
+  choose "Yes - information has been added, updated or removed"
+  fill_in "Describe the edit for users", with: "Some text"
+  click_save_and_continue
+end
+
 def visit_edit_page
   visit content_block_manager.new_content_block_manager_content_block_document_edition_path(@content_block.document)
 end
@@ -867,6 +873,8 @@ Then(/^I should be on the "([^"]*)" step$/) do |step|
     should_show_publish_form
   when "review"
     should_be_on_review_step
+  when "change_note"
+    should_be_on_change_note_step
   end
 end
 
@@ -920,4 +928,8 @@ end
 
 def should_be_on_review_step
   assert_text "Review email address"
+end
+
+def should_be_on_change_note_step
+  assert_text "Do users have to know the content has changed?"
 end

--- a/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
@@ -881,6 +881,12 @@ Then(/^I should see a back link to the "([^"]*)" step$/) do |step|
          end
   expect(page).to have_link("Back", href: link)
 end
+
+When(/^I add an internal note$/) do
+  fill_in "Describe the change for internal users", with: "Some internal note goes here"
+  click_save_and_continue
+end
+
 def should_show_edit_form
   should_show_edit_form_for_email_address_content_block(
     @content_block.document.title,

--- a/lib/engines/content_block_manager/test/factories/content_block_edition.rb
+++ b/lib/engines/content_block_manager/test/factories/content_block_edition.rb
@@ -18,6 +18,10 @@ FactoryBot.define do
 
     internal_change_note { "Something changed" }
 
+    change_note { "Something changed publicly" }
+
+    major_change { true }
+
     ContentBlockManager::ContentBlock::Schema.valid_schemas.each do |type|
       trait type.to_sym do
         document { build(:content_block_document, block_type: type) }

--- a/lib/engines/content_block_manager/test/factories/content_block_edition.rb
+++ b/lib/engines/content_block_manager/test/factories/content_block_edition.rb
@@ -16,6 +16,8 @@ FactoryBot.define do
 
     title { "Factory Title for Edition" }
 
+    internal_change_note { "Something changed" }
+
     ContentBlockManager::ContentBlock::Schema.valid_schemas.each do |type|
       trait type.to_sym do
         document { build(:content_block_document, block_type: type) }

--- a/lib/engines/content_block_manager/test/integration/content_block/editions_test.rb
+++ b/lib/engines/content_block_manager/test/integration/content_block/editions_test.rb
@@ -119,7 +119,7 @@ class ContentBlockManager::ContentBlock::EditionsTest < ActionDispatch::Integrat
       end
 
       it "redirects to the review links step when successful" do
-        redirects_to_step(ContentBlockManager::ContentBlock::Editions::WorkflowController::UPDATE_BLOCK_STEPS[:review_links]) do
+        redirects_to_step(:review_links) do
           post content_block_manager.content_block_manager_content_block_document_editions_path(content_block_document), params: {
             "content_block/edition": {
               document_attributes: {
@@ -176,7 +176,7 @@ class ContentBlockManager::ContentBlock::EditionsTest < ActionDispatch::Integrat
       end
 
       it "redirects to the review step when successful" do
-        redirects_to_step(ContentBlockManager::ContentBlock::Editions::WorkflowController::NEW_BLOCK_STEPS[:review]) do
+        redirects_to_step(:review) do
           post content_block_manager.content_block_manager_content_block_editions_path, params: {
             something: "else",
             "content_block/edition": {

--- a/lib/engines/content_block_manager/test/integration/content_block/workflow_test.rb
+++ b/lib/engines/content_block_manager/test/integration/content_block/workflow_test.rb
@@ -30,7 +30,7 @@ class ContentBlockManager::ContentBlock::WorkflowTest < ActionDispatch::Integrat
 
   describe "when creating a new content block" do
     describe "when reviewing the changes" do
-      let(:step) { ContentBlockManager::ContentBlock::Editions::WorkflowController::NEW_BLOCK_STEPS[:review] }
+      let(:step) { :review }
 
       describe "#show" do
         it "shows the new edition for review" do
@@ -51,7 +51,7 @@ class ContentBlockManager::ContentBlock::WorkflowTest < ActionDispatch::Integrat
     end
 
     describe "when the edition details have not been confirmed" do
-      let(:step) { ContentBlockManager::ContentBlock::Editions::WorkflowController::NEW_BLOCK_STEPS[:review] }
+      let(:step) { :review }
 
       describe "#update" do
         it "returns to the review page" do
@@ -65,7 +65,7 @@ class ContentBlockManager::ContentBlock::WorkflowTest < ActionDispatch::Integrat
 
   describe "when updating an existing content block" do
     describe "when reviewing the links" do
-      let(:step) { ContentBlockManager::ContentBlock::Editions::WorkflowController::UPDATE_BLOCK_STEPS[:review_links] }
+      let(:step) { :review_links }
 
       describe "#show" do
         it_returns_embedded_content do
@@ -83,7 +83,7 @@ class ContentBlockManager::ContentBlock::WorkflowTest < ActionDispatch::Integrat
     end
 
     describe "when scheduling or publishing" do
-      let(:step) { ContentBlockManager::ContentBlock::Editions::WorkflowController::UPDATE_BLOCK_STEPS[:schedule_publishing] }
+      let(:step) { :schedule_publishing }
 
       describe "#show" do
         it "shows the form" do
@@ -142,6 +142,24 @@ class ContentBlockManager::ContentBlock::WorkflowTest < ActionDispatch::Integrat
             assert_match(/#{I18n.t('activerecord.errors.models.content_block_manager/content_block/edition.attributes.schedule_publishing.blank')}/, response.body)
           end
         end
+      end
+    end
+  end
+
+  describe "when an unknown step is provided" do
+    describe "#show" do
+      it "shows the new edition for review" do
+        get content_block_manager.content_block_manager_content_block_workflow_path(id: edition.id, step: "some_random_step")
+
+        assert_response :missing
+      end
+    end
+
+    describe "#update" do
+      it "posts the new edition to the Publishing API and marks edition as published" do
+        put content_block_manager.content_block_manager_content_block_workflow_path(id: edition.id, step: "some_random_step")
+
+        assert_response :missing
       end
     end
   end

--- a/lib/engines/content_block_manager/test/integration/content_block/workflow_test.rb
+++ b/lib/engines/content_block_manager/test/integration/content_block/workflow_test.rb
@@ -168,7 +168,61 @@ class ContentBlockManager::ContentBlock::WorkflowTest < ActionDispatch::Integrat
 
           assert_equal edition.reload.internal_change_note, change_note
 
+          assert_redirected_to content_block_manager_content_block_workflow_path(id: edition.id, step: :change_note)
+        end
+      end
+    end
+
+    describe "when updating the change note" do
+      let(:step) { :change_note }
+
+      describe "#show" do
+        it "shows the form" do
+          get content_block_manager.content_block_manager_content_block_workflow_path(id: edition.id, step:)
+
+          assert_template "content_block_manager/content_block/editions/workflow/change_note"
+        end
+      end
+
+      describe "#update" do
+        it "adds the note and redirects" do
+          change_note = "This is my note"
+          put content_block_manager.content_block_manager_content_block_workflow_path(id: edition.id, step:),
+              params: {
+                "content_block/edition" => {
+                  "major_change" => "1",
+                  "change_note" => change_note,
+                },
+              }
+
+          assert_equal edition.reload.change_note, change_note
+          assert_equal edition.reload.major_change, true
+
           assert_redirected_to content_block_manager_content_block_workflow_path(id: edition.id, step: :review_update)
+        end
+
+        it "shows an error if the change is major and the change note is blank" do
+          put content_block_manager.content_block_manager_content_block_workflow_path(id: edition.id, step:),
+              params: {
+                "content_block/edition" => {
+                  "major_change" => "1",
+                  "change_note" => "",
+                },
+              }
+
+          assert_match(/#{I18n.t('activerecord.errors.models.content_block_manager/content_block/edition.blank', attribute: 'Change note')}/, response.body)
+        end
+
+        it "shows an error if major_change is blank" do
+          put content_block_manager.content_block_manager_content_block_workflow_path(id: edition.id, step:),
+              params: {
+                "content_block/edition" => {
+                  "major_change" => "",
+                  "change_note" => "",
+                },
+              }
+
+          assert_match(/#{I18n.t('activerecord.errors.models.content_block_manager/content_block/edition.attributes.major_change.inclusion')}/, response.body)
         end
       end
     end

--- a/lib/engines/content_block_manager/test/integration/content_block/workflow_test.rb
+++ b/lib/engines/content_block_manager/test/integration/content_block/workflow_test.rb
@@ -96,7 +96,7 @@ class ContentBlockManager::ContentBlock::WorkflowTest < ActionDispatch::Integrat
 
       describe "#update" do
         describe "when choosing to publish immediately" do
-          it "redirects to the review step" do
+          it "redirects to the internal note step" do
             scheduled_at = {
               "scheduled_publication(1i)": "",
               "scheduled_publication(2i)": "",
@@ -111,12 +111,12 @@ class ContentBlockManager::ContentBlock::WorkflowTest < ActionDispatch::Integrat
                   scheduled_at:,
                 }
 
-            assert_redirected_to content_block_manager_content_block_workflow_path(id: edition.id, step: :review_update)
+            assert_redirected_to content_block_manager_content_block_workflow_path(id: edition.id, step: :internal_note)
           end
         end
 
         describe "when scheduling publication" do
-          it "redirects to the review step" do
+          it "redirects to the internal note page" do
             scheduled_at = {
               "scheduled_publication(1i)": "2024",
               "scheduled_publication(2i)": "01",
@@ -130,7 +130,7 @@ class ContentBlockManager::ContentBlock::WorkflowTest < ActionDispatch::Integrat
               scheduled_at:,
             }
 
-            assert_redirected_to content_block_manager_content_block_workflow_path(id: edition.id, step: :review_update)
+            assert_redirected_to content_block_manager_content_block_workflow_path(id: edition.id, step: :internal_note)
           end
         end
 
@@ -141,6 +141,34 @@ class ContentBlockManager::ContentBlock::WorkflowTest < ActionDispatch::Integrat
             assert_template "content_block_manager/content_block/editions/workflow/schedule_publishing"
             assert_match(/#{I18n.t('activerecord.errors.models.content_block_manager/content_block/edition.attributes.schedule_publishing.blank')}/, response.body)
           end
+        end
+      end
+    end
+
+    describe "when updating the internal note" do
+      let(:step) { :internal_note }
+
+      describe "#show" do
+        it "shows the form" do
+          get content_block_manager.content_block_manager_content_block_workflow_path(id: edition.id, step:)
+
+          assert_template "content_block_manager/content_block/editions/workflow/internal_note"
+        end
+      end
+
+      describe "#update" do
+        it "adds the note and redirects" do
+          change_note = "This is my note"
+          put content_block_manager.content_block_manager_content_block_workflow_path(id: edition.id, step:),
+              params: {
+                "content_block/edition" => {
+                  "internal_change_note" => change_note,
+                },
+              }
+
+          assert_equal edition.reload.internal_change_note, change_note
+
+          assert_redirected_to content_block_manager_content_block_workflow_path(id: edition.id, step: :review_update)
         end
       end
     end

--- a/lib/engines/content_block_manager/test/unit/app/models/content_block_edition_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/models/content_block_edition_test.rb
@@ -21,6 +21,7 @@ class ContentBlockManager::ContentBlockEditionTest < ActiveSupport::TestCase
       updated_at:,
       details:,
       document_attributes: {
+        sluggable_string: "Something",
         block_type: "email_address",
       },
       creator:,
@@ -104,6 +105,37 @@ class ContentBlockManager::ContentBlockEditionTest < ActiveSupport::TestCase
 
     assert_invalid content_block_edition
     assert content_block_edition.errors.full_messages.include?("Title cannot be blank")
+  end
+
+  describe "change note validation" do
+    it "validates the presence of a change note if the change is major" do
+      content_block_edition.change_note = nil
+      content_block_edition.major_change = true
+
+      assert_invalid content_block_edition, context: :change_note
+      assert content_block_edition.errors.full_messages.include?("Change note cannot be blank")
+    end
+
+    it "is valid when the change is major and a change note is provided" do
+      content_block_edition.change_note = "something"
+      content_block_edition.major_change = true
+
+      assert_valid content_block_edition, context: :change_note
+    end
+
+    it "validates the presence of the major_change boolean" do
+      content_block_edition.major_change = nil
+
+      assert_invalid content_block_edition, context: :change_note
+      assert content_block_edition.errors.full_messages.include?("Select if users have to know the content has changed")
+    end
+
+    it "is valid when the change is minor and a change note is not provided" do
+      content_block_edition.change_note = nil
+      content_block_edition.major_change = false
+
+      assert_valid content_block_edition, context: :change_note
+    end
   end
 
   it "adds a creator and first edition author for new records" do

--- a/lib/engines/content_block_manager/test/unit/app/models/content_block_edition_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/models/content_block_edition_test.rb
@@ -12,6 +12,8 @@ class ContentBlockManager::ContentBlockEditionTest < ActiveSupport::TestCase
   let(:creator) { create(:user) }
   let(:organisation) { create(:organisation) }
   let(:internal_change_note) { "My internal change note" }
+  let(:change_note) { "My internal change note" }
+  let(:major_change) { true }
 
   let(:content_block_edition) do
     ContentBlockManager::ContentBlock::Edition.new(
@@ -25,6 +27,8 @@ class ContentBlockManager::ContentBlockEditionTest < ActiveSupport::TestCase
       organisation_id: organisation.id.to_s,
       title:,
       internal_change_note:,
+      change_note:,
+      major_change:,
     )
   end
 
@@ -42,6 +46,8 @@ class ContentBlockManager::ContentBlockEditionTest < ActiveSupport::TestCase
     assert_equal details, content_block_edition.details
     assert_equal title, content_block_edition.title
     assert_equal internal_change_note, content_block_edition.internal_change_note
+    assert_equal change_note, content_block_edition.change_note
+    assert_equal major_change, content_block_edition.major_change
   end
 
   it "persists the block type to the document" do

--- a/lib/engines/content_block_manager/test/unit/app/models/content_block_edition_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/models/content_block_edition_test.rb
@@ -11,6 +11,7 @@ class ContentBlockManager::ContentBlockEditionTest < ActiveSupport::TestCase
   let(:title) { "Edition title" }
   let(:creator) { create(:user) }
   let(:organisation) { create(:organisation) }
+  let(:internal_change_note) { "My internal change note" }
 
   let(:content_block_edition) do
     ContentBlockManager::ContentBlock::Edition.new(
@@ -23,6 +24,7 @@ class ContentBlockManager::ContentBlockEditionTest < ActiveSupport::TestCase
       creator:,
       organisation_id: organisation.id.to_s,
       title:,
+      internal_change_note:,
     )
   end
 
@@ -39,6 +41,7 @@ class ContentBlockManager::ContentBlockEditionTest < ActiveSupport::TestCase
     assert_equal updated_at, content_block_edition.updated_at
     assert_equal details, content_block_edition.details
     assert_equal title, content_block_edition.title
+    assert_equal internal_change_note, content_block_edition.internal_change_note
   end
 
   it "persists the block type to the document" do

--- a/test/support/model_helpers.rb
+++ b/test/support/model_helpers.rb
@@ -1,12 +1,12 @@
 module ModelHelpers
   extend ActiveSupport::Concern
 
-  def assert_valid(model)
-    assert model.valid?, "Expected #{model} to be valid."
+  def assert_valid(model, context: nil)
+    assert model.valid?(context), "Expected #{model} to be valid."
   end
 
-  def assert_invalid(model)
-    assert_not model.valid?, "Expected #{model} not to be valid."
+  def assert_invalid(model, context: nil)
+    assert_not model.valid?(context), "Expected #{model} not to be valid."
   end
 
   module ClassMethods


### PR DESCRIPTION
Trello card: https://trello.com/c/eqAcYy1U/828-add-internal-and-external-change-notes-when-editing-blocks

This adds screens to add internal change notes and external change notes (if the change is major). As part of this, I've refactored the Workflow controller to (try) and make it easier to follow. There's still scope for improvement, but I think we're getting there!

This doesn't include showing the notes on the confirm / view screens. I'll do this in a separate PR.

## Screenshots

![image](https://github.com/user-attachments/assets/59d88a9a-9db7-43e2-8da8-2bc53c8a45c5)

![image](https://github.com/user-attachments/assets/e7843f15-e429-4bf6-8df3-0e682b893018)
