### PR TITLE
Don't retry jobs that fail with `GdsApi::HTTPPayloadTooLarge`

### DIFF
--- a/app/sidekiq/publishing_api_document_republishing_worker.rb
+++ b/app/sidekiq/publishing_api_document_republishing_worker.rb
@@ -24,6 +24,9 @@ class PublishingApiDocumentRepublishingWorker < WorkerBase
       document.lock!
 
       document.republishing_actions.each { |action| send(action) }
+    rescue GdsApi::HTTPPayloadTooLarge => e
+      PublishingApiDocumentRepublishingWorker.sidekiq_options retry: 0
+      raise e
     end
   end
 


### PR DESCRIPTION
We're seeing a lot of republish job failures off the back of a recent bulk republish, whereby the documents in question are just far too large for the publishing platform to handle (too many attachments etc):
https://govuk.sentry.io/issues/6332398641/?environment=production&project=202259&referrer=issue-stream&statsPeriod=1h&stream_index=0

It's pointless retrying these, as the payload size won't change in between retries, and therefore it's always going to fail. We should instead log the exception, and kill the job.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
