### PR TITLE
content modelling/903 copy changes

### DIFF
--- a/lib/engines/content_block_manager/app/controllers/concerns/workflow/show_methods.rb
+++ b/lib/engines/content_block_manager/app/controllers/concerns/workflow/show_methods.rb
@@ -87,11 +87,16 @@ private
     @subschema = @schema.subschema(subschema_name)
     @step_name = current_step.name
     @action = @content_block_edition.document.is_new_block? ? "Add" : "Edit"
+    @add_button_text = has_embedded_objects ? "Add another #{subschema_name.humanize.singularize.downcase}" : "Add a #{@subschema.name.humanize.singularize.downcase}"
 
     if @subschema
       render :embedded_objects
     else
       raise ActionController::RoutingError, "Subschema #{subschema_name} does not exist"
     end
+  end
+
+  def has_embedded_objects
+    @content_block_edition.details[@subschema.block_type].present?
   end
 end

--- a/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/editions/embedded_objects_controller.rb
+++ b/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/editions/embedded_objects_controller.rb
@@ -10,7 +10,12 @@ class ContentBlockManager::ContentBlock::Editions::EmbeddedObjectsController < C
     @content_block_edition.add_object_to_details(@subschema.block_type, @object)
     @content_block_edition.save!
 
-    flash[:notice] = "#{@subschema.name.singularize} added. You can add another #{@subschema.name.singularize.downcase} or finish creating the #{@schema.name.singularize.downcase} block"
+    flash[:notice] = I18n.t(
+      "content_block_edition.create.embedded_objects.added_confirmation",
+      name_capitalized: @subschema.name.singularize,
+      name_downcase: @subschema.name.singularize.downcase,
+      schema_name: @schema.name.singularize.downcase,
+    )
     step = "#{Workflow::Step::SUBSCHEMA_PREFIX}#{@subschema.id}"
     redirect_to content_block_manager.content_block_manager_content_block_workflow_path(@content_block_edition, step:)
   rescue ActiveRecord::RecordInvalid
@@ -31,7 +36,12 @@ class ContentBlockManager::ContentBlock::Editions::EmbeddedObjectsController < C
     @content_block_edition.save!
 
     if params[:redirect_url].present?
-      flash[:notice] = "#{@subschema.name.singularize} edited. You can add another #{@subschema.name.singularize.downcase} or continue to create #{@schema.name.singularize.downcase} block"
+      flash[:notice] = I18n.t(
+        "content_block_edition.create.embedded_objects.edited_confirmation",
+        name_capitalized: @subschema.name.singularize,
+        name_downcase: @subschema.name.singularize.downcase,
+        schema_name: @schema.name.singularize.downcase,
+      )
       redirect_to params[:redirect_url], allow_other_host: false
     else
       redirect_to content_block_manager.review_embedded_object_content_block_manager_content_block_edition_path(

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/embedded_objects.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/embedded_objects.html.erb
@@ -36,7 +36,7 @@
 
       <% if @content_block_edition.document.is_new_block? %>
         <%= render "govuk_publishing_components/components/button", {
-          text: "Add a #{@subschema.name.singularize.downcase}",
+          text: @add_button_text,
           href: content_block_manager.new_embedded_object_content_block_manager_content_block_edition_path(
             @content_block_edition,
             object_type: @subschema.block_type,

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/embedded_objects.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/embedded_objects.html.erb
@@ -29,7 +29,7 @@
       <% else %>
         <% if I18n.exists?("content_block_edition.create.embedded_objects.#{@subschema.id}") %>
           <%= render "govuk_publishing_components/components/hint", {
-            text: t("content_block_edition.create.embedded_objects.#{@subschema.id}"),
+            text: t("content_block_edition.create.embedded_objects.#{@subschema.id}", block_type: @subschema.name.humanize(capitalize: false)),
           } %>
         <% end %>
       <% end %>

--- a/lib/engines/content_block_manager/config/locales/en.yml
+++ b/lib/engines/content_block_manager/config/locales/en.yml
@@ -39,7 +39,7 @@ en:
     create:
       title: "Create %{block_type}"
       embedded_objects:
-        rates: Enter rate details, including the amount. You can do this now or later.
+        rates: "Enter %{block_type} details. You can do this now or later."
         added_confirmation: "%{name_capitalized} added. You can add another %{name_downcase} or finish creating the %{schema_name} block."
         edited_confirmation: "%{name_capitalized} edited. You can add another %{name_downcase} or finish creating the %{schema_name} block."
     confirmation_page:

--- a/lib/engines/content_block_manager/config/locales/en.yml
+++ b/lib/engines/content_block_manager/config/locales/en.yml
@@ -40,6 +40,8 @@ en:
       title: "Create %{block_type}"
       embedded_objects:
         rates: Enter rate details, including the amount. You can do this now or later.
+        added_confirmation: "%{name_capitalized} added. You can add another %{name_downcase} or finish creating the %{schema_name} block."
+        edited_confirmation: "%{name_capitalized} edited. You can add another %{name_downcase} or finish creating the %{schema_name} block."
     confirmation_page:
       scheduled:
         banner: "%{block_type} scheduled to publish on %{date}"

--- a/lib/engines/content_block_manager/test/integration/content_block/editions/embedded_objects_test.rb
+++ b/lib/engines/content_block_manager/test/integration/content_block/editions/embedded_objects_test.rb
@@ -57,7 +57,7 @@ class ContentBlockManager::ContentBlock::Editions::EmbeddedObjectsTest < ActionD
           },
         },
       }
