### PR TITLE
(828) Additional workflow iterations

### DIFF
--- a/lib/engines/content_block_manager/app/controllers/concerns/can_schedule_or_publish.rb
+++ b/lib/engines/content_block_manager/app/controllers/concerns/can_schedule_or_publish.rb
@@ -74,13 +74,6 @@ module CanScheduleOrPublish
     ]
   end
 
-  def review_update_url
-    content_block_manager.content_block_manager_content_block_workflow_path(
-      @content_block_edition,
-      step: :review,
-    )
-  end
-
   def is_scheduling?
     @content_block_edition.scheduled_publication.present?
   end

--- a/lib/engines/content_block_manager/app/controllers/concerns/workflow.rb
+++ b/lib/engines/content_block_manager/app/controllers/concerns/workflow.rb
@@ -1,0 +1,31 @@
+module Workflow
+  class Step < Data.define(:name, :show_action, :update_action)
+    ALL = [
+      Step.new(:edit_draft, :edit_draft, nil),
+      Step.new(:review_links, :review_links, :redirect_to_next_step),
+      Step.new(:schedule_publishing, :schedule_publishing, :validate_schedule),
+      Step.new(:internal_note, :internal_note, :update_internal_note),
+      Step.new(:change_note, :change_note, :update_change_note),
+      Step.new(:review, :review, :validate_review_page),
+      Step.new(:confirmation, :confirmation, nil),
+    ].freeze
+
+    def self.by_name(name)
+      ALL.find { |step| step.name == name.to_sym }
+    end
+
+    def previous_step
+      ALL[index - 1]
+    end
+
+    def next_step
+      ALL[index + 1]
+    end
+
+  private
+
+    def index
+      ALL.find_index { |step| step.name == name.to_sym }
+    end
+  end
+end

--- a/lib/engines/content_block_manager/app/controllers/concerns/workflow/show_methods.rb
+++ b/lib/engines/content_block_manager/app/controllers/concerns/workflow/show_methods.rb
@@ -8,7 +8,6 @@ module Workflow::ShowMethods
     internal_note: :internal_note,
     change_note: :change_note,
     review: :review,
-    review_update: :review_update,
     confirmation: :confirmation,
   }.freeze
 
@@ -54,18 +53,8 @@ module Workflow::ShowMethods
     render :change_note
   end
 
-  def review_update
-    @content_block_edition = ContentBlockManager::ContentBlock::Edition.find(params[:id])
-
-    @url = review_update_url
-
-    render :review
-  end
-
   def review
     @content_block_edition = ContentBlockManager::ContentBlock::Edition.find(params[:id])
-
-    @url = review_url
 
     render :review
   end

--- a/lib/engines/content_block_manager/app/controllers/concerns/workflow/show_methods.rb
+++ b/lib/engines/content_block_manager/app/controllers/concerns/workflow/show_methods.rb
@@ -44,20 +44,12 @@ module Workflow::ShowMethods
 
   def internal_note
     @content_block_document = @content_block_edition.document
-    @back_path = content_block_manager.content_block_manager_content_block_workflow_path(
-      @content_block_edition,
-      step: :schedule_publishing,
-    )
 
     render :internal_note
   end
 
   def change_note
     @content_block_document = @content_block_edition.document
-    @back_path = content_block_manager.content_block_manager_content_block_workflow_path(
-      @content_block_edition,
-      step: :internal_note,
-    )
 
     render :change_note
   end
@@ -66,17 +58,12 @@ module Workflow::ShowMethods
     @content_block_edition = ContentBlockManager::ContentBlock::Edition.find(params[:id])
 
     @url = review_update_url
-    @back_path = content_block_manager.content_block_manager_content_block_workflow_path(
-      @content_block_edition,
-      step: :change_note,
-    )
 
     render :review
   end
 
   def review
     @content_block_edition = ContentBlockManager::ContentBlock::Edition.find(params[:id])
-    @back_path = content_block_manager.content_block_manager_content_block_documents_path
 
     @url = review_url
 

--- a/lib/engines/content_block_manager/app/controllers/concerns/workflow/show_methods.rb
+++ b/lib/engines/content_block_manager/app/controllers/concerns/workflow/show_methods.rb
@@ -1,16 +1,6 @@
 module Workflow::ShowMethods
   extend ActiveSupport::Concern
 
