### PR TITLE
Run cucumber tests in parallel

### DIFF
--- a/.github/workflows/cucumber.yml
+++ b/.github/workflows/cucumber.yml
@@ -8,7 +8,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node_rake_task: ["cucumber:ok"]
+        ci_node_total: [4]
+        ci_node_index: [0, 1, 2, 3]
     steps:
       - name: Remove image-bundled Chrome
         run: sudo apt-get purge google-chrome-stable
@@ -53,7 +54,9 @@ jobs:
         env:
           RAILS_ENV: test
           TEST_DATABASE_URL: ${{ steps.setup-mysql.outputs.db-url }}
-        run: bundle exec rake ${{ matrix.node_rake_task }}
+          CI_NODE_TOTAL: ${{ matrix.ci_node_total }}
+          CI_NODE_INDEX: ${{ matrix.ci_node_index }}
+        run: bundle exec ./bin/cucumber-ci
 
       - name: Upload screenshots
         uses: actions/upload-artifact@v4

--- a/bin/cucumber-ci
+++ b/bin/cucumber-ci
@@ -1,0 +1,23 @@
+#!/usr/bin/env ruby
+
+# This script is used during the GitHub Actions workflow
+# defined in .github/workflows/cucumber.yml.
+# It splits the cucumber suite into randomly-allocated groups
+# which are executed across multiple GitHub Actions 'matrix' nodes.
+
+test_files = [
+  Dir["features/*.feature"],
+  Dir["lib/engines/**/*.feature"],
+].flatten
+
+# Determine which CI node is running
+node_index = ENV["CI_NODE_INDEX"].to_i
+total_nodes = ENV["CI_NODE_TOTAL"].to_i
+
+tests = test_files.
+  sort.
+  shuffle(random: Random.new(ENV['GITHUB_SHA'].to_i(16))).
+  each_slice((test_files.length / total_nodes.to_f).ceil).
+  to_a[node_index]
+
+exec("bundle exec cucumber #{tests.join(' ')}")


### PR DESCRIPTION
This uses the same approach as minitest.yml to split the Cucumber tests into groups and run them in parallel across multiple containers, which should hopefully speed up the CI. 

The cucumber tests were already running in a matrix (I think as an artefact of there being two suites at one point), so it’s pretty trivial to split the tests up.

From an unscientific survey, this cuts the runtime down from ~7 minutes to ~3 minutes