### PR TITLE
Pass custom heading margin to design system

### DIFF
--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -60,8 +60,8 @@
                 text: yield(:title),
                 heading_level: 1,
                 font_size: "xl",
-                margin_bottom: 8,
               }
+              heading_options[:margin_bottom] = yield(:title_margin_bottom).present? ? yield(:title_margin_bottom).to_i : 8
             %>
             <%= render "govuk_publishing_components/components/heading", heading_options %>
           </div>


### PR DESCRIPTION
This was changed recently in this PR [1] to set a
default margin of 8, however it removed the
setting of custom margins via the
`title_margin_bottom` flag. So anywhere that had
set that was being ignored. This reinstates the
check for a custom setting, and if it isn't
present adds the default `8`.

[1] https://github.com/alphagov/whitehall/pull/9863

## previously
`title_margin_bottom` ignored
![Screenshot 2025-02-14 at 15 23 47](https://github.com/user-attachments/assets/69427cd5-e3d7-4966-a3a2-cd78e9121a59)



## now
`title_margin_bottom` used
![Screenshot 2025-02-14 at 15 24 42](https://github.com/user-attachments/assets/bd6f452a-6936-49cb-b430-b4126483463e)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
