### PR TITLE
(947) Back while creating a pension block transitions to edit flow in the pension screen

### DIFF
--- a/lib/engines/content_block_manager/app/controllers/concerns/workflow/show_methods.rb
+++ b/lib/engines/content_block_manager/app/controllers/concerns/workflow/show_methods.rb
@@ -6,6 +6,9 @@ module Workflow::ShowMethods
     @schema = ContentBlockManager::ContentBlock::Schema.find_by_block_type(@content_block_edition.document.block_type)
     @form = ContentBlockManager::ContentBlock::EditionForm::Edit.new(content_block_edition: @content_block_edition, schema: @schema)
 
+    @title = @content_block_edition.document.is_new_block? ? "Create #{@form.schema.name}" : "Change #{@form.schema.name}"
+    @back_path = @content_block_edition.document.is_new_block? ? content_block_manager.new_content_block_manager_content_block_document_path : @form.back_path
+
     render :edit_draft
   end
 

--- a/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/editions_controller.rb
+++ b/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/editions_controller.rb
@@ -5,12 +5,12 @@ class ContentBlockManager::ContentBlock::EditionsController < ContentBlockManage
 
   def new
     if params[:document_id]
-      @title = "Edit a content block"
+      @title = "Edit content block"
       @content_block_document = ContentBlockManager::ContentBlock::Document.find(params[:document_id])
       @schema = ContentBlockManager::ContentBlock::Schema.find_by_block_type(@content_block_document.block_type)
       content_block_edition = @content_block_document.latest_edition
     else
-      @title = "Create a content block"
+      @title = "Create content block"
       @schema = ContentBlockManager::ContentBlock::Schema.find_by_block_type(params[:block_type].underscore)
       content_block_edition = ContentBlockManager::ContentBlock::Edition.new
     end

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/documents/new.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/documents/new.html.erb
@@ -1,4 +1,4 @@
-<% content_for :context, "Create a content block" %>
+<% content_for :context, "Create content block" %>
 
 <% if @schemas %>
   <% content_for :back_link do %>

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/documents/schedule/edit.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/documents/schedule/edit.html.erb
@@ -1,6 +1,6 @@
 <%=
   render ContentBlockManager::Shared::SchedulePublishingComponent.new(
-    context: "Edit a content block",
+    context: "Edit content block",
     content_block_edition: @content_block_edition,
     params:,
     back_link: content_block_manager.content_block_manager_content_block_document_path(id: @content_block_edition.document.id),

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/edit_draft.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/edit_draft.html.erb
@@ -1,4 +1,4 @@
-<% content_for :context, product_name %>
+<% content_for :context, context %>
 <% content_for :title, @title %>
 
 <% content_for :back_link do %>

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/edit_draft.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/edit_draft.html.erb
@@ -1,9 +1,9 @@
 <% content_for :context, product_name %>
-<% content_for :title, "Change #{@form.schema.name}" %>
+<% content_for :title, @title %>
 
 <% content_for :back_link do %>
   <%= render "govuk_publishing_components/components/back_link", {
-    href: @form.back_path,
+    href: @back_path,
   } %>
 <% end %>
 

--- a/lib/engines/content_block_manager/test/integration/content_block/editions_test.rb
+++ b/lib/engines/content_block_manager/test/integration/content_block/editions_test.rb
@@ -27,7 +27,7 @@ class ContentBlockManager::ContentBlock::EditionsTest < ActionDispatch::Integrat
 
         visit content_block_manager.new_content_block_manager_content_block_document_edition_path(content_block_document)
 
-        assert_text "Edit a content block"
+        assert_text "Edit content block"
       end
     end
 
@@ -44,7 +44,7 @@ class ContentBlockManager::ContentBlock::EditionsTest < ActionDispatch::Integrat
 
         visit content_block_manager.new_content_block_manager_content_block_edition_path(block_type: "block-type")
 
-        assert_text "Create a content block"
+        assert_text "Create content block"
       end
     end
   end

--- a/lib/engines/content_block_manager/test/integration/content_block/workflow_test.rb
+++ b/lib/engines/content_block_manager/test/integration/content_block/workflow_test.rb
@@ -33,6 +33,19 @@ class ContentBlockManager::ContentBlock::WorkflowTest < ActionDispatch::Integrat
       ContentBlockManager::ContentBlock::Document.any_instance.stubs(:is_new_block?).returns(true)
     end
 
+    describe "when on the edit step" do
+      let(:step) { :edit_draft }
+
+      describe "#show" do
+        it "shows the correct title and back link" do
+          get content_block_manager.content_block_manager_content_block_workflow_path(id: edition.id, step:)
+
+          assert_equal assigns(:title), "Create #{schema.name}"
+          assert_equal assigns(:back_path), content_block_manager.new_content_block_manager_content_block_document_path
+        end
+      end
+    end
+
     describe "when reviewing the changes" do
       let(:step) { :review }
 
@@ -126,6 +139,13 @@ class ContentBlockManager::ContentBlock::WorkflowTest < ActionDispatch::Integrat
           get content_block_manager.content_block_manager_content_block_workflow_path(id: edition.id, step:)
 
           assert_template "content_block_manager/content_block/editions/workflow/edit_draft"
+        end
+
+        it "shows the correct title and back link" do
+          get content_block_manager.content_block_manager_content_block_workflow_path(id: edition.id, step:)
+
+          assert_equal assigns(:title), "Change #{schema.name}"
+          assert_equal assigns(:back_path), content_block_manager.content_block_manager_content_block_document_path(document)
         end
       end
 


### PR DESCRIPTION
Trello card: https://trello.com/c/oaI8GPfh/947-back-while-creating-a-pension-block-transitions-to-edit-flow-in-the-pension-screen

This fixes some of the inconsistencies detailed in the Trello card above