### PR TITLE
Fix component links on /component-guide

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,6 @@
 class ApplicationController < ActionController::Base
   include GDS::SSO::ControllerMethods
-
+  helper ComponentGuideHelper
   protect_from_forgery
 
   before_action :set_current_user

--- a/app/helpers/component_guide_helper.rb
+++ b/app/helpers/component_guide_helper.rb
@@ -1,0 +1,18 @@
+# This helper overrides Rails' generated `component_doc_path` method
+# that is used in the govuk_publishing_components gem:
+# https://github.com/alphagov/govuk_publishing_components/blob/a4c1e2d246249dc7d4e659a9a58c3fdf4a85d13e/app/controllers/govuk_publishing_components/component_guide_controller.rb#L168
+#
+# Without it, something in Whitehall overrides it to the
+# `/assets/whitehall` assets prefix path, so all of the links under
+#  `/component-guide/` are broken.
+#
+# This override really shouldn't be needed, but we've tried comparing
+# and contrasting with other apps where the override isn't needed
+# (e.g. Specialist Publisher) and no matter what we delete, edit or
+# comment out, the links continue to be broken. In the grand scheme
+# of things, this little override solves the problem pretty succinctly.
+module ComponentGuideHelper
+  def component_doc_path(component_id)
+    "/component-guide/#{component_id}"
+  end
+end

--- a/test/unit/app/helpers/component_guide_helper_test.rb
+++ b/test/unit/app/helpers/component_guide_helper_test.rb
@@ -1,0 +1,9 @@
+require "test_helper"
+
+class ComponentGuideHelperTest < ActionView::TestCase
+  include ComponentGuideHelper
+
+  test "overrides the `component_doc_path` method" do
+    assert_equal("/component-guide/foo", component_doc_path("foo"))
+  end
+end


### PR DESCRIPTION
Fixes #8728.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
