### PR TITLE
(941) Hide details if there is no change history

### DIFF
--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/document_timeline/timeline_item_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/document_timeline/timeline_item_component.html.erb
@@ -12,25 +12,13 @@
     <%= date %>
   </p>
 
-  <% if version.field_diffs.present? %>
+  <% if details_of_changes.present? %>
     <div class="timeline__diff-table">
       <%= render "govuk_publishing_components/components/details", {
         title: "Details of changes",
         open: is_latest,
       } do %>
-        <% capture do %>
-          <%= render ContentBlockManager::ContentBlock::Document::Show::DocumentTimeline::FieldChangesTableComponent.new(
-            version:,
-            schema:,
-            ) %>
-
-          <% embedded_object_diffs.each do |item| %>
-            <%= render ContentBlockManager::ContentBlock::Document::Show::DocumentTimeline::EmbeddedObject::FieldChangesTableComponent.new(
-              **item,
-              content_block_edition: version.item,
-              ) %>
-          <% end %>
-        <% end %>
+        <% details_of_changes %>
       <% end %>
     </div>
   <% end %>

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/document_timeline/timeline_item_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/document_timeline/timeline_item_component.rb
@@ -51,4 +51,31 @@ private
       end
     }.flatten
   end
+
+  def details_of_changes
+    @details_of_changes ||= begin
+      return "" if version.field_diffs.blank?
+
+      [
+        main_object_field_changes,
+        embedded_object_field_changes,
+      ].join.html_safe
+    end
+  end
+
+  def main_object_field_changes
+    render ContentBlockManager::ContentBlock::Document::Show::DocumentTimeline::FieldChangesTableComponent.new(
+      version:,
+      schema:,
+    )
+  end
+
+  def embedded_object_field_changes
+    embedded_object_diffs.map do |item|
+      render ContentBlockManager::ContentBlock::Document::Show::DocumentTimeline::EmbeddedObject::FieldChangesTableComponent.new(
+        **item,
+        content_block_edition: version.item,
+      )
+    end
+  end
 end

--- a/lib/engines/content_block_manager/test/factories/content_block_version.rb
+++ b/lib/engines/content_block_manager/test/factories/content_block_version.rb
@@ -2,15 +2,15 @@ FactoryBot.define do
   factory :content_block_version, class: "ContentBlockManager::ContentBlock::Version" do
     event { "created" }
     item do
-      create(
+      build(
         :content_block_edition,
-        document: create(
+        document: build(
           :content_block_document,
           block_type: "email_address",
         ),
       )
     end
-    whodunnit { create(:user).id }
+    whodunnit { build(:user).id }
     state {}
   end
 end


### PR DESCRIPTION
https://trello.com/c/REP99FWH/941-empty-details-of-changes-in-change-history

Sometimes change history can be present, but doesn’t have items within it. To get around this, we move the logic to the component and only render the details if there are any details rendered.

Additionally, I’ve changed the version factory to build, rather than create so we don’t have to create versions in the database unnecessarily