### PR TITLE
Add GA4 index to attachment component renders

### DIFF
--- a/app/helpers/attachments_helper.rb
+++ b/app/helpers/attachments_helper.rb
@@ -60,14 +60,15 @@ module AttachmentsHelper
   end
 
   def block_attachments(attachments = [], alternative_format_contact_email = nil)
-    attachments
-      .select { |attachment| !attachment.file? || attachment.attachment_data.all_asset_variants_uploaded? }
-      .map do |attachment|
+    filtered_attachments = attachments.select { |attachment| !attachment.file? || attachment.attachment_data.all_asset_variants_uploaded? }
+    filtered_attachments_size = filtered_attachments.size
+    filtered_attachments.each_with_index.map do |attachment, index|
       render(
         partial: "govuk_publishing_components/components/attachment",
         locals: {
           attachment: attachment_component_params(attachment, alternative_format_contact_email:),
           margin_bottom: 6,
+          details_ga4_attributes: { index_section: index + 1, index_section_count: filtered_attachments_size },
         },
       )
     end

--- a/test/unit/app/helpers/attachments_helper_test.rb
+++ b/test/unit/app/helpers/attachments_helper_test.rb
@@ -41,6 +41,25 @@ class AttachmentsHelperTest < ActionView::TestCase
     end
   end
 
+  test "block_attachments renders with GA4 indexes on the nested details component" do
+    alternative_format_contact_email = "test@example.com"
+    file_attachment_with_all_assets = create(:file_attachment)
+    attachments = [
+      file_attachment_with_all_assets,
+      file_attachment_with_all_assets,
+      file_attachment_with_all_assets,
+    ]
+
+    rendered_attachments = block_attachments(attachments, alternative_format_contact_email)
+    rendered_attachments.each.with_index do |rendered, index|
+      assert_select_within_html(rendered, ".gem-c-details") do |details|
+        ga4_event = JSON.parse(details.attribute("data-ga4-event"))
+        assert_equal ga4_event["index_section"], index + 1
+        assert_equal ga4_event["index_section_count"], 3
+      end
+    end
+  end
+
   test "component params for HTML attachment" do
     attachment = create(:html_attachment)
     expect_params = {


### PR DESCRIPTION
## What / Why
- Refactors how attachment HTML is generated so that the total amount of attachments and the index of the current attachment can be grabbed
- This is then passed through to the rendering of the `govuk_publishing_components` `attachment` component
- The `attachment` component then uses these values so set some GA4 tracking data on the `details` component it renders within it
- We need this to improve the GA4 tracking for `whitehall` attachments. Currently, every attachment that can have an accessible format has the same link text for the `Request an accessible format` link ([example here.](https://www.gov.uk/guidance/prove-your-english-language-abilities-with-a-secure-english-language-test-selt)) Therefore, performance analysts can't tell which one is being clicked on when an attachment is rendered via `whitehall`. If we add the index of the attachment and the total number of attachments to the GA4 data, then the performance analysts can use this to tell which `Request an accessible format` link is being clicked on.
    -  (Ideally we'd also be passing the attachment's title when tracking these link clicks, as that's much clearer than using indexes, but the performance analysts are still discussing the best way to handle that data on their side. Therefore we're using the indexes for now.)
- Trello card: https://trello.com/c/2nhQfMwl/848-fix-details-missing-indexsectioncount-across-various-formats
