### PR TITLE
Refactor timeline component

### DIFF
--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/document_timeline/field_changes_table_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/document_timeline/field_changes_table_component.html.erb
@@ -1,0 +1,19 @@
+<% if rows.present? %>
+  <%= render "govuk_publishing_components/components/table", {
+    first_cell_is_header: true,
+    head: [
+      {
+        text: tag.span("Fields", class: "govuk-visually-hidden"),
+      },
+      {
+        text: "Previous version",
+        format: "string",
+      },
+      {
+        text: "This version",
+        format: "string",
+      },
+    ],
+    rows:,
+  } %>
+<% end %>

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/document_timeline/field_changes_table_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/document_timeline/field_changes_table_component.rb
@@ -1,0 +1,19 @@
+class ContentBlockManager::ContentBlock::Document::Show::DocumentTimeline::FieldChangesTableComponent < ViewComponent::Base
+  def initialize(version:)
+    @version = version
+  end
+
+private
+
+  attr_reader :version
+
+  def rows
+    version.field_diffs.map do |field|
+      [
+        { text: field["field_name"].humanize },
+        { text: field["previous_value"] },
+        { text: field["new_value"] },
+      ]
+    end
+  end
+end

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/document_timeline/timeline_item_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/document_timeline/timeline_item_component.html.erb
@@ -1,0 +1,45 @@
+<div class="timeline__item">
+  <div class="timeline__header">
+    <% if is_latest %>
+      <span class="timeline__latest">Latest</span>
+      <br>
+    <% end %>
+    <h2 class="timeline__title"><%= title %></h2>
+    <p class="timeline__byline">by <%= byline %></p>
+  </div>
+
+  <p class="timeline__date">
+    <%= date %>
+  </p>
+
+  <% if version.field_diffs.present? %>
+    <div class="timeline__diff-table">
+      <%= render "govuk_publishing_components/components/details", {
+        title: "Details of changes",
+        open: is_latest,
+      } do %>
+        <% capture do %>
+          <%= render ContentBlockManager::ContentBlock::Document::Show::DocumentTimeline::FieldChangesTableComponent.new(
+            version:,
+          ) %>
+        <% end %>
+      <% end %>
+    </div>
+  <% end %>
+
+  <div>
+    <% if internal_change_note.present? %>
+      <div class="timeline__note timeline__note--internal">
+        <h2 class="timeline__title">Internal note</h2>
+        <p class="govuk-body"><%= internal_change_note %></p>
+      </div>
+    <% end %>
+
+    <% if change_note.present? %>
+      <div class="timeline__note timeline__note--public">
+        <h2 class="timeline__title">Public note</h2>
+        <p class="govuk-body"><%= change_note %></p>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/document_timeline/timeline_item_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/document_timeline/timeline_item_component.rb
@@ -1,0 +1,45 @@
+class ContentBlockManager::ContentBlock::Document::Show::DocumentTimeline::TimelineItemComponent < ViewComponent::Base
+  include ActionView::Helpers::RecordTagHelper
+
+  def initialize(version:, is_first_published_version:, is_latest:)
+    @version = version
+    @is_first_published_version = is_first_published_version
+    @is_latest = is_latest
+  end
+
+private
+
+  attr_reader :version, :is_first_published_version, :is_latest
+
+  def title
+    case version.state
+    when "published"
+      is_first_published_version ? "#{version.item.block_type.humanize} created" : version.state.capitalize
+    when "scheduled"
+      "Scheduled for publishing on #{version.item.scheduled_publication.to_fs(:long_ordinal_with_at)}"
+    else
+      "#{version.item.block_type.humanize} #{version.state}"
+    end
+  end
+
+  def date
+    tag.time(
+      version.created_at.to_fs(:long_ordinal_with_at),
+      class: "date",
+      datetime: version.created_at.iso8601,
+      lang: "en",
+    )
+  end
+
+  def byline
+    User.find_by_id(version.whodunnit)&.then { |user| helpers.linked_author(user, { class: "govuk-link" }) } || "unknown user"
+  end
+
+  def internal_change_note
+    version.item.internal_change_note
+  end
+
+  def change_note
+    version.item.change_note
+  end
+end

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/document_timeline_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/document_timeline_component.html.erb
@@ -1,66 +1,11 @@
 <h2 class="govuk-heading-l">Change history</h2>
 
 <div class="timeline">
