### PR TITLE
Bump govuk_publishing_components from 55.0.1 to 56.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -305,7 +305,7 @@ GEM
     govuk_personalisation (1.1.0)
       plek (>= 1.9.0)
       rails (>= 6, < 9)
-    govuk_publishing_components (54.0.1)
+    govuk_publishing_components (56.0.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown


### PR DESCRIPTION
Introducing this version bump manually to make it possible to add `data_attributes` to `<select>` elements within the Select component

## Related PRs

- The PR that updated the Select component in the `govuk_publishing_components` gem is https://github.com/alphagov/govuk_publishing_components/pull/4723 
- The PR that released version `56.0.0` is https://github.com/alphagov/govuk_publishing_components/pull/4728
- The draft PR that will make use of these updated Select components is https://github.com/alphagov/whitehall/pull/10069
