### PR TITLE
WIP: Separate out 'warning' vs 'error' link check reports

### DIFF
--- a/app/assets/stylesheets/components/_inset-prompt.scss
+++ b/app/assets/stylesheets/components/_inset-prompt.scss
@@ -16,8 +16,12 @@
 }
 
 .app-c-inset-prompt--error {
-  border-color: $govuk-error-colour;
-  background-color: govuk-tint($govuk-error-colour, 90%);
+  border-color: govuk-colour("red");
+  background-color: govuk-tint(govuk-colour("red"), 90%);
+}
+.app-c-inset-prompt--warning {
+  border-color: govuk-colour("orange");
+  background-color: govuk-tint(govuk-colour("orange"), 90%);
 }
 
 .app-c-inset-prompt__title {

--- a/app/controllers/admin/link_check_reports_controller.rb
+++ b/app/controllers/admin/link_check_reports_controller.rb
@@ -16,7 +16,6 @@ class Admin::LinkCheckReportsController < Admin::BaseController
 
   def show
     @report = LinkCheckerApiReport.find(params[:id])
-    @allow_new_report = params[:allow_new_report] || false
 
     respond_to do |format|
       format.html { redirect_to [:admin, @edition] }

--- a/app/models/concerns/edition/scopes/filterable_by_broken_links.rb
+++ b/app/models/concerns/edition/scopes/filterable_by_broken_links.rb
@@ -19,7 +19,7 @@ module Edition::Scopes::FilterableByBrokenLinks
     SELECT 1
     FROM link_checker_api_report_links
     WHERE link_checker_api_report_id = latest_link_checker_api_reports.id
-      AND link_checker_api_report_links.status IN ('danger', 'broken', 'caution')
+      AND link_checker_api_report_links.status IN ('danger', 'broken')
   )",
       )
     }

--- a/app/views/admin/editions/_govspeak_help.html.erb
+++ b/app/views/admin/editions/_govspeak_help.html.erb
@@ -6,7 +6,7 @@
   link_check_report ||= nil
 %>
 
-<%= render("admin/link_check_reports/link_check_report", report: link_check_report) if link_check_report %>
+<%= render("admin/link_check_reports/link_check_report", report: link_check_report, hide_button_to_create_new_report: true) if link_check_report %>
 
 <div class="govspeak-help">
   <h2 class="govuk-heading-l">Formatting</h2>

--- a/app/views/admin/editions/_govspeak_help.html.erb
+++ b/app/views/admin/editions/_govspeak_help.html.erb
@@ -6,7 +6,7 @@
   link_check_report ||= nil
 %>
 
-<%= render("admin/link_check_reports/link_check_report", report: link_check_report, allow_new_report: false) if link_check_report %>
+<%= render("admin/link_check_reports/link_check_report", report: link_check_report) if link_check_report %>
 
 <div class="govspeak-help">
   <h2 class="govuk-heading-l">Formatting</h2>

--- a/app/views/admin/editions/show/_main.html.erb
+++ b/app/views/admin/editions/show/_main.html.erb
@@ -224,7 +224,7 @@
               { text: translation.title },
               (@edition.editable? || @edition.can_delete?) ? {
                 text: raw([
-                  *(link_to("Edit", edit_admin_edition_translation_path(@edition, translation.locale), class: "govuk-link app-view-edition-summary__table-link") if @edition.editable?),
+                  *(link_to("Edit", edit_admin_edition_translation_path(@edition, translation.locale), class: "govuk-link app-view-summary__table-link") if @edition.editable?),
                   *(link_to("Delete", confirm_destroy_admin_edition_translation_path(@edition, translation.locale), class: "govuk-link gem-link--destructive") if @edition.can_delete?),
                 ].compact().join(" ")),
               } : nil,

