### PR TITLE
Add `search_results` tracking

### DIFF
--- a/app/assets/javascripts/admin/analytics-modules/ga4-search-results-setup.js
+++ b/app/assets/javascripts/admin/analytics-modules/ga4-search-results-setup.js
@@ -1,0 +1,104 @@
+'use strict'
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {}
+window.GOVUK.analyticsGa4.analyticsModules =
+  window.GOVUK.analyticsGa4.analyticsModules || {}
+;(function (Modules) {
+  Modules.Ga4SearchResultsSetup = {
+    init: function (noHashChange) {
+      if (!document.querySelector('[data-ga4-ecommerce]')) {
+        return
+      }
+
+      // if we have multiple tabs with search results
+      // then remove the attributes so that we only capture
+      // the search results in the visible tab
+      Array.from(
+        document.querySelectorAll(
+          '[data-module~="govuk-tabs"] [data-ga4-ecommerce]'
+        )
+      ).forEach((search) => {
+        search.removeAttribute('data-ga4-ecommerce')
+        search.setAttribute('data-search-track', true)
+      })
+
+      this.trackEcommerce()
+
+      if (!noHashChange) {
+        this.eventListener = this.trackEcommerce.bind(this)
+
+        window.addEventListener('hashchange', this.eventListener)
+
+        this.clearHashChange()
+      }
+    },
+
+    clearHashChange: function () {
+      // remove hashchange listener
+      // if no more search to track
+      if (
+        !document.querySelectorAll(
+          '[data-module~="govuk-tabs"] [data-search-track]'
+        ).length
+      ) {
+        window.removeEventListener('hashchange', this.eventListener)
+      } else {
+        window.addEventListener('hashchange', this.clearHashChange.bind(this), {
+          once: true
+        })
+      }
+    },
+
+    trackEcommerce: function () {
+      // this is because we have an instance of a search result
+      // page within a tab component and we only want to fire a
+      // search result event if the tab with the search result
+      // is visible
+
+      const hash = window.location.hash
+
+      let searchTarget = document.querySelector('[data-ga4-ecommerce]')
+
+      if (
+        !searchTarget &&
+        document.querySelector('[data-module~="govuk-tabs"]')
+      ) {
+        if (hash.length) {
+          searchTarget = document.querySelector(
+            `[data-module~="govuk-tabs"] ${hash} [data-search-track]`
+          )
+        } else {
+          // if search result is on the first tab
+          // and the page is loaded without an anchor
+
+          // get the first instance of a search in a tab
+          // on the page if it exists
+          searchTarget = document.querySelector(
+            '[data-module~="govuk-tabs"] section [data-search-track]'
+          )
+
+          if (searchTarget) {
+            const sectionOfSearchTarget = searchTarget.closest('section')
+
+            const sectionIndexOfSearchTarget = Array.from(
+              searchTarget
+                .closest('[data-module~="govuk-tabs"]')
+                .querySelectorAll('section')
+            ).indexOf(sectionOfSearchTarget)
+
+            searchTarget = !sectionIndexOfSearchTarget && searchTarget
+          }
+        }
+      }
+
+      if (searchTarget) {
+        searchTarget.removeAttribute('data-search-track')
+        searchTarget.setAttribute('data-ga4-ecommerce', true)
+
+        window.GOVUK.analyticsGa4.Ga4EcommerceTracker.init()
+
+        searchTarget.removeAttribute('data-ga4-ecommerce')
+      }
+    }
+  }
+})(window.GOVUK.analyticsGa4.analyticsModules)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -19,6 +19,7 @@
 //= require admin/analytics-modules/ga4-index-section-setup.js
 //= require admin/analytics-modules/ga4-button-setup.js
 //= require admin/analytics-modules/ga4-link-setup.js
+//= require admin/analytics-modules/ga4-search-results-setup.js
 //= require admin/analytics-modules/ga4-visual-editor-event-handlers.js
 //= require admin/analytics-modules/ga4-page-view-tracking.js
 //= require admin/analytics-modules/ga4-paste-tracker.js

