### PR TITLE
content modelling/949 change name to title

### DIFF
--- a/db/migrate/20250228111735_change_object_name_column_to_object_title.rb
+++ b/db/migrate/20250228111735_change_object_name_column_to_object_title.rb
@@ -1,0 +1,9 @@
+class ChangeObjectNameColumnToObjectTitle < ActiveRecord::Migration[8.0]
+  def up
+    rename_column :content_block_versions, :updated_embedded_object_name, :updated_embedded_object_title
+  end
+
+  def down
+    rename_column :content_block_versions, :updated_embedded_object_title, :updated_embedded_object_name
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_26_161012) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_28_111735) do
   create_table "assets", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.string "variant", null: false
@@ -249,7 +249,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_26_161012) do
     t.text "state"
     t.json "field_diffs"
     t.string "updated_embedded_object_type"
-    t.string "updated_embedded_object_name"
+    t.string "updated_embedded_object_title"
     t.index ["item_id"], name: "index_content_block_versions_on_item_id"
     t.index ["item_type"], name: "index_content_block_versions_on_item_type"
   end

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/document_timeline/embedded_object/field_changes_table_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/document_timeline/embedded_object/field_changes_table_component.rb
@@ -21,6 +21,6 @@ private
   end
 
   def caption
-    content_block_edition.details.dig(subschema_id, object_id, "name") || object_id.underscore.humanize
+    content_block_edition.details.dig(subschema_id, object_id, "title") || object_id.underscore.humanize
   end
 end

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/document_timeline/timeline_item_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/document_timeline/timeline_item_component.rb
@@ -29,7 +29,7 @@ private
   end
 
   def new_subschema_item_details
-    version.field_diffs.dig("details", updated_subschema_id, version.updated_embedded_object_name).map do |field_name, diff|
+    version.field_diffs.dig("details", updated_subschema_id, version.updated_embedded_object_title).map do |field_name, diff|
       [field_name.humanize, diff.new_value]
     end
   end

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/embedded_objects/summary_card_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/embedded_objects/summary_card_component.rb
@@ -1,13 +1,13 @@
 class ContentBlockManager::ContentBlock::Document::Show::EmbeddedObjects::SummaryCardComponent < ViewComponent::Base
-  def initialize(content_block_edition:, object_type:, object_name:)
+  def initialize(content_block_edition:, object_type:, object_title:)
     @content_block_edition = content_block_edition
     @object_type = object_type
-    @object_name = object_name
+    @object_title = object_title
   end
 
 private
 
-  attr_reader :content_block_edition, :object_type, :object_name
+  attr_reader :content_block_edition, :object_type, :object_title
 
   def title
     "#{object_type.titleize.singularize} details"
@@ -23,6 +23,6 @@ private
   end
 
   def object
-    content_block_edition.details.dig(object_type, object_name)
+    content_block_edition.details.dig(object_type, object_title)
   end
 end

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/embedded_objects/summary_cards_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/embedded_objects/summary_cards_component.html.erb
@@ -2,6 +2,6 @@
   <%= render ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponent.new(
     content_block_edition:,
     object_type:,
-    object_name: key,
+    object_title: key,
   ) %>
 <% end %>

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/embedded_objects/form_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/embedded_objects/form_component.rb
@@ -1,21 +1,21 @@
 class ContentBlockManager::ContentBlockEdition::Details::EmbeddedObjects::FormComponent < ContentBlockManager::ContentBlockEdition::Details::FormComponent
-  def initialize(content_block_edition:, schema:, object_name:, params:)
+  def initialize(content_block_edition:, schema:, object_title:, params:)
     @content_block_edition = content_block_edition
     @schema = schema
-    @object_name = object_name
+    @object_title = object_title
     @params = params || {}
   end
 
 private
 
-  attr_reader :content_block_edition, :schema, :object_name, :params
+  attr_reader :content_block_edition, :schema, :object_title, :params
 
   def component_args(field)
     {
       content_block_edition:,
       label: field.humanize,
-      field: [object_name, field],
-      id_suffix: "#{object_name}_#{field}",
+      field: [object_title, field],
+      id_suffix: "#{object_title}_#{field}",
       value: params[field],
     }
   end

--- a/lib/engines/content_block_manager/app/components/content_block_manager/shared/embedded_objects/summary_card_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/shared/embedded_objects/summary_card_component.rb
@@ -1,15 +1,15 @@
 class ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponent < ViewComponent::Base
-  def initialize(content_block_edition:, object_type:, object_name:, is_editable: false, redirect_url: nil)
+  def initialize(content_block_edition:, object_type:, object_title:, is_editable: false, redirect_url: nil)
     @content_block_edition = content_block_edition
     @object_type = object_type
-    @object_name = object_name
+    @object_title = object_title
     @is_editable = is_editable
     @redirect_url = redirect_url
   end
 
 private
 
-  attr_reader :content_block_edition, :object_type, :object_name, :is_editable, :redirect_url
+  attr_reader :content_block_edition, :object_type, :object_title, :is_editable, :redirect_url
 
   def title
     "#{object_type.titleize.singularize} details"
@@ -34,7 +34,7 @@ private
   def embed_code_row(key)
     {
       key: "Embed code",
-      value: content_block_edition.document.embed_code_for_field("#{object_type}/#{object_name}/#{key}"),
+      value: content_block_edition.document.embed_code_for_field("#{object_type}/#{object_title}/#{key}"),
       data: {
         "embed-code-row": "true",
       },
@@ -53,13 +53,13 @@ private
     unless is_editable
       {
         module: "copy-embed-code",
-        "embed-code": content_block_edition.document.embed_code_for_field("#{object_type}/#{object_name}/#{key}"),
+        "embed-code": content_block_edition.document.embed_code_for_field("#{object_type}/#{object_title}/#{key}"),
       }
     end
   end
 
   def object
-    content_block_edition.details.dig(object_type, object_name)
+    content_block_edition.details.dig(object_type, object_title)
   end
 
   def summary_card_actions
@@ -70,7 +70,7 @@ private
           href: helpers.content_block_manager.edit_embedded_object_content_block_manager_content_block_edition_path(
             content_block_edition,
             object_type:,
-            object_name:,
+            object_title:,
             redirect_url:,
           ),
         },