-  SHOW_ACTIONS = {
-    edit_draft: :edit_draft,
-    review_links: :review_links,
-    schedule_publishing: :schedule_publishing,
-    internal_note: :internal_note,
-    change_note: :change_note,
-    review: :review,
-    confirmation: :confirmation,
-  }.freeze
-
   def edit_draft
     @content_block_edition = ContentBlockManager::ContentBlock::Edition.find(params[:id])
     @form = ContentBlockManager::ContentBlock::EditionForm.for(

--- a/lib/engines/content_block_manager/app/controllers/concerns/workflow/update_methods.rb
+++ b/lib/engines/content_block_manager/app/controllers/concerns/workflow/update_methods.rb
@@ -4,29 +4,19 @@ module Workflow::UpdateMethods
   REVIEW_ERROR = Data.define(:attribute, :full_message)
 
   UPDATE_ACTIONS = {
-    review_links: :redirect_to_schedule,
+    review_links: :redirect_to_next_step,
     schedule_publishing: :validate_schedule,
     internal_note: :update_internal_note,
     change_note: :update_change_note,
     review: :validate_review_page,
   }.freeze
 
-  def redirect_to_schedule
-    redirect_to content_block_manager.content_block_manager_content_block_workflow_path(
-      id: @content_block_edition.id,
-      step: :schedule_publishing,
-    )
-  end
-
   def validate_schedule
     @content_block_edition = ContentBlockManager::ContentBlock::Edition.find(params[:id])
 
     validate_scheduled_edition
 
-    redirect_to content_block_manager.content_block_manager_content_block_workflow_path(
-      id: @content_block_edition.id,
-      step: :internal_note,
-    )
+    redirect_to_next_step
   rescue ActiveRecord::RecordInvalid
     render "content_block_manager/content_block/editions/workflow/schedule_publishing"
   end
@@ -34,20 +24,14 @@ module Workflow::UpdateMethods
   def update_internal_note
     @content_block_edition.update!(internal_change_note: edition_params[:internal_change_note])
 
-    redirect_to content_block_manager.content_block_manager_content_block_workflow_path(
-      id: @content_block_edition.id,
-      step: :change_note,
-    )
+    redirect_to_next_step
   end
 
   def update_change_note
     @content_block_edition.assign_attributes(change_note: edition_params[:change_note], major_change: edition_params[:major_change])
     @content_block_edition.save!(context: :change_note)
 
-    redirect_to content_block_manager.content_block_manager_content_block_workflow_path(
-      id: @content_block_edition.id,
-      step: :review,
-    )
+    redirect_to_next_step
   rescue ActiveRecord::RecordInvalid
     render :change_note
   end
@@ -60,5 +44,16 @@ module Workflow::UpdateMethods
     else
       schedule_or_publish
     end
+  end
+
+private
+
+  def redirect_to_next_step
+    next_step = Workflow::Step.by_name(params[:step])&.next_step
+
+    redirect_to content_block_manager.content_block_manager_content_block_workflow_path(
+      id: @content_block_edition.id,
+      step: next_step&.name,
+    )
   end
 end

--- a/lib/engines/content_block_manager/app/controllers/concerns/workflow/update_methods.rb
+++ b/lib/engines/content_block_manager/app/controllers/concerns/workflow/update_methods.rb
@@ -3,14 +3,6 @@ module Workflow::UpdateMethods
 
   REVIEW_ERROR = Data.define(:attribute, :full_message)
 
-  UPDATE_ACTIONS = {
-    review_links: :redirect_to_next_step,
-    schedule_publishing: :validate_schedule,
-    internal_note: :update_internal_note,
-    change_note: :update_change_note,
-    review: :validate_review_page,
-  }.freeze
-
   def validate_schedule
     @content_block_edition = ContentBlockManager::ContentBlock::Edition.find(params[:id])
 

--- a/lib/engines/content_block_manager/app/controllers/concerns/workflow/update_methods.rb
+++ b/lib/engines/content_block_manager/app/controllers/concerns/workflow/update_methods.rb
@@ -8,7 +8,6 @@ module Workflow::UpdateMethods
     schedule_publishing: :validate_schedule,
     internal_note: :update_internal_note,
     change_note: :update_change_note,
-    review_update: :validate_review_page,
     review: :validate_review_page,
   }.freeze
 
@@ -47,7 +46,7 @@ module Workflow::UpdateMethods
 
     redirect_to content_block_manager.content_block_manager_content_block_workflow_path(
       id: @content_block_edition.id,
-      step: :review_update,
+      step: :review,
     )
   rescue ActiveRecord::RecordInvalid
     render :change_note
@@ -57,20 +56,9 @@ module Workflow::UpdateMethods
     if params[:is_confirmed].blank?
       @confirm_error_copy = I18n.t("content_block_edition.review_page.errors.confirm")
       @error_summary_errors = [{ text: @confirm_error_copy, href: "#is_confirmed-0" }]
-      @url = on_review_page? ? review_url : review_update_url
-      render "content_block_manager/content_block/editions/workflow/review"
+      render :review
     else
       schedule_or_publish
     end
-  end
-
-private
-
-  def on_review_page?
-    params[:step] == :review
-  end
-
-  def on_review_update_page?
-    params[:step] == :review_update
   end
 end

