### PR TITLE
content modelling/833 timeline updates

### DIFF
--- a/config/initializers/formats.rb
+++ b/config/initializers/formats.rb
@@ -2,6 +2,7 @@ Date::DATE_FORMATS[:long_ordinal] = ->(date) { date.strftime("%e %B %Y").strip }
 Date::DATE_FORMATS[:short_ordinal] = "%B %Y"
 Date::DATE_FORMATS[:uk_short] = ->(date) { date.strftime("%d/%m/%Y").strip }
 Time::DATE_FORMATS[:long_ordinal] = ->(time) { time.strftime("%e %B %Y %H:%M").strip }
+Time::DATE_FORMATS[:long_ordinal_with_at] = ->(time) { [time.strftime("%e %B %Y").strip, time.strftime("%l:%M%P").strip].join(" at ") }
 Time::DATE_FORMATS[:date_with_time] = ->(time) { [time.strftime("%e %B %Y").strip, time.strftime("%l:%M%P").strip].join(" ") }
 Time::DATE_FORMATS[:one_month_precision] = "%B %Y"
 Time::DATE_FORMATS[:two_month_precision] = lambda do |time|

--- a/lib/engines/content_block_manager/app/assets/stylesheets/content_block_manager/components/_timeline-component.scss
+++ b/lib/engines/content_block_manager/app/assets/stylesheets/content_block_manager/components/_timeline-component.scss
@@ -21,6 +21,10 @@
   }
 }
 
