### PR TITLE
Add option to republish documents with attachemnts by edition state

### DIFF
--- a/lib/tasks/attachments/republish_attachments.rake
+++ b/lib/tasks/attachments/republish_attachments.rake
@@ -1,14 +1,15 @@
 desc "Republish all documents with non-pdf attachments"
-task :republish_attachments, %i[content_type weeks_ago] => :environment do |_, args|
+task :republish_attachments, %i[content_type weeks_ago state] => :environment do |_, args|
   content_type = args[:content_type]
   weeks_ago = args[:weeks_ago]
+  state = args[:state] || "published"
 
   query = Attachment.joins(:attachment_data)
                     .joins("JOIN editions ON editions.id = attachments.attachable_id AND attachments.attachable_type = 'Edition'")
                     .where.not(deleted: true)
                     .where.not(attachable: nil)
-                    .where(editions: { state: "published" })
 
+  query = query.where(editions: { state: }) if state
   query = query.where(attachment_data: { content_type: }) if content_type
   query = query.where("editions.public_timestamp >= :start_date", { start_date: Time.zone.now - weeks_ago.to_i.weeks }) if weeks_ago
 


### PR DESCRIPTION
This adds changes to the exisisting task to allow republishing of documents with various states, and not only published ones.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

Trello card: https://trello.com/c/c8SR0owc/3402-create-a-task-for-republishing-all-documents-with-csv-attachments