### PR TITLE
(937) Remove object-level embed codes

### DIFF
--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/index/summary_card_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/index/summary_card_component.rb
@@ -14,7 +14,6 @@ private
       organisation_item,
       status_item,
       (instructions_item if content_block_document.latest_edition.instructions_to_publishers.present?),
-      embed_code_item,
     ].compact
   end
 
@@ -64,17 +63,6 @@ private
     {
       key: "Instructions to publishers",
       value: content_block_edition.instructions_to_publishers.presence || "None",
-    }
-  end
-
-  def embed_code_item
-    {
-      key: "Embed code",
-      value: content_block_document.embed_code,
-      data: {
-        module: "copy-embed-code",
-        "embed-code": content_block_document.embed_code,
-      },
     }
   end
 

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/summary_card_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/summary_card_component.rb
@@ -14,23 +14,11 @@ private
       organisation_item,
       instructions_item,
       status_item,
-      embed_code_item,
     ].compact
   end
 
   def title
     "#{content_block_document.block_type.humanize} details"
-  end
-
-  def embed_code_item
-    {
-      key: "Embed code",
-      value: content_block_document.embed_code,
-      data: {
-        module: "copy-embed-code",
-        "embed-code": content_block_document.embed_code,
-      },
-    }
   end
 
   def title_item

--- a/lib/engines/content_block_manager/features/search_for_object.feature
+++ b/lib/engines/content_block_manager/features/search_for_object.feature
@@ -80,14 +80,6 @@ Feature: Search for a content object
     And I click to view results
     Then I should see a message that the filter dates are invalid
 
-  @javascript
-  Scenario: GDS Editor can copy embed code
-    When I visit the Content Block Manager home page
-    And I select the lead organisation "Ministry of Example"
-    And I click to view results
-    And I click to copy the embed code for the content block "ministry address"
-    Then the embed code should be copied to my clipboard
-
   Scenario: GDS Editor can view more than one page
     When 1 content blocks of type email_address have been created with the fields:
       | title | page 2 edition |

--- a/lib/engines/content_block_manager/features/step_definitions/embed_code_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/embed_code_steps.rb
@@ -1,9 +1,3 @@
-When("I click to copy the embed code") do
-  find("a", text: "Copy code").click
-  has_text?("Code copied")
-  @embed_code = @content_block.document.embed_code
-end
-
 When("I click to copy the embed code for the content block {string}") do |content_block_name|
   within(".govuk-summary-card", text: content_block_name) do
     find("a", text: "Copy code").click

--- a/lib/engines/content_block_manager/features/view_object.feature
+++ b/lib/engines/content_block_manager/features/view_object.feature
@@ -38,14 +38,6 @@ Feature: View a content object
     And I should see the rollup data for the dependent content
 
   @javascript
-  Scenario: GDS Editor can copy embed code for whole block
-    When I visit the Content Block Manager home page
-    Then I should see the details for all documents
-    When I click to view the document
-    And I click to copy the embed code
-    Then the embed code should be copied to my clipboard
-
-  @javascript
   Scenario: GDS Editor can copy embed code for a specific field
     When I visit the Content Block Manager home page
     When I click to view the document with title "My pension"

--- a/lib/engines/content_block_manager/test/components/content_block/document/index/summary_card_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/document/index/summary_card_component_test.rb
@@ -30,7 +30,7 @@ class ContentBlockManager::ContentBlock::Document::Index::SummaryCardComponentTe
 
     assert_selector ".govuk-link", text: "View"
 
-    assert_selector ".govuk-summary-list__row", count: 6
+    assert_selector ".govuk-summary-list__row", count: 5
 
     assert_selector ".govuk-summary-list__key", text: "Title"
     assert_selector ".govuk-summary-list__value", text: content_block_edition.title
@@ -49,11 +49,6 @@ class ContentBlockManager::ContentBlock::Document::Index::SummaryCardComponentTe
 
     assert_selector ".govuk-summary-list__key", text: "Status"
     assert_selector ".govuk-summary-list__value", text: "Published 1 day ago by #{content_block_edition.creator.name}"
-
-    assert_selector ".govuk-summary-list__row[data-module='copy-embed-code']", text: "Embed code"
-    assert_selector ".govuk-summary-list__row[data-embed-code='#{content_block_document.embed_code}']", text: "Embed code"
-    assert_selector ".govuk-summary-list__key", text: "Embed code"
-    assert_selector ".govuk-summary-list__value", text: content_block_document.embed_code
   end
 
   describe "when there are instructions to publishers" do
@@ -62,7 +57,7 @@ class ContentBlockManager::ContentBlock::Document::Index::SummaryCardComponentTe
 
       render_inline(ContentBlockManager::ContentBlock::Document::Index::SummaryCardComponent.new(content_block_document:))
 
-      assert_selector ".govuk-summary-list__row", count: 7
+      assert_selector ".govuk-summary-list__row", count: 6
 
       assert_selector ".govuk-summary-list__key", text: "Instructions to publishers"
       assert_selector ".govuk-summary-list__value", text: "instructions"

--- a/lib/engines/content_block_manager/test/components/content_block/document/show/summary_card_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/document/show/summary_card_component_test.rb
@@ -22,7 +22,7 @@ class ContentBlockManager::ContentBlock::Document::Show::SummaryCardComponentTes
   it "renders a published content block correctly" do
     render_inline(ContentBlockManager::ContentBlock::Document::Show::SummaryCardComponent.new(content_block_document:))
 
-    assert_selector ".govuk-summary-list__row", count: 7
+    assert_selector ".govuk-summary-list__row", count: 6
 
     assert_selector ".govuk-summary-card__title", text: "Email address details"
 
@@ -43,11 +43,6 @@ class ContentBlockManager::ContentBlock::Document::Show::SummaryCardComponentTes
 
     assert_selector ".govuk-summary-list__key", text: "Instructions to publishers"
     assert_selector ".govuk-summary-list__value", text: "None"
-
-    assert_selector ".govuk-summary-list__row[data-module='copy-embed-code']", text: "Embed code"
-    assert_selector ".govuk-summary-list__row[data-embed-code='#{content_block_document.embed_code}']", text: "Embed code"
-    assert_selector ".govuk-summary-list__key", text: "Embed code"
-    assert_selector ".govuk-summary-list__value", text: content_block_document.embed_code
   end
 
   it "renders a scheduled content block correctly" do
@@ -55,7 +50,7 @@ class ContentBlockManager::ContentBlock::Document::Show::SummaryCardComponentTes
 
     render_inline(ContentBlockManager::ContentBlock::Document::Show::SummaryCardComponent.new(content_block_document:))
 
-    assert_selector ".govuk-summary-list__row", count: 7
+    assert_selector ".govuk-summary-list__row", count: 6
 
     assert_selector ".govuk-summary-list__key", text: "Status"
     assert_selector ".govuk-summary-list__value", text: "Scheduled for publication at #{I18n.l(content_block_edition.scheduled_publication, format: :long_ordinal)}"


### PR DESCRIPTION
Trello card: https://trello.com/c/yZE4QHzz/937-remove-embed-code-for-pension-object

We’re not using these at the moment, so could be confusing.