--- a/app/views/admin/document_collection_group_document_search/add_by_title.html.erb
+++ b/app/views/admin/document_collection_group_document_search/add_by_title.html.erb
@@ -8,7 +8,7 @@
 <% content_for :context, @group.heading %>
 <% content_for :title_margin_bottom, 6 %>
 
-<div class="govuk-grid-row">
+<div class="govuk-grid-row" data-ga4-ecommerce data-ga4-search-query="<%= params[:title] %>">
   <div class="govuk-grid-column-two-thirds app-view-document-collection-document-search-bar">
     <%= form_with method: :get do |_form| %>
       <%= render "govuk_publishing_components/components/search", {
@@ -23,7 +23,7 @@
   <% unless @editions.nil? %>
     <div class="govuk-grid-column-two-thirds app-view-document-collection-document-search-results">
 
-      <p class="govuk-heading-s govuk-!-margin-bottom-3"><%= pluralize(number_with_delimiter(@editions.total_count), "document") %></p>
+      <p id="js-result-count" class="govuk-heading-s govuk-!-margin-bottom-3"><%= pluralize(number_with_delimiter(@editions.total_count), "document") %></p>
       <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
       <% if @editions.empty? %>

--- a/app/views/admin/editions/_search_results.html.erb
+++ b/app/views/admin/editions/_search_results.html.erb
@@ -3,7 +3,7 @@
     <p class="govuk-heading-s govuk-!-margin-bottom-1"><%= number_with_delimiter(@filter.force_published_count) %> force published</p>
     <p class="govuk-heading-s govuk-!-margin-bottom-3"><%= @filter.force_published_percentage %>% force published</p>
   <% else %>
-    <p class="govuk-heading-s govuk-!-margin-bottom-3"><%= pluralize(number_with_delimiter(@filter.editions.total_count), "document") %></p>
+    <p id="js-result-count" class="govuk-heading-s govuk-!-margin-bottom-3"><%= pluralize(number_with_delimiter(@filter.editions.total_count), "document") %></p>
 <% end %>
 
 <% if filter.editions.blank? %>

--- a/app/views/admin/editions/index.html.erb
+++ b/app/views/admin/editions/index.html.erb
@@ -2,7 +2,7 @@
 <% content_for :title, @filter.page_title %>
 <% content_for :page_full_width, true %>
 
-<div class="govuk-grid-row">
+<div class="govuk-grid-row" data-ga4-ecommerce data-ga4-search-query="<%= params[:title] %>">
   <div class="govuk-grid-column-one-third">
     <%= render "filter_options", filter_action: admin_editions_path %>
   </div>

--- a/app/views/admin/featurable_editions/_search_results.html.erb
+++ b/app/views/admin/featurable_editions/_search_results.html.erb
@@ -1,4 +1,4 @@
-<p class="govuk-heading-s govuk-!-margin-bottom-3"><%= pluralize(number_with_delimiter(paginator.total_count), "document") %></p>
+<p id="js-result-count" class="govuk-heading-s govuk-!-margin-bottom-3"><%= pluralize(number_with_delimiter(paginator.total_count), "document") %></p>
 
 <% if paginator.blank? %>
   <div class="govuk-body app-view-features-search-results__no_documents">

--- a/app/views/admin/shared/_featurable_editions.html.erb
+++ b/app/views/admin/shared/_featurable_editions.html.erb
@@ -3,7 +3,7 @@
   margin_bottom: 8,
 } %>
 
-<div class="govuk-grid-row">
+<div class="govuk-grid-row" data-ga4-ecommerce data-ga4-search-query="<%= params[:title] %>">
   <div class="govuk-grid-column-one-third">
     <%= render "admin/editions/filter_options", filter_by:, filter_action:, anchor: %>
   </div>