+.timeline__header {
+  margin-bottom: govuk-spacing(1);
+}
+
 .timeline__item {
   padding-bottom: govuk-spacing(6);
   padding-left: govuk-spacing(4);
@@ -50,7 +54,10 @@
 }
 
 .timeline__date {
-  @include govuk-font($size: 16);
+  @include govuk-font($size: 19);
+  margin-top: govuk-spacing(1);
+  margin-bottom: govuk-spacing(1);
+  color: $govuk-secondary-text-colour;
 }
 
 .timeline__description {

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/document_timeline_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/document_timeline_component.rb
@@ -22,7 +22,14 @@ private
   end
 
   def title(version)
-    "#{version.item.block_type.humanize} #{version.state}"
+    case version.state
+    when "published"
+      version.state.capitalize
+    when "scheduled"
+      "Scheduled for publishing on #{version.item.scheduled_publication.to_fs(:long_ordinal_with_at)}"
+    else
+      "#{version.item.block_type.humanize} #{version.state}"
+    end
   end
 
   def first_created_edition

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/document_timeline_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/document_timeline_component.rb
@@ -31,7 +31,7 @@ private
 
   def time_html(date_time)
     tag.time(
-      I18n.l(date_time, format: :long_ordinal),
+      date_time.to_fs(:long_ordinal_with_at),
       class: "date",
       datetime: date_time.iso8601,
       lang: "en",

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/document_timeline_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/document_timeline_component.rb
@@ -9,7 +9,7 @@ private
   attr_reader :content_block_versions
 
   def items
-    content_block_versions.reject { |version| version.state.nil? }.map do |version|
+    content_block_versions.reject { |version| show_to_user?(version) }.map do |version|
       {
         title: title(version),
         byline: User.find_by_id(version.whodunnit)&.then { |user| helpers.linked_author(user, { class: "govuk-link" }) } || "unknown user",
@@ -19,6 +19,10 @@ private
         change_note: change_note(version),
       }
     end
+  end
+
+  def show_to_user?(version)
+    version.state.nil? || version.state == "superseded"
   end
 
   def title(version)

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/document_timeline_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/document_timeline_component.rb
@@ -28,7 +28,11 @@ private
   def title(version)
     case version.state
     when "published"
-      version.state.capitalize
+      if version == first_published_version
+        "#{version.item.block_type.humanize} created"
+      else
+        version.state.capitalize
+      end
     when "scheduled"
       "Scheduled for publishing on #{version.item.scheduled_publication.to_fs(:long_ordinal_with_at)}"
     else
@@ -36,8 +40,8 @@ private
     end
   end
 
-  def first_created_edition
-    content_block_versions.last
+  def first_published_version
+    @first_published_version ||= content_block_versions[-2]
   end
 
   def time_html(date_time)

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/document_timeline_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/document_timeline_component.rb
@@ -9,7 +9,7 @@ private
   attr_reader :content_block_versions
 
   def items
-    content_block_versions.reject { |version| show_to_user?(version) }.map do |version|
+    content_block_versions.reject { |version| hide_from_user?(version) }.map do |version|
       {
         title: title(version),
         byline: User.find_by_id(version.whodunnit)&.then { |user| helpers.linked_author(user, { class: "govuk-link" }) } || "unknown user",
@@ -21,7 +21,7 @@ private
     end
   end
 
-  def show_to_user?(version)
+  def hide_from_user?(version)
     version.state.nil? || version.state == "superseded"
   end
 
@@ -41,7 +41,7 @@ private
   end
 
   def first_published_version
-    @first_published_version ||= content_block_versions[-2]
+    @first_published_version ||= content_block_versions.filter { |v| v.state == "published" }.min_by(&:created_at)
   end
 
   def time_html(date_time)

--- a/lib/engines/content_block_manager/features/edit_object.feature
+++ b/lib/engines/content_block_manager/features/edit_object.feature
@@ -34,7 +34,7 @@ Feature: Edit a content object
     When I click to view the content block
     Then the edition should have been updated successfully
     And I should be taken back to the document page
-    And I should see 2 publish events on the timeline
+    And I should see 1 publish events on the timeline
     And I should see the notes on the timeline
     And I should see the edition diff in a table
 

--- a/lib/engines/content_block_manager/features/step_definitions/timeline_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/timeline_steps.rb
@@ -4,7 +4,7 @@ Then("I should see the created event on the timeline") do
 end
 
 Then(/^I should see ([^"]*) publish events on the timeline$/) do |count|
-  expect(page).to have_selector(".timeline__title", text: "Email address published", count:)
+  expect(page).to have_selector(".timeline__title", text: "Published", count:)
 end
 
 Then("I should see the notes on the timeline") do
@@ -13,12 +13,12 @@ Then("I should see the notes on the timeline") do
 end
 
 Then("I should see the publish event on the timeline") do
-  expect(page).to have_selector(".timeline__title", text: "Email address published")
+  expect(page).to have_selector(".timeline__title", text: "Published")
   expect(page).to have_selector(".timeline__byline", text: "by Scheduled Publishing Robot")
 end
 
 Then("I should see the scheduled event on the timeline") do
-  expect(page).to have_selector(".timeline__title", text: "Email address scheduled")
+  expect(page).to have_selector(".timeline__title", text: "Scheduled")
   expect(page).to have_selector(".timeline__byline", text: "by #{@user.name}")
 end
 

--- a/lib/engines/content_block_manager/features/view_object.feature
+++ b/lib/engines/content_block_manager/features/view_object.feature
@@ -12,7 +12,7 @@ Feature: View a content object
     When I click to view the document
     Then I should be taken back to the document page
     And I should see the details for the email address content block
-    And I should see 1 publish events on the timeline
+    And I should see the created event on the timeline
 
   Scenario: GDS Editor views a content object using the content ID
     When I visit a block's content ID endpoint

--- a/lib/engines/content_block_manager/test/components/content_block/document/show/document_timeline_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/document/show/document_timeline_component_test.rb
@@ -21,6 +21,7 @@ class ContentBlockManager::ContentBlock::Document::Show::DocumentTimelineCompone
       :content_block_version,
       event: "created",
       whodunnit: user.id,
+      created_at: 4.days.ago,
       item:,
     )
     version_2 = create(
@@ -28,6 +29,7 @@ class ContentBlockManager::ContentBlock::Document::Show::DocumentTimelineCompone
       event: "updated",
       whodunnit: user.id,
       state: "published",
+      created_at: 3.days.ago,
       item:,
     )
     version_3 = create(
@@ -35,6 +37,7 @@ class ContentBlockManager::ContentBlock::Document::Show::DocumentTimelineCompone
       event: "updated",
       whodunnit: user.id,
       state: "published",
+      created_at: 2.days.ago,
       item:,
     )
     version_4 = create(
@@ -42,6 +45,7 @@ class ContentBlockManager::ContentBlock::Document::Show::DocumentTimelineCompone
       event: "updated",
       whodunnit: user.id,
       state: "scheduled",
+      created_at: 1.day.ago,
       item: scheduled_item,
     )
 
@@ -54,17 +58,17 @@ class ContentBlockManager::ContentBlock::Document::Show::DocumentTimelineCompone
     assert_equal "Scheduled for publishing on #{scheduled_item.scheduled_publication.to_fs(:long_ordinal_with_at)}", page.all(".timeline__title")[0].text
     assert_equal "by #{linked_author(user, { class: 'govuk-link' })}", page.all(".timeline__byline")[0].native.inner_html
     assert_equal  version_4.created_at.to_fs(:long_ordinal_with_at),
-                  page.all("time[datetime='#{version_4.created_at.iso8601}']")[0].text
+                  page.find("time[datetime='#{version_4.created_at.iso8601}']").text
 
     assert_equal "Published", page.all(".timeline__title")[1].text
     assert_equal "by #{linked_author(user, { class: 'govuk-link' })}", page.all(".timeline__byline")[1].native.inner_html
     assert_equal  version_2.created_at.to_fs(:long_ordinal_with_at),
-                  page.all("time[datetime='#{version_2.created_at.iso8601}']")[1].text
+                  page.find("time[datetime='#{version_2.created_at.iso8601}']").text
 
     assert_equal "Email address created", page.all(".timeline__title")[2].text
     assert_equal "by #{linked_author(user, { class: 'govuk-link' })}", page.all(".timeline__byline")[2].native.inner_html
     assert_equal  version_3.created_at.to_fs(:long_ordinal_with_at),
-                  page.all("time[datetime='#{version_3.created_at.iso8601}']")[2].text
+                  page.find("time[datetime='#{version_3.created_at.iso8601}']").text
 
     assert_no_selector ".govuk-table"
     assert_no_selector "h2", text: "Internal note"

--- a/lib/engines/content_block_manager/test/components/content_block/document/show/document_timeline_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/document/show/document_timeline_component_test.rb
@@ -34,25 +34,37 @@ class ContentBlockManager::ContentBlock::Document::Show::DocumentTimelineCompone
       :content_block_version,
       event: "updated",
       whodunnit: user.id,
+      state: "published",
+      item:,
+    )
+    version_4 = create(
+      :content_block_version,
+      event: "updated",
+      whodunnit: user.id,
       state: "scheduled",
       item: scheduled_item,
     )
 
     render_inline(ContentBlockManager::ContentBlock::Document::Show::DocumentTimelineComponent.new(
-                    content_block_versions: [version_3, version_2, version_1],
+                    content_block_versions: [version_4, version_3, version_2, version_1],
                   ))
 
     assert_selector ".timeline__item", count: 3
 
     assert_equal "Scheduled for publishing on #{scheduled_item.scheduled_publication.to_fs(:long_ordinal_with_at)}", page.all(".timeline__title")[0].text
     assert_equal "by #{linked_author(user, { class: 'govuk-link' })}", page.all(".timeline__byline")[0].native.inner_html
-    assert_equal  version_3.created_at.to_fs(:long_ordinal_with_at),
-                  page.all("time[datetime='#{version_3.created_at.iso8601}']")[1].text
+    assert_equal  version_4.created_at.to_fs(:long_ordinal_with_at),
+                  page.all("time[datetime='#{version_4.created_at.iso8601}']")[0].text
 
     assert_equal "Published", page.all(".timeline__title")[1].text
     assert_equal "by #{linked_author(user, { class: 'govuk-link' })}", page.all(".timeline__byline")[1].native.inner_html
     assert_equal  version_2.created_at.to_fs(:long_ordinal_with_at),
                   page.all("time[datetime='#{version_2.created_at.iso8601}']")[1].text
+
+    assert_equal "Email address created", page.all(".timeline__title")[2].text
+    assert_equal "by #{linked_author(user, { class: 'govuk-link' })}", page.all(".timeline__byline")[2].native.inner_html
+    assert_equal  version_3.created_at.to_fs(:long_ordinal_with_at),
+                  page.all("time[datetime='#{version_3.created_at.iso8601}']")[2].text
 
     assert_no_selector ".govuk-table"
     assert_no_selector "h2", text: "Internal note"

--- a/lib/engines/content_block_manager/test/components/content_block/document/show/document_timeline_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/document/show/document_timeline_component_test.rb
@@ -39,12 +39,12 @@ class ContentBlockManager::ContentBlock::Document::Show::DocumentTimelineCompone
 
     assert_equal "Email address scheduled", page.all(".timeline__title")[0].text
     assert_equal "by #{linked_author(user, { class: 'govuk-link' })}", page.all(".timeline__byline")[0].native.inner_html
-    assert_equal  I18n.l(version_3.created_at, format: :long_ordinal),
+    assert_equal  version_2.created_at.to_fs(:long_ordinal_with_at),
                   page.all("time[datetime='#{version_3.created_at.iso8601}']")[1].text
 
     assert_equal "Email address published", page.all(".timeline__title")[1].text
     assert_equal "by #{linked_author(user, { class: 'govuk-link' })}", page.all(".timeline__byline")[1].native.inner_html
-    assert_equal  I18n.l(version_2.created_at, format: :long_ordinal),
+    assert_equal  version_2.created_at.to_fs(:long_ordinal_with_at),
                   page.all("time[datetime='#{version_2.created_at.iso8601}']")[1].text
 
     assert_no_selector ".govuk-table"

--- a/lib/engines/content_block_manager/test/components/content_block/document/show/document_timeline_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/document/show/document_timeline_component_test.rb
@@ -10,6 +10,13 @@ class ContentBlockManager::ContentBlock::Document::Show::DocumentTimelineCompone
 
   test "renders a timeline component with events in correct order" do
     item = build(:content_block_edition, :email_address, change_note: nil, internal_change_note: nil)
+    scheduled_item = build(
+      :content_block_edition,
+      :email_address,
+      change_note: nil,
+      internal_change_note: nil,
+      scheduled_publication: 2.days.from_now,
+    )
     version_1 = create(
       :content_block_version,
       event: "created",
@@ -28,7 +35,7 @@ class ContentBlockManager::ContentBlock::Document::Show::DocumentTimelineCompone
       event: "updated",
       whodunnit: user.id,
       state: "scheduled",
-      item:,
+      item: scheduled_item,
     )
 
     render_inline(ContentBlockManager::ContentBlock::Document::Show::DocumentTimelineComponent.new(
@@ -37,12 +44,12 @@ class ContentBlockManager::ContentBlock::Document::Show::DocumentTimelineCompone
 
     assert_selector ".timeline__item", count: 2
 
-    assert_equal "Email address scheduled", page.all(".timeline__title")[0].text
+    assert_equal "Scheduled for publishing on #{scheduled_item.scheduled_publication.to_fs(:long_ordinal_with_at)}", page.all(".timeline__title")[0].text
     assert_equal "by #{linked_author(user, { class: 'govuk-link' })}", page.all(".timeline__byline")[0].native.inner_html
-    assert_equal  version_2.created_at.to_fs(:long_ordinal_with_at),
+    assert_equal  version_3.created_at.to_fs(:long_ordinal_with_at),
                   page.all("time[datetime='#{version_3.created_at.iso8601}']")[1].text
 
-    assert_equal "Email address published", page.all(".timeline__title")[1].text
+    assert_equal "Published", page.all(".timeline__title")[1].text
     assert_equal "by #{linked_author(user, { class: 'govuk-link' })}", page.all(".timeline__byline")[1].native.inner_html
     assert_equal  version_2.created_at.to_fs(:long_ordinal_with_at),
                   page.all("time[datetime='#{version_2.created_at.iso8601}']")[1].text
@@ -74,7 +81,7 @@ class ContentBlockManager::ContentBlock::Document::Show::DocumentTimelineCompone
       :content_block_version,
       event: "updated",
       whodunnit: user.id,
-      state: "scheduled",
+      state: "published",
       field_diffs: field_diffs,
     )
 

--- a/lib/engines/content_block_manager/test/components/content_block/document/show/document_timeline_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/document/show/document_timeline_component_test.rb
@@ -42,7 +42,7 @@ class ContentBlockManager::ContentBlock::Document::Show::DocumentTimelineCompone
                     content_block_versions: [version_3, version_2, version_1],
                   ))
 
-    assert_selector ".timeline__item", count: 2
+    assert_selector ".timeline__item", count: 3
 
     assert_equal "Scheduled for publishing on #{scheduled_item.scheduled_publication.to_fs(:long_ordinal_with_at)}", page.all(".timeline__title")[0].text
     assert_equal "by #{linked_author(user, { class: 'govuk-link' })}", page.all(".timeline__byline")[0].native.inner_html
@@ -127,5 +127,19 @@ class ContentBlockManager::ContentBlock::Document::Show::DocumentTimelineCompone
                   ))
 
     assert_selector "p", text: "changed a to b"
+  end
+
+  test "it does not render superseded update events" do
+    version = create(
+      :content_block_version,
+      event: "updated",
+      state: "superseded",
+    )
+
+    render_inline(ContentBlockManager::ContentBlock::Document::Show::DocumentTimelineComponent.new(
+                    content_block_versions: [version],
+                  ))
+
+    assert_no_selector ".timeline__item"
   end
 end


### PR DESCRIPTION
https://trello.com/c/JOyjhbTb/833-update-copy-in-content-block-history

figma design: https://www.figma.com/design/F2Uq6Ju6fsSk1CEMjXm2va/Content-Modelling?node-id=2406-17913&t=ujjqo8fVksJJFFQY-0

convo about copy which is still ongoing: https://gds.slack.com/archives/C062Z1FA2ES/p1738168595581529?thread_ts=1738146596.061529&cid=C062Z1FA2ES 

Some slightly finnicky changes needed for the timeline. It sounds like the content is still a bit up in the air, but this should match the design as it stands.

![Screenshot 2025-01-29 at 16-11-38 666 - GOV UK Content Block Manager](https://github.com/user-attachments/assets/835c8acd-6300-4c98-8d0f-3cec05f1c65e)


---
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
