### PR TITLE
Fix logic loop whereby docs can be continuously republished

### DIFF
--- a/app/models/link_checker_api_report.rb
+++ b/app/models/link_checker_api_report.rb
@@ -27,7 +27,7 @@ NOT EXISTS (
 
   def mark_report_as_completed(batch_report)
     UpdateFromBatchReport.new(self, batch_report).call
-    # RemoveDangerousLinksWorker.perform_async(edition.id) if danger_links.any?
+    RemoveDangerousLinksWorker.perform_async(edition.id) if danger_links.any?
   end
 
   def completed?

--- a/app/sidekiq/remove_dangerous_links_worker.rb
+++ b/app/sidekiq/remove_dangerous_links_worker.rb
@@ -1,6 +1,17 @@
 class RemoveDangerousLinksWorker < WorkerBase
   sidekiq_options queue: "publishing_api"
 
+  # Don't retry this job if it fails, because:
+  # 1. It's all 'internal' - so won't fail if a third party API is down,
+  #    and any failure is unlikely to resolve itself on a retry.
+  # 2. There are currently some cases where `ArgumentError` is raised
+  #    'legitimately'. E.g. for 'withdrawn' editions, for which we
+  #    haven't yet written the code to auto-remove dangerous links.
+  #    NB, they're logged as errors (rather than logs in Kibana) because
+  #    they're still 'actionable' errors that should be resolved on a
+  #    case by case basis.
+  sidekiq_options retry: 0
+
   def perform(edition_id)
     edition = find_and_validate_edition(edition_id)
 

--- a/test/unit/app/models/link_checker_api_report_test.rb
+++ b/test/unit/app/models/link_checker_api_report_test.rb
@@ -25,29 +25,29 @@ class LinkCheckerApiReportTest < ActiveSupport::TestCase
     assert LinkCheckerApiReport.where(edition:).count == 1
   end
 
-  # test "creates a RemoveDangerousLinksWorker if dangerous links detected" do
-  #   edition = create(:publication, body: "[dangerous link](http://www.example.com)")
-  #   report = LinkCheckerApiReport.create!(
-  #     batch_id: 300,
-  #     edition: edition,
-  #     status: "in_progress",
-  #   )
-  #   batch_report = link_checker_api_batch_report_hash(
-  #     id: 300,
-  #     status: "completed",
-  #     links: [
-  #       {
-  #         uri: "http://www.example.com",
-  #         status: "danger",
-  #         danger: ["This link is hosted on a domain which is on our list of suspicious domains"],
-  #       },
-  #     ],
-  #   ).with_indifferent_access
+  test "creates a RemoveDangerousLinksWorker if dangerous links detected" do
+    edition = create(:publication, body: "[dangerous link](http://www.example.com)")
+    report = LinkCheckerApiReport.create!(
+      batch_id: 300,
+      edition: edition,
+      status: "in_progress",
+    )
+    batch_report = link_checker_api_batch_report_hash(
+      id: 300,
+      status: "completed",
+      links: [
+        {
+          uri: "http://www.example.com",
+          status: "danger",
+          danger: ["This link is hosted on a domain which is on our list of suspicious domains"],
+        },
+      ],
+    ).with_indifferent_access
 
-  #   RemoveDangerousLinksWorker.expects(:perform_async).once
+    RemoveDangerousLinksWorker.expects(:perform_async).once
 
-  #   report.mark_report_as_completed(batch_report)
-  # end
+    report.mark_report_as_completed(batch_report)
+  end
 
   test "doesn't create RemoveDangerousLinksWorker if no dangerous links are detected" do
     edition = create(:publication, body: "[broken link](http://www.example.com/broken) [warning link](http://www.example.com/warning)")


### PR DESCRIPTION
Without this commit, the RemoveDangerousLinksWorker can get into a state where it continually editions and publishes the same content. Consider:

1. Edition ID `123` - ‘published’ - has danger links
2. The first worker creates a draft (124) and removes the links
3. ...which triggers a new link check report, sending the payload of ‘dangerous’ links to Link Checker APi
4. The first worker publishes the draft 124 - we want to finish here.
5. Link Checker API makes a callback to Whitehall saying edition 124 has dangerous links. Whitehall kicks off a new (second) worker, which creates a new draft and attempts to removes the links, but there’s nothing to do, so it silently succeeds
6. ...meanwhile, it may itself have triggered another worker. And so on.

This commit fixes things by checking whether the edition has changed at all as a result of the sanitization. The edition is only turned into a draft and published anew if there is a change to be made.

Trello: https://trello.com/c/tmnht4P1

---

Test instructions:

```
Edition.find(1653805).create_draft(User.find_by(name: "Scheduled Publishing Robot", uid: nil)).update!(body: "[malicious link](https://malicious.example.com)", minor_change: t
rue); Edition.last.update!(change_note: "tmp", state: "published")
```

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
