### PR TITLE
(910) Don’t change the object key when changing the name

### DIFF
--- a/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/editions/embedded_objects_controller.rb
+++ b/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/editions/embedded_objects_controller.rb
@@ -37,7 +37,7 @@ class ContentBlockManager::ContentBlock::Editions::EmbeddedObjectsController < C
       redirect_to content_block_manager.review_embedded_object_content_block_manager_content_block_edition_path(
         @content_block_edition,
         object_type: @subschema.block_type,
-        object_name: @content_block_edition.key_for_object(@object),
+        object_name: params[:object_name],
       )
     end
   rescue ActiveRecord::RecordInvalid

--- a/lib/engines/content_block_manager/app/models/content_block_manager/content_block/edition.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/content_block/edition.rb
@@ -53,13 +53,7 @@ module ContentBlockManager
       end
 
       def update_object_with_details(object_type, object_name, body)
-        key = key_for_object(body)
-
-        if key != object_name
-          details[object_type].delete(object_name)
-        end
-
-        add_object_to_details(object_type, body)
+        details[object_type][object_name] = body.to_h
       end
 
       def key_for_object(object)

--- a/lib/engines/content_block_manager/features/step_definitions/embedded_object_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/embedded_object_steps.rb
@@ -16,6 +16,7 @@ end
 When("I complete the {string} form with the following fields:") do |object_type, table|
   fields = table.hashes.first
   @details = fields
+  @object_name ||= @details["name"].parameterize
   fields.keys.each do |k|
     field = find_field "content_block_manager_content_block_edition_details_#{object_type.pluralize}_#{k}"
     if field.tag_name == "select"
@@ -37,7 +38,7 @@ Then("the {string} should have been created successfully") do |object_type|
 
   assert_not_nil edition
   assert_not_nil edition.document
-  key = @details["name"].parameterize
+  key = @object_name
 
   @details.keys.each do |k|
     assert_equal edition.details[object_type.parameterize.pluralize][key][k], @details[k]

--- a/lib/engines/content_block_manager/test/integration/content_block/editions/embedded_objects_test.rb
+++ b/lib/engines/content_block_manager/test/integration/content_block/editions/embedded_objects_test.rb
@@ -161,7 +161,7 @@ class ContentBlockManager::ContentBlock::Editions::EmbeddedObjectsTest < ActionD
       assert_equal "Something edited. You can add another something or continue to create schema block", flash[:notice]
     end
 
-    it "should rename the object if a new name is given" do
+    it "should not rename the object if a new name is given" do
       put content_block_manager.embedded_object_content_block_manager_content_block_edition_path(
         edition,
         object_type:,
@@ -180,12 +180,12 @@ class ContentBlockManager::ContentBlock::Editions::EmbeddedObjectsTest < ActionD
       assert_redirected_to content_block_manager.review_embedded_object_content_block_manager_content_block_edition_path(
         edition,
         object_type:,
-        object_name: "new-name",
+        object_name: "embedded",
       )
 
       updated_edition = edition.reload
 
-      assert_equal updated_edition.details, { "something" => { "new-name" => { "name" => "New Name", "is" => "different" } } }
+      assert_equal updated_edition.details, { "something" => { "embedded" => { "name" => "New Name", "is" => "different" } } }
     end
 
     it "should render errors if a validation error is thrown" do

--- a/lib/engines/content_block_manager/test/unit/app/models/content_block_edition_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/models/content_block_edition_test.rb
@@ -229,17 +229,10 @@ class ContentBlockManager::ContentBlockEditionTest < ActiveSupport::TestCase
       assert_equal content_block_edition.details["something"], { "my-thing" => { "name" => "My thing", "something" => "changed" } }
     end
 
-    it "removes the original object if the name changes" do
+    it "keeps the original key name if the name changes" do
       content_block_edition.update_object_with_details("something", "my-thing", { "name" => "Other thing", "something" => "changed" })
 
-      assert_equal content_block_edition.details["something"], { "other-thing" => { "name" => "Other thing", "something" => "changed" } }
-    end
-
-    it "creates a random key if a name is not provided" do
-      SecureRandom.expects(:alphanumeric).at_least_once.returns("RANDOM-STRING")
-      content_block_edition.update_object_with_details("something", "my-thing", { "something" => "changed" })
-
-      assert_equal content_block_edition.details["something"], { "random-string" => { "something" => "changed" } }
+      assert_equal content_block_edition.details["something"], { "my-thing" => { "name" => "Other thing", "something" => "changed" } }
     end
   end
 


### PR DESCRIPTION
Trello card: https://trello.com/c/TbeX7mVC/910-bug-editing-the-name-of-a-rate-causes-embed-code-to-break

This avoids the issue where changing the name of a rate breaks the embed code. It does mean that once a name is set, this means the key of the object is immutable, but this is a similar issue to how slugs work in other documents. We can revisit this if it becomes an issue.
