### PR TITLE
(828) Show changenotes in review and show screens

### DIFF
--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/summary_list_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/summary_list_component.rb
@@ -15,6 +15,7 @@ private
       organisation_item,
       instructions_item,
       status_item,
+      internal_change_note_item,
       embed_code_item,
     ].compact
   end
@@ -84,6 +85,13 @@ private
         value: last_updated_value,
       }
     end
+  end
+
+  def internal_change_note_item
+    {
+      field: "Internal change note",
+      value: content_block_document.latest_edition.internal_change_note.presence || "None",
+    }
   end
 
   def last_updated_value

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/summary_list_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/summary_list_component.rb
@@ -16,6 +16,7 @@ private
       instructions_item,
       status_item,
       internal_change_note_item,
+      *change_note_items,
       embed_code_item,
     ].compact
   end
@@ -48,19 +49,19 @@ private
   def organisation_item
     {
       field: "Lead organisation",
-      value: content_block_document.latest_edition.lead_organisation,
+      value: content_block_edition.lead_organisation,
     }
   end
 
   def instructions_item
     {
       field: "Instructions to publishers",
-      value: content_block_document.latest_edition.instructions_to_publishers.presence || "None",
+      value: content_block_edition.instructions_to_publishers.presence || "None",
     }
   end
 
   def details_items
-    content_block_document.latest_edition.details.map do |key, value|
+    content_block_edition.details.map do |key, value|
       {
         field: key.humanize,
         value:,
@@ -69,7 +70,7 @@ private
   end
 
   def status_item
-    if content_block_document.latest_edition.state == "scheduled"
+    if content_block_edition.state == "scheduled"
       {
         field: "Status",
         value: scheduled_value,
@@ -90,16 +91,34 @@ private
   def internal_change_note_item
     {
       field: "Internal change note",
-      value: content_block_document.latest_edition.internal_change_note.presence || "None",
+      value: content_block_edition.internal_change_note.presence || "None",
+    }
+  end
+
+  def change_note_items
+    content_block_edition.major_change ? [major_change_item, external_change_note_item] : [major_change_item]
+  end
+
+  def major_change_item
+    {
+      field: "Do users have to know the content has changed?",
+      value: content_block_edition.major_change ? "Yes" : "No",
+    }
+  end
+
+  def external_change_note_item
+    {
+      field: "Public change note",
+      value: content_block_edition.change_note,
     }
   end
 
   def last_updated_value
-    "Published #{time_ago_in_words(content_block_document.latest_edition.updated_at)} ago by #{content_block_document.latest_edition.creator.name}"
+    "Published #{time_ago_in_words(content_block_edition.updated_at)} ago by #{content_block_edition.creator.name}"
   end
 
   def scheduled_value
-    "Scheduled for publication at #{I18n.l(content_block_document.latest_edition.scheduled_publication, format: :long_ordinal)}"
+    "Scheduled for publication at #{I18n.l(content_block_edition.scheduled_publication, format: :long_ordinal)}"
   end
 
   def edit_action
@@ -107,5 +126,9 @@ private
       href: helpers.content_block_manager.new_content_block_manager_content_block_document_edition_path(content_block_document),
       link_text: "Edit",
     }
+  end
+
+  def content_block_edition
+    @content_block_edition = content_block_document.latest_edition
   end
 end

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/show/confirm_summary_list_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/show/confirm_summary_list_component.rb
@@ -15,6 +15,7 @@ private
       organisation_item,
       instructions_item,
       internal_change_note_item,
+      *change_note_items,
       status_item,
     ].compact
   end
@@ -62,6 +63,32 @@ private
       value: content_block_edition.internal_change_note.presence || "None",
       edit: {
         href: helpers.content_block_manager.content_block_manager_content_block_workflow_path(id: content_block_edition.id, step: :internal_note),
+        link_text: "Edit",
+      },
+    }
+  end
+
+  def change_note_items
+    content_block_edition.major_change ? [major_change_item, external_change_note_item] : [major_change_item]
+  end
+
+  def major_change_item
+    {
+      field: "Do users have to know the content has changed?",
+      value: content_block_edition.major_change ? "Yes" : "No",
+      edit: {
+        href: helpers.content_block_manager.content_block_manager_content_block_workflow_path(id: content_block_edition.id, step: :change_note),
+        link_text: "Edit",
+      },
+    }
+  end
+
+  def external_change_note_item
+    {
+      field: "Public change note",
+      value: content_block_edition.change_note,
+      edit: {
+        href: helpers.content_block_manager.content_block_manager_content_block_workflow_path(id: content_block_edition.id, step: :change_note),
         link_text: "Edit",
       },
     }

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/show/confirm_summary_list_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/show/confirm_summary_list_component.rb
@@ -14,6 +14,7 @@ private
       *details_items,
       organisation_item,
       instructions_item,
