### PR TITLE
Surface more info in link check report

### DIFF
--- a/app/controllers/admin/link_check_reports_controller.rb
+++ b/app/controllers/admin/link_check_reports_controller.rb
@@ -16,7 +16,6 @@ class Admin::LinkCheckReportsController < Admin::BaseController
 
   def show
     @report = LinkCheckerApiReport.find(params[:id])
-    @allow_new_report = params[:allow_new_report] || false
 
     respond_to do |format|
       format.html { redirect_to [:admin, @edition] }

--- a/app/models/link_checker_api_report/link.rb
+++ b/app/models/link_checker_api_report/link.rb
@@ -17,4 +17,8 @@ class LinkCheckerApiReport::Link < ApplicationRecord
       suggested_fix: payload.fetch("suggested_fix"),
     }
   end
+
+  def check_details
+    check_dangers.join(" and ") + check_errors.join(" and ") + check_warnings.join(" and ")
+  end
 end

--- a/app/views/admin/editions/_govspeak_help.html.erb
+++ b/app/views/admin/editions/_govspeak_help.html.erb
@@ -6,7 +6,7 @@
   link_check_report ||= nil
 %>
 
-<%= render("admin/link_check_reports/link_check_report", report: link_check_report, allow_new_report: false) if link_check_report %>
+<%= render("admin/link_check_reports/link_check_report", report: link_check_report, hide_button_to_create_new_report: true) if link_check_report %>
 
 <div class="govspeak-help">
   <h2 class="govuk-heading-l">Formatting</h2>

--- a/app/views/admin/editions/show/_main.html.erb
+++ b/app/views/admin/editions/show/_main.html.erb
@@ -224,7 +224,7 @@
               { text: translation.title },
               (@edition.editable? || @edition.can_delete?) ? {
                 text: raw([
-                  *(link_to("Edit", edit_admin_edition_translation_path(@edition, translation.locale), class: "govuk-link app-view-edition-summary__table-link") if @edition.editable?),
+                  *(link_to("Edit", edit_admin_edition_translation_path(@edition, translation.locale), class: "govuk-link app-view-summary__table-link") if @edition.editable?),
                   *(link_to("Delete", confirm_destroy_admin_edition_translation_path(@edition, translation.locale), class: "govuk-link gem-link--destructive") if @edition.can_delete?),
                 ].compact().join(" ")),
               } : nil,

--- a/app/views/admin/editions/show/_sidebar.html.erb
+++ b/app/views/admin/editions/show/_sidebar.html.erb
@@ -5,7 +5,6 @@
         partial: "admin/link_check_reports/link_check_report",
         locals: {
           report: @edition.link_check_report || LinkCheckerApiReport.new(edition: @edition),
-          allow_new_report: true,
         },
       ) if show_link_check_report?(@edition) %>
   <%= render partial: "admin/editions/show/sidebar_history_state", locals: { edition: @edition } %>

--- a/app/views/admin/link_check_reports/_link_check_report.html.erb
+++ b/app/views/admin/link_check_reports/_link_check_report.html.erb
@@ -1,3 +1,7 @@
+<%
+  hide_button_to_create_new_report ||= false
+%>
+
 <div data-module="broken-links-report">
   <% if report.new_record? %>
     <%= render "components/inset_prompt", {
@@ -15,7 +19,7 @@
       description: capture do %>
         <p class="govuk-body">Broken link report in progress.</p>
         <p class="govuk-body">
-          <%= link_to "Check progress", "", class: "govuk-link js-broken-links-refresh", data: { json_href: url_for(admin_edition_link_check_report_path(report.edition, report, format: :json, allow_new_report: allow_new_report.present? ? true : nil)) } %>
+          <%= link_to "Check progress", "", class: "govuk-link js-broken-links-refresh", data: { json_href: url_for(admin_edition_link_check_report_path(report.edition, report, format: :json)) } %>
         </p>
       <% end
     } %>
@@ -57,7 +61,7 @@
         <% if LinkCheckerApiService.has_admin_draft_links?(report.edition) %>
           <p class="govuk-body">It also contains links to draft documents that weren't checked.</p>
         <% end %>
