### PR TITLE
Make /government/get-involved an exact route

### DIFF
--- a/app/models/special_route.rb
+++ b/app/models/special_route.rb
@@ -7,7 +7,6 @@ class SpecialRoute
         title: "Government feed",
         description: "This route serves the feed of published content",
         rendering_app: Whitehall::RenderingApp::COLLECTIONS_FRONTEND,
-        type: "exact",
       },
       {
         base_path: "/government/get-involved",

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -14,8 +14,8 @@ namespace :publishing_api do
           format: "special_route",
           publishing_app: Whitehall::PublishingApp::WHITEHALL,
           update_type: "major",
-          type: "prefix",
           public_updated_at: Time.zone.now.iso8601,
+          type: "exact",
         }.merge(route),
       )
     end

--- a/test/unit/lib/tasks/publishing_api_test.rb
+++ b/test/unit/lib/tasks/publishing_api_test.rb
@@ -16,7 +16,7 @@ class PublishingApiRake < ActiveSupport::TestCase
           format: "special_route",
           publishing_app: Whitehall::PublishingApp::WHITEHALL,
           update_type: "major",
-          type: "prefix",
+          type: "exact",
           public_updated_at: Time.zone.now.iso8601,
         }
 


### PR DESCRIPTION
- The prefix route seems to be a hangover from when whitehall was rendering the Take Part items. These all now have their own content item, so anything under get-involved is either the get involved item or has its own route.
- Both of the SpecialRoute instances are now exact path, so make that the default in rake task and test, and remove it from the instances.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