--- a/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/editions/workflow_controller.rb
+++ b/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/editions/workflow_controller.rb
@@ -5,7 +5,7 @@ class ContentBlockManager::ContentBlock::Editions::WorkflowController < ContentB
 
   def show
     step = params[:step].to_sym
-    action = SHOW_ACTIONS[step]
+    action = Workflow::Step.by_name(step)&.show_action
 
     if action
       @content_block_edition = ContentBlockManager::ContentBlock::Edition.find(params[:id])
@@ -18,7 +18,7 @@ class ContentBlockManager::ContentBlock::Editions::WorkflowController < ContentB
 
   def update
     step = params[:step].to_sym
-    action = UPDATE_ACTIONS[step]
+    action = Workflow::Step.by_name(step)&.update_action
 
     if action
       @content_block_edition = ContentBlockManager::ContentBlock::Edition.find(params[:id])

--- a/lib/engines/content_block_manager/app/helpers/workflow_helper.rb
+++ b/lib/engines/content_block_manager/app/helpers/workflow_helper.rb
@@ -1,0 +1,15 @@
+module WorkflowHelper
+  def back_path(content_block_edition, current_step)
+    if current_step == "review" && content_block_edition.document.is_new_block?
+      content_block_manager.content_block_manager_content_block_documents_path
+    else
+      step = Workflow::Step.by_name(current_step)&.previous_step
+      return nil unless step
+
+      content_block_manager.content_block_manager_content_block_workflow_path(
+        content_block_edition,
+        step: step.name,
+      )
+    end
+  end
+end

--- a/lib/engines/content_block_manager/app/models/content_block_manager/content_block/document.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/content_block/document.rb
@@ -33,6 +33,10 @@ module ContentBlockManager
       def title
         @title ||= latest_edition&.title
       end
+
+      def is_new_block?
+        editions.count == 1
+      end
     end
   end
 end

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/change_note.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/change_note.html.erb
@@ -3,7 +3,7 @@
 <% content_for :title_margin_bottom, 4 %>
 <% content_for :back_link do %>
   <%= render "govuk_publishing_components/components/back_link", {
-    href: @back_path,
+    href: back_path(@content_block_edition, "change_note"),
   } %>
 <% end %>
 

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/internal_note.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/internal_note.html.erb
@@ -3,7 +3,7 @@
 <% content_for :title_margin_bottom, 4 %>
 <% content_for :back_link do %>
   <%= render "govuk_publishing_components/components/back_link", {
-    href: @back_path,
+    href: back_path(@content_block_edition, "internal_note"),
   } %>
 <% end %>
 

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/review.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/review.html.erb
@@ -1,8 +1,9 @@
 <% content_for :context, "Create a content block" %>
 <% content_for :title, "Review #{@content_block_edition.block_type.humanize.downcase}" %>
+
 <% content_for :back_link do %>
   <%= render "govuk_publishing_components/components/back_link", {
-    href: @back_path,
+    href: back_path(@content_block_edition, "review"),
   } %>
 <% end %>
 
@@ -23,7 +24,10 @@
   </div>
 </div>
 
