### PR TITLE
(867) Allow embedded objects to be created

### DIFF
--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/embedded_objects/form_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/embedded_objects/form_component.rb
@@ -1,0 +1,22 @@
+class ContentBlockManager::ContentBlockEdition::Details::EmbeddedObjects::FormComponent < ContentBlockManager::ContentBlockEdition::Details::FormComponent
+  def initialize(content_block_edition:, schema:, object_name:, params:)
+    @content_block_edition = content_block_edition
+    @schema = schema
+    @object_name = object_name
+    @params = params || {}
+  end
+
+private
+
+  attr_reader :content_block_edition, :schema, :object_name, :params
+
+  def component_args(field)
+    {
+      content_block_edition:,
+      label: field.humanize,
+      field: "#{object_name}[#{field}]",
+      id_suffix: "#{object_name}_#{field}",
+      value: params[field],
+    }
+  end
+end

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/base_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/base_component.rb
@@ -34,4 +34,12 @@ private
   def error_items
     errors_for(content_block_edition.errors, "details_#{@id_suffix || field}".to_sym)
   end
+
+  def hint
+    I18n.t("content_block_edition.details.hints.#{translation_lookup}", default: nil)
+  end
+
+  def translation_lookup
+    @id_suffix ? @id_suffix.gsub("_", ".") : field
+  end
 end

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/enum_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/enum_component.html.erb
@@ -1,0 +1,10 @@
+<%= render "govuk_publishing_components/components/select", {
+  label:,
+  name:,
+  id:,
+  value:,
+  hint:,
+  options:,
+  error_message:,
+  full_width: true,
+} %>

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/enum_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/enum_component.rb
@@ -1,0 +1,22 @@
+class ContentBlockManager::ContentBlockEdition::Details::Fields::EnumComponent < ContentBlockManager::ContentBlockEdition::Details::Fields::BaseComponent
+  def initialize(enum:, **args)
+    @enum = enum
+    super(**args)
+  end
+
+private
+
+  def options
+    ["", @enum].flatten.map do |item|
+      {
+        text: item.humanize,
+        value: item,
+        selected: item == value,
+      }
+    end
+  end
+
+  def error_message
+    error_items&.first&.fetch(:text)
+  end
+end

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/string_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/string_component.html.erb
@@ -6,4 +6,5 @@
   id:,
   value:,
   error_items:,
+  hint:,
 } %>

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/form_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/form_component.rb
@@ -12,9 +12,15 @@ private
     format = @schema.body.dig("properties", field, "type")
     if format == "string"
       ContentBlockManager::ContentBlockEdition::Details::Fields::StringComponent.new(
-        content_block_edition:,
-        field:,
+        **component_args(field),
       )
     end
+  end
+
+  def component_args(field)
+    {
+      content_block_edition:,
+      field:,
+    }
   end
 end

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/form_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/form_component.rb
@@ -11,9 +11,16 @@ private
   def component_for_field(field)
     format = @schema.body.dig("properties", field, "type")
     if format == "string"
-      ContentBlockManager::ContentBlockEdition::Details::Fields::StringComponent.new(
-        **component_args(field),
-      )
+      enum = @schema.body.dig("properties", field, "enum")
+      if enum
+        ContentBlockManager::ContentBlockEdition::Details::Fields::EnumComponent.new(
+          **component_args(field).merge(enum:),
+        )
+      else
+        ContentBlockManager::ContentBlockEdition::Details::Fields::StringComponent.new(
+          **component_args(field),
+        )
+      end
     end
   end
 

--- a/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/documents/schedule_controller.rb
+++ b/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/documents/schedule_controller.rb
@@ -8,11 +8,7 @@ class ContentBlockManager::ContentBlock::Documents::ScheduleController < Content
 
   def update
     document = ContentBlockManager::ContentBlock::Document.find(params[:document_id])
-    previous_edition = document.latest_edition
-    @content_block_edition = previous_edition.dup
-    @content_block_edition.state = "draft"
-    @content_block_edition.organisation = previous_edition.lead_organisation
-    @content_block_edition.creator = current_user
+    @content_block_edition = document.latest_edition.clone_edition(creator: current_user)
 
     validate_scheduled_edition
 

--- a/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/embedded_objects_controller.rb
+++ b/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/embedded_objects_controller.rb
@@ -1,0 +1,38 @@
+class ContentBlockManager::ContentBlock::EmbeddedObjectsController < ContentBlockManager::BaseController
+  before_action :initialize_document_and_schema
+
+  def new
+    @content_block_edition = @content_block_document.latest_edition
+  end
+
+  def create
+    @content_block_edition = @content_block_document.latest_edition.clone_edition(creator: current_user)
+    @params = object_params.dig(:details, @subschema.block_type)
+    @content_block_edition.add_object_to_details(@subschema.block_type, @params)
+    @content_block_edition.save!
+
+    ContentBlockManager::PublishEditionService.new.call(@content_block_edition)
+    flash[:notice] = "#{@subschema.name.singularize} created"
+    redirect_to content_block_manager.content_block_manager_content_block_document_path(@content_block_document)
+  rescue ActiveRecord::RecordInvalid
+    render :new
+  end
+
+private
+
+  def initialize_document_and_schema
+    @content_block_document = ContentBlockManager::ContentBlock::Document.find(params[:document_id])
+    @schema = ContentBlockManager::ContentBlock::Schema.find_by_block_type(@content_block_document.block_type)
+    @subschema = @schema.subschema(params[:object_type])
+
+    render "admin/errors/not_found", status: :not_found unless @subschema
+  end
+
+  def object_params
+    params.require("content_block/edition").permit(
+      details: {
+        @subschema.block_type.to_s => @subschema.permitted_params,
+      },
+    )
+  end
+end

