### PR TITLE
Highlight 'dangerous links'

### DIFF
--- a/app/components/admin/editions/tags_component.rb
+++ b/app/components/admin/editions/tags_component.rb
@@ -36,6 +36,8 @@ private
   def broken_links_report_tag
     return unless edition.link_check_report.present? && edition.link_check_report.completed?
 
+    return create_tag("Dangerous links") if edition.link_check_report.danger_links.any?
+
     return create_tag("Broken links") if edition.link_check_report.broken_links.any?
 
     create_tag("Link warnings") if edition.link_check_report.caution_links.any?
@@ -67,7 +69,7 @@ private
       "govuk-tag--green"
     when "Scheduled"
       "govuk-tag--turquoise"
-    when "Rejected", "Broken links", "Limited access"
+    when "Rejected", "Dangerous links", "Broken links", "Limited access"
       "govuk-tag--red"
     when "Withdrawn", "Unpublished"
       "govuk-tag--grey"

--- a/app/models/concerns/edition/scopes/filterable_by_broken_links.rb
+++ b/app/models/concerns/edition/scopes/filterable_by_broken_links.rb
@@ -19,7 +19,7 @@ module Edition::Scopes::FilterableByBrokenLinks
     SELECT 1
     FROM link_checker_api_report_links
     WHERE link_checker_api_report_id = latest_link_checker_api_reports.id
-      AND link_checker_api_report_links.status IN ('broken', 'caution')
+      AND link_checker_api_report_links.status IN ('danger', 'broken', 'caution')
   )",
       )
     }

--- a/app/models/link_checker_api_report.rb
+++ b/app/models/link_checker_api_report.rb
@@ -38,7 +38,7 @@ NOT EXISTS (
   end
 
   def has_problems?
-    links.any? { |l| %w[caution broken].include?(l.status) }
+    links.any? { |l| %w[caution broken danger].include?(l.status) }
   end
 
   def broken_links
@@ -47,5 +47,9 @@ NOT EXISTS (
 
   def caution_links
     links.select { |l| l.status == "caution" }
+  end
+
+  def danger_links
+    links.select { |l| l.status == "danger" }
   end
 end

--- a/app/models/link_checker_api_report/link.rb
+++ b/app/models/link_checker_api_report/link.rb
@@ -1,4 +1,5 @@
 class LinkCheckerApiReport::Link < ApplicationRecord
+  serialize :check_dangers, coder: YAML, type: Array
   serialize :check_errors, coder: YAML, type: Array
   serialize :check_warnings, coder: YAML, type: Array
 
@@ -13,8 +14,9 @@ class LinkCheckerApiReport::Link < ApplicationRecord
       uri: payload.fetch("uri"),
       status: payload.fetch("status"),
       checked: payload.fetch("checked"),
-      check_warnings: payload.fetch("warnings", []),
+      check_dangers: payload.fetch("dangers", []),
       check_errors: payload.fetch("errors", []),
+      check_warnings: payload.fetch("warnings", []),
       problem_summary: payload.fetch("problem_summary"),
       suggested_fix: payload.fetch("suggested_fix"),
     }

--- a/app/views/admin/link_check_reports/_link_check_report.html.erb
+++ b/app/views/admin/link_check_reports/_link_check_report.html.erb
@@ -19,12 +19,15 @@
         </p>
       <% end
     } %>
-  <% elsif report.broken_links.any? || report.caution_links.any? %>
+  <% elsif report.danger_links.any? || report.broken_links.any? || report.caution_links.any? %>
     <%= render "components/inset_prompt", {
       title: t("broken_links.title"),
       description: capture do %>
-        <% report.links.sort_by(&:status).group_by(&:status).each do |status, links| %>
-          <% next unless %w(broken caution).include? status %>
+        <%
+          status_order = { "danger" => 1, "broken" => 2, "caution" => 3 }
+          report.links.sort_by { |link| status_order[link.status] || 9999 }.group_by(&:status).each do |status, links|
+        %>
+          <% next unless %w(danger broken caution).include? status %>
 
           <p class="govuk-body"><%= t "broken_links.#{status}.subheading" %></p>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -66,6 +66,8 @@ en:
     opendocument:
       help_html: This file is in an <a href="https://www.gov.uk/guidance/using-open-document-formats-odf-in-your-organisation">OpenDocument</a> format
   broken_links:
+    danger:
+      subheading: We’ve found links in this document that may be dangerous
     broken:
       subheading: We’ve found links in this document that may be broken
     caution:

--- a/db/migrate/20250317152446_add_check_dangers_to_link.rb
+++ b/db/migrate/20250317152446_add_check_dangers_to_link.rb
@@ -1,0 +1,5 @@
+class AddCheckDangersToLink < ActiveRecord::Migration[8.0]
+  def change
+    add_column :link_checker_api_report_links, :check_dangers, :text, limit: 16.megabytes - 1
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_14_094940) do
+ActiveRecord::Schema[8.0].define(version: 2025_03_17_152446) do
   create_table "assets", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.string "variant", null: false
