### PR TITLE
Make 'identifier' slug-related behaviour more intuitive/flexible

### DIFF
--- a/app/models/html_attachment.rb
+++ b/app/models/html_attachment.rb
@@ -83,9 +83,7 @@ class HtmlAttachment < Attachment
   end
 
   def identifier
-    return slug if slug_eligible?
-
-    content_id
+    slug || content_id
   end
 
   def base_path
@@ -129,10 +127,6 @@ private
 
   def sluggable_string
     sluggable_locale? ? title : nil
-  end
-
-  def slug_eligible?
-    title.ascii_only? && sluggable_locale?
   end
 
   def clear_slug_if_non_english_locale

--- a/test/unit/app/models/html_attachment_test.rb
+++ b/test/unit/app/models/html_attachment_test.rb
@@ -249,11 +249,31 @@ class HtmlAttachmentTest < ActiveSupport::TestCase
     assert_equal expected_slug, attachment.to_param
   end
 
+  test "slug is created even if the English title contains non-ASCII characters (since it's highly unlikely to be ALL non-ASCII characters like other languages)" do
+    attachment = create(:html_attachment, locale: "en", title: "A page about copyright ©")
+
+    expected_slug = "a-page-about-copyright"
+    assert_equal expected_slug, attachment.slug
+    assert_equal expected_slug, attachment.to_param
+  end
+
   test "slug is cleared when changing from english to non-english" do
     attachment = create(:html_attachment, locale: "en")
 
     attachment.update!(locale: "fr")
     assert attachment.slug.blank?
+  end
+
+  test "#identifier falls back to content_id if no slug available" do
+    attachment = create(:html_attachment)
+    attachment.slug = nil
+    assert_equal attachment.content_id, attachment.identifier
+  end
+
+  test "#identifier uses the slug if it's been set, irrespective of locale" do
+    attachment = create(:html_attachment, locale: "cy")
+    attachment.slug = "foo"
+    assert_equal "foo", attachment.identifier
   end
 
   test "#translated_locales lists only the attachment's locale" do


### PR DESCRIPTION
This fixes a bug where a HTMLAttachment’s (English) slug is not used if the title has been changed to include a non-ASCII character. The wrong base path (with content ID instead of slug) was therefore surfaced in the Whitehall UI and causes a 404 for publishers.

---

A HTML Attachment's `slug` is only set if the locale is English. This is already [covered by tests](https://github.com/alphagov/whitehall/blob/55f9d09b246c4029900c5f43e24cf9aba1405bc4/test/unit/app/models/html_attachment_test.rb#L235-L257)

The `identifier` method is used in populating the `base_path` of the HTML attachment. It used to check if an edition was 'eligible' for a slug (i.e. non-ASCII and English) and otherwise return the content ID as the identifier.

But we're already doing that eligibility checking at the point of creating the slug. So if `slug` is defined, we should be using that. Moreover, it meant that if the title was updated to include a non-ASCII character (easily done, e.g. non-ASCII hyphen '—') then the wrong identifier was being returned (leading to 404 link when attempting to preview HTML attachment from within Whitehall).

The ASCII requirement was introduced in #9306. But FriendlyId is perfectly capable of coping with _some_ ASCII - see newly introduced test in this commit - we only wanted to force a content_id fallback for non-English locales.

So the new behaviour is much simpler: if a slug is defined, return it, otherwise return the content ID. In practice, this should mean that only English locales have slugs defined.

Trello: https://trello.com/c/72OAHt74

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