--- a/lib/engines/content_block_manager/app/models/content_block_manager/content_block/edition.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/content_block/edition.rb
@@ -30,6 +30,13 @@ module ContentBlockManager
           details:,
         ).render
       end
+
+      def add_object_to_details(object_type, body)
+        key = body["name"]&.parameterize.presence || SecureRandom.alphanumeric.downcase
+
+        details[object_type] ||= {}
+        details[object_type][key] = body.to_h
+      end
     end
   end
 end

--- a/lib/engines/content_block_manager/app/models/content_block_manager/content_block/edition.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/content_block/edition.rb
@@ -31,6 +31,15 @@ module ContentBlockManager
         ).render
       end
 
+      def clone_edition(creator:)
+        new_edition = dup
+        new_edition.state = "draft"
+        new_edition.organisation = lead_organisation
+        new_edition.creator = creator
+
+        new_edition
+      end
+
       def add_object_to_details(object_type, body)
         key = body["name"]&.parameterize.presence || SecureRandom.alphanumeric.downcase
 

--- a/lib/engines/content_block_manager/app/models/content_block_manager/content_block/schema.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/content_block/schema.rb
@@ -6,8 +6,26 @@ module ContentBlockManager
       VALID_SCHEMAS = %w[email_address postal_address pension].freeze
       private_constant :VALID_SCHEMAS
 
-      def self.valid_schemas
-        VALID_SCHEMAS
+      class << self
+        def valid_schemas
+          VALID_SCHEMAS
+        end
+
+        def all
+          @all ||= Services.publishing_api.get_schemas.select { |k, _v|
+            is_valid_schema?(k)
+          }.map { |id, full_schema|
+            full_schema.dig("definitions", "details")&.yield_self { |schema| new(id, schema) }
+          }.compact
+        end
+
+        def find_by_block_type(block_type)
+          all.find { |schema| schema.block_type == block_type } || raise(ArgumentError, "Cannot find schema for #{block_type}")
+        end
+
+        def is_valid_schema?(key)
+          key.start_with?(SCHEMA_PREFIX) && key.end_with?(*valid_schemas)
+        end
       end
 
       attr_reader :id, :body
@@ -29,8 +47,8 @@ module ContentBlockManager
         (@body["properties"].to_a - embedded_objects.to_a).to_h.keys
       end
 
-      def embedded_objects
-        @body["properties"].select { |_k, v| v["type"] == "object" }
+      def subschema(name)
+        subschemas.find { |s| s.id == name }
       end
 
       def permitted_params
@@ -41,20 +59,29 @@ module ContentBlockManager
         @block_type ||= id.delete_prefix("#{SCHEMA_PREFIX}_")
       end
 
-      def self.all
-        @all ||= Services.publishing_api.get_schemas.select { |k, _v|
-          is_valid_schema?(k)
-        }.map { |id, full_schema|
-          full_schema.dig("definitions", "details")&.yield_self { |schema| new(id, schema) }
-        }.compact
+      class EmbeddedSchema < Schema
+        def initialize(id, body)
+          body = body["patternProperties"]&.values&.first || raise(ArgumentError, "Subschema `#{id}` is invalid")
+          super(id, body)
+        end
+
+        def fields
+          @body["properties"].keys.sort_by { |field| @body["order"]&.index(field) }
+        end
+
+        def block_type
+          @id
+        end
       end
 
-      def self.find_by_block_type(block_type)
-        all.find { |schema| schema.block_type == block_type } || raise(ArgumentError, "Cannot find schema for #{block_type}")
+    private
+
+      def embedded_objects
+        @body["properties"].select { |_k, v| v["type"] == "object" }
       end
 
-      def self.is_valid_schema?(key)
-        key.start_with?(SCHEMA_PREFIX) && key.end_with?(*valid_schemas)
+      def subschemas
+        @subschemas ||= embedded_objects.map { |object| EmbeddedSchema.new(*object) }
       end
     end
   end

--- a/lib/engines/content_block_manager/app/validators/content_block_manager/details_validator.rb
+++ b/lib/engines/content_block_manager/app/validators/content_block_manager/details_validator.rb
@@ -7,7 +7,7 @@ class ContentBlockManager::DetailsValidator < ActiveModel::Validator
     errors.each do |e|
       if e["type"] == "required"
         add_blank_errors(e)
