### PR TITLE
Replace title component with heading on two views

### DIFF
--- a/app/views/admin/contact_translations/index.html.erb
+++ b/app/views/admin/contact_translations/index.html.erb
@@ -2,9 +2,12 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/title", {
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "New translation",
       context: @contact.title,
-      title: "New translation",
+      font_size: "xl",
+      heading_level: 1,
+      margin_bottom: 8,
     } %>
 
     <%= form_with url:admin_organisation_contact_translations_path(@contactable,@contact) do |form| %>

--- a/app/views/admin/edition_translations/new.html.erb
+++ b/app/views/admin/edition_translations/new.html.erb
@@ -6,9 +6,12 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/title", {
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "Add translation",
       context: @edition.title,
-      title: "Add translation",
+      font_size: "xl",
+      heading_level: 1,
+      margin_bottom: 8,
     } %>
 
     <%= form_with url: admin_edition_translations_path(@edition.id) do |form| %>

--- a/app/views/admin/edition_translations/new.html.erb
+++ b/app/views/admin/edition_translations/new.html.erb
@@ -1,8 +1,10 @@
 <% content_for :page_title, "Add translation" %>
 
-<%= render "govuk_publishing_components/components/back_link", {
-  href: admin_edition_path(@edition),
-} %>
+<% content_for :back_link do %>
+  <%= render "govuk_publishing_components/components/back_link", {
+    href: admin_edition_path(@edition),
+  } %>
+<% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/components/_select_with_search.html.erb
+++ b/app/views/components/_select_with_search.html.erb
@@ -13,7 +13,7 @@
 
 <%= content_tag :div, class: select_helper.css_classes, data: select_helper.data_attributes do %>
   <% if is_page_heading %>
-    <%= tag.h1 label_tag(id, label, class: select_helper.label_classes, id: "#{id}_label"), class: "gem-c-title__text" %>
+    <%= tag.h1 label_tag(id, label, class: select_helper.label_classes, id: "#{id}_label"), class: "govuk-heading-xl" %>
   <% else %>
     <%= label_tag(id, label, class: select_helper.label_classes, id: "#{id}_label") %>
   <% end %>


### PR DESCRIPTION
## What / Why
- Replaces the components gem `title` component with the `heading` component
- Trello card: https://trello.com/c/cYepys8K/476-replace-title-with-heading-in-whitehall
- Two of the changes are replacing component render statements. 
  - One of the templates required moving the `< Back` link out of the `<main>` element so that the spacing looked correct - it shouldn't be within the `<main>` otherwise that link sits too far down in the page.
- One of the commits is replacing a `gem-c-title__text` class with `gem-c-heading__text` in an app component. However this line of HTML isn't actually used anywhere in the repo - the rails boolean which renders this HTML ( `is_page_heading`) - is never set to `true` in any render statements. I wasn't sure if I should worry about removing functionality from the repo, especially as we don't own this app, so I've left it in, and just replaced the class. I think this change should be OK visually, because if you go to the [title component in our component guide 
](https://components.publishing.service.gov.uk/component-guide/title) and replace `gem-c-title__text` with `gem-c-heading__text` via `Inspect Element`, nothing visually changes, so theoretically nothing visual would change on this element either. CSS wise `.gem-c-title__text` and `.gem-c-heading__text` have minor differences, but I don't think it's enough to result in a major visual change.
- I've checked the changes on Integration.

## Pages to test if you'd like to test it yourself


### "Add translation" heading
- The "Add translation" heading exists when adding a new translation to a document. e.g. 
https://whitehall-admin.integration.publishing.service.gov.uk/government/admin/publications/1647318 - you might need to start a new draft first to see the add translation link

<img width="255" alt="image" src="https://github.com/user-attachments/assets/ddbb3a35-062d-47b9-b8eb-dda2ac1738eb" />
<img width="809" alt="image" src="https://github.com/user-attachments/assets/4f5d4d07-c03c-4452-82bf-1fded2beb2de" />

### "New translation" heading
- Create a new translation of the GDS organisation first if one doesn't exist: https://whitehall-admin.integration.publishing.service.gov.uk/government/admin/organisations/government-digital-service/translations
- Then on the Contacts tab, the contacts will have an "Add translation" link https://whitehall-admin.integration.publishing.service.gov.uk/government/admin/organisations/government-digital-service/contacts
- If you click on "Add translation", you get to the template with the change in this PR

<img width="587" alt="image" src="https://github.com/user-attachments/assets/3e548bdc-9068-48fa-be1a-6338411d47c4" />
<img width="624" alt="image" src="https://github.com/user-attachments/assets/c532de57-cdf5-4cf0-8614-bb9c2ba4d332" />


## Visual Changes

Everything moves up slightly, as the `title` component had some top padding, which will no longer exist.

| Before | After |
| --- | --- |
|<img width="956" alt="image" src="https://github.com/user-attachments/assets/3a3aa6ff-fadd-40b1-8e46-b0e020d55bdb" />|<img width="956" alt="image" src="https://github.com/user-attachments/assets/f61df956-cf36-428c-ab20-b1b928bf0d6c" />|
<img width="956" alt="image" src="https://github.com/user-attachments/assets/8910eccd-5285-49e0-a761-263047b4c6d5" />|<img width="956" alt="image" src="https://github.com/user-attachments/assets/aed465cc-dba3-43d5-b518-9d29599d8035" />|

