### PR TITLE
Prevent publishing draft editions that contain dangerous links

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -52,6 +52,7 @@ class Edition < ApplicationRecord
 
   validates_with SafeHtmlValidator
   validates_with NoFootnotesInGovspeakValidator, attribute: :body
+  validates_with LinkCheckReportValidator, on: :publish
   validates_with TaxonValidator, on: :publish, if: :requires_taxon?
 
   validates :creator, presence: true

--- a/app/validators/link_check_report_validator.rb
+++ b/app/validators/link_check_report_validator.rb
@@ -1,0 +1,16 @@
+class LinkCheckReportValidator < ActiveModel::Validator
+  def validate(edition)
+    if contains_dangerous_links?(edition)
+      edition.errors.add(
+        :base,
+        "This document has not been published. You need to remove dangerous links before publishing.".html_safe,
+      )
+    end
+  end
+
+private
+
+  def contains_dangerous_links?(edition)
+    edition.link_check_report.present? && edition.link_check_report.danger_links.any?
+  end
+end

--- a/test/unit/app/validators/link_check_report_validator_test.rb
+++ b/test/unit/app/validators/link_check_report_validator_test.rb
@@ -1,0 +1,49 @@
+require "test_helper"
+
+class LinkCheckReportValidatorTest < ActiveSupport::TestCase
+  setup do
+    @validator = LinkCheckReportValidator.new
+  end
+
+  test "is invalid when edition contains 'dangerous' links" do
+    edition = create(:draft_edition)
+    create(
+      :link_checker_api_report_completed,
+      edition: edition,
+      links: [
+        create(:link_checker_api_report_link, :danger, uri: "http://www.example.com"),
+      ],
+    )
+
+    @validator.validate(edition)
+
+    assert_equal 1, edition.errors.count
+    assert_equal(
+      "This document has not been published. You need to remove dangerous links before publishing.",
+      edition.errors[:base].first,
+    )
+  end
+
+  test "is valid when edition contains 'broken' links" do
+    edition = create(:draft_edition)
+    create(
+      :link_checker_api_report_completed,
+      edition: edition,
+      links: [
+        create(:link_checker_api_report_link, :broken, uri: "http://www.example.com"),
+      ],
+    )
+
+    @validator.validate(edition)
+
+    assert_equal 0, edition.errors.count
+  end
+
+  test "is valid when edition contains no link check report" do
+    edition = create(:draft_edition)
+
+    @validator.validate(edition)
+
+    assert_equal 0, edition.errors.count
+  end
+end


### PR DESCRIPTION
As of #10081, Whitehall now has the concept of a 'dangerous' link and has automation in place to remove such links from published editions. This commit introduces logic to prevent such links from being newly published in the first place.

Trello: https://trello.com/c/PLcGoXXf/

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
