### PR TITLE
Fix bad attachment data mime types

### DIFF
--- a/db/data_migration/2025040311460000_fix_bad_attachment_data_mime_types.rb
+++ b/db/data_migration/2025040311460000_fix_bad_attachment_data_mime_types.rb
@@ -1,0 +1,1 @@
+AttachmentData.where(content_type: "\"application/pdf\"").update_all(content_type: "application/pdf")


### PR DESCRIPTION
There are 154 `content_type` values set to `"\"application/pdf\""`, instead of `"application/pdf"`. This was breaking a data pipeline.

[Trello](https://trello.com/c/EmdtD0tK/3523-replicate-part-of-the-whitehall-database-in-google-bigquery)
