### PR TITLE
Remove unused 'should_generate_new_friendly_id?' methods

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -101,10 +101,6 @@ class Document < ApplicationRecord
     ).count > 1
   end
 
-  def should_generate_new_friendly_id?
-    sluggable_string.present?
-  end
-
   def update_slug_if_possible(new_title)
     return if ever_published_editions.present? || invalid?
 

--- a/app/models/external_attachment.rb
+++ b/app/models/external_attachment.rb
@@ -21,10 +21,6 @@ class ExternalAttachment < Attachment
     false
   end
 
-  def should_generate_new_friendly_id?
-    false
-  end
-
   # Is in OpenDocument format? (see https://en.wikipedia.org/wiki/OpenDocument)
   def opendocument?
     false

--- a/app/models/file_attachment.rb
+++ b/app/models/file_attachment.rb
@@ -42,10 +42,6 @@ class FileAttachment < Attachment
     "file"
   end
 
-  def should_generate_new_friendly_id?
-    false
-  end
-
   def publishing_api_details_for_format
     {
       accessible: accessible?,

--- a/app/models/html_attachment.rb
+++ b/app/models/html_attachment.rb
@@ -60,12 +60,6 @@ class HtmlAttachment < Attachment
     end
   end
 
-  def should_generate_new_friendly_id?
-    return false unless sluggable_locale?
-
-    slug.nil? || attachable.nil? || safely_resluggable?
-  end
-
   def deep_clone
     super.tap do |clone|
       clone.slug = slug


### PR DESCRIPTION
These methods don't appear to be called in any of our application codes nor our tests.

Trello: https://trello.com/c/72OAHt74

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
