### PR TITLE
content modelling/909 pension rate cadence

### DIFF
--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/enum_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/enum_component.rb
@@ -9,7 +9,7 @@ private
   def options
     ["", @enum].flatten.map do |item|
       {
-        text: item.humanize,
+        text: item,
         value: item,
         selected: item == value,
       }

--- a/lib/engines/content_block_manager/features/create_embedded_object.feature
+++ b/lib/engines/content_block_manager/features/create_embedded_object.feature
@@ -10,7 +10,7 @@ Feature: Create an embedded content object
       | field     | type   | format | required | enum           | pattern          |
       | name      | string | string | true     |                |                  |
       | amount    | string | string | true     |                | £[0-9]+\\.[0-9]+ |
-      | cadence   | string | string |          | weekly,monthly |                  |
+      | cadence   | string | string |          | a week,a month |                  |
     And a pension content block has been created
 
   Scenario: GDS editor creates a rate
@@ -20,7 +20,7 @@ Feature: Create an embedded content object
     Then I should see a form to create a "rate" for the content block
     When I complete the "rate" form with the following fields:
       | name    | amount  | cadence |
-      | my rate | £122.50 | weekly  |
+      | my rate | £122.50 | a week  |
     Then I should be asked to review my "rate"
     And I click create
     Then I should see a message that I need to confirm the details are correct
@@ -38,7 +38,7 @@ Feature: Create an embedded content object
     When I visit the page to create a new "rate" for the block
     When I complete the "rate" form with the following fields:
       | name    | amount        | cadence |
-      | my rate | NOT AN AMOUNT | weekly  |
+      | my rate | NOT AN AMOUNT | a week  |
     Then I should see an error for an invalid "amount"
 
   Scenario: GDS editor creates and edits a rate
@@ -46,11 +46,11 @@ Feature: Create an embedded content object
     Then I should see a form to create a "rate" for the content block
     When I complete the "rate" form with the following fields:
       | name    | amount  | cadence |
-      | my rate | £122.50 | weekly  |
+      | my rate | £122.50 | a week  |
     When I click edit
     And I complete the "rate" form with the following fields:
       | name          | amount  | cadence  |
-      | my other rate | £132.50 | monthly  |
+      | my other rate | £132.50 | a month  |
     Then I should be asked to review my "rate"
     When I review and confirm my "rate" is correct
     Then the "rate" should have been created successfully

--- a/lib/engines/content_block_manager/features/create_pension_object.feature
+++ b/lib/engines/content_block_manager/features/create_pension_object.feature
@@ -12,7 +12,7 @@ Feature: Create a content object
       | amount    | string | string | true     |                | £[0-9]+\\.[0-9]+ |
       | cadence   | string | string |          | a week,a month |                  |
 
-  Scenario: GDS editor creates a Pension
+  Scenario: GDS editor creates a Pension without a rate
     When I visit the Content Block Manager home page
     And I click to create an object
     Then I should see all the schemas listed
@@ -27,3 +27,21 @@ Feature: Create a content object
     And I review and confirm my answers are correct
     Then the edition should have been created successfully
     And I should be taken to the confirmation page for a new "pension"
+
+  Scenario: GDS editor creates a Pension with a rate
+    When I visit the Content Block Manager home page
+    And I click to create an object
+    Then I should see all the schemas listed
+    When I click on the "pension" schema
+    Then I should see a form for the schema
+    When I complete the form with the following fields:
+      | title            | description   | organisation        | instructions_to_publishers |
+      | my basic pension | this is basic | Ministry of Example | this is important  |
+    When I click to create a new "rate"
+    And I complete the "rate" form with the following fields:
+      | name     | amount  | cadence  |
+      | New rate | £127.91 | a month  |
+    Then I should be on the "embedded_rates" step
+    When I save and continue
+    And I review and confirm my answers are correct
+    Then I should be taken to the confirmation page for a new "pension"

--- a/lib/engines/content_block_manager/features/create_pension_object.feature
+++ b/lib/engines/content_block_manager/features/create_pension_object.feature
@@ -10,7 +10,7 @@ Feature: Create a content object
       | field     | type   | format | required | enum           | pattern          |
       | name      | string | string | true     |                |                  |
       | amount    | string | string | true     |                | £[0-9]+\\.[0-9]+ |
-      | cadence   | string | string |          | weekly,monthly |                  |
+      | cadence   | string | string |          | a week,a month |                  |
 
   Scenario: GDS editor creates a Pension
     When I visit the Content Block Manager home page

--- a/lib/engines/content_block_manager/features/edit_pension_object.feature
+++ b/lib/engines/content_block_manager/features/edit_pension_object.feature
@@ -10,11 +10,11 @@ Feature: Edit a pension object
       | field     | type   | format | required | enum           | pattern          |
       | name      | string | string | true     |                |                  |
       | amount    | string | string | true     |                | £[0-9]+\\.[0-9]+ |
-      | cadence   | string | string |          | weekly,monthly |                  |
+      | cadence   | string | string |          | a week,a month |                  |
     And a pension content block has been created
     And that pension has a rate with the following fields:
       | name    | amount  | cadence |
-      | My rate | £123.45 | weekly  |
+      | My rate | £123.45 | a week  |
 
   Scenario: GDS Editor edits a pension object
     When I visit the Content Block Manager home page
@@ -28,7 +28,7 @@ Feature: Edit a pension object
     When I click to edit the first rate
     When I complete the "rate" form with the following fields:
       | name    | amount  | cadence |