-      elsif e["type"] == "format"
+      elsif %w[format pattern].include?(e["type"])
         add_format_errors(e)
       end
     end

--- a/lib/engines/content_block_manager/app/validators/content_block_manager/details_validator.rb
+++ b/lib/engines/content_block_manager/app/validators/content_block_manager/details_validator.rb
@@ -16,20 +16,40 @@ class ContentBlockManager::DetailsValidator < ActiveModel::Validator
   def add_blank_errors(error)
     missing_keys = error.dig("details", "missing_keys") || []
     missing_keys.each do |k|
-      edition.errors.add("details_#{k}", :blank)
+      key = key_with_optional_prefix(error, k)
+      edition.errors.add(
+        "details_#{key}",
+        I18n.t("activerecord.errors.models.content_block_manager/content_block/edition.blank", attribute: k.humanize),
+      )
     end
   end
 
   def add_format_errors(error)
-    key = error["data_pointer"].delete_prefix("/")
-    edition.errors.add("details_#{key}", :invalid)
+    data_pointer = error["data_pointer"].delete_prefix("/")
+    field_items = data_pointer.split("/")
+    attribute = field_items.last
+    key = field_items.count > 1 ? "#{field_items.first}_#{attribute}" : attribute
+    edition.errors.add(
+      "details_#{key}",
+      I18n.t("activerecord.errors.models.content_block_manager/content_block/edition.invalid", attribute: attribute.humanize),
+    )
   end
 
   def validate_with_schema(edition)
     # Fetch the details and remove any blank fields (JSONSchema classes an empty string as valid,
     # unless a specific format has been specified)
-    details = edition.details.compact_blank
+    details = compact_nested(edition.details)
     schemer = JSONSchemer.schema(edition.schema.body)
     schemer.validate(details)
+  end
+
+private
+
+  def compact_nested(details)
+    details.compact_blank.map { |k, v| v.is_a?(Hash) ? [k, compact_nested(v)] : [k, v] }.to_h
+  end
+
+  def key_with_optional_prefix(error, key)
+    error["data_pointer"].present? ? "#{error['data_pointer'].split('/')[1]}_#{key}" : key
   end
 end

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/embedded_objects/new.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/embedded_objects/new.html.erb
@@ -1,0 +1,39 @@
+<% content_for :context, @content_block_document.title %>
+<% content_for :title, "Create #{@subschema.name.singularize.downcase}" %>
+
+<% content_for :back_link do %>
+  <%= render "govuk_publishing_components/components/back_link", {
+    href: content_block_manager.content_block_manager_content_block_document_path(@content_block_document),
+  } %>
+<% end %>
+
+<% if @content_block_edition %>
+  <% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @content_block_edition, parent_class: "content_block_manager_content_block_edition")) %>
+<% end %>
+
+<%= form_with url: content_block_manager.content_block_manager_content_block_document_embedded_objects_url(document_id: @content_block_document.id), method: :post do |form| %>
+  <%= form.hidden_field :object_type, value: @subschema.block_type %>
+
+  <%=
+    render ContentBlockManager::ContentBlockEdition::Details::EmbeddedObjects::FormComponent.new(
+      content_block_edition: @content_block_edition,
+      schema: @subschema,
+      object_name: @subschema.block_type,
+      params: @params,
+    )
+  %>
+
+  <div class="govuk-button-group govuk-!-margin-bottom-6">
+    <%= render "govuk_publishing_components/components/button", {
+      text: "Save and continue",
+      name: "save_and_continue",
+      value: "Save and continue",
+      type: "submit",
+    } %>
+    <%= render "govuk_publishing_components/components/button", {
+      text: "Cancel",
+      href: content_block_manager.content_block_manager_content_block_document_path(@content_block_document),
+      secondary_solid: true,
+    } %>
+  </div>
+<% end %>

--- a/lib/engines/content_block_manager/config/locales/en.yml
+++ b/lib/engines/content_block_manager/config/locales/en.yml
@@ -51,3 +51,7 @@ en:
     review_page:
       errors:
         confirm: Tick box to confirm details are correct
+    details:
+      hints:
+        rates:
+          amount: "Enter an exact amount, with the currency symbol - for example: £122.50"

--- a/lib/engines/content_block_manager/config/routes.rb
+++ b/lib/engines/content_block_manager/config/routes.rb
@@ -11,6 +11,7 @@ ContentBlockManager::Engine.routes.draw do
           post :new_document_options_redirect
         end
         resources :editions, only: %i[new create]
+        resources :embedded_objects, only: %i[new create], path_names: { new: ":object_type/new" }
         get "schedule/edit", to: "documents/schedule#edit", as: :schedule_edit
         put "schedule", to: "documents/schedule#update", as: :update_schedule
         patch "schedule", to: "documents/schedule#update"

--- a/lib/engines/content_block_manager/features/create_embedded_object.feature
+++ b/lib/engines/content_block_manager/features/create_embedded_object.feature
@@ -16,7 +16,7 @@ Feature: Create an embedded content object
     When I visit the page to create a new "rate" for the block
     Then I should see a form to create a "rate" for the content block
     When I complete the "rate" form with the following fields:
