### PR TITLE
Add GA4 tracking to `select_with_search`

### DIFF
--- a/app/assets/javascripts/admin/analytics-modules/ga4-select-with-search-tracker.js
+++ b/app/assets/javascripts/admin/analytics-modules/ga4-select-with-search-tracker.js
@@ -1,0 +1,56 @@
+'use strict'
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {}
+window.GOVUK.analyticsGa4.analyticsModules =
+  window.GOVUK.analyticsGa4.analyticsModules || {}
+;(function (Modules) {
+  Modules.Ga4SelectWithSearchSetup = {
+    init: function () {
+      const moduleElements = document.querySelectorAll(
+        "[data-module~='ga4-select-with-search-setup'] select"
+      )
+
+      moduleElements.forEach(function (moduleElement) {
+        moduleElement.addEventListener('addItem', function (event) {
+          const eventData = {
+            event: 'event_data',
+            event_data: {
+              event_name: 'select_component',
+              type: event.target.dataset.ga4DocumentType,
+              index: {
+                index_section_count: `${event.target.selectedIndex}`,
+                index_section: event.target.dataset.ga4IndexSection
+              },
+              text: event.detail.label,
+              section: event.target.dataset.ga4Section,
+              action: 'select'
+            }
+          }
+
+          window.GOVUK.analyticsGa4.core.sendData(eventData, 'event_data')
+        })
+
+        if (moduleElement.getAttribute('multiple') !== null) {
+          moduleElement.addEventListener('removeItem', function (event) {
+            const eventData = {
+              event: 'event_data',
+              event_data: {
+                event_name: 'select_component',
+                type: event.target.dataset.ga4DocumentType,
+                index: {
+                  index_section_count: `${event.detail.value}`,
+                  index_section: event.target.dataset.ga4IndexSection
+                },
+                text: event.detail.label,
+                section: event.target.dataset.ga4Section,
+                action: 'remove'
+              }
+            }
+
+            window.GOVUK.analyticsGa4.core.sendData(eventData, 'event_data')
+          })
+        }
+      })
+    }
+  }
+})(window.GOVUK.analyticsGa4.analyticsModules)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -21,6 +21,7 @@
 //= require admin/analytics-modules/ga4-visual-editor-event-handlers.js
 //= require admin/analytics-modules/ga4-page-view-tracking.js
 //= require admin/analytics-modules/ga4-paste-tracker.js
+//= require admin/analytics-modules/ga4-select-with-search-tracker.js
 
 //= require admin/modules/document-history-paginator
 //= require admin/modules/locale-switcher

--- a/app/views/admin/case_studies/_form.html.erb
+++ b/app/views/admin/case_studies/_form.html.erb
@@ -10,7 +10,7 @@
     id: "associations",
   } do %>
     <div class="govuk-!-margin-bottom-4">
-      <%= render "worldwide_organisation_fields", form: form, edition: edition %>
+      <%= render "worldwide_organisation_fields", form: form, edition: edition, index: "1" %>
 
       <%= render "world_location_fields", form: form, edition: edition %>
       <%= render "organisation_fields", form: form, edition: edition %>

--- a/app/views/admin/corporate_information_pages/_standard_fields.html.erb
+++ b/app/views/admin/corporate_information_pages/_standard_fields.html.erb
@@ -10,6 +10,11 @@
       heading_size: "l",
       error_items: errors_for(edition.errors, :corporate_information_page_type_id),
       include_blank: true,
