### PR TITLE
content modelling/942 change cadence to frequency

### DIFF
--- a/lib/engines/content_block_manager/app/models/content_block_manager/content_block/schema.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/content_block/schema.rb
@@ -81,7 +81,7 @@ module ContentBlockManager
         end
 
         def fields
-          @body["properties"].keys.sort_by { |field| @body["order"]&.index(field) }
+          @body["properties"].keys.sort_by { |field| @body["order"]&.index(field) }.sort_by { |field| config["field_order"]&.index(field) }
         end
 
         def block_type

--- a/lib/engines/content_block_manager/config/content_block_manager.yml
+++ b/lib/engines/content_block_manager/config/content_block_manager.yml
@@ -4,3 +4,8 @@ schemas:
       rates:
         embeddable_fields:
           - amount
+        field_order:
+          - name
+          - amount
+          - frequency
+          - description

--- a/lib/engines/content_block_manager/features/create_embedded_object.feature
+++ b/lib/engines/content_block_manager/features/create_embedded_object.feature
@@ -10,7 +10,7 @@ Feature: Create an embedded content object
       | field     | type   | format | required | enum           | pattern          |
       | name      | string | string | true     |                |                  |
       | amount    | string | string | true     |                | £[0-9]+\\.[0-9]+ |
-      | cadence   | string | string |          | a week,a month |                  |
+      | frequency | string | string |          | a week,a month |                  |
     And a pension content block has been created
 
   Scenario: GDS editor creates a rate
@@ -19,8 +19,8 @@ Feature: Create an embedded content object
     And I click to add a new "rate"
     Then I should see a form to create a "rate" for the content block
     When I complete the "rate" form with the following fields:
-      | name    | amount  | cadence |
-      | my rate | £122.50 | a week  |
+      | name    | amount  | frequency |
+      | my rate | £122.50 | a week    |
     Then I should be asked to review my "rate"
     And I click create
     Then I should see a message that I need to confirm the details are correct
@@ -37,20 +37,20 @@ Feature: Create an embedded content object
   Scenario: GDS editor sees validation errors for an invalid field
     When I visit the page to create a new "rate" for the block
     When I complete the "rate" form with the following fields:
-      | name    | amount        | cadence |
-      | my rate | NOT AN AMOUNT | a week  |
+      | name    | amount        | frequency |
+      | my rate | NOT AN AMOUNT | a week    |
     Then I should see an error for an invalid "amount"
 
   Scenario: GDS editor creates and edits a rate
     When I visit the page to create a new "rate" for the block
     Then I should see a form to create a "rate" for the content block
     When I complete the "rate" form with the following fields:
-      | name    | amount  | cadence |
-      | my rate | £122.50 | a week  |
+      | name    | amount  | frequency |
+      | my rate | £122.50 | a week    |
     When I click edit
     And I complete the "rate" form with the following fields:
-      | name          | amount  | cadence  |
-      | my other rate | £132.50 | a month  |
+      | name          | amount  | frequency |
+      | my other rate | £132.50 | a month   |
     Then I should be asked to review my "rate"
     When I review and confirm my "rate" is correct
     Then the "rate" should have been created successfully

--- a/lib/engines/content_block_manager/features/create_pension_object.feature
+++ b/lib/engines/content_block_manager/features/create_pension_object.feature
@@ -10,7 +10,7 @@ Feature: Create a content object
       | field     | type   | format | required | enum           | pattern          |
       | name      | string | string | true     |                |                  |
       | amount    | string | string | true     |                | £[0-9]+\\.[0-9]+ |
-      | cadence   | string | string |          | a week,a month |                  |
+      | frequency  | string | string |          | a week,a month |                  |
 
   Scenario: GDS editor creates a Pension without a rate
     When I visit the Content Block Manager home page
@@ -39,7 +39,7 @@ Feature: Create a content object
       | my basic pension | this is basic | Ministry of Example | this is important  |
     When I click to add a new "rate"
     And I complete the "rate" form with the following fields:
-      | name     | amount  | cadence  |
+      | name     | amount  | frequency |
       | New rate | £127.91 | a month  |
     Then I should be on the "embedded_rates" step
     When I save and continue

