### PR TITLE
Use textarea instead of input for contact street address field

### DIFF
--- a/app/views/admin/contacts/_form_fields.html.erb
+++ b/app/views/admin/contacts/_form_fields.html.erb
@@ -19,13 +19,13 @@
     </div>
 
     <div class="govuk-!-margin-bottom-4">
-      <%= render "govuk_publishing_components/components/input", {
+      <%= render "govuk_publishing_components/components/textarea", {
         label: {
           text: "Street address",
+          heading_size: "m",
         },
         name: "#{name}[street_address]",
-        id: "#{id}_street_address",
-        heading_size: "m",
+        textarea_id: "#{id}_street_address",
         value: contact_form.object.street_address,
         error_items: errors_for(contact_form.object.errors, :street_address),
       } %>


### PR DESCRIPTION
Some street addresses have multiple lines, so a textarea is needed here. 

## Before

Note incorrect use of Town/City line because street address doesn't use a text area!

![Screenshot 2025-01-24 at 15 57 32](https://github.com/user-attachments/assets/7d888915-6401-4cf3-a803-a2925b6b1b5c)

## After

![Screenshot 2025-01-24 at 15 56 39](https://github.com/user-attachments/assets/a61ed6c2-6b12-47fd-bf6b-241e34434e55)

Trello: https://trello.com/c/rrK5egiB