### PR TITLE
content modelling/832 notes on timeline

### DIFF
--- a/lib/engines/content_block_manager/app/assets/stylesheets/content_block_manager/components/_timeline-component.scss
+++ b/lib/engines/content_block_manager/app/assets/stylesheets/content_block_manager/components/_timeline-component.scss
@@ -51,8 +51,6 @@
 
 .timeline__date {
   @include govuk-font($size: 16);
-  margin-top: govuk-spacing(1);
-  margin-bottom: 0;
 }
 
 .timeline__description {
@@ -78,5 +76,11 @@
     margin-top: govuk-spacing(1);
     border: none;
     padding-left: 0;
+  }
+}
+
+.timeline__note {
+  .govuk-body {
+    margin-bottom: govuk-spacing(2);
   }
 }

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/document_timeline_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/document_timeline_component.html.erb
@@ -45,6 +45,22 @@
           <% end %>
         </div>
       <% end %>
+
+      <div>
+      <% if item[:internal_change_note].present? %>
+          <div class="timeline__note">
+            <h2 class="timeline__title">Internal note</h2>
+            <p class="govuk-body"><%= item[:internal_change_note] %></p>
+          </div>
+      <% end %>
+
+      <% if item[:change_note].present? %>
+          <div class="timeline__note">
+            <h2 class="timeline__title">Public note</h2>
+            <p class="govuk-body"><%= item[:change_note] %></p>
+          </div>
+      <% end %>
+      </div>
     </div>
   <% end %>
 </div>

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/document_timeline_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/document_timeline_component.rb
@@ -15,6 +15,8 @@ private
         byline: User.find_by_id(version.whodunnit)&.then { |user| helpers.linked_author(user, { class: "govuk-link" }) } || "unknown user",
         date: time_html(version.created_at),
         table_rows: table_rows(version),
+        internal_change_note: internal_change_note(version),
+        change_note: change_note(version),
       }
     end
   end
@@ -46,5 +48,13 @@ private
         ]
       end
     end
+  end
+
+  def internal_change_note(version)
+    version.item.internal_change_note
+  end
+
+  def change_note(version)
+    version.item.change_note
   end
 end

--- a/lib/engines/content_block_manager/features/edit_object.feature
+++ b/lib/engines/content_block_manager/features/edit_object.feature
@@ -35,6 +35,7 @@ Feature: Edit a content object
     Then the edition should have been updated successfully
     And I should be taken back to the document page
     And I should see 2 publish events on the timeline
+    And I should see the notes on the timeline
     And I should see the edition diff in a table
 
   Scenario: GDS editor cancels the creation of an object when reviewing links

