### PR TITLE
Make DB migration idempotent

### DIFF
--- a/db/migrate/20250314094940_make_edition_id_unique_on_link_checker_api_reports.rb
+++ b/db/migrate/20250314094940_make_edition_id_unique_on_link_checker_api_reports.rb
@@ -1,17 +1,23 @@
-# rubocop:disable Rails/BulkChangeTable
 class MakeEditionIdUniqueOnLinkCheckerApiReports < ActiveRecord::Migration[8.0]
   def change
-    # Step 1: Remove the foreign key constraint
-    remove_foreign_key :link_checker_api_reports, :editions
+    # Step 1: Remove the foreign key constraint if it exists
+    if foreign_key_exists?(:link_checker_api_reports, :editions)
+      remove_foreign_key :link_checker_api_reports, :editions
+    end
 
-    # Step 2: Remove the existing non-unique index
-    remove_index :link_checker_api_reports, :edition_id
+    # Step 2: Remove the existing non-unique index if it exists
+    if index_exists?(:link_checker_api_reports, :edition_id)
+      remove_index :link_checker_api_reports, :edition_id
+    end
 
-    # Step 3: Add a new unique index
-    add_index :link_checker_api_reports, :edition_id, unique: true
+    # Step 3: Add a new unique index (only if it doesn't already exist)
+    unless index_exists?(:link_checker_api_reports, :edition_id, unique: true)
+      add_index :link_checker_api_reports, :edition_id, unique: true
+    end
 
-    # Step 4: Re-add the foreign key constraint if required
-    add_foreign_key :link_checker_api_reports, :editions, column: :edition_id
+    # Step 4: Re-add the foreign key constraint if it doesn't already exist
+    unless foreign_key_exists?(:link_checker_api_reports, :editions)
+      add_foreign_key :link_checker_api_reports, :editions, column: :edition_id
+    end
   end
 end
-# rubocop:enable Rails/BulkChangeTable


### PR DESCRIPTION
We were seeing this failure on staging:

```
== 20250314094940 MakeEditionIdUniqueOnLinkCheckerApiReports: migrating =======
-- remove_foreign_key(:link_checker_api_reports, :editions)
bin/rails aborted!
StandardError: An error has occurred, all later migrations canceled: (StandardError)
Table 'link_checker_api_reports' has no foreign key for editions
/app/db/migrate/20250314094940_make_edition_id_unique_on_link_checker_api_reports.rb:5:in `change'
Caused by:
ArgumentError: Table 'link_checker_api_reports' has no foreign key for editions (ArgumentError)
            raise(ArgumentError, "Table '#{from_table}' has no foreign key for #{to_table || options}")
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/app/db/migrate/20250314094940_make_edition_id_unique_on_link_checker_api_reports.rb:5:in `change'
Tasks: TOP => db:migrate
```

This didn't happen on Integration.

It's possible that the branch had been deployed to and run on staging, and now on merge, we're encountering an error. So tweaking the migration to run idempotently.

Trello: https://trello.com/c/tmnht4P1

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
