### PR TITLE
Reindex parent organisations when child org added/destroyed

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -209,10 +209,10 @@ class Organisation < ApplicationRecord
 
   before_destroy { |r| throw :abort unless r.destroyable? }
   after_save :ensure_analytics_identifier
-  after_save :reindex_parent_organisations
+  after_save :reindex_associated_organisations
   after_save :republish_how_government_works_page_to_publishing_api, :republish_organisations_index_page_to_publishing_api
   after_save :patch_links_ministers_index_page_to_publishing_api, if: :ministerial_department?
-  after_destroy :reindex_parent_organisations
+  after_destroy :reindex_associated_organisations
   after_destroy :republish_organisations_index_page_to_publishing_api
   after_destroy :patch_links_ministers_index_page_to_publishing_api, if: :ministerial_department?
 
@@ -232,8 +232,8 @@ class Organisation < ApplicationRecord
     end
   end
 
-  def reindex_parent_organisations
-    parent_organisations.each(&:update_in_search_index)
+  def reindex_associated_organisations
+    (parent_organisations + child_organisations).each(&:update_in_search_index)
   end
 
   def republish_organisations_index_page_to_publishing_api

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -209,8 +209,10 @@ class Organisation < ApplicationRecord
 
   before_destroy { |r| throw :abort unless r.destroyable? }
   after_save :ensure_analytics_identifier
+  after_save :reindex_parent_organisations
   after_save :republish_how_government_works_page_to_publishing_api, :republish_organisations_index_page_to_publishing_api
   after_save :patch_links_ministers_index_page_to_publishing_api, if: :ministerial_department?
+  after_destroy :reindex_parent_organisations
   after_destroy :republish_organisations_index_page_to_publishing_api
   after_destroy :patch_links_ministers_index_page_to_publishing_api, if: :ministerial_department?
 
@@ -228,6 +230,10 @@ class Organisation < ApplicationRecord
       documents = Document.live.where(editions: { alternative_format_provider_id: self })
       documents.find_each { |d| Whitehall::PublishingApi.republish_document_async(d, bulk: true) }
     end
+  end
+
+  def reindex_parent_organisations
+    parent_organisations.each(&:update_in_search_index)
   end
 
   def republish_organisations_index_page_to_publishing_api

--- a/lib/data_hygiene/organisation_reslugger.rb
+++ b/lib/data_hygiene/organisation_reslugger.rb
@@ -20,7 +20,6 @@ module DataHygiene
       remove_from_search_index
       update_slug
       if organisation.is_a? Organisation
-        update_child_and_parent_organisations_in_search
         update_users
       end
     end
@@ -37,15 +36,6 @@ module DataHygiene
       # NOTE: This will trigger calls to both search_api and the Publishing API,
       # meaning that entries in both places will exist with the correct slug
       organisation.update!(slug: new_slug)
-    end
-
-    def update_child_and_parent_organisations_in_search
-      organisation.child_organisations.each do |child_org|
-        Whitehall::SearchIndex.add(child_org)
-      end
-      organisation.parent_organisations.each do |parent_org|
-        Whitehall::SearchIndex.add(parent_org)
-      end
     end
 
     def update_users

--- a/test/unit/app/models/organisation_test.rb
+++ b/test/unit/app/models/organisation_test.rb
@@ -188,7 +188,7 @@ class OrganisationTest < ActiveSupport::TestCase
     child_org2 = create(:organisation, parent_organisations: [parent_org1])
     _child_org3 = create(:organisation, parent_organisations: [parent_org2])
 
-    assert_equal [child_org1, child_org2], parent_org1.child_organisations
+    assert_equal [child_org1, child_org2], parent_org1.reload.child_organisations
   end
 
   test "#parent_organisations should return the child's parent organisations" do
@@ -456,6 +456,15 @@ class OrganisationTest < ActiveSupport::TestCase
     Whitehall::SearchIndex.expects(:add).once.with(child_org)
     Whitehall::SearchIndex.expects(:add).once.with(parent_org)
     child_org.save!
+  end
+
+  test "should reindex child organisation in search index on creating" do
+    child_org = create(:organisation)
+    parent_org = build(:organisation, child_organisations: [child_org])
+
+    Whitehall::SearchIndex.expects(:add).once.with(child_org)
+    Whitehall::SearchIndex.expects(:add).once.with(parent_org)
+    parent_org.save!
   end
 
   test "should add courts to index on creating" do


### PR DESCRIPTION
We've had several reports of Signon users having difficulty accessing Signon because they're a part of a child organisation and - unexpectedly - org editors of the parent organisation have been unable to administrate their accounts.

On inspection, the orgs in Signon are out of sync with the orgs in Whitehall. In the most recent example, the 'skills-england' org has no parent in Signon.

Looking at skills-england in Organisations API, we can see it does have a parent of 'department-for-education':
https://www.gov.uk/api/organisations/skills-england

The corresponding entry for 'department-for-education', however, lacks a 'child_organisations' relationship with 'skills-england': https://www.gov.uk/api/organisations/department-for-education

Since [Organisations API is populated by Search API](https://docs.publishing.service.gov.uk/manual/organisations-api.html#populating-the-organisations-api), we need to dig into Search API to find the issue. Sure enough, the corresponding Search API results for each org match what we're seeing in Organisations API:
- https://www.gov.uk/api/search.json?filter_link=/government/organisations/skills-england
- https://www.gov.uk/api/search.json?filter_link=/government/organisations/department-for-education

Looking in Whitehall, we had no special logic handling the indexing of parent organisations. We know we have to manually update orgs in Search API after save/destroy, but this was only being done on a per-organisation basis, so was never updating the parent/child relationship in Search API.

I've added some additional callbacks to update all parent organisations in Search API whenever a corresponding child org is created or destroyed.

PS: some 'reload' calls were required to fix a couple of tests that started failing as a result of this. I'm not entirely sure why, but I don't see any harm in it, since in production we don't tend to create and use an org and its attributes so procedurally.

Trello: https://trello.com/c/oPEsW9mH/3605-investigate-mismatch-between-whitehall-organisations-and-search-api

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
