### PR TITLE
Content modelling/968 bug defer payment welsh guide preview in edit journey leads to server error published state

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -242,7 +242,7 @@ GEM
       et-orbi (~> 1, >= 1.2.11)
       raabro (~> 1.4)
     fuzzy_match (2.1.0)
-    gds-api-adapters (98.2.0)
+    gds-api-adapters (98.3.0)
       addressable
       link_header
       null_logger

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/host_editions_table_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/host_editions_table_component.rb
@@ -73,7 +73,7 @@ private
 
   def frontend_path(content_item)
     if @is_preview
-      helpers.content_block_manager.host_content_preview_content_block_manager_content_block_edition_path(id: content_block_edition.id, host_content_id: content_item.host_content_id)
+      helpers.content_block_manager.host_content_preview_content_block_manager_content_block_edition_path(id: content_block_edition.id, host_content_id: content_item.host_content_id, locale: content_item.host_locale)
     else
       Plek.website_root + content_item.base_path
     end

--- a/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/editions/host_content_controller.rb
+++ b/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/editions/host_content_controller.rb
@@ -6,6 +6,7 @@ class ContentBlockManager::ContentBlock::Editions::HostContentController < Conte
       content_id: host_content_id,
       content_block_edition: @content_block_edition,
       base_path: params[:base_path],
+      locale: params[:locale],
     )
   end
 end

--- a/lib/engines/content_block_manager/app/models/content_block_manager/host_content_item.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/host_content_item.rb
@@ -10,6 +10,7 @@ module ContentBlockManager
     :unique_pageviews,
     :instances,
     :host_content_id,
+    :host_locale,
   )
 
     DEFAULT_ORDER = "-unique_pageviews".freeze
@@ -62,6 +63,7 @@ module ContentBlockManager
           unique_pageviews: record["unique_pageviews"],
           instances: record["instances"],
           host_content_id: record["host_content_id"],
+          host_locale: record["host_locale"],
         )
       end
     end

