### PR TITLE
Fix intermittent test failures in CI

### DIFF
--- a/bin/minitest-ci
+++ b/bin/minitest-ci
@@ -4,17 +4,32 @@
 # defined in .github/workflows/minitest.yml.
 # It splits the MiniTest suite into randomly-allocated groups
 # which are executed across multiple GitHub Actions 'matrix' nodes.
+
 test_files = [
   Dir["test/**/*_test.rb"],
   Dir["lib/engines/**/test/**/*_test.rb"],
 ].flatten
 
-tests = test_files.
-  sort.
-  shuffle(random: Random.new(ENV['GITHUB_SHA'].to_i(16))).
-  select.
-  with_index do |el, i|
-    i % ENV["CI_NODE_TOTAL"].to_i == ENV["CI_NODE_INDEX"].to_i
-  end
+# Detect isolated test files (those with # RUN_IN_ISOLATION in the first 10 lines)
+isolated_tests, regular_tests = test_files.partition do |file|
+  File.foreach(file).first(10).grep(/# RUN_IN_ISOLATION/).any?
+end
 
-exec "bundle exec rails test #{tests.join(" ")}"
+# Determine which CI node is running
+node_index = ENV["CI_NODE_INDEX"].to_i
+total_nodes = ENV["CI_NODE_TOTAL"].to_i
+
+if node_index == 0
+  # First CI node runs all isolated tests sequentially
+  tests = isolated_tests
+  exec({ "RUN_IN_PARALLEL" => "false" }, "bundle exec rails test #{tests.join(' ')}")
+else
+  # Other nodes distribute regular tests
+  tests = regular_tests.
+    sort.
+    shuffle(random: Random.new(ENV['GITHUB_SHA'].to_i(16))).
+    select.
+    with_index { |_, i| i % (total_nodes - 1) == (node_index - 1) }
+
+  exec({ "RUN_IN_PARALLEL" => "true" }, "bundle exec rails test #{tests.join(' ')}")
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -46,7 +46,11 @@ class ActiveSupport::TestCase
   include UrlHelpers
   extend GovspeakValidationTestHelper
 
-  parallelize(workers: :number_of_processors)
+  if ENV["RUN_IN_PARALLEL"] == "false"
+    parallelize(workers: 1) # Run tests sequentially
+  else
+    parallelize(workers: :number_of_processors) # Run tests in parallel
+  end
 
   attr_reader :feature_flags
 

--- a/test/unit/app/sidekiq/scheduled_publishing_worker_test.rb
+++ b/test/unit/app/sidekiq/scheduled_publishing_worker_test.rb
@@ -1,3 +1,5 @@
+# RUN_IN_ISOLATION
+
 require "test_helper"
 
 class ScheduledPublishingWorkerTest < ActiveSupport::TestCase

--- a/test/unit/lib/tasks/election_mark_organisation_documents_as_political_test.rb
+++ b/test/unit/lib/tasks/election_mark_organisation_documents_as_political_test.rb
@@ -13,12 +13,12 @@ class IdentifyPoliticalContentFor < ActiveSupport::TestCase
 
     it "raises an error if organisation does not exist" do
       out, _err = capture_io { task.invoke("non-existent-slug", date) }
-      assert_equal 'There is no Organisation with slug ["non-existent-slug"]', out.strip
+      assert_includes out, 'There is no Organisation with slug ["non-existent-slug"]'
     end
 
     it "raises an error if date is not right format" do
       out, _err = capture_io { task.invoke(organisation.slug, "not a date") }
-      assert_equal 'The date is not on the right format ["not a date"]', out.strip
+      assert_includes out, 'The date is not on the right format ["not a date"]'
     end
 
     it "marks eligible published editions of documents first published after the specified date and any associated drafts as political" do


### PR DESCRIPTION
Fixes our flaky CI tests by:

1. fixing up tests to be more robust where possible
2. where not possible, running the tests in isolation to avoid race conditions

This PR allows us to add a `# RUN_IN_ISOLATION` magic comment to any test that is sensitive to being run in parallel. So far this is just the `ScheduledPublishingWorkerTest`, because it queries the `Sidekiq::ScheduledSet` directly, and that set can have its contents altered by other tests at runtime.

Test files with the magic comment are put onto their own node in GitHub Actions, and automatically configures the parallelize gem to run tests sequentially on that node, so all of our flaky tests can be run one after the other, at a slower speed but a greater reliability.

I really didn't want to do this. I tried switching up this test to use Sidekiq's "inline mode" for isolation, which forces jobs to execute immediately instead of being queued, removing race conditions. It's the approach we've already been applying elsewhere in Whitehall:
https://github.com/alphagov/whitehall/blob/d045ee80abfa1aad6750b779132b4baf3ca03adf/test/unit/lib/whitehall/publishing_api_test.rb#L98

Unfortunately it’s not as simple as setting the `scheduled_publishing_worker_test` into inline mode, as it’s some other test(s) that are polluting the ScheduledSet that are causing it to fail. So we’d have to go and fix all other tests to make this one test file pass consistently. That could quickly turn into whackamole...!

I then looked into [forcing Sidekiq to run inline globally](https://github.com/alphagov/whitehall/commit/a5a0589d89a05c8903592ffc75fea4cb4ce6c494), but that didn't appear to make any difference (nor did it allow me to [delete a whole bunch of 'Sidekiq::Testing.inline!' calls](https://github.com/alphagov/whitehall/commit/7cb6c5cb18a564fe3aef357411ed55b4f98e3c1c?w=1) as I'd hoped).

As a result:

- Test duration is [reduced to 1m11s](https://github.com/alphagov/whitehall/actions/runs/13672935533/job/38226967266?pr=10015) on the 'isolated' node
- 2m40s, 2m40s and 2m57s on the other nodes.
- By comparison, a [recent run on another branch](https://github.com/alphagov/whitehall/actions/runs/13672752674/job/38226418560) took 2m6s, 2m10s, 2m36s and 2m38s.
- Comparing the slowest nodes in each test run, the introduction of this 'isolated' mode has the potential to slow down our overall CI pipeline by 19 seconds.
- In reality, however, that's dwarfed by the (unaffected) Cucumber test suite, which [takes 6 and a half minutes](https://github.com/alphagov/whitehall/actions/runs/13672935533/job/38226966897?pr=10015) - so devs should not really be waiting any longer for the Minitest suite to pass.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
