### PR TITLE
Change rendering app for Corporate Information Pages from government-frontend to frontend

### DIFF
--- a/app/models/corporate_information_page.rb
+++ b/app/models/corporate_information_page.rb
@@ -93,7 +93,7 @@ class CorporateInformationPage < Edition
   end
 
   def rendering_app
-    Whitehall::RenderingApp::GOVERNMENT_FRONTEND
+    Whitehall::RenderingApp::FRONTEND
   end
 
   def previously_published

--- a/test/unit/app/models/corporate_information_page_test.rb
+++ b/test/unit/app/models/corporate_information_page_test.rb
@@ -305,4 +305,8 @@ class CorporateInformationPageTest < ActiveSupport::TestCase
     PublishingApiDocumentRepublishingWorker.expects(:perform_async_in_queue).with("bulk_republishing", about_us.document_id, true).never
     about_us.touch
   end
+
+  test "is rendered by frontend" do
+    assert CorporateInformationPage.new.rendering_app == Whitehall::RenderingApp::FRONTEND
+  end
 end

--- a/test/unit/app/presenters/publishing_api/corporate_information_page_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/corporate_information_page_presenter_test.rb
@@ -177,7 +177,7 @@ module PublishingApi::CorporateInformationPagePresenterTest
     end
 
     test "rendering app" do
-      assert_attribute :rendering_app, "government-frontend"
+      assert_attribute :rendering_app, "frontend"
     end
 
     test "schema name" do


### PR DESCRIPTION
This must not be merged until https://github.com/alphagov/frontend/pull/4608 is merged and deployed.

Trello card: https://trello.com/c/EKDXTDsm/398-move-document-type-corporateinformationpage-from-government-frontend-to-frontend

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
