### PR TITLE
bump Content Block Tools 0.4.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,7 +133,7 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.0)
-    content_block_tools (0.3.1)
+    content_block_tools (0.4.2)
       actionview (>= 6)
     crack (1.0.0)
       bigdecimal

--- a/lib/engines/content_block_manager/app/models/content_block_manager/content_block/edition.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/content_block/edition.rb
@@ -22,12 +22,13 @@ module ContentBlockManager
         document.update!(latest_edition_id: id)
       end
 
-      def render
+      def render(embed_code)
         ContentBlockTools::ContentBlock.new(
           document_type: "content_block_#{block_type}",
           content_id: document.content_id,
           title:,
           details:,
+          embed_code:,
         ).render
       end
 

--- a/lib/engines/content_block_manager/app/services/content_block_manager/find_and_replace_embed_codes_service.rb
+++ b/lib/engines/content_block_manager/app/services/content_block_manager/find_and_replace_embed_codes_service.rb
@@ -9,7 +9,7 @@ module ContentBlockManager
         content_block = content_blocks.find { |c| c.document.content_id == reference.content_id }
         next if content_block.nil?
 
-        html.gsub!(reference.embed_code, content_block.render)
+        html.gsub!(reference.embed_code, content_block.render(reference.embed_code))
       end
 
       html

--- a/lib/engines/content_block_manager/app/services/content_block_manager/generate_preview_html.rb
+++ b/lib/engines/content_block_manager/app/services/content_block_manager/generate_preview_html.rb
@@ -72,7 +72,8 @@ module ContentBlockManager
 
     def replace_blocks(nokogiri_html)
       content_block_spans(nokogiri_html).each do |span|
-        span.replace content_block_edition.render
+        embed_code = span["data-embed-code"]
+        span.replace content_block_edition.render(embed_code)
       end
     end
 

--- a/lib/engines/content_block_manager/features/step_definitions/preview_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/preview_steps.rb
@@ -1,5 +1,7 @@
 When("I click on the first host document") do
   @current_host_document = @dependent_content.first
+  embed_code = "{{embed:#{@current_host_document['block_type']}:#{@current_host_document['content_id']}}}"
+
   stub_request(
     :get,
     "#{Plek.find('publishing-api')}/v2/content/#{@current_host_document['host_content_id']}",
@@ -21,7 +23,7 @@ When("I click on the first host document") do
     Plek.website_root + @current_host_document["base_path"],
   ).to_return(
     status: 200,
-    body: "<body><h1>#{@current_host_document['title']}</h1><p>iframe preview <a href=\"/other-page\">Link to other page</a></p>#{@content_block.render}</body>",
+    body: "<body><h1>#{@current_host_document['title']}</h1><p>iframe preview <a href=\"/other-page\">Link to other page</a></p>#{@content_block.render(embed_code)}</body>",
   )
 
   stub_request(
@@ -29,7 +31,7 @@ When("I click on the first host document") do
     "#{Plek.website_root}/other-page",
   ).to_return(
     status: 200,
-    body: "<body><h1>#{@current_host_document['title']}</h1><p>other page</p>#{@content_block.render}</body>",
+    body: "<body><h1>#{@current_host_document['title']}</h1><p>other page</p>#{@content_block.render(embed_code)}</body>",
   )
 
   click_on @current_host_document["title"]

--- a/lib/engines/content_block_manager/test/unit/app/models/content_block_edition_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/models/content_block_edition_test.rb
@@ -178,6 +178,7 @@ class ContentBlockManager::ContentBlockEditionTest < ActiveSupport::TestCase
     let(:rendered_response) { "RENDERED" }
     let(:stub_block) { stub("ContentBlockTools::ContentBlock", render: rendered_response) }
     let(:document) { content_block_edition.document }
+    let(:embed_code) { "embed_code" }
 
     it "initializes and renders a content block" do
       ContentBlockTools::ContentBlock.expects(:new)
@@ -186,9 +187,10 @@ class ContentBlockManager::ContentBlockEditionTest < ActiveSupport::TestCase
                                        content_id: document.content_id,
                                        title:,
                                        details:,
+                                       embed_code:,
                                      ).returns(stub_block)
 
-      assert_equal content_block_edition.render, rendered_response
+      assert_equal content_block_edition.render(embed_code), rendered_response
     end
   end
 

--- a/lib/engines/content_block_manager/test/unit/app/services/find_and_replace_embed_codes_service_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/services/find_and_replace_embed_codes_service_test.rb
@@ -22,8 +22,8 @@ class ContentBlockManager::FindAndReplaceEmbedCodesServiceTest < ActiveSupport::
 
     expected = "
       <p>Hello there</p>
-      <p>#{edition_2.render}</p>
-      <p>#{edition_1.render}</p>
+      <p>#{edition_2.render(edition_2.document.embed_code)}</p>
+      <p>#{edition_1.render(edition_1.document.embed_code)}</p>
     "
 
     result = ContentBlockManager::FindAndReplaceEmbedCodesService.call(html)

--- a/lib/engines/content_block_manager/test/unit/app/services/generate_preview_html_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/services/generate_preview_html_test.rb
@@ -11,13 +11,13 @@ class ContentBlockManager::GeneratePreviewHtmlTest < ActiveSupport::TestCase
   let(:host_base_path) { "/test" }
   let(:uri_mock) { mock }
   let(:fake_frontend_response) do
-    "<body class=\"govuk-body\"><p>test</p><span class=\"content-embed content-embed__content_block_email_address\" data-content-block=\"\" data-document-type=\"content_block_email_address\" data-content-id=\"#{preview_content_id}\">example@example.com</span></body>"
+    "<body class=\"govuk-body\"><p>test</p><span class=\"content-embed content-embed__content_block_email_address\" data-content-block=\"\" data-document-type=\"content_block_email_address\" data-embed-code=\"embed-code\" data-content-id=\"#{preview_content_id}\">example@example.com</span></body>"
   end
   let(:block_render) do
-    "<span class=\"content-embed content-embed__content_block_email_address\" data-content-block=\"\" data-document-type=\"content_block_email_address\" data-content-id=\"#{preview_content_id}\">new@new.com</span>"
+    "<span class=\"content-embed content-embed__content_block_email_address\" data-content-block=\"\" data-document-type=\"content_block_email_address\" data-embed-code=\"embed-code\" data-content-id=\"#{preview_content_id}\">new@new.com</span>"
   end
   let(:block_render_with_style) do
-    "<span class=\"content-embed content-embed__content_block_email_address\" data-content-block=\"\" data-document-type=\"content_block_email_address\" data-content-id=\"#{preview_content_id}\" style=\"background-color: yellow;\">new@new.com</span>"
+    "<span class=\"content-embed content-embed__content_block_email_address\" data-content-block=\"\" data-document-type=\"content_block_email_address\" data-content-id=\"#{preview_content_id}\" data-embed-code=\"embed-code\" style=\"background-color: yellow;\">new@new.com</span>"
   end
   let(:expected_html) do
     "<body class=\"govuk-body draft\"><p>test</p>#{block_render_with_style}</body>"


### PR DESCRIPTION
https://trello.com/c/Pomls5FJ/881-enable-preview-for-pension-blocks-in-whitehall

This requires passing an embed code to any Content
Block render methods. If this is for a preview, we
have to grab the code first from the HTML data
attribute.

this won't work properly until Publishing API done https://github.com/alphagov/publishing-api/pull/3128 

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