-  <% items.each_with_index do |item, i| %>
-    <div class="timeline__item">
-
-      <div class="timeline__header">
-        <% if i == 0 %>
-          <span class="timeline__latest">Latest</span>
-          <br>
-        <% end %>
-        <h2 class="timeline__title"><%= item[:title] %></h2>
-        <p class="timeline__byline">by <%= item[:byline] %></p>
-      </div>
-
-      <p class="timeline__date">
-        <%= item[:date] %>
-      </p>
-
-      <% if item[:table_rows].present? %>
-        <div class="timeline__diff-table">
-          <%= render "govuk_publishing_components/components/details", {
-            title: "Details of changes",
-            open: i == 0,
-          } do %>
-            <% capture do %>
-              <%= render "govuk_publishing_components/components/table", {
-                first_cell_is_header: true,
-                head: [
-                  {
-                    text: tag.span("Fields", class: "govuk-visually-hidden"),
-                  },
-                  {
-                    text: "Previous version",
-                    format: "string",
-                  },
-                  {
-                    text: "This version",
-                    format: "string",
-                  },
-                ],
-                rows: item[:table_rows],
-              } %>
-            <% end %>
-          <% end %>
-        </div>
-      <% end %>
-
-      <div>
-      <% if item[:internal_change_note].present? %>
-          <div class="timeline__note">
-            <h2 class="timeline__title">Internal note</h2>
-            <p class="govuk-body"><%= item[:internal_change_note] %></p>
-          </div>
-      <% end %>
-
-      <% if item[:change_note].present? %>
-          <div class="timeline__note">
-            <h2 class="timeline__title">Public note</h2>
-            <p class="govuk-body"><%= item[:change_note] %></p>
-          </div>
-      <% end %>
-      </div>
-    </div>
+  <% versions.each_with_index do |version, i| %>
+    <%= render ContentBlockManager::ContentBlock::Document::Show::DocumentTimeline::TimelineItemComponent.new(
+      version:,
+      is_first_published_version: version.id == first_published_version.id,
+      is_latest: i == 0,
+    ) %>
   <% end %>
 </div>

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/document_timeline_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/document_timeline_component.rb
@@ -8,68 +8,15 @@ private
 
   attr_reader :content_block_versions
 
-  def items
-    content_block_versions.reject { |version| hide_from_user?(version) }.map do |version|
-      {
-        title: title(version),
-        byline: User.find_by_id(version.whodunnit)&.then { |user| helpers.linked_author(user, { class: "govuk-link" }) } || "unknown user",
-        date: time_html(version.created_at),
-        table_rows: table_rows(version),
-        internal_change_note: internal_change_note(version),
-        change_note: change_note(version),
-      }
-    end
+  def versions
+    content_block_versions.reject { |version| hide_from_user?(version) }
   end
 
   def hide_from_user?(version)
     version.state.nil? || version.state == "superseded"
   end
 
-  def title(version)
-    case version.state
-    when "published"
-      if version == first_published_version
-        "#{version.item.block_type.humanize} created"
-      else
-        version.state.capitalize
-      end
-    when "scheduled"
-      "Scheduled for publishing on #{version.item.scheduled_publication.to_fs(:long_ordinal_with_at)}"
-    else
-      "#{version.item.block_type.humanize} #{version.state}"
-    end
-  end
-
   def first_published_version
     @first_published_version ||= content_block_versions.filter { |v| v.state == "published" }.min_by(&:created_at)
