### PR TITLE
Switch fields of operation rendering app to frontend

### DIFF
--- a/app/presenters/publishing_api/operational_fields_index_presenter.rb
+++ b/app/presenters/publishing_api/operational_fields_index_presenter.rb
@@ -18,7 +18,7 @@ module PublishingApi
         details: {},
         document_type: "fields_of_operation",
         public_updated_at: Time.zone.now,
-        rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
+        rendering_app: Whitehall::RenderingApp::FRONTEND,
         schema_name: "fields_of_operation",
       )
 

--- a/test/unit/app/presenters/publishing_api/operational_fields_index_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/operational_fields_index_presenter_test.rb
@@ -11,7 +11,7 @@ class PublishingApi::OperationalFieldsIndexPresenterTest < ActiveSupport::TestCa
       base_path: "/government/fields-of-operation",
       details: {},
       publishing_app: Whitehall::PublishingApp::WHITEHALL,
-      rendering_app: "government-frontend",
+      rendering_app: "frontend",
       schema_name: "fields_of_operation",
       document_type: "fields_of_operation",
       title: "Fields of operation",


### PR DESCRIPTION
As part of app consolidation https://github.com/alphagov/frontend/pull/4727

https://trello.com/c/O2owO9qW

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
