### PR TITLE
(957) Update copy for status field on CBM homepage

### DIFF
--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/index/summary_card_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/index/summary_card_component.rb
@@ -1,4 +1,6 @@
 class ContentBlockManager::ContentBlock::Document::Index::SummaryCardComponent < ViewComponent::Base
+  include ContentBlockManager::ContentBlock::EditionHelper
+
   def initialize(content_block_document:)
     @content_block_document = content_block_document
   end
@@ -84,10 +86,10 @@ private
   end
 
   def last_updated_value
-    "Published #{time_ago_in_words(content_block_edition.updated_at)} ago by #{content_block_edition.creator.name}"
+    "Published on #{published_date(content_block_edition)} by #{content_block_edition.creator.name}".html_safe
   end
 
   def scheduled_value
-    "Scheduled for publication at #{I18n.l(content_block_edition.scheduled_publication, format: :long_ordinal)}"
+    "Scheduled for publication at #{scheduled_date(content_block_edition)}".html_safe
   end
 end

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/summary_card_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/summary_card_component.rb
@@ -1,4 +1,6 @@
 class ContentBlockManager::ContentBlock::Document::Show::SummaryCardComponent < ViewComponent::Base
+  include ContentBlockManager::ContentBlock::EditionHelper
+
   def initialize(content_block_document:)
     @content_block_document = content_block_document
   end
@@ -72,11 +74,11 @@ private
   end
 
   def last_updated_value
-    "Published #{time_ago_in_words(content_block_edition.updated_at)} ago by #{content_block_edition.creator.name}"
+    "Published on #{published_date(content_block_edition)} by #{content_block_edition.creator.name}".html_safe
   end
 
   def scheduled_value
-    "Scheduled for publication at #{I18n.l(content_block_edition.scheduled_publication, format: :long_ordinal)}"
+    "Scheduled for publication at #{scheduled_date(content_block_edition)}".html_safe
   end
 
   def content_block_edition

--- a/lib/engines/content_block_manager/app/helpers/content_block_manager/content_block/edition_helper.rb
+++ b/lib/engines/content_block_manager/app/helpers/content_block_manager/content_block/edition_helper.rb
@@ -1,0 +1,19 @@
+module ContentBlockManager::ContentBlock::EditionHelper
+  def published_date(content_block_edition)
+    tag.time(
+      content_block_edition.updated_at.to_fs(:long_ordinal_with_at),
+      class: "date",
+      datetime: content_block_edition.updated_at.iso8601,
+      lang: "en",
+    )
+  end
+
+  def scheduled_date(content_block_edition)
+    tag.time(
+      content_block_edition.scheduled_publication.to_fs(:long_ordinal_with_at),
+      class: "date",
+      datetime: content_block_edition.scheduled_publication.iso8601,
+      lang: "en",
+    )
+  end
+end

--- a/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
@@ -423,7 +423,7 @@ end
 
 Then("I should see the scheduled date on the object") do
   expect(page).to have_selector(".govuk-summary-list__key", text: "Status")
-  expect(page).to have_selector(".govuk-summary-list__value", text: I18n.l(@future_date, format: :long_ordinal).squish)
+  expect(page).to have_selector(".govuk-summary-list__value", text: @future_date.to_fs(:long_ordinal_with_at).squish)
 end
 
 When("I continue after reviewing the links") do

--- a/lib/engines/content_block_manager/test/components/content_block/document/index/summary_card_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/document/index/summary_card_component_test.rb
@@ -5,6 +5,10 @@ class ContentBlockManager::ContentBlock::Document::Index::SummaryCardComponentTe
 
   include ContentBlockManager::Engine.routes.url_helpers
 
