### PR TITLE
Track `select` interactions in Whitehall

### DIFF
--- a/app/assets/javascripts/admin/analytics-modules/ga4-select-tracker.js
+++ b/app/assets/javascripts/admin/analytics-modules/ga4-select-tracker.js
@@ -1,0 +1,44 @@
+'use strict'
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {}
+window.GOVUK.analyticsGa4.analyticsModules =
+  window.GOVUK.analyticsGa4.analyticsModules || {}
+;(function (Modules) {
+  Modules.Ga4SelectSetup = {
+    init: function () {
+      const moduleElements = document.querySelectorAll(
+        "[data-module~='ga4-select-setup']"
+      )
+
+      moduleElements.forEach(function (moduleElement) {
+        moduleElement.addEventListener('change', function (event) {
+          const ga4DocumentType = moduleElement.dataset.ga4DocumentType
+
+          if (
+            event.target.tagName.toLowerCase() === 'select' &&
+            !event.target.getAttribute('hidden')
+          ) {
+            const eventData = {
+              event: 'event_data',
+              event_data: {
+                event_name: 'select_content',
+                type: event.target.dataset.ga4DocumentType || ga4DocumentType,
+                index: {
+                  index_section_count: `${event.target.selectedIndex}`,
+                  index_section: event.target.dataset.ga4IndexSection
+                },
+                text: event.target[event.target.selectedIndex].label,
+                section:
+                  event.target.dataset.ga4Section ||
+                  event.target.labels[0].innerText,
+                action: 'select'
+              }
+            }
+
+            window.GOVUK.analyticsGa4.core.sendData(eventData, 'event_data')
+          }
+        })
+      })
+    }
+  }
+})(window.GOVUK.analyticsGa4.analyticsModules)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -23,6 +23,7 @@
 //= require admin/analytics-modules/ga4-page-view-tracking.js
 //= require admin/analytics-modules/ga4-paste-tracker.js
 //= require admin/analytics-modules/ga4-select-with-search-tracker.js
+//= require admin/analytics-modules/ga4-select-tracker.js
 
 //= require admin/modules/document-history-paginator
 //= require admin/modules/locale-switcher

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -22,7 +22,8 @@
 
   <%= render partial: "shared/header" %>
 
-  <div class="govuk-width-container" data-module="ga4-event-tracker ga4-paste-tracker ga4-link-setup ga4-link-tracker ga4-button-setup ga4-select-with-search-setup ga4-index-section-setup">
+  <div class="govuk-width-container" data-module="ga4-event-tracker ga4-paste-tracker ga4-link-setup ga4-link-tracker ga4-button-setup ga4-select-with-search-setup ga4-index-section-setup ga4-select-setup" data-ga4-document-type="<%= action_name %>-<%= controller_name %>">
+
     <%= render "shared/phase_banner", {
       show_feedback_banner: t("admin.feedback.show_banner"),
     } %>