--- a/app/views/admin/statistics_announcement_publications/index.html.erb
+++ b/app/views/admin/statistics_announcement_publications/index.html.erb
@@ -4,7 +4,7 @@
 <% content_for :title_margin_bottom, 6 %>
 <% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @statistics_announcement)) %>
 
-<div class="govuk-grid-row">
+<div class="govuk-grid-row" data-ga4-ecommerce data-ga4-search-query="<%= params[:title] %>">
   <div class="govuk-grid-column-two-thirds">
     <%= render "govuk_publishing_components/components/inset_text", {
       text: "The type of the document you are trying to connect must match the type of the statistics announcement. Only #{@statistics_announcement.publication_type.plural_name} documents will be shown.",
@@ -21,7 +21,7 @@
     <% end %>
 
     <% if @filter %>
-      <p class="govuk-heading-s govuk-!-margin-bottom-3"><%= pluralize(number_with_delimiter(@filter.editions.total_count), "document") %></p>
+      <p id="js-result-count" class="govuk-heading-s govuk-!-margin-bottom-3"><%= pluralize(number_with_delimiter(@filter.editions.total_count), "document") %></p>
       <hr class="govuk-section-break--m">
       <%= render "govuk_publishing_components/components/table", {
         id: "table",

--- a/app/views/admin/statistics_announcements/_search_results.html.erb
+++ b/app/views/admin/statistics_announcements/_search_results.html.erb
@@ -1,4 +1,4 @@
-<h2 class="govuk-heading-s govuk-!-margin-bottom-3"><%= pluralize(number_with_delimiter(paginator.total_count), "document") %></h2>
+<h2 id="js-result-count" class="govuk-heading-s govuk-!-margin-bottom-3"><%= pluralize(number_with_delimiter(paginator.total_count), "document") %></h2>
 
 <% if paginator.blank? %>
   <p class="govuk-body app-view-edition-search-results__no_documents">No <%= filter.options[:dates] %> statistics announcements found</p>

--- a/app/views/admin/statistics_announcements/index.html.erb
+++ b/app/views/admin/statistics_announcements/index.html.erb
@@ -17,7 +17,7 @@
   </div>
 </div>
 
-<div class="govuk-grid-row">
+<div class="govuk-grid-row" data-ga4-ecommerce data-ga4-search-query="<%= params[:title] %>">
   <div class="govuk-grid-column-one-third">
     <%= render "filter_options" %>
   </div>

--- a/spec/javascripts/admin/analytics-modules/ga4-search-results-setup.spec.js
+++ b/spec/javascripts/admin/analytics-modules/ga4-search-results-setup.spec.js
@@ -1,0 +1,138 @@
+describe('GOVUK.analyticsGa4.analyticsModules.Ga4SearchResultsSetup', function () {
+  const container = document.createElement('div')
+  container.id = 'container'
+  document.body.appendChild(container)
+
+  describe('if search outside tabs component', function () {
+    it('start Ga4EcommerceTracker', function () {
+      container.innerHTML = `
+        <div data-ga4-ecommerce></div>
+      `
+
+      const mockGa4EcommerceTrackerInit = spyOn(
+        window.GOVUK.analyticsGa4.Ga4EcommerceTracker,
+        'init'
+      )
+
+      window.GOVUK.analyticsGa4.analyticsModules.Ga4SearchResultsSetup.init(
+        true
+      )
+
+      expect(mockGa4EcommerceTrackerInit).toHaveBeenCalled()
+    })
+  })
+
+  describe('if search within tabs component', function () {
+    const sections = [
+      `<section id="not-search"></section>`,
+      `<section id="search"><div data-ga4-ecommerce></div></section>`
+    ]
+
+    beforeEach(function () {
+      container.innerHTML = `
+        <div data-module="govuk-tabs">
+        </div>
+      `
+    })
+
+    describe('does start Ga4EcommerceTracker', function () {
+      it('when search in first tab and hash empty', function () {
+        container.querySelector('div').innerHTML = Array.from(sections)
+          .reverse()
+          .join('')
+
+        const mockGa4EcommerceTrackerInit = spyOn(
+          window.GOVUK.analyticsGa4.Ga4EcommerceTracker,
+          'init'
+        )
+
+        window.GOVUK.analyticsGa4.analyticsModules.Ga4SearchResultsSetup.init(
+          true
+        )
+
+        expect(mockGa4EcommerceTrackerInit).toHaveBeenCalled()
+      })
+
+      it('when hash equal to id of tab section on init', function () {
+        container.querySelector('div').innerHTML = sections.join('')
+
+        const mockGa4EcommerceTrackerInit = spyOn(
+          window.GOVUK.analyticsGa4.Ga4EcommerceTracker,
+          'init'
+        )
+
+        window.location = '#search'
+
+        window.GOVUK.analyticsGa4.analyticsModules.Ga4SearchResultsSetup.init(
+          true
+        )
+
+        expect(mockGa4EcommerceTrackerInit).toHaveBeenCalled()
+      })
+
+      it('when hash equal to id of tab section after init', function () {
+        container.querySelector('div').innerHTML = sections.join('')
+
+        const mockGa4EcommerceTrackerInit = spyOn(
+          window.GOVUK.analyticsGa4.Ga4EcommerceTracker,
+          'init'
+        )
+
+        window.GOVUK.analyticsGa4.analyticsModules.Ga4SearchResultsSetup.init()
+
+        window.location = '#search'
+
+        // this event would fire in browser on hash change
+        // when the tab component changes the URL on
+        // changing a tab
+        window.dispatchEvent(new Event('hashchange'))
+
+        expect(mockGa4EcommerceTrackerInit).toHaveBeenCalled()
+      })
+    })
+
+    describe('does not start Ga4EcommerceTracker', function () {
+      it('when search not in first tab and hash empty', function () {
+        container.querySelector('div').innerHTML = sections.join('')
+
+        const mockGa4EcommerceTrackerInit = spyOn(
+          window.GOVUK.analyticsGa4.Ga4EcommerceTracker,
+          'init'
+        )
+
+        window.GOVUK.analyticsGa4.analyticsModules.Ga4SearchResultsSetup.init(
+          true
+        )
+
+        expect(mockGa4EcommerceTrackerInit).not.toHaveBeenCalled()
+      })
+
+      it(`when search in first tab and hash not id of first tab`, function () {
+        window.location = '#not-search'
+
+        container.querySelector('div').innerHTML = Array.from(sections)
+          .reverse()
+          .join('')
+
+        const mockGa4EcommerceTrackerInit = spyOn(
+          window.GOVUK.analyticsGa4.Ga4EcommerceTracker,
+          'init'
+        )
+
+        window.GOVUK.analyticsGa4.analyticsModules.Ga4SearchResultsSetup.init(
+          true
+        )
+
+        expect(mockGa4EcommerceTrackerInit).not.toHaveBeenCalled()
+      })
+    })
+
+    afterEach(function () {
+      window.location = '#'
+    })
+  })
+
+  afterAll(function () {
+    container.remove()
+  })
+})


### PR DESCRIPTION
## What
Use `Ga4EcommerceTracker` from [govuk_publishing_components](https://github.com/alphagov/govuk_publishing_components/blob/main/app/assets/javascripts/govuk_publishing_components/analytics-ga4/ga4-ecommerce-tracker.js) to track when a user views a search results page.

### More details 
- Add required data attributes to elements on identified search results pages for `Ga4EcommerceTracker` to function
- Implement `Ga4SearchResultsSetup` which runs `Ga4EcommerceTracker.init` on page load unless search result is within tab (in which case it only runs `Ga4EcommerceTracker.init` if the tab containing the search result is visible)

**NB** Search results should not be within tabs, if all search results are moved out of tab components then we can simply this code significantly

## Why

Part of adding GA4 Tracking to Whitehall.

Trello: https://trello.com/c/4BesXrbX/3622-search-results-page-tracking-on-whitehall-app

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
