### PR TITLE
content modelling/899 embed code no js

### DIFF
--- a/lib/engines/content_block_manager/app/assets/javascripts/content_block_manager/modules/copy-embed-code.js
+++ b/lib/engines/content_block_manager/app/assets/javascripts/content_block_manager/modules/copy-embed-code.js
@@ -14,6 +14,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {}
 
     this.module.append(dd)
     this.module.classList.remove('govuk-summary-list__row--no-actions')
+    this.removeEmbedCodeCardRows()
   }
 
   CopyEmbedCode.prototype.createLink = function () {
@@ -75,6 +76,13 @@ window.GOVUK.Modules = window.GOVUK.Modules || {}
       document.body.removeChild(textArea)
 
       resolve()
+    })
+  }
+
+  CopyEmbedCode.prototype.removeEmbedCodeCardRows = function () {
+    const cardRows = document.querySelectorAll('[data-embed-code-row="true"]')
+    cardRows.forEach((row) => {
+      row.remove()
     })
   }
 

--- a/lib/engines/content_block_manager/app/components/content_block_manager/shared/embedded_objects/summary_card_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/shared/embedded_objects/summary_card_component.rb
@@ -16,13 +16,29 @@ private
   end
 
   def rows
-    object.keys.map do |key|
-      {
-        key: key.titleize,
-        value: object[key],
-        data: copy_embed_code(key),
-      }
-    end
+    object.keys.map { |key|
+      rows = [
+        {
+          key: key.titleize,
+          value: object[key],
+          data: copy_embed_code(key),
+        },
+      ]
+      rows.push(embed_code_row(key))
+      rows
+    }.flatten
+  end
+
+  # This generates a row containing the embed code for the field above it -
+  # it will be deleted if javascript is enabled by copy-embed-code.js.
+  def embed_code_row(key)
+    {
+      key: "Embed code",
+      value: content_block_edition.document.embed_code_for_field("#{object_type}/#{object_name}/#{key}"),
+      data: {
+        "embed-code-row": "delete-if-js",
+      },
+    }
   end
 
   def copy_embed_code(key)

--- a/lib/engines/content_block_manager/app/components/content_block_manager/shared/embedded_objects/summary_card_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/shared/embedded_objects/summary_card_component.rb
@@ -36,7 +36,7 @@ private
       key: "Embed code",
       value: content_block_edition.document.embed_code_for_field("#{object_type}/#{object_name}/#{key}"),
       data: {
-        "embed-code-row": "delete-if-js",
+        "embed-code-row": "true",
       },
     }
   end

--- a/lib/engines/content_block_manager/features/step_definitions/embed_code_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/embed_code_steps.rb
@@ -27,3 +27,9 @@ Then("the embed code should be copied to my clipboard") do
   clip_text = page.evaluate_async_script("navigator.clipboard.readText().then(arguments[0])")
   expect(clip_text).to eq(@embed_code)
 end
+
+Then("the embed code for the content block {string}, rate {string} and field {string} should be visible") do |pension_title, rate_name, field_name|
+  edition = ContentBlockManager::ContentBlock::Edition.find_by(title: pension_title)
+  embed_code = edition.document.embed_code_for_field("rates/#{rate_name.parameterize.presence}/#{field_name}")
+  expect(page).to have_content(embed_code)
+end

--- a/lib/engines/content_block_manager/features/view_object.feature
+++ b/lib/engines/content_block_manager/features/view_object.feature
@@ -52,3 +52,7 @@ Feature: View a content object
     And I click to copy the embed code for the pension "My pension", rate "My rate" and field "name"
     Then the embed code should be copied to my clipboard
 
+  Scenario: GDS Editor without javascript can see embed code
+    When I visit the Content Block Manager home page
+    When I click to view the document with title "My pension"
+    Then the embed code for the content block "My pension", rate "My rate" and field "amount" should be visible