-      | name    | amount |
-      | my rate | 122.50 |
+      | name    | amount  |
+      | my rate | £122.50 |
     Then the "rate" should have been created successfully
     And I should see confirmation that my "rate" has been created

--- a/lib/engines/content_block_manager/features/create_embedded_object.feature
+++ b/lib/engines/content_block_manager/features/create_embedded_object.feature
@@ -21,3 +21,15 @@ Feature: Create an embedded content object
       | my rate | £122.50 | weekly  |
     Then the "rate" should have been created successfully
     And I should see confirmation that my "rate" has been created
+
+  Scenario: GDS editor sees validation errors for required fields
+    When I visit the page to create a new "rate" for the block
+    And I click save
+    Then I should see errors for the required "rate" fields
+
+  Scenario: GDS editor sees validation errors for an invalid field
+    When I visit the page to create a new "rate" for the block
+    When I complete the "rate" form with the following fields:
+      | name    | amount        | cadence |
+      | my rate | NOT AN AMOUNT | weekly  |
+    Then I should see an error for an invalid "amount"

--- a/lib/engines/content_block_manager/features/create_embedded_object.feature
+++ b/lib/engines/content_block_manager/features/create_embedded_object.feature
@@ -7,16 +7,17 @@ Feature: Create an embedded content object
       | field         | type   | format | required |
       | description   | string | string | true     |
     And the schema "pension" has a subschema with the name "rates" and the following fields:
-      | field  | type   | format | required |
-      | name   | string | string | true     |
-      | amount | string | string | true     |
+      | field     | type   | format | required | enum           | pattern          |
+      | name      | string | string | true     |                |                  |
+      | amount    | string | string | true     |                | £[0-9]+\\.[0-9]+ |
+      | cadence   | string | string |          | weekly,monthly |                  |
     And a pension content block has been created
 
   Scenario: GDS editor creates a rate
     When I visit the page to create a new "rate" for the block
     Then I should see a form to create a "rate" for the content block
     When I complete the "rate" form with the following fields:
-      | name    | amount  |
-      | my rate | £122.50 |
+      | name    | amount  | cadence |
+      | my rate | £122.50 | weekly  |
     Then the "rate" should have been created successfully
     And I should see confirmation that my "rate" has been created

--- a/lib/engines/content_block_manager/features/create_embedded_object.feature
+++ b/lib/engines/content_block_manager/features/create_embedded_object.feature
@@ -1,0 +1,22 @@
+Feature: Create an embedded content object
+
+  Background:
+    Given I am a GDS admin
+    And the organisation "Ministry of Example" exists
+    And a schema "pension" exists with the following fields:
+      | field         | type   | format | required |
+      | description   | string | string | true     |
+    And the schema "pension" has a subschema with the name "rates" and the following fields:
+      | field  | type   | format | required |
+      | name   | string | string | true     |
+      | amount | string | string | true     |
+    And a pension content block has been created
+
+  Scenario: GDS editor creates a rate
+    When I visit the page to create a new "rate" for the block
+    Then I should see a form to create a "rate" for the content block
+    When I complete the "rate" form with the following fields:
+      | name    | amount |
+      | my rate | 122.50 |
+    Then the "rate" should have been created successfully
+    And I should see confirmation that my "rate" has been created

--- a/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
@@ -185,6 +185,23 @@ Given("an email address content block has been created") do
   @content_blocks.push(@content_block)
 end
 
+Given("a pension content block has been created") do
+  @content_blocks ||= []
+  organisation = create(:organisation)
+  @content_block = create(
+    :content_block_edition,
+    :pension,
+    details: { description: "Some text" },
+    creator: @user,
+    organisation:,
+    title: "My pension",
+  )
+  ContentBlockManager::ContentBlock::Edition::HasAuditTrail.acting_as(@user) do
+    @content_block.publish!
+  end
+  @content_blocks.push(@content_block)
+end
+
 Given(/^([^"]*) content blocks of type ([^"]*) have been created with the fields:$/) do |count, block_type, table|
   fields = table.rows_hash
   organisation_name = fields.delete("organisation")

--- a/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
@@ -485,3 +485,9 @@ And(/^I update the content block and publish$/) do
   publish_now
   review_and_confirm
 end
+
+Then("I should see an error for an invalid {string}") do |attribute|
+  expect(page).to have_content(
+    I18n.t("activerecord.errors.models.content_block_manager/content_block/edition.invalid", attribute: attribute.humanize),
+  )
+end

--- a/lib/engines/content_block_manager/features/step_definitions/embedded_object_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/embedded_object_steps.rb
@@ -17,7 +17,12 @@ When("I complete the {string} form with the following fields:") do |object_type,
   fields = table.hashes.first
   @details = fields
   fields.keys.each do |k|
-    fill_in "content_block_manager_content_block_edition_details_#{object_type.pluralize}_#{k}", with: @details[k]
+    field = find_field "content_block_manager_content_block_edition_details_#{object_type.pluralize}_#{k}"
+    if field.tag_name == "select"
+      select @details[k].humanize, from: field[:id]
+    else
+      fill_in field[:id], with: @details[k]
+    end
   end
 
   click_save_and_continue