--- a/app/views/admin/editions/show/_sidebar.html.erb
+++ b/app/views/admin/editions/show/_sidebar.html.erb
@@ -5,7 +5,6 @@
         partial: "admin/link_check_reports/link_check_report",
         locals: {
           report: @edition.link_check_report || LinkCheckerApiReport.new(edition: @edition),
-          allow_new_report: true,
         },
       ) if show_link_check_report?(@edition) %>
   <%= render partial: "admin/editions/show/sidebar_history_state", locals: { edition: @edition } %>

--- a/app/views/admin/link_check_reports/_link_check_report.html.erb
+++ b/app/views/admin/link_check_reports/_link_check_report.html.erb
@@ -15,7 +15,7 @@
       description: capture do %>
         <p class="govuk-body">Broken link report in progress.</p>
         <p class="govuk-body">
-          <%= link_to "Check progress", "", class: "govuk-link js-broken-links-refresh", data: { json_href: url_for(admin_edition_link_check_report_path(report.edition, report, format: :json, allow_new_report: allow_new_report.present? ? true : nil)) } %>
+          <%= link_to "Check progress", "", class: "govuk-link js-broken-links-refresh", data: { json_href: url_for(admin_edition_link_check_report_path(report.edition, report, format: :json)) } %>
         </p>
       <% end
     } %>
@@ -57,12 +57,10 @@
         <% if LinkCheckerApiService.has_admin_draft_links?(report.edition) %>
           <p class="govuk-body">It also contains links to draft documents that weren't checked.</p>
         <% end %>
-        <% if allow_new_report %>
-          <%= render partial: "admin/link_check_reports/form", locals: {
-            edition: report.edition,
-            button_text: "Check again",
-          } %>
-        <% end %>
+        <%= render partial: "admin/link_check_reports/form", locals: {
+          edition: report.edition,
+          button_text: "Check again",
+        } %>
         <p class="govuk-body govuk-!-font-size-16">Last checked: <%= l(report.updated_at, format: :long_ordinal) %></p>
       <% end,
       error: true
@@ -78,13 +76,11 @@
             It contains links to draft documents that weren't checked.
           </p>
         <% end %>
-        <% if allow_new_report %>
-          <%= render partial: "admin/link_check_reports/form", locals: {
-            edition: report.edition,
-            button_text: "Check again",
-            secondary_quiet: true,
-          } %>
-        <% end %>
+        <%= render partial: "admin/link_check_reports/form", locals: {
+          edition: report.edition,
+          button_text: "Check again",
+          secondary_quiet: true,
+        } %>
       <% end
     } %>
   <% end %>

--- a/app/views/admin/link_check_reports/_link_check_report.html.erb
+++ b/app/views/admin/link_check_reports/_link_check_report.html.erb
@@ -63,6 +63,7 @@
             button_text: "Check again",
           } %>
         <% end %>
+        <p class="govuk-body govuk-!-font-size-16">Last checked: <%= l(report.updated_at, format: :long_ordinal) %></p>
       <% end,
       error: true
     } %>

--- a/app/views/admin/link_check_reports/_link_check_report.html.erb
+++ b/app/views/admin/link_check_reports/_link_check_report.html.erb
@@ -61,7 +61,7 @@
           edition: report.edition,
           button_text: "Check again",
         } %>
-        <p class="govuk-body govuk-!-font-size-16">Last checked: <%= l(report.updated_at, format: :long_ordinal) %></p>
+        <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-top-5">Last checked: <%= l(report.updated_at, format: :long_ordinal) %></p>
       <% end,
       error: true
     } %>

