### PR TITLE
(900) Update amount field to text input with prefix component

### DIFF
--- a/lib/engines/content_block_manager/app/assets/javascripts/content_block_manager/application.js
+++ b/lib/engines/content_block_manager/app/assets/javascripts/content_block_manager/application.js
@@ -1,1 +1,2 @@
 //= require ./modules/copy-embed-code
+//= require ./modules/form-prefix

--- a/lib/engines/content_block_manager/app/assets/javascripts/content_block_manager/modules/form-prefix.js
+++ b/lib/engines/content_block_manager/app/assets/javascripts/content_block_manager/modules/form-prefix.js
@@ -1,0 +1,42 @@
+'use strict'
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {}
+;(function (Modules) {
+  function FormPrefix(module) {
+    this.module = module
+  }
+
+  FormPrefix.prototype.init = function () {
+    // Create a prefix element
+    const prefix = document.createElement('span')
+    prefix.classList.add('govuk-input__prefix')
+    prefix.setAttribute('aria-hidden', 'true')
+    prefix.textContent = this.module.dataset.prefix
+
+    // Add a wrapper with the prefix
+    const wrapper = document.createElement('div')
+    wrapper.classList.add('govuk-input__wrapper')
+    this.module.parentNode.insertBefore(wrapper, this.module)
+    wrapper.appendChild(this.module)
+    wrapper.insertBefore(prefix, this.module)
+
+    // Remove the prefix from the text boxes value
+    if (this.module.value.startsWith(this.module.dataset.prefix)) {
+      this.module.value = this.module.value.slice(
+        this.module.dataset.prefix.length
+      )
+    }
+
+    // Add a listener to add the prefix once the form is submitted
+    this.module.form.addEventListener('submit', this.appendPrefix.bind(this))
+  }
+
+  FormPrefix.prototype.appendPrefix = function (e) {
+    const form = this.module.form
+    const inputName = this.module.name
+
+    form[inputName].value = this.module.dataset.prefix + form[inputName].value
+  }
+
+  Modules.FormPrefix = FormPrefix
+})(window.GOVUK.Modules)

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/embedded_objects/form_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/embedded_objects/form_component.rb
@@ -1,9 +1,10 @@
 class ContentBlockManager::ContentBlockEdition::Details::EmbeddedObjects::FormComponent < ContentBlockManager::ContentBlockEdition::Details::FormComponent
-  def initialize(content_block_edition:, schema:, object_name:, params:)
+  def initialize(content_block_edition:, schema:, object_name:, params:, prefix: nil)
     @content_block_edition = content_block_edition
     @schema = schema
     @object_name = object_name
     @params = params || {}
+    @prefix = prefix
   end
 
 private

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/string_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/string_component.html.erb
@@ -7,4 +7,5 @@
   value:,
   error_items:,
   hint:,
+  data:,
 } %>

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/string_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/string_component.rb
@@ -1,2 +1,25 @@
 class ContentBlockManager::ContentBlockEdition::Details::Fields::StringComponent < ContentBlockManager::ContentBlockEdition::Details::Fields::BaseComponent
+  def initialize(content_block_edition:, field:, label: nil, value: nil, id_suffix: nil, prefix: nil)
+    @prefix = prefix
+    super(content_block_edition:, field:, label:, value:, id_suffix:)
+  end
+
+private
+
+  attr_reader :prefix
+
+  def value
+    @value || content_block_edition.details&.fetch(
+      field,
+      prefix,
+    )
+  end
+
+  def data
+    if prefix
+      { "prefix" => prefix, "module" => "form-prefix" }
+    else
+      {}
+    end
+  end
 end

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/form_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/form_component.rb
@@ -18,7 +18,7 @@ private
         )
       else
         ContentBlockManager::ContentBlockEdition::Details::Fields::StringComponent.new(
-          **component_args(field),
+          **component_args(field).merge(prefix: prefix_for_field(field)).compact,
         )
       end
     end
@@ -29,5 +29,9 @@ private
       content_block_edition:,
       field:,
     }
+  end
+
+  def prefix_for_field(field)
+    @schema.config_for_field(field).dig("field_args", "prefix")
   end
 end

--- a/lib/engines/content_block_manager/app/models/content_block_manager/content_block/schema.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/content_block/schema.rb
@@ -73,6 +73,10 @@ module ContentBlockManager
         config["embeddable_fields"] || fields
       end
 
+      def config_for_field(field)
+        config.dig("fields", field) || {}
+      end
+
       class EmbeddedSchema < Schema
         def initialize(id, body, parent_schema_id)
           @parent_schema_id = parent_schema_id

--- a/lib/engines/content_block_manager/config/content_block_manager.yml
+++ b/lib/engines/content_block_manager/config/content_block_manager.yml
@@ -2,5 +2,9 @@ schemas:
   content_block_pension:
     subschemas:
       rates:
