### PR TITLE
content modelling/903 update copy

### DIFF
--- a/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/editions/embedded_objects_controller.rb
+++ b/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/editions/embedded_objects_controller.rb
@@ -10,7 +10,7 @@ class ContentBlockManager::ContentBlock::Editions::EmbeddedObjectsController < C
     @content_block_edition.add_object_to_details(@subschema.block_type, @object)
     @content_block_edition.save!
 
-    flash[:notice] = "#{@subschema.name.singularize} created. You can add another #{@subschema.name.singularize.downcase} or continue to create #{@schema.name.singularize.downcase} block"
+    flash[:notice] = "#{@subschema.name.singularize} added. You can add another #{@subschema.name.singularize.downcase} or finish creating the #{@schema.name.singularize.downcase} block"
     step = "#{Workflow::Step::SUBSCHEMA_PREFIX}#{@subschema.id}"
     redirect_to content_block_manager.content_block_manager_content_block_workflow_path(@content_block_edition, step:)
   rescue ActiveRecord::RecordInvalid

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/documents/embedded_objects/new.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/documents/embedded_objects/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :context, @content_block_document.title %>
-<% content_for :title, "Create #{@subschema.name.singularize.downcase}" %>
+<% content_for :title, "Add a #{@subschema.name.singularize.downcase}" %>
 
 <% content_for :back_link do %>
   <%= render "govuk_publishing_components/components/back_link", {

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/documents/show.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/documents/show.html.erb
@@ -61,7 +61,7 @@
       </div>
       <div class="govuk-grid-column-one-half subschema-listing__create-button-wrapper">
         <%= render "govuk_publishing_components/components/button", {
-          text: "Create #{subschema.name.singularize.downcase}",
+          text: "Add a #{subschema.name.singularize.downcase}",
           href: content_block_manager.new_content_block_manager_content_block_document_embedded_object_path(
             @content_block_document,
             object_type: subschema.id,

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/embedded_objects/new.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/embedded_objects/new.html.erb
@@ -1,5 +1,5 @@
 <% content_for :context, @content_block_edition.title %>
-<% content_for :title, "Create #{@subschema.name.singularize.downcase}" %>
+<% content_for :title, "Add a #{@subschema.name.singularize.downcase}" %>
 
 <% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @content_block_edition, parent_class: "content_block_manager_content_block_edition")) %>
 

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/embedded_objects/review.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/embedded_objects/review.html.erb
@@ -49,7 +49,7 @@
         error: flash[:error],
         items: [
           {
-            label: "By editing this content block you are confirming that, to the best of your knowledge, the details you are providing are correct.",
+            label: "I confirm that the details I’ve put into the content block have been checked and are factually correct.",
             value: true,
           },
         ],

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/embedded_objects.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/embedded_objects.html.erb
@@ -1,5 +1,5 @@
 <% content_for :context, context %>
-<% content_for :title, @subschema.name %>
+<% content_for :title, "Add #{@subschema.name.humanize(capitalize: false)}" %>
 <% content_for :title_margin_bottom, 4 %>
 <% content_for :back_link do %>
   <%= render "govuk_publishing_components/components/back_link", {

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/embedded_objects.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/embedded_objects.html.erb
@@ -33,7 +33,7 @@
       <% end %>
 
       <%= render "govuk_publishing_components/components/button", {
-        text: "Create #{@subschema.name.singularize.downcase}",
+        text: "Add a #{@subschema.name.singularize.downcase}",
         href: content_block_manager.new_embedded_object_content_block_manager_content_block_edition_path(
           @content_block_edition,
           object_type: @subschema.block_type,

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/review.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/review.html.erb
@@ -68,7 +68,7 @@
           error: @confirm_error_copy,
           items: [
             {
-              label: "By #{@content_block_edition.document.is_new_block? ? "creating" : "editing"} this content block you are confirming that, to the best of your knowledge, the details you are providing are correct.",
+              label: "I confirm that the details I’ve put into the content block have been checked and are factually correct.",
               value: true,
             },
           ],

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/review_links.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/review_links.html.erb
@@ -8,7 +8,7 @@
 <% end %>
 
 <p class="govuk-body">
-  The list does not include content in PDF or beyond <a href="https://gov.uk" class="govuk-link">GOV.UK</a>.
+  This list shows the places where the change will be made. It does not include content in PDFs or beyond <a href="https://gov.uk" class="govuk-link">GOV.UK</a>.
 </p>
 
 <%=

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/shared/_form.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/shared/_form.html.erb
@@ -43,7 +43,7 @@
       text: "Instructions to publishers (optional)",
     },
     name: "content_block/edition[instructions_to_publishers]",
-    hint: "Add information that's important for anyone editing this block to know. For example, 'Tell HMRC's content team when this block changes because they're responsible for its factual accuracy.'",
+    hint: "Add information that’s important for anyone editing this block to know. For example, who to contact about the block if you have questions.",
     textarea_id: "#{parent_class}_instructions_to_publishers",
     value: @form.content_block_edition&.instructions_to_publishers,
     error_items: errors_for(@form.content_block_edition.errors, "instructions_to_publishers".to_sym),

--- a/lib/engines/content_block_manager/features/create_embedded_object.feature
+++ b/lib/engines/content_block_manager/features/create_embedded_object.feature
@@ -16,7 +16,7 @@ Feature: Create an embedded content object
   Scenario: GDS editor creates a rate
     When I visit the Content Block Manager home page
     And I click to view the document
-    And I click to create a new "rate"
+    And I click to add a new "rate"
     Then I should see a form to create a "rate" for the content block
     When I complete the "rate" form with the following fields:
       | name    | amount  | cadence |

--- a/lib/engines/content_block_manager/features/create_pension_object.feature
+++ b/lib/engines/content_block_manager/features/create_pension_object.feature
@@ -37,7 +37,7 @@ Feature: Create a content object
     When I complete the form with the following fields:
       | title            | description   | organisation        | instructions_to_publishers |
       | my basic pension | this is basic | Ministry of Example | this is important  |
-    When I click to create a new "rate"
+    When I click to add a new "rate"
     And I complete the "rate" form with the following fields:
       | name     | amount  | cadence  |
       | New rate | £127.91 | a month  |

--- a/lib/engines/content_block_manager/features/edit_pension_object.feature
+++ b/lib/engines/content_block_manager/features/edit_pension_object.feature
@@ -60,7 +60,7 @@ Feature: Edit a pension object
     And I click to view the document
     And I click to edit the "pension"
     When I fill out the form
-    And I click to create a new "rate"
+    And I click to add a new "rate"
     And I complete the "rate" form with the following fields:
       | name     | amount  | cadence  |
       | New rate | £127.91 | a month  |

--- a/lib/engines/content_block_manager/features/step_definitions/embedded_object_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/embedded_object_steps.rb
@@ -6,7 +6,7 @@ When("I visit the page to create a new {string} for the block") do |object_type|
 end
 
 Then("I should see a form to create a {string} for the content block") do |object_type|
-  expect(page).to have_text("Create #{object_type}")
+  expect(page).to have_text("Add a #{object_type}")
 end
 
 Then("I should see confirmation that my {string} has been created") do |object_type|

--- a/lib/engines/content_block_manager/features/step_definitions/embedded_object_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/embedded_object_steps.rb
@@ -61,8 +61,8 @@ And("I should see details of my {string}") do |object_type|
   end
 end
 
-And("I click to create a new {string}") do |object_type|
-  click_on "Create #{object_type}"
+And("I click to add a new {string}") do |object_type|
+  click_on "Add a #{object_type}"
 end
 
 And("I review and confirm my {string} is correct") do |_object_type|

--- a/lib/engines/content_block_manager/features/support/form_step_helpers.rb
+++ b/lib/engines/content_block_manager/features/support/form_step_helpers.rb
@@ -45,5 +45,5 @@ def should_be_on_change_note_step
 end
 
 def should_be_on_subschema_step(subschema)
-  assert_text subschema.titleize
+  assert_text "Add #{subschema.humanize(capitalize: false)}"
 end

--- a/lib/engines/content_block_manager/test/integration/content_block/editions/embedded_objects_test.rb
+++ b/lib/engines/content_block_manager/test/integration/content_block/editions/embedded_objects_test.rb
@@ -57,7 +57,7 @@ class ContentBlockManager::ContentBlock::Editions::EmbeddedObjectsTest < ActionD
           },
         },
       }
