### PR TITLE
Remove direct rackup dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,11 +43,6 @@ gem "pdf-reader"
 gem "plek"
 gem "ptools"
 gem "rack"
-# TODO: remove after next version of Puma is released
-# See https://github.com/puma/puma/pull/3532
-# `require: false` is needed because you can't actually `require "rackup"`
-# due to a different bug: https://github.com/rack/rackup/commit/d03e1789
-gem "rackup", "1.0.0", require: false
 gem "rails-i18n"
 gem "rails_translation_manager"
 gem "rake"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1094,7 +1094,6 @@ DEPENDENCIES
   ptools
   rack
   rack-test
-  rackup (= 1.0.0)
   rails (~> 7.2.2)
   rails-controller-testing
   rails-dom-testing


### PR DESCRIPTION
We no longer need to pin rackup to version 1 since updating to Puma 6.5

Trello: https://trello.com/c/gQ5F9ysj