+      ga_data: {
+        document_type: "#{action_name}-#{controller_name}",
+        index_section: 1,
+        section: "Type",
+      },
       options: corporate_information_page_types(@organisation).map do |type, value|
         {
           text: type,

--- a/app/views/admin/detailed_guides/_form.html.erb
+++ b/app/views/admin/detailed_guides/_form.html.erb
@@ -23,6 +23,11 @@
           label: "Related guides",
           heading_size: "m",
           options: taggable_detailed_guides_container(edition.related_detailed_guide_ids),
+          ga_data: {
+            document_type: "#{action_name}-#{controller_name}",
+            index_section: 3,
+            section: "Related guides",
+          },
           select: {
             multiple: true,
           },

--- a/app/views/admin/editionable_social_media_accounts/_form.html.erb
+++ b/app/views/admin/editionable_social_media_accounts/_form.html.erb
@@ -8,6 +8,11 @@
         heading_size: "l",
         include_blank: true,
         error_items: errors_for(social_media_account.errors, :social_media_service_id),
+        ga_data: {
+          document_type: "#{action_name}-#{controller_name}",
+          index_section: 1,
+          section: "Service (required)",
+        },
         options: SocialMediaService.all.map do |service|
           {
             text: service.name,

--- a/app/views/admin/editions/_appointment_fields.html.erb
+++ b/app/views/admin/editions/_appointment_fields.html.erb
@@ -6,6 +6,11 @@
     label: "Ministers",
     heading_size: "m",
     options: taggable_ministerial_role_appointments_container(edition.role_appointment_ids),
+    ga_data: {
+      document_type: "#{action_name}-#{controller_name}",
+      index_section: 14,
+      section: "Ministers",
+    },
     select: {
       multiple: true,
     },

--- a/app/views/admin/editions/_filter_options.html.erb
+++ b/app/views/admin/editions/_filter_options.html.erb
@@ -29,6 +29,11 @@
         id: "author_filter",
         name: "author",
         heading_size: "s",
+        ga_data: {
+          document_type: "#{action_name}-#{controller_name}",
+          index_section: 2,
+          section: "Author",
+        },
         options: admin_author_filter_options(current_user).map do |name, id|
           {
             text: name,
@@ -45,6 +50,11 @@
         id: "organisation_filter",
         name: "organisation",
         heading_size: "s",
+        ga_data: {
+          document_type: "#{action_name}-#{controller_name}",
+          index_section: 3,
+          section: "Organisation",
+        },
         grouped_options: admin_organisation_filter_options(@filter.options[:organisation]),
       } %>
     <% end %>
@@ -55,6 +65,11 @@
         id: "world_location_filter",
         name: "world_location",
         heading_size: "s",
+        ga_data: {
+          document_type: "#{action_name}-#{controller_name}",
+          index_section: 4,
+          section: "World location",
+        },
         options: admin_world_location_filter_options(current_user).map do |name, id|
           {
             text: name,
@@ -71,6 +86,11 @@
         id: "type_filter",
         name: "type",
         heading_size: "s",
+        ga_data: {
+          document_type: "#{action_name}-#{controller_name}",
+          index_section: 5,
+          section: "Document type",
+        },
         grouped_options: filter_edition_type_opt_groups(current_user, @filter.options[:type]),
       } %>
     <% end %>
@@ -81,6 +101,11 @@
         id: "state_filter",
         name: "state",
         heading_size: "s",
+        ga_data: {
+          document_type: "#{action_name}-#{controller_name}",
+          index_section: 6,
+          section: "State",
+        },
         options: admin_state_filter_options.map do |text, value|
           {
             text: text,

--- a/app/views/admin/editions/_locale_fields.html.erb
+++ b/app/views/admin/editions/_locale_fields.html.erb
@@ -24,6 +24,11 @@
           label: "Document language",
           heading_size: "m",
           include_blank: true,
+          ga_data: {
+            document_type: "#{action_name}-#{controller_name}",
+            index_section: 2,
+            section: "Document language",
+          },
           errors: errors_for(edition.errors, :primary_locale),
           options: locale_options.map do |language, value|
             {

--- a/app/views/admin/editions/_operational_field_fields.html.erb
+++ b/app/views/admin/editions/_operational_field_fields.html.erb
@@ -5,6 +5,11 @@
   heading_size: "l",
   error_items: errors_for(edition.errors, :operational_field_id),
   include_blank: true,
+  ga_data: {
+    document_type: "#{action_name}-#{controller_name}",
+    index_section: 1,
+    section: "Field of operation (required)",
+  },
   options: OperationalField.all.map do |operation|
     {
       text: operation.name,

--- a/app/views/admin/editions/_organisation_fields.html.erb
+++ b/app/views/admin/editions/_organisation_fields.html.erb
@@ -16,6 +16,11 @@
               label: "Lead organisation #{index + 1}",
               heading_size: "s",
               include_blank: true,
+              ga_data: {
+                document_type: "#{action_name}-#{controller_name}",
+                index_section: "#{index + 17}",
+                section: "Lead organisation #{index + 1}",
+              },
               options: taggable_organisations_container([lead_organisation_id]),
           } %>
         <% end %>
@@ -27,6 +32,11 @@
         id: "edition_supporting_organisation_ids",
         name: "edition[supporting_organisation_ids][]",
         include_blank: true,
+        ga_data: {
+          document_type: "#{action_name}-#{controller_name}",
+          index_section: 21,
+          section: "Supporting organisations",
+        },
         label: "Supporting organisations",
         heading_size: "m",
         options: taggable_organisations_container(edition.edition_organisations.reject(&:lead?).map(&:organisation_id)),

--- a/app/views/admin/editions/_role_fields.html.erb
+++ b/app/views/admin/editions/_role_fields.html.erb
@@ -1,4 +1,5 @@
 <% required = false unless defined?(required) %>
+<% index = "1" unless defined?(index) %>
 
 <% cache_if edition.role_ids.empty?, "#{taggable_roles_cache_digest}-design-system" do %>
   <%= render "components/select_with_search", {
@@ -7,6 +8,11 @@
     error_items: errors_for(edition.errors, :roles),
     label: "Roles" + "#{' (required)' if required}",
     heading_size: "m",
+    ga_data: {
+      document_type: "#{action_name}-#{controller_name}",
+      index_section: index,
+      section: "Roles" + "#{' (required)' if required}",
+    },
     options: taggable_roles_container(edition.role_ids),
     select: {
       multiple: true,

--- a/app/views/admin/editions/_statistical_data_set_fields.html.erb
+++ b/app/views/admin/editions/_statistical_data_set_fields.html.erb
@@ -6,6 +6,11 @@
     label: "Statistical data sets",
     heading_size: "m",
     options: taggable_statistical_data_sets_container(edition.statistical_data_set_document_ids),
+    ga_data: {
+      document_type: "#{action_name}-#{controller_name}",
+      index_section: 1,
+      section: "Statistical data sets",
+    },
     select: {
       multiple: true,
     },

--- a/app/views/admin/editions/_topical_event_fields.html.erb
+++ b/app/views/admin/editions/_topical_event_fields.html.erb
@@ -5,6 +5,11 @@
     include_blank: true,
     label: "Topical events",
     heading_size: "m",
+    ga_data: {
+      document_type: "#{action_name}-#{controller_name}",
+      index_section: 15,
+      section: "Topical events",
+    },
     options: TopicalEvent.order(:name).map do |topical_event|
       {
         text: topical_event.name,

--- a/app/views/admin/editions/_world_location_fields.html.erb
+++ b/app/views/admin/editions/_world_location_fields.html.erb
@@ -1,4 +1,5 @@
 <% required = false unless defined?(required) %>
+<% index = "1" unless defined?(index) %>
 
 <% cache_if edition.world_location_ids.empty?, "#{taggable_world_locations_cache_digest}-design-system" do %>
   <%= render "components/select_with_search", {
@@ -6,6 +7,11 @@
     name: "edition[world_location_ids][]",
     error_items: errors_for(edition.errors, :world_locations),
     label: "World locations" + "#{' (required)' if required}",
+    ga_data: {
+      document_type: "#{action_name}-#{controller_name}",
+      index_section: index,
+      section: "World locations" + "#{' (required)' if required}",
+    },
     heading_size: "m",
     options: taggable_world_locations_container(edition.world_location_ids),
     select: {

--- a/app/views/admin/editions/_worldwide_organisation_fields.html.erb
+++ b/app/views/admin/editions/_worldwide_organisation_fields.html.erb
@@ -7,6 +7,11 @@
     name: "edition[worldwide_organisation_document_ids][]",
     error_items: errors_for(edition.errors, :worldwide_organisations),
     include_blank: true,
+    ga_data: {
+      document_type: "#{action_name}-#{controller_name}",
+      index_section: index,
+      section: "Worldwide organisations" + "#{' (required)' if required}",
+    },
     label: "Worldwide organisations" + "#{' (required)' if required}",
     heading_size: "m",
     options: taggable_worldwide_organisations_container(edition.worldwide_organisation_document_ids),

--- a/app/views/admin/editions/_worldwide_organisation_fields.html.erb
+++ b/app/views/admin/editions/_worldwide_organisation_fields.html.erb
@@ -1,4 +1,5 @@
 <% required = false unless defined?(required) %>
+<% index = "1" unless defined?(index) %>
 
 <% cache_if edition.worldwide_organisation_document_ids.empty?, "#{taggable_worldwide_organisations_cache_digest}-design-system" do %>
   <%= render "components/select_with_search", {

--- a/app/views/admin/historical_accounts/_form.html.erb
+++ b/app/views/admin/historical_accounts/_form.html.erb
@@ -22,6 +22,11 @@
         error_items: errors_for(historical_account.errors, :political_parties),
         label: "Political parties (required)",
         heading_size: "l",
+        ga_data: {
+          document_type: "#{action_name}-#{controller_name}",
+          index_section: 2,
+          section: "Political parties (required)",
+        },
         options: PoliticalParty.all.map do |party|
           {
             text: party.name,

--- a/app/views/admin/needs/edit.html.erb
+++ b/app/views/admin/needs/edit.html.erb
@@ -11,6 +11,11 @@
           include_blank: true,
           label: "Select associated user needs",
           heading_size: "l",
+          ga_data: {
+            document_type: "#{action_name}-#{controller_name}",
+            index_section: 1,
+            section: "Select associated user needs",
+          },
           options: taggable_needs_container(@document.need_ids),
           select: {
             multiple: true,

--- a/app/views/admin/news_articles/_form.html.erb
+++ b/app/views/admin/news_articles/_form.html.erb
@@ -19,7 +19,7 @@
       <%= render "topical_event_fields", form: form, edition: edition %>
 
       <div class="app-view-edit-edition__world-organisation-fields govuk-!-margin-bottom-4">
-        <%= render "worldwide_organisation_fields", form: form, edition: edition, required: true %>
+        <%= render "worldwide_organisation_fields", form: form, edition: edition, required: true, index: "3" %>
       </div>
 
       <%= render "world_location_fields", form: form, edition: edition %>

--- a/app/views/admin/news_articles/_news_article_type_fields.html.erb
+++ b/app/views/admin/news_articles/_news_article_type_fields.html.erb
@@ -7,6 +7,11 @@
     value: edition.news_article_type_id,
     error_items: errors_for(edition.errors, :news_article_type_id),
     include_blank: true,
+    ga_data: {
+      document_type: "#{action_name}-#{controller_name}",
+      index_section: 1,
+      section: "News article type (required)",
+    },
     options: NewsArticleType.all.map do |type|
       {
         text: type.singular_name,

--- a/app/views/admin/organisations/_closed_fields.html.erb
+++ b/app/views/admin/organisations/_closed_fields.html.erb
@@ -5,6 +5,11 @@
   heading_size: "m",
   error_items: errors_for(organisation.errors, :govuk_closed_status),
   include_blank: true,
+  ga_data: {
+    document_type: "#{action_name}-#{controller_name}",
+    index_section: 1,
+    section: "Reason for closure (required)",
+  },
   options: [
     {
       text: "No longer exists",
@@ -50,6 +55,11 @@
   include_blank: true,
   label: "Superseding organisations",
   heading_size: "m",
+  ga_data: {
+    document_type: "#{action_name}-#{controller_name}",
+    index_section: 2,
+    section: "Superseding organisations",
+  },
   options: (Organisation.with_translations(:en) - [organisation]).map do |org|
               {
                 text: org.name,

--- a/app/views/admin/organisations/_form.html.erb
+++ b/app/views/admin/organisations/_form.html.erb
@@ -44,6 +44,11 @@
     heading_size: "l",
     error_items: errors_for(organisation.errors, :organisation_logo_type_id),
     include_blank: true,
+    ga_data: {
+      document_type: "#{action_name}-#{controller_name}",
+      index_section: 4,
+      section: "Logo crest (required)",
+    },
     options: OrganisationLogoType.all.map do |logo_type|
       {
         text: logo_type.title,
@@ -79,6 +84,11 @@
     heading_size: "l",
     error_items: errors_for(organisation.errors, :organisation_brand_colour_id),
     include_blank: true,
+    ga_data: {
+      document_type: "#{action_name}-#{controller_name}",
+      index_section: 6,
+      section: "Brand colour",
+    },
     options: OrganisationBrandColour.all.map do |brand_colour|
       {
         text: brand_colour.title,
@@ -124,6 +134,11 @@
     heading_size: "l",
     error_items: errors_for(organisation.errors, :organisation_type_key),
     include_blank: true,
+    ga_data: {
+      document_type: "#{action_name}-#{controller_name}",
+      index_section: 7,
+      section: "Organisation type (required)",
+    },
     options: OrganisationType.in_listing_order.map do |type|
       {
         text: type.name,
@@ -242,6 +257,11 @@
       id: "organisation_parent_organisation_ids",
       name: "organisation[parent_organisation_ids][]",
       label: "Sponsoring organisations",
+      ga_data: {
+        document_type: "#{action_name}-#{controller_name}",
+        index_section: 15,
+        section: "Sponsoring organisations",
+      },
       heading_size: "m",
       options: (Organisation.with_translations(:en) - [organisation]).map do |org|
                   {
@@ -271,6 +291,11 @@
         id: "organisation_topical_event_ids_#{topical_event_organisation.ordering}",
         heading_size: "s",
         include_blank: true,
+        ga_data: {
+          document_type: "#{action_name}-#{controller_name}",
+          index_section: 1,
+          section: "Topical Event #{topical_event_organisation.ordering + 1}",
+        },
         options: TopicalEvent.all.map do |topical_event|
           {
             text: topical_event.name,

--- a/app/views/admin/publications/_publication_type_fields.html.erb
+++ b/app/views/admin/publications/_publication_type_fields.html.erb
@@ -7,6 +7,11 @@
     value: edition.publication_type_id,
     error_items: errors_for(edition.errors, :publication_type_id),
     include_blank: true,
+    ga_data: {
+      document_type: "#{action_name}-#{controller_name}",
+      index_section: 1,
+      section: "Publication type (required)",
+    },
     grouped_options: [
       [
         "Common types",

--- a/app/views/admin/role_appointments/_form.html.erb
+++ b/app/views/admin/role_appointments/_form.html.erb
@@ -3,6 +3,11 @@
   label: "Person (required)",
   heading_size: "l",
   name: "role_appointment[person_id]",
+  ga_data: {
+    document_type: "#{action_name}-#{controller_name}",
+    index_section: 1,
+    section: "Person (required)",
+  },
   options:
     disambiguated_people_names.map { |person_name, person_id|
       {

--- a/app/views/admin/roles/_form.html.erb
+++ b/app/views/admin/roles/_form.html.erb
@@ -34,6 +34,11 @@
     label: "Organisations",
     heading_size: "l",
     name: "role[organisation_ids][]",
+    ga_data: {
+      document_type: "#{action_name}-#{controller_name}",
+      index_section: 3,
+      section: "Organisations",
+    },
     options: Organisation.with_translations(:en).map do |org|
       {
         text: org.select_name,

--- a/app/views/admin/social_media_accounts/_form.html.erb
+++ b/app/views/admin/social_media_accounts/_form.html.erb
@@ -8,6 +8,11 @@
           name: "social_media_account[social_media_service_id]",
           heading_size: "l",
           include_blank: true,
+          ga_data: {
+            document_type: "#{action_name}-#{controller_name}",
+            index_section: 1,
+            section: "Service (required)",
+          },
           error_items: errors_for(social_media_account.errors, :social_media_service_id),
           options: SocialMediaService.all.map do |service|
             {

--- a/app/views/admin/speeches/_speaker_select_field.html.erb
+++ b/app/views/admin/speeches/_speaker_select_field.html.erb
@@ -3,6 +3,11 @@
     id: "edition_role_appointment_id",
     name: "edition[role_appointment_id]",
     label: "",
+    ga_data: {
+      document_type: "#{action_name}-#{controller_name}",
+      index_section: 1,
+      section: "Edition role appointment ID",
+    },
     error_items: errors_for(edition.errors, :role_appointment_id),
     include_blank: true,
     options: taggable_role_appointments_container([edition.role_appointment_id]),

--- a/app/views/admin/speeches/_speech_type_fields.html.erb
+++ b/app/views/admin/speeches/_speech_type_fields.html.erb
@@ -7,6 +7,11 @@
     value: edition.speech_type_id,
     error_items: errors_for(edition.errors, :speech_type_id),
     include_blank: true,
+    ga_data: {
+      document_type: "#{action_name}-#{controller_name}",
+      index_section: 1,
+      section: "Speech type",
+    },
     options: SpeechType.primary.map do |type|
       {
         text: type.singular_name,

--- a/app/views/admin/statistics_announcements/_filter_options.html.erb
+++ b/app/views/admin/statistics_announcements/_filter_options.html.erb
@@ -20,6 +20,11 @@
       id: "organisation_filter",
       name: "organisation_id",
       heading_size: "s",
+      ga_data: {
+        document_type: "#{action_name}-#{controller_name}",
+        index_section: 1,
+        section: "Organisation",
+      },
       grouped_options: admin_organisation_filter_options(@filter.options[:organisation_id]),
     } %>
 

--- a/app/views/admin/statistics_announcements/_form.html.erb
+++ b/app/views/admin/statistics_announcements/_form.html.erb
@@ -56,6 +56,11 @@
     label: "Organisations (required)",
     heading_size: "l",
     name: "statistics_announcement[organisation_ids][]",
+    ga_data: {
+      document_type: "#{action_name}-#{controller_name}",
+      index_section: 4,
+      section: "Organisations (required)",
+    },
     options: Organisation.with_translations.order("organisation_translations.name").map do |org|
       {
         text: org.select_name,

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -11,6 +11,11 @@
         include_blank: true,
         label: "Locations",
         heading_size: "l",
+        ga_data: {
+          document_type: "#{action_name}-#{controller_name}",
+          index_section: 1,
+          section: "Locations",
+        },
         options: WorldLocation.all.map do |l|
           {
             text: l.name,

--- a/app/views/admin/worldwide_organisation_pages/_form.html.erb
+++ b/app/views/admin/worldwide_organisation_pages/_form.html.erb
@@ -11,6 +11,11 @@
       heading_size: "l",
       error_items: errors_for(worldwide_organisation_page.errors, :corporate_information_page_type_id),
       include_blank: true,
+      ga_data: {
+        document_type: "#{action_name}-#{controller_name}",
+        index_section: 1,
+        section: "Type",
+      },
       options: corporate_information_page_types(@worldwide_organisation).map do |type, value|
         {
           text: type,

--- a/app/views/components/_select_with_search.html.erb
+++ b/app/views/components/_select_with_search.html.erb
@@ -2,6 +2,7 @@
   id ||= false
   label ||= false
   name ||= id
+  ga_data ||= {}
 
   shared_helper = GovukPublishingComponents::Presenters::SharedHelper.new(local_assigns)
   heading_size = false unless shared_helper.valid_heading_size?(heading_size)
@@ -26,5 +27,6 @@
     } %>
   <% end %>
 
-  <%= select_tag name, select_helper.options_html, id: id, class: select_helper.select_classes, multiple:, aria: select_helper.aria %>
+  <%= select_tag name, select_helper.options_html, id: id, class: select_helper.select_classes, multiple:, aria: select_helper.aria, "data-ga4-document-type": ga_data[:document_type], "data-ga4-index-section": ga_data[:index_section], "data-ga4-section": ga_data[:section] %>
+
 <% end %>

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -22,7 +22,7 @@
 
   <%= render partial: "shared/header" %>
 
-  <div class="govuk-width-container" data-module="ga4-event-tracker ga4-paste-tracker ga4-link-setup ga4-link-tracker ga4-button-setup">
+  <div class="govuk-width-container" data-module="ga4-event-tracker ga4-paste-tracker ga4-link-setup ga4-link-tracker ga4-button-setup ga4-select-with-search-setup">
     <%= render "shared/phase_banner", {
       show_feedback_banner: t("admin.feedback.show_banner"),
     } %>

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/index/filter_options_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/index/filter_options_component.html.erb
@@ -51,6 +51,11 @@
               name: "lead_organisation",
               include_blank: false,
               options: options_for_lead_organisation([@filters[:lead_organisation]]),
+              ga_data: {
+                document_type: "#{action_name}-#{controller_name}",
+                index_section: 3,
+                section: "Lead organisation",
+              },
             }
           ),
         },

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/shared/_form.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/shared/_form.html.erb
@@ -33,6 +33,11 @@
     include_blank: true,
     label: "Lead organisation",
     options: taggable_organisations_container([@form.content_block_edition.edition_organisation&.organisation_id]),
+    ga_data: {
+      document_type: "#{action_name}-#{controller_name}",
+      index_section: 1,
+      section: "Lead organisation",
+    },
     select: {
       multiple: false,
     },

--- a/spec/javascripts/admin/analytics-modules/ga4-select-with-search-setup.spec.js
+++ b/spec/javascripts/admin/analytics-modules/ga4-select-with-search-setup.spec.js
@@ -1,0 +1,151 @@
+describe('GOVUK.analyticsGa4.analyticsModules.GA4SelectWithSearchEventHandlers', function () {
+  it('triggers GA4 when an addItem event occurs on selects', function () {
+    const container = document.createElement('div')
+    container.setAttribute('data-module', 'ga4-select-with-search-setup')
+
+    const select = document.createElement('select')
+    select.setAttribute('data-ga4-document-type', 'new-consultations')
+    select.setAttribute('data-ga4-index-section', '20')
+    select.setAttribute('data-ga4-section', 'Lead organisation')
+
+    const option = document.createElement('option')
+    option.setAttribute('value', '1')
+    option.setAttribute('selected', '')
+    option.innerText = 'First organisation name'
+
+    select.appendChild(option)
+    container.appendChild(select)
+    document.body.appendChild(container)
+
+    const ga4SelectWithSearchEventHandlers =
+      GOVUK.analyticsGa4.analyticsModules.Ga4SelectWithSearchSetup
+
+    ga4SelectWithSearchEventHandlers.init()
+
+    const mockGa4SendData = spyOn(window.GOVUK.analyticsGa4.core, 'sendData')
+
+    select.dispatchEvent(
+      new CustomEvent('addItem', {
+        detail: { label: 'First organisation name' }
+      })
+    )
+
+    const expectedAttributes = {
+      event: 'event_data',
+      event_data: {
+        event_name: 'select_component',
+        type: 'new-consultations',
+        index: {
+          index_section_count: '0',
+          index_section: '20'
+        },
+        text: 'First organisation name',
+        section: 'Lead organisation',
+        action: 'select'
+      }
+    }
+
+    expect(mockGa4SendData).toHaveBeenCalledWith(
+      expectedAttributes,
+      'event_data'
+    )
+  })
+
+  it('triggers GA4 when a removeItem event occurs on selects that have the "multiple" attribute', function () {
+    const container = document.createElement('div')
+    container.setAttribute('data-module', 'ga4-select-with-search-setup')
+
+    const select = document.createElement('select')
+    select.setAttribute('multiple', 'multiple')
+    select.setAttribute('data-ga4-document-type', 'new-consultations')
+    select.setAttribute('data-ga4-index-section', '20')
+    select.setAttribute('data-ga4-section', 'Lead organisation')
+
+    const option = document.createElement('option')
+    option.setAttribute('value', '1')
+    option.setAttribute('selected', '')
+    option.innerText = 'First organisation name'
+
+    select.appendChild(option)
+    container.appendChild(select)
+    document.body.appendChild(container)
+
+    const ga4SelectWithSearchEventHandlers =
+      GOVUK.analyticsGa4.analyticsModules.Ga4SelectWithSearchSetup
+
+    ga4SelectWithSearchEventHandlers.init()
+
+    const mockGa4SendData = spyOn(window.GOVUK.analyticsGa4.core, 'sendData')
+
+    select.dispatchEvent(
+      new CustomEvent('removeItem', {
+        detail: { label: 'First organisation name', value: '1' }
+      })
+    )
+
+    const expectedAttributes = {
+      event: 'event_data',
+      event_data: {
+        event_name: 'select_component',
+        type: 'new-consultations',
+        text: 'First organisation name',
+        index: {
+          index_section_count: '1',
+          index_section: '20'
+        },
+        section: 'Lead organisation',
+        action: 'remove'
+      }
+    }
+
+    expect(mockGa4SendData).toHaveBeenCalledWith(
+      expectedAttributes,
+      'event_data'
+    )
+  })
+
+  it('does not trigger GA4 when a removeItem event occurs on selects that do not have the "multiple" attribute', function () {
+    const container = document.createElement('div')
+    container.setAttribute('data-module', 'ga4-select-with-search-setup')
+
+    const select = document.createElement('select')
+    select.setAttribute('data-ga4-document-type', 'new-consultations')
+    select.setAttribute('data-ga4-index-section', '20')
+    select.setAttribute('data-ga4-section', 'Lead organisation')
+
+    const option = document.createElement('option')
+    option.setAttribute('value', '1')
+    option.setAttribute('selected', '')
+    option.innerText = 'First organisation name'
+
+    select.appendChild(option)
+    container.appendChild(select)
+    document.body.appendChild(container)
+
+    const ga4SelectWithSearchEventHandlers =
+      GOVUK.analyticsGa4.analyticsModules.Ga4SelectWithSearchSetup
+
+    ga4SelectWithSearchEventHandlers.init()
+
+    const mockGa4SendData = spyOn(window.GOVUK.analyticsGa4.core, 'sendData')
+
+    select.dispatchEvent(
+      new CustomEvent('removeItem', {
+        detail: { label: 'First organisation name' }
+      })
+    )
+
+    const expectedAttributes = {
+      event_name: 'select_component',
+      type: 'new-consultations',
+      text: 'First organisation name',
+      section: 'Lead organisation',
+      action: 'remove'
+    }
+
+    expect(mockGa4SendData).not.toHaveBeenCalledWith(
+      expectedAttributes,
+      'event_data'
+    )
+  })
+})


### PR DESCRIPTION
## What

Send data to GA4 upon changes to `select_with_search` component. Details provided in the [Trello card](https://trello.com/c/gm92ppp8/776-component-level-tracking-track-dropdown-interactions-on-whitehall) include requirements to send data to GA4 in response to:

1. `change` events triggered on `select` elements 
2. removal of an item from the multi-select variant of `select_with_search`

## How

The requirements have been met by introducing:
1. new `data-` attributes into the component HTML 
2. a JavaScript analytics module to send data to GA4 in response to `addItem` and `removeItem` events 

`addItem` and `removeItem` are custom events triggered by `choices.js` on the underlying `select` elements when a user performs these actions on a mounted `select_with_search` component.

## Performance analyst review

On 13 March, PAs tested the implementation on Integration and said it seems fine. 

## Paths tested

The following paths have been provided by PAs in response to their testing. Here's what data is being provided to GA4 for each.

### New consultation (path is `/government/admin/consultations/new`)

Lead organisation 1

```json
{
 "event": "event_data",
 "event_data": {
  "action": "select",
  "event_name": "select_component",
  "index": {
   "index_section_count": "1",
   "index_section": "17"
  },
  "section": "Lead organisation 1",
  "text": "HM Revenue & Customs (HMRC)",
  "type": "new-consultations"
 },
 "govuk_gem_version": "54.0.1",
 "timestamp": "1741857295779"
}
```

Lead organisation 2

```json
{
 "event": "event_data",
 "event_data": {
  "action": "select",
  "event_name": "select_component",
  "index": {
   "index_section_count": "1",
   "index_section": "18"
  },
  "section": "Lead organisation 2",
  "text": "HM Revenue & Customs (HMRC)",
  "type": "new-consultations"
 },
 "govuk_gem_version": "54.0.1",
 "timestamp": "1741857401033"
}
```

Lead organisation 3

```json
{
 "event": "event_data",
 "event_data": {
  "action": "select",
  "event_name": "select_component",
  "index": {
   "index_section_count": "1",
   "index_section": "19"
  },
  "section": "Lead organisation 3",
  "text": "HM Revenue & Customs (HMRC)",
  "type": "new-consultations"
 },
 "govuk_gem_version": "54.0.1",
 "timestamp": "1741857446887"
}
```

Lead organisation 4

```json
{
 "event": "event_data",
 "event_data": {
  "action": "select",
  "event_name": "select_component",
  "index": {
   "index_section_count": "1",
   "index_section": "20"
  },
  "section": "Lead organisation 4",
  "text": "HM Revenue & Customs (HMRC)",
  "type": "new-consultations"
 },
 "govuk_gem_version": "54.0.1",
 "timestamp": "1741857477920"
}
```

Supporting organisations (adding an item)

```json
{
 "event": "event_data",
 "event_data": {
  "action": "select",
  "event_name": "select_component",
  "index": {
   "index_section_count": "1",
   "index_section": "21"
  },
  "section": "Supporting organisations",
  "text": "HM Revenue & Customs (HMRC)",
  "type": "new-consultations"
 },
 "govuk_gem_version": "54.0.1",
 "timestamp": "1741857858922"
}
```

Supporting organisations (removing the same item)

```json
{
 "event": "event_data",
 "event_data": {
  "action": "remove",
  "event_name": "select_component",
  "index": {
   "index_section_count": "1",
   "index_section": "21"
  },
  "section": "Supporting organisations",
  "text": "HM Revenue & Customs (HMRC)",
  "type": "new-consultations"
 },
 "govuk_gem_version": "54.0.1",
 "timestamp": "1741858616617"
}
```

### Content block manager (path is `/content-block-manager/?lead_organisation=`)

Lead organisation

```json
{
 "event": "event_data",
 "event_data": {
  "action": "select",
  "event_name": "select_component",
  "index": {
   "index_section_count": "1",
   "index_section": "3"
  },
  "section": "Lead organisation",
  "text": "HM Revenue & Customs (HMRC)",
  "type": "index-documents"
 },
 "govuk_gem_version": "54.0.1",
 "timestamp": "1741858789201"
}
```

### Statistics announcements (path is `/government/admin/statistics_announcements`)

Organisation

```json
{
 "event": "event_data",
 "event_data": {
  "action": "select",
  "event_name": "select_component",
  "index": {
   "index_section_count": "2",
   "index_section": "1"
  },
  "section": "Organisation",
  "text": "HM Revenue & Customs (HMRC)",
  "type": "index-statistics_announcements"
 },
 "govuk_gem_version": "54.0.1",
 "timestamp": "1741859394068"
}
```