+        fields:
+          amount:
+            field_args:
+              prefix: £
         embeddable_fields:
           - amount

--- a/lib/engines/content_block_manager/config/locales/en.yml
+++ b/lib/engines/content_block_manager/config/locales/en.yml
@@ -51,7 +51,3 @@ en:
     review_page:
       errors:
         confirm: Tick box to confirm details are correct
-    details:
-      hints:
-        rates:
-          amount: "Enter an exact amount, with the currency symbol - for example: £122.50"

--- a/lib/engines/content_block_manager/features/create_embedded_object.feature
+++ b/lib/engines/content_block_manager/features/create_embedded_object.feature
@@ -31,7 +31,9 @@ Feature: Create an embedded content object
 
   Scenario: GDS editor sees validation errors for required fields
     When I visit the page to create a new "rate" for the block
-    And I click save
+    When I complete the "rate" form with the following fields:
+      | name    | amount        | cadence |
+      |         |               |         |
     Then I should see errors for the required "rate" fields
 
   Scenario: GDS editor sees validation errors for an invalid field
@@ -55,3 +57,18 @@ Feature: Create an embedded content object
     When I review and confirm my "rate" is correct
     Then the "rate" should have been created successfully
     And I should see confirmation that my "rate" has been created
+
+  @javascript
+  Scenario: The currency symbol is prefixed for amounts
+    When I visit the Content Block Manager home page
+    And I click to view the document
+    And I click to create a new "rate"
+    Then I should see a form to create a "rate" for the content block
+    When I complete the "rate" form with the following fields:
+      | name    | amount  | cadence |
+      | my rate | 122.50 | weekly  |
+    Then I should be asked to review my "rate"
+    And I click create
+    Then I should see a message that I need to confirm the details are correct
+    When I review and confirm my "rate" is correct
+    Then the value of the "amount" for my "rate" should be "£122.50"

--- a/lib/engines/content_block_manager/features/step_definitions/embedded_object_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/embedded_object_steps.rb
@@ -112,3 +112,10 @@ And(/^I should see the updated rates for that block$/) do
     assert_text @details[k]
   end
 end
+
+Then("the value of the {string} for my {string} should be {string}") do |attribute, object, expected_value|
+  edition = ContentBlockManager::ContentBlock::Edition.all.last
+  key = @object_name
+
+  assert_equal edition.details[object.pluralize][key][attribute], expected_value
+end

--- a/lib/engines/content_block_manager/spec/content_block_manager/form-prefix.spec.js
+++ b/lib/engines/content_block_manager/spec/content_block_manager/form-prefix.spec.js
@@ -1,0 +1,50 @@
+'use strict'
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {}
+
+describe('GOVUK.Modules.FormPrefix', function () {
+  let prefix, fixture, formPrefix, form
+
+  beforeEach(function () {
+    prefix = '£'
+    fixture = document.createElement('input')
+    fixture.setAttribute('type', 'text')
+    fixture.setAttribute('data-prefix', prefix)
+    fixture.setAttribute('data-module', 'form-prefix')
+    fixture.setAttribute('name', 'amount')
+    fixture.setAttribute('value', '£1234')
+
+    form = document.createElement('form')
+    form.appendChild(fixture)
+
+    document.body.append(form)
+
+    formPrefix = new GOVUK.Modules.FormPrefix(fixture)
+    formPrefix.init()
+  })
+
+  afterEach(function () {
+    form.innerHTML = ''
+  })
+
+  it('should add a prefix element', function () {
+    const wrapper = document.querySelector('.govuk-input__wrapper')
+    expect(wrapper).toBeTruthy()
+
+    const prefixElement = wrapper.querySelector('.govuk-input__prefix')
+    expect(prefixElement).toBeTruthy()
+    expect(prefixElement.textContent).toBe(prefix)
+  })
+
+  it('should remove the prefix from the input', function () {
+    expect(fixture.value).toBe('1234')
+  })
+
+  it('should add the prefix back to the element on submit', function () {
+    form.addEventListener('submit', function (e) {
+      expect(fixture.value).toBe('£1234')
+      e.preventDefault()
+    })
+    form.dispatchEvent(new Event('submit', { cancelable: true }))
+  })
+})

--- a/lib/engines/content_block_manager/test/components/content_block/edition/details/embedded_objects/form_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/details/embedded_objects/form_component_test.rb
@@ -32,7 +32,6 @@ class ContentBlockManager::ContentBlockEdition::Details::EmbeddedObjects::FormCo
       label: "Foo",
       field: [object_name, "foo"],
       id_suffix: "#{object_name}_foo",
