### PR TITLE
Unify APIs for the 'autocomplete' and 'select with search' components

### DIFF
--- a/app/assets/javascripts/components/autocomplete.js
+++ b/app/assets/javascripts/components/autocomplete.js
@@ -14,22 +14,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {}
       selectElement: $select,
       minLength: 3,
       showAllValues: $select.multiple,
-      showNoOptionsFound: true,
-      onConfirm: function (query) {
-        let matchingOption
-        if (query) {
-          matchingOption = [].filter.call($select.options, function (option) {
-            return (option.textContent || option.innerText) === query
-          })[0]
-        } else {
-          matchingOption = [].filter.call($select.options, function (option) {
-            return option.value === ''
-          })[0]
-        }
-        if (matchingOption) {
-          matchingOption.selected = true
-        }
-      }
+      showNoOptionsFound: true
     }
 
     const assignedOptions = JSON.parse(

--- a/app/helpers/admin/taggable_content_helper.rb
+++ b/app/helpers/admin/taggable_content_helper.rb
@@ -1,15 +1,6 @@
 # A bunch of helpers for efficiently generating select options for taggable
 # content, e.g. topics, organisations, etc.
 module Admin::TaggableContentHelper
-  # Returns an Array that represents the current set of taggable topical
-  # events. Each element of the array consists of two values: the name and ID
-  # of the topical event.
-  def taggable_topical_events_container
-    Rails.cache.fetch(taggable_topical_events_cache_digest, expires_in: 1.day) do
-      TopicalEvent.order(:name).map { |te| [te.name, te.id] }
-    end
-  end
-
   # Returns an Array that represents the current set of taggable organisations.
   # Each element of the array consists of two values: the select_name and the
   # ID of the organisation
@@ -51,17 +42,6 @@ module Admin::TaggableContentHelper
   def taggable_role_appointments_container
     Rails.cache.fetch(taggable_role_appointments_cache_digest, expires_in: 1.day) do
       role_appointments_container_for(RoleAppointment)
-    end
-  end
-
-  # Returns an Array that represents the taggable ministerial roles. Each
-  # element of the array consists of two values: the name of the ministerial
-  # role with the organisation and current holder and its ID.
-  def taggable_ministerial_roles_container
-    Rails.cache.fetch(taggable_ministerial_roles_cache_digest, expires_in: 1.day) do
-      MinisterialRole.with_translations.with_translations_for(:organisations).alphabetical_by_person.map do |role|
-        ["#{role.name}, #{role.organisations.map(&:name).to_sentence} (#{role.current_person_name})", role.id]
-      end
     end
   end
 
@@ -112,17 +92,6 @@ module Admin::TaggableContentHelper
     end
   end
 
-  # Returns an Array representing the taggable document collections and their
-  # groups. Each element of the array consists of two values: the
-  # collection/group name and the ID of the group.
-  def taggable_document_collection_groups_container
-    Rails.cache.fetch(taggable_document_collection_groups_cache_digest, expires_in: 1.day) do
-      DocumentCollection.latest_edition.alphabetical.includes(:groups).flat_map do |collection|
-        collection.groups.map { |group| ["#{collection.title} (#{group.heading})", group.id] }
-      end
-    end
-  end
-
   # Returns an Array that represents the taggable worldwide organisations.
   # Each element of the array consists of two values: the name of the worldwide
   # organisation and its ID.
@@ -166,13 +135,6 @@ module Admin::TaggableContentHelper
     @taggable_role_appointments_cache_digest ||= calculate_digest(RoleAppointment.order(:id), "role-appointments")
   end
 
-  # Returns an MD5 digest representing the current set of taggable ministerial
-  # rile appointments. THis will change if any ministerial role is added or
-  # updated.
-  def taggable_ministerial_roles_cache_digest
-    @taggable_ministerial_roles_cache_digest ||= calculate_digest(MinisterialRole.order(:id), "ministerial-roles")
-  end
-
   # Returns an MD5 digest representing all the detailed guides. This wil change
   # if any detailed guides are added or updated.
   def taggable_detailed_guides_cache_digest
@@ -202,13 +164,6 @@ module Admin::TaggableContentHelper
   # changed.
   def taggable_alternative_format_providers_cache_digest
     @taggable_alternative_format_providers_cache_digest ||= calculate_digest(Organisation.order(:id), "alternative-format-providers")
-  end
-
-  # Returns an MD5 digest representing the taggable document collection
-  # groups. This will change if any document collection or group within
-  # the collection is changed or any new ones are added.
-  def taggable_document_collection_groups_cache_digest
-    @taggable_document_collection_groups_cache_digest ||= calculate_digest(Document.where(document_type: "DocumentCollection").order(:id), "document-collection-groups")
   end
 
   # Returns an MD5 digest representing the taggable worldwide organisations. This

--- a/app/helpers/admin/taggable_content_helper.rb
+++ b/app/helpers/admin/taggable_content_helper.rb
@@ -1,29 +1,34 @@
 # A bunch of helpers for efficiently generating select options for taggable
 # content, e.g. topics, organisations, etc.
 module Admin::TaggableContentHelper
-  # Returns an Array that represents the current set of taggable organisations.
-  # Each element of the array consists of two values: the select_name and the
-  # ID of the organisation
-  def taggable_organisations_container
+  def taggable_organisations_container(selected_ids = [])
     cached_taggable_organisations.map do |o|
-      [o.select_name, o.id]
+      {
+        text: o.select_name,
+        value: o.id,
+        selected: selected_ids.include?(o.id),
+      }
     end
   end
 
-  # Returns an Array that represents the current set of taggable ministerial
-  # role appointments (both past and present). Each element of the array
-  # consists of two values: a selectable label (consisting of the person, the
-  # role, the date the role was held if it's in the past, and the organisations
-  # the person belongs to) and the ID of the role appointment.
-  def taggable_ministerial_role_appointments_container
+  def taggable_ministerial_role_appointments_container(selected_ids = [])
     cached_taggable_ministerial_role_appointments.map do |appointment|
-      [role_appointment_label(appointment), appointment.id]
+      {
+        text: role_appointment_label(appointment),
+        value: appointment.id,
+        selected: selected_ids.include?(appointment.id),
+      }
     end
   end
 
-  def taggable_needs_container
+  def taggable_needs_container(selected_ids)
     Services.publishing_api.get_linkables(document_type: "need").to_a.map do |need|
-      need.values_at("title", "content_id")
+      title, content_id = need.values_at("title", "content_id")
+      {
+        text: title,
+        value: content_id,
+        selected: selected_ids.include?(content_id),
+      }
     end
   rescue GdsApi::TimedOutException, GdsApi::HTTPServerError
     stale_data = Rails.cache.fetch("need.linkables")
@@ -32,66 +37,73 @@ module Admin::TaggableContentHelper
     raise
   end
 
-  # Returns an Array that represents the current set of taggable roles (both
-  # past and present). Each element of the array consists of two values: a
-  # selectable label (consisting of the person, the role, the date the role was
-  # held if it's in the past, and the organisations the person belongs to) and
-  # the ID of the role appointment.
-  def taggable_role_appointments_container
+  def taggable_role_appointments_container(selected_ids = [])
     cached_taggable_role_appointments.map do |appointment|
-      [role_appointment_label(appointment), appointment.id]
+      {
+        text: role_appointment_label(appointment),
+        value: appointment.id,
+        selected: selected_ids.include?(appointment.id),
+      }
     end
   end
 
-  # Returns an Array that represents the current set of taggable detauled
-  # guides. Each element of the array consists of two values: the guide title
-  # and its ID.
-  def taggable_detailed_guides_container
+  def taggable_detailed_guides_container(selected_ids = [])
     cached_taggable_detailed_guides.map do |d|
-      [d.title, d.id]
+      {
+        text: d.title,
+        value: d.id,
+        selected: selected_ids.include?(d.id),
+      }
     end
   end
 
-  # Returns an Array that represents the current set of taggable statistical
-  # data sets. Each elements of the array consists of two values: the data
-  # set title and its ID.
-  def taggable_statistical_data_sets_container
+  def taggable_statistical_data_sets_container(selected_ids = [])
     cached_taggable_statistical_data_sets.map do |data_set|
-      [data_set.title, data_set.document_id]
+      {
+        text: data_set.title,
+        value: data_set.document_id,
+        selected: selected_ids.include?(data_set.document_id),
+      }
     end
   end
 
-  # Returns an Array that represents the taggable world locations. Each element
-  # of the array consists of two values: the location name and its ID
-  def taggable_world_locations_container
+  def taggable_world_locations_container(selected_ids = [])
     cached_taggable_world_locations.map do |w|
-      [w.name, w.id]
+      {
+        text: w.name,
+        value: w.id,
+        selected: selected_ids.include?(w.id),
+      }
     end
   end
 
-  # Returns an Array that represents the taggable roles. Each element of the
-  # array consists of two values: the role name and its ID
-  def taggable_roles_container
+  def taggable_roles_container(selected_ids = [])
     cached_taggable_roles.map do |w|
-      [w.name, w.id]
+      {
+        text: w.name,
+        value: w.id,
+        selected: selected_ids.include?(w.id),
+      }
     end
   end
 
-  # Returns an Array that represents the taggable alternative format providers.
-  # Each element of the array consists of two values: the label (organisation
-  # and the email address if avaiable) and the ID of the organisation.
-  def taggable_alternative_format_providers_container
+  def taggable_alternative_format_providers_container(selected_ids = [])
     cached_taggable_alternative_format_providers.map do |o|
-      ["#{o.name} (#{o.alternative_format_contact_email.presence || '-'})", o.id]
+      {
+        text: "#{o.name} (#{o.alternative_format_contact_email.presence || '-'})",
+        value: o.id,
+        selected: selected_ids.include?(o.id),
+      }
     end
   end
 
-  # Returns an Array that represents the taggable worldwide organisations.
-  # Each element of the array consists of two values: the name of the worldwide
-  # organisation and its ID.
-  def taggable_worldwide_organisations_container
+  def taggable_worldwide_organisations_container(selected_ids = [])
     cached_taggable_worldwide_organisations.map do |wo|
-      [wo.title, wo.document.id]
+      {
+        text: wo.title,
+        value: wo.document.id,
+        selected: selected_ids.include?(wo.document.id),
+      }
     end
   end
 

--- a/app/helpers/admin/taggable_content_helper.rb
+++ b/app/helpers/admin/taggable_content_helper.rb
@@ -5,8 +5,8 @@ module Admin::TaggableContentHelper
   # Each element of the array consists of two values: the select_name and the
   # ID of the organisation
   def taggable_organisations_container
-    Rails.cache.fetch(taggable_organisations_cache_digest, expires_in: 1.day) do
-      Organisation.with_translations.order("organisation_translations.name").map { |o| [o.select_name, o.id] }
+    cached_taggable_organisations.map do |o|
+      [o.select_name, o.id]
     end
   end
 
@@ -16,16 +16,14 @@ module Admin::TaggableContentHelper
   # role, the date the role was held if it's in the past, and the organisations
   # the person belongs to) and the ID of the role appointment.
   def taggable_ministerial_role_appointments_container
-    Rails.cache.fetch(taggable_ministerial_role_appointments_cache_digest, expires_in: 1.day) do
-      role_appointments_container_for(RoleAppointment.for_ministerial_roles)
+    cached_taggable_ministerial_role_appointments.map do |appointment|
+      [role_appointment_label(appointment), appointment.id]
     end
   end
 
   def taggable_needs_container
-    Rails.cache.fetch("need.linkables", expires_in: 1.minute) do
-      Services.publishing_api.get_linkables(document_type: "need").to_a.map do |need|
-        need.values_at("title", "content_id")
-      end
+    Services.publishing_api.get_linkables(document_type: "need").to_a.map do |need|
+      need.values_at("title", "content_id")
     end
   rescue GdsApi::TimedOutException, GdsApi::HTTPServerError
     stale_data = Rails.cache.fetch("need.linkables")
@@ -40,8 +38,8 @@ module Admin::TaggableContentHelper
   # held if it's in the past, and the organisations the person belongs to) and
   # the ID of the role appointment.
   def taggable_role_appointments_container
-    Rails.cache.fetch(taggable_role_appointments_cache_digest, expires_in: 1.day) do
-      role_appointments_container_for(RoleAppointment)
+    cached_taggable_role_appointments.map do |appointment|
+      [role_appointment_label(appointment), appointment.id]
     end
   end
 
@@ -49,8 +47,8 @@ module Admin::TaggableContentHelper
   # guides. Each element of the array consists of two values: the guide title
   # and its ID.
   def taggable_detailed_guides_container
-    Rails.cache.fetch(taggable_detailed_guides_cache_digest, expires_in: 1.day) do
-      DetailedGuide.alphabetical.latest_edition.active.map { |d| [d.title, d.id] }
+    cached_taggable_detailed_guides.map do |d|
+      [d.title, d.id]
     end
   end
 
@@ -58,26 +56,24 @@ module Admin::TaggableContentHelper
   # data sets. Each elements of the array consists of two values: the data
   # set title and its ID.
   def taggable_statistical_data_sets_container
-    Rails.cache.fetch(taggable_statistical_data_sets_cache_digest, expires_in: 1.day) do
-      StatisticalDataSet.with_translations.latest_edition.map do |data_set|
-        [data_set.title, data_set.document_id]
-      end
+    cached_taggable_statistical_data_sets.map do |data_set|
+      [data_set.title, data_set.document_id]
     end
   end
 
   # Returns an Array that represents the taggable world locations. Each element
   # of the array consists of two values: the location name and its ID
   def taggable_world_locations_container
-    Rails.cache.fetch(taggable_world_locations_cache_digest, expires_in: 1.day) do
-      WorldLocation.ordered_by_name.where(active: true).map { |w| [w.name, w.id] }
+    cached_taggable_world_locations.map do |w|
+      [w.name, w.id]
     end
   end
 
   # Returns an Array that represents the taggable roles. Each element of the
   # array consists of two values: the role name and its ID
   def taggable_roles_container
-    Rails.cache.fetch(taggable_roles_cache_digest, expires_in: 1.day) do
-      Role.order(:name).map { |w| [w.name, w.id] }
+    cached_taggable_roles.map do |w|
+      [w.name, w.id]
     end
   end
 
@@ -85,10 +81,8 @@ module Admin::TaggableContentHelper
   # Each element of the array consists of two values: the label (organisation
   # and the email address if avaiable) and the ID of the organisation.
   def taggable_alternative_format_providers_container
-    Rails.cache.fetch(taggable_alternative_format_providers_cache_digest, expires_in: 1.day) do
-      Organisation.alphabetical.map do |o|
-        ["#{o.name} (#{o.alternative_format_contact_email.presence || '-'})", o.id]
-      end
+    cached_taggable_alternative_format_providers.map do |o|
+      ["#{o.name} (#{o.alternative_format_contact_email.presence || '-'})", o.id]
     end
   end
 
@@ -96,8 +90,14 @@ module Admin::TaggableContentHelper
   # Each element of the array consists of two values: the name of the worldwide
   # organisation and its ID.
   def taggable_worldwide_organisations_container
-    Rails.cache.fetch(taggable_worldwide_organisations_cache_digest, expires_in: 1.day) do
-      WorldwideOrganisation.with_translations.latest_edition.map { |wo| [wo.title, wo.document.id] }
+    cached_taggable_worldwide_organisations.map do |wo|
+      [wo.title, wo.document.id]
+    end
+  end
+
+  def cached_taggable_organisations
+    Rails.cache.fetch(taggable_organisations_cache_digest, expires_in: 1.day) do
+      Organisation.with_translations.order("organisation_translations.name")
     end
   end
 
@@ -115,6 +115,12 @@ module Admin::TaggableContentHelper
     @taggable_organisations_cache_digest ||= calculate_digest(Organisation.order(:id), "organisations")
   end
 
+  def cached_taggable_ministerial_role_appointments
+    Rails.cache.fetch(taggable_ministerial_role_appointments_cache_digest, expires_in: 1.day) do
+      role_appointments_container_for(RoleAppointment.for_ministerial_roles)
+    end
+  end
+
   # Returns an MD5 digest representing the current set of taggable ministerial
   # role appointments. This will change if any role appointments are added or
   # changed, and also if an occupied MinisterialRole is updated.
@@ -128,11 +134,23 @@ module Admin::TaggableContentHelper
     )
   end
 
