### PR TITLE
Content modelling/954 rate timeline

### DIFF
--- a/lib/engines/content_block_manager/app/assets/stylesheets/content_block_manager/components/_timeline-component.scss
+++ b/lib/engines/content_block_manager/app/assets/stylesheets/content_block_manager/components/_timeline-component.scss
@@ -91,3 +91,7 @@
     margin-bottom: govuk-spacing(2);
   }
 }
+
+.timeline__embedded-item-list {
+  margin-bottom: govuk-spacing(1);
+}

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/document_timeline/timeline_item_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/document_timeline/timeline_item_component.html.erb
@@ -8,10 +8,6 @@
     <p class="timeline__byline">by <%= byline %></p>
   </div>
 
-  <p class="timeline__date">
-    <%= date %>
-  </p>
-
   <% if version.is_embedded_update? %>
     <ul class="govuk-list timeline__embedded-item-list">
         <li class="timeline__embedded-item-list__item">
@@ -19,7 +15,13 @@
           <span class="timeline__embedded-item-list__value"><%= new_subschema_item_details[:new_value] %></span>
         </li>
     </ul>
-  <% elsif details_of_changes.present? %>
+  <% end %>
+
+  <p class="timeline__date">
+      <%= date %>
+  </p>
+
+  <% if show_details_of_changes? %>
     <div class="timeline__diff-table">
       <%= render "govuk_publishing_components/components/details", {
         title: "Details of changes",

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/document_timeline/timeline_item_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/document_timeline/timeline_item_component.html.erb
@@ -14,12 +14,10 @@
 
   <% if version.is_embedded_update? %>
     <ul class="govuk-list timeline__embedded-item-list">
-      <% new_subschema_item_details.each do |field_name, value| %>
         <li class="timeline__embedded-item-list__item">
-          <strong class="timeline__embedded-item-list__key"><%= field_name %>:</strong>
-          <span class="timeline__embedded-item-list__value"><%= value %></span>
+          <strong class="timeline__embedded-item-list__key"><%= new_subschema_item_details[:field] %>:</strong>
+          <span class="timeline__embedded-item-list__value"><%= new_subschema_item_details[:new_value] %></span>
         </li>
-      <% end %>
     </ul>
   <% elsif details_of_changes.present? %>
     <div class="timeline__diff-table">

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/document_timeline/timeline_item_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/document_timeline/timeline_item_component.rb
@@ -29,9 +29,8 @@ private
   end
 
   def new_subschema_item_details
-    version.field_diffs.dig("details", updated_subschema_id, version.updated_embedded_object_title).map do |field_name, diff|
-      [field_name.humanize, diff.new_value]
-    end
+    field_diff = version.field_diffs.dig("details", updated_subschema_id, version.updated_embedded_object_title).first
+    { field: field_diff[0].humanize, new_value: field_diff[1].new_value }
   end
 
   def date

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/document_timeline/timeline_item_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/document_timeline/timeline_item_component.rb
@@ -62,6 +62,10 @@ private
     }.flatten
   end
 
+  def show_details_of_changes?
+    !version.is_embedded_update? && details_of_changes.present?
+  end
+
   def details_of_changes
     @details_of_changes ||= begin
       return "" if version.field_diffs.blank?

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/document_timeline/timeline_item_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/document_timeline/timeline_item_component.rb
@@ -14,7 +14,7 @@ private
 
   def title
     if version.is_embedded_update?
-      "#{updated_subschema_id.humanize.singularize} created"
+      "#{updated_subschema_id.humanize.singularize} added"
     elsif version.state == "published"
       is_first_published_version ? "#{version.item.block_type.humanize} created" : version.state.capitalize
     elsif version.state == "scheduled"

--- a/lib/engines/content_block_manager/test/components/content_block/document/show/document_timeline/timeline_item_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/document/show/document_timeline/timeline_item_component_test.rb
@@ -276,6 +276,7 @@ class ContentBlockManager::ContentBlock::Document::Show::DocumentTimeline::Timel
       render_inline component
 
       assert_selector ".timeline__embedded-item-list__item", count: 1
+      assert_no_selector "summary"
       assert_selector ".timeline__embedded-item-list .timeline__embedded-item-list__item:nth-child(1) .timeline__embedded-item-list__key", text: "Field1:"
       assert_selector ".timeline__embedded-item-list .timeline__embedded-item-list__item:nth-child(1) .timeline__embedded-item-list__value", text: "Field 1 value"
     end

--- a/lib/engines/content_block_manager/test/components/content_block/document/show/document_timeline/timeline_item_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/document/show/document_timeline/timeline_item_component_test.rb
@@ -275,11 +275,9 @@ class ContentBlockManager::ContentBlock::Document::Show::DocumentTimeline::Timel
     it "renders the details of the updated object" do
       render_inline component
 
+      assert_selector ".timeline__embedded-item-list__item", count: 1
       assert_selector ".timeline__embedded-item-list .timeline__embedded-item-list__item:nth-child(1) .timeline__embedded-item-list__key", text: "Field1:"
       assert_selector ".timeline__embedded-item-list .timeline__embedded-item-list__item:nth-child(1) .timeline__embedded-item-list__value", text: "Field 1 value"
-
-      assert_selector ".timeline__embedded-item-list .timeline__embedded-item-list__item:nth-child(2) .timeline__embedded-item-list__key", text: "Field2:"
-      assert_selector ".timeline__embedded-item-list .timeline__embedded-item-list__item:nth-child(2) .timeline__embedded-item-list__value", text: "Field 2 value"
     end
   end
 end

--- a/lib/engines/content_block_manager/test/components/content_block/document/show/document_timeline/timeline_item_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/document/show/document_timeline/timeline_item_component_test.rb
@@ -269,7 +269,7 @@ class ContentBlockManager::ContentBlock::Document::Show::DocumentTimeline::Timel
     it "renders the correct title" do
       render_inline component
 
-      assert_selector ".timeline__title", text: "Embedded schema created"
+      assert_selector ".timeline__title", text: "Embedded schema added"
     end
 
     it "renders the details of the updated object" do


### PR DESCRIPTION
https://trello.com/c/zImRNwjA/954-timeline-rate-added-tweaks

![Screenshot 2025-02-28 at 12 52 41](https://github.com/user-attachments/assets/74714be6-9158-4f25-bd05-448b639b8d61)



----
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