-      value: nil,
     ).returns(foo_stub)
 
     ContentBlockManager::ContentBlockEdition::Details::Fields::StringComponent.expects(:new).with(
@@ -40,7 +39,6 @@ class ContentBlockManager::ContentBlockEdition::Details::EmbeddedObjects::FormCo
       label: "Bar",
       field: [object_name, "bar"],
       id_suffix: "#{object_name}_bar",
-      value: nil,
     ).returns(bar_stub)
 
     component = ContentBlockManager::ContentBlockEdition::Details::EmbeddedObjects::FormComponent.new(
@@ -72,7 +70,6 @@ class ContentBlockManager::ContentBlockEdition::Details::EmbeddedObjects::FormCo
       label: "Bar",
       field: [object_name, "bar"],
       id_suffix: "#{object_name}_bar",
-      value: nil,
     ).returns(bar_stub)
 
     component = ContentBlockManager::ContentBlockEdition::Details::EmbeddedObjects::FormComponent.new(

--- a/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/string_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/string_component_test.rb
@@ -60,6 +60,49 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::StringComponent
     assert_selector 'input[value="some custom value"]'
   end
 
+  describe "prefix" do
+    it "should allow a prefix to be set" do
+      render_inline(
+        ContentBlockManager::ContentBlockEdition::Details::Fields::StringComponent.new(
+          content_block_edition:,
+          field: "email_address",
+          value: "some custom value",
+          prefix: "£",
+        ),
+      )
+
+      assert_selector 'input[data-prefix="£"][data-module="form-prefix"]'
+    end
+
+    it "should add a prefix to the value if the value is not set" do
+      render_inline(
+        ContentBlockManager::ContentBlockEdition::Details::Fields::StringComponent.new(
+          content_block_edition:,
+          field: "email_address",
+          value: nil,
+          prefix: "£",
+        ),
+      )
+
+      assert_selector 'input[value="£"]'
+    end
+
+    it "should ignore the prefix if the details contain a value" do
+      content_block_edition.details = { "email_address": "example@example.com" }
+
+      render_inline(
+        ContentBlockManager::ContentBlockEdition::Details::Fields::StringComponent.new(
+          content_block_edition:,
+          field: "email_address",
+          value: nil,
+          prefix: "£",
+        ),
+      )
+
+      assert_selector 'input[value="example@example.com"]'
+    end
+  end
+
   describe "hints" do
     it "should render hint text when a translation exists" do
       I18n.expects(:t).with("content_block_edition.details.hints.email_address", default: nil).returns("Some hint text")

--- a/lib/engines/content_block_manager/test/support/integration_test_helpers.rb
+++ b/lib/engines/content_block_manager/test/support/integration_test_helpers.rb
@@ -13,6 +13,7 @@ module ContentBlockManager::IntegrationTestHelpers
       block_type:,
       permitted_params: %i[foo bar],
       subschemas:,
+      config_for_field: {},
     )
     subschemas.each do |subschema|
       schema.stubs(:subschema).with(subschema.id).returns(subschema)

--- a/lib/engines/content_block_manager/test/unit/app/models/content_block_schema_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/models/content_block_schema_test.rb
@@ -341,4 +341,46 @@ class ContentBlockManager::SchemaTest < ActiveSupport::TestCase
       end
     end
   end
+
+  describe "#config_for_field" do
+    describe "when config exists for a given field" do
+      before do
+        ContentBlockManager::ContentBlock::Schema
+          .stubs(:schema_settings)
+          .returns({
+            "schemas" => {
+              schema.id => {
+                "fields" => {
+                  "my_field" => { "foo" => "bar" },
+                },
+              },
+            },
+          })
+      end
+
+      it "returns that config" do
+        assert_equal schema.config_for_field("my_field"), { "foo" => "bar" }
+      end
+    end
+
+    describe "when config does not exist for a given field" do
+      before do
+        ContentBlockManager::ContentBlock::Schema
+          .stubs(:schema_settings)
+          .returns({
+            "schemas" => {
+              schema.id => {
+                "fields" => {
+                  "another_field" => { "foo" => "bar" },
+                },
+              },
+            },
+          })
+      end
+
+      it "returns an empty hash" do
+        assert_equal schema.config_for_field("my_field"), {}
+      end
+    end
+  end
 end


### PR DESCRIPTION
Trello card: https://trello.com/c/3bpVWCMn/900-update-amount-field-to-text-input-with-prefix-component

This adds some configuration to add a prefix to fields. It's not as simple as simply changing the component if we want a prefix, as we still want the value contained in the prefix to be part of the resulting value. To get around this, if we want a prefix we add some Javascript to add the prefix element to the input, removing the prefix from the value of the field. Once the form is submitted, we update the value to add the prefix back.

This gracefully degrades without Javascript to just adding the prefix value to the input field if there is no value present.

## Screenshot

![image](https://github.com/user-attachments/assets/16b6330e-c07f-4e8f-b60e-343422c3b2c1)