-        <% if allow_new_report %>
+        <% unless hide_button_to_create_new_report %>
           <%= render partial: "admin/link_check_reports/form", locals: {
             edition: report.edition,
             button_text: "Check again",
@@ -78,7 +82,7 @@
             It contains links to draft documents that weren't checked.
           </p>
         <% end %>
-        <% if allow_new_report %>
+        <% unless hide_button_to_create_new_report %>
           <%= render partial: "admin/link_check_reports/form", locals: {
             edition: report.edition,
             button_text: "Check again",

--- a/app/views/admin/link_check_reports/_link_check_report.html.erb
+++ b/app/views/admin/link_check_reports/_link_check_report.html.erb
@@ -42,7 +42,9 @@
                     </span>
                   </summary>
                   <div class="govuk-details__text">
-                    <p class="govuk-body"><%= link.problem_summary %></p>
+                    <p class="govuk-body">
+                      <%= link.problem_summary %>: <%= link.check_details %>
+                    </p>
                     <% if link.suggested_fix %>
                       <p class="govuk-body">Suggested fix: <%= link.suggested_fix %></p>
                     <% end %>

--- a/app/views/admin/link_check_reports/_link_check_report.html.erb
+++ b/app/views/admin/link_check_reports/_link_check_report.html.erb
@@ -35,7 +35,7 @@
 
           <p class="govuk-body"><%= t "broken_links.#{status}.subheading" %></p>
 
-          <ul class="govuk-list app-view-edition-summary__broken-links-report">
+          <ul class="govuk-list app-view-summary__broken-links-report">
             <% links.each do |link| %>
               <li>
                 <%= link_to link.uri.truncate(50), link.uri, title: link.uri, class: "govuk-link" %>

--- a/app/views/admin/link_check_reports/_link_check_report.html.erb
+++ b/app/views/admin/link_check_reports/_link_check_report.html.erb
@@ -63,6 +63,7 @@
             button_text: "Check again",
           } %>
         <% end %>
+        <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-top-5">Last checked: <%= l(report.updated_at, format: :long_ordinal) %></p>
       <% end,
       error: true
     } %>

--- a/test/unit/app/models/link_checker_api_report/link_test.rb
+++ b/test/unit/app/models/link_checker_api_report/link_test.rb
@@ -1,0 +1,43 @@
+require "test_helper"
+
+class LinkTest < ActiveSupport::TestCase
+  test "sets attributes from payload" do
+    timestamp = Time.zone.now
+    link = LinkCheckerApiReport::Link.new(
+      uri: "http://example.com",
+      status: "broken",
+      checked: timestamp,
+      check_dangers: [],
+      check_errors: ["Some error"],
+      check_warnings: [],
+      problem_summary: "Problem",
+      suggested_fix: "Fix the left felange",
+    )
+
+    assert_equal "http://example.com", link.uri
+    assert_equal "broken", link.status
+    assert_equal timestamp, link.checked
+    assert_equal [], link.check_dangers
+    assert_equal ["Some error"], link.check_errors
+    assert_equal [], link.check_warnings
+    assert_equal "Problem", link.problem_summary
+    assert_equal "Fix the left felange", link.suggested_fix
+  end
+
+  test "has a `check_details` method that concatenates array, and is agnostic about whether link state is danger/error/warning" do
+    link = LinkCheckerApiReport::Link.new(
+      check_errors: ["Some error", "Some other error"],
+    )
+    assert_equal "Some error and Some other error", link.check_details
+
+    link = LinkCheckerApiReport::Link.new(
+      check_dangers: ["Some danger", "Danger"],
+    )
+    assert_equal "Some danger and Danger", link.check_details
+
+    link = LinkCheckerApiReport::Link.new(
+      check_warnings: ["Some warning"],
+    )
+    assert_equal "Some warning", link.check_details
+  end
+end


### PR DESCRIPTION
Link Checker API defines up to three separate user-facing messages per link error:

1. `problem_summary` (e.g. “Page not found”)
2. `check_errors|warnings|dangers` (e.g. “This page was not found (404).“) (array, as far as I can tell, it only ever has one item)
3. `suggested_fix` (e.g. “Find where the content is now hosted and link to that instead.“) (string, or nil)

