### PR TITLE
Fix rendering embed codes in preview host documents

### DIFF
--- a/lib/engines/content_block_manager/app/services/content_block_manager/find_and_replace_embed_codes_service.rb
+++ b/lib/engines/content_block_manager/app/services/content_block_manager/find_and_replace_embed_codes_service.rb
@@ -5,7 +5,7 @@ module ContentBlockManager
     end
 
     def call
-      embed_content_references.each do |reference|
+      embed_content_references.uniq.each do |reference|
         content_block = content_blocks.find { |c| c.document.content_id == reference.content_id }
         next if content_block.nil?
 

--- a/lib/engines/content_block_manager/test/unit/app/services/find_and_replace_embed_codes_service_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/services/find_and_replace_embed_codes_service_test.rb
@@ -18,12 +18,14 @@ class ContentBlockManager::FindAndReplaceEmbedCodesServiceTest < ActiveSupport::
       <p>Hello there</p>
       <p>#{edition_2.document.embed_code}</p>
       <p>#{edition_1.document.embed_code}</p>
+      <p>#{edition_2.document.embed_code}</p>
     "
 
     expected = "
       <p>Hello there</p>
       <p>#{edition_2.render(edition_2.document.embed_code)}</p>
       <p>#{edition_1.render(edition_1.document.embed_code)}</p>
+      <p>#{edition_2.render(edition_2.document.embed_code)}</p>
     "
 
     result = ContentBlockManager::FindAndReplaceEmbedCodesService.call(html)


### PR DESCRIPTION
https://trello.com/c/fP2L929o/901-bug-email-preview-in-mainstream-publisher-not-displaying-correctly

The helper method in Content Block Tools that finds
content block embeds was recently set to
return mutliple references to one block [1] - this
then caused a knock-on effect for rendering blocks in
a document, because it would try to replace the
embed code multiple times, causing issues now that
the embed code is returned in the data attributes of
a span. We should only need to run gsub once to replace
all the embed codes for a reference, so I'm calling `uniq`
in the code that uses the Tool.

[1] alphagov/govuk_content_block_tools#6

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
