### PR TITLE
(907) Allow fields with copy code to be configured

### DIFF
--- a/lib/engines/content_block_manager/app/components/content_block_manager/shared/embedded_objects/summary_card_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/shared/embedded_objects/summary_card_component.rb
@@ -21,10 +21,10 @@ private
         {
           key: key.titleize,
           value: object[key],
-          data: copy_embed_code(key),
+          data: is_embeddable?(key) ? copy_embed_code(key) : nil,
         },
       ]
-      rows.push(embed_code_row(key)) unless is_editable
+      rows.push(embed_code_row(key)) unless is_editable || !is_embeddable?(key)
       rows
     }.flatten
   end
@@ -39,6 +39,14 @@ private
         "embed-code-row": "true",
       },
     }
+  end
+
+  def embeddable_fields
+    @embeddable_fields = content_block_edition.document.schema.subschema(object_type).embeddable_fields
+  end
+
+  def is_embeddable?(key)
+    embeddable_fields.include?(key)
   end
 
   def copy_embed_code(key)

--- a/lib/engines/content_block_manager/app/models/content_block_manager/content_block/document.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/content_block/document.rb
@@ -50,6 +50,10 @@ module ContentBlockManager
         editions.where(state: :draft).order(created_at: :asc).last
       end
 
+      def schema
+        @schema ||= ContentBlockManager::ContentBlock::Schema.find_by_block_type(block_type)
+      end
+
     private
 
       def embed_code_prefix

--- a/lib/engines/content_block_manager/app/models/content_block_manager/content_block/schema.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/content_block/schema.rb
@@ -69,6 +69,10 @@ module ContentBlockManager
         @block_type ||= id.delete_prefix("#{SCHEMA_PREFIX}_")
       end
 
+      def embeddable_fields
+        config["embeddable_fields"] || fields
+      end
+
       class EmbeddedSchema < Schema
         def initialize(id, body, parent_schema_id)
           @parent_schema_id = parent_schema_id

--- a/lib/engines/content_block_manager/config/content_block_manager.yml
+++ b/lib/engines/content_block_manager/config/content_block_manager.yml
@@ -1,0 +1,6 @@
+schemas:
+  content_block_pension:
+    subschemas:
+      rates:
+        embeddable_fields:
+          - amount

--- a/lib/engines/content_block_manager/features/view_object.feature
+++ b/lib/engines/content_block_manager/features/view_object.feature
@@ -49,7 +49,7 @@ Feature: View a content object
   Scenario: GDS Editor can copy embed code for a specific field
     When I visit the Content Block Manager home page
     When I click to view the document with title "My pension"
-    And I click to copy the embed code for the pension "My pension", rate "My rate" and field "name"
+    And I click to copy the embed code for the pension "My pension", rate "My rate" and field "amount"
     Then the embed code should be copied to my clipboard
 
   Scenario: GDS Editor without javascript can see embed code

--- a/lib/engines/content_block_manager/test/factories/content_block_document.rb
+++ b/lib/engines/content_block_manager/test/factories/content_block_document.rb
@@ -7,10 +7,19 @@ FactoryBot.define do
     latest_edition_id { nil }
     live_edition_id { nil }
 
+    transient do
+      schema { nil }
+    end
+
     ContentBlockManager::ContentBlock::Schema.valid_schemas.each do |type|
       trait type.to_sym do
         block_type { type }
+        schema { build(:content_block_schema, block_type: type) }
       end
+    end
+
+    after(:build) do |content_block_document, evaluator|
+      content_block_document.stubs(:schema).returns(evaluator.schema)
     end
   end
 end

--- a/lib/engines/content_block_manager/test/unit/app/models/content_block_document_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/models/content_block_document_test.rb
@@ -185,4 +185,20 @@ class ContentBlockManager::ContentBlockDocumentTest < ActiveSupport::TestCase
       assert_equal newest_draft, document.latest_draft
     end
   end
+
+  describe "#schema" do
+    let(:document) { build(:content_block_document, :email_address) }
+    let(:schema) { build(:content_block_schema) }
+
+    it "returns a schema object" do
+      document.unstub(:schema)
+
+      ContentBlockManager::ContentBlock::Schema
+        .expects(:find_by_block_type)
+        .with(document.block_type)
+        .returns(schema)
+
+      assert_equal document.schema, schema
+    end
+  end
 end

--- a/lib/engines/content_block_manager/test/unit/app/models/content_block_schema_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/models/content_block_schema_test.rb
@@ -309,4 +309,36 @@ class ContentBlockManager::SchemaTest < ActiveSupport::TestCase
       end
     end
   end
+
+  describe "#embeddable_fields" do
+    describe "when config exists for a schema" do
+      before do
+        ContentBlockManager::ContentBlock::Schema
+          .stubs(:schema_settings)
+          .returns({
+            "schemas" => {
+              schema.id => {
+                "embeddable_fields" => %w[something else],
+              },
+            },
+          })
+      end
+
+      it "returns the config values" do
+        assert_equal schema.embeddable_fields, %w[something else]
+      end
+    end
+
+    describe "when config does not exist for a schema" do
+      before do
+        ContentBlockManager::ContentBlock::Schema
+          .stubs(:schema_settings)
+          .returns({})
+      end
+
+      it "returns the fields" do
+        assert_equal schema.embeddable_fields, schema.fields
+      end
+    end
+  end
 end

--- a/lib/engines/content_block_manager/test/unit/app/models/content_block_schema_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/models/content_block_schema_test.rb
@@ -265,6 +265,17 @@ class ContentBlockManager::SchemaTest < ActiveSupport::TestCase
     end
   end
 
+  describe ".schema_settings" do
+    it "should return the schema settings" do
+      stub_schema = stub("schema_settings")
+      YAML.expects(:load_file)
+          .with(ContentBlockManager::ContentBlock::Schema::CONFIG_PATH)
+          .returns(stub_schema)
+
+      assert_equal ContentBlockManager::ContentBlock::Schema.schema_settings, stub_schema
+    end
+  end
+
   describe "when a schema has embedded objects" do
     let(:body) do
       {


### PR DESCRIPTION
Trello card: https://trello.com/c/aSyUk0AR/907-allow-fields-with-copy-code-to-be-configured

This adds a new configuration file that allows us to configure which fields can have a copy code associated (defaults to all fields). This config file will also be useful for us to define fun things like custom fields and ordering of fields too.

## Screenshot

![image](https://github.com/user-attachments/assets/9577c8ee-6663-444b-8bd8-42519c008858)
