### PR TITLE
Fix Audit Log

### DIFF
--- a/test/unit/app/sidekiq/remove_dangerous_links_worker_test.rb
+++ b/test/unit/app/sidekiq/remove_dangerous_links_worker_test.rb
@@ -15,6 +15,7 @@ class RemoveDangerousLinksWorkerTest < ActiveSupport::TestCase
         RemoveDangerousLinksWorker.new.perform(published_edition.id)
 
         assert_not_equal(published_edition.id, published_edition.document.live_edition.id)
+        assert_equal(User.find_by(name: "Scheduled Publishing Robot").id, published_edition.versions.last.whodunnit.to_i)
       end
 
       it "removes dangerous links from the body of the new edition" do


### PR DESCRIPTION
Whilst we were creating the draft edition as "Scheduled Publishing Robot", our audit gem requires that we wrap all method calls in an 'acting_as' block.

Screenshot of the attribution working:

![attributed to Scheduled Publishing Robot](https://github.com/user-attachments/assets/1aa4b5d5-7723-4311-bda4-0a98e596e80a)

We can see in the screenshots in #10081 that without this commit, attributions are linked to "User (removed)".

Trello: https://trello.com/c/tmnht4P1

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
