### PR TITLE
(888) Remove “New” prefix on summary card

### DIFF
--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/show/confirm_summary_card_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/show/confirm_summary_card_component.rb
@@ -30,7 +30,7 @@ private
   def details_items
     content_block_edition.first_class_details.map do |key, value|
       {
-        key: "New #{key.humanize.downcase}",
+        key: key.humanize,
         value:,
       }
     end

--- a/lib/engines/content_block_manager/test/components/content_block/edition/show/confirm_summary_card_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/show/confirm_summary_card_component_test.rb
@@ -43,7 +43,7 @@ class ContentBlockManager::ContentBlockEdition::Show::ConfirmSummaryCardComponen
     assert_selector ".govuk-summary-list__row:nth-child(1) .govuk-summary-list__key", text: "Title"
     assert_selector ".govuk-summary-list__row:nth-child(1) .govuk-summary-list__value", text: "Some edition title"
 
-    assert_selector ".govuk-summary-list__row:nth-child(2) .govuk-summary-list__key", text: "New interesting fact"
+    assert_selector ".govuk-summary-list__row:nth-child(2) .govuk-summary-list__key", text: "Interesting fact"
     assert_selector ".govuk-summary-list__row:nth-child(2) .govuk-summary-list__value", text: "value of fact"
 
     assert_selector ".govuk-summary-list__row:nth-child(3) .govuk-summary-list__key", text: "Lead organisation"


### PR DESCRIPTION
Trello card: https://trello.com/c/ZxLPpJcT/888-description-showing-as-new-description-in-create-edit-journeys

This was in the initial design, but we’ve decided it might be a bit confusing