@@ -690,6 +690,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_14_094940) do
     t.datetime "updated_at", precision: nil, null: false
     t.text "problem_summary", size: :medium
     t.text "suggested_fix", size: :medium
+    t.text "check_dangers", size: :medium
     t.index ["link_checker_api_report_id"], name: "index_link_checker_api_report_id"
   end
 

--- a/test/components/admin/editions/tags_component_test.rb
+++ b/test/components/admin/editions/tags_component_test.rb
@@ -75,6 +75,21 @@ class Admin::Editions::TagsComponentTest < ViewComponent::TestCase
     assert_equal expected_output, output
   end
 
+  test "adds a dangerous links tag if the last report has dangerous links" do
+    edition = build(:edition)
+    links_report = build(:link_checker_api_report_completed, edition: edition)
+    danger_link = build(:link_checker_api_report_link, :danger, link_checker_api_report_id: links_report.id)
+
+    edition.stubs(:link_check_report).returns(links_report)
+    links_report.stubs(:danger_links).returns([danger_link])
+
+    expected_output = "<span class=\"govuk-tag govuk-tag--s govuk-tag--blue\">Draft</span> " \
+      "<span class=\"govuk-tag govuk-tag--s govuk-tag--red\">Dangerous links</span>"
+    output = render_inline(Admin::Editions::TagsComponent.new(edition)).to_html.strip
+
+    assert_equal expected_output, output
+  end
+
   test "adds a broken links tag if the last report has broken links" do
     edition = build(:edition)
     links_report = build(:link_checker_api_report_completed, edition: edition)

--- a/test/factories/link_checker_api_report_link.rb
+++ b/test/factories/link_checker_api_report_link.rb
@@ -7,5 +7,9 @@ FactoryBot.define do
     trait :broken do
       status { "broken" }
     end
+
+    trait :danger do
+      status { "danger" }
+    end
   end
 end

--- a/test/unit/app/models/admin/edition_filter_test.rb
+++ b/test/unit/app/models/admin/edition_filter_test.rb
@@ -238,16 +238,21 @@ class Admin::EditionFilterTest < ActiveSupport::TestCase
     edition_with_pending_link = create(
       :published_publication,
     )
+    edition_with_danger_link = create(
+      :published_publication,
+    )
     broken_link = create(:link_checker_api_report_link, uri: "https://www.gov.uk/broken-link", status: "broken")
     caution_link = create(:link_checker_api_report_link, uri: "https://www.gov.uk/caution-link", status: "caution")
     ok_link = create(:link_checker_api_report_link, uri: "https://www.gov.uk/ok-link", status: "ok")
     pending_link = create(:link_checker_api_report_link, uri: "https://www.gov.uk/pending-link", status: "pending")
+    danger_link = create(:link_checker_api_report_link, uri: "https://www.gov.uk/danger-link", status: "danger")
     create(:link_checker_api_report, batch_id: 1, edition: edition_with_broken_link, links: [broken_link])
     create(:link_checker_api_report, batch_id: 2, edition: edition_with_caution_link, links: [caution_link])
     create(:link_checker_api_report, batch_id: 3, edition: edition_with_ok_link, links: [ok_link])
     create(:link_checker_api_report, batch_id: 4, edition: edition_with_pending_link, links: [pending_link])
+    create(:link_checker_api_report, batch_id: 5, edition: edition_with_danger_link, links: [danger_link])
 
-    assert_equal [edition_with_broken_link, edition_with_caution_link], Admin::EditionFilter.new(Edition, @current_user, only_broken_links: true).editions.sort_by(&:id)
+    assert_equal [edition_with_broken_link, edition_with_caution_link, edition_with_danger_link], Admin::EditionFilter.new(Edition, @current_user, only_broken_links: true).editions.sort_by(&:id)
   end
 
   test "should filter by overdue reviews" do


### PR DESCRIPTION
In https://github.com/alphagov/link-checker-api/pull/969, a new 'danger' status was added (alongside 'broken' and 'warning' - the latter referred to as 'caution'), to denote a separate class of links which are considered 'dangerous' and should not be published.

This first PR simply supports the 'danger link' concept and surfaces it as such in the editor. In a subsequent PR, we will build upon the concept (e.g. to auto-remove dangerous links, or to prevent publishing editions that contain dangerous links).

Dangerous links surfaced in search results:

> ![Screenshot 2025-03-17 at 15 53 44](https://github.com/user-attachments/assets/c874e148-b7fa-4e39-83fb-8edc32c8b4b3)

Dangerous links surfaced in edition admin view:

![Screenshot 2025-03-17 at 16 19 13](https://github.com/user-attachments/assets/e25edf28-147e-4426-8282-2b54c6aa291d)

Trello: https://trello.com/c/tmnht4P1

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
