### PR TITLE
Stop repeating locale keys

### DIFF
--- a/lib/locale.rb
+++ b/lib/locale.rb
@@ -31,6 +31,10 @@ Locale = Struct.new(:code) do
     end
   end
 
+  def self.all_keys
+    load_language_configs.keys
+  end
+
   def self.non_english
     all.reject(&:english?)
   end

--- a/lib/whitehall.rb
+++ b/lib/whitehall.rb
@@ -1,3 +1,5 @@
+require_relative "./locale"
+
 module Whitehall
   autoload :Random, "whitehall/random"
   autoload :RandomKey, "whitehall/random_key"
@@ -27,74 +29,7 @@ module Whitehall
   end
 
   def self.available_locales
-    %i[
-      ar
-      az
-      be
-      bg
-      bn
-      cs
-      cy
-      da
-      de
-      dr
-      el
-      en
-      es
-      es-419
-      et
-      fa
-      fi
-      fr
-      gd
-      gu
-      he
-      hi
-      hr
-      hu
-      hy
-      id
-      is
-      it
-      ja
-      ka
-      kk
-      ko
-      lt
-      lv
-      ms
-      mt
-      ne
-      nl
-      no
-      pa
-      pa-pk
-      pl
-      ps
-      pt
-      ro
-      ru
-      si
-      sk
-      sl
-      so
-      sq
-      sr
-      sv
-      sw
-      ta
-      th
-      tk
-      tr
-      uk
-      ur
-      uz
-      vi
-      yi
-      zh
-      zh-hk
-      zh-tw
-    ]
+    Locale.all_keys.map(&:to_sym)
   end
 
   def self.system_binaries

--- a/test/unit/lib/locale_test.rb
+++ b/test/unit/lib/locale_test.rb
@@ -1,6 +1,16 @@
 require "test_helper"
 
 class LocaleTest < ActiveSupport::TestCase
+  test "provides a list of all available locale symbols" do
+    Locale.stubs(:load_language_configs).returns({
+      "ar" => { "direction" => "rtl" },
+      "en" => { "direction" => "ltr" },
+      "fr" => { "direction" => "ltr" },
+      "ur" => { "direction" => "rtl" },
+    })
+    assert_equal %w[ar en fr ur], Locale.all_keys
+  end
+
   test "provides a list of all available locales" do
     Locale.stubs(:load_language_configs).returns({
       "ar" => { "direction" => "rtl" },


### PR DESCRIPTION
We already have this information via the Locale model, so no need to repeat it in two places.

Trello: https://trello.com/c/T2neQSyf/3319-add-language-support-for-kyrgyz

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