--- a/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/documents/embedded_objects_controller.rb
+++ b/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/documents/embedded_objects_controller.rb
@@ -16,7 +16,7 @@ class ContentBlockManager::ContentBlock::Documents::EmbeddedObjectsController < 
     redirect_to content_block_manager.review_embedded_object_content_block_manager_content_block_edition_path(
       @content_block_edition,
       object_type: @subschema.block_type,
-      object_name: @content_block_edition.key_for_object(@params),
+      object_title: @content_block_edition.key_for_object(@params),
     )
   rescue ActiveRecord::RecordInvalid
     render :new

--- a/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/editions/embedded_objects_controller.rb
+++ b/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/editions/embedded_objects_controller.rb
@@ -19,15 +19,15 @@ class ContentBlockManager::ContentBlock::Editions::EmbeddedObjectsController < C
 
   def edit
     @redirect_url = params[:redirect_url]
-    @object_name = params[:object_name]
-    @object = @content_block_edition.details.dig(params[:object_type], params[:object_name])
+    @object_title = params[:object_title]
+    @object = @content_block_edition.details.dig(params[:object_type], params[:object_title])
 
     render "admin/errors/not_found", status: :not_found unless @object
   end
 
   def update
     @object = object_params(@subschema).dig(:details, @subschema.block_type)
-    @content_block_edition.update_object_with_details(params[:object_type], params[:object_name], @object)
+    @content_block_edition.update_object_with_details(params[:object_type], params[:object_title], @object)
     @content_block_edition.save!
 
     if params[:redirect_url].present?
@@ -37,17 +37,17 @@ class ContentBlockManager::ContentBlock::Editions::EmbeddedObjectsController < C
       redirect_to content_block_manager.review_embedded_object_content_block_manager_content_block_edition_path(
         @content_block_edition,
         object_type: @subschema.block_type,
-        object_name: params[:object_name],
+        object_title: params[:object_title],
       )
     end
   rescue ActiveRecord::RecordInvalid
     @redirect_url = params[:redirect_url]
-    @object_name = params[:object_name]
+    @object_title = params[:object_title]
     render :edit
   end
 
   def review
-    @object_name = params[:object_name]
+    @object_title = params[:object_title]
   end
 
   def publish
@@ -56,11 +56,11 @@ class ContentBlockManager::ContentBlock::Editions::EmbeddedObjectsController < C
       redirect_path = content_block_manager.review_embedded_object_content_block_manager_content_block_edition_path(
         @content_block_edition,
         object_type: @subschema.block_type,
-        object_name: params[:object_name],
+        object_title: params[:object_title],
       )
     else
       @content_block_edition.updated_embedded_object_type = @subschema.block_type
-      @content_block_edition.updated_embedded_object_name = params[:object_name]
+      @content_block_edition.updated_embedded_object_name = params[:object_title]
       ContentBlockManager::PublishEditionService.new.call(@content_block_edition)
       flash[:notice] = "#{@subschema.name.singularize} created"
       redirect_path = content_block_manager.content_block_manager_content_block_document_path(@content_block_edition.document)

--- a/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/editions/embedded_objects_controller.rb
+++ b/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/editions/embedded_objects_controller.rb
@@ -60,7 +60,7 @@ class ContentBlockManager::ContentBlock::Editions::EmbeddedObjectsController < C
       )
     else
       @content_block_edition.updated_embedded_object_type = @subschema.block_type
-      @content_block_edition.updated_embedded_object_name = params[:object_title]
+      @content_block_edition.updated_embedded_object_title = params[:object_title]
       ContentBlockManager::PublishEditionService.new.call(@content_block_edition)
       flash[:notice] = "#{@subschema.name.singularize} created"
       redirect_path = content_block_manager.content_block_manager_content_block_document_path(@content_block_edition.document)

--- a/lib/engines/content_block_manager/app/models/content_block_manager/content_block/edition.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/content_block/edition.rb
@@ -55,12 +55,12 @@ module ContentBlockManager
         details[object_type][key] = body.to_h
       end
 
-      def update_object_with_details(object_type, object_name, body)
-        details[object_type][object_name] = body.to_h
+      def update_object_with_details(object_type, object_title, body)
+        details[object_type][object_title] = body.to_h
       end
 
       def key_for_object(object)
-        object["name"]&.parameterize.presence || SecureRandom.alphanumeric.downcase
+        object["title"]&.parameterize.presence || SecureRandom.alphanumeric.downcase
       end
 
       def has_entries_for_subschema_id?(subschema_id)

--- a/lib/engines/content_block_manager/app/models/content_block_manager/content_block/edition/has_audit_trail.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/content_block/edition/has_audit_trail.rb
@@ -19,7 +19,7 @@ module ContentBlockManager
       after_update :record_update
     end
 
-    attr_accessor :updated_embedded_object_type, :updated_embedded_object_name
+    attr_accessor :updated_embedded_object_type, :updated_embedded_object_title
 
   private
 
@@ -37,7 +37,7 @@ module ContentBlockManager
           user:, state:,
           field_diffs: generate_diff,
           updated_embedded_object_type:,
-          updated_embedded_object_name:
+          updated_embedded_object_title:
         )
       end
     end

--- a/lib/engines/content_block_manager/app/models/content_block_manager/content_block/version.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/content_block/version.rb
@@ -12,7 +12,7 @@ module ContentBlockManager
       end
 
       def is_embedded_update?