--- a/lib/engines/content_block_manager/features/step_definitions/embedded_object_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/embedded_object_steps.rb
@@ -1,0 +1,36 @@
+When("I visit the page to create a new {string} for the block") do |object_type|
+  visit content_block_manager.new_content_block_manager_content_block_document_embedded_object_path(
+    document_id: @content_block.document.id,
+    object_type: object_type.pluralize,
+  )
+end
+
+Then("I should see a form to create a {string} for the content block") do |object_type|
+  expect(page).to have_text("Create #{object_type}")
+end
+
+Then("I should see confirmation that my {string} has been created") do |object_type|
+  expect(page).to have_text("#{object_type.titleize} created")
+end
+
+When("I complete the {string} form with the following fields:") do |object_type, table|
+  fields = table.hashes.first
+  @details = fields
+  fields.keys.each do |k|
+    fill_in "content_block_manager_content_block_edition_details_#{object_type.pluralize}_#{k}", with: @details[k]
+  end
+
+  click_save_and_continue
+end
+
+Then("the {string} should have been created successfully") do |object_type|
+  edition = ContentBlockManager::ContentBlock::Edition.all.last
+
+  assert_not_nil edition
+  assert_not_nil edition.document
+  key = @details["name"].parameterize
+
+  @details.keys.each do |k|
+    assert_equal edition.details[object_type.parameterize.pluralize][key][k], @details[k]
+  end
+end

--- a/lib/engines/content_block_manager/features/step_definitions/embedded_object_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/embedded_object_steps.rb
@@ -39,3 +39,11 @@ Then("the {string} should have been created successfully") do |object_type|
     assert_equal edition.details[object_type.parameterize.pluralize][key][k], @details[k]
   end
 end
+
+Then("I should see errors for the required {string} fields") do |object_type|
+  schema = @schemas.values.first.subschema(object_type.pluralize)
+  required_fields = schema.body["required"]
+  required_fields.each do |required_field|
+    assert_text "#{ContentBlockManager::ContentBlock::Edition.human_attribute_name("details_#{required_field}")} cannot be blank", minimum: 2
+  end
+end

--- a/lib/engines/content_block_manager/features/support/schema_helpers.rb
+++ b/lib/engines/content_block_manager/features/support/schema_helpers.rb
@@ -4,7 +4,7 @@ def create_schema(fields)
     "required" => fields.select { |f| f["required"] == "true" }.map { |f| f["field"] },
     "additionalProperties" => false,
     "properties" => fields.map { |f|
-      [f["field"], { "type" => f["type"], "format" => f["format"] }]
+      [f["field"], { "type" => f["type"], "format" => f["format"], "enum" => f["enum"]&.split(","), "pattern" => f["pattern"] }.compact_blank!]
     }.to_h,
   }
 end

--- a/lib/engines/content_block_manager/features/support/schema_helpers.rb
+++ b/lib/engines/content_block_manager/features/support/schema_helpers.rb
@@ -1,0 +1,10 @@
+def create_schema(fields)
+  {
+    "type" => "object",
+    "required" => fields.select { |f| f["required"] == "true" }.map { |f| f["field"] },
+    "additionalProperties" => false,
+    "properties" => fields.map { |f|
+      [f["field"], { "type" => f["type"], "format" => f["format"] }]
+    }.to_h,
+  }
+end

--- a/lib/engines/content_block_manager/test/components/content_block/edition/details/embedded_objects/form_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/details/embedded_objects/form_component_test.rb
@@ -1,0 +1,90 @@
+require "test_helper"
+
+class ContentBlockManager::ContentBlockEdition::Details::EmbeddedObjects::FormComponentTest < ViewComponent::TestCase
+  extend Minitest::Spec::DSL
+
+  let(:body) do
+    {
+      "type" => "object",
+      "required" => %w[foo bar],
+      "additionalProperties" => false,
+      "properties" => {
+        "foo" => {
+          "type" => "string",
+        },
+        "bar" => {
+          "type" => "string",
+        },
+      },
+    }
+  end
+
+  let(:content_block_edition) { build(:content_block_edition) }
+  let(:schema) { build(:content_block_schema, body:) }
+
+  let(:foo_stub) { stub("string_component") }
+  let(:bar_stub) { stub("string_component") }
+  let(:object_name) { "some_object" }
+
+  it "renders fields for each property" do
+    ContentBlockManager::ContentBlockEdition::Details::Fields::StringComponent.expects(:new).with(
+      content_block_edition:,
+      label: "Foo",
+      field: "#{object_name}[foo]",
+      id_suffix: "#{object_name}_foo",
+      value: nil,
+    ).returns(foo_stub)
+
+    ContentBlockManager::ContentBlockEdition::Details::Fields::StringComponent.expects(:new).with(
+      content_block_edition:,
+      label: "Bar",
+      field: "#{object_name}[bar]",
+      id_suffix: "#{object_name}_bar",
+      value: nil,
+    ).returns(bar_stub)
+
+    component = ContentBlockManager::ContentBlockEdition::Details::EmbeddedObjects::FormComponent.new(
+      content_block_edition:,
+      schema:,
+      object_name:,
+      params: nil,
+    )
+
+    component.expects(:render).with(foo_stub)
+    component.expects(:render).with(bar_stub)
+
+    render_inline(component)
+  end
+
+  it "sends the value of a field if present in the params argument" do
+    params = { "foo" => "something" }
+
+    ContentBlockManager::ContentBlockEdition::Details::Fields::StringComponent.expects(:new).with(
+      content_block_edition:,
+      label: "Foo",
+      field: "#{object_name}[foo]",
+      id_suffix: "#{object_name}_foo",
+      value: "something",
+    ).returns(foo_stub)
+
+    ContentBlockManager::ContentBlockEdition::Details::Fields::StringComponent.expects(:new).with(
+      content_block_edition:,
+      label: "Bar",
+      field: "#{object_name}[bar]",
+      id_suffix: "#{object_name}_bar",
+      value: nil,
+    ).returns(bar_stub)
+
+    component = ContentBlockManager::ContentBlockEdition::Details::EmbeddedObjects::FormComponent.new(
+      content_block_edition:,
+      schema:,
+      object_name:,
+      params:,
+    )
+
+    component.expects(:render).with(foo_stub)
+    component.expects(:render).with(bar_stub)
+
+    render_inline(component)
+  end
+end

