### PR TITLE
Make sure multiple select with search sends a nil value when all selections are removed

### DIFF
--- a/app/views/components/_select_with_search.html.erb
+++ b/app/views/components/_select_with_search.html.erb
@@ -27,6 +27,10 @@
     } %>
   <% end %>
 
+  <%# Create null input so that the value is cleared if no options are selected %>
+  <% if multiple %>
+    <%= hidden_field_tag name, nil %>
+  <% end %>
   <%= select_tag name, select_helper.options_html, id: id, class: select_helper.select_classes, multiple:, aria: select_helper.aria, "data-ga4-document-type": ga_data[:document_type], "data-ga4-index-section": ga_data[:index_section], "data-ga4-section": ga_data[:section] %>
 
 <% end %>

--- a/test/integration/components/select_with_search_test.rb
+++ b/test/integration/components/select_with_search_test.rb
@@ -60,4 +60,12 @@ class SelectWithSearchTest < ActionDispatch::IntegrationTest
       assert node[:'aria-describedby'] =~ /error-(.+)/
     end
   end
+
+  test "it renders a hidden null input so that the value is still included in form submission when multiple selection is enabled" do
+    load_example "with_multiple_select_enabled"
+    assert_selector "input[name='dropdown-with-multiple']", visible: :hidden do |node|
+      assert node[:type] == "hidden"
+      assert node[:value].nil?
+    end
+  end
 end


### PR DESCRIPTION
HTTP form data is unable to represent empty arrays. If a select has a name like "test[]" and no selected value then the name of the select will be dropped from the form data when the result is submitted. However, by creating a hidden input with the same name we can make sure that the form data will look like 'test[0]=""' instead of 'test=[]'. If the select has a value, then that will override the nil value.

Trello: https://trello.com/c/mZqawRIP
