### PR TITLE
content-modelling/ redirect back to "Add objects" page in create flow)

### DIFF
--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/embedded_objects/shared/_form.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/embedded_objects/shared/_form.html.erb
@@ -18,7 +18,7 @@
   } %>
   <%= render "govuk_publishing_components/components/button", {
     text: "Cancel",
-    href: @redirect_url,
+    href: @redirect_url.presence || content_block_manager.content_block_manager_content_block_workflow_path(id: @content_block_edition.id, step: "embedded_#{@subschema.block_type}"),
     secondary_solid: true,
   } %>
 </div>

--- a/lib/engines/content_block_manager/features/create_pension_object.feature
+++ b/lib/engines/content_block_manager/features/create_pension_object.feature
@@ -46,6 +46,19 @@ Feature: Create a content object
     And I review and confirm my answers are correct
     Then I should be taken to the confirmation page for a new "pension"
 
+  Scenario: GDS editor creates a Pension and cancels on the first rate
+    When I visit the Content Block Manager home page
+    And I click to create an object
+    Then I should see all the schemas listed
+    When I click on the "pension" schema
+    Then I should see a form for the schema
+    When I complete the form with the following fields:
+      | title            | description   | organisation        | instructions_to_publishers |
+      | my basic pension | this is basic | Ministry of Example | this is important  |
+    When I click to add a new "rate"
+    And I click the cancel link
+    Then I should be on the "embedded_rates" step
+
   Scenario: GDS editor clicks back and is taken back to rates
     When I visit the Content Block Manager home page
     And I click to create an object


### PR DESCRIPTION
https://trello.com/c/Qav7InZp/931-cancelling-create-rate-leads-to-error-messages

there was an optional value for a `@redirect_url`
that is set during the edit flow - it isn't clear
that this is required, so when it is not we want
to default to send them back to the 'add a' page,
as this should make sense either in create or edit
flow.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