--- a/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/enum_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/enum_component_test.rb
@@ -1,0 +1,62 @@
+require "test_helper"
+
+class ContentBlockManager::ContentBlockEdition::Details::Fields::EnumComponentTest < ViewComponent::TestCase
+  extend Minitest::Spec::DSL
+
+  let(:content_block_edition) { build(:content_block_edition, :email_address) }
+
+  it "should render an select field with default parameters" do
+    render_inline(
+      ContentBlockManager::ContentBlockEdition::Details::Fields::EnumComponent.new(
+        content_block_edition:,
+        field: "something",
+        enum: %w[item_1 item_2],
+      ),
+    )
+
+    expected_name = "content_block/edition[details][something]"
+    expected_id = "#{ContentBlockManager::ContentBlockEdition::Details::Fields::BaseComponent::PARENT_CLASS}_details_something"
+
+    assert_selector "label", text: "Something"
+    assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"]"
+    assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"] option[value=\"\"]"
+    assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"] option[value=\"item_1\"]", text: "Item 1"
+    assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"] option[value=\"item_2\"]", text: "Item 2"
+  end
+
+  it "should show an option as selected when value is given" do
+    render_inline(
+      ContentBlockManager::ContentBlockEdition::Details::Fields::EnumComponent.new(
+        content_block_edition:,
+        field: "something",
+        enum: %w[item_1 item_2],
+        value: "item_1",
+      ),
+    )
+
+    expected_name = "content_block/edition[details][something]"
+    expected_id = "#{ContentBlockManager::ContentBlockEdition::Details::Fields::BaseComponent::PARENT_CLASS}_details_something"
+
+    assert_selector "label", text: "Something"
+    assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"]"
+    assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"] option[value=\"\"]"
+    assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"] option[value=\"item_1\"][selected]", text: "Item 1"
+    assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"] option[value=\"item_2\"]", text: "Item 2"
+  end
+
+  it "should show errors when present" do
+    content_block_edition.errors.add(:details_something, "Some error goes here")
+
+    render_inline(
+      ContentBlockManager::ContentBlockEdition::Details::Fields::EnumComponent.new(
+        content_block_edition:,
+        field: "something",
+        enum: [],
+      ),
+    )
+
+    assert_selector ".govuk-form-group--error"
+    assert_selector ".govuk-error-message", text: "Some error goes here"
+    assert_selector "select.govuk-select--error"
+  end
+end

--- a/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/string_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/string_component_test.rb
@@ -59,4 +59,35 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::StringComponent
 
     assert_selector 'input[value="some custom value"]'
   end
+
+  describe "hints" do
+    it "should render hint text when a translation exists" do
+      I18n.expects(:t).with("content_block_edition.details.hints.email_address", default: nil).returns("Some hint text")
+
+      render_inline(
+        ContentBlockManager::ContentBlockEdition::Details::Fields::StringComponent.new(
+          content_block_edition:,
+          field: "email_address",
+          value: "some custom value",
+        ),
+      )
+
+      assert_selector ".govuk-hint", text: "Some hint text"
+    end
+
+    it "should use the id_suffix for the hint text when provided" do
+      I18n.expects(:t).with("content_block_edition.details.hints.my.suffix", default: nil).returns("Some hint text")
+
+      render_inline(
+        ContentBlockManager::ContentBlockEdition::Details::Fields::StringComponent.new(
+          content_block_edition:,
+          field: "email_address",
+          value: "some custom value",
+          id_suffix: "my_suffix",
+        ),
+      )
+
+      assert_selector ".govuk-hint", text: "Some hint text"
+    end
+  end
 end

