### PR TITLE
Allow deletion of people without current role appointments or former ministerial roles

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -62,7 +62,7 @@ class Person < ApplicationRecord
   end
 
   def destroyable?
-    role_appointments.empty?
+    current_role_appointments.empty? && ministerial_roles.empty?
   end
 
   def name

--- a/test/unit/app/models/person_test.rb
+++ b/test/unit/app/models/person_test.rb
@@ -119,15 +119,23 @@ class PersonTest < ActiveSupport::TestCase
     assert_equal news_articles[0..0], person.published_news_articles
   end
 
-  test "should not be destroyable when it has appointments" do
+  test "should not be destroyable when it has current appointments" do
     person = create(:person)
     _ = create(:role_appointment, person:)
     assert_not person.destroyable?
     assert_equal false, person.destroy
   end
 
-  test "should be destroyable when it has no appointments" do
-    person = create(:person, role_appointments: [])
+  test "should not be destroyable when it has previous ministerial appointments" do
+    person = create(:person)
+    _ = create(:ministerial_role_appointment, :ended, person:)
+    assert_not person.destroyable?
+    assert_equal false, person.destroy
+  end
+
+  test "should be destroyable when it has no current appointments or ministerial appointments" do
+    person = create(:person)
+    _ = create(:board_member_role_appointment, :ended, person:)
     assert person.destroyable?
     assert person.destroy
   end


### PR DESCRIPTION
We occasionally get duplicates of the same person existing where people have held various board member roles in different organisations, etc.

These people are not linked to on any govuk pages because organisation pages only show current appointment holders, and only ministerial roles have their own pages showing historical office holders.

It therefore seems reasonable to allow the deletion of these "orphaned" people, so that they are no longer present on GOV.UK and also do not appear in the Whitehall people list.

This will enable the user who has reported https://govuk.zendesk.com/agent/tickets/6068030 to at least delete the duplicate people. We may want to consider allow redirection is there is a valid use case.

Trello: https://trello.com/c/zzmAwGPV
