### PR TITLE
Revert "Add GA4 index to attachment component renders"

### DIFF
--- a/app/helpers/attachments_helper.rb
+++ b/app/helpers/attachments_helper.rb
@@ -60,15 +60,14 @@ module AttachmentsHelper
   end
 
   def block_attachments(attachments = [], alternative_format_contact_email = nil)
-    filtered_attachments = attachments.select { |attachment| !attachment.file? || attachment.attachment_data.all_asset_variants_uploaded? }
-    filtered_attachments_size = filtered_attachments.size
-    filtered_attachments.each_with_index.map do |attachment, index|
+    attachments
+      .select { |attachment| !attachment.file? || attachment.attachment_data.all_asset_variants_uploaded? }
+      .map do |attachment|
       render(
         partial: "govuk_publishing_components/components/attachment",
         locals: {
           attachment: attachment_component_params(attachment, alternative_format_contact_email:),
           margin_bottom: 6,
-          details_ga4_attributes: { index_section: index + 1, index_section_count: filtered_attachments_size },
         },
       )
     end

--- a/test/unit/app/helpers/attachments_helper_test.rb
+++ b/test/unit/app/helpers/attachments_helper_test.rb
@@ -41,25 +41,6 @@ class AttachmentsHelperTest < ActionView::TestCase
     end
   end
 
-  test "block_attachments renders with GA4 indexes on the nested details component" do
-    alternative_format_contact_email = "test@example.com"
-    file_attachment_with_all_assets = create(:file_attachment)
-    attachments = [
-      file_attachment_with_all_assets,
-      file_attachment_with_all_assets,
-      file_attachment_with_all_assets,
-    ]
-
-    rendered_attachments = block_attachments(attachments, alternative_format_contact_email)
-    rendered_attachments.each.with_index do |rendered, index|
-      assert_select_within_html(rendered, ".gem-c-details") do |details|
-        ga4_event = JSON.parse(details.attribute("data-ga4-event"))
-        assert_equal ga4_event["index_section"], index + 1
-        assert_equal ga4_event["index_section_count"], 3
-      end
-    end
-  end
-
   test "component params for HTML attachment" do
     attachment = create(:html_attachment)
     expect_params = {


### PR DESCRIPTION
Reverts alphagov/whitehall#9996

The code works, but it wasn't giving us what we wanted analytics wise - so we'll revert it.