### PR TITLE
Allow embedded objects to be returned in schema

### DIFF
--- a/lib/engines/content_block_manager/app/models/content_block_manager/content_block/schema.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/content_block/schema.rb
@@ -3,11 +3,29 @@ module ContentBlockManager
     class Schema
       SCHEMA_PREFIX = "content_block".freeze
 
-      VALID_SCHEMAS = %w[email_address postal_address].freeze
+      VALID_SCHEMAS = %w[email_address postal_address pension].freeze
       private_constant :VALID_SCHEMAS
 
-      def self.valid_schemas
-        VALID_SCHEMAS
+      class << self
+        def valid_schemas
+          VALID_SCHEMAS
+        end
+
+        def all
+          @all ||= Services.publishing_api.get_schemas.select { |k, _v|
+            is_valid_schema?(k)
+          }.map { |id, full_schema|
+            full_schema.dig("definitions", "details")&.yield_self { |schema| new(id, schema) }
+          }.compact
+        end
+
+        def find_by_block_type(block_type)
+          all.find { |schema| schema.block_type == block_type } || raise(ArgumentError, "Cannot find schema for #{block_type}")
+        end
+
+        def is_valid_schema?(key)
+          key.start_with?(SCHEMA_PREFIX) && key.end_with?(*valid_schemas)
+        end
       end
 
       attr_reader :id, :body
@@ -26,7 +44,11 @@ module ContentBlockManager
       end
 
       def fields
-        @body["properties"].keys
+        (@body["properties"].to_a - embedded_objects.to_a).to_h.keys
+      end
+
+      def subschema(name)
+        subschemas.find { |s| s.id == name }
       end
 
       def permitted_params
@@ -37,20 +59,29 @@ module ContentBlockManager
         @block_type ||= id.delete_prefix("#{SCHEMA_PREFIX}_")
       end
 
-      def self.all
-        @all ||= Services.publishing_api.get_schemas.select { |k, _v|
-          is_valid_schema?(k)
-        }.map { |id, full_schema|
-          full_schema.dig("definitions", "details")&.yield_self { |schema| new(id, schema) }
-        }.compact
+      class EmbeddedSchema < Schema
+        def initialize(id, body)
+          body = body["patternProperties"]&.values&.first || raise(ArgumentError, "Subschema `#{id}` is invalid")
+          super(id, body)
+        end
+
+        def fields
+          @body["properties"].keys.sort_by { |field| @body["order"]&.index(field) }
+        end
+
+        def block_type
+          @id
+        end
       end
 
-      def self.find_by_block_type(block_type)
-        all.find { |schema| schema.block_type == block_type } || raise(ArgumentError, "Cannot find schema for #{block_type}")
+    private
+
+      def embedded_objects
+        @body["properties"].select { |_k, v| v["type"] == "object" }
       end
 
-      def self.is_valid_schema?(key)
-        key.start_with?(SCHEMA_PREFIX) && key.end_with?(*valid_schemas)
+      def subschemas
+        @subschemas ||= embedded_objects.map { |object| EmbeddedSchema.new(*object) }
       end
     end
   end

--- a/lib/engines/content_block_manager/test/unit/app/models/content_block_schema_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/models/content_block_schema_test.rb
@@ -22,6 +22,113 @@ class ContentBlockManager::SchemaTest < ActiveSupport::TestCase
     assert_equal schema.block_type, "email_address"
   end
 
+  describe "when a schema has embedded objects" do
+    let(:body) do
+      {
+        "properties" => {
+          "foo" => {
+            "type" => "string",
+          },
+          "bar" => {
+            "type" => "object",
+            "patternProperties" => {
+              "*" => {
+                "type" => "object",
+                "properties" => {
+                  "my_string" => {
+                    "type" => "string",
+                  },
+                  "something_else" => {
+                    "type" => "string",
+                  },
+                },
+              },
+            },
+          },
+        },
+      }
+    end
+
+    describe "#fields" do
+      it "removes object fields" do
+        assert_equal schema.fields, %w[foo]
+      end
+    end
+
+    describe "#subschema" do
+      it "returns a given subschema" do
+        subschema = schema.subschema("bar")
+
+        assert_equal subschema.id, "bar"
+        assert_equal subschema.fields, %w[my_string something_else]
+      end
+
+      describe "when an order is given in the subschema" do
+        let(:body) do
+          {
+            "properties" => {
+              "foo" => {
+                "type" => "string",
+              },
+              "bar" => {
+                "type" => "object",
+                "patternProperties" => {
+                  "*" => {
+                    "type" => "object",
+                    "order" => %w[something_else my_string],
+                    "properties" => {
+                      "my_string" => {
+                        "type" => "string",
+                      },
+                      "something_else" => {
+                        "type" => "string",
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          }
+        end
+
+        it "orders fields when an order is given" do
+          subschema = schema.subschema("bar")
+
+          assert_equal subschema.fields, %w[something_else my_string]
+        end
+      end
+
+      describe "when an invalid subschema is given" do
+        let(:body) do
+          {
+            "properties" => {
+              "foo" => {
+                "type" => "string",
+              },
+              "bar" => {
+                "type" => "object",
+                "properties" => {
+                  "my_string" => {
+                    "type" => "string",
+                  },
+                  "something_else" => {
+                    "type" => "string",
+                  },
+                },
+              },
+            },
+          }
+        end
+
+        it "raises an error" do
+          assert_raises ArgumentError, "Subschema `bar` is invalid" do
+            schema.subschema("bar")
+          end
+        end
+      end
+    end
+  end
+
   describe ".permitted_params" do
     it "returns permitted params" do
       assert_equal schema.permitted_params, %w[foo bar]
@@ -33,6 +140,7 @@ class ContentBlockManager::SchemaTest < ActiveSupport::TestCase
       assert_equal ContentBlockManager::ContentBlock::Schema.valid_schemas, %w[
         email_address
         postal_address
+        pension
       ]
     end
   end


### PR DESCRIPTION
This allows us to pull out an embedded schema from any properties that have a `type` of `object`. As we’re making some assumptions about the shape of a hash, we raise an error if the shape is not what we expect.

Additionally, we remove any embedded objects from the `fields` method, so a pension object can be created without any rates.