### PR TITLE
Fix logic that prevents retries on `HTTPPayloadTooLarge`

### DIFF
--- a/test/integration/workers/publishing_api_document_republishing_worker_integration_test.rb
+++ b/test/integration/workers/publishing_api_document_republishing_worker_integration_test.rb
@@ -136,11 +136,9 @@ class PublishingApiDocumentRepublishingWorkerIntegrationTest < ActiveSupport::Te
       Whitehall::PublishingApi.expects(:publish).raises(GdsApi::HTTPPayloadTooLarge.new("413 Request Entity Too Large"))
       worker = PublishingApiDocumentRepublishingWorker.new
 
-      assert_equal(worker.sidekiq_options_hash["retry"], true)
-      assert_raises(GdsApi::HTTPPayloadTooLarge) do
+      assert_raises(Sidekiq::JobRetry::Skip) do
         worker.perform(edition.document.id)
       end
-      assert_equal(worker.sidekiq_options_hash["retry"], 0)
     end
   end
 


### PR DESCRIPTION
As evidenced by the `retry: true` in https://govuk.sentry.io/issues/6332398641/?alert_rule_id=9401721&alert_type=issue&environment=production&notification_uuid=dfa0a84d-f6b3-457a-ac8c-6ab0e9f29156&project=202259&referrer=slack, the worker is still retrying even after encountering `GdsApi::HTTPPayloadTooLarge`, despite the `rescue` block attempting to set `retry: 0`. The issue is that `sidekiq_options` is not mutable at runtime for a single execution.

Why This Is Happening:

- `PublishingApiDocumentRepublishingWorker.sidekiq_options retry: 0` only sets options for future jobs and does not affect the currently executing job.

- Sidekiq's job retry mechanism is configured at the time the job is enqueued, so modifying it within the job execution does not change the behavior of the currently running instance.

- The test passes because it's running in an isolated instance of the worker, but in a real Sidekiq execution, the retry behavior is already locked in when the job was first scheduled.

To fix it, we need to explicitly re-raise an exception that Sidekiq will not retry. Sidekiq has a built-in `Sidekiq::JobRetry::Skip` exception that prevents retries.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
