### PR TITLE
Fix flaky Cucumber tests on CI

### DIFF
--- a/.github/workflows/cucumber.yml
+++ b/.github/workflows/cucumber.yml
@@ -10,6 +10,16 @@ jobs:
       matrix:
         node_rake_task: ["cucumber:ok"]
     steps:
+      - name: Remove image-bundled Chrome
+        run: sudo apt-get purge google-chrome-stable
+
+      - name: Setup Chrome
+        uses: browser-actions/setup-chrome@v1
+        with:
+          chrome-version: 128
+          install-chromedriver: true
+          install-dependencies: true
+
       - name: Setup MySQL
         id: setup-mysql
         uses: alphagov/govuk-infrastructure/.github/actions/setup-mysql@main

--- a/features/support/capybara.rb
+++ b/features/support/capybara.rb
@@ -8,6 +8,17 @@ Capybara.default_max_wait_time = 5
 # in the GOV.UK Design System.
 Capybara.automatic_label_click = true
 
+Capybara.register_driver :headless_chrome do |app|
+  chrome_options = GovukTest.headless_chrome_selenium_options
+  chrome_options.add_argument("--no-sandbox")
+
+  Capybara::Selenium::Driver.new(
+    app,
+    browser: :chrome,
+    options: chrome_options,
+  )
+end
+
 module ScreenshotHelper
   def screenshot(name = "capybara")
     page.driver.render(Rails.root.join("tmp/#{name}.png"), full: true)


### PR DESCRIPTION
Taking inspiration from https://github.com/alphagov/signon/pull/3663, we're adapting our CI to try to avoid a [regular flaking test](https://github.com/alphagov/whitehall/actions/runs/13919783421/job/38951970911?pr=10072):

```
Couldn't find Consultation with [WHERE `editions`.`type` = ? AND `editions`.`state` != 'deleted' AND `edition_translations`.`title` = ? AND `edition_translations`.`locale` IN (?, ?)] (ActiveRecord::RecordNotFound)
./features/step_definitions/consultation_steps.rb:76:in `block (2 levels) in <top (required)>'
./features/step_definitions/consultation_steps.rb:75:in `/^I can see the primary locale for consultation "(.*?)" is "(.*?)"$/'
features/consultations.feature:50:in `I can see the primary locale for consultation "Beard Length Review" is "cy"'

Failing Scenarios:
cucumber features/consultations.feature:47 # Scenario: Creating a new draft consultation in another language
```

This started around the time the most recent ubuntu-latest image for GitHub Actions was released:
https://github.com/actions/runner-images/pull/11761

Summary of changes:

- add `--no-sandbox` flag to Chromedriver startup (GovukTest will do this for us if we set the `GOVUK_TEST_CHROME_NO_SANDBOX` environment variable, but the theory is that making the change here keeps all these temporary fixes in one place)
- remove the version of Chrome that the actions/runner-images image bundles for us, so that Selenium doesn't try to use it
- install an old version of Chrome and Chromedriver

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
