### PR TITLE
Populate GA4 `document_type` using Rails variables

### DIFF
--- a/app/helpers/admin/analytics_helper.rb
+++ b/app/helpers/admin/analytics_helper.rb
@@ -1,6 +1,6 @@
 module Admin
   module AnalyticsHelper
-    def track_analytics_data_on_load(title)
+    def track_analytics_data_on_load(controller_name, action_name)
       {
         event: "page_view",
         page_view: {
@@ -8,7 +8,7 @@ module Admin
           user_created_at: current_user&.created_at&.to_date,
           user_organisation_name: current_user&.organisation_name,
           user_role: current_user&.role,
-          document_type: title,
+          document_type: "#{action_name}-#{controller_name}",
         },
       }.to_json
     end

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -16,7 +16,7 @@
            environment: environment,
            browser_title: ("Error: " if yield(:error_summary).present?).to_s + sanitized_title do %>
 
-  <div data-module="ga4-page-view-tracking" data-attributes='<%= track_analytics_data_on_load(sanitized_title) %>'></div>
+  <div data-module="ga4-page-view-tracking" data-attributes='<%= track_analytics_data_on_load(controller_name, action_name) %>'></div>
 
   <%= render "govuk_publishing_components/components/skip_link" %>
 


### PR DESCRIPTION
## What

Updates the existing analytics helper to use a combination of the controller name and the action name as an imperfect proxy for the concept of a `document_type` in Whitehall. The Trello card for this ticket is "[Track document_type variable on GTM page load](https://trello.com/c/LQjqDVcZ/3438-track-documenttype-variable-on-gtm-page-load?search_id=c5be5c9c-f3b9-405c-8f3c-88c60d704b9a)".

A range of options were explored in an earlier spike - see [this PR](https://github.com/alphagov/whitehall/pull/9593) and [this Trello card](https://trello.com/c/R2kwIDVF/3137-spike-decide-on-page-grouping-categorisation-for-analytics).

### `dataLayer` examples from this implementation

| Screenshot  | `document_type` passed to `dataLayer`  |
|---|---|
| ![image](https://github.com/user-attachments/assets/cb935d09-df36-44a3-8e73-676d64e6beb3) | `index-dashboard`  |
| ![image](https://github.com/user-attachments/assets/869860b4-3af1-4b66-a354-b06398a5ec6d) | `index-new_document`  |
| ![image](https://github.com/user-attachments/assets/27b9e168-52fb-461b-9128-5f92582fb071) | `new-consultations`  |
| ![image](https://github.com/user-attachments/assets/1a4382d5-18d7-4328-aaff-30befe9b0a7b) | `index-corporate_information_pages`  |
| ![image](https://github.com/user-attachments/assets/446f90f3-3f87-45fe-a27b-a6aa200de879) | `index-statistics_announcements` |

## Why 

Performance Analysts would like the GA4 `dataLayer` to be populated with a `document_type` every time a page loads, reflecting the implementation present in GOV.UK. Because Whitehall is a content management system that does not currently have the concept of a `document_type`, an earlier spike explored options. The implementation in this PR builds upon the exploration of using `controller_name` as the document type in #9593 to use an interpolated string of both `action_name` and `controller_name` because this will provide additional information to Performance Analysts. 