### PR TITLE
Make unpublishing operation asynchronous

### DIFF
--- a/app/services/service_listeners/publishing_api_pusher.rb
+++ b/app/services/service_listeners/publishing_api_pusher.rb
@@ -18,7 +18,7 @@ module ServiceListeners
         api.patch_links(edition)
         api.save_draft_translation(edition, options.fetch(:locale))
       when "unpublish"
-        api.unpublish_async(edition.unpublishing)
+        api.unpublish_sync(edition.unpublishing)
       when "withdraw"
         edition.translations.each do |translation|
           api.publish_withdrawal_async(

--- a/app/services/service_listeners/publishing_api_pusher.rb
+++ b/app/services/service_listeners/publishing_api_pusher.rb
@@ -21,7 +21,7 @@ module ServiceListeners
         api.unpublish_sync(edition.unpublishing)
       when "withdraw"
         edition.translations.each do |translation|
-          api.publish_withdrawal_async(
+          api.publish_withdrawal_sync(
             edition.content_id,
             edition.unpublishing.explanation,
             edition.unpublishing.unpublished_at,

--- a/lib/whitehall/publishing_api.rb
+++ b/lib/whitehall/publishing_api.rb
@@ -150,10 +150,6 @@ module Whitehall
       PublishingApiWithdrawalWorker.perform_async(document_content_id, explanation, locale.to_s, false, unpublished_at.to_s)
     end
 
-    def self.unpublish_async(unpublishing)
-      PublishingApiUnpublishingWorker.perform_async(unpublishing.id)
-    end
-
     def self.unpublish_sync(unpublishing)
       PublishingApiUnpublishingWorker.new.perform(unpublishing.id)
     end

--- a/lib/whitehall/publishing_api.rb
+++ b/lib/whitehall/publishing_api.rb
@@ -146,8 +146,8 @@ module Whitehall
       PublishingApiVanishWorker.perform_async(document_content_id, locale.to_s)
     end
 
-    def self.publish_withdrawal_async(document_content_id, explanation, unpublished_at, locale = I18n.default_locale.to_s)
-      PublishingApiWithdrawalWorker.perform_async(document_content_id, explanation, locale.to_s, false, unpublished_at.to_s)
+    def self.publish_withdrawal_sync(document_content_id, explanation, unpublished_at, locale = I18n.default_locale.to_s)
+      PublishingApiWithdrawalWorker.new.perform(document_content_id, explanation, locale.to_s, false, unpublished_at.to_s)
     end
 
     def self.unpublish_sync(unpublishing)

--- a/lib/whitehall/publishing_api.rb
+++ b/lib/whitehall/publishing_api.rb
@@ -154,6 +154,10 @@ module Whitehall
       PublishingApiUnpublishingWorker.perform_async(unpublishing.id)
     end
 
+    def self.unpublish_sync(unpublishing)
+      PublishingApiUnpublishingWorker.new.perform(unpublishing.id)
+    end
+
     def self.save_draft_redirect_async(base_path, redirects, locale = I18n.default_locale.to_s)
       PublishingApiRedirectWorker.perform_async(
         base_path,

--- a/test/unit/app/models/edition/searchable_test.rb
+++ b/test/unit/app/models/edition/searchable_test.rb
@@ -64,7 +64,7 @@ class Edition::SearchableTest < ActiveSupport::TestCase
   test "should add edition to search index on withdrawing" do
     edition = create(:published_searchable_edition)
 
-    Whitehall::PublishingApi.stubs(:publish_withdrawal_async)
+    Whitehall::PublishingApi.stubs(:publish_withdrawal_sync)
 
     edition.build_unpublishing(explanation: "Old policy", unpublishing_reason_id: UnpublishingReason::Withdrawn.id)
 

--- a/test/unit/app/services/service_listeners/publishing_api_pusher_test.rb
+++ b/test/unit/app/services/service_listeners/publishing_api_pusher_test.rb
@@ -66,11 +66,11 @@ module ServiceListeners
         unpublishing_reason_id: UnpublishingReason::Withdrawn.id,
       )
 
-      Whitehall::PublishingApi.expects(:publish_withdrawal_async)
+      Whitehall::PublishingApi.expects(:publish_withdrawal_sync)
         .with(edition.document.content_id, edition.unpublishing.explanation, edition.unpublishing.unpublished_at, edition.primary_locale)
 
       translations.each do |translation|
-        Whitehall::PublishingApi.expects(:publish_withdrawal_async)
+        Whitehall::PublishingApi.expects(:publish_withdrawal_sync)
           .with(edition.document.content_id, edition.unpublishing.explanation, edition.unpublishing.unpublished_at, translation.to_s)
       end
 

--- a/test/unit/app/services/service_listeners/publishing_api_pusher_test.rb
+++ b/test/unit/app/services/service_listeners/publishing_api_pusher_test.rb
@@ -83,7 +83,7 @@ module ServiceListeners
 
     test "unpublish publishes the unpublishing" do
       edition = create(:unpublished_publication)
-      Whitehall::PublishingApi.expects(:unpublish_async).with(edition.unpublishing)
+      Whitehall::PublishingApi.expects(:unpublish_sync).with(edition.unpublishing)
       stub_associated_document_pusher(edition, "unpublish")
       Sidekiq::Testing.inline! do
         PublishingApiPusher.new(edition).push(event: "unpublish")

--- a/test/unit/lib/whitehall/publishing_api_test.rb
+++ b/test/unit/lib/whitehall/publishing_api_test.rb
@@ -323,12 +323,6 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     assert_requested gone_request
   end
 
-  test ".unpublish_async queues a PublishingApiUnpublishingWorker job for the unpublishing" do
-    unpublishing = build(:unpublishing, id: 1)
-    PublishingApiUnpublishingWorker.expects(:perform_async).with(1)
-    Whitehall::PublishingApi.unpublish_async(unpublishing)
-  end
-
   test ".unpublish_sync immediately runs a PublishingApiUnpublishingWorker job for the unpublishing" do
     unpublishing = build(:unpublishing, id: 1)
     stubbed_worker = stub("worker", perform: nil)

--- a/test/unit/lib/whitehall/publishing_api_test.rb
+++ b/test/unit/lib/whitehall/publishing_api_test.rb
@@ -331,6 +331,19 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     Whitehall::PublishingApi.unpublish_sync(unpublishing)
   end
 
+  test ".publish_withdrawal_sync immediately runs a PublishingApiWithdrawalWorker job for the withdrawal" do
+    document_content_id = "12345"
+    explanation = "This document has been withdrawn"
+    unpublished_at = Time.zone.now
+    locale = "en"
+
+    stubbed_worker = stub("worker", perform: nil)
+    PublishingApiWithdrawalWorker.expects(:new).returns(stubbed_worker)
+    stubbed_worker.expects(:perform).with(document_content_id, explanation, locale.to_s, false, unpublished_at.to_s)
+
+    Whitehall::PublishingApi.publish_withdrawal_sync(document_content_id, explanation, unpublished_at, locale)
+  end
+
   test ".publish handles the specific exception" do
     raises_exception = lambda { |_, _, _|
       body = {

--- a/test/unit/lib/whitehall/publishing_api_test.rb
+++ b/test/unit/lib/whitehall/publishing_api_test.rb
@@ -329,6 +329,14 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     Whitehall::PublishingApi.unpublish_async(unpublishing)
   end
 
+  test ".unpublish_sync immediately runs a PublishingApiUnpublishingWorker job for the unpublishing" do
+    unpublishing = build(:unpublishing, id: 1)
+    stubbed_worker = stub("worker", perform: nil)
+    PublishingApiUnpublishingWorker.expects(:new).returns(stubbed_worker)
+    stubbed_worker.expects(:perform).with(1)
+    Whitehall::PublishingApi.unpublish_sync(unpublishing)
+  end
+
   test ".publish handles the specific exception" do
     raises_exception = lambda { |_, _, _|
       body = {


### PR DESCRIPTION
The ‘unpublish’ action in Whitehall currently creates a worker to call Publishing API asynchronously. It should be updated to call Publishing API synchronously.

We should then listen for the response from Publishing API, and should catch any 4xx error and avoid updating the state of the document in Whitehall, and display an error message to the user.

Trello: https://trello.com/c/xlvNUI3c/3382-make-whitehalls-unpublishing-call-to-publishing-api-synchronous

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
