### PR TITLE
Remove 'format_name' property from schema files

### DIFF
--- a/lib/finders/case_studies.json
+++ b/lib/finders/case_studies.json
@@ -15,7 +15,6 @@
     "filter": {
       "format": "case_study"
     },
-    "format_name": "Case studies: Real-life examples of government activity",
     "show_summaries": true,
     "default_documents_per_page": 50
   },

--- a/lib/finders/people.json
+++ b/lib/finders/people.json
@@ -15,7 +15,6 @@
     "filter": {
       "format": "person"
     },
-    "format_name": "All ministers and senior officials on GOV.UK",
     "show_summaries": true,
     "default_documents_per_page": 50
   },


### PR DESCRIPTION
Not to be confused with the widely used 'format_name' method names in Whitehall (e.g. 'detailed guidance' in
https://github.com/alphagov/publishing-api/pull/3112)

These keys exactly duplicate the `title` property in the JSON file and are ultimately unused by finder-frontend and can be removed.

See https://github.com/alphagov/publishing-api/pull/3112

Trello: https://trello.com/c/ZiFU2o6B/3389-iterate-specialist-publisher-edit-new-finder-forms

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
