### PR TITLE
(945) Add test IDs for summary card component

### DIFF
--- a/lib/engines/content_block_manager/app/components/content_block_manager/shared/embedded_objects/summary_card_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/shared/embedded_objects/summary_card_component.rb
@@ -21,12 +21,24 @@ private
         {
           key: key.titleize,
           value: object[key],
-          data: is_embeddable?(key) ? copy_embed_code(key) : nil,
+          data: data_attributes_for_row(key),
         },
       ]
-      rows.push(embed_code_row(key)) unless is_editable || !is_embeddable?(key)
+      rows.push(embed_code_row(key)) if should_show_embed_code?(key)
       rows
     }.flatten
+  end
+
+  def data_attributes_for_row(key)
+    attributes = {
+      testid: (object_title.parameterize + "_#{key}").underscore,
+    }
+    attributes.merge!(copy_embed_code(key)) if should_show_embed_code?(key)
+    attributes
+  end
+
+  def should_show_embed_code?(key)
+    !is_editable && is_embeddable?(key)
   end
 
   # This generates a row containing the embed code for the field above it -
@@ -50,12 +62,10 @@ private
   end
 
   def copy_embed_code(key)
-    unless is_editable
-      {
-        module: "copy-embed-code",
-        "embed-code": content_block_edition.document.embed_code_for_field("#{object_type}/#{object_title}/#{key}"),
-      }
-    end
+    {
+      module: "copy-embed-code",
+      "embed-code": content_block_edition.document.embed_code_for_field("#{object_type}/#{object_title}/#{key}"),
+    }
   end
 
   def object

--- a/lib/engines/content_block_manager/test/components/shared/embedded_objects/summary_card_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/shared/embedded_objects/summary_card_component_test.rb
@@ -36,17 +36,17 @@ class ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponentTest < V
 
     assert_selector ".govuk-summary-card__title", text: "Embedded Object details"
 
-    assert_selector ".govuk-summary-list__row", text: /Name/ do
+    assert_selector ".govuk-summary-list__row[data-testid='my_embedded_object_name']", text: /Name/ do
       assert_selector ".govuk-summary-list__key", text: "Name"
       assert_selector ".govuk-summary-list__value", text: "My Embedded Object"
     end
 
-    assert_selector ".govuk-summary-list__row", text: /Field 1/ do
+    assert_selector ".govuk-summary-list__row[data-testid='my_embedded_object_field_1']", text: /Field 1/ do
       assert_selector ".govuk-summary-list__key", text: "Field 1"
       assert_selector ".govuk-summary-list__value", text: "Value 1"
     end
 
-    assert_selector ".govuk-summary-list__row", text: /Field 2/ do
+    assert_selector ".govuk-summary-list__row[data-testid='my_embedded_object_field_2']", text: /Field 2/ do
       assert_selector ".govuk-summary-list__key", text: "Field 2"
       assert_selector ".govuk-summary-list__value", text: "Value 2"
     end


### PR DESCRIPTION
Trello card: https://trello.com/c/DOjHweAf/945-look-into-e2e-testing

We’re prepping some end to end tests, and best practice is to use `data-testid` attributes, rather than CSS (https://playwright.dev/docs/locators#locate-by-test-id) so let’s add a some test IDs to make it easier and less brittle to grab the elements that we want.