### PR TITLE
Set read_consultation_principles to true for all post publication consultation editions

### DIFF
--- a/db/data_migration/202501231521000_retroactively_accept_consultation_principles.rb
+++ b/db/data_migration/202501231521000_retroactively_accept_consultation_principles.rb
@@ -1,0 +1,6 @@
+# When the validation requiring publishers to confirm that they have considered the consultation principles was introduced,
+# we did not backdate this to existing consultations. This means that some consultations cannot be withdrawn, unwithdrawn
+# or unpublished because they are not technically valid, despite being public on GOV.UK. This data migration retroactively
+# confirms that all post-publication consultations have considered the consultation principles.
+
+Consultation.where(state: Edition::POST_PUBLICATION_STATES).update_all(read_consultation_principles: true)


### PR DESCRIPTION
When the validation requiring publishers to confirm that they have considered the consultation principles was introduced in 797909f215a62261ce763a339a515ccb8833ef4f, we did not backdate this to existing consultations. This means that some consultations cannot be withdrawn, unwithdrawn or unpublished because they are not technically valid, despite being public on GOV.UK. This data migration retroactively confirms that all post-publication consultations have considered the consultation principles.

Trello: https://trello.com/c/nf4GMMi7