--- a/lib/engines/content_block_manager/features/edit_pension_object.feature
+++ b/lib/engines/content_block_manager/features/edit_pension_object.feature
@@ -10,11 +10,11 @@ Feature: Edit a pension object
       | field     | type   | format | required | enum           | pattern          |
       | name      | string | string | true     |                |                  |
       | amount    | string | string | true     |                | £[0-9]+\\.[0-9]+ |
-      | cadence   | string | string |          | a week,a month |                  |
+      | frequency | string | string |          | a week,a month |                  |
     And a pension content block has been created
     And that pension has a rate with the following fields:
-      | name    | amount  | cadence |
-      | My rate | £123.45 | a week  |
+      | name    | amount  | frequency |
+      | My rate | £123.45 | a week    |
 
   Scenario: GDS Editor edits a pension object
     When I visit the Content Block Manager home page
@@ -62,8 +62,8 @@ Feature: Edit a pension object
     When I fill out the form
     And I click to add a new "rate"
     And I complete the "rate" form with the following fields:
-      | name     | amount  | cadence  |
-      | New rate | £127.91 | a month  |
+      | name     | amount  | frequency |
+      | New rate | £127.91 | a month   |
     Then I should be on the "embedded_rates" step
     And I should see the updated rates for that block
     When I save and continue

--- a/lib/engines/content_block_manager/features/step_definitions/embedded_object_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/embedded_object_steps.rb
@@ -84,7 +84,7 @@ And(/^that pension has a rate with the following fields:$/) do |table|
     rate[:name].parameterize.to_s => {
       "name" => rate[:name],
       "amount" => rate[:amount],
-      "cadence" => rate[:cadence],
+      "frequency" => rate[:frequency],
     },
   }
   @content_block.save!

--- a/lib/engines/content_block_manager/features/view_object.feature
+++ b/lib/engines/content_block_manager/features/view_object.feature
@@ -9,11 +9,11 @@ Feature: View a content object
       | field     | type   | format | required | enum           | pattern          |
       | name      | string | string | true     |                |                  |
       | amount    | string | string | true     |                | £[0-9]+\\.[0-9]+ |
-      | cadence   | string | string |          | a week,a month |                  |
+      | frequency | string | string |          | a week,a month |                  |
     And a pension content block has been created
     And that pension has a rate with the following fields:
-      | name    | amount  | cadence |
-      | My rate | £123.45 | a week  |
+      | name    | amount  | frequency |
+      | My rate | £123.45 | a week    |
     And a schema "email_address" exists with the following fields:
       | email_address |
     And an email address content block has been created

--- a/lib/engines/content_block_manager/lib/tasks/update_rates_cadence_to_frequency.rake
+++ b/lib/engines/content_block_manager/lib/tasks/update_rates_cadence_to_frequency.rake
@@ -1,0 +1,17 @@
+namespace :content_block_manager do
+  desc "Change Rate key cadence to frequency"
+  task change_rates_cadence: :environment do
+    ContentBlockManager::ContentBlock::Document.where(block_type: "pension").find_each do |document|
+      document.editions.each do |edition|
+        edition.details["rates"]&.each do |key, value|
+          next if value["cadence"].blank?
+
+          puts "updating #{key} on #{edition.title}"
+          edition.details["rates"][key]["frequency"] = value["cadence"]
+          edition.details["rates"][key].delete("cadence")
+        end
+        edition.save!
+      end
+    end
+  end
+end

--- a/lib/engines/content_block_manager/test/components/content_block/edition/host_content/preview_details_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/host_content/preview_details_component_test.rb
@@ -25,9 +25,9 @@ class ContentBlockManager::ContentBlockEdition::HostContent::PreviewDetailsCompo
         "description": "Basic state pension",
         "rates": {
           "rate1":
-            { "name": "rate1", "amount": "£100.5", "cadence": "a week", "description": "" },
+            { "name": "rate1", "amount": "£100.5", "frequency": "a week", "description": "" },
           "rate2":
-              { "name": "rate2", "amount": "£11.1", "cadence": "a month", "description": "1111" },
+              { "name": "rate2", "amount": "£11.1", "frequency": "a month", "description": "1111" },
         },
       })
     end

--- a/lib/engines/content_block_manager/test/unit/app/models/content_block_schema_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/models/content_block_schema_test.rb
@@ -106,6 +106,59 @@ class ContentBlockManager::SchemaTest < ActiveSupport::TestCase
         end
       end
 