--- a/lib/engines/content_block_manager/test/components/content_block/edition/details/form_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/details/form_component_test.rb
@@ -15,6 +15,10 @@ class ContentBlockManager::ContentBlockEdition::Details::FormComponentTest < Vie
         "bar" => {
           "type" => "string",
         },
+        "baz" => {
+          "type" => "string",
+          "enum" => %w[some enum],
+        },
       },
     }
   end
@@ -25,6 +29,7 @@ class ContentBlockManager::ContentBlockEdition::Details::FormComponentTest < Vie
   it "renders fields for each property" do
     foo_stub = stub("string_component")
     bar_stub = stub("string_component")
+    baz_stub = stub("string_component")
 
     ContentBlockManager::ContentBlockEdition::Details::Fields::StringComponent.expects(:new).with(
       content_block_edition:,
@@ -36,6 +41,12 @@ class ContentBlockManager::ContentBlockEdition::Details::FormComponentTest < Vie
       field: "bar",
     ).returns(bar_stub)
 
+    ContentBlockManager::ContentBlockEdition::Details::Fields::EnumComponent.expects(:new).with(
+      content_block_edition:,
+      field: "baz",
+      enum: %w[some enum],
+    ).returns(baz_stub)
+
     component = ContentBlockManager::ContentBlockEdition::Details::FormComponent.new(
       content_block_edition:,
       schema:,
@@ -43,6 +54,7 @@ class ContentBlockManager::ContentBlockEdition::Details::FormComponentTest < Vie
 
     component.expects(:render).with(foo_stub)
     component.expects(:render).with(bar_stub)
+    component.expects(:render).with(baz_stub)
 
     render_inline(component)
   end

--- a/lib/engines/content_block_manager/test/unit/app/models/content_block_edition_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/models/content_block_edition_test.rb
@@ -201,7 +201,7 @@ class ContentBlockManager::ContentBlockEditionTest < ActiveSupport::TestCase
 
     it "appends to the object if it already exists" do
       content_block_edition.details["something"] = {
-        "another-thing" => {}
+        "another-thing" => {},
       }
 
       content_block_edition.add_object_to_details("something", { "name" => "My thing", "something" => "else" })
@@ -213,6 +213,27 @@ class ContentBlockManager::ContentBlockEditionTest < ActiveSupport::TestCase
       content_block_edition.add_object_to_details("something", { "something" => "else" })
 
       assert_equal content_block_edition.details["something"], { "random-string" => { "something" => "else" } }
+    end
+  end
+
+  describe "#clone_edition" do
+    it "clones an edition in draft with the specified creator" do
+      content_block_edition = create(
+        :content_block_edition, :email_address,
+        title: "Some title",
+        details: { "my" => "details" },
+        state: "published"
+      )
+      creator = create(:user)
+
+      new_edition = content_block_edition.clone_edition(creator:)
+
+      assert_equal new_edition.state, "draft"
+      assert_nil new_edition.id
+      assert_equal new_edition.organisation, content_block_edition.lead_organisation
+      assert_equal new_edition.creator, creator
+      assert_equal new_edition.title, content_block_edition.title
+      assert_equal new_edition.details, content_block_edition.details
     end
   end
 end

--- a/lib/engines/content_block_manager/test/unit/app/models/content_block_edition_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/models/content_block_edition_test.rb
@@ -191,4 +191,28 @@ class ContentBlockManager::ContentBlockEditionTest < ActiveSupport::TestCase
       assert_equal content_block_edition.render, rendered_response
     end
   end
+
+  describe "#add_object_to_details" do
+    it "adds an object with the correct key to the details hash" do
+      content_block_edition.add_object_to_details("something", { "name" => "My thing", "something" => "else" })
+
+      assert_equal content_block_edition.details["something"], { "my-thing" => { "name" => "My thing", "something" => "else" } }
+    end
+
+    it "appends to the object if it already exists" do
+      content_block_edition.details["something"] = {
+        "another-thing" => {}
+      }
+
+      content_block_edition.add_object_to_details("something", { "name" => "My thing", "something" => "else" })
+      assert_equal content_block_edition.details["something"], { "another-thing" => {}, "my-thing" => { "name" => "My thing", "something" => "else" } }
+    end
+
+    it "creates a random key if a name is not provided" do
+      SecureRandom.expects(:alphanumeric).returns("RANDOM-STRING")
+      content_block_edition.add_object_to_details("something", { "something" => "else" })
+
+      assert_equal content_block_edition.details["something"], { "random-string" => { "something" => "else" } }
+    end
+  end
 end

--- a/lib/engines/content_block_manager/test/unit/app/validators/details_validator_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/validators/details_validator_test.rb
@@ -127,6 +127,37 @@ class ContentBlockManager::DetailsValidatorTest < ActiveSupport::TestCase
     assert_error errors:, key: :details_things_something_else, type: "invalid", attribute: "Something else"
   end
 
+  describe "validating against a regular expression" do
+    let(:body) do
+      {
+        "type" => "object",
+        "required" => %w[foo],
+        "additionalProperties" => false,
+        "properties" => {
+          "foo" => {
+            "type" => "string",
+            "pattern" => "£[0-9]+\\.[0-9]+",
+          },
+        },
+      }
+    end
+
+    it "returns an error if the pattern is incorrect" do
+      content_block_edition = build(
+        :content_block_edition,
+        :email_address,
+        details: {
+          foo: "1234",
+        },
+        schema:,
+      )
+
+      assert_equal content_block_edition.valid?, false
+      errors = content_block_edition.errors
+      assert_error errors:, key: :details_foo, type: "invalid", attribute: "Foo"
+    end
+  end
+
   def assert_error(errors:, key:, type:, attribute:)
     assert_equal errors[key], [I18n.t("activerecord.errors.models.content_block_manager/content_block/edition.#{type}", attribute:)]
   end

--- a/lib/engines/content_block_manager/test/unit/app/validators/details_validator_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/validators/details_validator_test.rb
@@ -17,6 +17,24 @@ class ContentBlockManager::DetailsValidatorTest < ActiveSupport::TestCase
           "type" => "string",
           "format" => "date",
         },
