### PR TITLE
Add margin_bottom to heading_options

### DIFF
--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -60,8 +60,8 @@
                 text: yield(:title),
                 heading_level: 1,
                 font_size: "xl",
+                margin_bottom: 8,
               }
-              heading_options[:margin_bottom] = yield(:title_margin_bottom).to_i if yield(:title_margin_bottom).present?
             %>
             <%= render "govuk_publishing_components/components/heading", heading_options %>
           </div>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## What
This PR amends the `margin_bottom` option for the main heading to always include a bottom margin. Previously, this would be set to `nil` if `title_margin_bottom` wasn't present however this didn't remove the bottom margin - rather it fell back to the [title component's](https://components.publishing.service.gov.uk/component-guide/title) default bottom margin of 50px. Since the heading component doesn't include a default bottom margin, [switching to this component](https://github.com/alphagov/whitehall/pull/9835) resulted in removing the spacing beneath the main heading altogether. This PR reinstates it.

## Why
To reinstate the original spacing.

## Visual changes
Spacing below the main heading has been reinstated.