### PR TITLE
Retire the 'select with search' component in favour of 'autocomplete'

### DIFF
--- a/app/helpers/admin/edition_actions_helper.rb
+++ b/app/helpers/admin/edition_actions_helper.rb
@@ -93,61 +93,45 @@ module Admin::EditionActionsHelper
   end
 
   def filter_edition_type_opt_groups(user, selected)
-    [
-      [
-        "",
-        [
-          {
-            text: "All types",
-            value: "",
-            selected: selected.blank?,
-          },
-        ],
-      ],
-      [
-        "Types",
-        type_options_container(user).map do |text, value|
-          {
-            text:,
-            value:,
-            selected: selected == value,
-          }
-        end,
-      ],
-      [
-        "Publication sub-types",
-        PublicationType.ordered_by_prevalence.map do |sub_type|
-          value = "publication_#{sub_type.id}"
-          {
-            text: sub_type.plural_name,
-            value:,
-            selected: selected == value,
-          }
-        end,
-      ],
-      [
-        "News article sub-types",
-        NewsArticleType.all.map do |sub_type|
-          value = "news_article_#{sub_type.id}"
-          {
-            text: sub_type.plural_name,
-            value:,
-            selected: selected == value,
-          }
-        end,
-      ],
-      [
-        "Speech sub-types",
-        SpeechType.all.map do |sub_type|
-          value = "speech_#{sub_type.id}"
-          {
-            text: sub_type.plural_name,
-            value:,
-            selected: selected == value,
-          }
-        end,
-      ],
+    all_types_option = [
+      {
+        text: "All types",
+        value: "",
+        selected: selected.blank?,
+      },
     ]
+    types = type_options_container(user).map do |text, value|
+      {
+        text:,
+        value:,
+        selected: selected == value,
+      }
+    end
+    publication_sub_types =  PublicationType.ordered_by_prevalence.map do |sub_type|
+      value = "publication_#{sub_type.id}"
+      {
+        text: "Publication: #{sub_type.plural_name}",
+        value:,
+        selected: selected == value,
+      }
+    end
+    news_article_sub_types = NewsArticleType.all.map do |sub_type|
+      value = "news_article_#{sub_type.id}"
+      {
+        text: "News article: #{sub_type.plural_name}",
+        value:,
+        selected: selected == value,
+      }
+    end
+    speech_sub_types = SpeechType.all.map do |sub_type|
+      value = "speech_#{sub_type.id}"
+      {
+        text: "Speech: #{sub_type.plural_name}",
+        value:,
+        selected: selected == value,
+      }
+    end
+    all_types_option + types + publication_sub_types + news_article_sub_types + speech_sub_types
   end
 
 private

--- a/app/helpers/admin/editions_helper.rb
+++ b/app/helpers/admin/editions_helper.rb
@@ -14,44 +14,26 @@ module Admin::EditionsHelper
   end
 
   def admin_organisation_filter_options(selected_organisation)
-    organisations = Organisation.with_translations(:en).order(:name).excluding_govuk_status_closed || []
-    closed_organisations = Organisation.with_translations(:en).closed || []
-    if current_user.organisation
-      organisations = [current_user.organisation] + (organisations - [current_user.organisation])
-    end
-
-    [
-      [
-        "",
-        [
-          {
-            text: "All organisations",
-            value: "",
-            selected: selected_organisation.blank?,
-          },
-        ],
-      ],
-      [
-        "Live organisations",
-        organisations.map do |organisation|
-          {
-            text: organisation.select_name,
-            value: organisation.id,
-            selected: selected_organisation.to_s == organisation.id.to_s,
-          }
-        end,
-      ],
-      [
-        "Closed organisations",
-        closed_organisations.map do |organisation|
-          {
-            text: organisation.select_name,
-            value: organisation.id,
-            selected: selected_organisation.to_s == organisation.id.to_s,
-          }
-        end,
-      ],
+    blank_option = [
+      {
+        text: "All organisations",
+        value: "",
+        selected: selected_organisation.blank?,
+      },
     ]
+    open_organisations = Organisation.with_translations(:en).order(:name).excluding_govuk_status_closed || []
+    if current_user.organisation
+      open_organisations = [current_user.organisation] + (organisations - [current_user.organisation])
+    end
+    closed_organisations = Organisation.with_translations(:en).closed || []
+
+    blank_option + (open_organisations + closed_organisations).map do |organisation|
+      {
+        text: organisation.select_name,
+        value: organisation.id,
+        selected: selected_organisation.to_s == organisation.id.to_s,
+      }
+    end
   end
 
   def admin_author_filter_options(current_user)

--- a/app/helpers/admin/editions_helper.rb
+++ b/app/helpers/admin/editions_helper.rb
@@ -14,20 +14,20 @@ module Admin::EditionsHelper
   end
 
   def admin_organisation_filter_options(selected_organisation)
-    blank_option = [
-      {
-        text: "All organisations",
-        value: "",
-        selected: selected_organisation.blank?,
-      },
-    ]
+    # blank_option = [
+    #   {
+    #     text: "All organisations",
+    #     value: "",
+    #     selected: selected_organisation.blank?,
+    #   },
+    # ]
     open_organisations = Organisation.with_translations(:en).order(:name).excluding_govuk_status_closed || []
     if current_user.organisation
-      open_organisations = [current_user.organisation] + (organisations - [current_user.organisation])
+      open_organisations = [current_user.organisation] + (open_organisations - [current_user.organisation])
     end
     closed_organisations = Organisation.with_translations(:en).closed || []
 
-    blank_option + (open_organisations + closed_organisations).map do |organisation|
+    (open_organisations + closed_organisations).map do |organisation|
       {
         text: organisation.select_name,
         value: organisation.id,

--- a/app/views/admin/corporate_information_pages/_standard_fields.html.erb
+++ b/app/views/admin/corporate_information_pages/_standard_fields.html.erb
@@ -3,7 +3,7 @@
   <%= form.hidden_field :lock_version %>
 
   <% unless form.object.persisted? %>
-    <%= render "components/select_with_search", {
+    <%= render "components/autocomplete", {
       id: "edition_corporate_information_page_type_id",
       name: "edition[corporate_information_page_type_id]",
       label: "Type",

--- a/app/views/admin/editionable_social_media_accounts/_form.html.erb
+++ b/app/views/admin/editionable_social_media_accounts/_form.html.erb
@@ -1,7 +1,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= form_for social_media_account, url: destination do |form| %>
-      <%= render "components/select_with_search", {
+      <%= render "components/autocomplete", {
         label: "Service (required)",
         id: "social_media_account_social_media_service_id",
         name: "social_media_account[social_media_service_id]",

--- a/app/views/admin/editions/_filter_options.html.erb
+++ b/app/views/admin/editions/_filter_options.html.erb
@@ -40,12 +40,12 @@
     <% end %>
 
     <% if filter_by.include?(:organisation) %>
-      <%= render "components/select_with_search", {
+      <%= render "components/autocomplete", {
         label: "Organisation",
         id: "organisation_filter",
         name: "organisation",
         heading_size: "s",
-        grouped_options: admin_organisation_filter_options(@filter.options[:organisation]),
+        options: admin_organisation_filter_options(@filter.options[:organisation]),
       } %>
     <% end %>
 

--- a/app/views/admin/editions/_filter_options.html.erb
+++ b/app/views/admin/editions/_filter_options.html.erb
@@ -24,7 +24,7 @@
     <% end %>
 
     <% if filter_by.include?(:author) %>
-      <%= render "components/select_with_search", {
+      <%= render "components/autocomplete", {
         label: "Author",
         id: "author_filter",
         name: "author",
@@ -50,7 +50,7 @@
     <% end %>
 
     <% if filter_by.include?(:world_location) %>
-      <%= render "components/select_with_search", {
+      <%= render "components/autocomplete", {
         label: "World location",
         id: "world_location_filter",
         name: "world_location",
@@ -77,7 +77,7 @@
     <% end %>
 
     <% if filter_by.include?(:state) %>
-      <%= render "components/select_with_search", {
+      <%= render "components/autocomplete", {
         label: "State",
         id: "state_filter",
         name: "state",

--- a/app/views/admin/editions/_filter_options.html.erb
+++ b/app/views/admin/editions/_filter_options.html.erb
@@ -66,7 +66,7 @@
     <% end %>
 
     <% if filter_by.include?(:type) %>
-      <%= render "components/autocomplete", {
+    <%= render "govuk_publishing_components/components/select", {
         label: "Document type",
         id: "type_filter",
         name: "type",

--- a/app/views/admin/editions/_filter_options.html.erb
+++ b/app/views/admin/editions/_filter_options.html.erb
@@ -66,12 +66,13 @@
     <% end %>
 
     <% if filter_by.include?(:type) %>
-      <%= render "components/select_with_search", {
+      <%= render "components/autocomplete", {
         label: "Document type",
         id: "type_filter",
         name: "type",
         heading_size: "s",
-        grouped_options: filter_edition_type_opt_groups(current_user, @filter.options[:type]),
+        include_blank: true,
+        options: filter_edition_type_opt_groups(current_user, @filter.options[:type]),
       } %>
     <% end %>
 

--- a/app/views/admin/editions/_locale_fields.html.erb
+++ b/app/views/admin/editions/_locale_fields.html.erb
@@ -18,7 +18,7 @@
         label: "Create a foreign language only #{edition.model_name.human.downcase}",
         value: "1",
         checked: form.object.primary_locale != "en",
-        conditional: (render "components/select_with_search", {
+        conditional: (render "components/autocomplete", {
           id: "edition_primary_locale",
           name: "edition[primary_locale]",
           label: "Document language",

--- a/app/views/admin/editions/_operational_field_fields.html.erb
+++ b/app/views/admin/editions/_operational_field_fields.html.erb
@@ -1,4 +1,4 @@
-<%= render "components/select_with_search", {
+<%= render "components/autocomplete", {
   id: "edition_operational_field_id",
   label: "Field of operation (required)",
   name: "edition[operational_field_id]",

--- a/app/views/admin/editions/_organisation_fields.html.erb
+++ b/app/views/admin/editions/_organisation_fields.html.erb
@@ -10,7 +10,7 @@
       <% 0.upto(3) do |index| %>
         <% lead_organisation_id = lead_organisation_id_at_index(edition, index) %>
         <% cache_if lead_organisation_id.nil?, "#{taggable_organisations_cache_digest}-lead" do %>
-          <%= render "components/select_with_search", {
+          <%= render "components/autocomplete", {
               id: "edition_lead_organisation_ids_#{index + 1}",
               name: "edition[lead_organisation_ids][]",
               label: "Lead organisation #{index + 1}",

--- a/app/views/admin/news_articles/_news_article_type_fields.html.erb
+++ b/app/views/admin/news_articles/_news_article_type_fields.html.erb
@@ -1,5 +1,5 @@
 <div class="app-view-edition-form__subtype-fields js-app-view-edition-form__subtype-fields" data-format-advice="<%= NewsArticleType::FORMAT_ADVICE %>">
-  <%= render "components/select_with_search", {
+  <%= render "components/autocomplete", {
     name: "edition[news_article_type_id]",
     id: "edition_news_article_type_id",
     label: "News article type (required)",

--- a/app/views/admin/organisations/_closed_fields.html.erb
+++ b/app/views/admin/organisations/_closed_fields.html.erb
@@ -1,4 +1,4 @@
-<%= render "components/select_with_search", {
+<%= render "components/autocomplete", {
   label: "Reason for closure (required)",
   name: "organisation[govuk_closed_status]",
   id: "organisation_govuk_closed_status",

--- a/app/views/admin/organisations/_form.html.erb
+++ b/app/views/admin/organisations/_form.html.erb
@@ -37,7 +37,7 @@
     error_items: errors_for(organisation.errors, :logo_formatted_name),
   } %>
 
-  <%= render "components/select_with_search", {
+  <%= render "components/autocomplete", {
     label: "Logo crest (required)",
     name: "organisation[organisation_logo_type_id]",
     id: "organisation_organisation_logo_type_id",
@@ -72,7 +72,7 @@
     } %>
   </div>
 
-  <%= render "components/select_with_search", {
+  <%= render "components/autocomplete", {
     label: "Brand colour",
     name: "organisation[organisation_brand_colour_id]",
     id: "organisation_organisation_brand_colour_id",
@@ -117,7 +117,7 @@
     error_items: errors_for(organisation.errors, :url),
   } %>
 
-  <%= render "components/select_with_search", {
+  <%= render "components/autocomplete", {
     label: "Organisation type (required)",
     name: "organisation[organisation_type_key]",
     id: "organisation_organisation_type_key",
@@ -265,7 +265,7 @@
       <%= hidden_field_tag "organisation[topical_event_organisations_attributes][][ordering]", topical_event_organisation.ordering %>
       <%= hidden_field_tag "organisation[topical_event_organisations_attributes][][id]", topical_event_organisation.id %>
 
-      <%= render "components/select_with_search", {
+      <%= render "components/autocomplete", {
         label: "Topical Event #{topical_event_organisation.ordering + 1}",
         name: "organisation[topical_event_organisations_attributes][][topical_event_id]",
         id: "organisation_topical_event_ids_#{topical_event_organisation.ordering}",

--- a/app/views/admin/publications/_publication_type_fields.html.erb
+++ b/app/views/admin/publications/_publication_type_fields.html.erb
@@ -1,5 +1,28 @@
 <div class="app-view-edition-form__subtype-fields js-app-view-edition-form__subtype-fields" data-format-advice="<%= PublicationType::FORMAT_ADVICE %>">
-  <%= render "components/select_with_search", {
+  <%
+    primary_publication_types = PublicationType.primary.map do |publication_type|
+      {
+        text: publication_type.singular_name,
+        value: publication_type.id,
+        selected: edition.publication_type_id == publication_type.id,
+      }
+    end
+    less_common_publication_types = PublicationType.less_common.map do |publication_type|
+      {
+        text: "Less common: #{publication_type.singular_name}",
+        value: publication_type.id,
+        selected: edition.publication_type_id == publication_type.id,
+      }
+    end
+    use_discouraged_publication_types = PublicationType.use_discouraged.map do |publication_type|
+      {
+        text: "Deprecated: #{publication_type.singular_name}",
+        value: publication_type.id,
+        selected: edition.publication_type_id == publication_type.id,
+      }
+    end
+  %>
+  <%= render "components/autocomplete", {
     id: "edition_publication_type_id",
     name: "edition[publication_type_id]",
     label: "Publication type (required)",
@@ -7,32 +30,7 @@
     value: edition.publication_type_id,
     error_items: errors_for(edition.errors, :publication_type_id),
     include_blank: true,
-    grouped_options: [
-      [
-        "Common types",
-        PublicationType.primary,
-      ],
-      [
-        "Less common types",
-        PublicationType.less_common,
-      ],
-      [
-        "Use discouraged",
-        PublicationType.use_discouraged,
-      ],
-    ]
-    .map do |group|
-      [
-        group.first,
-        group.second.map do |publication_type|
-          {
-            text: publication_type.singular_name,
-            value: publication_type.id,
-            selected: edition.publication_type_id == publication_type.id,
-          }
-        end,
-      ]
-    end,
+    options: primary_publication_types + less_common_publication_types + use_discouraged_publication_types,
   } %>
 
   <% if edition.publication_type_id.present? %>

--- a/app/views/admin/publications/_publication_type_fields.html.erb
+++ b/app/views/admin/publications/_publication_type_fields.html.erb
@@ -22,7 +22,7 @@
       }
     end
   %>
-  <%= render "components/autocomplete", {
+  <%= render "govuk_publishing_components/components/select", {
     id: "edition_publication_type_id",
     name: "edition[publication_type_id]",
     label: "Publication type (required)",

--- a/app/views/admin/role_appointments/_form.html.erb
+++ b/app/views/admin/role_appointments/_form.html.erb
@@ -1,4 +1,4 @@
-<%= render "/components/select_with_search", {
+<%= render "/components/autocomplete", {
   id: "role_appointment_person_id",
   label: "Person (required)",
   heading_size: "l",

--- a/app/views/admin/social_media_accounts/_form.html.erb
+++ b/app/views/admin/social_media_accounts/_form.html.erb
@@ -2,7 +2,7 @@
   <div class="govuk-grid-column-two-thirds">
     <%= form_for [:admin, socialable, social_media_account] do |form| %>
       <% if I18n.locale == I18n.default_locale %>
-        <%= render "components/select_with_search", {
+        <%= render "components/autocomplete", {
           label: "Service (required)",
           id: "social_media_account_social_media_service_id",
           name: "social_media_account[social_media_service_id]",

--- a/app/views/admin/speeches/_speaker_select_field.html.erb
+++ b/app/views/admin/speeches/_speaker_select_field.html.erb
@@ -1,5 +1,5 @@
 <% cache_if edition.role_appointment_id.nil?, "#{taggable_role_appointments_cache_digest}-design-system" do %>
-  <%= render "components/select_with_search", {
+  <%= render "components/autocomplete", {
     id: "edition_role_appointment_id",
     name: "edition[role_appointment_id]",
     label: "",

--- a/app/views/admin/speeches/_speech_type_fields.html.erb
+++ b/app/views/admin/speeches/_speech_type_fields.html.erb
@@ -1,5 +1,5 @@
 <div class="app-view-edition-form__subtype-fields js-app-view-edition-form__subtype-fields" data-format-advice="<%= SpeechType::FORMAT_ADVICE %>">
-  <%= render "components/select_with_search", {
+  <%= render "components/autocomplete", {
     name: "edition[speech_type_id]",
     id: "edition_speech_type_id",
     label: "Speech type",

--- a/app/views/admin/statistics_announcements/_filter_options.html.erb
+++ b/app/views/admin/statistics_announcements/_filter_options.html.erb
@@ -15,12 +15,12 @@
       value: @filter.options[:title],
     } %>
 
-    <%= render "components/select_with_search", {
+    <%= render "components/autocomplete", {
       label: "Organisation",
       id: "organisation_filter",
       name: "organisation_id",
       heading_size: "s",
-      grouped_options: admin_organisation_filter_options(@filter.options[:organisation_id]),
+      options: admin_organisation_filter_options(@filter.options[:organisation_id]),
     } %>
 
     <%= render "govuk_publishing_components/components/select", {

--- a/app/views/admin/worldwide_organisation_pages/_form.html.erb
+++ b/app/views/admin/worldwide_organisation_pages/_form.html.erb
@@ -4,7 +4,7 @@
     admin_worldwide_organisation_pages_path(@worldwide_organisation) do |form| %>
 
   <% unless form.object.persisted? %>
-    <%= render "components/select_with_search", {
+    <%= render "components/autocomplete", {
       id: "worldwide_organisation_page_corporate_information_page_type_id",
       name: "worldwide_organisation_page[corporate_information_page_type_id]",
       label: "Type",

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/index/filter_options_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/index/filter_options_component.html.erb
@@ -46,7 +46,7 @@
         },
         content: {
           html: (
-            render "components/select_with_search", {
+            render "components/autocomplete", {
               id: "lead_organisation",
               name: "lead_organisation",
               include_blank: false,


### PR DESCRIPTION
This PR is superseded by #9959.

---

This is a POC PR that removes the 'select_with_search' component and migrates all existing usage to either:

1.  the 'select' component (if the list of options was small and search functionality not essential), converting the 'grouped options' to a flat list with prefixes
2. the 'autocomplete' (if the list of options was big and search functionality still needed), since 'grouped options' aren't very useful in a very long list anyway

Before merging, we would need to fix the issue whereby autocomplete auto-selects the first option (when 'multiple' isn't set) and you have to clear it to even see what the other options are:

![Screenshot 2025-02-21 at 15 41 07](https://github.com/user-attachments/assets/315c38b9-8c0e-4b5a-b4fa-114084a0bd4a)

Trello: https://trello.com/c/pmbL2yId/3411-consolidate-the-autocomplete-selectwithsearch-components-in-whitehall

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
