### PR TITLE
content-modelling/988 show content block updates whatever state host content is in

### DIFF
--- a/app/models/host_content_update_event.rb
+++ b/app/models/host_content_update_event.rb
@@ -22,7 +22,7 @@ class HostContentUpdateEvent < Data.define(:author, :created_at, :content_id, :c
   end
 
   def is_for_current_edition?(edition)
-    edition.published_at && created_at.after?(edition.published_at) && !is_for_newer_edition?(edition)
+    !edition.unpublished? && created_at.after?(edition.created_at) && !is_for_newer_edition?(edition)
   end
 
   def is_for_older_edition?(edition)

--- a/test/unit/app/models/host_content_update_event_test.rb
+++ b/test/unit/app/models/host_content_update_event_test.rb
@@ -83,12 +83,12 @@ class HostContentUpdateEventTest < ActiveSupport::TestCase
     let(:created_at) { Time.zone.now - 1.month }
     let(:host_content_update_event) { build(:host_content_update_event, created_at:) }
 
+    before do
+      edition.stubs(:created_at).returns(created_at - 12.months)
+    end
+
     describe "when the edition is published" do
       let(:edition) { build(:edition) }
-
-      before do
-        edition.stubs(:published_at).returns(created_at - 12.months)
-      end
 
       describe "when the event occurred after the edition was superseded" do
         before do
@@ -143,6 +143,28 @@ class HostContentUpdateEventTest < ActiveSupport::TestCase
 
     describe "when the edition is draft" do
       let(:edition) { build(:edition, :draft) }
+
+      describe "#is_for_newer_edition?" do
+        it "returns false" do
+          assert_not host_content_update_event.is_for_newer_edition?(edition)
+        end
+      end
+
+      describe "#is_for_current_edition?" do
+        it "returns true" do
+          assert host_content_update_event.is_for_current_edition?(edition)
+        end
+      end
+
+      describe "#is_for_older_edition?" do
+        it "returns false" do
+          assert_not host_content_update_event.is_for_older_edition?(edition)
+        end
+      end
+    end
+
+    describe "when the edition is unpublished" do
+      let(:edition) { build(:edition, :unpublished) }
 
       describe "#is_for_newer_edition?" do
         it "returns false" do


### PR DESCRIPTION
https://trello.com/c/ydkPdznT/988-allow-updates-to-objects-to-appear-in-the-history-and-notes-for-whitehall-draft-editions-story

If a Document has an embedded content block, we want to show changes to that content block in the
document's history, if it is any state except `unpublished`. 

`unpublished` looks like the only final state when a Document will have no further changes, from looking at `workflow.rb`, `withdrawn` can be `unwithdrawn`.

I've had a play with this branch on Integration and seems to work as expected


<img width="546" alt="Screenshot 2025-03-26 at 16 59 55" src="https://github.com/user-attachments/assets/5d0697f5-9859-4c16-9b7a-e915305b1362" />


---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
