### PR TITLE
Remove the "raise a support request" button

### DIFF
--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/documents/index.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/documents/index.html.erb
@@ -20,16 +20,9 @@
     </div>
     <div class="govuk-grid-column-one-half content-block-manager-header--column-right">
       <div>
-        <span class="govuk-!-margin-right-2">
           <%= render "govuk_publishing_components/components/button", {
             text: "Create content block",
             href: content_block_manager.new_content_block_manager_content_block_document_path,
-          } %>
-        </span>
-          <%= render "govuk_publishing_components/components/button", {
-            text: "Raise a support request",
-            href: support_url,
-            secondary_solid: true,
           } %>
       </div>
     </div>

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/documents/show.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/documents/show.html.erb
@@ -11,17 +11,10 @@
     <h1 class="govuk-heading-xl"><%= @content_block_document.title %></h1>
   </div>
   <div class="govuk-grid-column-one-half content-block-manager-header--column-right">
-    <div class="govuk-button-group">
       <%= render "govuk_publishing_components/components/button", {
         text: "Edit #{@content_block_document.block_type.humanize.downcase}",
         href: content_block_manager.new_content_block_manager_content_block_document_edition_path(@content_block_document),
       } %>
-      <%= render "govuk_publishing_components/components/button", {
-        text: "Raise a support request",
-        href: support_url,
-        secondary_solid: true,
-      } %>
-    </div>
   </div>
 </div>
 

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/confirmation.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/confirmation.html.erb
@@ -22,11 +22,6 @@
           value: "view",
           href: content_block_manager.content_block_manager_content_block_document_path(@content_block_edition.document.id),
       } %>
-      <%= render "govuk_publishing_components/components/button", {
-        text: "Raise a support request",
-        href: support_url,
-        secondary_solid: true,
-      } %>
     </div>
   </div>
 </div>

--- a/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
@@ -99,8 +99,6 @@ And("I should be taken to the confirmation page for a published block") do
       content_block_edition.document,
     ),
   )
-
-  has_support_button
 end
 
 And("I should be taken to the confirmation page for a new block") do
@@ -115,8 +113,6 @@ And("I should be taken to the confirmation page for a new block") do
       content_block.document,
     ),
   )
-
-  has_support_button
 end
 
 And("I should be taken to the confirmation page for a new {string}") do |block_type|
@@ -131,8 +127,6 @@ And("I should be taken to the confirmation page for a new {string}") do |block_t
       content_block.document,
     ),
   )
-
-  has_support_button
 end
 
 When("I click to view the content block") do
@@ -157,8 +151,6 @@ When("I should be taken to the scheduled confirmation page") do
       content_block_edition.document,
     ),
   )
-
-  has_support_button
 end
 
 Then("I should be taken back to the document page") do

--- a/lib/engines/content_block_manager/features/support/helpers.rb
+++ b/lib/engines/content_block_manager/features/support/helpers.rb
@@ -70,13 +70,6 @@ def click_save_and_continue
   click_on "Save and continue"
 end
 
-def has_support_button
-  expect(page).to have_link(
-    "Raise a support request",
-    href: Whitehall.support_url,
-  )
-end
-
 def schedule_change(number_of_days)
   choose "Schedule the edit for the future"
   @future_date = number_of_days.days.since(Time.zone.now)


### PR DESCRIPTION
As we are relying on the link in the banner and
footer for support, we do not need this button
anymore.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
