### PR TITLE
(934) Fix the rates step getting skipped when going back

### DIFF
--- a/lib/engines/content_block_manager/app/controllers/concerns/workflow.rb
+++ b/lib/engines/content_block_manager/app/controllers/concerns/workflow.rb
@@ -1,15 +1,15 @@
 module Workflow
-  class Step < Data.define(:name, :show_action, :update_action)
+  class Step < Data.define(:name, :show_action, :update_action, :included_in_create_journey)
     SUBSCHEMA_PREFIX = "embedded_".freeze
 
     ALL = [
-      Step.new(:edit_draft, :edit_draft, :update_draft),
-      Step.new(:review_links, :review_links, :redirect_to_next_step),
-      Step.new(:internal_note, :internal_note, :update_internal_note),
-      Step.new(:change_note, :change_note, :update_change_note),
-      Step.new(:schedule_publishing, :schedule_publishing, :validate_schedule),
-      Step.new(:review, :review, :validate_review_page),
-      Step.new(:confirmation, :confirmation, nil),
+      Step.new(:edit_draft, :edit_draft, :update_draft, true),
+      Step.new(:review_links, :review_links, :redirect_to_next_step, false),
+      Step.new(:internal_note, :internal_note, :update_internal_note, false),
+      Step.new(:change_note, :change_note, :update_change_note, false),
+      Step.new(:schedule_publishing, :schedule_publishing, :validate_schedule, false),
+      Step.new(:review, :review, :validate_review_page, true),
+      Step.new(:confirmation, :confirmation, nil, true),
     ].freeze
 
     def is_subschema?

--- a/lib/engines/content_block_manager/app/controllers/concerns/workflow/show_methods.rb
+++ b/lib/engines/content_block_manager/app/controllers/concerns/workflow/show_methods.rb
@@ -69,12 +69,9 @@ module Workflow::ShowMethods
   end
 
   def back_path
-    step = is_reviewing_new_block? ? :edit_draft : previous_step.name
-    return nil unless step
-
     content_block_manager.content_block_manager_content_block_workflow_path(
       @content_block_edition,
-      step:,
+      step: previous_step.name,
     )
   end
   included do
@@ -82,10 +79,6 @@ module Workflow::ShowMethods
   end
 
 private
-
-  def is_reviewing_new_block?
-    current_step.name == :review && @content_block_edition.document.is_new_block?
-  end
 
   def embedded_objects(subschema_name)
     @subschema = @schema.subschema(subschema_name)

--- a/lib/engines/content_block_manager/app/controllers/concerns/workflow/steps.rb
+++ b/lib/engines/content_block_manager/app/controllers/concerns/workflow/steps.rb
@@ -12,7 +12,7 @@ module Workflow::Steps
                    Workflow::Step.new(
                      "#{Workflow::Step::SUBSCHEMA_PREFIX}#{subschema.id}".to_sym,
                      "#{Workflow::Step::SUBSCHEMA_PREFIX}#{subschema.id}".to_sym,
-                     :redirect_to_next_subschema_or_continue,
+                     :redirect_to_next_step,
                      true,
                    )
                  end

--- a/lib/engines/content_block_manager/app/controllers/concerns/workflow/update_methods.rb
+++ b/lib/engines/content_block_manager/app/controllers/concerns/workflow/update_methods.rb
@@ -14,35 +14,12 @@ module Workflow::UpdateMethods
     )
     @content_block_edition.save!
 
-    if @content_block_edition.document.is_new_block?
-      redirect_to content_block_manager.content_block_manager_content_block_workflow_path(
-        id: @content_block_edition.id,
-        step: :review,
-      )
-    else
-      redirect_to_next_step
-    end
+    redirect_to_next_step
   rescue ActiveRecord::RecordInvalid
     @schema = ContentBlockManager::ContentBlock::Schema.find_by_block_type(@content_block_edition.document.block_type)
     @form = ContentBlockManager::ContentBlock::EditionForm::Edit.new(content_block_edition: @content_block_edition, schema: @schema)
 
     render :edit_draft
-  end
-
-  def redirect_to_next_subschema_or_continue
-    @content_block_edition = ContentBlockManager::ContentBlock::Edition.find(params[:id])
-    if @content_block_edition.document.is_new_block?
-      if next_step.is_subschema?
-        redirect_to_next_step
-      else
-        redirect_to content_block_manager.content_block_manager_content_block_workflow_path(
-          id: @content_block_edition.id,
-          step: :review,
-        )
-      end
-    else
-      redirect_to_next_step
-    end
   end
 
   def validate_schedule

--- a/lib/engines/content_block_manager/features/create_pension_object.feature
+++ b/lib/engines/content_block_manager/features/create_pension_object.feature
@@ -45,3 +45,15 @@ Feature: Create a content object
     When I save and continue
     And I review and confirm my answers are correct
     Then I should be taken to the confirmation page for a new "pension"