-      | My rate | £122.50 | weekly  |
+      | My rate | £122.50 | a week  |
     Then I should be on the "embedded_rates" step
     And I should see the updated rates for that block
     When I save and continue
@@ -63,7 +63,7 @@ Feature: Edit a pension object
     And I click to create a new "rate"
     And I complete the "rate" form with the following fields:
       | name     | amount  | cadence  |
-      | New rate | £127.91 | monthly  |
+      | New rate | £127.91 | a month  |
     Then I should be on the "embedded_rates" step
     And I should see the updated rates for that block
     When I save and continue

--- a/lib/engines/content_block_manager/features/step_definitions/embedded_object_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/embedded_object_steps.rb
@@ -20,7 +20,7 @@ When("I complete the {string} form with the following fields:") do |object_type,
   fields.keys.each do |k|
     field = find_field "content_block_manager_content_block_edition_details_#{object_type.pluralize}_#{k}"
     if field.tag_name == "select"
-      select @details[k].humanize, from: field[:id]
+      select @details[k], from: field[:id]
     else
       fill_in field[:id], with: @details[k]
     end

--- a/lib/engines/content_block_manager/features/view_object.feature
+++ b/lib/engines/content_block_manager/features/view_object.feature
@@ -9,11 +9,11 @@ Feature: View a content object
       | field     | type   | format | required | enum           | pattern          |
       | name      | string | string | true     |                |                  |
       | amount    | string | string | true     |                | £[0-9]+\\.[0-9]+ |
-      | cadence   | string | string |          | weekly,monthly |                  |
+      | cadence   | string | string |          | a week,a month |                  |
     And a pension content block has been created
     And that pension has a rate with the following fields:
       | name    | amount  | cadence |
-      | My rate | £123.45 | weekly  |
+      | My rate | £123.45 | a week  |
     And a schema "email_address" exists with the following fields:
       | email_address |
     And an email address content block has been created

--- a/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/enum_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/enum_component_test.rb
@@ -10,7 +10,7 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::EnumComponentTe
       ContentBlockManager::ContentBlockEdition::Details::Fields::EnumComponent.new(
         content_block_edition:,
         field: "something",
-        enum: %w[item_1 item_2],
+        enum: ["a week", "a month"],
       ),
     )
 
@@ -20,8 +20,8 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::EnumComponentTe
     assert_selector "label", text: "Something"
     assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"]"
     assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"] option[value=\"\"]"
-    assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"] option[value=\"item_1\"]", text: "Item 1"
-    assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"] option[value=\"item_2\"]", text: "Item 2"
+    assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"] option[value=\"a week\"]", text: "a week"
+    assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"] option[value=\"a month\"]", text: "a month"
   end
 
   it "should show an option as selected when value is given" do
@@ -29,8 +29,8 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::EnumComponentTe
       ContentBlockManager::ContentBlockEdition::Details::Fields::EnumComponent.new(
         content_block_edition:,
         field: "something",
-        enum: %w[item_1 item_2],
-        value: "item_1",
+        enum: %w[a week a month],
+        value: "a week",
       ),
     )
 
@@ -40,8 +40,8 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::EnumComponentTe
     assert_selector "label", text: "Something"
     assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"]"
     assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"] option[value=\"\"]"
-    assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"] option[value=\"item_1\"][selected]", text: "Item 1"
-    assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"] option[value=\"item_2\"]", text: "Item 2"
+    assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"] option[value=\"a week\"][selected]", text: "a week"
+    assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"] option[value=\"a month\"]", text: "a  month"
   end
 
   it "should show errors when present" do

--- a/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/enum_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/enum_component_test.rb
@@ -29,7 +29,7 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::EnumComponentTe
       ContentBlockManager::ContentBlockEdition::Details::Fields::EnumComponent.new(
         content_block_edition:,
         field: "something",
-        enum: %w[a week a month],
+        enum: ["a week", "a month"],
         value: "a week",
       ),
     )
@@ -41,7 +41,7 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::EnumComponentTe
     assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"]"
     assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"] option[value=\"\"]"
     assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"] option[value=\"a week\"][selected]", text: "a week"
-    assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"] option[value=\"a month\"]", text: "a  month"
+    assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"] option[value=\"a month\"]", text: "a month"
   end
 
   it "should show errors when present" do

--- a/lib/engines/content_block_manager/test/components/content_block/edition/host_content/preview_details_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/host_content/preview_details_component_test.rb
@@ -25,9 +25,9 @@ class ContentBlockManager::ContentBlockEdition::HostContent::PreviewDetailsCompo
         "description": "Basic state pension",
         "rates": {
           "rate1":
-            { "name": "rate1", "amount": "£100.5", "cadence": "weekly", "description": "" },
+            { "name": "rate1", "amount": "£100.5", "cadence": "a week", "description": "" },
           "rate2":
-              { "name": "rate2", "amount": "£11.1", "cadence": "monthly", "description": "1111" },
+              { "name": "rate2", "amount": "£11.1", "cadence": "a month", "description": "1111" },
         },
       })
     end


### PR DESCRIPTION
https://trello.com/c/z9afIAop/909-update-cadence-label-and-values

This updates to reflect the new enum value for a rate's cadence https://github.com/alphagov/whitehall/pull/9960

![Screenshot 2025-02-20 at 15 31 14](https://github.com/user-attachments/assets/78855e5e-0684-43ba-a56d-0f40dbf9887b)


- **update pension rate examples to expect full copy**
- **update feature test coverage for creating pension**

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
