### PR TITLE
content modelling/830 show changes to a content block

### DIFF
--- a/db/migrate/20250124165847_add_field_diffs_to_content_block_versions.rb
+++ b/db/migrate/20250124165847_add_field_diffs_to_content_block_versions.rb
@@ -1,0 +1,13 @@
+class AddFieldDiffsToContentBlockVersions < ActiveRecord::Migration[7.1]
+  def up
+    change_table :content_block_versions, bulk: true do |t|
+      t.json "field_diffs"
+    end
+  end
+
+  def down
+    change_table :content_block_versions, bulk: true do |t|
+      t.remove :field_diffs
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_01_22_155447) do
+ActiveRecord::Schema[7.1].define(version: 2025_01_24_165847) do
   create_table "assets", charset: "utf8mb3", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.string "variant", null: false
@@ -247,6 +247,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_01_22_155447) do
     t.string "whodunnit"
     t.datetime "created_at", precision: nil, null: false
     t.text "state"
+    t.json "field_diffs"
     t.index ["item_id"], name: "index_content_block_versions_on_item_id"
     t.index ["item_type"], name: "index_content_block_versions_on_item_type"
   end

--- a/lib/engines/content_block_manager/app/assets/stylesheets/content_block_manager/components/_timeline-component.scss
+++ b/lib/engines/content_block_manager/app/assets/stylesheets/content_block_manager/components/_timeline-component.scss
@@ -70,3 +70,13 @@
   display: inline-block !important;
   margin-bottom: 10px !important;
 }
+
+.timeline__diff-table {
+  margin-top: govuk-spacing(1);
+
+  .govuk-details__text {
+    margin-top: govuk-spacing(1);
+    border: none;
+    padding-left: 0;
+  }
+}

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/document_timeline_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/document_timeline_component.html.erb
@@ -16,6 +16,35 @@
       <p class="timeline__date">
         <%= item[:date] %>
       </p>
+
+      <% if item[:table_rows].present? %>
+        <div class="timeline__diff-table">
+          <%= render "govuk_publishing_components/components/details", {
+            title: "Details of changes",
+            open: i == 0,
+          } do %>
+            <% capture do %>
+              <%= render "govuk_publishing_components/components/table", {
+                first_cell_is_header: true,
+                head: [
+                  {
+                    text: tag.span("Fields", class: "govuk-visually-hidden"),
+                  },
+                  {
+                    text: "Previous version",
+                    format: "string",
+                  },
+                  {
+                    text: "This version",
+                    format: "string",
+                  },
+                ],
+                rows: item[:table_rows],
+              } %>
+            <% end %>
+          <% end %>
+        </div>
+      <% end %>
     </div>
   <% end %>
 </div>

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/document_timeline_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/document_timeline_component.rb
@@ -14,6 +14,7 @@ private
         title: title(version),
         byline: User.find_by_id(version.whodunnit)&.then { |user| helpers.linked_author(user, { class: "govuk-link" }) } || "unknown user",
         date: time_html(version.created_at),
+        table_rows: table_rows(version),
       }
     end
   end
@@ -33,5 +34,17 @@ private
       datetime: date_time.iso8601,
       lang: "en",
     )
+  end
+
+  def table_rows(version)
+    if version.field_diffs.present?
+      version.field_diffs.map do |field|
+        [
+          { text: field["field_name"].humanize },
+          { text: field["previous_value"] },
+          { text: field["new_value"] },
+        ]
+      end
+    end
   end
 end

--- a/lib/engines/content_block_manager/app/models/content_block_manager/content_block/edition/has_audit_trail.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/content_block/edition/has_audit_trail.rb
@@ -28,7 +28,7 @@ module ContentBlockManager
       unless draft?
         user = Current.user
         state = try(:state)
-        versions.create!(event: "updated", user:, state:)
+        versions.create!(event: "updated", user:, state:, field_diffs: ContentBlockManager::ContentBlock::FieldDiff.all_for_edition(edition: self))
       end
     end
   end

--- a/lib/engines/content_block_manager/app/models/content_block_manager/content_block/field_diff.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/content_block/field_diff.rb
@@ -1,0 +1,41 @@
+module ContentBlockManager
+  module ContentBlock
+    class FieldDiff < Data.define(:field_name, :new_value, :previous_value)
+      def self.all_for_edition(edition:)
+        if edition.document.is_new_block?
+          nil
+        else
+          field_diffs = []
+          previous_edition = edition.document.editions.includes(:edition_organisation, :organisation)[-2]
+          if previous_edition.title != edition.title
+            field_diffs.append(new(field_name: "title", previous_value: previous_edition.title, new_value: edition.title))
+          end
+          if previous_edition.details != edition.details
+            previous_edition.details.each do |key, value|
+              next unless value != edition.details[key]
+
+              field_diffs.append(new(field_name: key, previous_value: value, new_value: edition.details[key]))
+            end
+          end
+          previous_org = previous_edition.lead_organisation
+          new_org = edition.lead_organisation
+          if new_org != previous_org
+            field_diffs.append(new(
+                                 field_name: "lead_organisation",
+                                 previous_value: previous_org.name,
+                                 new_value: edition.lead_organisation.name,
+                               ))
+          end
+          if previous_edition.instructions_to_publishers != edition.instructions_to_publishers
+            field_diffs.append(new(
+                                 field_name: "instructions_to_publishers",
+                                 previous_value: previous_edition.instructions_to_publishers,
+                                 new_value: edition.instructions_to_publishers,
+                               ))
+          end
+          field_diffs unless field_diffs.empty?
+        end
+      end
+    end
+  end
+end

