### PR TITLE
(933) Fix back link when creating a new object

### DIFF
--- a/lib/engines/content_block_manager/app/controllers/concerns/workflow/show_methods.rb
+++ b/lib/engines/content_block_manager/app/controllers/concerns/workflow/show_methods.rb
@@ -69,22 +69,23 @@ module Workflow::ShowMethods
   end
 
   def back_path
-    if current_step.name == "review" && @content_block_edition.document.is_new_block?
-      content_block_manager.content_block_manager_content_block_documents_path
-    else
-      return nil unless previous_step
+    step = is_reviewing_new_block? ? :edit_draft : previous_step.name
+    return nil unless step
 
-      content_block_manager.content_block_manager_content_block_workflow_path(
-        @content_block_edition,
-        step: previous_step.name,
-      )
-    end
+    content_block_manager.content_block_manager_content_block_workflow_path(
+      @content_block_edition,
+      step:,
+    )
   end
   included do
     helper_method :back_path
   end
 
 private
+
+  def is_reviewing_new_block?
+    current_step.name == :review && @content_block_edition.document.is_new_block?
+  end
 
   def embedded_objects(subschema_name)
     @subschema = @schema.subschema(subschema_name)

--- a/lib/engines/content_block_manager/features/create_email_object.feature
+++ b/lib/engines/content_block_manager/features/create_email_object.feature
@@ -24,7 +24,8 @@ Feature: Create a content object
       | title            | email_address   | department | organisation        | instructions_to_publishers |
       | my email address | foo@example.com | Somewhere  | Ministry of Example | this is important  |
     Then I am asked to review my answers
-    And I review and confirm my answers are correct
+    And I should see a back link to the "edit_draft" step
+    When I review and confirm my answers are correct
     Then the edition should have been created successfully
     And I should be taken to the confirmation page for a new block
 

--- a/lib/engines/content_block_manager/features/step_definitions/back_link_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/back_link_steps.rb
@@ -17,6 +17,7 @@ Then("I should see a back link to the show page") do
 end
 
 Then(/^I should see a back link to the "([^"]*)" step$/) do |step|
+  @content_block ||= ContentBlockManager::ContentBlock::Edition.last
   link = if step == "edit"
            content_block_manager.new_content_block_manager_content_block_document_edition_path(@content_block.document)
          else

--- a/lib/engines/content_block_manager/test/unit/app/controllers/concerns/workflow/show_methods_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/controllers/concerns/workflow/show_methods_test.rb
@@ -61,13 +61,16 @@ class Workflow::ShowMethodsTest < ActionDispatch::IntegrationTest
     describe "when editing an existing block" do
       let(:is_new_block) { true }
 
-      it "returns the homepage link for the review step" do
-        current_step = mock("Workflow::Step", name: "review")
+      it "returns the edit draft step" do
+        current_step = mock("Workflow::Step", name: :review)
         previous_step = mock("Workflow::Step")
 
         test_class = ShowMethodsTestClass.new(current_step:, previous_step:, content_block_edition:)
 
-        assert_equal test_class.back_path, content_block_manager.content_block_manager_content_block_documents_path
+        assert_equal test_class.back_path, content_block_manager.content_block_manager_content_block_workflow_path(
+          content_block_edition,
+          step: :edit_draft,
+        )
       end
     end
   end


### PR DESCRIPTION
Trello card: https://trello.com/c/If0yOiyQ/933-create-flow-can-get-confused-and-become-edit-flow

This was being calculated incorrectly, because the step name is a symbol, not a string. Additionally, we should go back to the edit step, not the index.