-        updated_embedded_object_type && updated_embedded_object_name
+        updated_embedded_object_type && updated_embedded_object_title
       end
     end
   end

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/documents/embedded_objects/new.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/documents/embedded_objects/new.html.erb
@@ -18,7 +18,7 @@
     render ContentBlockManager::ContentBlockEdition::Details::EmbeddedObjects::FormComponent.new(
       content_block_edition: @content_block_edition,
       schema: @subschema,
-      object_name: @subschema.block_type,
+      object_title: @subschema.block_type,
       params: @params,
     )
   %>

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/embedded_objects/edit.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/embedded_objects/edit.html.erb
@@ -7,7 +7,7 @@
     url: content_block_manager.embedded_object_content_block_manager_content_block_edition_path(
       @content_block_edition,
       object_type: @subschema.block_type,
-      object_name: @object_name,
+      object_title: @object_title,
     ), method: :put) do |form| %>
   <%= form.hidden_field :redirect_url, value: @redirect_url %>
   <%= render partial: "content_block_manager/content_block/editions/embedded_objects/shared/form", locals: { form: } %>

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/embedded_objects/review.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/embedded_objects/review.html.erb
@@ -6,7 +6,7 @@
     href: content_block_manager.edit_embedded_object_content_block_manager_content_block_edition_path(
       @content_block_edition,
       object_type: @subschema.block_type,
-      object_name: @object_name,
+      object_title: @object_title,
     ),
   } %>
 <% end %>
@@ -23,7 +23,7 @@
     <%= render ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponent.new(
       content_block_edition: @content_block_edition,
       object_type: @subschema.block_type,
-      object_name: @object_name,
+      object_title: @object_title,
       is_editable: true,
     ) %>
   </div>
@@ -35,7 +35,7 @@
           url: content_block_manager.publish_embedded_object_content_block_manager_content_block_edition_path(
             @content_block_edition,
             object_type: @subschema.block_type,
-            object_name: @object_name,
+            object_title: @object_title,
           ),
           id: "review",
           method: :post,

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/embedded_objects/shared/_form.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/embedded_objects/shared/_form.html.erb
@@ -4,7 +4,7 @@
   render ContentBlockManager::ContentBlockEdition::Details::EmbeddedObjects::FormComponent.new(
     content_block_edition: @content_block_edition,
     schema: @subschema,
-    object_name: @subschema.block_type,
+    object_title: @subschema.block_type,
     params: @object,
   )
 %>

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/embedded_objects.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/embedded_objects.html.erb
@@ -20,7 +20,7 @@
             <%= render ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponent.new(
               content_block_edition: @content_block_edition,
               object_type: @subschema.block_type,
-              object_name: k,
+              object_title: k,
               is_editable: true,
               redirect_url: request.fullpath,
               ) %>

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/review.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/review.html.erb
@@ -28,7 +28,7 @@
           <%= render ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponent.new(
             content_block_edition: @content_block_edition,
             object_type: subschema.id,
-            object_name: k,
+            object_title: k,
             is_editable: true,
             redirect_url: content_block_manager.content_block_manager_content_block_workflow_path(@content_block_edition, step: "#{Workflow::Step::SUBSCHEMA_PREFIX}#{subschema.id}"),
             ) %>

--- a/lib/engines/content_block_manager/config/content_block_manager.yml
+++ b/lib/engines/content_block_manager/config/content_block_manager.yml
@@ -5,7 +5,7 @@ schemas:
         embeddable_fields:
           - amount
         field_order:
-          - name
+          - title
           - amount
           - frequency
           - description

--- a/lib/engines/content_block_manager/config/routes.rb
+++ b/lib/engines/content_block_manager/config/routes.rb
@@ -25,10 +25,10 @@ ContentBlockManager::Engine.routes.draw do
           end
           get "embedded-objects/:object_type/new", to: "editions/embedded_objects#new", as: :new_embedded_object
           post "embedded-objects/:object_type", to: "editions/embedded_objects#create", as: :create_embedded_object
-          get "embedded-objects/:object_type/:object_name/edit", to: "editions/embedded_objects#edit", as: :edit_embedded_object
-          put "embedded-objects/:object_type/:object_name", to: "editions/embedded_objects#update", as: :embedded_object
-          get "embedded-objects/:object_type/:object_name/review", to: "editions/embedded_objects#review", as: :review_embedded_object
-          post "embedded-objects/:object_type/:object_name/publish", to: "editions/embedded_objects#publish", as: :publish_embedded_object
+          get "embedded-objects/:object_type/:object_title/edit", to: "editions/embedded_objects#edit", as: :edit_embedded_object
+          put "embedded-objects/:object_type/:object_title", to: "editions/embedded_objects#update", as: :embedded_object
+          get "embedded-objects/:object_type/:object_title/review", to: "editions/embedded_objects#review", as: :review_embedded_object
+          post "embedded-objects/:object_type/:object_title/publish", to: "editions/embedded_objects#publish", as: :publish_embedded_object
           get :preview, to: "editions/host_content#preview", path: "host-content/:host_content_id/preview", as: :host_content_preview
         end
       end

--- a/lib/engines/content_block_manager/features/create_embedded_object.feature
+++ b/lib/engines/content_block_manager/features/create_embedded_object.feature
@@ -8,7 +8,7 @@ Feature: Create an embedded content object
       | description   | string | string | true     |
     And the schema "pension" has a subschema with the name "rates" and the following fields:
       | field     | type   | format | required | enum           | pattern          |
-      | name      | string | string | true     |                |                  |
+      | title     | string | string | true     |                |                  |
       | amount    | string | string | true     |                | £[0-9]+\\.[0-9]+ |
       | frequency | string | string |          | a week,a month |                  |
     And a pension content block has been created
@@ -19,7 +19,7 @@ Feature: Create an embedded content object
     And I click to add a new "rate"
     Then I should see a form to create a "rate" for the content block
     When I complete the "rate" form with the following fields:
-      | name    | amount  | frequency |
+      | title   | amount  | frequency |
       | my rate | £122.50 | a week    |
     Then I should be asked to review my "rate"
     And I click create
@@ -37,7 +37,7 @@ Feature: Create an embedded content object
   Scenario: GDS editor sees validation errors for an invalid field
     When I visit the page to create a new "rate" for the block
     When I complete the "rate" form with the following fields:
-      | name    | amount        | frequency |
+      | title   | amount        | frequency |
       | my rate | NOT AN AMOUNT | a week    |
     Then I should see an error for an invalid "amount"
 
@@ -45,11 +45,11 @@ Feature: Create an embedded content object
     When I visit the page to create a new "rate" for the block
     Then I should see a form to create a "rate" for the content block
     When I complete the "rate" form with the following fields:
-      | name    | amount  | frequency |
+      | title   | amount  | frequency |
       | my rate | £122.50 | a week    |
     When I click edit
     And I complete the "rate" form with the following fields:
