### PR TITLE
Fix bug resulting in failure to publish worldwide orgs

### DIFF
--- a/app/models/worldwide_organisation.rb
+++ b/app/models/worldwide_organisation.rb
@@ -41,6 +41,11 @@ class WorldwideOrganisation < Edition
 
         new_office.save!
 
+        if @edition.main_office == office
+          new_edition.main_office = new_office
+          new_edition.save!(validate: false)
+        end
+
         if @edition.office_shown_on_home_page?(office)
           new_edition.add_office_to_home_page!(new_office)
         end

--- a/test/unit/app/models/worldwide_organisation_test.rb
+++ b/test/unit/app/models/worldwide_organisation_test.rb
@@ -199,12 +199,14 @@ class WorldwideOrganisationTest < ActiveSupport::TestCase
     contact = create(:contact, translated_into: [:es])
     create(:contact_number, translated_into: [:es], contact:)
     published_worldwide_organisation = create(:worldwide_organisation, :published, translated_into: [:es])
-    create(
+    office = create(
       :worldwide_office,
       edition: published_worldwide_organisation,
       contact:,
       services: [create(:worldwide_service)],
     )
+    published_worldwide_organisation.main_office = office
+    published_worldwide_organisation.save!(validate: false)
 
     draft_worldwide_organisation = published_worldwide_organisation.create_draft(create(:writer))
     published_worldwide_organisation.reload
@@ -232,6 +234,10 @@ class WorldwideOrganisationTest < ActiveSupport::TestCase
 
     assert_equal published_worldwide_organisation.offices.first.contact.translations.find_by(locale: :en).attributes.except("id", "contact_id"),
                  draft_worldwide_organisation.offices.first.contact.translations.find_by(locale: :en).attributes.except("id", "contact_id")
+
+    assert published_worldwide_organisation.main_office != draft_worldwide_organisation.main_office
+    assert_equal published_worldwide_organisation.main_office.attributes.except("id", "edition_id"),
+                 draft_worldwide_organisation.main_office.attributes.except("id", "edition_id")
   end
 
   test "should retain home page lists for offices when new draft of published edition is created" do


### PR DESCRIPTION
When a new edition of a worldwide org was created, the main office association was still pointing to an office belonging to the previous edition. This was causing errors when attempting to publish the new edition because the edition ended up with a duplicate contact link.

We have to save the new edition without validating after setting the main office, because the edition is invalid due to a missing change note.

Trello: https://trello.com/c/mmFI321J
Zendesk ticket: https://govuk.zendesk.com/agent/tickets/6043537