### PR TITLE
WIP add search index method to landing page

### DIFF
--- a/app/models/landing_page.rb
+++ b/app/models/landing_page.rb
@@ -41,6 +41,10 @@ class LandingPage < Edition
     end
   end
 
+  def search_index
+    {}
+  end
+
 private
 
   def base_path_must_not_be_taken


### PR DESCRIPTION
*Draft because I haven't worked out how to test this, or whether it's best to just nuke the Attachable include*

This is needed because the Attachable module assumes that the class its attached to has a search_index method, which landing page doesn't. This usually comes from the Searchable module, but we don't need any of that behaviour.

Actually we don't need Attachable either, I don't think - I think it's a hangover from when we were attaching CSVs to use for line graphs. But we're not doing line graphs now. We could remove it, but I'm slightly nervous about breaking something.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
