### PR TITLE
content-modelling/fix - do not show embed code row

### DIFF
--- a/lib/engines/content_block_manager/app/components/content_block_manager/shared/embedded_objects/summary_card_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/shared/embedded_objects/summary_card_component.rb
@@ -24,7 +24,7 @@ private
           data: copy_embed_code(key),
         },
       ]
-      rows.push(embed_code_row(key))
+      rows.push(embed_code_row(key)) unless is_editable
       rows
     }.flatten
   end

--- a/lib/engines/content_block_manager/test/components/shared/embedded_objects/summary_card_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/shared/embedded_objects/summary_card_component_test.rb
@@ -92,6 +92,8 @@ class ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponentTest < V
         object_name: "my-embedded-object",
       )
 
+      assert_selector ".govuk-summary-list__row", count: 3
+
       assert_selector ".govuk-summary-card__actions .govuk-summary-card__action:nth-child(1) a[href='#{expected_edit_path}']", text: "Edit"
 
       assert_selector ".govuk-summary-list__row", text: /Name/ do
@@ -146,6 +148,21 @@ class ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponentTest < V
       assert_no_selector ".govuk-summary-list__row[data-embed-code='#{content_block_edition.document.embed_code_for_field('embedded-objects/my-embedded-object/name')}']", text: "Name"
       assert_no_selector ".govuk-summary-list__row[data-embed-code='#{content_block_edition.document.embed_code_for_field('embedded-objects/my-embedded-object/field-1')}']", text: "Field 1"
       assert_no_selector ".govuk-summary-list__row[data-embed-code='#{content_block_edition.document.embed_code_for_field('embedded-objects/my-embedded-object/field-2')}']", text: "Field 2"
+    end
+
+    it "does not embed code row" do
+      component = ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponent.new(
+        content_block_edition:,
+        object_type: "embedded-objects",
+        object_name: "my-embedded-object",
+        is_editable: true,
+      )
+
+      render_inline component
+
+      assert_no_selector ".govuk-summary-list__row[data-embed-code-row='true']", text: content_block_edition.document.embed_code_for_field("embedded-objects/my-embedded-object/name")
+      assert_no_selector ".govuk-summary-list__row[data-embed-code-row='true']", text: content_block_edition.document.embed_code_for_field("embedded-objects/my-embedded-object/field-1")
+      assert_no_selector ".govuk-summary-list__row[data-embed-code-row='true']", text: content_block_edition.document.embed_code_for_field("embedded-objects/my-embedded-object/field-2")
     end
   end
 end


### PR DESCRIPTION
when embedded object is being edited, we should not see the embed code row, as the user doesn't need it at that stage, and the 'copy code' javascript is not in place to hide the row.

--

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