--- a/lib/engines/content_block_manager/features/edit_object.feature
+++ b/lib/engines/content_block_manager/features/edit_object.feature
@@ -35,6 +35,7 @@ Feature: Edit a content object
     Then the edition should have been updated successfully
     And I should be taken back to the document page
     And I should see 2 publish events on the timeline
+    And I should see the edition diff in a table
 
   Scenario: GDS editor cancels the creation of an object when reviewing links
     When I visit the Content Block Manager home page

--- a/lib/engines/content_block_manager/features/step_definitions/timeline_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/timeline_steps.rb
@@ -16,3 +16,8 @@ Then("I should see the scheduled event on the timeline") do
   expect(page).to have_selector(".timeline__title", text: "Email address scheduled")
   expect(page).to have_selector(".timeline__byline", text: "by #{@user.name}")
 end
+
+And("I should see the edition diff in a table") do
+  expect(page).to have_selector(".govuk-table__cell", text: "Changed title")
+  expect(page).to have_selector(".govuk-table__cell", text: @content_block.document.title)
+end

--- a/lib/engines/content_block_manager/test/unit/app/models/content_block_field_diff_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/models/content_block_field_diff_test.rb
@@ -1,0 +1,165 @@
+require "test_helper"
+
+class ContentBlockManager::ContentBlockFieldDiffTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
+  let(:user) { create("user") }
+  let(:organisation) { build(:organisation) }
+  let(:document) { build(:content_block_document, :email_address) }
+
+  describe "#all_for_edition" do
+    describe "when there are no changes" do
+      it "returns nil" do
+        Current.user = user
+        create(
+          :content_block_edition,
+          creator: user,
+          document:,
+          title: "same title",
+          instructions_to_publishers: "same instructions",
+          details: { "email_address": "old@example.com" },
+          organisation:,
+        )
+        new_edition = create(
+          :content_block_edition,
+          creator: user,
+          document:,
+          title: "same title",
+          instructions_to_publishers: "same instructions",
+          details: { "email_address": "old@example.com" },
+          organisation:,
+        )
+
+        new_edition.publish!
+
+        assert_equal ContentBlockManager::ContentBlock::FieldDiff.all_for_edition(edition: new_edition), nil
+      end
+    end
+    describe "when all changeable fields have changed" do
+      it "provides changes in correct order" do
+        new_organisation = build(:organisation)
+        Current.user = user
+        _previous_edition = create(
+          :content_block_edition,
+          creator: user,
+          document:,
+          title: "same title",
+          instructions_to_publishers: "same instructions",
+          details: { "email_address": "old@example.com" },
+          organisation:,
+        )
+        new_edition = create(
+          :content_block_edition,
+          creator: user,
+          document:,
+          title: "new title",
+          instructions_to_publishers: "new instructions",
+          details: { "email_address": "new@example.com" },
+          state: "draft",
+          organisation: new_organisation,
+        )
+
+        new_edition.publish!
+
+        expected_diffs = [
+          { "field_name" => "title", "new_value" => "new title", "previous_value" => "same title" },
+          { "field_name" => "email_address", "new_value" => "new@example.com", "previous_value" => "old@example.com" },
+          { "field_name" => "lead_organisation", "new_value" => new_organisation.name, "previous_value" => organisation.name },
+          { "field_name" => "instructions_to_publishers", "new_value" => "new instructions", "previous_value" => "same instructions" },
+        ]
+
+        assert_equal ContentBlockManager::ContentBlock::FieldDiff.all_for_edition(edition: new_edition).to_json, expected_diffs.to_json
+      end
+    end
+
+    describe "when a top level field on an edition has changed" do
+      %w[title instructions_to_publishers].each do |field|
+        it "records the changes" do
+          old_value = "old_value"
+          new_value = "new_value"
+          Current.user = user
+
+          previous_edition = create(
+            :content_block_edition,
+            creator: user,
+            document:,
+            organisation:,
+          )
+          previous_edition.update!(field => old_value)
+          new_edition = create(
+            :content_block_edition,
+            creator: user,
+            document:,
+            state: "draft",
+            organisation:,
+          )
+          new_edition.update!(field => new_value)
+
+          new_edition.publish!
+
+          expected_diffs = [{ "field_name" => field, "new_value" => new_value, "previous_value" => old_value }]
+
+          assert_equal ContentBlockManager::ContentBlock::FieldDiff.all_for_edition(edition: new_edition).to_json, expected_diffs.to_json
+        end
+      end
+
+      describe "when the organisation has changed" do
+        it "records the changes" do
+          old_organisation = build(:organisation, id: "123", name: "Old Organisation")
+
+          Current.user = user
+          _previous_edition = create(
+            :content_block_edition,
+            creator: user,
+            document:,
+            organisation: old_organisation,
+          )
+          new_edition = create(
+            :content_block_edition,
+            creator: user,
+            document:,
+            state: "draft",
+            organisation: build(:organisation, name: "New Organisation", id: "456"),
+          )
+
+          new_edition.publish!
+
+          expected_diffs = [{ "field_name" => "lead_organisation", "new_value" => "New Organisation", "previous_value" => "Old Organisation" }]
+
+          assert_equal ContentBlockManager::ContentBlock::FieldDiff.all_for_edition(edition: new_edition).to_json, expected_diffs.to_json
+        end
+      end
+    end
+
+    describe "when a field in the edition details has changed" do
+      it "records the changes" do
+        Current.user = user
+        _previous_edition = create(
+          :content_block_edition,
+          creator: user,
+          document:,
+          title: "same title",
+          instructions_to_publishers: "same instructions",
+          details: { "email_address": "old@example.com" },
+          organisation:,
+        )
+        new_edition = create(
+          :content_block_edition,
+          creator: user,
+          document:,
+          title: "same title",
+          instructions_to_publishers: "same instructions",
+          details: { "email_address": "new@example.com" },
+          state: "draft",
+          organisation:,
+        )
+
+        new_edition.publish!
+
+        expected_diffs = [{ "field_name" => "email_address", "new_value" => "new@example.com", "previous_value" => "old@example.com" }]
+
+        assert_equal ContentBlockManager::ContentBlock::FieldDiff.all_for_edition(edition: new_edition).to_json, expected_diffs.to_json
+      end
+    end
+  end
+end

