### PR TITLE
Apply GA4 tracking to flash notices

### DIFF
--- a/app/components/admin/flash_message_component.rb
+++ b/app/components/admin/flash_message_component.rb
@@ -12,5 +12,14 @@ class Admin::FlashMessageComponent < ViewComponent::Base
     end
   end
 
-  def data_attributes; end
+  def data_attributes
+    {
+      module: "ga4-auto-tracker",
+      "ga4-auto": {
+        event_name: "flash_notice",
+        text: message,
+        action: "success_alerts",
+      }.to_json,
+    }
+  end
 end


### PR DESCRIPTION
## What

Introduces the `data_attributes` required for `ga4-auto-tracker` to the flash notice component.

This reflects the approach used in [an earlier PR](https://github.com/alphagov/whitehall/pull/9820)  that added tracking to flash alerts

### Expected dataLayer

```javascript
event_data: {
   event_name: 'flash_notice',
   type: undefined,
   text :'<flash text>', // This is the text of the flash message
   section: undefined,
   action: 'success_alerts'
}
```

### Screenshot

<details>

<summary>Flash message with GA4 `dataLayer` in console</summary>

<img width="659" alt="Screenshot showing flash message and GA4 datalayer" src="https://github.com/user-attachments/assets/a86d8bf6-e5ff-44dc-a527-10c2a8a5f7b6" />

</details>

## Why 

We want to capture information about flash messages presented to users during their journey.

## Performance analyst review

Change has been tested by Performance Analysts in Integration who have confirmed it works as expected from their perspective.

## Related PRs

- https://github.com/alphagov/whitehall/pull/9820