We [only surface 1 and 3 in the UI](https://whitehall-admin.staging.publishing.service.gov.uk/government/admin/organisations/government-digital-service/corporate_information_pages/1648031), meaning:

1. Users are missing out on potentially valuable information
2. We’re needlessly storing a lot of extra data (~2.8 million links at time of writing)
3. Text is being configured in Link Checker API and potentially not used anywhere, leading to rot

Relatedly, we have a card to [improve the “Page blocks robots” error message](https://trello.com/c/Ep0YKe0w/28-improve-broken-links-checker-guidance) as it was confusing users.

This PR therefore surfaces the `check_errors`/`check_warnings`/`check_dangers` data to the link check report area of the UI.

## Screenshots

On page load:

> ![Screenshot 2025-03-25 at 10 34 46](https://github.com/user-attachments/assets/7483056c-e8f7-4a38-a133-7107ba32dc84)

Link expanded:

> ![Screenshot 2025-03-25 at 10 34 53](https://github.com/user-attachments/assets/399eadc9-9470-4b3e-a696-9117a30e61e7)

More links expanded:

> ![Screenshot 2025-03-25 at 10 35 00](https://github.com/user-attachments/assets/25089346-5961-43cc-b7b0-0eea81990c65)


## Architecture

A typical link:

```
LinkCheckerApiReport.find(115296719).broken_links.first
=> 
#<LinkCheckerApiReport::link:0x0000ffff61b73200
 id: 94973639,
 link_checker_api_report_id: 115296719,
 uri: "REDACTED",
 status: "broken",
 checked: "2025-03-24 09:32:04.000000000 +0000",
 check_warnings: [],
 check_errors: ["This page was not found (404)."],
 ordering: 0,
 created_at: "2025-03-24 09:32:03.000000000 +0000",
 updated_at: "2025-03-24 09:32:04.000000000 +0000",
 problem_summary: "Page not found",
 suggested_fix: "Find where the content is now hosted and link to t...",
 check_dangers: []>
```

Common errors:

```
LinkCheckerApiReport::Link.where(status: "broken").last(10000).group_by(&:problem_summary).map { |_, arr| arr.pluck(:problem_summary, :check_errors, :suggested_fix).first }
=> 
[["Page not found", ["This redirects to a page not found (404)."], "Find where the content is now hosted and link to that instead."],
 ["Page requires login", ["A login is required to view this page."], nil],
 ["Website unavailable", ["The website hosting this link is offline."], "Determine if this is a temporary issue or the resource is no longer available."],
 ["Page unavailable", ["This redirects to a page that is unavailable (400)."], "Contact the site administrator to see if they have an issue that can be fixed."],
 ["Invalid URL", ["This link is missing the scheme (http, ftp, mailto)."], "Check this is correct manually."],
 ["Broken Redirect", ["This page has a redirect loop and won't open."], nil]]
```

Common warnings:

```
LinkCheckerApiReport::Link.where(status: "caution").last(10000).group_by(&:problem_summary).map { |_, arr| arr.pluck(:problem_summary, :check_warnings, :suggested_fix).first }
=> 
[["Bad Redirect", ["This redirects too many times and will open slowly."], "Link directly to: https://blogs.fcdo.gov.uk/ukinmacedonia"],
 ["Page unavailable", ["This redirects to a page responding unusally (202)."], "Contact the site administrator to see if they have an issue that can be fixed."],
 ["Page blocks robots", ["This redirects to a page that blocked our link checker from accessing the website."], nil],
 ["Security problem", ["This page has a security problem that users may be alerted to."], "Contact the site administrator to see if they have an issue that can be fixed."],
 ["Slow page", ["This page is slow loading and may frustrate users."], "Contact the site administrator to see if they have an issue that can be fixed."],
 ["Unusual URL", ["This links to something which we don't support."], "Check this is correct manually."],
 ["Login details in URL", ["This link contains login credentials which you may not want to share publicly."], "Link to an alternative location of this resource, which doesn't require credentials."]]
```

Common dangers:

```
LinkCheckerApiReport::Link.where(status: "danger").last(10000).group_by(&:problem_summary).map { |_, arr| arr.pluck(:problem_summary, :check_dangers, :suggested_fix).first }
=> [["Suspicious Destination", [], nil]]
```

Trello: https://trello.com/c/uIpabmKR/846-improve-content-design-of-link-check-reports

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
