### PR TITLE
Change rendering app for Fatality Notices from government-frontend to frontend

### DIFF
--- a/app/models/fatality_notice.rb
+++ b/app/models/fatality_notice.rb
@@ -37,7 +37,7 @@ class FatalityNotice < Announcement
   end
 
   def rendering_app
-    Whitehall::RenderingApp::GOVERNMENT_FRONTEND
+    Whitehall::RenderingApp::FRONTEND
   end
 
   def base_path

--- a/test/unit/app/models/fatality_notice_test.rb
+++ b/test/unit/app/models/fatality_notice_test.rb
@@ -47,7 +47,7 @@ class FatalityNoticeTest < ActiveSupport::TestCase
     assert_not fatality_notice.can_be_marked_political?
   end
 
-  test "is rendered by government-frontend" do
-    assert FatalityNotice.new.rendering_app == Whitehall::RenderingApp::GOVERNMENT_FRONTEND
+  test "is rendered by frontend" do
+    assert FatalityNotice.new.rendering_app == Whitehall::RenderingApp::FRONTEND
   end
 end

--- a/test/unit/app/presenters/publishing_api/fatality_notice_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/fatality_notice_presenter_test.rb
@@ -47,8 +47,8 @@ class PublishingApi::FatalityNoticePresenterTest < ActiveSupport::TestCase
     assert_equal Whitehall::PublishingApp::WHITEHALL, @presented_content[:publishing_app]
   end
 
-  test "it presents the rendering_app as government-frontend" do
-    assert_equal "government-frontend", @presented_content[:rendering_app]
+  test "it presents the rendering_app as frontend" do
+    assert_equal "frontend", @presented_content[:rendering_app]
   end
 
   test "it presents the schema_name as fatality_notice" do


### PR DESCRIPTION
https://trello.com/c/2QCsgFab/492-move-fatality-notices-from-government-frontend-to-frontend

Not to be merged until https://github.com/alphagov/frontend/pull/4640 is merged and deployed.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