-      assert_equal "Something created. You can add another something or continue to create schema block", flash[:notice]
+      assert_equal "Something added. You can add another something or finish creating the schema block", flash[:notice]
     end
   end
 

--- a/lib/engines/content_block_manager/test/integration/content_block/workflow_test.rb
+++ b/lib/engines/content_block_manager/test/integration/content_block/workflow_test.rb
@@ -48,7 +48,7 @@ class ContentBlockManager::ContentBlock::WorkflowTest < ActionDispatch::Integrat
           visit content_block_manager.content_block_manager_content_block_workflow_path(id: edition.id, step:)
 
           assert_text "Create content block"
-          assert_text "By creating this content block you are confirming that, to the best of your knowledge, the details you are providing are correct."
+          assert_text "I confirm that the details I’ve put into the content block have been checked and are factually correct."
         end
       end
 
@@ -413,7 +413,7 @@ class ContentBlockManager::ContentBlock::WorkflowTest < ActionDispatch::Integrat
         visit content_block_manager.content_block_manager_content_block_workflow_path(id: edition.id, step:)
 
         assert_text "Edit content block"
-        assert_text "By editing this content block you are confirming that, to the best of your knowledge, the details you are providing are correct."
+        assert_text "I confirm that the details I’ve put into the content block have been checked and are factually correct."
       end
     end
   end


### PR DESCRIPTION
https://trello.com/c/rWeozFDl/903-update-copy-for-pensions-based-on-recent-copy-changes

Updating copy for Pensions as per doc https://docs.google.com/document/d/1zTD5BNxoGyS5kMoPT3FNNlBs54HgwZWQdViQ0bnmYAQ/edit?tab=t.0

The only thing not done yet is `cadence` becoming  `frequency` as this needs changing on the schema as well.

- **change hint copy**
- **change title on embedded_objects add screen**
- **change button for adding an embedded object**
- **change copy for embedded objects form**
- **change flash copy for embedded objects**
- **change confirmation copy**
- **update review copy**

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