+  def cached_taggable_role_appointments
+    Rails.cache.fetch(taggable_role_appointments_cache_digest, expires_in: 1.day) do
+      role_appointments_container_for(RoleAppointment)
+    end
+  end
+
   # Returns an MD5 digest representing the current set of taggable ministerial
   # role appointments. This will change if any role appointments are added or
   # changed, and also if an occupied Role is updated.
   def taggable_role_appointments_cache_digest
     @taggable_role_appointments_cache_digest ||= calculate_digest(RoleAppointment.order(:id), "role-appointments")
+  end
+
+  def cached_taggable_detailed_guides
+    Rails.cache.fetch(taggable_detailed_guides_cache_digest, expires_in: 1.day) do
+      DetailedGuide.alphabetical.latest_edition.active
+    end
   end
 
   # Returns an MD5 digest representing all the detailed guides. This wil change
@@ -141,10 +159,22 @@ module Admin::TaggableContentHelper
     @taggable_detailed_guides_cache_digest ||= calculate_digest(Document.where(document_type: "DetailedGuide").order(:id), "detailed-guides")
   end
 
+  def cached_taggable_statistical_data_sets
+    Rails.cache.fetch(taggable_statistical_data_sets_cache_digest, expires_in: 1.day) do
+      StatisticalDataSet.with_translations.latest_edition
+    end
+  end
+
   # Returns an MD5 digest representing the taggable statistical data sets. This
   # will change if any statistical data set is added or updated.
   def taggable_statistical_data_sets_cache_digest
     @taggable_statistical_data_sets_cache_digest ||= calculate_digest(Document.where(document_type: "StatisticalDataSet").order(:id), "statistical-data-sets")
+  end
+
+  def cached_taggable_world_locations
+    Rails.cache.fetch(taggable_world_locations_cache_digest, expires_in: 1.day) do
+      WorldLocation.ordered_by_name.where(active: true)
+    end
   end
 
   # Returns an MD5 digest representing the taggable world locations. This will
@@ -153,10 +183,22 @@ module Admin::TaggableContentHelper
     @taggable_world_locations_cache_digest ||= calculate_digest(WorldLocation.order(:id), "world-locations")
   end
 
+  def cached_taggable_roles
+    Rails.cache.fetch(taggable_roles_cache_digest, expires_in: 1.day) do
+      Role.order(:name)
+    end
+  end
+
   # Returns an MD5 digest representing the taggable roles. This will
   # change if any world locations are added or updated.
   def taggable_roles_cache_digest
     @taggable_roles_cache_digest ||= calculate_digest(Role.order(:id), "roles")
+  end
+
+  def cached_taggable_alternative_format_providers
+    Rails.cache.fetch(taggable_alternative_format_providers_cache_digest, expires_in: 1.day) do
+      Organisation.alphabetical
+    end
   end
 
   # Returns an MD5 digest representing the taggable alternative format
@@ -164,6 +206,12 @@ module Admin::TaggableContentHelper
   # changed.
   def taggable_alternative_format_providers_cache_digest
     @taggable_alternative_format_providers_cache_digest ||= calculate_digest(Organisation.order(:id), "alternative-format-providers")
+  end
+
+  def cached_taggable_worldwide_organisations
+    Rails.cache.fetch(taggable_worldwide_organisations_cache_digest, expires_in: 1.day) do
+      WorldwideOrganisation.with_translations.latest_edition
+    end
   end
 
   # Returns an MD5 digest representing the taggable worldwide organisations. This
@@ -184,7 +232,7 @@ private
       .includes(:person)
       .with_translations_for(:organisations)
       .with_translations_for(:role)
-      .ascending_start_date.map { |appointment| [role_appointment_label(appointment), appointment.id] }
+      .ascending_start_date
   end
 
   def role_appointment_label(appointment)

--- a/app/views/admin/corporate_information_pages/_standard_fields.html.erb
+++ b/app/views/admin/corporate_information_pages/_standard_fields.html.erb
@@ -8,7 +8,7 @@
       name: "edition[corporate_information_page_type_id]",
       label: "Type",
       heading_size: "l",
-      error_message: errors_for_input(edition.errors, :corporate_information_page_type_id),
+      error_items: errors_for(edition.errors, :corporate_information_page_type_id),
       include_blank: true,
       options: corporate_information_page_types(@organisation).map do |type, value|
         {

--- a/app/views/admin/detailed_guides/_form.html.erb
+++ b/app/views/admin/detailed_guides/_form.html.erb
@@ -22,10 +22,9 @@
           include_blank: true,
           label: "Related guides",
           heading_size: "m",
+          options: taggable_detailed_guides_container(edition.related_detailed_guide_ids),
           select: {
-            options: taggable_detailed_guides_container,
             multiple: true,
-            selected: edition.related_detailed_guide_ids,
           },
         } %>
       <% end %>

--- a/app/views/admin/detailed_guides/_form.html.erb
+++ b/app/views/admin/detailed_guides/_form.html.erb
@@ -20,9 +20,7 @@
           name: "edition[related_detailed_guide_ids][]",
           error_items: errors_for(edition.errors, :related_detailed_guide_ids),
           include_blank: true,