-      | name          | amount  | frequency |
+      | title         | amount  | frequency |
       | my other rate | £132.50 | a month   |
     Then I should be asked to review my "rate"
     When I review and confirm my "rate" is correct

--- a/lib/engines/content_block_manager/features/create_pension_object.feature
+++ b/lib/engines/content_block_manager/features/create_pension_object.feature
@@ -8,7 +8,7 @@ Feature: Create a content object
       | description   | string | string | true     |
     And the schema "pension" has a subschema with the name "rates" and the following fields:
       | field     | type   | format | required | enum           | pattern          |
-      | name      | string | string | true     |                |                  |
+      | title     | string | string | true     |                |                  |
       | amount    | string | string | true     |                | £[0-9]+\\.[0-9]+ |
       | frequency  | string | string |          | a week,a month |                  |
 
@@ -39,7 +39,7 @@ Feature: Create a content object
       | my basic pension | this is basic | Ministry of Example | this is important  |
     When I click to add a new "rate"
     And I complete the "rate" form with the following fields:
-      | name     | amount  | frequency |
+      | title    | amount  | frequency |
       | New rate | £127.91 | a month  |
     Then I should be on the "add_embedded_rates" step
     When I save and continue

--- a/lib/engines/content_block_manager/features/edit_pension_object.feature
+++ b/lib/engines/content_block_manager/features/edit_pension_object.feature
@@ -8,12 +8,12 @@ Feature: Edit a pension object
       | description   | string | string | true     |
     And the schema "pension" has a subschema with the name "rates" and the following fields:
       | field     | type   | format | required | enum           | pattern          |
-      | name      | string | string | true     |                |                  |
+      | title     | string | string | true     |                |                  |
       | amount    | string | string | true     |                | £[0-9]+\\.[0-9]+ |
       | frequency | string | string |          | a week,a month |                  |
     And a pension content block has been created
     And that pension has a rate with the following fields:
-      | name    | amount  | frequency |
+      | title   | amount  | frequency |
       | My rate | £123.45 | a week    |
 
   Scenario: GDS Editor edits a pension object
@@ -28,7 +28,7 @@ Feature: Edit a pension object
     And I should not see a button to add a new "rate"
     When I click to edit the first rate
     When I complete the "rate" form with the following fields:
-      | name    | amount  | frequency |
+      | title   | amount  | frequency |
       | My rate | £122.50 | a week    |
     Then I should be on the "edit_embedded_rates" step
     And I should see the updated rates for that block

--- a/lib/engines/content_block_manager/features/step_definitions/embedded_object_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/embedded_object_steps.rb
@@ -46,7 +46,7 @@ Then("the {string} should have been created successfully") do |object_type|
 
   version = edition.versions.order("created_at asc").first
   assert_equal version.updated_embedded_object_type, object_type.pluralize
-  assert_equal version.updated_embedded_object_name, @object_title
+  assert_equal version.updated_embedded_object_title, @object_title
 end
 
 Then("I should see errors for the required {string} fields") do |object_type|

--- a/lib/engines/content_block_manager/features/step_definitions/embedded_object_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/embedded_object_steps.rb
@@ -16,7 +16,7 @@ end
 When("I complete the {string} form with the following fields:") do |object_type, table|
   fields = table.hashes.first
   @details = fields
-  @object_name ||= @details["name"].parameterize
+  @object_title ||= @details["title"].parameterize
   fields.keys.each do |k|
     field = find_field "content_block_manager_content_block_edition_details_#{object_type.pluralize}_#{k}"
     if field.tag_name == "select"
@@ -38,7 +38,7 @@ Then("the {string} should have been created successfully") do |object_type|
 
   assert_not_nil edition
   assert_not_nil edition.document
-  key = @object_name
+  key = @object_title
 
   @details.keys.each do |k|
     assert_equal edition.details[object_type.parameterize.pluralize][key][k], @details[k]
@@ -46,7 +46,7 @@ Then("the {string} should have been created successfully") do |object_type|
 
   version = edition.versions.order("created_at asc").first
   assert_equal version.updated_embedded_object_type, object_type.pluralize
-  assert_equal version.updated_embedded_object_name, @object_name
+  assert_equal version.updated_embedded_object_name, @object_title
 end
 
 Then("I should see errors for the required {string} fields") do |object_type|
