### PR TITLE
Bump content_block_tools from 0.4.3 to 0.4.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,7 +133,7 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.0)
-    content_block_tools (0.4.3)
+    content_block_tools (0.4.4)
       actionview (>= 6)
     crack (1.0.0)
       bigdecimal


### PR DESCRIPTION
this contains a fix for getting nested fields from
content block embed fields

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