--- a/lib/engines/content_block_manager/test/unit/app/models/content_block_version_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/models/content_block_version_test.rb
@@ -1,0 +1,60 @@
+require "test_helper"
+
+class ContentBlockManager::ContentBlockVersionTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
+  let(:event) { "created" }
+  let(:item) do
+    create(
+      :content_block_edition,
+      document: create(:content_block_document, :email_address),
+    )
+  end
+  let(:whodunnit) { SecureRandom.uuid }
+  let(:field_diffs) do
+    [
+      ContentBlockManager::ContentBlock::FieldDiff.new(
+        field_name: "some_field",
+        new_value: "new value",
+        previous_value: "previous value",
+      ),
+    ].to_json
+  end
+
+  let(:content_block_version) do
+    ContentBlockManager::ContentBlock::Version.new(
+      event:,
+      item:,
+      whodunnit:,
+    )
+  end
+
+  it "exists with required data" do
+    content_block_version.save!
+
+    assert_equal event, content_block_version.event
+    assert_equal item, content_block_version.item
+    assert_equal whodunnit, content_block_version.whodunnit
+  end
+
+  it "exists with optional state" do
+    content_block_version.update!(state: "scheduled")
+
+    assert_equal "scheduled", content_block_version.state
+  end
+
+  it "exists with optional field_diffs" do
+    content_block_version.update!(field_diffs:)
+
+    assert_equal field_diffs, content_block_version.field_diffs
+  end
+
+  it "validates the presence of a correct event" do
+    assert_raises(ArgumentError) do
+      _content_block_version = create(
+        :content_block_version,
+        event: "invalid",
+      )
+    end
+  end
+end


### PR DESCRIPTION
- **add edition's field diff to content block versions**

we want to show the changes that have been made to
a block when updating - this takes a snapshot of
the difference between the user generated fields
and saves them as a json blob, with the key being
the field name.

I'm hesitant to use json as it isn't typed, but I
explored [1] codifying the data structure
previously and it proved too complicated and
inefficient, especially as the fields need to be
displayed to the user in a certain order of
priority, and we don't know exactly what the
fields we're saving will be. By using the Data
class to show the shape of the items, this is
hopefully a halfway house. Shoving everything in a
json blob seems like a middle ground between just
calculating everything at run time and having a
genuine record of the change.

[1] https://github.com/alphagov/whitehall/pull/9838

- **Add content block changes table to timeline**

As design
![Screenshot 2025-01-24 at 16 56 02](https://github.com/user-attachments/assets/e83c67b0-12dd-4175-87f3-c7b4da596036)


---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