+  include ActionView::Helpers::TagHelper
+  include ActionView::Helpers::SanitizeHelper
+  include ContentBlockManager::ContentBlock::EditionHelper
+
   let(:content_block_edition) do
     create(
       :content_block_edition,
@@ -20,6 +24,10 @@ class ContentBlockManager::ContentBlock::Document::Index::SummaryCardComponentTe
   end
 
   let(:content_block_document) { content_block_edition.document }
+
+  before do
+    content_block_document.expects(:latest_edition).at_least_once.returns(content_block_edition)
+  end
 
   it "renders a published content block as a summary card" do
     render_inline(ContentBlockManager::ContentBlock::Document::Index::SummaryCardComponent.new(content_block_document:))
@@ -48,7 +56,7 @@ class ContentBlockManager::ContentBlock::Document::Index::SummaryCardComponentTe
     assert_no_selector ".govuk-summary-list__value", text: "None"
 
     assert_selector ".govuk-summary-list__key", text: "Status"
-    assert_selector ".govuk-summary-list__value", text: "Published 1 day ago by #{content_block_edition.creator.name}"
+    assert_selector ".govuk-summary-list__value", text: "Published on #{strip_tags published_date(content_block_edition)} by #{content_block_edition.creator.name}"
   end
 
   describe "when there are instructions to publishers" do
@@ -61,6 +69,20 @@ class ContentBlockManager::ContentBlock::Document::Index::SummaryCardComponentTe
 
       assert_selector ".govuk-summary-list__key", text: "Instructions to publishers"
       assert_selector ".govuk-summary-list__value", text: "instructions"
+    end
+  end
+
+  describe "when the edition is scheduled" do
+    it "returns the scheduled value" do
+      content_block_edition.state = "scheduled"
+      content_block_edition.scheduled_publication = Time.zone.now
+
+      render_inline(ContentBlockManager::ContentBlock::Document::Index::SummaryCardComponent.new(content_block_document:))
+
+      assert_selector ".govuk-summary-list__row", count: 5
+
+      assert_selector ".govuk-summary-list__key", text: "Status"
+      assert_selector ".govuk-summary-list__value", text: "Scheduled for publication at #{strip_tags scheduled_date(content_block_edition)}"
     end
   end
 end

--- a/lib/engines/content_block_manager/test/components/content_block/document/show/summary_card_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/document/show/summary_card_component_test.rb
@@ -2,6 +2,11 @@ require "test_helper"
 
 class ContentBlockManager::ContentBlock::Document::Show::SummaryCardComponentTest < ViewComponent::TestCase
   extend Minitest::Spec::DSL
+
+  include ActionView::Helpers::TagHelper
+  include ActionView::Helpers::SanitizeHelper
+  include ContentBlockManager::ContentBlock::EditionHelper
+
   include ContentBlockManager::Engine.routes.url_helpers
 
   let(:organisation) { create(:organisation, name: "Department for Example") }
@@ -39,7 +44,7 @@ class ContentBlockManager::ContentBlock::Document::Show::SummaryCardComponentTes
     assert_selector ".govuk-summary-list__value", text: "Department for Example"
 
     assert_selector ".govuk-summary-list__key", text: "Status"
-    assert_selector ".govuk-summary-list__value", text: "Published 1 day ago by #{content_block_edition.creator.name}"
+    assert_selector ".govuk-summary-list__value", text: "Published on #{strip_tags published_date(content_block_edition)} by #{content_block_edition.creator.name}"
 
     assert_selector ".govuk-summary-list__key", text: "Instructions to publishers"
     assert_selector ".govuk-summary-list__value", text: "None"
@@ -53,7 +58,7 @@ class ContentBlockManager::ContentBlock::Document::Show::SummaryCardComponentTes
     assert_selector ".govuk-summary-list__row", count: 6
 
     assert_selector ".govuk-summary-list__key", text: "Status"
-    assert_selector ".govuk-summary-list__value", text: "Scheduled for publication at #{I18n.l(content_block_edition.scheduled_publication, format: :long_ordinal)}"
+    assert_selector ".govuk-summary-list__value", text: "Scheduled for publication at #{strip_tags scheduled_date(content_block_edition)}"
     assert_selector ".govuk-summary-list__actions", text: "Edit schedule"
     assert_selector ".govuk-summary-list__actions a[href='#{content_block_manager_content_block_document_schedule_edit_path(content_block_document)}']"
   end

--- a/lib/engines/content_block_manager/test/unit/app/helpers/content_block_manager/content_block/edition_helper_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/helpers/content_block_manager/content_block/edition_helper_test.rb
@@ -1,0 +1,39 @@
+require "test_helper"
+
+class ContentBlockManager::ContentBlock::EditionHelperTest < ActionView::TestCase
+  extend Minitest::Spec::DSL
+
+  include ContentBlockManager::ContentBlock::EditionHelper
+
+  let(:content_block_edition) do
+    build(:content_block_edition,
+          updated_at: Time.zone.now - 2.days,
+          scheduled_publication: Time.zone.now + 3.days)
+  end
+
+  describe "#published_date" do
+    it "calls the time tag helper with the `updated_at` value of the edition" do
+      tag.expects(:time).with(
+        content_block_edition.updated_at.to_fs(:long_ordinal_with_at),
+        class: "date",
+        datetime: content_block_edition.updated_at.iso8601,
+        lang: "en",
+      ).returns("STUB")
+
+      assert_equal "STUB", published_date(content_block_edition)
+    end
+  end
+
+  describe "#scheduled_date" do
+    it "calls the time tag helper with the `scheduled_publication` value of the edition" do
+      tag.expects(:time).with(
+        content_block_edition.scheduled_publication.to_fs(:long_ordinal_with_at),
+        class: "date",
+        datetime: content_block_edition.scheduled_publication.iso8601,
+        lang: "en",
+      ).returns("STUB")
+
+      assert_equal "STUB", scheduled_date(content_block_edition)
+    end
+  end
+end


### PR DESCRIPTION
Trello card: https://trello.com/c/b29H4p2O/957-update-copy-for-status-field-on-cbm-homepage

This updates the published and scheduled dates to be specific dates, instead of vague relative ones. This was highlighted in a UAT when users failed to find an object that was published between two specific dates.

## Screenshots

### Before

![image](https://github.com/user-attachments/assets/8801379e-77f7-416d-8275-47be193f198a)

![image](https://github.com/user-attachments/assets/c214440f-0d0a-44aa-a7a1-91051b8cd2fb)

### After

![image](https://github.com/user-attachments/assets/1817ea0e-bd11-4525-ae88-4895d3be517a)

![image](https://github.com/user-attachments/assets/0f4b6b7f-84aa-4946-8352-fb823f489f41)