-          label: {
-            text: "Related guides",
-          },
+          label: "Related guides",
           heading_size: "m",
           select: {
             options: taggable_detailed_guides_container,

--- a/app/views/admin/detailed_guides/_form.html.erb
+++ b/app/views/admin/detailed_guides/_form.html.erb
@@ -19,12 +19,13 @@
           id: "edition_related_detailed_guide_ids",
           name: "edition[related_detailed_guide_ids][]",
           error_items: errors_for(edition.errors, :related_detailed_guide_ids),
+          include_blank: true,
           label: {
             text: "Related guides",
             heading_size: "m",
           },
           select: {
-            options: [""] + taggable_detailed_guides_container,
+            options: taggable_detailed_guides_container,
             multiple: true,
             selected: edition.related_detailed_guide_ids,
           },

--- a/app/views/admin/detailed_guides/_form.html.erb
+++ b/app/views/admin/detailed_guides/_form.html.erb
@@ -22,8 +22,8 @@
           include_blank: true,
           label: {
             text: "Related guides",
-            heading_size: "m",
           },
+          heading_size: "m",
           select: {
             options: taggable_detailed_guides_container,
             multiple: true,

--- a/app/views/admin/editionable_social_media_accounts/_form.html.erb
+++ b/app/views/admin/editionable_social_media_accounts/_form.html.erb
@@ -7,7 +7,7 @@
         name: "social_media_account[social_media_service_id]",
         heading_size: "l",
         include_blank: true,
-        error_message: errors_for_input(social_media_account.errors, :social_media_service_id),
+        error_items: errors_for(social_media_account.errors, :social_media_service_id),
         options: SocialMediaService.all.map do |service|
           {
             text: service.name,

--- a/app/views/admin/editions/_accessible_attachment_field.html.erb
+++ b/app/views/admin/editions/_accessible_attachment_field.html.erb
@@ -11,7 +11,11 @@
 
       <select name="edition[alternative_format_provider_id]" id="edition_alternative_format_provider_id" class="govuk-select" aria-describedby="alternative-format-provider-hint">
         <option></option>
-        <% taggable_alternative_format_providers_container.each do |name, id| %>
+        <%
+          taggable_alternative_format_providers_container.each do |hash|
+            name = hash[:text]
+            id = hash[:value]
+        %>
           <option
             value="<%= id %>"
             <%= "disabled='disabled'" if name.end_with?("(-)") %>

--- a/app/views/admin/editions/_appointment_fields.html.erb
+++ b/app/views/admin/editions/_appointment_fields.html.erb
@@ -5,8 +5,8 @@
     include_blank: true,
     label: {
       text: "Ministers",
-      heading_size: "m",
     },
+    heading_size: "m",
     select: {
       options: taggable_ministerial_role_appointments_container,
       multiple: true,

--- a/app/views/admin/editions/_appointment_fields.html.erb
+++ b/app/views/admin/editions/_appointment_fields.html.erb
@@ -2,12 +2,13 @@
   <%= render "components/autocomplete", {
     id: "edition_role_appointment_ids",
     name: "edition[role_appointment_ids][]",
+    include_blank: true,
     label: {
       text: "Ministers",
       heading_size: "m",
     },
     select: {
-      options: [""] + taggable_ministerial_role_appointments_container,
+      options: taggable_ministerial_role_appointments_container,
       multiple: true,
       selected: edition.role_appointment_ids,
     },

--- a/app/views/admin/editions/_appointment_fields.html.erb
+++ b/app/views/admin/editions/_appointment_fields.html.erb
@@ -3,9 +3,7 @@
     id: "edition_role_appointment_ids",
     name: "edition[role_appointment_ids][]",
     include_blank: true,
-    label: {
-      text: "Ministers",
-    },
+    label: "Ministers",
     heading_size: "m",
     select: {
       options: taggable_ministerial_role_appointments_container,

--- a/app/views/admin/editions/_appointment_fields.html.erb
+++ b/app/views/admin/editions/_appointment_fields.html.erb
@@ -5,10 +5,9 @@
     include_blank: true,
     label: "Ministers",
     heading_size: "m",
+    options: taggable_ministerial_role_appointments_container(edition.role_appointment_ids),
     select: {
-      options: taggable_ministerial_role_appointments_container,
       multiple: true,
-      selected: edition.role_appointment_ids,
     },
   } %>
 <% end %>

--- a/app/views/admin/editions/_operational_field_fields.html.erb
+++ b/app/views/admin/editions/_operational_field_fields.html.erb
@@ -3,7 +3,7 @@
   label: "Field of operation (required)",
   name: "edition[operational_field_id]",
   heading_size: "l",
-  error_message: errors_for_input(edition.errors, :operational_field_id),
+  error_items: errors_for(edition.errors, :operational_field_id),
   include_blank: true,
   options: OperationalField.all.map do |operation|
     {

--- a/app/views/admin/editions/_organisation_fields.html.erb
+++ b/app/views/admin/editions/_organisation_fields.html.erb
@@ -35,8 +35,8 @@
         include_blank: true,
         label: {
           text: "Supporting organisations",
-          heading_size: "m",
         },
+        heading_size: "m",
         select: {
           multiple: true,
           selected: edition.edition_organisations.reject(&:lead?).map(&:organisation_id),

--- a/app/views/admin/editions/_organisation_fields.html.erb
+++ b/app/views/admin/editions/_organisation_fields.html.erb
@@ -16,13 +16,7 @@
               label: "Lead organisation #{index + 1}",
               heading_size: "s",
               include_blank: true,
-              options: taggable_organisations_container.map do |name, id|
-              {
-                text: name,
-                value: id,
-                selected: id == lead_organisation_id,
-              }
-             end,
+              options: taggable_organisations_container([lead_organisation_id]),
           } %>
         <% end %>
       <% end %>
@@ -35,10 +29,9 @@
         include_blank: true,
         label: "Supporting organisations",
         heading_size: "m",
+        options: taggable_organisations_container(edition.edition_organisations.reject(&:lead?).map(&:organisation_id)),
         select: {
           multiple: true,
-          selected: edition.edition_organisations.reject(&:lead?).map(&:organisation_id),
-          options: taggable_organisations_container,
         },
       } %>
     <% end %>

--- a/app/views/admin/editions/_organisation_fields.html.erb
+++ b/app/views/admin/editions/_organisation_fields.html.erb
@@ -32,6 +32,7 @@
       <%= render "components/autocomplete", {
         id: "edition_supporting_organisation_ids",
         name: "edition[supporting_organisation_ids][]",
+        include_blank: true,
         label: {
           text: "Supporting organisations",
           heading_size: "m",
@@ -39,7 +40,7 @@
         select: {
           multiple: true,
           selected: edition.edition_organisations.reject(&:lead?).map(&:organisation_id),
-          options: [""] + taggable_organisations_container,
+          options: taggable_organisations_container,
         },
       } %>
     <% end %>

--- a/app/views/admin/editions/_organisation_fields.html.erb
+++ b/app/views/admin/editions/_organisation_fields.html.erb
@@ -33,9 +33,7 @@
         id: "edition_supporting_organisation_ids",
         name: "edition[supporting_organisation_ids][]",
         include_blank: true,
-        label: {
-          text: "Supporting organisations",
-        },
+        label: "Supporting organisations",
         heading_size: "m",
         select: {
           multiple: true,

--- a/app/views/admin/editions/_role_fields.html.erb
+++ b/app/views/admin/editions/_role_fields.html.erb
@@ -5,9 +5,7 @@
     id: "edition_roles",
     name: "edition[role_ids][]",
     error_items: errors_for(edition.errors, :roles),
-    label: {
-      text: "Roles" + "#{' (required)' if required}",
-    },
+    label: "Roles" + "#{' (required)' if required}",
     heading_size: "m",
     select: {
       options: taggable_roles_container,

--- a/app/views/admin/editions/_role_fields.html.erb
+++ b/app/views/admin/editions/_role_fields.html.erb
@@ -7,8 +7,8 @@
     error_items: errors_for(edition.errors, :roles),
     label: {
       text: "Roles" + "#{' (required)' if required}",
-      heading_size: "m",
     },
+    heading_size: "m",
     select: {
       options: taggable_roles_container,
       multiple: true,

--- a/app/views/admin/editions/_role_fields.html.erb
+++ b/app/views/admin/editions/_role_fields.html.erb
@@ -7,10 +7,9 @@
     error_items: errors_for(edition.errors, :roles),
     label: "Roles" + "#{' (required)' if required}",
     heading_size: "m",
+    options: taggable_roles_container(edition.role_ids),
     select: {
-      options: taggable_roles_container,
       multiple: true,
-      selected: edition.role_ids,
     },
   } %>
 <% end %>

--- a/app/views/admin/editions/_statistical_data_set_fields.html.erb
+++ b/app/views/admin/editions/_statistical_data_set_fields.html.erb
@@ -5,8 +5,8 @@
     include_blank: true,
     label: {
       text: "Statistical data sets",
-      heading_size: "m",
     },
+    heading_size: "m",
     select: {
       options: taggable_statistical_data_sets_container,
       multiple: true,

--- a/app/views/admin/editions/_statistical_data_set_fields.html.erb
+++ b/app/views/admin/editions/_statistical_data_set_fields.html.erb
@@ -2,12 +2,13 @@
   <%= render "components/autocomplete", {
     id: "edition_statistical_data_set_document_ids",
     name: "edition[statistical_data_set_document_ids][]",
+    include_blank: true,
     label: {
       text: "Statistical data sets",
       heading_size: "m",
     },
     select: {
-      options: [""] + taggable_statistical_data_sets_container,
+      options: taggable_statistical_data_sets_container,
       multiple: true,
       selected: edition.statistical_data_set_document_ids,
     },

--- a/app/views/admin/editions/_statistical_data_set_fields.html.erb
+++ b/app/views/admin/editions/_statistical_data_set_fields.html.erb
@@ -3,9 +3,7 @@
     id: "edition_statistical_data_set_document_ids",
     name: "edition[statistical_data_set_document_ids][]",
     include_blank: true,
-    label: {
-      text: "Statistical data sets",
-    },
+    label: "Statistical data sets",
     heading_size: "m",
     select: {
       options: taggable_statistical_data_sets_container,

--- a/app/views/admin/editions/_statistical_data_set_fields.html.erb
+++ b/app/views/admin/editions/_statistical_data_set_fields.html.erb
@@ -5,10 +5,9 @@
     include_blank: true,
     label: "Statistical data sets",
     heading_size: "m",
+    options: taggable_statistical_data_sets_container(edition.statistical_data_set_document_ids),
     select: {
-      options: taggable_statistical_data_sets_container,
       multiple: true,
-      selected: edition.statistical_data_set_document_ids,
     },
   } %>
 <% end %>

--- a/app/views/admin/editions/_topical_event_fields.html.erb
+++ b/app/views/admin/editions/_topical_event_fields.html.erb
@@ -2,12 +2,13 @@
   <%= render "components/autocomplete", {
     id: "edition_topical_event_ids",
     name: "edition[topical_event_ids][]",
+    include_blank: true,
     label: {
       text: "Topical events",
       heading_size: "m",
     },
     select: {
-      options: [""] + TopicalEvent.order(:name).map { |topical_event| [topical_event.name, topical_event.id]},
+      options: TopicalEvent.order(:name).map { |topical_event| [topical_event.name, topical_event.id]},
       multiple: true,
       selected: edition.topical_event_ids,
     },

--- a/app/views/admin/editions/_topical_event_fields.html.erb
+++ b/app/views/admin/editions/_topical_event_fields.html.erb
@@ -5,8 +5,8 @@
     include_blank: true,
     label: {
       text: "Topical events",
-      heading_size: "m",
     },
+    heading_size: "m",
     select: {
       options: TopicalEvent.order(:name).map { |topical_event| [topical_event.name, topical_event.id]},
       multiple: true,

--- a/app/views/admin/editions/_topical_event_fields.html.erb
+++ b/app/views/admin/editions/_topical_event_fields.html.erb
@@ -5,10 +5,15 @@
     include_blank: true,
     label: "Topical events",
     heading_size: "m",
+    options: TopicalEvent.order(:name).map do |topical_event|
+      {
+        text: topical_event.name,
+        value: topical_event.id,
+        selected: edition.topical_event_ids.include?(topical_event.id),
+      }
+    end,
     select: {
-      options: TopicalEvent.order(:name).map { |topical_event| [topical_event.name, topical_event.id]},
       multiple: true,
-      selected: edition.topical_event_ids,
     },
   } %>
 <% end %>

--- a/app/views/admin/editions/_topical_event_fields.html.erb
+++ b/app/views/admin/editions/_topical_event_fields.html.erb
@@ -3,9 +3,7 @@
     id: "edition_topical_event_ids",
     name: "edition[topical_event_ids][]",
     include_blank: true,
-    label: {
-      text: "Topical events",
-    },
+    label: "Topical events",
     heading_size: "m",
     select: {
       options: TopicalEvent.order(:name).map { |topical_event| [topical_event.name, topical_event.id]},

--- a/app/views/admin/editions/_world_location_fields.html.erb
+++ b/app/views/admin/editions/_world_location_fields.html.erb
@@ -7,10 +7,9 @@
     error_items: errors_for(edition.errors, :world_locations),
     label: "World locations" + "#{' (required)' if required}",
     heading_size: "m",
+    options: taggable_world_locations_container(edition.world_location_ids),
     select: {
-      options: taggable_world_locations_container,
       multiple: true,
-      selected: edition.world_location_ids,
     },
   } %>
 <% end %>

--- a/app/views/admin/editions/_world_location_fields.html.erb
+++ b/app/views/admin/editions/_world_location_fields.html.erb
@@ -7,8 +7,8 @@
     error_items: errors_for(edition.errors, :world_locations),
     label: {
       text: "World locations" + "#{' (required)' if required}",
-      heading_size: "m",
     },
+    heading_size: "m",
     select: {
       options: taggable_world_locations_container,
       multiple: true,

--- a/app/views/admin/editions/_world_location_fields.html.erb
+++ b/app/views/admin/editions/_world_location_fields.html.erb
@@ -5,9 +5,7 @@
     id: "edition_world_locations",
     name: "edition[world_location_ids][]",
     error_items: errors_for(edition.errors, :world_locations),
-    label: {
-      text: "World locations" + "#{' (required)' if required}",
-    },
+    label: "World locations" + "#{' (required)' if required}",
     heading_size: "m",
     select: {
       options: taggable_world_locations_container,

--- a/app/views/admin/editions/_worldwide_organisation_fields.html.erb
+++ b/app/views/admin/editions/_worldwide_organisation_fields.html.erb
@@ -8,10 +8,9 @@
     include_blank: true,
     label: "Worldwide organisations" + "#{' (required)' if required}",
     heading_size: "m",
+    options: taggable_worldwide_organisations_container(edition.worldwide_organisation_document_ids),
     select: {
-      options: taggable_worldwide_organisations_container,
       multiple: true,
-      selected: edition.worldwide_organisation_document_ids,
     },
   } %>
 <% end %>

--- a/app/views/admin/editions/_worldwide_organisation_fields.html.erb
+++ b/app/views/admin/editions/_worldwide_organisation_fields.html.erb
@@ -8,8 +8,8 @@
     include_blank: true,
     label: {
       text:  "Worldwide organisations" + "#{' (required)' if required}",
-      heading_size: "m",
     },
+    heading_size: "m",
     select: {
       options: taggable_worldwide_organisations_container,
       multiple: true,

--- a/app/views/admin/editions/_worldwide_organisation_fields.html.erb
+++ b/app/views/admin/editions/_worldwide_organisation_fields.html.erb
@@ -5,12 +5,13 @@
     id: "edition_worldwide_organisation_document_ids",
     name: "edition[worldwide_organisation_document_ids][]",
     error_items: errors_for(edition.errors, :worldwide_organisations),
+    include_blank: true,
     label: {
       text:  "Worldwide organisations" + "#{' (required)' if required}",
       heading_size: "m",
     },
     select: {
-      options: [""] + taggable_worldwide_organisations_container,
+      options: taggable_worldwide_organisations_container,
       multiple: true,
       selected: edition.worldwide_organisation_document_ids,
     },

--- a/app/views/admin/editions/_worldwide_organisation_fields.html.erb
+++ b/app/views/admin/editions/_worldwide_organisation_fields.html.erb
@@ -6,9 +6,7 @@
     name: "edition[worldwide_organisation_document_ids][]",
     error_items: errors_for(edition.errors, :worldwide_organisations),
     include_blank: true,
-    label: {
-      text:  "Worldwide organisations" + "#{' (required)' if required}",
-    },
+    label: "Worldwide organisations" + "#{' (required)' if required}",
     heading_size: "m",
     select: {
       options: taggable_worldwide_organisations_container,

--- a/app/views/admin/historical_accounts/_form.html.erb
+++ b/app/views/admin/historical_accounts/_form.html.erb
@@ -22,15 +22,15 @@
         error_items: errors_for(historical_account.errors, :political_parties),
         label: "Political parties (required)",
         heading_size: "l",
+        options: PoliticalParty.all.map do |party|
+          {
+            text: party.name,
+            value: party.id,
+            selected: historical_account.political_party_ids.include?(party.id),
+          }
+        end,
         select: {
-          options: PoliticalParty.all.map do |party|
-            [
-              party.name,
-              party.id,
-            ]
-          end,
           multiple: true,
-          selected: historical_account.political_party_ids,
         },
       } %>
 

--- a/app/views/admin/historical_accounts/_form.html.erb
+++ b/app/views/admin/historical_accounts/_form.html.erb
@@ -20,9 +20,7 @@
         id: "historical_account_political_parties",
         name: "historical_account[political_party_ids][]",
         error_items: errors_for(historical_account.errors, :political_parties),
-        label: {
-          text: "Political parties (required)",
-        },
+        label: "Political parties (required)",
         heading_size: "l",
         select: {
           options: PoliticalParty.all.map do |party|

--- a/app/views/admin/historical_accounts/_form.html.erb
+++ b/app/views/admin/historical_accounts/_form.html.erb
@@ -22,8 +22,8 @@
         error_items: errors_for(historical_account.errors, :political_parties),
         label: {
           text: "Political parties (required)",
-          heading_size: "l",
         },
+        heading_size: "l",
         select: {
           options: PoliticalParty.all.map do |party|
             [

--- a/app/views/admin/needs/edit.html.erb
+++ b/app/views/admin/needs/edit.html.erb
@@ -11,10 +11,9 @@
           include_blank: true,
           label: "Select associated user needs",
           heading_size: "l",
+          options: taggable_needs_container(@document.need_ids),
           select: {
-            options: taggable_needs_container,
             multiple: true,
-            selected: @document.need_ids,
           },
       } %>
 

--- a/app/views/admin/needs/edit.html.erb
+++ b/app/views/admin/needs/edit.html.erb
@@ -9,9 +9,7 @@
           id: "need_ids",
           name: "need_ids[]",
           include_blank: true,
-          label: {
-            text: "Select associated user needs",
-          },
+          label: "Select associated user needs",
           heading_size: "l",
           select: {
             options: taggable_needs_container,

--- a/app/views/admin/needs/edit.html.erb
+++ b/app/views/admin/needs/edit.html.erb
@@ -8,6 +8,7 @@
       <%= render "components/autocomplete", {
           id: "need_ids",
           name: "need_ids[]",
+          include_blank: true,
           label: {
             text: "Select associated user needs",
             bold: true,
@@ -15,7 +16,7 @@
           },
           heading_size: "l",
           select: {
-            options: [""] + taggable_needs_container,
+            options: taggable_needs_container,
             multiple: true,
             selected: @document.need_ids,
           },

--- a/app/views/admin/needs/edit.html.erb
+++ b/app/views/admin/needs/edit.html.erb
@@ -11,8 +11,6 @@
           include_blank: true,
           label: {
             text: "Select associated user needs",
-            bold: true,
-            required: true,
           },
           heading_size: "l",
           select: {

--- a/app/views/admin/news_articles/_news_article_type_fields.html.erb
+++ b/app/views/admin/news_articles/_news_article_type_fields.html.erb
@@ -5,7 +5,7 @@
     label: "News article type (required)",
     heading_size: "l",
     value: edition.news_article_type_id,
-    error_message: errors_for_input(edition.errors, :news_article_type_id),
+    error_items: errors_for(edition.errors, :news_article_type_id),
     include_blank: true,
     options: NewsArticleType.all.map do |type|
       {

--- a/app/views/admin/organisations/_closed_fields.html.erb
+++ b/app/views/admin/organisations/_closed_fields.html.erb
@@ -50,8 +50,8 @@
   include_blank: true,
   label: {
     text: "Superseding organisations",
-    heading_size: "m",
   },
+  heading_size: "m",
   select: {
     options: (Organisation.with_translations(:en) - [organisation]).map do |org|
                [

--- a/app/views/admin/organisations/_closed_fields.html.erb
+++ b/app/views/admin/organisations/_closed_fields.html.erb
@@ -50,15 +50,15 @@
   include_blank: true,
   label: "Superseding organisations",
   heading_size: "m",
+  options: (Organisation.with_translations(:en) - [organisation]).map do |org|
+              {
+                text: org.name,
+                value: org.id,
+                selected: organisation.superseding_organisation_ids.include?(org.id),
+              }
+            end,
   select: {
-    options: (Organisation.with_translations(:en) - [organisation]).map do |org|
-               [
-                 org.name,
-                 org.id,
-               ]
-             end,
     multiple: true,
-    selected: organisation.superseding_organisation_ids,
   },
 } %>
 

--- a/app/views/admin/organisations/_closed_fields.html.erb
+++ b/app/views/admin/organisations/_closed_fields.html.erb
@@ -48,9 +48,7 @@
   id: "organisation_superseding_organisation_ids",
   name: "organisation[superseding_organisation_ids][]",
   include_blank: true,
-  label: {
-    text: "Superseding organisations",
-  },
+  label: "Superseding organisations",
   heading_size: "m",
   select: {
     options: (Organisation.with_translations(:en) - [organisation]).map do |org|

--- a/app/views/admin/organisations/_closed_fields.html.erb
+++ b/app/views/admin/organisations/_closed_fields.html.erb
@@ -47,18 +47,18 @@
 <%= render "components/autocomplete", {
   id: "organisation_superseding_organisation_ids",
   name: "organisation[superseding_organisation_ids][]",
+  include_blank: true,
   label: {
     text: "Superseding organisations",
     heading_size: "m",
   },
   select: {
-    options: [""] +
-      (Organisation.with_translations(:en) - [organisation]).map do |org|
-        [
-          org.name,
-          org.id,
-        ]
-      end,
+    options: (Organisation.with_translations(:en) - [organisation]).map do |org|
+               [
+                 org.name,
+                 org.id,
+               ]
+             end,
     multiple: true,
     selected: organisation.superseding_organisation_ids,
   },

--- a/app/views/admin/organisations/_closed_fields.html.erb
+++ b/app/views/admin/organisations/_closed_fields.html.erb
@@ -3,7 +3,7 @@
   name: "organisation[govuk_closed_status]",
   id: "organisation_govuk_closed_status",
   heading_size: "m",
-  error_message: errors_for_input(organisation.errors, :govuk_closed_status),
+  error_items: errors_for(organisation.errors, :govuk_closed_status),
   include_blank: true,
   options: [
     {

--- a/app/views/admin/organisations/_form.html.erb
+++ b/app/views/admin/organisations/_form.html.erb
@@ -243,15 +243,15 @@
       name: "organisation[parent_organisation_ids][]",
       label: "Sponsoring organisations",
       heading_size: "m",
+      options: (Organisation.with_translations(:en) - [organisation]).map do |org|
+                  {
+                    text: org.name,
+                    value: org.id,
+                    selected: organisation.parent_organisation_ids.include?(org.id),
+                  }
+                end,
       select: {
-        options: (Organisation.with_translations(:en) - [organisation]).map do |org|
-                   [
-                     org.name,
-                     org.id,
-                   ]
-                 end,
         multiple: true,
-        selected: organisation.parent_organisation_ids,
       },
     } %>
 

--- a/app/views/admin/organisations/_form.html.erb
+++ b/app/views/admin/organisations/_form.html.erb
@@ -241,9 +241,7 @@
     <%= render "components/autocomplete", {
       id: "organisation_parent_organisation_ids",
       name: "organisation[parent_organisation_ids][]",
-      label: {
-        text: "Sponsoring organisations",
-      },
+      label: "Sponsoring organisations",
       heading_size: "m",
       select: {
         options: (Organisation.with_translations(:en) - [organisation]).map do |org|

--- a/app/views/admin/organisations/_form.html.erb
+++ b/app/views/admin/organisations/_form.html.erb
@@ -42,7 +42,7 @@
     name: "organisation[organisation_logo_type_id]",
     id: "organisation_organisation_logo_type_id",
     heading_size: "l",
-    error_message: errors_for_input(organisation.errors, :organisation_logo_type_id),
+    error_items: errors_for(organisation.errors, :organisation_logo_type_id),
     include_blank: true,
     options: OrganisationLogoType.all.map do |logo_type|
       {
@@ -77,7 +77,7 @@
     name: "organisation[organisation_brand_colour_id]",
     id: "organisation_organisation_brand_colour_id",
     heading_size: "l",
-    error_message: errors_for_input(organisation.errors, :organisation_brand_colour_id),
+    error_items: errors_for(organisation.errors, :organisation_brand_colour_id),
     include_blank: true,
     options: OrganisationBrandColour.all.map do |brand_colour|
       {
@@ -122,7 +122,7 @@
     name: "organisation[organisation_type_key]",
     id: "organisation_organisation_type_key",
     heading_size: "l",
-    error_message: errors_for_input(organisation.errors, :organisation_type_key),
+    error_items: errors_for(organisation.errors, :organisation_type_key),
     include_blank: true,
     options: OrganisationType.in_listing_order.map do |type|
       {

--- a/app/views/admin/organisations/_form.html.erb
+++ b/app/views/admin/organisations/_form.html.erb
@@ -243,8 +243,8 @@
       name: "organisation[parent_organisation_ids][]",
       label: {
         text: "Sponsoring organisations",
-        heading_size: "m",
       },
+      heading_size: "m",
       select: {
         options: (Organisation.with_translations(:en) - [organisation]).map do |org|
                    [

--- a/app/views/admin/organisations/_form.html.erb
+++ b/app/views/admin/organisations/_form.html.erb
@@ -246,13 +246,12 @@
         heading_size: "m",
       },
       select: {
-        options: [""] +
-          (Organisation.with_translations(:en) - [organisation]).map do |org|
-            [
-              org.name,
-              org.id,
-            ]
-          end,
+        options: (Organisation.with_translations(:en) - [organisation]).map do |org|
+                   [
+                     org.name,
+                     org.id,
+                   ]
+                 end,
         multiple: true,
         selected: organisation.parent_organisation_ids,
       },

--- a/app/views/admin/publications/_publication_type_fields.html.erb
+++ b/app/views/admin/publications/_publication_type_fields.html.erb
@@ -5,7 +5,7 @@
     label: "Publication type (required)",
     heading_size: "l",
     value: edition.publication_type_id,
-    error_message: errors_for_input(edition.errors, :publication_type_id),
+    error_items: errors_for(edition.errors, :publication_type_id),
     include_blank: true,
     grouped_options: [
       [

--- a/app/views/admin/role_appointments/_form.html.erb
+++ b/app/views/admin/role_appointments/_form.html.erb
@@ -14,7 +14,7 @@
       form.object.new_record? || option[:selected]
     end,
   include_blank: form.object.new_record?,
-  error_message: errors_for_input(form.object.errors, :person_id),
+  error_items: errors_for(form.object.errors, :person_id),
 } %>
 
 <% if form.object.new_record? %>

--- a/app/views/admin/roles/_form.html.erb
+++ b/app/views/admin/roles/_form.html.erb
@@ -34,8 +34,14 @@
     label: "Organisations",
     heading_size: "l",
     name: "role[organisation_ids][]",
+    options: Organisation.with_translations(:en).map do |org|
+      {
+        text: org.select_name,
+        value: org.id,
+        selected: role.organisation_ids.include?(org.id),
+      }
+    end,
     select: {
-      options:  options_from_collection_for_select(Organisation.with_translations(:en), "id", "select_name", role.organisation_ids),
       multiple: true,
     },
   } %>

--- a/app/views/admin/roles/_form.html.erb
+++ b/app/views/admin/roles/_form.html.erb
@@ -31,9 +31,7 @@
 
   <%= render "components/autocomplete", {
     id: "role_organisation_ids",
-    label: {
-      text: "Organisations",
-    },
+    label: "Organisations",
     heading_size: "l",
     name: "role[organisation_ids][]",
     select: {

--- a/app/views/admin/roles/_form.html.erb
+++ b/app/views/admin/roles/_form.html.erb
@@ -33,8 +33,8 @@
     id: "role_organisation_ids",
     label: {
       text: "Organisations",
-      heading_size: "l",
     },
+    heading_size: "l",
     name: "role[organisation_ids][]",
     select: {
       options:  options_from_collection_for_select(Organisation.with_translations(:en), "id", "select_name", role.organisation_ids),

--- a/app/views/admin/social_media_accounts/_form.html.erb
+++ b/app/views/admin/social_media_accounts/_form.html.erb
@@ -8,7 +8,7 @@
           name: "social_media_account[social_media_service_id]",
           heading_size: "l",
           include_blank: true,
-          error_message: errors_for_input(social_media_account.errors, :social_media_service_id),
+          error_items: errors_for(social_media_account.errors, :social_media_service_id),
           options: SocialMediaService.all.map do |service|
             {
               text: service.name,

--- a/app/views/admin/speeches/_speaker_select_field.html.erb
+++ b/app/views/admin/speeches/_speaker_select_field.html.erb
@@ -3,7 +3,7 @@
     id: "edition_role_appointment_id",
     name: "edition[role_appointment_id]",
     label: "",
-    error_message: errors_for_input(edition.errors, :role_appointment_id),
+    error_items: errors_for(edition.errors, :role_appointment_id),
     include_blank: true,
     options: taggable_role_appointments_container([edition.role_appointment_id]),
   } %>

--- a/app/views/admin/speeches/_speaker_select_field.html.erb
+++ b/app/views/admin/speeches/_speaker_select_field.html.erb
@@ -5,12 +5,6 @@
     label: "",
     error_message: errors_for_input(edition.errors, :role_appointment_id),
     include_blank: true,
-    options: taggable_role_appointments_container.map do |speaker, value|
-      {
-        text: speaker,
-        value: value,
-        selected: value == edition.role_appointment_id,
-      }
-    end,
+    options: taggable_role_appointments_container([edition.role_appointment_id]),
   } %>
 <% end %>

--- a/app/views/admin/speeches/_speech_type_fields.html.erb
+++ b/app/views/admin/speeches/_speech_type_fields.html.erb
@@ -5,7 +5,7 @@
     label: "Speech type",
     heading_size: "l",
     value: edition.speech_type_id,
-    error_message: errors_for_input(edition.errors, :speech_type_id),
+    error_items: errors_for(edition.errors, :speech_type_id),
     include_blank: true,
     options: SpeechType.primary.map do |type|
       {

--- a/app/views/admin/statistics_announcements/_form.html.erb
+++ b/app/views/admin/statistics_announcements/_form.html.erb
@@ -55,8 +55,8 @@
     id: "statistics_announcement_organisations",
     label: {
       text: "Organisations (required)",
-      heading_size: "l",
     },
+    heading_size: "l",
     name: "statistics_announcement[organisation_ids][]",
     select: {
       options:  options_from_collection_for_select(Organisation.with_translations.order("organisation_translations.name"), "id", "name", statistics_announcement.organisation_ids),

--- a/app/views/admin/statistics_announcements/_form.html.erb
+++ b/app/views/admin/statistics_announcements/_form.html.erb
@@ -56,8 +56,14 @@
     label: "Organisations (required)",
     heading_size: "l",
     name: "statistics_announcement[organisation_ids][]",
+    options: Organisation.with_translations.order("organisation_translations.name").map do |org|
+      {
+        text: org.select_name,
+        value: org.id,
+        selected: statistics_announcement.organisation_ids.include?(org.id),
+      }
+    end,
     select: {
-      options:  options_from_collection_for_select(Organisation.with_translations.order("organisation_translations.name"), "id", "name", statistics_announcement.organisation_ids),
       multiple: true,
     },
     error_items: errors_for(statistics_announcement.errors, :organisations),

--- a/app/views/admin/statistics_announcements/_form.html.erb
+++ b/app/views/admin/statistics_announcements/_form.html.erb
@@ -53,9 +53,7 @@
 
   <%= render "components/autocomplete", {
     id: "statistics_announcement_organisations",
-    label: {
-      text: "Organisations (required)",
-    },
+    label: "Organisations (required)",
     heading_size: "l",
     name: "statistics_announcement[organisation_ids][]",
     select: {

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -11,8 +11,8 @@
         include_blank: true,
         label: {
           text: "Locations",
-          heading_size: "l",
         },
+        heading_size: "l",
         select: {
           multiple: true,
           selected: form.object.world_location_ids,

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -9,9 +9,7 @@
         id: "user_world_location_ids",
         name: "user[world_location_ids][]",
         include_blank: true,
-        label: {
-          text: "Locations",
-        },
+        label: "Locations",
         heading_size: "l",
         select: {
           multiple: true,

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -8,6 +8,7 @@
       <%= render "components/autocomplete", {
         id: "user_world_location_ids",
         name: "user[world_location_ids][]",
+        include_blank: true,
         label: {
           text: "Locations",
           heading_size: "l",
@@ -15,7 +16,7 @@
         select: {
           multiple: true,
           selected: form.object.world_location_ids,
-          options: [""] + WorldLocation.all.map { |l| [l.name, l.id] },
+          options: WorldLocation.all.map { |l| [l.name, l.id] },
         },
       } %>
       <div class="govuk-button-group">

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -11,10 +11,15 @@
         include_blank: true,
         label: "Locations",
         heading_size: "l",
+        options: WorldLocation.all.map do |l|
+          {
+            text: l.name,
+            value: l.id,
+            selected: form.object.world_location_ids.include?(l.id),
+          }
+        end,
         select: {
           multiple: true,
-          selected: form.object.world_location_ids,
-          options: WorldLocation.all.map { |l| [l.name, l.id] },
         },
       } %>
       <div class="govuk-button-group">

--- a/app/views/admin/worldwide_organisation_pages/_form.html.erb
+++ b/app/views/admin/worldwide_organisation_pages/_form.html.erb
@@ -9,7 +9,7 @@
       name: "worldwide_organisation_page[corporate_information_page_type_id]",
       label: "Type",
       heading_size: "l",
-      error_message: errors_for_input(worldwide_organisation_page.errors, :corporate_information_page_type_id),
+      error_items: errors_for(worldwide_organisation_page.errors, :corporate_information_page_type_id),
       include_blank: true,
       options: corporate_information_page_types(@worldwide_organisation).map do |type, value|
         {

--- a/app/views/components/_autocomplete.html.erb
+++ b/app/views/components/_autocomplete.html.erb
@@ -16,6 +16,9 @@
   data_attributes[:module].strip!
   data_attributes.merge!(autocomplete_configuration_options:)
 
+  select_helper = GovukPublishingComponents::Presenters::SelectWithSearchHelper.new(local_assigns)
+  aria_describedby = { describedby: select_helper.describedby }
+
   root_classes = %w(app-c-autocomplete govuk-form-group)
   root_classes << "govuk-form-group--error" if error_items.any?
 %>
@@ -26,6 +29,13 @@
     text: label,
     heading_size:,
   } %>
+
+  <% if select_helper.hint %>
+    <%= render "govuk_publishing_components/components/hint", {
+      id: select_helper.hint_id,
+      text: hint,
+    } %>
+  <% end %>
 
   <% if error_items.any? %>
     <%= render "govuk_publishing_components/components/error_message", {
@@ -41,10 +51,6 @@
                  class: "govuk-hint app-c-autocomplete__multiselect-instructions" %>
   <% end %>
 
-  <%
-    select_helper = GovukPublishingComponents::Presenters::SelectWithSearchHelper.new(local_assigns)
-    aria_describedby = { describedby: select_helper.describedby }
-  %>
   <%= select_tag(
     name,
     select_helper.options_html,

--- a/app/views/components/_autocomplete.html.erb
+++ b/app/views/components/_autocomplete.html.erb
@@ -1,5 +1,6 @@
 <%
   id ||= "autocomplete-#{SecureRandom.hex(4)}"
+  name ||= id
   error_id = "error-#{SecureRandom.hex(4)}"
   error_items ||= []
   aria = error_id if error_items.any?

--- a/app/views/components/_autocomplete.html.erb
+++ b/app/views/components/_autocomplete.html.erb
@@ -45,6 +45,5 @@
     ),
     id: id,
     class: "govuk-select",
-    size: select[:size],
     multiple: select[:multiple] %>
 <% end %>

--- a/app/views/components/_autocomplete.html.erb
+++ b/app/views/components/_autocomplete.html.erb
@@ -4,6 +4,7 @@
   error_items ||= []
   aria = error_id if error_items.any?
   select ||= {}
+  include_blank ||= false
   autocomplete_configuration_options ||= {
     showAllValues: true,
   }
@@ -38,7 +39,10 @@
   <% end %>
 
   <%= select_tag name,
-    options_for_select(select[:options], select[:selected]),
+    options_for_select(
+      include_blank ? ([""] + select[:options]) : select[:options],
+      select[:selected],
+    ),
     id: id,
     class: "govuk-select",
     size: select[:size],

--- a/app/views/components/_autocomplete.html.erb
+++ b/app/views/components/_autocomplete.html.erb
@@ -5,7 +5,6 @@
   error_items ||= []
   aria = error_id if error_items.any?
   select ||= {}
-  include_blank ||= false
   heading_size ||= nil
   autocomplete_configuration_options ||= {
     showAllValues: true,
@@ -42,12 +41,16 @@
                  class: "govuk-hint app-c-autocomplete__multiselect-instructions" %>
   <% end %>
 
-  <%= select_tag name,
-    options_for_select(
-      include_blank ? ([""] + select[:options]) : select[:options],
-      select[:selected],
-    ),
+  <%
+    select_helper = GovukPublishingComponents::Presenters::SelectWithSearchHelper.new(local_assigns)
+    aria_describedby = { describedby: select_helper.describedby }
+  %>
+  <%= select_tag(
+    name,
+    select_helper.options_html,
     id: id,
-    class: "govuk-select",
-    multiple: select[:multiple] %>
+    class: select_helper.select_classes,
+    aria: aria_describedby,
+    multiple: select[:multiple],
+  ) %>
 <% end %>

--- a/app/views/components/_autocomplete.html.erb
+++ b/app/views/components/_autocomplete.html.erb
@@ -4,7 +4,9 @@
   error_items ||= []
   aria = error_id if error_items.any?
   select ||= {}
-  autocomplete_configuration_options ||= {}
+  autocomplete_configuration_options ||= {
+    showAllValues: true,
+  }
 
   data_attributes ||= {}
   data_attributes[:module] ||= ""

--- a/app/views/components/_autocomplete.html.erb
+++ b/app/views/components/_autocomplete.html.erb
@@ -23,8 +23,9 @@
 <%= tag.div class: root_classes, data: data_attributes do %>
   <%= render "govuk_publishing_components/components/label", {
     html_for: id,
+    text: label,
     heading_size:,
-  }.merge(label.symbolize_keys) %>
+  } %>
 
   <% if error_items.any? %>
     <%= render "govuk_publishing_components/components/error_message", {

--- a/app/views/components/_autocomplete.html.erb
+++ b/app/views/components/_autocomplete.html.erb
@@ -5,6 +5,7 @@
   aria = error_id if error_items.any?
   select ||= {}
   include_blank ||= false
+  heading_size ||= nil
   autocomplete_configuration_options ||= {
     showAllValues: true,
   }
@@ -22,6 +23,7 @@
 <%= tag.div class: root_classes, data: data_attributes do %>
   <%= render "govuk_publishing_components/components/label", {
     html_for: id,
+    heading_size:,
   }.merge(label.symbolize_keys) %>
 
   <% if error_items.any? %>

--- a/app/views/components/_select_with_search.html.erb
+++ b/app/views/components/_select_with_search.html.erb
@@ -2,7 +2,6 @@
   id ||= false
   label ||= false
   name ||= id
-  is_page_heading ||= false
 
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
   heading_size = false unless shared_helper.valid_heading_size?(heading_size)
@@ -12,11 +11,7 @@
 %>
 
 <%= content_tag :div, class: select_helper.css_classes, data: select_helper.data_attributes do %>
-  <% if is_page_heading %>
-    <%= tag.h1 label_tag(id, label, class: select_helper.label_classes, id: "#{id}_label"), class: "govuk-heading-xl" %>
-  <% else %>
-    <%= label_tag(id, label, class: select_helper.label_classes, id: "#{id}_label") %>
-  <% end %>
+  <%= label_tag(id, label, class: select_helper.label_classes, id: "#{id}_label") %>
 
   <% if select_helper.hint %>
     <%= render "govuk_publishing_components/components/hint", {

--- a/app/views/components/_select_with_search.html.erb
+++ b/app/views/components/_select_with_search.html.erb
@@ -6,8 +6,6 @@
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
   heading_size = false unless shared_helper.valid_heading_size?(heading_size)
   select_helper = GovukPublishingComponents::Presenters::SelectWithSearchHelper.new(local_assigns)
-
-  aria_describedby = { describedby: select_helper.describedby }
 %>
 
 <%= content_tag :div, class: select_helper.css_classes, data: select_helper.data_attributes do %>
@@ -20,12 +18,12 @@
     } %>
   <% end %>
 
-  <% if select_helper.error_message %>
+  <% if select_helper.error_items.any? %>
     <%= render "govuk_publishing_components/components/error_message", {
       id: select_helper.error_id,
-      text: select_helper.error_message,
+      items: select_helper.error_items,
     } %>
   <% end %>
 
-  <%= select_tag name, select_helper.options_html, id: id, class: select_helper.select_classes, aria: aria_describedby %>
+  <%= select_tag name, select_helper.options_html, id: id, class: select_helper.select_classes, aria: select_helper.aria %>
 <% end %>

--- a/app/views/components/docs/autocomplete.yml
+++ b/app/views/components/docs/autocomplete.yml
@@ -76,6 +76,20 @@ examples:
         - text: United Kingdom
           value: uk
 
+  with_hint:
+    description: When a hint is included the `aria-describedby` attribute of the select is included to point to the hint. When an error and a hint are present, that attribute includes the IDs of both the hint and the error.
+    data:
+      id: dropdown-with-hint
+      name: dropdown-with-hint
+      label: Choose your preferred thing
+      hint: You might need some more information here
+      hint_id: optional-hint-id
+      options:
+      - text: Something
+        value: option1
+      - text: Something else
+        value: option2
+
   with_error:
     data:
       name: autocomplete-with-error

--- a/app/views/components/docs/autocomplete.yml
+++ b/app/views/components/docs/autocomplete.yml
@@ -12,8 +12,7 @@ examples:
     data:
       id: autocomplete
       name: autocomplete
-      label:
-        text: Select your country
+      label: Select your country
       select:
         options:
           -
@@ -31,8 +30,7 @@ examples:
       id: autocomplete
       name: autocomplete
       include_blank: true
-      label:
-        text: Select your country
+      label: Select your country
       select:
         options:
           -
@@ -50,8 +48,7 @@ examples:
       id: autocomplete
       name: autocomplete
       include_blank: true
-      label:
-        text: Select your country
+      label: Select your country
       heading_size: xl
       select:
         options:
@@ -69,8 +66,7 @@ examples:
     data:
       id: autocomplete-selected
       name: autocomplete-selected
-      label:
-        text: Select your country
+      label: Select your country
       hint: Only a few countries are available
       select:
         options:
@@ -88,8 +84,7 @@ examples:
   with_error:
     data:
       name: autocomplete-with-error
-      label:
-        text: Autocomplete with error
+      label: Autocomplete with error
       select:
         options:
           -
@@ -108,8 +103,7 @@ examples:
     data:
       id: autocomplete-multiselect
       name: autocomplete-multiselect
-      label:
-        text: Select your country
+      label: Select your country
       select:
         multiple: true
         options:
@@ -133,8 +127,7 @@ examples:
       data_attributes:
         module: not-a-module
         loose: moose
-      label:
-        text: Select your country
+      label: Select your country
       select:
         options:
           -
@@ -151,8 +144,7 @@ examples:
     data:
       id: autocomplete-configuration-options
       name: autocomplete-configuration-options
-      label:
-        text: Status
+      label: Status
       select:
         multiple: true
         options:

--- a/app/views/components/docs/autocomplete.yml
+++ b/app/views/components/docs/autocomplete.yml
@@ -45,6 +45,26 @@ examples:
             - United Kingdom
             - uk
 
+  with_custom_heading_size:
+    data:
+      id: autocomplete
+      name: autocomplete
+      include_blank: true
+      label:
+        text: Select your country
+      heading_size: xl
+      select:
+        options:
+          -
+            - France
+            - fr
+          -
+            - Germany
+            - de
+          -
+            - United Kingdom
+            - uk
+
   with_selected_value:
     data:
       id: autocomplete-selected

--- a/app/views/components/docs/autocomplete.yml
+++ b/app/views/components/docs/autocomplete.yml
@@ -13,17 +13,13 @@ examples:
       id: autocomplete
       name: autocomplete
       label: Select your country
-      select:
-        options:
-          -
-            - France
-            - fr
-          -
-            - Germany
-            - de
-          -
-            - United Kingdom
-            - uk
+      options:
+        - text: France
+          value: fr
+        - text: Germany
+          value: de
+        - text: United Kingdom
+          value: uk
 
   with_blank_option:
     data:
@@ -31,17 +27,13 @@ examples:
       name: autocomplete
       include_blank: true
       label: Select your country
-      select:
-        options:
-          -
-            - France
-            - fr
-          -
-            - Germany
-            - de
-          -
-            - United Kingdom
-            - uk
+      options:
+        - text: France
+          value: fr
+        - text: Germany
+          value: de
+        - text: United Kingdom
+          value: uk
 
   with_missing_name:
     description: If no name is provided, name defaults to the (required) value of id.
@@ -61,17 +53,13 @@ examples:
       include_blank: true
       label: Select your country
       heading_size: xl
-      select:
-        options:
-          -
-            - France
-            - fr
-          -
-            - Germany
-            - de
-          -
-            - United Kingdom
-            - uk
+      options:
+        - text: France
+          value: fr
+        - text: Germany
+          value: de
+        - text: United Kingdom
+          value: uk
 
   with_selected_value:
     data:
@@ -79,34 +67,26 @@ examples:
       name: autocomplete-selected
       label: Select your country
       hint: Only a few countries are available
-      select:
-        options:
-          -
-            - France
-            - fr
-          -
-            - Germany
-            - de
-          -
-            - United Kingdom
-            - uk
-        selected: de
+      options:
+        - text: France
+          value: fr
+        - text: Germany
+          value: de
+          selected: true
+        - text: United Kingdom
+          value: uk
 
   with_error:
     data:
       name: autocomplete-with-error
       label: Autocomplete with error
-      select:
-        options:
-          -
-            - France
-            - fr
-          -
-            - Germany
-            - de
-          -
-            - United Kingdom
-            - uk
+      options:
+        - text: France
+          value: fr
+        - text: Germany
+          value: de
+        - text: United Kingdom
+          value: uk
       error_items:
         - text: There is a problem with this input
 
@@ -117,19 +97,15 @@ examples:
       label: Select your country
       select:
         multiple: true
-        options:
-          -
-            - France
-            - fr
-          -
-            - Germany
-            - de
-          -
-            - United Kingdom
-            - uk
-        selected:
-            - fr
-            - de
+      options:
+        - text: France
+          value: fr
+          selected: true
+        - text: Germany
+          value: de
+          selected: true
+        - text: United Kingdom
+          value: uk
 
   with_data_attributes:
     data:
@@ -139,17 +115,13 @@ examples:
         module: not-a-module
         loose: moose
       label: Select your country
-      select:
-        options:
-          -
-            - France
-            - fr
-          -
-            - Germany
-            - de
-          -
-            - United Kingdom
-            - uk
+      options:
+        - text: France
+          value: fr
+        - text: Germany
+          value: de
+        - text: United Kingdom
+          value: uk
 
   autocomplete_with_configuration_options:
     data:
@@ -158,15 +130,12 @@ examples:
       label: Status
       select:
         multiple: true
-        options:
-          -
-            - France
-            - fr
-          -
-            - Germany
-            - de
-          -
-            - United Kingdom
-            - uk
+      options:
+        - text: France
+          value: fr
+        - text: Germany
+          value: de
+        - text: United Kingdom
+          value: uk
       autocomplete_configuration_options:
         showAllValues: false

--- a/app/views/components/docs/autocomplete.yml
+++ b/app/views/components/docs/autocomplete.yml
@@ -43,6 +43,17 @@ examples:
             - United Kingdom
             - uk
 
+  with_missing_name:
+    description: If no name is provided, name defaults to the (required) value of id.
+    data:
+      id: dropdown-with-different-id-and-name
+      label: My Dropdown
+      options:
+      - text: Option one
+        value: option1
+      - text: Option two
+        value: option2
+
   with_custom_heading_size:
     data:
       id: autocomplete

--- a/app/views/components/docs/autocomplete.yml
+++ b/app/views/components/docs/autocomplete.yml
@@ -51,7 +51,6 @@ examples:
       name: autocomplete-selected
       label:
         text: Select your country
-        bold: true
       hint: Only a few countries are available
       select:
         options:

--- a/app/views/components/docs/autocomplete.yml
+++ b/app/views/components/docs/autocomplete.yml
@@ -17,7 +17,24 @@ examples:
       select:
         options:
           -
-            -
+            - France
+            - fr
+          -
+            - Germany
+            - de
+          -
+            - United Kingdom
+            - uk
+
+  with_blank_option:
+    data:
+      id: autocomplete
+      name: autocomplete
+      include_blank: true
+      label:
+        text: Select your country
+      select:
+        options:
           -
             - France
             - fr
@@ -101,8 +118,6 @@ examples:
         text: Select your country
       select:
         options:
-          -
-            -
           -
             - France
             - fr

--- a/app/views/components/docs/select_with_search.yml
+++ b/app/views/components/docs/select_with_search.yml
@@ -159,12 +159,12 @@ examples:
       - text: Something else
         value: option2
   with_error:
-    description: If the user has to select an option, it is recommended that a radio button is used instead of a select, but this is not always possible. Note that `error_id` is optional, if it is not passed one will be generated automatically.
+    description: An arbitrary number of separate error items can be passed to the component.
     data:
       id: dropdown-with-error
       label: How will you be travelling to the conference?
-      error_message: Please choose an option
-      error_id: error_id
+      error_items:
+        - text: Please choose an option
       include_blank: true
       options:
       - text: Public transport

--- a/app/views/components/docs/select_with_search.yml
+++ b/app/views/components/docs/select_with_search.yml
@@ -120,6 +120,20 @@ examples:
         value: option1
       - text: Option two
         value: option2
+  with_data_attributes:
+    data:
+      id: dropdown-with-data-attributes
+      data_attributes:
+        module: not-a-module
+        loose: moose
+      label: Select your country
+      options:
+        - text: France
+          value: fr
+        - text: Germany
+          value: de
+        - text: United Kingdom
+          value: uk
   with_preselect:
     data:
       id: dropdown-with-preselect

--- a/app/views/components/docs/select_with_search.yml
+++ b/app/views/components/docs/select_with_search.yml
@@ -170,15 +170,3 @@ examples:
         value: option2
       - text: Option three
         value: option3
-  with_page_heading:
-    description: This adds a `h1` element with a label element inside containing the text supplied.
-    data:
-      id: select-with-page-heading
-      label: This is a page heading
-      heading_size: xl
-      is_page_heading: true
-      options:
-      - text: Option one
-        value: option1
-      - text: Option two
-        value: option2

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/index/filter_options_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/index/filter_options_component.html.erb
@@ -50,7 +50,7 @@
               id: "lead_organisation",
               name: "lead_organisation",
               include_blank: false,
-              options: options_for_lead_organisation,
+              options: options_for_lead_organisation([@filters[:lead_organisation]]),
             }
           ),
         },

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/index/filter_options_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/index/filter_options_component.rb
@@ -17,25 +17,19 @@ private
     end
   end
 
-  def all_organisations_option
+  def all_organisations_option(selected_orgs)
     {
       text: "All organisations",
       value: "",
-      selected: @filters.none? || @filters[:lead_organisation]&.empty?,
+      selected: selected_orgs.compact.empty?,
     }
   end
 
-  def taggable_organisations_options
-    helpers.taggable_organisations_container.map do |name, id|
-      {
-        text: name,
-        value: id,
-        selected: @filters.any? && @filters[:lead_organisation] == id.to_s,
-      }
-    end
+  def taggable_organisations_options(selected_orgs)
+    helpers.taggable_organisations_container(selected_orgs)
   end
 
-  def options_for_lead_organisation
-    [all_organisations_option, taggable_organisations_options].flatten
+  def options_for_lead_organisation(selected_orgs = [])
+    [all_organisations_option(selected_orgs), taggable_organisations_options(selected_orgs)].flatten
   end
 end

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/shared/_form.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/shared/_form.html.erb
@@ -38,9 +38,6 @@
       options: [""] + taggable_organisations_container,
       selected: @form.content_block_edition.edition_organisation&.organisation_id,
     },
-    autocomplete_configuration_options: {
-      showAllValues: true,
-    },
   } %>
 
   <%= render "govuk_publishing_components/components/textarea", {

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/shared/_form.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/shared/_form.html.erb
@@ -32,10 +32,9 @@
     error_items: errors_for(@form.content_block_edition.errors, "lead_organisation".to_sym),
     include_blank: true,
     label: "Lead organisation",
+    options: taggable_organisations_container([@form.content_block_edition.edition_organisation&.organisation_id]),
     select: {
       multiple: false,
-      options: taggable_organisations_container,
-      selected: @form.content_block_edition.edition_organisation&.organisation_id,
     },
   } %>
 

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/shared/_form.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/shared/_form.html.erb
@@ -31,9 +31,7 @@
     name: "content_block/edition[organisation_id]",
     error_items: errors_for(@form.content_block_edition.errors, "lead_organisation".to_sym),
     include_blank: true,
-    label: {
-      text: "Lead organisation",
-    },
+    label: "Lead organisation",
     select: {
       multiple: false,
       options: taggable_organisations_container,

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/shared/_form.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/shared/_form.html.erb
@@ -30,12 +30,13 @@
     id: "#{parent_class}_lead_organisation",
     name: "content_block/edition[organisation_id]",
     error_items: errors_for(@form.content_block_edition.errors, "lead_organisation".to_sym),
+    include_blank: true,
     label: {
       text: "Lead organisation",
     },
     select: {
       multiple: false,
-      options: [""] + taggable_organisations_container,
+      options: taggable_organisations_container,
       selected: @form.content_block_edition.edition_organisation&.organisation_id,
     },
   } %>

--- a/lib/engines/content_block_manager/test/components/content_block/document/index/filter_options_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/document/index/filter_options_component_test.rb
@@ -11,9 +11,10 @@ class ContentBlockManager::ContentBlock::Document::Index::FilterOptionsComponent
     helper_mock.stubs(:content_block_manager_content_block_documents_path).returns("path")
     helper_mock.stubs(:content_block_manager_root_path).returns("path")
 
-    helper_mock.stubs(:taggable_organisations_container).returns(
-      [["Department of Placeholder", 1], ["Ministry of Example", 2]],
-    )
+    helper_mock.stubs(:taggable_organisations_container).returns([
+      { text: "Department of Placeholder", value: 1 },
+      { text: "Ministry of Example", value: 2 },
+    ])
 
     ContentBlockManager::ContentBlock::Schema.stubs(:valid_schemas).returns(%w[email_address postal_address])
   end
@@ -70,6 +71,10 @@ class ContentBlockManager::ContentBlock::Document::Index::FilterOptionsComponent
   end
 
   it "selects organisation if selected in filters" do
+    helper_mock.stubs(:taggable_organisations_container).returns([
+      { text: "Department of Placeholder", value: 1 },
+      { text: "Ministry of Example", value: 2, selected: true },
+    ])
     render_inline(
       ContentBlockManager::ContentBlock::Document::Index::FilterOptionsComponent.new(
         filters: { lead_organisation: "2" },

--- a/lib/govuk_publishing_components/presenters/select_with_search_helper.rb
+++ b/lib/govuk_publishing_components/presenters/select_with_search_helper.rb
@@ -7,11 +7,9 @@ module GovukPublishingComponents
     class SelectWithSearchHelper
       include ActionView::Helpers::FormOptionsHelper
 
-      attr_reader :options, :selected_options
+      attr_reader :options, :selected_options, :error_id, :error_items, :aria
 
       delegate :describedby,
-               :error_id,
-               :error_message,
                :hint_id,
                :hint,
                :label_classes,
@@ -20,6 +18,9 @@ module GovukPublishingComponents
 
       def initialize(local_assigns)
         @select_helper = SelectHelper.new(local_assigns.except(:options, :grouped_options))
+        @error_id = "error-#{SecureRandom.hex(4)}"
+        @error_items = local_assigns[:error_items] || []
+        @aria = @error_items.any? ? { describedby: @error_id } : @describedby
         @options = local_assigns[:options]
         @grouped_options = local_assigns[:grouped_options]
         @include_blank = local_assigns[:include_blank]
@@ -29,7 +30,7 @@ module GovukPublishingComponents
 
       def css_classes
         classes = %w[app-c-select-with-search govuk-form-group]
-        classes << "govuk-form-group--error" if error_message
+        classes << "govuk-form-group--error" if error_items.any?
         classes
       end
 

--- a/lib/govuk_publishing_components/presenters/select_with_search_helper.rb
+++ b/lib/govuk_publishing_components/presenters/select_with_search_helper.rb
@@ -7,7 +7,7 @@ module GovukPublishingComponents
     class SelectWithSearchHelper
       include ActionView::Helpers::FormOptionsHelper
 
-      attr_reader :options, :selected_option
+      attr_reader :options, :selected_options
 
       delegate :describedby,
                :error_id,
@@ -23,6 +23,7 @@ module GovukPublishingComponents
         @options = local_assigns[:options]
         @grouped_options = local_assigns[:grouped_options]
         @include_blank = local_assigns[:include_blank]
+        @selected_options = []
         @local_assigns = local_assigns
       end
 
@@ -40,7 +41,7 @@ module GovukPublishingComponents
           blank_option_if_include_blank +
             options_for_select(
               transform_options(@options),
-              selected_option,
+              selected_options,
             )
         end
       end
@@ -67,15 +68,15 @@ module GovukPublishingComponents
         end
         single_options.flatten!
 
-        options_for_select(transform_options(single_options), selected_option) +
-          grouped_options_for_select(transform_grouped_options(grouped_options), selected_option)
+        options_for_select(transform_options(single_options), selected_options) +
+          grouped_options_for_select(transform_grouped_options(grouped_options), selected_options)
       end
 
     private
 
       def transform_options(options)
         options.map do |option|
-          @selected_option = option[:value] if option[:selected]
+          @selected_options << option[:value] if option[:selected]
           [
             option[:text],
             option[:value],

--- a/lib/govuk_publishing_components/presenters/select_with_search_helper.rb
+++ b/lib/govuk_publishing_components/presenters/select_with_search_helper.rb
@@ -46,9 +46,11 @@ module GovukPublishingComponents
       end
 
       def data_attributes
-        {
-          "module": "select-with-search",
-        }.compact
+        data_attributes = @local_assigns[:data_attributes] || {}
+        data_attributes[:module] ||= ""
+        data_attributes[:module] << " select-with-search"
+        data_attributes[:module].strip!
+        data_attributes
       end
 
       def grouped_and_ungrouped_options_for_select(unsorted_options)

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint:js": "eslint --cache --cache-location .cache/eslint --color --ignore-path .gitignore -- \"**/*.js\"",
     "lint:scss": "stylelint app/assets/stylesheets/",
     "lint:prettier": "prettier --cache --cache-location .cache/prettier --cache-strategy content --check -- \"**/*.{js,scss}\"",
+    "lint:prettier:fix": "prettier --write \"**/*.{js,scss}\"",
     "jasmine:prepare": "RAILS_ENV=test bundle exec rails assets:clobber assets:precompile",
     "jasmine:ci": "yarn run jasmine:prepare && yarn run jasmine-browser-runner runSpecs",
     "jasmine:browser": "yarn run jasmine:prepare && yarn run jasmine-browser-runner"

--- a/test/components/autocomplete_test.rb
+++ b/test/components/autocomplete_test.rb
@@ -9,9 +9,7 @@ class AutocompleteComponentTest < ComponentTestCase
     {
       id: "id",
       name: "name",
-      label: {
-        text: "text",
-      },
+      label: "text",
       select: {
         options: [
           ["France", "fr"],

--- a/test/components/autocomplete_test.rb
+++ b/test/components/autocomplete_test.rb
@@ -85,7 +85,14 @@ class AutocompleteComponentTest < ComponentTestCase
     assert_select ".app-c-autocomplete .govuk-select option[value='uk'][selected='selected']"
   end
 
-  test "accepts data attribures" do
+  test "accepts a hint" do
+    data = component_data
+    data[:hint] = "hint"
+    render_component(data)
+    assert_select ".govuk-hint", text: "hint"
+  end
+
+  test "accepts data attributes" do
     data = component_data
     data[:data_attributes] = {
       module: "not-a-module",

--- a/test/components/autocomplete_test.rb
+++ b/test/components/autocomplete_test.rb
@@ -49,6 +49,13 @@ class AutocompleteComponentTest < ComponentTestCase
     assert_select ".app-c-autocomplete .govuk-select option[value='']"
   end
 
+  test "passes heading size to label component" do
+    data = component_data
+    data[:heading_size] = "xl"
+    render_component(data)
+    assert_select ".govuk-label.govuk-label--xl"
+  end
+
   test "renders with an error" do
     data = component_data
     data[:error_items] = [

--- a/test/components/autocomplete_test.rb
+++ b/test/components/autocomplete_test.rb
@@ -10,13 +10,11 @@ class AutocompleteComponentTest < ComponentTestCase
       id: "id",
       name: "name",
       label: "text",
-      select: {
-        options: [
-          ["France", "fr"],
-          ["Germany", "de"],
-          ["United Kingdom", "uk"],
-        ],
-      },
+      options: [
+        { text: "France", value: "fr" },
+        { text: "Germany", value: "de" },
+        { text: "United Kingdom", value: "uk" },
+      ],
     }
   end
 
@@ -44,9 +42,9 @@ class AutocompleteComponentTest < ComponentTestCase
 
   test "renders with a selected option" do
     data = component_data
-    data[:select][:selected] = "de"
+    data[:options].first[:selected] = true
     render_component(data)
-    assert_select ".app-c-autocomplete .govuk-select option[value='de'][selected='selected']"
+    assert_select ".app-c-autocomplete .govuk-select option[value='fr'][selected='selected']"
   end
 
   test "renders with a blank option" do
@@ -76,13 +74,15 @@ class AutocompleteComponentTest < ComponentTestCase
 
   test "renders in multiple mode" do
     data = component_data
+    data[:select] = {}
     data[:select][:multiple] = true
-    data[:select][:selected] = %w[fr de]
+    data[:options].first[:selected] = true
+    data[:options].last[:selected] = true
     render_component(data)
     assert_select ".app-c-autocomplete .govuk-select[multiple='multiple']"
     assert_select ".app-c-autocomplete .govuk-select option[value='fr'][selected='selected']"
-    assert_select ".app-c-autocomplete .govuk-select option[value='de'][selected='selected']"
-    assert_select ".app-c-autocomplete .govuk-select option[value='uk'][selected='selected']", false
+    assert_select ".app-c-autocomplete .govuk-select option[value='de'][selected='selected']", false
+    assert_select ".app-c-autocomplete .govuk-select option[value='uk'][selected='selected']"
   end
 
   test "accepts data attribures" do

--- a/test/components/autocomplete_test.rb
+++ b/test/components/autocomplete_test.rb
@@ -26,6 +26,15 @@ class AutocompleteComponentTest < ComponentTestCase
     end
   end
 
+  test "defaults the 'name' to be the same as 'id'" do
+    data_without_name = component_data.dup
+    data_without_name.delete(:name)
+    render_component(data_without_name)
+    assert_select ".app-c-autocomplete"
+    assert_select ".govuk-select[id='id'][name='id']"
+    assert_select ".govuk-label", text: "text"
+  end
+
   test "renders the basic component" do
     render_component(component_data)
     assert_select ".app-c-autocomplete"

--- a/test/components/autocomplete_test.rb
+++ b/test/components/autocomplete_test.rb
@@ -14,7 +14,6 @@ class AutocompleteComponentTest < ComponentTestCase
       },
       select: {
         options: [
-          [""],
           ["France", "fr"],
           ["Germany", "de"],
           ["United Kingdom", "uk"],
@@ -41,6 +40,13 @@ class AutocompleteComponentTest < ComponentTestCase
     data[:select][:selected] = "de"
     render_component(data)
     assert_select ".app-c-autocomplete .govuk-select option[value='de'][selected='selected']"
+  end
+
+  test "renders with a blank option" do
+    data = component_data
+    data[:include_blank] = true
+    render_component(data)
+    assert_select ".app-c-autocomplete .govuk-select option[value='']"
   end
 
   test "renders with an error" do

--- a/test/integration/components/select_with_search_test.rb
+++ b/test/integration/components/select_with_search_test.rb
@@ -44,4 +44,12 @@ class SelectWithSearchTest < ActionDispatch::IntegrationTest
       assert_equal rendered_options, %w[Cardiff Swansea]
     end
   end
+
+  test "it renders custom data attributes" do
+    load_example "with_data_attributes"
+    assert_selector ".app-c-select-with-search" do |node|
+      assert node[:'data-module'] == "not-a-module select-with-search"
+      assert node[:'data-loose'] == "moose"
+    end
+  end
 end

--- a/test/integration/components/select_with_search_test.rb
+++ b/test/integration/components/select_with_search_test.rb
@@ -52,4 +52,12 @@ class SelectWithSearchTest < ActionDispatch::IntegrationTest
       assert node[:'data-loose'] == "moose"
     end
   end
+
+  test "it renders error messages" do
+    load_example "with_error"
+    assert_selector ".govuk-form-group--error"
+    assert_selector "select[name='dropdown-with-error']" do |node|
+      assert node[:'aria-describedby'] =~ /error-(.+)/
+    end
+  end
 end

--- a/test/unit/app/helpers/admin/taggable_content_helper_test.rb
+++ b/test/unit/app/helpers/admin/taggable_content_helper_test.rb
@@ -7,9 +7,9 @@ class Admin::TaggableContentHelperTest < ActionView::TestCase
     organisation_a = create(:organisation, name: "Organisation A", acronym: "OA")
 
     assert_equal [
-      ["Organisation A (OA)", organisation_a.id],
-      ["Organisation B (OB)", organisation_b.id],
-      ["Organisation C (OC)", organisation_c.id],
+      { text: "Organisation A (OA)", value: organisation_a.id, selected: false },
+      { text: "Organisation B (OB)", value: organisation_b.id, selected: false },
+      { text: "Organisation C (OC)", value: organisation_c.id, selected: false },
     ],
                  taggable_organisations_container
   end
@@ -34,9 +34,9 @@ class Admin::TaggableContentHelperTest < ActionView::TestCase
     )
 
     assert_equal [
-      ["Fred Flintstone, Leader, Ministry for Rocks and Bones", current_leader_appointment.id],
-      ["Joe Rockhead, Deputy Leader, Ministry for Rocks and Bones", deputy_leader_appointment.id],
-      ["Mr. Slate, Leader (12 May 1960 to 14 May 1972), Ministry for Rocks and Bones", old_leader_appointment.id],
+      { text: "Fred Flintstone, Leader, Ministry for Rocks and Bones", value: current_leader_appointment.id, selected: false },
+      { text: "Joe Rockhead, Deputy Leader, Ministry for Rocks and Bones", value: deputy_leader_appointment.id, selected: false },
+      { text: "Mr. Slate, Leader (12 May 1960 to 14 May 1972), Ministry for Rocks and Bones", value: old_leader_appointment.id, selected: false },
     ],
                  taggable_ministerial_role_appointments_container
   end
@@ -67,9 +67,9 @@ class Admin::TaggableContentHelperTest < ActionView::TestCase
     current_leader_appointment = create(:role_appointment, role: leader, person: slate)
 
     assert_equal [
-      ["Mr. Slate, Leader, Ministry for Rocks and Bones", current_leader_appointment.id],
-      ["Joe Rockhead, Leader (12 May 2006 to 11 May 2011), Ministry for Rocks and Bones", old_leader_appointment.id],
-      ["Karen Granite, Leader (12 May 2003 to 11 May 2006), Ministry for Rocks and Bones", older_leader_appointment.id],
+      { text: "Mr. Slate, Leader, Ministry for Rocks and Bones", value: current_leader_appointment.id, selected: false },
+      { text: "Joe Rockhead, Leader (12 May 2006 to 11 May 2011), Ministry for Rocks and Bones", value: old_leader_appointment.id, selected: false },
+      { text: "Karen Granite, Leader (12 May 2003 to 11 May 2006), Ministry for Rocks and Bones", value: older_leader_appointment.id, selected: false },
     ],
                  taggable_ministerial_role_appointments_container
   end
@@ -94,9 +94,9 @@ class Admin::TaggableContentHelperTest < ActionView::TestCase
     )
 
     assert_equal [
-      ["James Brown, Minister of Funk, Ministry for Funk", minister_appointment.id],
-      ["George Clinton, Board Member, Ministry for Funk", board_member_appointment.id],
-      ["Little Richard, Minister of Funk (05 December 1932 to 14 May 1972), Ministry for Funk", old_minister_appointment.id],
+      { text: "James Brown, Minister of Funk, Ministry for Funk", value: minister_appointment.id, selected: false },
+      { text: "George Clinton, Board Member, Ministry for Funk", value: board_member_appointment.id, selected: false },
+      { text: "Little Richard, Minister of Funk (05 December 1932 to 14 May 1972), Ministry for Funk", value: old_minister_appointment.id, selected: false },
     ],
                  taggable_role_appointments_container
   end
@@ -108,9 +108,9 @@ class Admin::TaggableContentHelperTest < ActionView::TestCase
     guide_c = create(:submitted_detailed_guide, title: "Guide C")
 
     assert_equal [
-      [guide_a.title, guide_a.id],
-      [guide_b.title, guide_b.id],
-      [guide_c.title, guide_c.id],
+      { text: guide_a.title, value: guide_a.id, selected: false },
+      { text: guide_b.title, value: guide_b.id, selected: false },
+      { text: guide_c.title, value: guide_c.id, selected: false },
     ],
                  taggable_detailed_guides_container
   end
@@ -121,9 +121,9 @@ class Admin::TaggableContentHelperTest < ActionView::TestCase
     data_set3 = create(:submitted_statistical_data_set)
 
     assert_equal [
-      [data_set1.title, data_set1.document_id],
-      [data_set2.title, data_set2.document_id],
-      [data_set3.title, data_set3.document_id],
+      { text: data_set1.title, value: data_set1.document_id, selected: false },
+      { text: data_set2.title, value: data_set2.document_id, selected: false },
+      { text: data_set3.title, value: data_set3.document_id, selected: false },
     ],
                  taggable_statistical_data_sets_container
   end
@@ -135,9 +135,9 @@ class Admin::TaggableContentHelperTest < ActionView::TestCase
     create(:world_location, name: "United Kingdom", active: false)
 
     assert_equal [
-      ["Andorra", location_a.id],
-      ["Brazil", location_b.id],
-      ["Croatia", location_c.id],
+      { text: "Andorra", value: location_a.id, selected: false },
+      { text: "Brazil", value: location_b.id, selected: false },
+      { text: "Croatia", value: location_c.id, selected: false },
     ],
                  taggable_world_locations_container
   end
@@ -148,9 +148,9 @@ class Admin::TaggableContentHelperTest < ActionView::TestCase
     organisation_t = create(:organisation, alternative_format_contact_email: "lee.perry@melodica.uk", name: "Department for the Preseveration of Melodicas")
 
     assert_equal [
-      ["Department for Hair and Makeup (-)", organisation_h.id],
-      ["Department for the Preseveration of Melodicas (lee.perry@melodica.uk)", organisation_t.id],
-      ["Ministry of Strange Fruit (barry@strange-fruit.uk)", organisation_m.id],
+      { text: "Department for Hair and Makeup (-)", value: organisation_h.id, selected: false },
+      { text: "Department for the Preseveration of Melodicas (lee.perry@melodica.uk)", value: organisation_t.id, selected: false },
+      { text: "Ministry of Strange Fruit (barry@strange-fruit.uk)", value: organisation_m.id, selected: false },
     ],
                  taggable_alternative_format_providers_container
   end

--- a/test/unit/app/helpers/admin/taggable_content_helper_test.rb
+++ b/test/unit/app/helpers/admin/taggable_content_helper_test.rb
@@ -1,19 +1,6 @@
 require "test_helper"
 
 class Admin::TaggableContentHelperTest < ActionView::TestCase
-  test "#taggable_topical_events_container returns an array of name/ID pairs for all TopicalEvents" do
-    event_a = create(:topical_event, name: "Event A")
-    event_c = create(:topical_event, name: "Event C")
-    event_b = create(:topical_event, name: "Event B")
-
-    assert_equal [
-      ["Event A", event_a.id],
-      ["Event B", event_b.id],
-      ["Event C", event_c.id],
-    ],
-                 taggable_topical_events_container
-  end
-
   test "#taggable_organisations_container returns an array of select_name/ID pairs for all Organisations" do
     organisation_c = create(:organisation, name: "Organisation C", acronym: "OC")
     organisation_b = create(:organisation, name: "Organisation B", acronym: "OB")
@@ -114,23 +101,6 @@ class Admin::TaggableContentHelperTest < ActionView::TestCase
                  taggable_role_appointments_container
   end
 
-  test "#taggable_ministerial_roles_container returns an array of label/ID pairs for all the ministerial roles" do
-    create(:board_member_role)
-    minister_b = create(:ministerial_role, name: "Minister B", organisations: [create(:organisation, name: "Jazz Ministry")])
-    minister_a = create(:ministerial_role, name: "Minister A", organisations: minister_b.organisations)
-    minister_c = create(:ministerial_role, name: "Minister C", organisations: [create(:organisation, name: "Ministry of Outer Space")])
-
-    create(:role_appointment, role: minister_a, person: create(:person, forename: "Sun", surname: "Ra"))
-    create(:role_appointment, role: minister_c, person: create(:person, forename: "George", surname: "Clinton"))
-
-    assert_equal [
-      ["Minister B, Jazz Ministry (Minister B)", minister_b.id],
-      ["Minister C, Ministry of Outer Space (George Clinton)", minister_c.id],
-      ["Minister A, Jazz Ministry (Sun Ra)", minister_a.id],
-    ],
-                 taggable_ministerial_roles_container
-  end
-
   test "#taggable_detailed_guides_container returns an array of label/ID pairs for all active detailed guides" do
     guide_b = create(:published_detailed_guide, title: "Guide B")
     guide_a = create(:draft_detailed_guide, title: "Guide A")
@@ -183,21 +153,6 @@ class Admin::TaggableContentHelperTest < ActionView::TestCase
       ["Ministry of Strange Fruit (barry@strange-fruit.uk)", organisation_m.id],
     ],
                  taggable_alternative_format_providers_container
-  end
-
-  test "#taggable_document_collection_groups_container returns an array of label/ID pairs for document collection groups" do
-    group1 = create(:document_collection_group, heading: "Group 1")
-    group2 = create(:document_collection_group, heading: "Group 2")
-    group3 = create(:document_collection_group, heading: "Group 3")
-    create(:document_collection, title: "Collection 1", groups: [group1])
-    create(:document_collection, title: "Collection 2", groups: [group2, group3])
-
-    assert_equal [
-      ["Collection 1 (Group 1)", group1.id],
-      ["Collection 2 (Group 2)", group2.id],
-      ["Collection 2 (Group 3)", group3.id],
-    ],
-                 taggable_document_collection_groups_container
   end
 
   test "#taggable_ministerial_role_appointments_cache_digest changes when a role appointment is updated" do


### PR DESCRIPTION
Trello: https://trello.com/c/pmbL2yId/3411-remove-the-selectwithsearch-component-from-whitehall

This PR is a refactor, to make the data structures used by 'autocomplete' and 'select with search' more alike, to enable us to consolidate the components in a future PR. There are *no user facing changes* here: all the same existing components are used and there should be no change to look/feel/functionality.

Changes:

- Removes some unused features from both 'autocomplete' and 'select with search'
- Changes 'autocomplete' to define its options as an array of hashes, making it more expressive (allowing options to be defined as 'selected') and bringing it in line with 'select with search'
  - The 'autocomplete' component now uses the `SelectWithSearchHelper` class as a result (so that both components have one way of converting the array of hashes into the 'options HTML').
  - And as a result, we've also had to tweak the helper class to accept a `multiple` parameter.
- Changes 'autocomplete' to have a proper `include_blank: true` option instead of having to prefix an empty string
- Changes 'select with search' to define its error messages as an array of errors, making it more flexible and bringing it in line with 'autocomplete' and the vast majority of other components
- Patches some minor functionality that is currently unused, but will make it easier to consolidate the components in the next PR. E.g. overriding data attributes, defaulting a value for `name`.

This leaves the components' data structures with one main difference each:

- The 'autocomplete' component doesn't yet support the 'grouped_options' property for the 'select with search' component
- The 'select with search' component doesn't yet support the 'multiple' property for the 'autocomplete' component
  - NB, 'select with search' also doesn't support `autocomplete_configuration_options`, but given that's specific to the accessible-autocomplete-multiselect library, that's not something we'd want to carry over. It also isn't currently used - it's just a documented feature.

In the next PR, we'll either switch all 'select_with_search' calls to use 'autocomplete' instead, or switch all 'autocomplete' calls to use 'select_with_search'. Whichever component is left unused will be deleted as part of the same PR. It also makes it easier to swap out the component for a [more accessible alternative](https://trello.com/c/tFmr25TL/647-implement-accessible-replacement-for-accessible-autocomplete-multiselect) in future, as we'll only be dealing with one kind of component (and one set of 'parameters' passed to the component) instead of two.

## Background

There are currently 17 instances of "autocomplete" and 24 instances of "select_with_search".

* ‘autocomplete’ was [added in August 2022](https://github.com/alphagov/whitehall/pull/6727) (copied over [from Content Publisher](https://github.com/alphagov/content-publisher/blob/main/app/assets/javascripts/components/autocomplete.js))
* ‘select_with_search’ was [added in March 2023](https://github.com/alphagov/whitehall/pull/7406).

Neither the latter PR nor the [Trello card](https://trello.com/c/G8Uagrjg/1154-create-an-app-component-for-single-select-with-search) explain why ‘autocomplete’ wasn’t used instead (nor indeed makes any mention of ‘autocomplete’ at all). It may have been an attempt to side-step the known problems with accessible-autocomplete component, or it may be that search_with_select was used as a drop in jQuery-less replacement for how Whitehall _was_ using Select2. Some resources Kevin was able to dig up:

- https://github.com/ollietreend/govuk-choices
- [Autocomplete in Whitehall](https://docs.google.com/document/d/199HXtDjT2b8kMGJ-r4FjTius2mM_XPHKbyBR0vgPKZQ/edit)
- [Selects in Whitehall publisher](https://docs.google.com/spreadsheets/d/1cLyqhKfcSv3h6phJhpUQqV83byf0WhU57g0hPKJcgRM/edit)

In any case, both components look very similar and share a lot of functionality. Here is a key table of differences:

| autocomplete | select_with_search |
|---|---|
| Allows multiple | Does not allow multiple |
| Powered by GOV.UK's accessible-autocomplete-multiselect (a fork of accessible-autocomplete) | Powered by Choices.js |
| Defines options as an array `[text, value]` | Defines options as a hash `{ text:, value: }`
| Defines 'selected' option as a separate `selected: <value>` | Defines 'selected' option inline in the hash |
| Defines label as a hash `text:, bold: true` | Defines label as a string, alongside a `heading_size` option to change its size |
| Has no page heading option | Has a `is_page_heading: true` boolean |
| Has `error_items` array | Has `error_message`/`error_id` |
| Doesn't support [grouped options](https://apidock.com/rails/v6.0.0/ActionView/Helpers/FormOptionsHelper/grouped_options_for_select) | Supports grouped options via `grouped_options` property |
| Required `[""] +` prefix when specifying blank option | Has `include_blank: true` boolean |

There is little point in maintaining two highly similar but differently architected components: we should pick only one, and retire the other.

## Deployment note

This has been successfully tested on Integration. One thing to note: because the cached objects in TaggableContentHelper have changed, we need to clear the cache with `Rails.cache.clear` after deploy, otherwise users will see the generic "server issue" error. See https://govuk.sentry.io/issues/6317660943/activity/?environment=integration&project=202259&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&statsPeriod=1h&stream_index=1

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
