### PR TITLE
Temporarily avoid creating RemoveDangerousLinksWorker

### DIFF
--- a/app/models/link_checker_api_report.rb
+++ b/app/models/link_checker_api_report.rb
@@ -27,7 +27,7 @@ NOT EXISTS (
 
   def mark_report_as_completed(batch_report)
     UpdateFromBatchReport.new(self, batch_report).call
-    RemoveDangerousLinksWorker.perform_async(edition.id) if danger_links.any?
+    # RemoveDangerousLinksWorker.perform_async(edition.id) if danger_links.any?
   end
 
   def completed?

--- a/test/unit/app/models/link_checker_api_report_test.rb
+++ b/test/unit/app/models/link_checker_api_report_test.rb
@@ -25,29 +25,29 @@ class LinkCheckerApiReportTest < ActiveSupport::TestCase
     assert LinkCheckerApiReport.where(edition:).count == 1
   end
 
-  test "creates a RemoveDangerousLinksWorker if dangerous links detected" do
-    edition = create(:publication, body: "[dangerous link](http://www.example.com)")
-    report = LinkCheckerApiReport.create!(
-      batch_id: 300,
-      edition: edition,
-      status: "in_progress",
-    )
-    batch_report = link_checker_api_batch_report_hash(
-      id: 300,
-      status: "completed",
-      links: [
-        {
-          uri: "http://www.example.com",
-          status: "danger",
-          danger: ["This link is hosted on a domain which is on our list of suspicious domains"],
-        },
-      ],
-    ).with_indifferent_access
+  # test "creates a RemoveDangerousLinksWorker if dangerous links detected" do
+  #   edition = create(:publication, body: "[dangerous link](http://www.example.com)")
+  #   report = LinkCheckerApiReport.create!(
+  #     batch_id: 300,
+  #     edition: edition,
+  #     status: "in_progress",
+  #   )
+  #   batch_report = link_checker_api_batch_report_hash(
+  #     id: 300,
+  #     status: "completed",
+  #     links: [
+  #       {
+  #         uri: "http://www.example.com",
+  #         status: "danger",
+  #         danger: ["This link is hosted on a domain which is on our list of suspicious domains"],
+  #       },
+  #     ],
+  #   ).with_indifferent_access
 
-    RemoveDangerousLinksWorker.expects(:perform_async).once
+  #   RemoveDangerousLinksWorker.expects(:perform_async).once
 
-    report.mark_report_as_completed(batch_report)
-  end
+  #   report.mark_report_as_completed(batch_report)
+  # end
 
   test "doesn't create RemoveDangerousLinksWorker if no dangerous links are detected" do
     edition = create(:publication, body: "[broken link](http://www.example.com/broken) [warning link](http://www.example.com/warning)")


### PR DESCRIPTION
This hasn't run on Production yet, but has been tested locally and on Integration and Staging. It seems to be working well, but there is a potential logic loop that could cause multiple republishes (see #10091), and locally we're seeing more 'editorial remarks' being created than we should.

We're therefore commenting out the bit of code that causes a republish, to allow time to investigate further and gain a bit more confidence before releasing to Production.

Trello: https://trello.com/b/0n3p84mY

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
