### PR TITLE
content modelling/899 copy embed code

### DIFF
--- a/lib/engines/content_block_manager/app/components/content_block_manager/shared/embedded_objects/summary_card_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/shared/embedded_objects/summary_card_component.html.erb
@@ -1,4 +1,4 @@
-<%= render "components/summary_card", {
+<%= render "govuk_publishing_components/components/summary_card", {
   title:,
   rows:,
   summary_card_actions:,

--- a/lib/engines/content_block_manager/app/components/content_block_manager/shared/embedded_objects/summary_card_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/shared/embedded_objects/summary_card_component.rb
@@ -20,6 +20,10 @@ private
       {
         key: key.titleize,
         value: object[key],
+        data: {
+          module: "copy-embed-code",
+          "embed-code": content_block_edition.document.embed_code_for_field("#{object_type}/#{object_name}/#{key}"),
+        },
       }
     end
   end

--- a/lib/engines/content_block_manager/app/components/content_block_manager/shared/embedded_objects/summary_card_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/shared/embedded_objects/summary_card_component.rb
@@ -1,15 +1,15 @@
 class ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponent < ViewComponent::Base
-  def initialize(content_block_edition:, object_type:, object_name:, show_edit_action: false, redirect_url: nil)
+  def initialize(content_block_edition:, object_type:, object_name:, is_editable: false, redirect_url: nil)
     @content_block_edition = content_block_edition
     @object_type = object_type
     @object_name = object_name
-    @show_edit_action = show_edit_action
+    @is_editable = is_editable
     @redirect_url = redirect_url
   end
 
 private
 
-  attr_reader :content_block_edition, :object_type, :object_name, :show_edit_action, :redirect_url
+  attr_reader :content_block_edition, :object_type, :object_name, :is_editable, :redirect_url
 
   def title
     "#{object_type.titleize.singularize} details"
@@ -29,7 +29,7 @@ private
   end
 
   def summary_card_actions
-    if show_edit_action
+    if is_editable
       [
         {
           label: "Edit",

--- a/lib/engines/content_block_manager/app/components/content_block_manager/shared/embedded_objects/summary_card_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/shared/embedded_objects/summary_card_component.rb
@@ -20,10 +20,16 @@ private
       {
         key: key.titleize,
         value: object[key],
-        data: {
-          module: "copy-embed-code",
-          "embed-code": content_block_edition.document.embed_code_for_field("#{object_type}/#{object_name}/#{key}"),
-        },
+        data: copy_embed_code(key),
+      }
+    end
+  end
+
+  def copy_embed_code(key)
+    unless is_editable
+      {
+        module: "copy-embed-code",
+        "embed-code": content_block_edition.document.embed_code_for_field("#{object_type}/#{object_name}/#{key}"),
       }
     end
   end

--- a/lib/engines/content_block_manager/app/models/content_block_manager/content_block/document.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/content_block/document.rb
@@ -27,7 +27,11 @@ module ContentBlockManager
       scope :live, -> { where.not(latest_edition_id: nil) }
 
       def embed_code
-        "{{embed:content_block_#{block_type}:#{content_id}}}"
+        "#{embed_code_prefix}}}"
+      end
+
+      def embed_code_for_field(field_path)
+        "#{embed_code_prefix}/#{field_path}}}"
       end
 
       def title
@@ -44,6 +48,12 @@ module ContentBlockManager
 
       def latest_draft
         editions.where(state: :draft).order(created_at: :asc).last
+      end
+
+    private
+
+      def embed_code_prefix
+        "{{embed:content_block_#{block_type}:#{content_id}"
       end
     end
   end

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/embedded_objects/review.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/embedded_objects/review.html.erb
@@ -24,7 +24,7 @@
       content_block_edition: @content_block_edition,
       object_type: @subschema.block_type,
       object_name: @object_name,
-      show_edit_action: true,
+      is_editable: true,
     ) %>
   </div>
 </div>

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/embedded_objects.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/embedded_objects.html.erb
@@ -21,7 +21,7 @@
               content_block_edition: @content_block_edition,
               object_type: @subschema.block_type,
               object_name: k,
-              show_edit_action: true,
+              is_editable: true,
               redirect_url: request.fullpath,
               ) %>
           </div>

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/review.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/review.html.erb
@@ -29,7 +29,7 @@
             content_block_edition: @content_block_edition,
             object_type: subschema.id,
             object_name: k,
-            show_edit_action: true,
+            is_editable: true,
             redirect_url: content_block_manager.content_block_manager_content_block_workflow_path(@content_block_edition, step: "#{Workflow::Step::SUBSCHEMA_PREFIX}#{subschema.id}"),
             ) %>
         </div>

--- a/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
@@ -300,6 +300,12 @@ When("I click to view the document") do
   click_link href: content_block_manager.content_block_manager_content_block_document_path(@content_block.document)
 end
 
+When("I click to view the document with title {string}") do |title|
+  content_block = ContentBlockManager::ContentBlock::Edition.where(title:).first
+
+  click_link href: content_block_manager.content_block_manager_content_block_document_path(content_block.document)
+end
+
 When("I click to view the edition") do
   @schema = @schemas[@content_block.document.block_type]
   click_link href: content_block_manager.content_block_manager_content_block_edition_path(@content_block)

--- a/lib/engines/content_block_manager/features/step_definitions/embed_code_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/embed_code_steps.rb
@@ -13,6 +13,15 @@ When("I click to copy the embed code for the content block {string}") do |conten
   end
 end
 
+When("I click to copy the embed code for the pension {string}, rate {string} and field {string}") do |pension_title, rate_name, field_name|
+  within(".govuk-summary-list__row", text: field_name.humanize) do
+    find("a", text: "Copy code").click
+    has_text?("Code copied")
+    edition = ContentBlockManager::ContentBlock::Edition.find_by(title: pension_title)
+    @embed_code = edition.document.embed_code_for_field("rates/#{rate_name.parameterize.presence}/#{field_name}")
+  end
+end
+
 Then("the embed code should be copied to my clipboard") do
   page.driver.browser.execute_cdp("Browser.grantPermissions", origin: page.server_url, permissions: %w[clipboardReadWrite])
   clip_text = page.evaluate_async_script("navigator.clipboard.readText().then(arguments[0])")

--- a/lib/engines/content_block_manager/features/view_object.feature
+++ b/lib/engines/content_block_manager/features/view_object.feature
@@ -2,6 +2,18 @@ Feature: View a content object
   Background:
     Given I am a GDS admin
     And the organisation "Ministry of Example" exists
+    And a schema "pension" exists with the following fields:
+      | field         | type   | format | required |
+      | description   | string | string | true     |
+    And the schema "pension" has a subschema with the name "rates" and the following fields:
+      | field     | type   | format | required | enum           | pattern          |
+      | name      | string | string | true     |                |                  |
+      | amount    | string | string | true     |                | £[0-9]+\\.[0-9]+ |
+      | cadence   | string | string |          | weekly,monthly |                  |
+    And a pension content block has been created
+    And that pension has a rate with the following fields:
+      | name    | amount  | cadence |
+      | My rate | £123.45 | weekly  |
     And a schema "email_address" exists with the following fields:
       | email_address |
     And an email address content block has been created
@@ -26,10 +38,17 @@ Feature: View a content object
     And I should see the rollup data for the dependent content
 
   @javascript
-  Scenario: GDS Editor can copy embed code
+  Scenario: GDS Editor can copy embed code for whole block
     When I visit the Content Block Manager home page
     Then I should see the details for all documents
     When I click to view the document
     And I click to copy the embed code
+    Then the embed code should be copied to my clipboard
+
+  @javascript
+  Scenario: GDS Editor can copy embed code for a specific field
+    When I visit the Content Block Manager home page
+    When I click to view the document with title "My pension"
+    And I click to copy the embed code for the pension "My pension", rate "My rate" and field "name"
     Then the embed code should be copied to my clipboard
 

--- a/lib/engines/content_block_manager/test/components/shared/embedded_objects/summary_card_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/shared/embedded_objects/summary_card_component_test.rb
@@ -45,65 +45,6 @@ class ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponentTest < V
     end
   end
 
-  it "renders a summary list with edit link" do
-    component = ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponent.new(
-      content_block_edition:,
-      object_type: "embedded-objects",
-      object_name: "my-embedded-object",
-      is_editable: true,
-    )
-
-    render_inline component
-
-    assert_selector ".govuk-summary-card__title", text: "Embedded Object details"
-
-    expected_edit_path = edit_embedded_object_content_block_manager_content_block_edition_path(
-      content_block_edition,
-      object_type: "embedded-objects",
-      object_name: "my-embedded-object",
-    )
-
-    assert_selector ".govuk-summary-card__actions .govuk-summary-card__action:nth-child(1) a[href='#{expected_edit_path}']", text: "Edit"
-
-    assert_selector ".govuk-summary-list__row", text: /Name/ do
-      assert_selector ".govuk-summary-list__key", text: "Name"
-      assert_selector ".govuk-summary-list__value", text: "My Embedded Object"
-    end
-
-    assert_selector ".govuk-summary-list__row", text: /Field 1/ do
-      assert_selector ".govuk-summary-list__key", text: "Field 1"
-      assert_selector ".govuk-summary-list__value", text: "Value 1"
-    end
-
-    assert_selector ".govuk-summary-list__row", text: /Field 2/ do
-      assert_selector ".govuk-summary-list__key", text: "Field 2"
-      assert_selector ".govuk-summary-list__value", text: "Value 2"
-    end
-  end
-
-  it "renders a summary list with edit link and redirect url if provided" do
-    component = ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponent.new(
-      content_block_edition:,
-      object_type: "embedded-objects",
-      object_name: "my-embedded-object",
-      is_editable: true,
-      redirect_url: "https://example.com",
-    )
-
-    render_inline component
-
-    assert_selector ".govuk-summary-card__title", text: "Embedded Object details"
-
-    expected_edit_path = edit_embedded_object_content_block_manager_content_block_edition_path(
-      content_block_edition,
-      object_type: "embedded-objects",
-      object_name: "my-embedded-object",
-      redirect_url: "https://example.com",
-    )
-
-    assert_selector ".govuk-summary-card__actions .govuk-summary-card__action:nth-child(1) a[href='#{expected_edit_path}']", text: "Edit"
-  end
-
   it "renders copy code buttons" do
     component = ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponent.new(
       content_block_edition:,
@@ -116,5 +57,81 @@ class ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponentTest < V
     assert_selector ".govuk-summary-list__row[data-embed-code='#{content_block_edition.document.embed_code_for_field('embedded-objects/my-embedded-object/name')}']", text: "Name"
     assert_selector ".govuk-summary-list__row[data-embed-code='#{content_block_edition.document.embed_code_for_field('embedded-objects/my-embedded-object/field-1')}']", text: "Field 1"
     assert_selector ".govuk-summary-list__row[data-embed-code='#{content_block_edition.document.embed_code_for_field('embedded-objects/my-embedded-object/field-2')}']", text: "Field 2"
+  end
+
+  describe "when card is editable" do
+    it "renders a summary list with edit link" do
+      component = ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponent.new(
+        content_block_edition:,
+        object_type: "embedded-objects",
+        object_name: "my-embedded-object",
+        is_editable: true,
+      )
+
+      render_inline component
+
+      assert_selector ".govuk-summary-card__title", text: "Embedded Object details"
+
+      expected_edit_path = edit_embedded_object_content_block_manager_content_block_edition_path(
+        content_block_edition,
+        object_type: "embedded-objects",
+        object_name: "my-embedded-object",
+      )
+
+      assert_selector ".govuk-summary-card__actions .govuk-summary-card__action:nth-child(1) a[href='#{expected_edit_path}']", text: "Edit"
+
+      assert_selector ".govuk-summary-list__row", text: /Name/ do
+        assert_selector ".govuk-summary-list__key", text: "Name"
+        assert_selector ".govuk-summary-list__value", text: "My Embedded Object"
+      end
+
+      assert_selector ".govuk-summary-list__row", text: /Field 1/ do
+        assert_selector ".govuk-summary-list__key", text: "Field 1"
+        assert_selector ".govuk-summary-list__value", text: "Value 1"
+      end
+
+      assert_selector ".govuk-summary-list__row", text: /Field 2/ do
+        assert_selector ".govuk-summary-list__key", text: "Field 2"
+        assert_selector ".govuk-summary-list__value", text: "Value 2"
+      end
+    end
+
+    it "renders a summary list with edit link and redirect url if provided" do
+      component = ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponent.new(
+        content_block_edition:,
+        object_type: "embedded-objects",
+        object_name: "my-embedded-object",
+        is_editable: true,
+        redirect_url: "https://example.com",
+      )
+
+      render_inline component
+
+      assert_selector ".govuk-summary-card__title", text: "Embedded Object details"
+
+      expected_edit_path = edit_embedded_object_content_block_manager_content_block_edition_path(
+        content_block_edition,
+        object_type: "embedded-objects",
+        object_name: "my-embedded-object",
+        redirect_url: "https://example.com",
+      )
+
+      assert_selector ".govuk-summary-card__actions .govuk-summary-card__action:nth-child(1) a[href='#{expected_edit_path}']", text: "Edit"
+    end
+
+    it "does not render copy code button" do
+      component = ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponent.new(
+        content_block_edition:,
+        object_type: "embedded-objects",
+        object_name: "my-embedded-object",
+        is_editable: true,
+      )
+
+      render_inline component
+
+      assert_no_selector ".govuk-summary-list__row[data-embed-code='#{content_block_edition.document.embed_code_for_field('embedded-objects/my-embedded-object/name')}']", text: "Name"
+      assert_no_selector ".govuk-summary-list__row[data-embed-code='#{content_block_edition.document.embed_code_for_field('embedded-objects/my-embedded-object/field-1')}']", text: "Field 1"
+      assert_no_selector ".govuk-summary-list__row[data-embed-code='#{content_block_edition.document.embed_code_for_field('embedded-objects/my-embedded-object/field-2')}']", text: "Field 2"
+    end
   end
 end

--- a/lib/engines/content_block_manager/test/components/shared/embedded_objects/summary_card_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/shared/embedded_objects/summary_card_component_test.rb
@@ -50,7 +50,7 @@ class ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponentTest < V
       content_block_edition:,
       object_type: "embedded-objects",
       object_name: "my-embedded-object",
-      show_edit_action: true,
+      is_editable: true,
     )
 
     render_inline component
@@ -86,7 +86,7 @@ class ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponentTest < V
       content_block_edition:,
       object_type: "embedded-objects",
       object_name: "my-embedded-object",
-      show_edit_action: true,
+      is_editable: true,
       redirect_url: "https://example.com",
     )
 