--- a/app/views/admin/link_check_reports/_link_check_report.html.erb
+++ b/app/views/admin/link_check_reports/_link_check_report.html.erb
@@ -1,3 +1,7 @@
+<%
+  hide_button_to_create_new_report ||= false
+%>
+
 <div data-module="broken-links-report">
   <% if report.new_record? %>
     <%= render "components/inset_prompt", {
@@ -57,10 +61,12 @@
         <% if LinkCheckerApiService.has_admin_draft_links?(report.edition) %>
           <p class="govuk-body">It also contains links to draft documents that weren't checked.</p>
         <% end %>
-        <%= render partial: "admin/link_check_reports/form", locals: {
-          edition: report.edition,
-          button_text: "Check again",
-        } %>
+        <% unless hide_button_to_create_new_report %>
+          <%= render partial: "admin/link_check_reports/form", locals: {
+            edition: report.edition,
+            button_text: "Check again",
+          } %>
+        <% end %>
         <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-top-5">Last checked: <%= l(report.updated_at, format: :long_ordinal) %></p>
       <% end,
       error: true
@@ -76,11 +82,13 @@
             It contains links to draft documents that weren't checked.
           </p>
         <% end %>
-        <%= render partial: "admin/link_check_reports/form", locals: {
-          edition: report.edition,
-          button_text: "Check again",
-          secondary_quiet: true,
-        } %>
+        <% unless hide_button_to_create_new_report %>
+          <%= render partial: "admin/link_check_reports/form", locals: {
+            edition: report.edition,
+            button_text: "Check again",
+            secondary_quiet: true,
+          } %>
+        <% end %>
       <% end
     } %>
   <% end %>

--- a/app/views/admin/link_check_reports/_link_check_report.html.erb
+++ b/app/views/admin/link_check_reports/_link_check_report.html.erb
@@ -31,7 +31,7 @@
 
           <p class="govuk-body"><%= t "broken_links.#{status}.subheading" %></p>
 
-          <ul class="govuk-list app-view-edition-summary__broken-links-report">
+          <ul class="govuk-list app-view-summary__broken-links-report">
             <% links.each do |link| %>
               <li>
                 <%= link_to link.uri.truncate(50), link.uri, title: link.uri, class: "govuk-link" %>

--- a/app/views/admin/link_check_reports/_link_check_report.html.erb
+++ b/app/views/admin/link_check_reports/_link_check_report.html.erb
@@ -25,7 +25,7 @@
     } %>
   <% elsif report.danger_links.any? || report.broken_links.any? || report.caution_links.any? %>
     <%= render "components/inset_prompt", {
-      title: t("broken_links.title"),
+      title: report.caution_links.any? ? t("broken_links.title_warning") : t("broken_links.title_error"),
       description: capture do %>
         <%
           status_order = { "danger" => 1, "broken" => 2, "caution" => 3 }
@@ -69,7 +69,8 @@
         <% end %>
         <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-top-5">Last checked: <%= l(report.updated_at, format: :long_ordinal) %></p>
       <% end,
-      error: true
+      error: report.danger_links.any? || report.broken_links.any?,
+      warning: !(report.danger_links.any? || report.broken_links.any?) && report.caution_links.any?,
     } %>
   <% else %>
     <%= render "components/inset_prompt", {

--- a/app/views/components/_inset_prompt.html.erb
+++ b/app/views/components/_inset_prompt.html.erb
@@ -4,9 +4,11 @@
   items ||= []
   id ||= nil
   error = false if error.nil?
+  warning = false if warning.nil?
   data_attributes ||= {}
   root_classes = %w[app-c-inset-prompt]
   root_classes << "app-c-inset-prompt--error" if error
+  root_classes << "app-c-inset-prompt--warning" if warning
 %>
 <% if title || description %>
   <%= tag.div class: root_classes, id: id, data: data_attributes do %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -72,7 +72,8 @@ en:
       subheading: We’ve found links in this document that may be broken
     caution:
       subheading: We’ve found some issues with links that may indicate problems, you should apply caution in linking to them
-    title: Broken links
+    title_error: Broken links
+    title_warning: Potential link issues
   contact:
     access_and_opening_times: Access and opening times
     contact_form: Contact form


### PR DESCRIPTION
Screenshot:

![Screenshot 2025-03-25 at 11 40 58](https://github.com/user-attachments/assets/72961749-56ec-4595-8898-a12d8bababb7)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
