### PR TITLE
Ensure each document is only republished once when republishing all documents of a document type

### DIFF
--- a/app/services/bulk_republisher.rb
+++ b/app/services/bulk_republisher.rb
@@ -66,7 +66,8 @@ class BulkRepublisher
     if non_editionable_content_types.include?(content_type)
       republish_all_by_non_editionable_type(content_type_klass)
     else
-      republish_all_documents_by_ids(content_type_klass.pluck(:document_id))
+      republishable_document_ids = content_type_klass.joins("INNER JOIN documents ON documents.latest_edition_id = editions.id").pluck(:document_id)
+      republish_all_documents_by_ids(republishable_document_ids)
     end
   end
 

--- a/test/unit/app/services/bulk_republisher_test.rb
+++ b/test/unit/app/services/bulk_republisher_test.rb
@@ -345,6 +345,17 @@ class BulkRepublisherTest < ActiveSupport::TestCase
         end
         BulkRepublisher.new.republish_all_by_type("CaseStudy")
       end
+
+      test "only republishes each document once even if the document has multiple editions" do
+        case_study = create(:published_case_study)
+        create(:draft_case_study, document: case_study.document)
+        PublishingApiDocumentRepublishingWorker.expects(:perform_async_in_queue).once.with(
+          "bulk_republishing",
+          case_study.document_id,
+          true,
+        )
+        BulkRepublisher.new.republish_all_by_type("CaseStudy")
+      end
     end
 
     context "for non-editionable content types, like Contact, when publishable to Publishing API" do


### PR DESCRIPTION
We can do this by making sure that we only queue a document for editions which are the latest edition of the document. Every document has one latest edition. Previously we were kicking off a republishing job for every edition of each document. This caused an excessive number of jobs and could result in table locking issues if republishing jobs for the same document attempt to run concurrently.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