+      describe "when an order is given in the config" do
+        let(:body) do
+          {
+            "properties" => {
+              "rate" => {
+                "type" => "object",
+                "patternProperties" => {
+                  "*" => {
+                    "type" => "object",
+                    "properties" => {
+                      "name" => {
+                        "type" => "string",
+                      },
+                      "amount" => {
+                        "type" => "string",
+                      },
+                      "description" => {
+                        "type" => "string",
+                      },
+                      "frequency" => {
+                        "type" => "string",
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          }
+        end
+
+        before do
+          ContentBlockManager::ContentBlock::Schema
+            .stubs(:schema_settings)
+            .returns({
+              "schemas" => {
+                schema.id => {
+                  "subschemas" => {
+                    "rate" => {
+                      "field_order" => %w[name amount frequency description],
+                    },
+                  },
+                },
+              },
+            })
+        end
+
+        it "orders fields when an order is given" do
+          subschema = schema.subschema("rate")
+
+          assert_equal subschema.fields, %w[name amount frequency description]
+        end
+      end
+
       describe "when an invalid subschema is given" do
         let(:body) do
           {

--- a/lib/engines/content_block_manager/test/unit/lib/tasks/update_rates_cadence_to_frequency_test.rb
+++ b/lib/engines/content_block_manager/test/unit/lib/tasks/update_rates_cadence_to_frequency_test.rb
@@ -1,0 +1,64 @@
+require "test_helper"
+require "rake"
+
+class UpdateRatesCadenceToFrequencyTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
+  teardown do
+    Rake::Task["content_block_manager:change_rates_cadence"].reenable
+  end
+
+  let(:schema) { build(:content_block_schema, block_type: "content_block_pension", body: {}) }
+
+  before do
+    ContentBlockManager::ContentBlock::Schema.expects(:find_by_block_type).returns(schema).at_least_once
+  end
+
+  it "updates the rate cadences" do
+    document = create(:content_block_document, :pension)
+
+    edition_1 = create(:content_block_edition, document:, title: "Edition 1", details: {
+      "description": "Edition 1",
+      "rates": {
+        "rate1":
+          { "name": "rate1", "amount": "£100.5", "cadence": "a week", "description": "" },
+      },
+    })
+
+    edition_2 = create(:content_block_edition, document:, title: "Edition 4", details: {
+      "description": "Edition 4",
+      "rates": {
+        "rate1":
+          { "name": "rate1", "amount": "£100.5", "cadence": "a week", "description": "" },
+        "rate2":
+          { "name": "rate2", "amount": "£100.5", "cadence": "a month", "description": "" },
+      },
+    })
+
+    document_2 = create(:content_block_document, :pension)
+
+    _edition_3 = create(:content_block_edition, document: document_2, title: "Edition 3", details: {
+      "description": "Edition 3",
+    })
+
+    edition_4 = create(:content_block_edition, document: document_2, title: "Edition 4", details: {
+      "description": "Edition 4",
+      "rates": {
+        "rate1":
+          { "name": "rate1", "amount": "£100.5", "frequency": "a week", "description": "" },
+      },
+    })
+
+    Rake.application.invoke_task("content_block_manager:change_rates_cadence")
+
+    assert_equal "a week", edition_1.reload.details.dig("rates", "rate1", "frequency")
+    assert_nil edition_1.reload.details.dig("rates", "rate1", "cadence")
+
+    assert_equal "a week", edition_2.reload.details.dig("rates", "rate1", "frequency")
+    assert_equal "a month", edition_2.reload.details.dig("rates", "rate2", "frequency")
+    assert_nil edition_2.reload.details.dig("rates", "rate1", "cadence")
+    assert_nil edition_2.reload.details.dig("rates", "rate2", "cadence")
+
+    assert_equal "a week", edition_4.reload.details.dig("rates", "rate1", "frequency")
+  end
+end


### PR DESCRIPTION
https://trello.com/c/kthgiJOk/942-change-cadence-to-frequency-on-rate

This makes updates needed by the schema change here: https://github.com/alphagov/publishing-api/pull/3164

Now includes ordering of fields based on UI requirements


![Screenshot 2025-02-26 at 17 29 15](https://github.com/user-attachments/assets/b4fd991b-d371-4258-a9a7-7c8c82405cbc)



- **add rake task to change rate key**
- **update test schemas to reflect new frequency key on rates**
- **re order fields from config**

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
