### PR TITLE
Output failing tests when a test suite fails

### DIFF
--- a/bin/minitest-ci
+++ b/bin/minitest-ci
@@ -17,4 +17,12 @@ tests = test_files.
     i % ENV["CI_NODE_TOTAL"].to_i == ENV["CI_NODE_INDEX"].to_i
   end
 
-exec "bundle exec rails test #{tests.join(" ")}"
+result = %x(bundle exec rails test #{tests.join(" ")})
+
+puts result
+
+# If the tests fail, output the tests in the failing subset of tests, to aid with debugging.
+unless $? == 0
+  puts "Test files run: \n#{tests.join("\n")}"
+  exit 1
+end


### PR DESCRIPTION
Sometimes there’s issues with a particular order of tests (one specific one we're seeing is with Sidekiq tests - see https://github.com/alphagov/whitehall/actions/runs/13069262982/job/36467157548?pr=9858). If this happens, we output the tests that were run in that shard. This should hopefully help narrow down what tests are leaking state, so we can stop it from happening in future.