--- a/spec/javascripts/admin/analytics-modules/ga4-select-tracker.spec.js
+++ b/spec/javascripts/admin/analytics-modules/ga4-select-tracker.spec.js
@@ -1,0 +1,122 @@
+describe('GOVUK.analyticsGa4.analyticsModules.Ga4SelectSetup', function () {
+  let container, select, option, label, expectedAttributes
+
+  const documentType = 'document-type'
+  const labelContent = 'Select label'
+
+  beforeEach(function () {
+    expectedAttributes = {
+      event: 'event_data',
+      event_data: {
+        event_name: 'select_content',
+        type: 'new-consultations',
+        index: {
+          index_section_count: '0',
+          index_section: '20'
+        },
+        text: 'Email address for ordering attachment files',
+        section: 'Settings',
+        action: 'select'
+      }
+    }
+
+    container = document.createElement('div')
+    container.setAttribute('data-module', 'ga4-select-setup')
+    container.setAttribute('data-ga4-document-type', documentType)
+
+    label = document.createElement('label')
+    label.innerText = labelContent
+    label.setAttribute('for', 'select-test')
+
+    select = document.createElement('select')
+    select.id = 'select-test'
+    select.setAttribute('data-ga4-document-type', 'new-consultations')
+    select.setAttribute('data-ga4-index-section', '20')
+    select.setAttribute('data-ga4-section', 'Settings')
+
+    option = document.createElement('option')
+    option.setAttribute('value', '1')
+    option.setAttribute('selected', '')
+    option.innerText = 'Email address for ordering attachment files'
+
+    select.appendChild(option)
+    container.appendChild(label)
+    container.appendChild(select)
+    document.body.appendChild(container)
+  })
+
+  it(`triggers GA4 in response to change events on selects that are not replaced by choices.js`, function () {
+    const ga4SelectEventHandlers =
+      GOVUK.analyticsGa4.analyticsModules.Ga4SelectSetup
+
+    ga4SelectEventHandlers.init()
+
+    const mockGa4SendData = spyOn(window.GOVUK.analyticsGa4.core, 'sendData')
+
+    select.dispatchEvent(new Event('change', { bubbles: true }))
+
+    expect(mockGa4SendData).toHaveBeenCalledWith(
+      expectedAttributes,
+      'event_data'
+    )
+  })
+
+  it(`does not trigger GA4 in response to change events on selects that are replaced by choices.js`, function () {
+    select.setAttribute('hidden', true)
+
+    const ga4SelectEventHandlers =
+      GOVUK.analyticsGa4.analyticsModules.Ga4SelectSetup
+
+    ga4SelectEventHandlers.init()
+
+    const mockGa4SendData = spyOn(window.GOVUK.analyticsGa4.core, 'sendData')
+
+    select.dispatchEvent(new Event('change', { bubbles: true }))
+
+    expect(mockGa4SendData).not.toHaveBeenCalled()
+  })
+
+  it(`uses document type from container if not specified on select`, function () {
+    select.removeAttribute('data-ga4-document-type')
+
+    const ga4SelectEventHandlers =
+      GOVUK.analyticsGa4.analyticsModules.Ga4SelectSetup
+
+    ga4SelectEventHandlers.init()
+
+    const mockGa4SendData = spyOn(window.GOVUK.analyticsGa4.core, 'sendData')
+
+    select.dispatchEvent(new Event('change', { bubbles: true }))
+
+    expectedAttributes.event_data.type = documentType
+
+    expect(mockGa4SendData).toHaveBeenCalledWith(
+      expectedAttributes,
+      'event_data'
+    )
+  })
+
+  it(`uses label of select for section if not specified on select`, function () {
+    select.removeAttribute('data-ga4-section')
+
+    const ga4SelectEventHandlers =
+      GOVUK.analyticsGa4.analyticsModules.Ga4SelectSetup
+
+    ga4SelectEventHandlers.init()
+
+    const mockGa4SendData = spyOn(window.GOVUK.analyticsGa4.core, 'sendData')
+
+    select.dispatchEvent(new Event('change', { bubbles: true }))
+
+    expectedAttributes.event_data.section = labelContent
+
+    expect(mockGa4SendData).toHaveBeenCalledWith(
+      expectedAttributes,
+      'event_data'
+    )
+  })
+
+  afterEach(function () {
+    document.body.removeChild(container)
+  })
+})


### PR DESCRIPTION
## What

Sends data to GA4 in response to `change` events that occur on those `<select>` elements which are not part of a `select_with_search` component. Further information is provided in the [Trello card](https://trello.com/c/xQAjZFsB/3446-component-level-tracking-track-select-dropdown-interactions-on-whitehall)

- [x] Introduce new analytics module with tests (See 6a2d54a496013155cc9dec37d2a2f697a20b8ed8)
- [x] Decorate native `<select>` elements within the codebase (See 310e6cc5c31d463e37c7c22d5881d7ad301be7a9)
- [x] Understand how we might decorate `<select>` elements coming from the components Gem with `data_attributes`[^1]
- [x] Decorate all ~29 instances of `govuk_publishing_components/components/select` in Whitehall
- [x] PAs to confirm approach to indexing grouped and visually hidden fields

## How 

Introduces a new analytics `GA4SelectSetup` module that sends data to GA4 in response to `change` events on _only_ those select elements that are not part of a `select_with_search` component (See https://github.com/alphagov/whitehall/pull/9983 for details of how the `select_with_search` components are tracked using custom events provided by choices.js).

Following the implementation of other analytics modules, a new module is added to the HTML (`ga4-select-setup`) to allow for control of when this tracking is enabled.

## Performance analyst review

This has been reviewed and accepted by Jinish Gohil, team PA.

## Related PRs

- https://github.com/alphagov/whitehall/pull/9983 Introduced GA4 tracking to `select_with_search` components
- https://github.com/alphagov/govuk_publishing_components/pull/4723 updated the publishing components gem to allow select elements to accept data attributes
- https://github.com/alphagov/whitehall/pull/10122 introduced a JavaScript module that populates the `ga4-index-section` client-side

[^1]: Achieving this required an update to the publishing components gem, which was done in this PR https://github.com/alphagov/govuk_publishing_components/pull/4723