--- a/lib/engines/content_block_manager/features/step_definitions/timeline_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/timeline_steps.rb
@@ -7,6 +7,11 @@ Then(/^I should see ([^"]*) publish events on the timeline$/) do |count|
   expect(page).to have_selector(".timeline__title", text: "Email address published", count:)
 end
 
+Then("I should see the notes on the timeline") do
+  expect(page).to have_selector("p", text: @internal_note)
+  expect(page).to have_selector("p", text: @change_note)
+end
+
 Then("I should see the publish event on the timeline") do
   expect(page).to have_selector(".timeline__title", text: "Email address published")
   expect(page).to have_selector(".timeline__byline", text: "by Scheduled Publishing Robot")

--- a/lib/engines/content_block_manager/features/support/helpers.rb
+++ b/lib/engines/content_block_manager/features/support/helpers.rb
@@ -71,13 +71,15 @@ def update_content_block
 end
 
 def add_internal_note
-  fill_in "Describe the change for internal users", with: "Some internal note goes here"
+  @internal_note = "Some internal note goes here"
+  fill_in "Describe the change for internal users", with: @internal_note
   click_save_and_continue
 end
 
 def add_change_note
+  @change_note = "Some text"
   choose "Yes - information has been added, updated or removed"
-  fill_in "Describe the edit for users", with: "Some text"
+  fill_in "Describe the edit for users", with: @change_note
   click_save_and_continue
 end
 

--- a/lib/engines/content_block_manager/test/components/content_block/document/show/document_timeline_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/document/show/document_timeline_component_test.rb
@@ -4,42 +4,44 @@ class ContentBlockManager::ContentBlock::Document::Show::DocumentTimelineCompone
   include Rails.application.routes.url_helpers
   include ActionView::Helpers::UrlHelper
   include ApplicationHelper
+  extend Minitest::Spec::DSL
+  
+  let(:user) { create(:user) }
 
   test "renders a timeline component with events in correct order" do
-    @user = create(:user)
-    @version_1 = create(
+    version_1 = create(
       :content_block_version,
       event: "created",
-      whodunnit: @user.id,
+      whodunnit: user.id,
     )
-    @version_2 = create(
+    version_2 = create(
       :content_block_version,
       event: "updated",
-      whodunnit: @user.id,
+      whodunnit: user.id,
       state: "published",
     )
-    @version_3 = create(
+    version_3 = create(
       :content_block_version,
       event: "updated",
-      whodunnit: @user.id,
+      whodunnit: user.id,
       state: "scheduled",
     )
 
     render_inline(ContentBlockManager::ContentBlock::Document::Show::DocumentTimelineComponent.new(
-                    content_block_versions: [@version_3, @version_2, @version_1],
+                    content_block_versions: [version_3, version_2, version_1],
                   ))
 
     assert_selector ".timeline__item", count: 2
 
     assert_equal "Email address scheduled", page.all(".timeline__title")[0].text
-    assert_equal "by #{linked_author(@user, { class: 'govuk-link' })}", page.all(".timeline__byline")[0].native.inner_html
-    assert_equal  I18n.l(@version_3.created_at, format: :long_ordinal),
-                  page.all("time[datetime='#{@version_3.created_at.iso8601}']")[1].text
+    assert_equal "by #{linked_author(user, { class: 'govuk-link' })}", page.all(".timeline__byline")[0].native.inner_html
+    assert_equal  I18n.l(version_3.created_at, format: :long_ordinal),
+                  page.all("time[datetime='#{version_3.created_at.iso8601}']")[1].text
 
     assert_equal "Email address published", page.all(".timeline__title")[1].text
-    assert_equal "by #{linked_author(@user, { class: 'govuk-link' })}", page.all(".timeline__byline")[1].native.inner_html
-    assert_equal  I18n.l(@version_2.created_at, format: :long_ordinal),
-                  page.all("time[datetime='#{@version_2.created_at.iso8601}']")[1].text
+    assert_equal "by #{linked_author(user, { class: 'govuk-link' })}", page.all(".timeline__byline")[1].native.inner_html
+    assert_equal  I18n.l(version_2.created_at, format: :long_ordinal),
+                  page.all("time[datetime='#{version_2.created_at.iso8601}']")[1].text
 
     assert_no_selector ".govuk-table"
   end
@@ -62,17 +64,16 @@ class ContentBlockManager::ContentBlock::Document::Show::DocumentTimelineCompone
         "previous_value": "old instructions",
       },
     ]
-    @user = create(:user)
-    @version = create(
+    version = create(
       :content_block_version,
       event: "updated",
-      whodunnit: @user.id,
+      whodunnit: user.id,
       state: "scheduled",
       field_diffs: field_diffs,
     )
 
     render_inline(ContentBlockManager::ContentBlock::Document::Show::DocumentTimelineComponent.new(
-                    content_block_versions: [@version],
+                    content_block_versions: [version],
                   ))
 
     assert_equal "old title", page.all("td")[0].text


### PR DESCRIPTION
- **refactor doc timeline test**
- **add change notes to document timeline**

Using the previously-added notes to display on timeline. Will tidy up remaining style tweaks in next ticket.

![Screenshot 2025-01-28 at 15 28 14](https://github.com/user-attachments/assets/5401365c-bfe5-43af-856a-54a3a4db70ca)


---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
