### PR TITLE
Add search filter for 'dangerous links'

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -417,7 +417,7 @@ private
   end
 
   def params_filters
-    params.slice(:type, :state, :organisation, :author, :page, :title, :world_location, :from_date, :to_date, :only_broken_links, :review_overdue)
+    params.slice(:type, :state, :organisation, :author, :page, :title, :world_location, :from_date, :to_date, :only_broken_links, :only_danger_links, :review_overdue)
           .permit!
           .to_h
   end

--- a/app/models/admin/edition_filter.rb
+++ b/app/models/admin/edition_filter.rb
@@ -121,6 +121,7 @@ module Admin
       editions = editions.from_date(from_date) if from_date
       editions = editions.to_date(to_date) if to_date
       editions = editions.only_broken_links if only_broken_links
+      editions = editions.only_danger_links if only_danger_links
       editions = editions.review_overdue if review_overdue
 
       editions = editions.includes(:unpublishing) if include_unpublishing?
@@ -259,6 +260,10 @@ module Admin
 
     def only_broken_links
       options[:only_broken_links].present?
+    end
+
+    def only_danger_links
+      options[:only_danger_links].present?
     end
 
     def review_overdue

--- a/app/models/concerns/edition/scopes/filterable_by_broken_links.rb
+++ b/app/models/concerns/edition/scopes/filterable_by_broken_links.rb
@@ -23,5 +23,27 @@ module Edition::Scopes::FilterableByBrokenLinks
   )",
       )
     }
+
+    scope :only_danger_links, lambda {
+      joins(
+        "
+  LEFT JOIN (
+    SELECT id, edition_id
+    FROM link_checker_api_reports
+    GROUP BY edition_id
+    ORDER BY id DESC
+  ) AS latest_link_checker_api_reports
+    ON latest_link_checker_api_reports.edition_id = editions.id
+   AND latest_link_checker_api_reports.id = (SELECT MAX(id) FROM link_checker_api_reports WHERE link_checker_api_reports.edition_id = editions.id)",
+      ).where(
+        "
+  EXISTS (
+    SELECT 1
+    FROM link_checker_api_report_links
+    WHERE link_checker_api_report_id = latest_link_checker_api_reports.id
+      AND link_checker_api_report_links.status IN ('danger')
+  )",
+      )
+    }
   end
 end

--- a/app/views/admin/editions/_filter_options.html.erb
+++ b/app/views/admin/editions/_filter_options.html.erb
@@ -1,5 +1,5 @@
 <%
-  filter_by ||= [:title, :author, :organisation, :world_location, :type, :state, :date, :only_broken_links, :review_overdue]
+  filter_by ||= [:title, :author, :organisation, :world_location, :type, :state, :date, :only_broken_links, :only_danger_links, :review_overdue]
   anchor ||= anchor || ""
   raise "filter action required" unless defined?(filter_action)
 %>
@@ -156,6 +156,21 @@
             value: "1",
             bold: true,
             checked: params["only_broken_links"],
+          },
+        ],
+      } %>
+    <% end %>
+
+    <% if filter_by.include?(:only_danger_links) %>
+      <%= render "govuk_publishing_components/components/checkboxes", {
+        name: "only_danger_links",
+        small: true,
+        items: [
+          {
+            label: "Only dangerous links",
+            value: "1",
+            bold: true,
+            checked: params["only_danger_links"],
           },
         ],
       } %>

--- a/test/unit/app/models/admin/edition_filter_test.rb
+++ b/test/unit/app/models/admin/edition_filter_test.rb
@@ -255,6 +255,36 @@ class Admin::EditionFilterTest < ActiveSupport::TestCase
     assert_equal [edition_with_broken_link, edition_with_caution_link, edition_with_danger_link], Admin::EditionFilter.new(Edition, @current_user, only_broken_links: true).editions.sort_by(&:id)
   end
 
+  test "should filter by dangerous links" do
+    edition_with_broken_link = create(
+      :published_publication,
+    )
+    edition_with_caution_link = create(
+      :published_publication,
+    )
+    edition_with_ok_link = create(
+      :published_publication,
+    )
+    edition_with_pending_link = create(
+      :published_publication,
+    )
+    edition_with_danger_link = create(
+      :published_publication,
+    )
+    broken_link = create(:link_checker_api_report_link, uri: "https://www.gov.uk/broken-link", status: "broken")
+    caution_link = create(:link_checker_api_report_link, uri: "https://www.gov.uk/caution-link", status: "caution")
+    ok_link = create(:link_checker_api_report_link, uri: "https://www.gov.uk/ok-link", status: "ok")
+    pending_link = create(:link_checker_api_report_link, uri: "https://www.gov.uk/pending-link", status: "pending")
+    danger_link = create(:link_checker_api_report_link, uri: "https://www.gov.uk/danger-link", status: "danger")
+    create(:link_checker_api_report, batch_id: 1, edition: edition_with_broken_link, links: [broken_link])
+    create(:link_checker_api_report, batch_id: 2, edition: edition_with_caution_link, links: [caution_link])
+    create(:link_checker_api_report, batch_id: 3, edition: edition_with_ok_link, links: [ok_link])
+    create(:link_checker_api_report, batch_id: 4, edition: edition_with_pending_link, links: [pending_link])
+    create(:link_checker_api_report, batch_id: 5, edition: edition_with_danger_link, links: [danger_link])
+
+    assert_equal [edition_with_danger_link], Admin::EditionFilter.new(Edition, @current_user, only_danger_links: true).editions.sort_by(&:id)
+  end
+
   test "should filter by overdue reviews" do
     document = create(:document)
     edition_with_overdue_reminder = create(:published_edition, document:)


### PR DESCRIPTION
This adds a "Only dangerous links" checkbox on the Whitehall search page, to enable us to easily surface any dangerous links en-masse, then manually resolve them.

PR 10081 should automatically remove dangerous links from published editions, but dangerous links can still linger in draft or scheduled editions, as well as in published editions that have a newer draft. So having an easy way of surfacing all of those would be useful.

Most of the code is copied over from the "Only broken links" checkbox.

NB: should we make this a dropdown, and break it down into caution/error/danger links?

Trello: https://trello.com/c/tmnht4P1

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