--- a/lib/engines/content_block_manager/spec/content_block_manager/copy-embed-code.spec.js
+++ b/lib/engines/content_block_manager/spec/content_block_manager/copy-embed-code.spec.js
@@ -8,6 +8,14 @@ describe('GOVUK.Modules.CopyEmbedCode', function () {
     fixture.innerHTML = `
       <dt class="govuk-summary-list__key">Embed code</dt>
       <dd class="govuk-summary-list__value">${embedCode}</dd>
+      <div class="test-delete-me govuk-summary-list__row govuk-summary-list__row--no-actions" data-embed-code-row="true">
+                <dt class="govuk-summary-list__key">
+                  Embed code
+                </dt>
+                <dt class="govuk-summary-list__value">
+                  1234
+                </dt>
+      </div>
     `
     document.body.append(fixture)
 
@@ -74,5 +82,11 @@ describe('GOVUK.Modules.CopyEmbedCode', function () {
     expect(copyLink.textContent).toEqual('Copy code')
 
     jasmine.clock().uninstall()
+  })
+
+  it('hides the row showing the embed code', async function () {
+    expect(fixture.querySelectorAll('[data-embed-code-row="true"]')).toHaveSize(
+      0
+    )
   })
 })

--- a/lib/engines/content_block_manager/test/components/shared/embedded_objects/summary_card_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/shared/embedded_objects/summary_card_component_test.rb
@@ -59,6 +59,20 @@ class ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponentTest < V
     assert_selector ".govuk-summary-list__row[data-embed-code='#{content_block_edition.document.embed_code_for_field('embedded-objects/my-embedded-object/field-2')}']", text: "Field 2"
   end
 
+  it "renders an embed code row for each field" do
+    component = ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponent.new(
+      content_block_edition:,
+      object_type: "embedded-objects",
+      object_name: "my-embedded-object",
+    )
+
+    render_inline component
+
+    assert_selector ".govuk-summary-list__row[data-embed-code-row='delete-if-js']", text: content_block_edition.document.embed_code_for_field("embedded-objects/my-embedded-object/name")
+    assert_selector ".govuk-summary-list__row[data-embed-code-row='delete-if-js']", text: content_block_edition.document.embed_code_for_field("embedded-objects/my-embedded-object/field-1")
+    assert_selector ".govuk-summary-list__row[data-embed-code-row='delete-if-js']", text: content_block_edition.document.embed_code_for_field("embedded-objects/my-embedded-object/field-2")
+  end
+
   describe "when card is editable" do
     it "renders a summary list with edit link" do
       component = ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponent.new(

--- a/lib/engines/content_block_manager/test/components/shared/embedded_objects/summary_card_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/shared/embedded_objects/summary_card_component_test.rb
@@ -68,9 +68,9 @@ class ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponentTest < V
 
     render_inline component
 
-    assert_selector ".govuk-summary-list__row[data-embed-code-row='delete-if-js']", text: content_block_edition.document.embed_code_for_field("embedded-objects/my-embedded-object/name")
-    assert_selector ".govuk-summary-list__row[data-embed-code-row='delete-if-js']", text: content_block_edition.document.embed_code_for_field("embedded-objects/my-embedded-object/field-1")
-    assert_selector ".govuk-summary-list__row[data-embed-code-row='delete-if-js']", text: content_block_edition.document.embed_code_for_field("embedded-objects/my-embedded-object/field-2")
+    assert_selector ".govuk-summary-list__row[data-embed-code-row='true']", text: content_block_edition.document.embed_code_for_field("embedded-objects/my-embedded-object/name")
+    assert_selector ".govuk-summary-list__row[data-embed-code-row='true']", text: content_block_edition.document.embed_code_for_field("embedded-objects/my-embedded-object/field-1")
+    assert_selector ".govuk-summary-list__row[data-embed-code-row='true']", text: content_block_edition.document.embed_code_for_field("embedded-objects/my-embedded-object/field-2")
   end
 
   describe "when card is editable" do


### PR DESCRIPTION
https://trello.com/c/Hr1mmk1C/899-add-copy-embed-code-to-attributes


- **Add a no javascript option for embed codes in embedded objects**
- **Remove embed code card row**

## No js
![Screenshot 2025-02-19 at 10 05 07](https://github.com/user-attachments/assets/749377bc-818a-421b-b948-d603a404f76b)

## with js
![Screenshot 2025-02-19 at 10 05 30](https://github.com/user-attachments/assets/44e0d5ab-f2d6-4d92-8d33-c246f7a434fd)


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