+      internal_change_note_item,
       status_item,
     ].compact
   end
@@ -52,6 +53,17 @@ private
     {
       field: "Instructions to publishers",
       value: content_block_edition.instructions_to_publishers.presence || "None",
+    }
+  end
+
+  def internal_change_note_item
+    {
+      field: "Internal change note",
+      value: content_block_edition.internal_change_note.presence || "None",
+      edit: {
+        href: helpers.content_block_manager.content_block_manager_content_block_workflow_path(id: content_block_edition.id, step: :internal_note),
+        link_text: "Edit",
+      },
     }
   end
 

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/change_note.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/change_note.html.erb
@@ -18,6 +18,7 @@
 
       <%= render "govuk_publishing_components/components/radio", {
         name: "content_block/edition[major_change]",
+        hint: "Some content types show public change notes. GOV.UK users can subscribe to email alerts and RSS feeds and receive public change notes. Telling users when published information has changed is important for transparency.",
         id: "content_block_manager_content_block_edition_major_change",
         error_items: errors_for(@content_block_edition.errors, :major_change),
         items: [
@@ -25,7 +26,7 @@
             value: "1",
             checked: @content_block_edition.major_change === true,
             text: "Yes - information has been added, updated or removed",
-            hint_text: "A change note will be published on the page and emailed to users subscribed to email alerts. The 'last updated' date will change.",
+            hint_text: "A change note will be published on every relevant page containing the content block you've changed. Change notes will also be emailed to users subscribed to email alerts for every page affected by this change. The 'last updated' date will change on pages that display it.",
             bold: true,
             conditional: render("govuk_publishing_components/components/textarea", {
               label: {
@@ -35,8 +36,7 @@
               id: "content_block_manager_content_block_edition_change_note",
               error_items: errors_for(@content_block_edition.errors, :change_note),
               value: @content_block_edition.change_note,
-              hint: (tag.p('Tell users what has changed, where and why. Write in full sentences, leading with the most important words. For example, "College A has been removed from the registered sponsors list because its licence has been suspended."', class: "govuk-!-margin-bottom-0 govuk-!-margin-top-0") +
-                link_to("Guidance about change notes (opens in a new tab)", "https://www.gov.uk/guidance/content-design/writing-for-gov-uk#change-notes", target: "_blank", class: "govuk-link", rel: "noopener")).html_safe,
+              hint: "Tell users what has been edited, where and why. Write in full sentences, leading with the most important words. For example, \"The full basic State Pension rate has changed from £85 per week to £93.60 per week.\"",
             }),
           },
           {

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/internal_note.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/internal_note.html.erb
@@ -1,5 +1,5 @@
 <% content_for :context, context %>
-<% content_for :title, "Add internal change note" %>
+<% content_for :title, "Create internal change note" %>
 <% content_for :title_margin_bottom, 4 %>
 <% content_for :back_link do %>
   <%= render "govuk_publishing_components/components/back_link", {
@@ -15,7 +15,7 @@
       ), method: :put do %>
       <%= render "govuk_publishing_components/components/textarea", {
         label: {
-          text: "Describe the change for internal users",
+          text: "Explain what changes you did or did not make and why. This adds a record in the change history.",
         },
         name: "content_block/edition[internal_change_note]",
         id: "content_block_manager_content_block_edition_title",

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/shared/_form.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/shared/_form.html.erb
@@ -48,6 +48,7 @@
       text: "Instructions to publishers (optional)",
     },
     name: "content_block/edition[instructions_to_publishers]",
+    hint: "Add a lasting note for anyone editing this content block, for example 'Tell HMRC's content team when this block changes.'",
     textarea_id: "#{parent_class}_instructions_to_publishers",
     value: @form.content_block_edition&.instructions_to_publishers,
     error_items: errors_for(@form.content_block_edition.errors, "instructions_to_publishers".to_sym),

--- a/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
@@ -275,7 +275,7 @@ Then("I should see the details for the email address content block") do
 end
 
 When("I click the first edit link") do
-  click_link "Edit"
+  click_link "Edit", match: :first
 end
 
 When("I fill out the form") do

--- a/lib/engines/content_block_manager/features/support/helpers.rb
+++ b/lib/engines/content_block_manager/features/support/helpers.rb
@@ -72,7 +72,7 @@ end
 
 def add_internal_note
   @internal_note = "Some internal note goes here"
-  fill_in "Describe the change for internal users", with: @internal_note
+  fill_in "Explain what changes you did or did not make and why. This adds a record in the change history.", with: @internal_note
   click_save_and_continue
 end
 

--- a/lib/engines/content_block_manager/test/components/content_block/document/show/summary_list_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/document/show/summary_list_component_test.rb
@@ -15,6 +15,7 @@ class ContentBlockManager::ContentBlock::Document::Show::SummaryListComponentTes
       scheduled_publication: Time.zone.now,
       state: "published",
       updated_at: 1.day.ago,
+      internal_change_note: "Some internal change note",
     )
   end
   let(:content_block_document) { content_block_edition.document }
@@ -22,7 +23,7 @@ class ContentBlockManager::ContentBlock::Document::Show::SummaryListComponentTes
   it "renders a published content block correctly" do
     render_inline(ContentBlockManager::ContentBlock::Document::Show::SummaryListComponent.new(content_block_document:))
 
-    assert_selector ".govuk-summary-list__row", count: 8
+    assert_selector ".govuk-summary-list__row", count: 9
     assert_selector ".govuk-summary-list__actions", count: 1
 
     assert_selector ".govuk-summary-list__key", text: "Email address details"
@@ -43,6 +44,9 @@ class ContentBlockManager::ContentBlock::Document::Show::SummaryListComponentTes
     assert_selector ".govuk-summary-list__key", text: "Status"
     assert_selector ".govuk-summary-list__value", text: "Published 1 day ago by #{content_block_edition.creator.name}"
 
+    assert_selector ".govuk-summary-list__key", text: "Internal change note"
+    assert_selector ".govuk-summary-list__value", text: "Some internal change note"
+
     assert_selector ".govuk-summary-list__key", text: "Instructions to publishers"
     assert_selector ".govuk-summary-list__value", text: "None"
 
@@ -57,7 +61,7 @@ class ContentBlockManager::ContentBlock::Document::Show::SummaryListComponentTes
 
     render_inline(ContentBlockManager::ContentBlock::Document::Show::SummaryListComponent.new(content_block_document:))
 
-    assert_selector ".govuk-summary-list__row", count: 8
+    assert_selector ".govuk-summary-list__row", count: 9
 
     assert_selector ".govuk-summary-list__key", text: "Status"
     assert_selector ".govuk-summary-list__value", text: "Scheduled for publication at #{I18n.l(content_block_edition.scheduled_publication, format: :long_ordinal)}"

--- a/lib/engines/content_block_manager/test/components/content_block/document/show/summary_list_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/document/show/summary_list_component_test.rb
@@ -16,6 +16,7 @@ class ContentBlockManager::ContentBlock::Document::Show::SummaryListComponentTes
       state: "published",
       updated_at: 1.day.ago,
       internal_change_note: "Some internal change note",
+      major_change: false,
     )
   end
   let(:content_block_document) { content_block_edition.document }
@@ -23,7 +24,7 @@ class ContentBlockManager::ContentBlock::Document::Show::SummaryListComponentTes
   it "renders a published content block correctly" do
     render_inline(ContentBlockManager::ContentBlock::Document::Show::SummaryListComponent.new(content_block_document:))
 
-    assert_selector ".govuk-summary-list__row", count: 9
+    assert_selector ".govuk-summary-list__row", count: 10
     assert_selector ".govuk-summary-list__actions", count: 1
 
     assert_selector ".govuk-summary-list__key", text: "Email address details"
@@ -50,6 +51,9 @@ class ContentBlockManager::ContentBlock::Document::Show::SummaryListComponentTes
     assert_selector ".govuk-summary-list__key", text: "Instructions to publishers"
     assert_selector ".govuk-summary-list__value", text: "None"
 
+    assert_selector ".govuk-summary-list__key", text: "Do users have to know the content has changed?"
+    assert_selector ".govuk-summary-list__value", text: "No"
+
     assert_selector ".govuk-summary-list__row[data-module='copy-embed-code']", text: "Embed code"
     assert_selector ".govuk-summary-list__row[data-embed-code='#{content_block_document.embed_code}']", text: "Embed code"
     assert_selector ".govuk-summary-list__key", text: "Embed code"
@@ -61,7 +65,7 @@ class ContentBlockManager::ContentBlock::Document::Show::SummaryListComponentTes
 
     render_inline(ContentBlockManager::ContentBlock::Document::Show::SummaryListComponent.new(content_block_document:))
 
-    assert_selector ".govuk-summary-list__row", count: 9
+    assert_selector ".govuk-summary-list__row", count: 10
 
     assert_selector ".govuk-summary-list__key", text: "Status"
     assert_selector ".govuk-summary-list__value", text: "Scheduled for publication at #{I18n.l(content_block_edition.scheduled_publication, format: :long_ordinal)}"
@@ -77,6 +81,23 @@ class ContentBlockManager::ContentBlock::Document::Show::SummaryListComponentTes
 
       assert_selector ".govuk-summary-list__key", text: "Instructions to publishers"
       assert_selector ".govuk-summary-list__value", text: "instructions"
+    end
+  end
+
+  describe "when there is a major change" do
+    it "renders the change note" do
+      content_block_document.latest_edition.major_change = true
+      content_block_document.latest_edition.change_note = "change note"
+
+      render_inline(ContentBlockManager::ContentBlock::Document::Show::SummaryListComponent.new(content_block_document:))
+
+      assert_selector ".govuk-summary-list__row", count: 11
+
+      assert_selector ".govuk-summary-list__key", text: "Do users have to know the content has changed?"
+      assert_selector ".govuk-summary-list__value", text: "Yes"
+
+      assert_selector ".govuk-summary-list__key", text: "Public change note"
+      assert_selector ".govuk-summary-list__value", text: "change note"
     end
   end
 end

--- a/lib/engines/content_block_manager/test/components/content_block/edition/show/confirm_summary_list_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/show/confirm_summary_list_component_test.rb
@@ -59,6 +59,56 @@ class ContentBlockManager::ContentBlockEdition::Show::ConfirmSummaryListComponen
     assert_selector ".govuk-summary-list__row:nth-child(6) .govuk-summary-list__actions a[href='#{content_block_manager_content_block_workflow_path(id: content_block_edition.id, step: :internal_note)}']"
   end
 
+  describe "when the change is major" do
+    it "shows the public change note" do
+      content_block_edition = create(
+        :content_block_edition,
+        :email_address,
+        instructions_to_publishers: "some instructions",
+        major_change: true,
+        change_note: "Some change note",
+      )
+
+      render_inline(ContentBlockManager::ContentBlockEdition::Show::ConfirmSummaryListComponent.new(
+                      content_block_edition:,
+                    ))
+
+      assert_selector ".govuk-summary-list__row:nth-child(6) .govuk-summary-list__key", text: "Do users have to know the content has changed?"
+      assert_selector ".govuk-summary-list__row:nth-child(6) .govuk-summary-list__value", text: "Yes"
+      assert_selector ".govuk-summary-list__row:nth-child(6) .govuk-summary-list__actions", text: "Edit"
+      assert_selector ".govuk-summary-list__row:nth-child(6) .govuk-summary-list__actions a[href='#{content_block_manager_content_block_workflow_path(id: content_block_edition.id, step: :change_note)}']"
+
+      assert_selector ".govuk-summary-list__row:nth-child(7) .govuk-summary-list__key", text: "Public change note"
+      assert_selector ".govuk-summary-list__row:nth-child(7) .govuk-summary-list__value", text: "Some change note"
+      assert_selector ".govuk-summary-list__row:nth-child(7) .govuk-summary-list__actions", text: "Edit"
+      assert_selector ".govuk-summary-list__row:nth-child(7) .govuk-summary-list__actions a[href='#{content_block_manager_content_block_workflow_path(id: content_block_edition.id, step: :change_note)}']"
+    end
+  end
+
+  describe "when the change is not major" do
+    it "shows the public change note" do
+      content_block_edition = create(
+        :content_block_edition,
+        :email_address,
+        instructions_to_publishers: "some instructions",
+        major_change: false,
+        change_note: "Some change note",
+      )
+
+      render_inline(ContentBlockManager::ContentBlockEdition::Show::ConfirmSummaryListComponent.new(
+                      content_block_edition:,
+                    ))
+
+      assert_selector ".govuk-summary-list__row:nth-child(6) .govuk-summary-list__key", text: "Do users have to know the content has changed?"
+      assert_selector ".govuk-summary-list__row:nth-child(6) .govuk-summary-list__value", text: "No"
+      assert_selector ".govuk-summary-list__row:nth-child(6) .govuk-summary-list__actions", text: "Edit"
+      assert_selector ".govuk-summary-list__row:nth-child(6) .govuk-summary-list__actions a[href='#{content_block_manager_content_block_workflow_path(id: content_block_edition.id, step: :change_note)}']"
+
+      refute_selector ".govuk-summary-list__key", text: "Public change note"
+      refute_selector ".govuk-summary-list__value", text: "Some change note"
+    end
+  end
+
   describe "when the content block is scheduled" do
     it "shows the scheduled date time" do
       organisation = create(:organisation, name: "Department for Example")

--- a/lib/engines/content_block_manager/test/components/content_block/edition/show/confirm_summary_list_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/show/confirm_summary_list_component_test.rb
@@ -2,6 +2,8 @@ require "test_helper"
 
 class ContentBlockManager::ContentBlockEdition::Show::ConfirmSummaryListComponentTest < ViewComponent::TestCase
   extend Minitest::Spec::DSL
+  include ContentBlockManager::Engine.routes.url_helpers
+
   it "it renders instructions to publishers" do
     content_block_edition = create(
       :content_block_edition,
@@ -29,22 +31,32 @@ class ContentBlockManager::ContentBlockEdition::Show::ConfirmSummaryListComponen
       details: { "interesting_fact" => "value of fact" },
       organisation:,
       document: content_block_document,
+      internal_change_note: "Some internal info",
     )
 
     render_inline(ContentBlockManager::ContentBlockEdition::Show::ConfirmSummaryListComponent.new(
                     content_block_edition:,
                   ))
 
-    assert_selector ".govuk-summary-list__key", text: "Email address details"
-    assert_selector ".govuk-summary-list__actions", text: "Edit"
-    assert_selector ".govuk-summary-list__key", text: "Title"
-    assert_selector ".govuk-summary-list__value", text: "Some edition title"
-    assert_selector ".govuk-summary-list__key", text: "New interesting fact"
-    assert_selector ".govuk-summary-list__value", text: "value of fact"
-    assert_selector ".govuk-summary-list__key", text: "Lead organisation"
-    assert_selector ".govuk-summary-list__value", text: "Department for Example"
-    assert_selector ".govuk-summary-list__key", text: "Instructions to publishers"
-    assert_selector ".govuk-summary-list__value", text: "None"
+    assert_selector ".govuk-summary-list__row:nth-child(1) .govuk-summary-list__key", text: "Email address details"
+    assert_selector ".govuk-summary-list__row:nth-child(1) .govuk-summary-list__actions", text: "Edit"
+
+    assert_selector ".govuk-summary-list__row:nth-child(2) .govuk-summary-list__key", text: "Title"
+    assert_selector ".govuk-summary-list__row:nth-child(2) .govuk-summary-list__value", text: "Some edition title"
+
+    assert_selector ".govuk-summary-list__row:nth-child(3) .govuk-summary-list__key", text: "New interesting fact"
+    assert_selector ".govuk-summary-list__row:nth-child(3) .govuk-summary-list__value", text: "value of fact"
+
+    assert_selector ".govuk-summary-list__row:nth-child(4) .govuk-summary-list__key", text: "Lead organisation"
+    assert_selector ".govuk-summary-list__row:nth-child(4) .govuk-summary-list__value", text: "Department for Example"
+
+    assert_selector ".govuk-summary-list__row:nth-child(5) .govuk-summary-list__key", text: "Instructions to publishers"
+    assert_selector ".govuk-summary-list__row:nth-child(5) .govuk-summary-list__value", text: "None"
+
+    assert_selector ".govuk-summary-list__row:nth-child(6) .govuk-summary-list__key", text: "Internal change note"
+    assert_selector ".govuk-summary-list__row:nth-child(6) .govuk-summary-list__value", text: "Some internal info"
+    assert_selector ".govuk-summary-list__row:nth-child(6) .govuk-summary-list__actions", text: "Edit"
+    assert_selector ".govuk-summary-list__row:nth-child(6) .govuk-summary-list__actions a[href='#{content_block_manager_content_block_workflow_path(id: content_block_edition.id, step: :internal_note)}']"
   end
 
   describe "when the content block is scheduled" do


### PR DESCRIPTION
Trello card: https://trello.com/c/eqAcYy1U/828-add-internal-and-external-change-notes-when-editing-blocks

This adds Change note related content to the review and show screens for a content block:

## Screenshots

![image](https://github.com/user-attachments/assets/66de7fbc-d78e-4b49-a527-fbf3ff51f738)

![image](https://github.com/user-attachments/assets/40244338-8ba2-4882-ab0d-9546ea350b67)