-  end
-
-  def time_html(date_time)
-    tag.time(
-      date_time.to_fs(:long_ordinal_with_at),
-      class: "date",
-      datetime: date_time.iso8601,
-      lang: "en",
-    )
-  end
-
-  def table_rows(version)
-    if version.field_diffs.present?
-      version.field_diffs.map do |field|
-        [
-          { text: field["field_name"].humanize },
-          { text: field["previous_value"] },
-          { text: field["new_value"] },
-        ]
-      end
-    end
-  end
-
-  def internal_change_note(version)
-    version.item.internal_change_note
-  end
-
-  def change_note(version)
-    version.item.change_note
   end
 end

--- a/lib/engines/content_block_manager/test/components/content_block/document/show/document_timeline/field_changes_table_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/document/show/document_timeline/field_changes_table_component_test.rb
@@ -1,0 +1,52 @@
+require "test_helper"
+
+class ContentBlockManager::ContentBlock::Document::Show::DocumentTimeline::FieldChangesTableComponentTest < ViewComponent::TestCase
+  extend Minitest::Spec::DSL
+
+  let(:user) { build_stubbed(:user) }
+
+  it "renders the edition diff table in correct order" do
+    field_diffs = [
+      {
+        "field_name": "title",
+        "new_value": "new title",
+        "previous_value": "old title",
+      },
+      {
+        "field_name": "email_address",
+        "new_value": "new@email.com",
+        "previous_value": "old@email.com",
+      },
+      {
+        "field_name": "instructions_to_publishers",
+        "new_value": "new instructions",
+        "previous_value": "old instructions",
+      },
+    ]
+    version = build(
+      :content_block_version,
+      event: "updated",
+      whodunnit: user.id,
+      state: "published",
+      field_diffs: field_diffs,
+    )
+
+    render_inline(
+      ContentBlockManager::ContentBlock::Document::Show::DocumentTimeline::FieldChangesTableComponent.new(
+        version:,
+      ),
+    )
+
+    assert_selector "tr:nth-child(1) th:nth-child(1)", text: "Title"
+    assert_selector "tr:nth-child(1) td:nth-child(2)", text: "old title"
+    assert_selector "tr:nth-child(1) td:nth-child(3)", text: "new title"
+
+    assert_selector "tr:nth-child(2) th:nth-child(1)", text: "Email address"
+    assert_selector "tr:nth-child(2) td:nth-child(2)", text: "old@email.com"
+    assert_selector "tr:nth-child(2) td:nth-child(3)", text: "new@email.com"
+
+    assert_selector "tr:nth-child(3) th:nth-child(1)", text: "Instructions to publishers"
+    assert_selector "tr:nth-child(3) td:nth-child(2)", text: "old instructions"
+    assert_selector "tr:nth-child(3) td:nth-child(3)", text: "new instructions"
+  end
+end

