### PR TITLE
content-modelling/ update phase banner

### DIFF
--- a/lib/engines/content_block_manager/app/views/shared/_phase_banner.html.erb
+++ b/lib/engines/content_block_manager/app/views/shared/_phase_banner.html.erb
@@ -1,13 +1,13 @@
 <%= render "govuk_publishing_components/components/phase_banner", {
-    phase: "Alpha",
-    message: sanitize("This is a new service - your
+    phase: "Beta",
+    message: sanitize("For support, to delete a content block or to give feedback, email
         #{
       mail_to(
-        "govuk-publishing-content-modelling-team@digital.cabinet-office.gov.uk",
-        "feedback",
+        "feedback-content-modelling@digital.cabinet-office.gov.uk",
+        "feedback-content-modelling@digital.cabinet-office.gov.uk",
         {
           class: "govuk-link",
         },
         )
-    } will help us to improve it.", attributes: %w(class href)),
+    }.", attributes: %w(class href)),
   } %>

--- a/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
@@ -447,8 +447,8 @@ And(/^I should see the object store's navigation$/) do
 end
 
 And("I should see the object store's phase banner") do
-  expect(page).to have_selector(".govuk-tag", text: "Alpha")
-  expect(page).to have_link("feedback", href: "mailto:govuk-publishing-content-modelling-team@digital.cabinet-office.gov.uk")
+  expect(page).to have_selector(".govuk-tag", text: "Beta")
+  expect(page).to have_link("feedback-content-modelling@digital.cabinet-office.gov.uk", href: "mailto:feedback-content-modelling@digital.cabinet-office.gov.uk")
 end
 
 Then(/^I should still see the live edition on the homepage$/) do

--- a/test/functional/admin/errors_controller_test.rb
+++ b/test/functional/admin/errors_controller_test.rb
@@ -56,7 +56,7 @@ class Admin::ErrorsControllerTest < ActionDispatch::IntegrationTest
         get "/#{error_code}"
 
         assert_select ".govuk-header__product-name", text: ContentBlockManager.product_name
-        assert_select ".govuk-phase-banner__content__tag", text: "Alpha"
+        assert_select ".govuk-phase-banner__content__tag", text: "Beta"
       end
 
       it "should render the product name in the title" do


### PR DESCRIPTION
https://trello.com/c/snJSIUEW/922-update-banner-for-private-beta-26-feb

We are now moving to Beta, this updates our banner
with the new phase and new copy needed.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
