### PR TITLE
Disable search indexing for news articles, consultations and calls for evidence

### DIFF
--- a/app/models/call_for_evidence.rb
+++ b/app/models/call_for_evidence.rb
@@ -127,6 +127,10 @@ class CallForEvidence < Publicationesque
     )
   end
 
+  def can_index_in_search?
+    false
+  end
+
   def allows_html_attachments?
     true
   end

--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -141,6 +141,10 @@ class Consultation < Publicationesque
     )
   end
 
+  def can_index_in_search?
+    false
+  end
+
   def allows_html_attachments?
     true
   end

--- a/app/models/news_article.rb
+++ b/app/models/news_article.rb
@@ -92,6 +92,10 @@ class NewsArticle < Announcement
     PublishingApi::NewsArticlePresenter
   end
 
+  def can_index_in_search?
+    false
+  end
+
 private
 
   def organisations_are_not_associated

--- a/test/unit/app/services/service_listeners/search_indexer_test.rb
+++ b/test/unit/app/services/service_listeners/search_indexer_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class ServiceListeners::SearchIndexerTest < ActiveSupport::TestCase
   test "#index! indexes published edition" do
-    edition = create(:published_news_article)
+    edition = create(:published_case_study)
 
     expect_indexing(edition)
     ServiceListeners::SearchIndexer.new(edition).index!
@@ -42,10 +42,10 @@ class ServiceListeners::SearchIndexerTest < ActiveSupport::TestCase
   end
 
   test "#index! removes the edition from the search index if the current edition cannot be indexed, but the previous edition was indexed" do
-    english_edition = create(:news_article_world_news_story, :published)
+    english_edition = create(:case_study, :published)
     ServiceListeners::SearchIndexer.new(english_edition).index!
     non_english_edition = I18n.with_locale(:fr) do
-      create(:news_article_world_news_story, :published, primary_locale: :fr, document: english_edition.document)
+      create(:case_study, :published, primary_locale: :fr, document: english_edition.document)
     end
 
     expect_removal_from_index(english_edition)

--- a/test/unit/lib/data_hygiene/person_reslugger_test.rb
+++ b/test/unit/lib/data_hygiene/person_reslugger_test.rb
@@ -42,21 +42,16 @@ class PersonSlugChangerTest < ActiveSupport::TestCase
   end
 
   test "re-indexes all the published dependent documents" do
-    published_news = create(:published_news_article)
-    draft_news = create(:draft_news_article)
     role_appointment = create(
       :role_appointment,
       person: @person,
-      editions: [published_news, draft_news],
     )
 
     published_speech = create(:published_speech, role_appointment:)
     draft_speech = create(:draft_speech, role_appointment:)
 
     Whitehall::SearchIndex.stubs(:add)
-    Whitehall::SearchIndex.expects(:add).with(published_news)
     Whitehall::SearchIndex.expects(:add).with(published_speech)
-    Whitehall::SearchIndex.expects(:add).with(draft_news).never
     Whitehall::SearchIndex.expects(:add).with(draft_speech).never
     @reslugger.run!
   end


### PR DESCRIPTION
There is now configuration in Search API to allow these document types to be indexed via Publishing API

Related Search API PRs:

https://github.com/alphagov/search-api/pull/3142
https://github.com/alphagov/search-api/pull/3143

Trello: https://trello.com/c/A5uNzU3G

