### PR TITLE
(883) Hide the create journey for non pension blocks in production

### DIFF
--- a/config/features.rb
+++ b/config/features.rb
@@ -25,4 +25,7 @@ Flipflop.configure do
   feature :govspeak_visual_editor, description: "Enables a visual editor for Govspeak fields", default: false
   feature :override_government, description: "Enables GDS Editors and Admins to override the government associated with a document", default: false
   feature :show_link_to_content_block_manager, description: "Shows link to Content Block Manager from Whitehall editor", default: Whitehall.integration_or_staging?
+  feature :show_all_content_block_types,
+          description: "Show all applicable content block types in Content Block Manager",
+          default: Whitehall.integration_or_staging? || !Rails.env.production?
 end

--- a/lib/engines/content_block_manager/app/models/content_block_manager/content_block/document/document_filter.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/content_block/document/document_filter.rb
@@ -76,6 +76,7 @@ module ContentBlockManager
 
     def unpaginated_documents
       documents = ContentBlock::Document
+      documents = documents.where(block_type: ContentBlock::Schema.valid_schemas)
       documents = documents.live
       documents = documents.joins(:latest_edition)
       documents = documents.with_keyword(@filters[:keyword]) if @filters[:keyword].present?

--- a/lib/engines/content_block_manager/app/models/content_block_manager/content_block/schema.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/content_block/schema.rb
@@ -10,7 +10,7 @@ module ContentBlockManager
 
       class << self
         def valid_schemas
-          VALID_SCHEMAS
+          Flipflop.show_all_content_block_types? ? VALID_SCHEMAS : %w[pension]
         end
 
         def all

--- a/lib/engines/content_block_manager/test/unit/app/models/content_block_edition/document/document_filter_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/models/content_block_edition/document/document_filter_test.rb
@@ -7,7 +7,11 @@ class ContentBlockManager::DocumentFilterTest < ActiveSupport::TestCase
     let(:document_scope_mock) { mock }
 
     before do
-      ContentBlockManager::ContentBlock::Document.expects(:live).returns(document_scope_mock)
+      ContentBlockManager::ContentBlock::Document
+        .expects(:where)
+        .with(block_type: ContentBlockManager::ContentBlock::Schema.valid_schemas)
+        .returns(document_scope_mock)
+      document_scope_mock.expects(:live).returns(document_scope_mock)
       document_scope_mock.expects(:joins).with(:latest_edition).returns(document_scope_mock)
       document_scope_mock.expects(:distinct).returns(document_scope_mock)
       document_scope_mock.expects(:order).with("content_block_editions.updated_at DESC").returns(document_scope_mock)

--- a/lib/engines/content_block_manager/test/unit/app/models/content_block_schema_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/models/content_block_schema_test.rb
@@ -144,12 +144,23 @@ class ContentBlockManager::SchemaTest < ActiveSupport::TestCase
   end
 
   describe ".valid_schemas" do
-    test "it returns the contents of the VALID_SCHEMA constant" do
+    it "returns the contents of the VALID_SCHEMA constant" do
       assert_equal ContentBlockManager::ContentBlock::Schema.valid_schemas, %w[
         email_address
         postal_address
         pension
       ]
+    end
+
+    describe "when the show_all_content_block_types feature flag is turned off" do
+      before do
+        test_strategy = Flipflop::FeatureSet.current.test!
+        test_strategy.switch!(:show_all_content_block_types, false)
+      end
+
+      it "only returns pensions" do
+        assert_equal ContentBlockManager::ContentBlock::Schema.valid_schemas, %w[pension]
+      end
     end
   end
 


### PR DESCRIPTION
Trello card: https://trello.com/c/jG9xJBTQ/883-hide-the-create-journey-for-non-pension-blocks-in-production

This removes unsupported schemas from the `valid_schemas` array if the feature flag is not set (defaults to `true` in non-production environments). It also ensures that unsupported blocks are not listed on the frontend either.