-<%= form_with(url: @url, method: :put) do %>
+<%= form_with(
+      url: content_block_manager.content_block_manager_content_block_workflow_path(@content_block_edition, step: :review),
+      method: :put,
+    ) do %>
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <%= render "govuk_publishing_components/components/checkboxes", {

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/review_links.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/review_links.html.erb
@@ -3,7 +3,7 @@
 <% content_for :title_margin_bottom, 4 %>
 <% content_for :back_link do %>
   <%= render "govuk_publishing_components/components/back_link", {
-    href: content_block_manager.new_content_block_manager_content_block_document_edition_path(@content_block_document),
+    href: back_path(@content_block_edition, "review_links"),
   } %>
 <% end %>
 

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/schedule_publishing.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/schedule_publishing.html.erb
@@ -3,10 +3,7 @@
       content_block_edition: @content_block_edition,
       params:,
       context:,
-      back_link: content_block_manager.content_block_manager_content_block_workflow_path(
-        @content_block_edition,
-        step: :review_links,
-      ),
+      back_link: back_path(@content_block_edition, "schedule_publishing"),
       form_url: content_block_manager.content_block_manager_content_block_workflow_path(
         @content_block_edition,
         step: :schedule_publishing,

--- a/lib/engines/content_block_manager/features/edit_object.feature
+++ b/lib/engines/content_block_manager/features/edit_object.feature
@@ -16,7 +16,7 @@ Feature: Edit a content object
     And I should see a back link to the document page
     When I fill out the form
     Then I should be on the "review_links" step
-    And I should see a back link to the "edit" step
+    And I should see a back link to the "edit_draft" step
     When I continue after reviewing the links
     Then I should be on the "schedule_publishing" step
     And I should see a back link to the "review_links" step

--- a/lib/engines/content_block_manager/test/integration/content_block/workflow_test.rb
+++ b/lib/engines/content_block_manager/test/integration/content_block/workflow_test.rb
@@ -198,7 +198,7 @@ class ContentBlockManager::ContentBlock::WorkflowTest < ActionDispatch::Integrat
           assert_equal edition.reload.change_note, change_note
           assert_equal edition.reload.major_change, true
 
-          assert_redirected_to content_block_manager_content_block_workflow_path(id: edition.id, step: :review_update)
+          assert_redirected_to content_block_manager_content_block_workflow_path(id: edition.id, step: :review)
         end
 
         it "shows an error if the change is major and the change note is blank" do

--- a/lib/engines/content_block_manager/test/unit/app/controllers/concerns/workflow_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/controllers/concerns/workflow_test.rb
@@ -1,0 +1,46 @@
+require "test_helper"
+
+class ContentBlockManager::ContentBlock::WorkflowTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
+  describe "Step" do
+    describe ".by_name" do
+      it "returns a step by its name" do
+        step = Workflow::Step.by_name("review_links")
+
+        assert_equal step&.name, :review_links
+      end
+    end
+
+    describe "#next_step" do
+      [
+        %i[edit_draft review_links],
+        %i[review_links schedule_publishing],
+        %i[schedule_publishing internal_note],
+        %i[internal_note change_note],
+        %i[change_note review],
+        %i[review confirmation],
+      ].each do |current_step, expected_step|
+        it "returns #{expected_step} step when the current step is #{current_step}" do
+          step = Workflow::Step.by_name(current_step)
+          assert_equal step&.next_step&.name, expected_step
+        end
+      end
+    end
+
+    describe "#previous_step" do
+      [
+        %i[review_links edit_draft],
+        %i[schedule_publishing review_links],
+        %i[internal_note schedule_publishing],
+        %i[change_note internal_note],
+        %i[review change_note],
+      ].each do |current_step, expected_step|
+        it "returns #{expected_step} step when the current step is #{current_step}" do
+          step = Workflow::Step.by_name(current_step)
+          assert_equal step&.previous_step&.name, expected_step
+        end
+      end
+    end
+  end
+end

--- a/lib/engines/content_block_manager/test/unit/app/helpers/workflow_helpers_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/helpers/workflow_helpers_test.rb
@@ -1,0 +1,44 @@
+require "test_helper"
+
+class ContentBlockManager::WorkflowHelperTest < ActionView::TestCase
+  extend Minitest::Spec::DSL
+
+  include WorkflowHelper
+
+  let(:content_block_edition) { build_stubbed(:content_block_edition) }
+  let(:stub_document) { stub(:document, is_new_block?: is_new_block) }
+
+  before do
+    content_block_edition.stubs(:document).returns(stub_document)
+  end
+
+  describe "#back_path" do
+    describe "when editing an existing block" do
+      let(:is_new_block) { false }
+
+      it "returns the name of the next step" do
+        current_step_name = "my_step"
+        expected_step_name = "something"
+
+        current_step = mock("Workflow::Step")
+        previous_step = mock("Workflow::Step", name: expected_step_name)
+
+        Workflow::Step.expects(:by_name).with(current_step_name).returns(current_step)
+        current_step.expects(:previous_step).returns(previous_step)
+
+        assert_equal back_path(content_block_edition, current_step_name), content_block_manager.content_block_manager_content_block_workflow_path(
+          content_block_edition,
+          step: expected_step_name,
+        )
+      end
+    end
+  end
+
+  describe "when editing an existing block" do
+    let(:is_new_block) { true }
+
+    it "returns the homepage link for the review step" do
+      assert_equal back_path(content_block_edition, "review"), content_block_manager.content_block_manager_content_block_documents_path
+    end
+  end
+end

--- a/lib/engines/content_block_manager/test/unit/app/models/content_block_document_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/models/content_block_document_test.rb
@@ -130,4 +130,18 @@ class ContentBlockManager::ContentBlockDocumentTest < ActiveSupport::TestCase
       assert_equal latest_edition.title, document.title
     end
   end
+
+  describe "#is_new_block?" do
+    it "returns true when there is one associated edition" do
+      document = create(:content_block_document, :email_address, editions: create_list(:content_block_edition, 1, :email_address))
+
+      assert document.is_new_block?
+    end
+
+    it "returns false when there is more than one associated edition" do
+      document = create(:content_block_document, :email_address, editions: create_list(:content_block_edition, 2, :email_address))
+
+      assert_not document.is_new_block?
+    end
+  end
 end


### PR DESCRIPTION
Trello card: https://trello.com/c/eqAcYy1U/828-add-internal-and-external-change-notes-when-editing-blocks

This simplifies the workflow code further, having one source of truth for the workflow steps, adding some useful helpers to get the next/previous steps, and removing some confusing code.