--- a/lib/engines/content_block_manager/test/components/content_block/document/show/document_timeline/timeline_item_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/document/show/document_timeline/timeline_item_component_test.rb
@@ -1,0 +1,158 @@
+require "test_helper"
+
+class ContentBlockManager::ContentBlock::Document::Show::DocumentTimeline::TimelineItemComponentTest < ViewComponent::TestCase
+  include Rails.application.routes.url_helpers
+  include ActionView::Helpers::UrlHelper
+  include ApplicationHelper
+  extend Minitest::Spec::DSL
+
+  let(:user) { create(:user) }
+
+  let(:content_block_edition) { build(:content_block_edition, :email_address, change_note: nil, internal_change_note: nil) }
+  let(:version) do
+    build(
+      :content_block_version,
+      event: "created",
+      whodunnit: user.id,
+      state: "published",
+      created_at: 4.days.ago,
+      item: content_block_edition,
+    )
+  end
+
+  let(:is_latest) { false }
+  let(:is_first_published_version) { false }
+
+  let(:table_stub) { stub("table_component") }
+
+  let(:component) do
+    ContentBlockManager::ContentBlock::Document::Show::DocumentTimeline::TimelineItemComponent.new(
+      version:,
+      is_first_published_version:,
+      is_latest:,
+    )
+  end
+
+  describe "when not the latest or first published" do
+    before do
+      render_inline component
+    end
+
+    it "renders a timeline item component" do
+      assert_selector ".timeline__title", text: "Published"
+      page.find ".timeline__byline" do |byline|
+        assert_includes byline.native.to_s, "by #{linked_author(user, { class: 'govuk-link' })}"
+      end
+      assert_selector "time[datetime='#{version.created_at.iso8601}']", text: version.created_at.to_fs(:long_ordinal_with_at)
+    end
+
+    it "does not show the latest tag" do
+      refute_selector ".timeline__latest", text: "Latest"
+    end
+
+    it "does not show the table component" do
+      refute_selector ".timeline__diff-table"
+    end
+  end
+
+  describe "when the version is the first published version" do
+    let(:is_latest) { false }
+    let(:is_first_published_version) { true }
+
+    before do
+      render_inline component
+    end
+
+    it "returns a created title" do
+      assert_selector ".timeline__title", text: "Email address created"
+    end
+  end
+
+  describe "when the version is the latest version" do
+    let(:is_latest) { true }
+    let(:is_first_published_version) { false }
+
+    before do
+      render_inline component
+    end
+
+    it "shows the latest tag" do
+      assert_selector ".timeline__latest", text: "Latest"
+    end
+  end
+
+  describe "when external changenotes are present" do
+    let(:content_block_edition) { build(:content_block_edition, :email_address, change_note: "changed a to b", internal_change_note: nil) }
+
+    before do
+      render_inline component
+    end
+
+    it "shows the change note" do
+      assert_selector ".timeline__note--public p", text: "changed a to b"
+    end
+  end
+
+  describe "when internal changenotes are present" do
+    let(:content_block_edition) { build(:content_block_edition, :email_address, change_note: nil, internal_change_note: "changed x to y") }
+
+    before do
+      render_inline component
+    end
+
+    it "shows the change note" do
+      assert_selector ".timeline__note--internal p", text: "changed x to y"
+    end
+  end
+
+  describe "when field diffs are present" do
+    let(:field_diffs) { [{ "something" => "here" }] }
+    let(:version) do
+      build(
+        :content_block_version,
+        event: "created",
+        whodunnit: user.id,
+        state: "published",
+        created_at: 4.days.ago,
+        item: content_block_edition,
+        field_diffs:,
+      )
+    end
+
+    it "renders the table component" do
+      table_component = ContentBlockManager::ContentBlock::Document::Show::DocumentTimeline::FieldChangesTableComponent.new(
+        version: build(:content_block_version, field_diffs: []),
+      )
+
+      ContentBlockManager::ContentBlock::Document::Show::DocumentTimeline::FieldChangesTableComponent
+        .expects(:new)
+        .with(version:)
+        .returns(table_component)
+
+      component
+        .expects(:render)
+        .with("govuk_publishing_components/components/details", { title: "Details of changes", open: false })
+        .with_block_given
+        .yields
+
+      component
+        .expects(:render)
+        .with(table_component)
+        .once
+
+      render_inline component
+    end
+
+    describe "when the version is the latest version" do
+      let(:is_latest) { true }
+
+      it "renders the details as open" do
+        component
+          .expects(:render)
+          .with("govuk_publishing_components/components/details", { title: "Details of changes", open: true })
+
+        render_inline component
+      end
+    end
+  end
+end


### PR DESCRIPTION
This breaks up each timeline component into a seperate component, as well as making the field changes component into a single component, which makes them easier to test.

I originally did this as some prep for adding embedded object histories, but think it's best to leave this until we have the ability to edit embedded objects.