-      assert_equal "Something added. You can add another something or finish creating the schema block", flash[:notice]
+      assert_equal "Something added. You can add another something or finish creating the schema block.", flash[:notice]
     end
   end
 
@@ -158,7 +158,7 @@ class ContentBlockManager::ContentBlock::Editions::EmbeddedObjectsTest < ActionD
       }
 
       assert_redirected_to content_block_manager.content_block_manager_content_block_documents_path
-      assert_equal "Something edited. You can add another something or continue to create schema block", flash[:notice]
+      assert_equal "Something edited. You can add another something or finish creating the schema block.", flash[:notice]
     end
 
     it "should not rename the object if a new title is given" do

--- a/lib/engines/content_block_manager/test/integration/content_block/workflow_test.rb
+++ b/lib/engines/content_block_manager/test/integration/content_block/workflow_test.rb
@@ -89,8 +89,8 @@ class ContentBlockManager::ContentBlock::WorkflowTest < ActionDispatch::Integrat
     describe "when subschemas are present" do
       let(:subschemas) do
         [
-          stub("subschema", id: "subschema_1", name: "subschema_1", block_type: "subschema_1"),
-          stub("subschema", id: "subschema_2", name: "subschema_2", block_type: "subschema_1"),
+          stub("subschema_1", id: "subschema_1", name: "subschema_1", block_type: "subschema_1", embeddable_fields: []),
+          stub("subschema_2", id: "subschema_2", name: "subschema_2", block_type: "subschema_1"),
         ]
       end
 
@@ -107,6 +107,18 @@ class ContentBlockManager::ContentBlock::WorkflowTest < ActionDispatch::Integrat
           get content_block_manager.content_block_manager_content_block_workflow_path(id: edition.id, step: "embedded_subschema_2")
 
           assert_template "content_block_manager/content_block/editions/workflow/embedded_objects"
+        end
+
+        describe "when there are existing subschema blocks created already" do
+          let(:details) { { subschema_1: { existing_subschema: { name: "existing subschema" } } } }
+          let(:edition) { create(:content_block_edition, document:, details:, organisation:, instructions_to_publishers: "instructions", title: "Some Edition Title") }
+
+          it "shows the existing block and how to add another embedded block" do
+            visit content_block_manager.content_block_manager_content_block_workflow_path(id: edition.id, step: "embedded_subschema_1")
+
+            assert_text "existing subschema"
+            assert_text "Add another subschema 1"
+          end
         end
       end
 


### PR DESCRIPTION
https://trello.com/c/rWeozFDl/903-update-copy-for-pensions-based-on-recent-copy-changes

- **move flash notice to translation file**
- **parameterize enter block details copy**
- **dynamic button copy when adding new embedded object**


--

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