+        "things" => {
+          "type" => "object",
+          "patternProperties" => {
+            "^[a-z0-9]+(?:-[a-z0-9]+)*$" => {
+              "type" => "object",
+              "required" => %w[my_string],
+              "properties" => {
+                "my_string" => {
+                  "type" => "string",
+                },
+                "something_else" => {
+                  "type" => "string",
+                  "format" => "email",
+                },
+              },
+            },
+          },
+        },
       },
     }
   end
@@ -35,10 +53,10 @@ class ContentBlockManager::DetailsValidatorTest < ActiveSupport::TestCase
     )
 
     assert_equal content_block_edition.valid?, false
-    assert_equal content_block_edition.errors.full_messages, [
-      I18n.t("activerecord.errors.models.content_block_manager/content_block/edition.blank", attribute: "Foo"),
-      I18n.t("activerecord.errors.models.content_block_manager/content_block/edition.blank", attribute: "Bar"),
-    ]
+    errors = content_block_edition.errors
+
+    assert_error errors:, key: :details_foo, type: "blank", attribute: "Foo"
+    assert_error errors:, key: :details_bar, type: "blank", attribute: "Bar"
   end
 
   test "it validates the format of fields" do
@@ -53,9 +71,63 @@ class ContentBlockManager::DetailsValidatorTest < ActiveSupport::TestCase
     )
 
     assert_equal content_block_edition.valid?, false
-    assert_equal content_block_edition.errors.full_messages, [
-      I18n.t("activerecord.errors.models.content_block_manager/content_block/edition.invalid", attribute: "Foo"),
-      I18n.t("activerecord.errors.models.content_block_manager/content_block/edition.invalid", attribute: "Bar"),
-    ]
+    errors = content_block_edition.errors
+
+    assert_equal errors.count, 2
+    assert_error errors:, key: :details_foo, type: "invalid", attribute: "Foo"
+    assert_error errors:, key: :details_bar, type: "invalid", attribute: "Bar"
+  end
+
+  it "validates the presence of nested fields in nested objects" do
+    content_block_edition = build(
+      :content_block_edition,
+      :email_address,
+      details: {
+        foo: "foo@example.com",
+        bar: "2022-01-01",
+        things: {
+          "something-else": {
+            my_string: "",
+            something_else: "",
+          },
+        },
+      },
+      schema:,
+    )
+
+    assert_equal content_block_edition.valid?, false
+
+    errors = content_block_edition.errors
+
+    assert_equal errors.count, 1
+    assert_error errors:, key: :details_things_my_string, type: "blank", attribute: "My string"
+  end
+
+  it "validates the format of nested fields in nested objects" do
+    content_block_edition = build(
+      :content_block_edition,
+      :email_address,
+      details: {
+        foo: "foo@example.com",
+        bar: "2022-01-01",
+        things: {
+          "something-else": {
+            my_string: "something",
+            something_else: "Not an email",
+          },
+        },
+      },
+      schema:,
+    )
+
+    assert_equal content_block_edition.valid?, false
+
+    errors = content_block_edition.errors
+
+    assert_error errors:, key: :details_things_something_else, type: "invalid", attribute: "Something else"
+  end
+
+  def assert_error(errors:, key:, type:, attribute:)
+    assert_equal errors[key], [I18n.t("activerecord.errors.models.content_block_manager/content_block/edition.#{type}", attribute:)]
   end
 end


### PR DESCRIPTION
Trello card: https://trello.com/c/tPWQl692/867-allow-embedded-objects-to-be-created-in-content-block-manager

This adds a new endpoint to create an embedded object if one exists. It's not (yet) linked from anywhere, and we don't have a confirmation screen, but this puts all the pieces in place for us to iterate on.

## Screenshots

![image](https://github.com/user-attachments/assets/2f9c5a51-6647-4973-b852-e146de6553c0)

![image](https://github.com/user-attachments/assets/0a867836-5137-48c7-a82c-2ded30e39647)
