### PR TITLE
Cross-link to govuk-docker guide

### DIFF
--- a/docs/tips_for_local_development.md
+++ b/docs/tips_for_local_development.md
@@ -1,4 +1,9 @@
-# Tips for working on whitehall locally
+# Tips for working on Whitehall locally
+
+See also:
+
+- [govuk-docker: Publishing Content from Whitehall for Developing Government Frontend](https://docs.publishing.service.gov.uk/repos/govuk-docker/how-tos/publishing-content-on-whitehall.html)
+- [Unofficial notes doc](https://docs.google.com/document/d/1PnZwCGjtgsvArzGGcLM102F2jctFi1J0NwI6WdBLem8/edit)
 
 ## Installing Whitehall gems locally
 


### PR DESCRIPTION
I spent ages trying to find the `taxonomy` rake task instructions. This link may have helped!

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