+
+  Scenario: GDS editor clicks back and is taken back to rates
+    When I visit the Content Block Manager home page
+    And I click to create an object
+    And I click on the "pension" schema
+    When I complete the form with the following fields:
+      | title            | description   | organisation        | instructions_to_publishers |
+      | my basic pension | this is basic | Ministry of Example | this is important  |
+    And I click the back link
+    And I click save
+    Then I should be on the "embedded_rates" step
+

--- a/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
@@ -509,3 +509,7 @@ Then("I should see an error for an invalid {string}") do |attribute|
     I18n.t("activerecord.errors.models.content_block_manager/content_block/edition.invalid", attribute: attribute.humanize),
   )
 end
+
+And(/^I click the back link$/) do
+  click_on "Back"
+end

--- a/lib/engines/content_block_manager/test/unit/app/controllers/concerns/workflow/show_methods_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/controllers/concerns/workflow/show_methods_test.rb
@@ -31,47 +31,19 @@ class Workflow::ShowMethodsTest < ActionDispatch::IntegrationTest
 
   describe "#back_path" do
     let(:content_block_edition) { build_stubbed(:content_block_edition) }
-    let(:stub_document) { stub(:document, is_new_block?: is_new_block) }
 
-    before do
-      content_block_edition.stubs(:document).returns(stub_document)
-    end
+    it "returns the name of the previous step" do
+      expected_step_name = "something"
 
-    describe "#back_path" do
-      describe "when editing an existing block" do
-        let(:is_new_block) { false }
+      current_step = mock("Workflow::Step")
+      previous_step = mock("Workflow::Step", name: expected_step_name)
 
-        it "returns the name of the next step" do
-          current_step_name = "my_step"
-          expected_step_name = "something"
+      test_class = ShowMethodsTestClass.new(current_step:, previous_step:, content_block_edition:)
 
-          current_step = mock("Workflow::Step", name: current_step_name)
-          previous_step = mock("Workflow::Step", name: expected_step_name)
-
-          test_class = ShowMethodsTestClass.new(current_step:, previous_step:, content_block_edition:)
-
-          assert_equal test_class.back_path, content_block_manager.content_block_manager_content_block_workflow_path(
-            content_block_edition,
-            step: expected_step_name,
-          )
-        end
-      end
-    end
-
-    describe "when editing an existing block" do
-      let(:is_new_block) { true }
-
-      it "returns the edit draft step" do
-        current_step = mock("Workflow::Step", name: :review)
-        previous_step = mock("Workflow::Step")
-
-        test_class = ShowMethodsTestClass.new(current_step:, previous_step:, content_block_edition:)
-
-        assert_equal test_class.back_path, content_block_manager.content_block_manager_content_block_workflow_path(
-          content_block_edition,
-          step: :edit_draft,
-        )
-      end
+      assert_equal test_class.back_path, content_block_manager.content_block_manager_content_block_workflow_path(
+        content_block_edition,
+        step: expected_step_name,
+      )
     end
   end
 end

--- a/lib/engines/content_block_manager/test/unit/app/controllers/concerns/workflow/steps_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/controllers/concerns/workflow/steps_test.rb
@@ -146,8 +146,8 @@ class Workflow::StepsTest < ActionDispatch::IntegrationTest
       it "inserts the subschemas into the flow" do
         assert_equal workflow.steps, [
           Workflow::Step::ALL[0],
-          Workflow::Step.new(:embedded_something, :embedded_something, :redirect_to_next_subschema_or_continue, true),
-          Workflow::Step.new(:embedded_something_else, :embedded_something_else, :redirect_to_next_subschema_or_continue, true),
+          Workflow::Step.new(:embedded_something, :embedded_something, :redirect_to_next_step, true),
+          Workflow::Step.new(:embedded_something_else, :embedded_something_else, :redirect_to_next_step, true),
           Workflow::Step::ALL[1..],
         ].flatten
       end
@@ -202,8 +202,8 @@ class Workflow::StepsTest < ActionDispatch::IntegrationTest
       it "removes steps not included in the create journey" do
         assert_equal workflow.steps, [
           Workflow::Step.new(:edit_draft, :edit_draft, :update_draft, true),
-          Workflow::Step.new(:embedded_something, :embedded_something, :redirect_to_next_subschema_or_continue, true),
-          Workflow::Step.new(:embedded_something_else, :embedded_something_else, :redirect_to_next_subschema_or_continue, true),
+          Workflow::Step.new(:embedded_something, :embedded_something, :redirect_to_next_step, true),
+          Workflow::Step.new(:embedded_something_else, :embedded_something_else, :redirect_to_next_step, true),
           Workflow::Step.new(:review, :review, :validate_review_page, true),
           Workflow::Step.new(:confirmation, :confirmation, nil, true),
         ].flatten


### PR DESCRIPTION
Trello card: https://trello.com/c/tkp354pt/934-rates-step-getting-skipped-when-going-back

This refactors the Steps, so we get the correct order depending on if a step is new or not, including the steps for embedded blocks.