### PR TITLE
Rename devolved administration to devolved government

### DIFF
--- a/app/models/organisation_type.rb
+++ b/app/models/organisation_type.rb
@@ -4,7 +4,7 @@ class OrganisationType
     advisory_ndpb: { name: "Advisory non-departmental public body", analytics_prefix: "PB", agency_or_public_body: true, non_departmental_public_body: true, allowed_promotional: false },
     civil_service: { name: "Civil Service", analytics_prefix: "CS", agency_or_public_body: false, non_departmental_public_body: false, allowed_promotional: true },
     court: { name: "Court", analytics_prefix: "CO", agency_or_public_body: false, non_departmental_public_body: false, allowed_promotional: false },
-    devolved_administration: { name: "Devolved administration", analytics_prefix: "DA", agency_or_public_body: false, non_departmental_public_body: false, allowed_promotional: false },
+    devolved_administration: { name: "Devolved government", analytics_prefix: "DA", agency_or_public_body: false, non_departmental_public_body: false, allowed_promotional: false },
     executive_agency: { name: "Executive agency", analytics_prefix: "EA", agency_or_public_body: true, non_departmental_public_body: false, allowed_promotional: false },
     executive_ndpb: { name: "Executive non-departmental public body", analytics_prefix: "PB", agency_or_public_body: true, non_departmental_public_body: true, allowed_promotional: false },
     executive_office: { name: "Executive office", analytics_prefix: "EO", agency_or_public_body: false, non_departmental_public_body: false, allowed_promotional: true },

--- a/test/unit/app/presenters/publishing_api/organisations_index_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/organisations_index_presenter_test.rb
@@ -191,7 +191,7 @@ class PublishingApi::OrganisationsPresenterTest < ActiveSupport::TestCase
               crest: "single-identity",
             },
             separate_website: true,
-            format: "Devolved administration",
+            format: "Devolved government",
             updated_at: Time.zone.now,
             slug: organisation_seven.slug,
             acronym: nil,


### PR DESCRIPTION
We've recently updated our style guide to say that users should use the term 'devolved governments' in content, rather than 'devolved administrations'.

To make sure that change is reflected in our own content, can you please do the following?

On Whitehall, rename the ‘devolved administration’ organisation type to ‘devolved government'

Work with the navigation team in web to:

update the organisation list to rename ‘Devolved administrations’ section to ‘Devolved governments'

update the organisation descriptions for the Scottish Government, Welsh Government and NI Executive (for example “Welsh Government is a devolved government…”)

https://trello.com/c/YEpaI8T4/3385-change-devolved-administrations-to-devolved-governments

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
