### PR TITLE
ignore any subschemas on preview page

### DIFF
--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/host_content/preview_details_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/host_content/preview_details_component.rb
@@ -7,11 +7,13 @@ class ContentBlockManager::ContentBlockEdition::HostContent::PreviewDetailsCompo
 private
 
   def list_items
-    [*details_items, instances_item]
+    [*details_items.compact, instances_item]
   end
 
   def details_items
     @content_block_edition.details.map do |key, value|
+      next unless value.is_a?(String)
+
       { key: key.humanize, value: }
     end
   end

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/host_content/preview.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/host_content/preview.html.erb
@@ -1,7 +1,7 @@
 <% content_for :page_title, "Preview content block in host document" %>
 <% content_for :context, "Preview #{@content_block_edition.block_type.humanize.downcase}" %>
 <% content_for :title, @preview_content.title %>
-<% content_for :title_margin_bottom, 3 %>
+<% content_for :title_margin_bottom, 1 %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds govuk-body govuk-!-margin-bottom-0">

--- a/lib/engines/content_block_manager/test/components/content_block/edition/host_content/preview_details_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/host_content/preview_details_component_test.rb
@@ -18,4 +18,30 @@ class ContentBlockManager::ContentBlockEdition::HostContent::PreviewDetailsCompo
     assert_selector "li", text: "Email address: example@example.com"
     assert_selector "li", text: "Instances: 2"
   end
+
+  context "when there are subschemas in the edition's details" do
+    let(:content_block_edition) do
+      build(:content_block_edition, :pension, details: {
+        "description": "Basic state pension",
+        "rates": {
+          "rate1":
+            { "name": "rate1", "amount": "£100.5", "cadence": "weekly", "description": "" },
+          "rate2":
+              { "name": "rate2", "amount": "£11.1", "cadence": "monthly", "description": "1111" },
+        },
+      })
+    end
+    it "returns a list of details for preview content" do
+      render_inline(
+        ContentBlockManager::ContentBlockEdition::HostContent::PreviewDetailsComponent.new(
+          content_block_edition:,
+          preview_content:,
+        ),
+      )
+
+      assert_selector "li", count: 2
+      assert_selector "li", text: "Description: Basic state pension"
+      assert_selector "li", text: "Instances: 2"
+    end
+  end
 end


### PR DESCRIPTION
https://trello.com/c/Pomls5FJ/881-enable-preview-for-pension-blocks-in-cbm

we don't have a design for how these subschemas
should be displayed, and the length of this
component could get out of control if we show
every field, so just ignoring until we have a
direction.

## previous
![Screenshot 2025-02-14 at 15 41 29](https://github.com/user-attachments/assets/cd5cadd4-942c-407f-ab89-ada0d0122c31)

## now 
![Screenshot 2025-02-14 at 15 33 25](https://github.com/user-attachments/assets/1029a0ac-c007-454f-97e3-38f178529738)



---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
