### PR TITLE
Automatically remove dangerous links from published editions

### DIFF
--- a/app/models/link_checker_api_report.rb
+++ b/app/models/link_checker_api_report.rb
@@ -26,7 +26,7 @@ NOT EXISTS (
   end
 
   def mark_report_as_completed(batch_report)
-    UpdateFromBatchReport.new(self, batch_report).update
+    UpdateFromBatchReport.new(self, batch_report).call
   end
 
   def completed?

--- a/app/models/link_checker_api_report.rb
+++ b/app/models/link_checker_api_report.rb
@@ -27,6 +27,7 @@ NOT EXISTS (
 
   def mark_report_as_completed(batch_report)
     UpdateFromBatchReport.new(self, batch_report).call
+    RemoveDangerousLinksWorker.perform_async(edition.id) if danger_links.any?
   end
 
   def completed?

--- a/app/models/link_checker_api_report/link.rb
+++ b/app/models/link_checker_api_report/link.rb
@@ -14,7 +14,7 @@ class LinkCheckerApiReport::Link < ApplicationRecord
       uri: payload.fetch("uri"),
       status: payload.fetch("status"),
       checked: payload.fetch("checked"),
-      check_dangers: payload.fetch("dangers", []),
+      check_dangers: payload.fetch("danger", []),
       check_errors: payload.fetch("errors", []),
       check_warnings: payload.fetch("warnings", []),
       problem_summary: payload.fetch("problem_summary"),

--- a/app/models/link_checker_api_report/update_from_batch_report.rb
+++ b/app/models/link_checker_api_report/update_from_batch_report.rb
@@ -4,7 +4,7 @@ class LinkCheckerApiReport::UpdateFromBatchReport
     @payload = payload
   end
 
-  def update
+  def call
     ActiveRecord::Base.transaction do
       update_report
       links = payload.fetch("links", [])

--- a/app/sidekiq/remove_dangerous_links_worker.rb
+++ b/app/sidekiq/remove_dangerous_links_worker.rb
@@ -1,0 +1,7 @@
+class RemoveDangerousLinksWorker < WorkerBase
+  sidekiq_options queue: "publishing_api"
+
+  def perform(edition_id)
+    # TODO: Implement this method
+  end
+end

--- a/app/sidekiq/remove_dangerous_links_worker.rb
+++ b/app/sidekiq/remove_dangerous_links_worker.rb
@@ -2,6 +2,48 @@ class RemoveDangerousLinksWorker < WorkerBase
   sidekiq_options queue: "publishing_api"
 
   def perform(edition_id)
-    # TODO: Implement this method
+    edition = find_and_validate_edition(edition_id)
+
+    dangerous_links = edition.link_check_report.danger_links.map(&:uri)
+    return unless dangerous_links.any?
+
+    # Set up the new draft edition and remove the dangerous links
+    draft_edition = edition.create_draft(robot_user)
+    draft_edition.update!(minor_change: true)
+    remove_danger_links!(draft_edition.id, dangerous_links)
+
+    #  Publish the new edition
+    edition_publisher = Whitehall.edition_services.force_publisher(
+      draft_edition,
+      user: robot_user,
+      remark: "Dangerous links automatically removed: #{dangerous_links.join(', ')}",
+    )
+    edition_publisher.perform!
+  end
+
+private
+
+  def find_and_validate_edition(edition_id)
+    edition = Edition.find(edition_id)
+    if !edition.published?
+      raise ArgumentError, "#{edition.state} edition with ID #{edition_id} passed to RemoveDangerousLinksWorker: expecting 'published'"
+    elsif edition.document.latest_edition.draft?
+      raise ArgumentError, "Published edition with ID #{edition_id} passed to RemoveDangerousLinksWorker but it already has a draft. Aborting to avoid overwriting."
+    end
+
+    edition
+  end
+
+  def robot_user
+    User.find_by(name: "Scheduled Publishing Robot", uid: nil)
+  end
+
+  def remove_danger_links!(edition_id, dangerous_links)
+    edition = Edition.find(edition_id)
+    sanitized_body = edition.body.dup
+    dangerous_links.each do |uri|
+      sanitized_body.gsub!(uri, "#link-removed")
+    end
+    edition.update!(body: sanitized_body)
   end
 end

--- a/test/unit/app/models/link_checker_api_report_test.rb
+++ b/test/unit/app/models/link_checker_api_report_test.rb
@@ -24,4 +24,57 @@ class LinkCheckerApiReportTest < ActiveSupport::TestCase
 
     assert LinkCheckerApiReport.where(edition:).count == 1
   end
+
+  test "creates a RemoveDangerousLinksWorker if dangerous links detected" do
+    edition = create(:publication, body: "[dangerous link](http://www.example.com)")
+    report = LinkCheckerApiReport.create!(
+      batch_id: 300,
+      edition: edition,
+      status: "in_progress",
+    )
+    batch_report = link_checker_api_batch_report_hash(
+      id: 300,
+      status: "completed",
+      links: [
+        {
+          uri: "http://www.example.com",
+          status: "danger",
+          danger: ["This link is hosted on a domain which is on our list of suspicious domains"],
+        },
+      ],
+    ).with_indifferent_access
+
+    RemoveDangerousLinksWorker.expects(:perform_async).once
+
+    report.mark_report_as_completed(batch_report)
+  end
+
+  test "doesn't create RemoveDangerousLinksWorker if no dangerous links are detected" do
+    edition = create(:publication, body: "[broken link](http://www.example.com/broken) [warning link](http://www.example.com/warning)")
+    report = LinkCheckerApiReport.create!(
+      batch_id: 123,
+      edition: edition,
+      status: "in_progress",
+    )
+    batch_report = link_checker_api_batch_report_hash(
+      id: 123,
+      status: "completed",
+      links: [
+        {
+          uri: "http://www.example.com/broken",
+          status: "broken",
+          errors: ["broken link"],
+        },
+        {
+          uri: "http://www.example.com/warning",
+          status: "caution",
+          warnings: ["This link is hosted on a domain which is on our list of suspicious domains"],
+        },
+      ],
+    ).with_indifferent_access
+
+    RemoveDangerousLinksWorker.expects(:perform_async).never
+
+    report.mark_report_as_completed(batch_report)
+  end
 end

--- a/test/unit/app/sidekiq/remove_dangerous_links_worker_test.rb
+++ b/test/unit/app/sidekiq/remove_dangerous_links_worker_test.rb
@@ -1,0 +1,113 @@
+require "test_helper"
+
+class RemoveDangerousLinksWorkerTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
+  describe "#perform" do
+    before do
+      User.create!(name: "Scheduled Publishing Robot") unless User.find_by(name: "Scheduled Publishing Robot")
+    end
+
+    describe "the happy path" do
+      it "creates and publishes a new edition" do
+        published_edition = create(:publication, :published)
+        create_danger_link_check_report(published_edition)
+        RemoveDangerousLinksWorker.new.perform(published_edition.id)
+
+        assert_not_equal(published_edition.id, published_edition.document.live_edition.id)
+      end
+
+      it "removes dangerous links from the body of the new edition" do
+        dangerous_body = <<~GOVSPEAK
+          [dangerous link](http://www.example.com)
+          <a href="http://www.example.com">dangerous link again</a>
+          [another way of linking to dangerous link][danger]
+
+          [danger]: http://www.example.com
+        GOVSPEAK
+
+        sterilised_body = <<~GOVSPEAK
+          [dangerous link](#link-removed)
+          <a href="#link-removed">dangerous link again</a>
+          [another way of linking to dangerous link][danger]
+
+          [danger]: #link-removed
+        GOVSPEAK
+
+        published_edition = create(
+          :publication,
+          :published,
+          body: dangerous_body,
+        )
+        create_danger_link_check_report(published_edition)
+        RemoveDangerousLinksWorker.new.perform(published_edition.id)
+
+        assert_equal(sterilised_body, published_edition.document.live_edition.body)
+      end
+
+      it "saves an internal changenote against the new edition" do
+        published_edition = create(:publication, :published)
+        create_danger_link_check_report(published_edition)
+        RemoveDangerousLinksWorker.new.perform(published_edition.id)
+
+        assert_equal(
+          "Dangerous links automatically removed: http://www.example.com",
+          published_edition.document.latest_edition.editorial_remarks.last.body,
+        )
+      end
+    end
+
+    describe "error handling" do
+      it "raises an exception if the passed edition is not 'published'" do
+        draft_edition = create(:publication, :draft)
+        create_danger_link_check_report(draft_edition)
+
+        error = assert_raises(ArgumentError) do
+          RemoveDangerousLinksWorker.new.perform(draft_edition.id)
+        end
+        assert_equal "draft edition with ID #{draft_edition.id} passed to RemoveDangerousLinksWorker: expecting 'published'", error.message
+      end
+
+      it "does nothing if the edition is published but there is a newer draft (we don't want to risk overwriting with our changes)" do
+        published_edition = create(:publication, :published)
+        create_danger_link_check_report(published_edition)
+        published_edition.create_draft(create(:user))
+
+        error = assert_raises(ArgumentError) do
+          RemoveDangerousLinksWorker.new.perform(published_edition.id)
+        end
+        assert_equal "Published edition with ID #{published_edition.id} passed to RemoveDangerousLinksWorker but it already has a draft. Aborting to avoid overwriting.", error.message
+      end
+
+      it "does nothing if there are no dangerous links" do
+        published_edition = create(:publication, :published)
+        create_happy_link_check_report(published_edition)
+
+        worker = RemoveDangerousLinksWorker.new
+        worker.expects(:remove_danger_links!).never
+
+        worker.perform(published_edition.id)
+      end
+    end
+  end
+
+private
+
+  def create_danger_link_check_report(edition)
+    create(
+      :link_checker_api_report_completed,
+      edition: edition,
+      links: [
+        create(:link_checker_api_report_link, :danger, uri: "http://www.example.com"),
+      ],
+    )
+  end
+
+  def create_happy_link_check_report(edition)
+    create(
+      :link_checker_api_report_completed,
+      edition: edition,
+      links: [],
+    )
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/tmnht4P1

## What and Why

If we're informed of a domain that is no longer safe, but is referenced across a number of our pages, then it is not feasible for our content designers to step in and manually fix them all in a timely manner. Instead, we need an automated approach. This commit introduces a blunt tool to find and replace all references to the dangerous domain with a `#link-removed` value.

Whilst ideally we'd have a content designer address these on a case by case basis - finding an alternative URL to link to, for example, or removing the link but adding some historical context - we're not able to do that in an automated way. The alternative is to either:

1. remove the link and link text altogether, which could lead to a confusing 'absence' of content
2. remove the link but keep the link text, which could be odd if the link text reads something like "click here"
3. replace the link with a `#`, so that it's still a link but doesn't do anything.
4. replace the link with an anchor tag that leads nowhere, i.e. `#link-removed`, so that it's still a link, it doesn't do anything, and it's clearer to the user and to the publisher what has happened.

I've opted for option 4. I've done so with minimal HTML / GovSpeak wrangling, as I can't envisage a situation where we'd even want to display the name of a dangerous domain, so finding-and-replacing only `<a>` link tags seemed an unnecessary complexity when we can simply find and replace all instances of the string.

## Architecture

This new `RemoveDangerousLinksWorker`, triggered via the Link Checker API batch report callback only if a dangerous link was detected, does the following:

1. Validates that the edition is 'published'. There's little point in fixing up superseded editions, and 'draft' editions haven't yet been published, so we're better off surfacing dangerous link warnings in the UI for the publisher to resolve it properly. 
2. Validates that there is no existing 'draft' edition. We don't want to risk overwriting the publisher's draft with an auto generated draft edition that is identical to the live edition but with dangerous links removed.
3. Validates that there are indeed 'danger' links in the link check report, that need removing.
4. Creates a draft edition, removes the dangerous links, and force publishes the edition as a minor change, with an internal note explaining what has happened.

Since https://github.com/alphagov/whitehall/pull/10077, we should be refreshing every link check report for every published edition on GOV.UK roughly every 7 days, meaning we don't have to wait too long for all dangerous links to be systematically removed. Dangerous links will be driven by the configuration of 'suspicious domains', as will be documented in https://github.com/alphagov/link-checker-api/pull/988.

There is room for improvement, but it can come later. Suggestions:

1. Check that the body of the edition changes after calling `remove_danger_links!`, before bothering to create a draft.
2. Better handle the "published with draft" state.
3. Add support for "scheduled" states.

## Screenshots / testing

With a body containing 'bad' domains [as per Link Checker API's seeds.rb](https://github.com/alphagov/link-checker-api/blob/e56e923da2a0c95ecfb78066ba230ca6d0463994/db/seeds.rb#L10):

> ![Screenshot 2025-03-20 at 16 39 51](https://github.com/user-attachments/assets/ffd193a6-31f0-4416-8203-10121756cfd3)

I managed to set up a 'published' edition with dangerous links locally, using `Edition.find(1653798).update!(change_note: "tmp", major_change_published_at: Time.zone.now, state: "published")`:

> ![Screenshot 2025-03-20 at 16 49 21](https://github.com/user-attachments/assets/711eef4a-b75a-4d3a-9754-3f2540bcf958)

After running `RemoveDangerousLinksWorker.new.perform(1653798)` locally, we can see the publication is superseded:

> ![Screenshot 2025-03-20 at 16 49 38](https://github.com/user-attachments/assets/a70e57ab-c044-4655-8d99-b2242d12417e)

And the new edition is published and has details in the change history (NB, ignore the jump of 2 from 1653798 to 1653800. 1653799 was a draft edition I'd accidentally created earlier in my testing, and subsequently deleted before the above `RemoveDangerousLinksWorker` call):

> ![Screenshot 2025-03-20 at 16 50 05](https://github.com/user-attachments/assets/ed94e96f-27e7-4cf3-bc6c-05f6609a8f71)

And inspecting the body, the links have been replaced:

> ![Screenshot 2025-03-20 at 16 50 32](https://github.com/user-attachments/assets/07f93bd2-d8a5-445f-b18c-50744fa9c48b)


---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.