### PR TITLE
(908) Stop continue editing from removing existing embedded objects

### DIFF
--- a/lib/engines/content_block_manager/app/controllers/concerns/workflow/update_methods.rb
+++ b/lib/engines/content_block_manager/app/controllers/concerns/workflow/update_methods.rb
@@ -5,7 +5,13 @@ module Workflow::UpdateMethods
 
   def update_draft
     @content_block_edition = ContentBlockManager::ContentBlock::Edition.find(params[:id])
-    @content_block_edition.assign_attributes(edition_params.except(:creator, :document_attributes))
+
+    @content_block_edition.assign_attributes(
+      title: edition_params[:title],
+      organisation_id: edition_params[:organisation_id],
+      instructions_to_publishers: edition_params[:instructions_to_publishers],
+      details: @content_block_edition.details.merge(edition_params[:details]),
+    )
     @content_block_edition.save!
 
     if @content_block_edition.document.is_new_block?

--- a/lib/engines/content_block_manager/app/models/content_block_manager/content_block/edition/has_lead_organisation.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/content_block/edition/has_lead_organisation.rb
@@ -12,7 +12,7 @@ module ContentBlockManager
     end
 
     def organisation_id=(organisation_id)
-      if organisation_id.empty?
+      if organisation_id.blank?
         self.edition_organisation = nil
       else
         edition_organisation = build_edition_organisation

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/documents/show.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/documents/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for :page_full_width, true %>
 <% content_for :page_title, @content_block_document.title %>
 <% content_for :back_link do %>
   <%= render "govuk_publishing_components/components/back_link", {

--- a/lib/engines/content_block_manager/features/edit_pension_object.feature
+++ b/lib/engines/content_block_manager/features/edit_pension_object.feature
@@ -76,3 +76,14 @@ Feature: Edit a pension object
     When I click to view the content block
     Then the edition should have been updated successfully
     And I should see details of my "rate"
+
+  Scenario: GDS editor sees notification about an in-progress draft
+    When I visit the Content Block Manager home page
+    And I click to view the document
+    And I click to edit the "pension"
+    And I fill out the form
+    And I click the cancel link
+    And I click to save and come back later
+    When I click on the link to continue editing
+    And I click save
+    Then I should see the rates for that block

--- a/lib/engines/content_block_manager/test/integration/content_block/workflow_test.rb
+++ b/lib/engines/content_block_manager/test/integration/content_block/workflow_test.rb
@@ -137,16 +137,33 @@ class ContentBlockManager::ContentBlock::WorkflowTest < ActionDispatch::Integrat
               params: {
                 "content_block/edition" => {
                   "title" => "New title",
+                  "organisation_id" => organisation.id,
                   "details" => {
                     "foo" => "bar",
                   },
                 },
               }
 
+          assert_redirected_to content_block_manager_content_block_workflow_path(id: edition.id, step: :review_links)
+
           assert_equal edition.reload.title, "New title"
           assert_equal edition.reload.details["foo"], "bar"
+          assert_equal edition.reload.details["bar"], "Bar text"
+        end
 
-          assert_redirected_to content_block_manager_content_block_workflow_path(id: edition.id, step: :review_links)
+        it "updates the block with an empty string if a details field is blank" do
+          put content_block_manager.content_block_manager_content_block_workflow_path(id: edition.id, step:),
+              params: {
+                "content_block/edition" => {
+                  "title" => "New title",
+                  "organisation_id" => organisation.id,
+                  "details" => {
+                    "foo" => "",
+                  },
+                },
+              }
+
+          assert_equal edition.reload.details["foo"], ""
         end
 
         it "updates the block and redirects to the review page if editing a new block" do
@@ -156,16 +173,18 @@ class ContentBlockManager::ContentBlock::WorkflowTest < ActionDispatch::Integrat
               params: {
                 "content_block/edition" => {
                   "title" => "New title",
+                  "organisation_id" => organisation.id,
                   "details" => {
                     "foo" => "bar",
                   },
                 },
               }
 
+          assert_redirected_to content_block_manager_content_block_workflow_path(id: edition.id, step: :review)
+
           assert_equal edition.reload.title, "New title"
           assert_equal edition.reload.details["foo"], "bar"
-
-          assert_redirected_to content_block_manager_content_block_workflow_path(id: edition.id, step: :review)
+          assert_equal edition.reload.details["bar"], "Bar text"
         end
 
         it "shows an error if a required field is blank" do


### PR DESCRIPTION
Trello card: https://trello.com/c/BsSW5pPS/908-bug-continue-editing-hides-existing-rates

Before, when editing a draft, the details that a user gave overrode the whole details object, meaning all embedded documents were removed.

This assigns only the attributes we’re interested in, as well as merging the details hash from the form input, so anything that hasn’t come from the form remains intact.

I’ve also had to update the `organisation_id=` method to set the organisation to nil if `organisation_id` is an empty string.