### PR TITLE
Make edition ID unique on Link Checker API Reports

### DIFF
--- a/db/migrate/20250314094940_make_edition_id_unique_on_link_checker_api_reports.rb
+++ b/db/migrate/20250314094940_make_edition_id_unique_on_link_checker_api_reports.rb
@@ -1,0 +1,17 @@
+# rubocop:disable Rails/BulkChangeTable
+class MakeEditionIdUniqueOnLinkCheckerApiReports < ActiveRecord::Migration[8.0]
+  def change
+    # Step 1: Remove the foreign key constraint
+    remove_foreign_key :link_checker_api_reports, :editions
+
+    # Step 2: Remove the existing non-unique index
+    remove_index :link_checker_api_reports, :edition_id
+
+    # Step 3: Add a new unique index
+    add_index :link_checker_api_reports, :edition_id, unique: true
+
+    # Step 4: Re-add the foreign key constraint if required
+    add_foreign_key :link_checker_api_reports, :editions, column: :edition_id
+  end
+end
+# rubocop:enable Rails/BulkChangeTable

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_14_094300) do
+ActiveRecord::Schema[8.0].define(version: 2025_03_14_094940) do
   create_table "assets", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.string "variant", null: false
@@ -701,7 +701,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_14_094300) do
     t.datetime "updated_at", precision: nil, null: false
     t.integer "edition_id"
     t.index ["batch_id"], name: "index_link_checker_api_reports_on_batch_id", unique: true
-    t.index ["edition_id"], name: "index_link_checker_api_reports_on_edition_id"
+    t.index ["edition_id"], name: "index_link_checker_api_reports_on_edition_id", unique: true
   end
 
   create_table "nation_inapplicabilities", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|

--- a/test/unit/app/models/admin/edition_filter_test.rb
+++ b/test/unit/app/models/admin/edition_filter_test.rb
@@ -250,18 +250,6 @@ class Admin::EditionFilterTest < ActiveSupport::TestCase
     assert_equal [edition_with_broken_link, edition_with_caution_link], Admin::EditionFilter.new(Edition, @current_user, only_broken_links: true).editions.sort_by(&:id)
   end
 
-  test "should only filter by the most recent broken link report" do
-    edition = create(
-      :published_publication,
-    )
-    broken_link = create(:link_checker_api_report_link, uri: "https://www.gov.uk/broken-link", status: "broken")
-    ok_link = create(:link_checker_api_report_link, uri: "https://www.gov.uk/ok-link", status: "ok")
-    create(:link_checker_api_report, batch_id: 1, edition: edition, links: [broken_link])
-    create(:link_checker_api_report, batch_id: 2, edition: edition, links: [ok_link])
-
-    assert_equal [], Admin::EditionFilter.new(Edition, @current_user, only_broken_links: true).editions.sort_by(&:id)
-  end
-
   test "should filter by overdue reviews" do
     document = create(:document)
     edition_with_overdue_reminder = create(:published_edition, document:)


### PR DESCRIPTION
Now that we've switched to only storing one link check report per
edition, and we've removed all historic 'arrays' of reports, in
https://github.com/alphagov/whitehall/pull/10042

...we can now enforce this rule at the database level with a
uniqueness constraint.

Trello: https://trello.com/c/tmnht4P1

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
