### PR TITLE
Add support for multiple select in 'select_with_search' component

### DIFF
--- a/app/assets/javascripts/components/select-with-search.js
+++ b/app/assets/javascripts/components/select-with-search.js
@@ -28,6 +28,16 @@ window.GOVUK.Modules = window.GOVUK.Modules || {}
       searchResultLimit: 100,
       removeItemButton: this.select.multiple,
       labelId: this.select.id + '_label',
+      callbackOnInit: function () {
+        // For the multiple select, move the input field to
+        // the top of the feedback area, so that the selected
+        // 'lozenges' appear afterwards in a more natural flow
+        if (this.dropdown.type === 'select-multiple') {
+          const inner = this.containerInner.element
+          const input = this.input.element
+          inner.prepend(input)
+        }
+      },
       // https://fusejs.io/api/options.html
       fuseOptions: {
         ignoreLocation: true, // matches any part of the string

--- a/app/assets/javascripts/components/select-with-search.js
+++ b/app/assets/javascripts/components/select-with-search.js
@@ -15,7 +15,9 @@ window.GOVUK.Modules = window.GOVUK.Modules || {}
     )
 
     if (placeholderOption && placeholderOption.textContent === '') {
-      placeholderOption.textContent = 'Select one'
+      placeholderOption.textContent = this.select.multiple
+        ? 'Select all that apply'
+        : 'Select one'
     }
 
     this.choices = new window.Choices(this.select, {
@@ -24,6 +26,7 @@ window.GOVUK.Modules = window.GOVUK.Modules || {}
       shouldSort: false, // show options and groups in the order they were given
       itemSelectText: '',
       searchResultLimit: 100,
+      removeItemButton: this.select.multiple,
       labelId: this.select.id + '_label',
       // https://fusejs.io/api/options.html
       fuseOptions: {

--- a/app/assets/stylesheets/components/_select-with-search.scss
+++ b/app/assets/stylesheets/components/_select-with-search.scss
@@ -128,29 +128,40 @@
       cursor: text;
     }
 
+    .choices__item {
+      position: relative;
+    }
+
     // Delete button X
     .choices__button {
-      position: relative;
-      top: -2px;
-      display: inline-block;
-      margin-top: 0;
-      margin-right: -4px;
-      margin-bottom: 0;
-      margin-left: 8px;
-      padding-left: 16px;
-      border-left: 1px solid #929191;
+      position: absolute;
+      top: 0;
+      bottom: 0;
+      right: 0;
+      width: 32px;
+      border-left: 1px solid govuk-colour("mid-grey");
+      border-right: 1px solid govuk-colour("mid-grey");
       background-image: url("data:image/svg+xml,%3Csvg width='21' height='21' viewBox='0 0 21 21' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='%230b0c0c' fill-rule='evenodd'%3E%3Cpath d='M2.592.044l18.364 18.364-2.548 2.548L.044 2.592z'/%3E%3Cpath d='M0 18.364L18.364 0l2.548 2.548L2.548 20.912z'/%3E%3C/g%3E%3C/svg%3E");
       background-size: 12px;
-      width: 12px;
-      height: 100%;
-      line-height: 1;
-      opacity: 0.75;
       border-radius: 0;
 
-      &:hover,
-      &:focus {
-        opacity: 1;
+      &:hover {
+        background-color: govuk-colour("mid-grey");
+        border-color: govuk-colour("dark-grey");
+        box-shadow: 0 2px 0 govuk-colour("dark-grey");
       }
+
+      &:focus {
+        background-color: $govuk-focus-colour;
+        box-shadow: 0 2px 0 $govuk-focus-text-colour;
+      }
+    }
+  }
+
+  // Type: Select Multiple ONLY
+  .choices[data-type*="select-multiple"] {
+    .choices__input {
+      display: block;
     }
   }
 
@@ -199,32 +210,33 @@
   }
 
   .choices__list--multiple {
-    display: inline;
+    display: block;
+
+    &:not(:empty) {
+      margin-block-start: 6px;
+      border-block-start: 1px solid $govuk-border-colour;
+      padding-block-end: 5px;
+    }
   }
 
   .choices__list--multiple .choices__item {
-    display: inline-block;
-    vertical-align: middle;
-    padding: 4px 10px;
-    margin-right: 4px;
-    margin-bottom: 4px;
-    background-color: #f3f2f1;
-    box-shadow: 0 2px 0 #929191;
+    display: inline-flex;
+    align-items: center;
+    padding: 6px 10px;
+    margin: 9px 9px 0 0;
+    background-color: govuk-colour("light-grey");
+    box-shadow: 0 2px 0 govuk-colour("mid-grey");
     line-height: 1;
-    color: #0b0c0c;
+    color: $govuk-text-colour;
     box-sizing: border-box;
 
     &[data-deletable] {
-      padding-right: 5px;
+      padding-right: 42px;
     }
 
     [dir="rtl"] & {
       margin-right: 0;
       margin-left: 3.75px;
-    }
-
-    &.is-highlighted {
-      background-color: $govuk-focus-colour;
     }
 
     .is-disabled & {

--- a/app/views/components/_select_with_search.html.erb
+++ b/app/views/components/_select_with_search.html.erb
@@ -6,6 +6,7 @@
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
   heading_size = false unless shared_helper.valid_heading_size?(heading_size)
   select_helper = GovukPublishingComponents::Presenters::SelectWithSearchHelper.new(local_assigns)
+  multiple = local_assigns[:select].present? ? local_assigns[:select][:multiple] : false
 %>
 
 <%= content_tag :div, class: select_helper.css_classes, data: select_helper.data_attributes do %>
@@ -25,5 +26,5 @@
     } %>
   <% end %>
 
-  <%= select_tag name, select_helper.options_html, id: id, class: select_helper.select_classes, aria: select_helper.aria %>
+  <%= select_tag name, select_helper.options_html, id: id, class: select_helper.select_classes, multiple:, aria: select_helper.aria %>
 <% end %>

--- a/app/views/components/docs/select_with_search.yml
+++ b/app/views/components/docs/select_with_search.yml
@@ -184,3 +184,22 @@ examples:
         value: option2
       - text: Option three
         value: option3
+  with_multiple_select_enabled:
+    description: Allow multiple items to be selected and de-selected.
+    data:
+      id: dropdown-with-multiple
+      label: Select your country
+      include_blank: true
+      select:
+        multiple: true
+      options:
+        - text: France
+          value: fr
+          selected: false
+        - text: Germany
+          value: de
+          selected: false
+        - text: The United Kingdom of Great Britain and Northern Ireland
+          value: uk
+        - text: Democratic Republic of the Congo
+          value: cg


### PR DESCRIPTION
This is needed to deprecate the 'autocomplete' component. Choices.js supports multiple select mode out of the box: we just need to pass the `multiple: true` boolean to the Rails `select_tag` helper (which adds the `multiple="multiple"` attribute to the rendered `<select>` tag).

## Screenshots of 'multiple' support so far

The resulting UI is a bit different to the 'autocomplete' equivalent, but not so different that it should be detrimental to our users.

[Related guides](https://whitehall-admin.integration.publishing.service.gov.uk/government/admin/detailed-guides/new) dropdown. NB: there is a similar ([slow](https://govuk.zendesk.com/agent/tickets/5839628)) performance in both cases.

The landing page view has a similar affordance (we lose the 'dropdown' icon, but gain some placeholder text. Either one is relatively simple to add/remove if necessary). The search experience is identical too. What differs is the 'on choose' behaviour: 'autocomplete' exits the dropdown whereas 'select with search' keeps the dropdown open. The representation of selected options is different too ('autocomplete' shows the options below the input, and 'select with search' shows them inline).

| Before | After |
|-------|-------|
|![related_guides-closed-ac](https://github.com/user-attachments/assets/fd9e5beb-fc48-483a-9eb7-683c0530291c)|![related_guides-closed-sws](https://github.com/user-attachments/assets/9e0daee7-748d-4ed5-a725-04557981dbd2)| | On page load | On page load |
|![related_guides-open-ac](https://github.com/user-attachments/assets/a1d8745f-45a3-42eb-b378-d8b2744d9f5c)|![Screenshot 2025-02-20 at 14 54 38](https://github.com/user-attachments/assets/54b647bf-f8b6-4647-860e-6e57a98bdea0)| | On focus | On focus |
|![related_guides-selected-ac](https://github.com/user-attachments/assets/f6821fbb-2520-459a-8cf1-c6e0d2725760)|![Screenshot 2025-02-20 at 14 51 59](https://github.com/user-attachments/assets/52643bde-bae0-4ecd-aa24-fabbdc58e93a)| | On choice made | On choice made |
|As above |![related_guides-selected-sws](https://github.com/user-attachments/assets/f10097e1-f2c7-46a9-a7a7-6b0ae7acb12f)| | On blur | On blur |

Trello: https://trello.com/c/jBjHrNou/3492-replicate-ux-of-multiple-autocomplete-into-selectwithsearch-component

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