--- a/lib/engines/content_block_manager/app/models/content_block_manager/preview_content.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/preview_content.rb
@@ -6,7 +6,7 @@ module ContentBlockManager
         metadata = Services.publishing_api.get_host_content_item_for_content_id(
           content_block_edition.document.content_id,
           content_id,
-          { locale: }
+          { locale: },
         ).parsed_content
         html = ContentBlockManager::GeneratePreviewHtml.new(
           content_id:,

--- a/lib/engines/content_block_manager/app/models/content_block_manager/preview_content.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/preview_content.rb
@@ -1,11 +1,12 @@
 module ContentBlockManager
   class PreviewContent < Data.define(:title, :html, :instances_count)
     class << self
-      def for_content_id(content_id:, content_block_edition:, base_path: nil)
-        content_item = Services.publishing_api.get_content(content_id).parsed_content
+      def for_content_id(content_id:, content_block_edition:, base_path: nil, locale: "en")
+        content_item = Services.publishing_api.get_content(content_id, { locale: }).parsed_content
         metadata = Services.publishing_api.get_host_content_item_for_content_id(
           content_block_edition.document.content_id,
           content_id,
+          { locale: }
         ).parsed_content
         html = ContentBlockManager::GeneratePreviewHtml.new(
           content_id:,

--- a/lib/engines/content_block_manager/app/models/content_block_manager/preview_content.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/preview_content.rb
@@ -12,6 +12,7 @@ module ContentBlockManager
           content_id:,
           content_block_edition:,
           base_path: base_path || content_item["base_path"],
+          locale:,
         ).call
 
         ContentBlockManager::PreviewContent.new(

--- a/lib/engines/content_block_manager/app/services/content_block_manager/generate_preview_html.rb
+++ b/lib/engines/content_block_manager/app/services/content_block_manager/generate_preview_html.rb
@@ -6,10 +6,11 @@ module ContentBlockManager
   class GeneratePreviewHtml
     include ContentBlockManager::Engine.routes.url_helpers
 
-    def initialize(content_id:, content_block_edition:, base_path:)
+    def initialize(content_id:, content_block_edition:, base_path:, locale:)
       @content_id = content_id
       @content_block_edition = content_block_edition
       @base_path = base_path
+      @locale = locale
     end
 
     def call
@@ -25,7 +26,7 @@ module ContentBlockManager
     BLOCK_STYLE = "background-color: yellow;".freeze
     ERROR_HTML = "<html><body><p>Preview not found</p></body></html>".freeze
 
-    attr_reader :content_block_edition, :content_id, :base_path
+    attr_reader :content_block_edition, :content_id, :base_path, :locale
 
     def frontend_path
       frontend_base_path + base_path
@@ -45,11 +46,11 @@ module ContentBlockManager
     end
 
     def update_local_link_paths(nokogiri_html)
-      url = host_content_preview_content_block_manager_content_block_edition_path(id: content_block_edition.id, host_content_id: content_id)
+      url = host_content_preview_content_block_manager_content_block_edition_path(id: content_block_edition.id, host_content_id: content_id, locale:)
       nokogiri_html.css("a").each do |link|
         next if link[:href].start_with?("//") || link[:href].start_with?("http")
 
-        link[:href] = "#{url}?base_path=#{link[:href]}"
+        link[:href] = "#{url}&base_path=#{link[:href]}"
         link[:target] = "_parent"
       end
 

--- a/lib/engines/content_block_manager/features/step_definitions/dependent_content_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/dependent_content_steps.rb
@@ -27,6 +27,7 @@ When(/^dependent content exists for a content block$/) do
       "last_edited_by_editor_id" => host_editor_id,
       "last_edited_at" => 2.days.ago.to_s,
       "host_content_id" => "abc12345",
+      "host_locale" => "en",
       "instances" => 1,
       "primary_publishing_organisation" => {
         "content_id" => SecureRandom.uuid,

--- a/lib/engines/content_block_manager/features/step_definitions/preview_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/preview_steps.rb
@@ -5,7 +5,7 @@ When("I click on the first host document") do
   stub_request(
     :get,
     "#{Plek.find('publishing-api')}/v2/content/#{@current_host_document['host_content_id']}",
-  ).to_return(
+  ).with(query: { locale: "en" }).to_return(
     status: 200,
     body: {
       details: {
@@ -20,7 +20,7 @@ When("I click on the first host document") do
 
   stub_request(
     :get,
-    Plek.website_root + @current_host_document["base_path"],
+    "#{Plek.website_root}#{@current_host_document['base_path']}",
   ).to_return(
     status: 200,
     body: "<body><h1>#{@current_host_document['title']}</h1><p>iframe preview <a href=\"/other-page\">Link to other page</a></p>#{@content_block.render(embed_code)}</body>",

--- a/lib/engines/content_block_manager/features/support/dependent_content.rb
+++ b/lib/engines/content_block_manager/features/support/dependent_content.rb
@@ -1,5 +1,6 @@
-def stub_publishing_api_has_embedded_content_details(dependent_content)
+def stub_publishing_api_has_embedded_content_details(dependent_content, locale = "en")
   url = %r{\A#{GdsApi::TestHelpers::PublishingApi::PUBLISHING_API_V2_ENDPOINT}/content/[0-9a-fA-F-]{36}/host-content/#{dependent_content['host_content_id']}}
   stub_request(:get, url)
+    .with(query: { locale: })
     .to_return(body: dependent_content.to_json)
 end

--- a/lib/engines/content_block_manager/test/components/content_block/document/show/host_editions_table_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/document/show/host_editions_table_component_test.rb
@@ -28,6 +28,7 @@ class ContentBlockManager::ContentBlock::Document::Show::HostEditionsTableCompon
       "publishing_organisation" => publishing_organisation,
       "unique_pageviews" => unique_pageviews,
       "host_content_id" => SecureRandom.uuid,
+      "host_locale" => "en",
       "instances" => 1,
     )
   end
@@ -179,7 +180,7 @@ class ContentBlockManager::ContentBlock::Document::Show::HostEditionsTableCompon
           ),
         )
 
-        assert_selector "a[href='#{host_content_preview_content_block_manager_content_block_edition_path(id: content_block_edition.id, host_content_id: host_content_item.host_content_id)}']", text: host_content_item.title
+        assert_selector "a[href='#{host_content_preview_content_block_manager_content_block_edition_path(id: content_block_edition.id, host_content_id: host_content_item.host_content_id, locale: host_content_item.host_locale)}']", text: host_content_item.title
       end
     end
 

--- a/lib/engines/content_block_manager/test/factories/host_content_item.rb
+++ b/lib/engines/content_block_manager/test/factories/host_content_item.rb
@@ -10,6 +10,7 @@ FactoryBot.define do
     unique_pageviews { 123 }
     instances { 1 }
     host_content_id { SecureRandom.uuid }
+    host_locale { "en" }
 
     initialize_with do
       new(title:,
@@ -21,6 +22,7 @@ FactoryBot.define do
           last_edited_at:,
           unique_pageviews:,
           host_content_id:,
+          host_locale:,
           instances:)
     end
   end

--- a/lib/engines/content_block_manager/test/unit/app/models/host_content_item_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/models/host_content_item_test.rb
@@ -31,6 +31,7 @@ class ContentBlockManager::HostContentItemTest < ActiveSupport::TestCase
             "unique_pageviews" => 123,
             "instances" => 1,
             "host_content_id" => host_content_id,
+            "host_locale" => "en",
             "primary_publishing_organisation" => {
               "content_id" => SecureRandom.uuid,
               "title" => "bar",
@@ -115,6 +116,7 @@ class ContentBlockManager::HostContentItemTest < ActiveSupport::TestCase
       assert_equal result[0].unique_pageviews, response_body["results"][0]["unique_pageviews"]
       assert_equal result[0].instances, response_body["results"][0]["instances"]
       assert_equal result[0].host_content_id, response_body["results"][0]["host_content_id"]
+      assert_equal result[0].host_locale, response_body["results"][0]["host_locale"]
 
       assert_equal result[0].publishing_organisation, expected_publishing_organisation
     end

--- a/lib/engines/content_block_manager/test/unit/app/models/preview_content_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/models/preview_content_test.rb
@@ -50,7 +50,7 @@ class ContentBlockManager::PreviewContentTest < ActiveSupport::TestCase
         preview_content = ContentBlockManager::PreviewContent.for_content_id(
           content_id: host_content_id,
           content_block_edition: block_to_preview,
-          )
+        )
 
         assert_equal host_title, preview_content.title
         assert_equal 2, preview_content.instances_count
@@ -71,7 +71,7 @@ class ContentBlockManager::PreviewContentTest < ActiveSupport::TestCase
           content_id: host_content_id,
           content_block_edition: block_to_preview,
           base_path:,
-          )
+        )
       end
     end
 

--- a/lib/engines/content_block_manager/test/unit/app/models/preview_content_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/models/preview_content_test.rb
@@ -43,7 +43,8 @@ class ContentBlockManager::PreviewContentTest < ActiveSupport::TestCase
         ContentBlockManager::GeneratePreviewHtml.expects(:new)
                                                 .with(content_id: host_content_id,
                                                       content_block_edition: block_to_preview,
-                                                      base_path: host_base_path)
+                                                      base_path: host_base_path,
+                                                      locale: "en")
                                                 .returns(preview_response)
 
         preview_content = ContentBlockManager::PreviewContent.for_content_id(
@@ -62,7 +63,8 @@ class ContentBlockManager::PreviewContentTest < ActiveSupport::TestCase
         ContentBlockManager::GeneratePreviewHtml.expects(:new)
                                                 .with(content_id: host_content_id,
                                                       content_block_edition: block_to_preview,
-                                                      base_path:)
+                                                      base_path:,
+                                                      locale: "en")
                                                 .returns(preview_response)
 
         ContentBlockManager::PreviewContent.for_content_id(
@@ -85,7 +87,8 @@ class ContentBlockManager::PreviewContentTest < ActiveSupport::TestCase
         ContentBlockManager::GeneratePreviewHtml.expects(:new)
                                                 .with(content_id: host_content_id,
                                                       content_block_edition: block_to_preview,
-                                                      base_path: host_base_path)
+                                                      base_path: host_base_path,
+                                                      locale: "cy")
                                                 .returns(preview_response)
 
         preview_content = ContentBlockManager::PreviewContent.for_content_id(

--- a/lib/engines/content_block_manager/test/unit/app/services/generate_preview_html_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/services/generate_preview_html_test.rb
@@ -33,7 +33,7 @@ class ContentBlockManager::GeneratePreviewHtmlTest < ActiveSupport::TestCase
   end
 
   it "returns the preview html" do
-    Net::HTTP.expects(:get).with(URI(Plek.website_root + host_base_path)).returns(fake_frontend_response)
+    Net::HTTP.expects(:get).with(URI("#{Plek.website_root}#{host_base_path}")).returns(fake_frontend_response)
 
     expected_content = Nokogiri::HTML.parse(expected_html).to_s
 
@@ -41,6 +41,7 @@ class ContentBlockManager::GeneratePreviewHtmlTest < ActiveSupport::TestCase
       content_id: host_content_id,
       content_block_edition: block_to_preview,
       base_path: host_base_path,
+      locale: "en",
     ).call
 
     assert_equal expected_content, actual_content
@@ -48,7 +49,7 @@ class ContentBlockManager::GeneratePreviewHtmlTest < ActiveSupport::TestCase
 
   it "shows an error template when the request to the frontend throws an error" do
     exception = StandardError.new("Something went wrong")
-    Net::HTTP.expects(:get).with(URI(Plek.website_root + host_base_path)).raises(exception)
+    Net::HTTP.expects(:get).with(URI("#{Plek.website_root}#{host_base_path}")).raises(exception)
 
     expected_content = Nokogiri::HTML.parse(error_html).to_s
 
@@ -56,6 +57,7 @@ class ContentBlockManager::GeneratePreviewHtmlTest < ActiveSupport::TestCase
       content_id: host_content_id,
       content_block_edition: block_to_preview,
       base_path: host_base_path,
+      locale: "en",
     ).call
 
     assert_equal expected_content, actual_content
@@ -67,12 +69,13 @@ class ContentBlockManager::GeneratePreviewHtmlTest < ActiveSupport::TestCase
         <a href='https://example.com'>External link</a>
         <a href='//example.com'>Protocol relative link</a>
       "
-    Net::HTTP.expects(:get).with(URI(Plek.website_root + host_base_path)).returns(fake_frontend_response)
+    Net::HTTP.expects(:get).with(URI("#{Plek.website_root}#{host_base_path}")).returns(fake_frontend_response)
 
     actual_content = ContentBlockManager::GeneratePreviewHtml.new(
       content_id: host_content_id,
       content_block_edition: block_to_preview,
       base_path: host_base_path,
+      locale: "en",
     ).call
 
     url = host_content_preview_content_block_manager_content_block_edition_path(id: block_to_preview.id, host_content_id:)
@@ -80,7 +83,7 @@ class ContentBlockManager::GeneratePreviewHtmlTest < ActiveSupport::TestCase
     expected_content = Nokogiri::HTML.parse("
         <html>
           <body class=' draft'>
-            <a href='#{url}?base_path=/foo' target='_parent'>Internal link</a>
+            <a href='#{url}?locale=en&base_path=/foo' target='_parent'>Internal link</a>
             <a href='https://example.com'>External link</a>
             <a href='//example.com'>Protocol relative link</a>
           </body>


### PR DESCRIPTION
https://trello.com/c/8SRwSAUh/968-bug-defer-payment-welsh-guide-preview-in-edit-journey-leads-to-server-error-published-state

We discovered some issues with preview when a document has a locale which is not English. We've made some upstream changes that now allow us to receive the locale of host items, as well as fetch single host content items with a specific locale (sometimes items can have the same content ID, but different locales). 

This requires a bit of passing around of locales, but I've tested it locally with a non-english locale and it seems to work!