--- a/lib/engines/content_block_manager/test/components/shared/embedded_objects/summary_card_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/shared/embedded_objects/summary_card_component_test.rb
@@ -103,4 +103,18 @@ class ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponentTest < V
 
     assert_selector ".govuk-summary-card__actions .govuk-summary-card__action:nth-child(1) a[href='#{expected_edit_path}']", text: "Edit"
   end
+
+  it "renders copy code buttons" do
+    component = ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponent.new(
+      content_block_edition:,
+      object_type: "embedded-objects",
+      object_name: "my-embedded-object",
+    )
+
+    render_inline component
+
+    assert_selector ".govuk-summary-list__row[data-embed-code='#{content_block_edition.document.embed_code_for_field('embedded-objects/my-embedded-object/name')}']", text: "Name"
+    assert_selector ".govuk-summary-list__row[data-embed-code='#{content_block_edition.document.embed_code_for_field('embedded-objects/my-embedded-object/field-1')}']", text: "Field 1"
+    assert_selector ".govuk-summary-list__row[data-embed-code='#{content_block_edition.document.embed_code_for_field('embedded-objects/my-embedded-object/field-2')}']", text: "Field 2"
+  end
 end

--- a/lib/engines/content_block_manager/test/unit/app/models/content_block_document_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/models/content_block_document_test.rb
@@ -59,6 +59,13 @@ class ContentBlockManager::ContentBlockDocumentTest < ActiveSupport::TestCase
 
       assert_equal document.embed_code, "{{embed:content_block_email_address:#{uuid}}}"
     end
+
+    it "returns embed code for a particular field" do
+      uuid = SecureRandom.uuid
+      document = create(:content_block_document, :pension, content_id: uuid)
+
+      assert_equal document.embed_code_for_field("rates/rate2/name"), "{{embed:content_block_pension:#{uuid}/rates/rate2/name}}"
+    end
   end
 
   describe "latest_edition" do


### PR DESCRIPTION
https://trello.com/c/Hr1mmk1C/899-add-copy-embed-code-to-attributes

![Screenshot 2025-02-17 at 16 21 12](https://github.com/user-attachments/assets/46a47a6b-f74d-44ba-bee8-3eeb7c843b31)

Adding the 'copy code' to specific attributes on a rate.
This involves first calculating what the embed code is for the nested field, then adding the module to the row in the summary card.

The copy code should only appear next to Amount for MVP, but that can be done in future PR.


---
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