@@ -85,8 +85,8 @@ end
 And(/^that pension has a rate with the following fields:$/) do |table|
   rate = table.hashes.first
   @content_block.details["rates"] = {
-    rate[:name].parameterize.to_s => {
-      "name" => rate[:name],
+    rate[:title].parameterize.to_s => {
+      "title" => rate[:title],
       "amount" => rate[:amount],
       "frequency" => rate[:frequency],
     },

--- a/lib/engines/content_block_manager/features/view_object.feature
+++ b/lib/engines/content_block_manager/features/view_object.feature
@@ -12,7 +12,7 @@ Feature: View a content object
       | frequency | string | string |          | a week,a month |                  |
     And a pension content block has been created
     And that pension has a rate with the following fields:
-      | name    | amount  | frequency |
+      | title   | amount  | frequency |
       | My rate | £123.45 | a week    |
     And a schema "email_address" exists with the following fields:
       | email_address |

--- a/lib/engines/content_block_manager/lib/tasks/update_rates_name_to_title.rake
+++ b/lib/engines/content_block_manager/lib/tasks/update_rates_name_to_title.rake
@@ -1,0 +1,17 @@
+namespace :content_block_manager do
+  desc "Change Rate key name to title"
+  task change_rates_name: :environment do
+    ContentBlockManager::ContentBlock::Document.where(block_type: "pension").find_each do |document|
+      document.editions.each do |edition|
+        edition.details["rates"]&.each do |key, value|
+          next if value["name"].blank?
+
+          puts "updating #{key} on #{edition.title}"
+          edition.details["rates"][key]["title"] = value["name"]
+          edition.details["rates"][key].delete("name")
+        end
+        edition.save!
+      end
+    end
+  end
+end

--- a/lib/engines/content_block_manager/test/components/content_block/document/show/document_timeline/embedded_object/field_changes_table_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/document/show/document_timeline/embedded_object/field_changes_table_component_test.rb
@@ -10,7 +10,7 @@ class ContentBlockManager::ContentBlock::Document::Show::DocumentTimeline::Embed
   end
 
   let(:content_block_edition) do
-    build(:content_block_edition, details: { "my_subschema" => { "something" => { "name" => "My thing" } } })
+    build(:content_block_edition, details: { "my_subschema" => { "something" => { "title" => "My thing" } } })
   end
 
   it "renders the edition diff table" do
@@ -30,7 +30,7 @@ class ContentBlockManager::ContentBlock::Document::Show::DocumentTimeline::Embed
     assert_selector "tr:nth-child(1) td:nth-child(3)", text: "new@email.com"
   end
 
-  describe "when a name cannot be found for the object" do
+  describe "when a title cannot be found for the object" do
     let(:content_block_edition) do
       build(:content_block_edition, details: {})
     end

--- a/lib/engines/content_block_manager/test/components/content_block/document/show/document_timeline/timeline_item_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/document/show/document_timeline/timeline_item_component_test.rb
@@ -258,7 +258,7 @@ class ContentBlockManager::ContentBlock::Document::Show::DocumentTimeline::Timel
         item: content_block_edition,
         field_diffs:,
         updated_embedded_object_type: "embedded_schema",
-        updated_embedded_object_name: "something",
+        updated_embedded_object_title: "something",
       )
     end
 

--- a/lib/engines/content_block_manager/test/components/content_block/document/show/embedded_objects/summary_cards_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/document/show/embedded_objects/summary_cards_component_test.rb
@@ -7,12 +7,12 @@ class ContentBlockManager::ContentBlock::Document::Show::EmbeddedObjects::Summar
     {
       "embedded-objects" => {
         "my-embedded-object" => {
-          "name" => "My Embedded Object",
+          "title" => "My Embedded Object",
           "field-1" => "Value 1",
           "field-2" => "Value 2",
         },
         "my-other-embedded-object" => {
-          "name" => "My Embedded Object",
+          "title" => "My Embedded Object",
           "field-1" => "Value 1",
           "field-2" => "Value 2",
         },
@@ -34,13 +34,13 @@ class ContentBlockManager::ContentBlock::Document::Show::EmbeddedObjects::Summar
     ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponent.expects(:new).with(
       content_block_edition:,
       object_type: "embedded-objects",
-      object_name: "my-embedded-object",
+      object_title: "my-embedded-object",
     ).returns(object1_double)
 
     ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponent.expects(:new).with(
       content_block_edition:,
       object_type: "embedded-objects",
-      object_name: "my-other-embedded-object",
+      object_title: "my-other-embedded-object",
     ).returns(object2_double)
 
     component = ContentBlockManager::ContentBlock::Document::Show::EmbeddedObjects::SummaryCardsComponent.new(

--- a/lib/engines/content_block_manager/test/components/content_block/edition/details/embedded_objects/form_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/details/embedded_objects/form_component_test.rb
@@ -24,29 +24,29 @@ class ContentBlockManager::ContentBlockEdition::Details::EmbeddedObjects::FormCo
 
   let(:foo_stub) { stub("string_component") }
   let(:bar_stub) { stub("string_component") }
-  let(:object_name) { "some_object" }
+  let(:object_title) { "some_object" }
 
   it "renders fields for each property" do
     ContentBlockManager::ContentBlockEdition::Details::Fields::StringComponent.expects(:new).with(
       content_block_edition:,
       label: "Foo",
-      field: [object_name, "foo"],
-      id_suffix: "#{object_name}_foo",
+      field: [object_title, "foo"],
+      id_suffix: "#{object_title}_foo",
       value: nil,
     ).returns(foo_stub)
 
     ContentBlockManager::ContentBlockEdition::Details::Fields::StringComponent.expects(:new).with(
       content_block_edition:,
       label: "Bar",
-      field: [object_name, "bar"],
-      id_suffix: "#{object_name}_bar",
+      field: [object_title, "bar"],
+      id_suffix: "#{object_title}_bar",
       value: nil,
     ).returns(bar_stub)
 
     component = ContentBlockManager::ContentBlockEdition::Details::EmbeddedObjects::FormComponent.new(
       content_block_edition:,
       schema:,
-      object_name:,
+      object_title:,
       params: nil,
     )
 
@@ -62,23 +62,23 @@ class ContentBlockManager::ContentBlockEdition::Details::EmbeddedObjects::FormCo
     ContentBlockManager::ContentBlockEdition::Details::Fields::StringComponent.expects(:new).with(
       content_block_edition:,
       label: "Foo",
-      field: [object_name, "foo"],
-      id_suffix: "#{object_name}_foo",
+      field: [object_title, "foo"],
+      id_suffix: "#{object_title}_foo",
       value: "something",
     ).returns(foo_stub)
 
     ContentBlockManager::ContentBlockEdition::Details::Fields::StringComponent.expects(:new).with(
       content_block_edition:,
       label: "Bar",
-      field: [object_name, "bar"],
-      id_suffix: "#{object_name}_bar",
+      field: [object_title, "bar"],
+      id_suffix: "#{object_title}_bar",
       value: nil,
     ).returns(bar_stub)
 
     component = ContentBlockManager::ContentBlockEdition::Details::EmbeddedObjects::FormComponent.new(
       content_block_edition:,
       schema:,
-      object_name:,
+      object_title:,
       params:,
     )
 

--- a/lib/engines/content_block_manager/test/components/content_block/edition/host_content/preview_details_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/host_content/preview_details_component_test.rb
@@ -25,9 +25,9 @@ class ContentBlockManager::ContentBlockEdition::HostContent::PreviewDetailsCompo
         "description": "Basic state pension",
         "rates": {
           "rate1":
-            { "name": "rate1", "amount": "£100.5", "frequency": "a week", "description": "" },
+            { "title": "rate1", "amount": "£100.5", "frequency": "a week", "description": "" },
           "rate2":
-              { "name": "rate2", "amount": "£11.1", "frequency": "a month", "description": "1111" },
+              { "title": "rate2", "amount": "£11.1", "frequency": "a month", "description": "1111" },
         },
       })
     end

--- a/lib/engines/content_block_manager/test/components/shared/embedded_objects/summary_card_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/shared/embedded_objects/summary_card_component_test.rb
@@ -29,7 +29,7 @@ class ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponentTest < V
     component = ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponent.new(
       content_block_edition:,
       object_type: "embedded-objects",
-      object_name: "my-embedded-object",
+      object_title: "my-embedded-object",
     )
 
     render_inline component
@@ -56,7 +56,7 @@ class ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponentTest < V
     component = ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponent.new(
       content_block_edition:,
       object_type: "embedded-objects",
-      object_name: "my-embedded-object",
+      object_title: "my-embedded-object",
     )
 
     render_inline component
@@ -70,7 +70,7 @@ class ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponentTest < V
     component = ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponent.new(
       content_block_edition:,
       object_type: "embedded-objects",
-      object_name: "my-embedded-object",
+      object_title: "my-embedded-object",
     )
 
     render_inline component
@@ -87,7 +87,7 @@ class ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponentTest < V
       component = ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponent.new(
         content_block_edition:,
         object_type: "embedded-objects",
-        object_name: "my-embedded-object",
+        object_title: "my-embedded-object",
       )
 
       render_inline component
@@ -102,7 +102,7 @@ class ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponentTest < V
       component = ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponent.new(
         content_block_edition:,
         object_type: "embedded-objects",
-        object_name: "my-embedded-object",
+        object_title: "my-embedded-object",
       )
 
       render_inline component
@@ -119,7 +119,7 @@ class ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponentTest < V
       component = ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponent.new(
         content_block_edition:,
         object_type: "embedded-objects",
-        object_name: "my-embedded-object",
+        object_title: "my-embedded-object",
         is_editable: true,
       )
 
@@ -130,7 +130,7 @@ class ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponentTest < V
       expected_edit_path = edit_embedded_object_content_block_manager_content_block_edition_path(
         content_block_edition,
         object_type: "embedded-objects",
-        object_name: "my-embedded-object",
+        object_title: "my-embedded-object",
       )
 
       assert_selector ".govuk-summary-list__row", count: 3
@@ -157,7 +157,7 @@ class ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponentTest < V
       component = ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponent.new(
         content_block_edition:,
         object_type: "embedded-objects",
-        object_name: "my-embedded-object",
+        object_title: "my-embedded-object",
         is_editable: true,
         redirect_url: "https://example.com",
       )
@@ -169,7 +169,7 @@ class ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponentTest < V
       expected_edit_path = edit_embedded_object_content_block_manager_content_block_edition_path(
         content_block_edition,
         object_type: "embedded-objects",
-        object_name: "my-embedded-object",
+        object_title: "my-embedded-object",
         redirect_url: "https://example.com",
       )
 
@@ -180,7 +180,7 @@ class ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponentTest < V
       component = ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponent.new(
         content_block_edition:,
         object_type: "embedded-objects",
-        object_name: "my-embedded-object",
+        object_title: "my-embedded-object",
         is_editable: true,
       )
 
@@ -195,7 +195,7 @@ class ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponentTest < V
       component = ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponent.new(
         content_block_edition:,
         object_type: "embedded-objects",
-        object_name: "my-embedded-object",
+        object_title: "my-embedded-object",
         is_editable: true,
       )
 

--- a/lib/engines/content_block_manager/test/integration/content_block/editions/embedded_objects_test.rb
+++ b/lib/engines/content_block_manager/test/integration/content_block/editions/embedded_objects_test.rb
@@ -13,10 +13,10 @@ class ContentBlockManager::ContentBlock::Editions::EmbeddedObjectsTest < ActionD
     login_as(user)
   end
 
-  let(:edition) { create(:content_block_edition, :email_address, details: { "something" => { "embedded" => { "name" => "Embedded", "is" => "here" } } }) }
+  let(:edition) { create(:content_block_edition, :email_address, details: { "something" => { "embedded" => { "title" => "Embedded", "is" => "here" } } }) }
 
   let(:stub_schema) { stub("schema", body: [], name: "Schema") }
-  let(:stub_subschema) { stub("subschema", name: "Something", block_type: object_type, fields: [], permitted_params: %w[name is], id: "something") }
+  let(:stub_subschema) { stub("subschema", name: "Something", block_type: object_type, fields: [], permitted_params: %w[title is], id: "something") }
 
   let(:object_type) { "something" }
 
@@ -34,7 +34,7 @@ class ContentBlockManager::ContentBlock::Editions::EmbeddedObjectsTest < ActionD
         "content_block/edition" => {
           details: {
             object_type => {
-              "name" => "New Thing",
+              "title" => "New Thing",
               "is" => "something",
             },
           },
@@ -50,10 +50,10 @@ class ContentBlockManager::ContentBlock::Editions::EmbeddedObjectsTest < ActionD
       assert_equal updated_edition.details, {
         "something" => {
           "embedded" => {
-            "name" => "Embedded", "is" => "here"
+            "title" => "Embedded", "is" => "here"
           },
           "new-thing" => {
-            "name" => "New Thing", "is" => "something"
+            "title" => "New Thing", "is" => "something"
           },
         },
       }
@@ -66,21 +66,21 @@ class ContentBlockManager::ContentBlock::Editions::EmbeddedObjectsTest < ActionD
       get content_block_manager.edit_embedded_object_content_block_manager_content_block_edition_path(
         edition,
         object_type:,
-        object_name: "embedded",
+        object_title: "embedded",
       )
 
       assert_equal assigns(:content_block_edition), edition
       assert_equal assigns(:schema), stub_schema
       assert_equal assigns(:subschema), stub_subschema
-      assert_equal assigns(:object_name), "embedded"
-      assert_equal assigns(:object), { "is" => "here", "name" => "Embedded" }
+      assert_equal assigns(:object_title), "embedded"
+      assert_equal assigns(:object), { "is" => "here", "title" => "Embedded" }
     end
 
     it "should assign the redirect_url if given" do
       get content_block_manager.edit_embedded_object_content_block_manager_content_block_edition_path(
         edition,
         object_type:,
-        object_name: "embedded",
+        object_title: "embedded",
         redirect_url: "https://example.com",
       )
 
@@ -93,7 +93,7 @@ class ContentBlockManager::ContentBlock::Editions::EmbeddedObjectsTest < ActionD
       get content_block_manager.edit_embedded_object_content_block_manager_content_block_edition_path(
         edition,
         object_type: "something_else",
-        object_name: "embedded",
+        object_title: "embedded",
       )
 
       assert_equal response.status, 404
@@ -105,7 +105,7 @@ class ContentBlockManager::ContentBlock::Editions::EmbeddedObjectsTest < ActionD
       get content_block_manager.edit_embedded_object_content_block_manager_content_block_edition_path(
         edition,
         object_type:,
-        object_name: "something_else",
+        object_title: "something_else",
       )
 
       assert_equal response.status, 404
@@ -117,12 +117,12 @@ class ContentBlockManager::ContentBlock::Editions::EmbeddedObjectsTest < ActionD
       put content_block_manager.embedded_object_content_block_manager_content_block_edition_path(
         edition,
         object_type:,
-        object_name: "embedded",
+        object_title: "embedded",
       ), params: {
         "content_block/edition" => {
           details: {
             object_type => {
-              "name" => "Embedded",
+              "title" => "Embedded",
               "is" => "different",
             },
           },
@@ -132,25 +132,25 @@ class ContentBlockManager::ContentBlock::Editions::EmbeddedObjectsTest < ActionD
       assert_redirected_to content_block_manager.review_embedded_object_content_block_manager_content_block_edition_path(
         edition,
         object_type:,
-        object_name: "embedded",
+        object_title: "embedded",
       )
 
       updated_edition = edition.reload
 
-      assert_equal updated_edition.details, { "something" => { "embedded" => { "name" => "Embedded", "is" => "different" } } }
+      assert_equal updated_edition.details, { "something" => { "embedded" => { "title" => "Embedded", "is" => "different" } } }
     end
 
     it "should redirect if a redirect_url is given" do
       put content_block_manager.embedded_object_content_block_manager_content_block_edition_path(
         edition,
         object_type:,
-        object_name: "embedded",
+        object_title: "embedded",
       ), params: {
         redirect_url: content_block_manager.content_block_manager_content_block_documents_path,
         "content_block/edition" => {
           details: {
             object_type => {
-              "name" => "Embedded",
+              "title" => "Embedded",
               "is" => "different",
             },
           },
@@ -161,16 +161,16 @@ class ContentBlockManager::ContentBlock::Editions::EmbeddedObjectsTest < ActionD
       assert_equal "Something edited. You can add another something or continue to create schema block", flash[:notice]
     end
 
-    it "should not rename the object if a new name is given" do
+    it "should not rename the object if a new title is given" do
       put content_block_manager.embedded_object_content_block_manager_content_block_edition_path(
         edition,
         object_type:,
-        object_name: "embedded",
+        object_title: "embedded",
       ), params: {
         "content_block/edition" => {
           details: {
             object_type => {
-              "name" => "New Name",
+              "title" => "New Name",
               "is" => "different",
             },
           },
@@ -180,12 +180,12 @@ class ContentBlockManager::ContentBlock::Editions::EmbeddedObjectsTest < ActionD
       assert_redirected_to content_block_manager.review_embedded_object_content_block_manager_content_block_edition_path(
         edition,
         object_type:,
-        object_name: "embedded",
+        object_title: "embedded",
       )
 
       updated_edition = edition.reload
 
-      assert_equal updated_edition.details, { "something" => { "embedded" => { "name" => "New Name", "is" => "different" } } }
+      assert_equal updated_edition.details, { "something" => { "embedded" => { "title" => "New Name", "is" => "different" } } }
     end
 
     it "should render errors if a validation error is thrown" do
@@ -194,12 +194,12 @@ class ContentBlockManager::ContentBlock::Editions::EmbeddedObjectsTest < ActionD
       put content_block_manager.embedded_object_content_block_manager_content_block_edition_path(
         edition,
         object_type:,
-        object_name: "embedded",
+        object_title: "embedded",
       ), params: {
         "content_block/edition" => {
           details: {
             object_type => {
-              "name" => "New Name",
+              "title" => "New Name",
               "is" => "different",
             },
           },
@@ -209,9 +209,9 @@ class ContentBlockManager::ContentBlock::Editions::EmbeddedObjectsTest < ActionD
       assert_equal assigns(:content_block_edition), edition
       assert_equal assigns(:schema), stub_schema
       assert_equal assigns(:subschema), stub_subschema
-      assert_equal assigns(:object_name), "embedded"
+      assert_equal assigns(:object_title), "embedded"
       assert_equal assigns(:object).to_h, {
-        "name" => "New Name",
+        "title" => "New Name",
         "is" => "different",
       }
 

--- a/lib/engines/content_block_manager/test/unit/app/models/content_block_edition/has_audit_trail_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/models/content_block_edition/has_audit_trail_test.rb
@@ -58,7 +58,7 @@ class ContentBlockManager::HasAuditTrailTest < ActiveSupport::TestCase
       )
       edition.expects(:generate_diff).returns({})
       edition.updated_embedded_object_type = "something"
-      edition.updated_embedded_object_name = "here"
+      edition.updated_embedded_object_title = "here"
 
       assert_changes -> { edition.versions.count }, from: 1, to: 2 do
         edition.publish!
@@ -67,7 +67,7 @@ class ContentBlockManager::HasAuditTrailTest < ActiveSupport::TestCase
       version = edition.versions.first
 
       assert_equal edition.updated_embedded_object_type, version.updated_embedded_object_type
-      assert_equal edition.updated_embedded_object_name, version.updated_embedded_object_name
+      assert_equal edition.updated_embedded_object_title, version.updated_embedded_object_title
     end
 
     it "does not record a version when updating an existing draft" do

--- a/lib/engines/content_block_manager/test/unit/app/models/content_block_edition_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/models/content_block_edition_test.rb
@@ -196,9 +196,9 @@ class ContentBlockManager::ContentBlockEditionTest < ActiveSupport::TestCase
 
   describe "#add_object_to_details" do
     it "adds an object with the correct key to the details hash" do
-      content_block_edition.add_object_to_details("something", { "name" => "My thing", "something" => "else" })
+      content_block_edition.add_object_to_details("something", { "title" => "My thing", "something" => "else" })
 
-      assert_equal content_block_edition.details["something"], { "my-thing" => { "name" => "My thing", "something" => "else" } }
+      assert_equal content_block_edition.details["something"], { "my-thing" => { "title" => "My thing", "something" => "else" } }
     end
 
     it "appends to the object if it already exists" do
@@ -206,11 +206,11 @@ class ContentBlockManager::ContentBlockEditionTest < ActiveSupport::TestCase
         "another-thing" => {},
       }
 
-      content_block_edition.add_object_to_details("something", { "name" => "My thing", "something" => "else" })
-      assert_equal content_block_edition.details["something"], { "another-thing" => {}, "my-thing" => { "name" => "My thing", "something" => "else" } }
+      content_block_edition.add_object_to_details("something", { "title" => "My thing", "something" => "else" })
+      assert_equal content_block_edition.details["something"], { "another-thing" => {}, "my-thing" => { "title" => "My thing", "something" => "else" } }
     end
 
-    it "creates a random key if a name is not provided" do
+    it "creates a random key if a title is not provided" do
       SecureRandom.expects(:alphanumeric).returns("RANDOM-STRING")
       content_block_edition.add_object_to_details("something", { "something" => "else" })
 
@@ -220,19 +220,19 @@ class ContentBlockManager::ContentBlockEditionTest < ActiveSupport::TestCase
 
   describe "#update_object_with_details" do
     before do
-      content_block_edition.details["something"] = { "my-thing" => { "name" => "My thing", "something" => "else" } }
+      content_block_edition.details["something"] = { "my-thing" => { "title" => "My thing", "something" => "else" } }
     end
 
     it "updates a given object's details" do
-      content_block_edition.update_object_with_details("something", "my-thing", { "name" => "My thing", "something" => "changed" })
+      content_block_edition.update_object_with_details("something", "my-thing", { "title" => "My thing", "something" => "changed" })
 
-      assert_equal content_block_edition.details["something"], { "my-thing" => { "name" => "My thing", "something" => "changed" } }
+      assert_equal content_block_edition.details["something"], { "my-thing" => { "title" => "My thing", "something" => "changed" } }
     end
 
-    it "keeps the original key name if the name changes" do
-      content_block_edition.update_object_with_details("something", "my-thing", { "name" => "Other thing", "something" => "changed" })
+    it "keeps the original key if the title changes" do
+      content_block_edition.update_object_with_details("something", "my-thing", { "title" => "Other thing", "something" => "changed" })
 
-      assert_equal content_block_edition.details["something"], { "my-thing" => { "name" => "Other thing", "something" => "changed" } }
+      assert_equal content_block_edition.details["something"], { "my-thing" => { "title" => "Other thing", "something" => "changed" } }
     end
   end
 

--- a/lib/engines/content_block_manager/test/unit/app/models/content_block_version_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/models/content_block_version_test.rb
@@ -77,9 +77,9 @@ class ContentBlockManager::ContentBlockVersionTest < ActiveSupport::TestCase
       assert_not content_block_version.is_embedded_update?
     end
 
-    it "returns true when updated_embedded_object_type and updated_embedded_object_name are set" do
+    it "returns true when updated_embedded_object_type and updated_embedded_object_title are set" do
       content_block_version.updated_embedded_object_type = "something"
-      content_block_version.updated_embedded_object_name = "something"
+      content_block_version.updated_embedded_object_title = "something"
 
       assert content_block_version.is_embedded_update?
     end

--- a/lib/engines/content_block_manager/test/unit/lib/tasks/update_rates_name_to_title_test.rb
+++ b/lib/engines/content_block_manager/test/unit/lib/tasks/update_rates_name_to_title_test.rb
@@ -1,0 +1,50 @@
+require "test_helper"
+require "rake"
+
+class UpdateRatesNameToTitleTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
+  teardown do
+    Rake::Task["content_block_manager:change_rates_name"].reenable
+  end
+
+  let(:schema) { build(:content_block_schema, block_type: "content_block_pension", body: {}) }
+
+  before do
+    ContentBlockManager::ContentBlock::Schema.expects(:find_by_block_type).returns(schema).at_least_once
+  end
+
+  it "updates the rate names" do
+    document = create(:content_block_document, :pension)
+
+    edition_1 = create(:content_block_edition, document:, title: "Edition 1", details: {
+      "description": "Edition 1",
+      "rates": {
+        "rate1":
+          { "name": "rate1", "amount": "£100.5", "frequency": "a week", "description": "" },
+      },
+    })
+
+    document_2 = create(:content_block_document, :pension)
+
+    edition_2 = create(:content_block_edition, document: document_2, title: "Edition 4", details: {
+      "description": "Edition 4",
+      "rates": {
+        "rate1":
+          { "name": "rate1", "amount": "£100.5", "frequency": "a week", "description": "" },
+        "rate2":
+          { "name": "rate2", "amount": "£100.5", "frequency": "a month", "description": "" },
+      },
+    })
+
+    Rake.application.invoke_task("content_block_manager:change_rates_name")
+
+    assert_equal "rate1", edition_1.reload.details.dig("rates", "rate1", "title")
+    assert_nil edition_1.reload.details.dig("rates", "rate1", "name")
+
+    assert_equal "rate1", edition_2.reload.details.dig("rates", "rate1", "title")
+    assert_equal "rate2", edition_2.reload.details.dig("rates", "rate2", "title")
+    assert_nil edition_2.reload.details.dig("rates", "rate1", "name")
+    assert_nil edition_2.reload.details.dig("rates", "rate2", "name")
+  end
+end


### PR DESCRIPTION
https://trello.com/c/bMiirLNG/949-rate-object-attribute-should-be-title

Can be merged once Publishing API changes made: https://github.com/alphagov/publishing-api/pull/3165

Wherever we have the `name` key on an embedded object it should now be `title` - including where the key for the object is generated, and on versions.

- **add rake task to change name to title on embedded objects**
- **change embedded object `name` to `title`**
- **change rename `updated_embedded_object_name` to `updated_embedded_object_title`**

----

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
