### PR TITLE
Consolidate search partials ahead of adding analytics to search pages

### DIFF
--- a/app/controllers/admin/statistics_announcements_controller.rb
+++ b/app/controllers/admin/statistics_announcements_controller.rb
@@ -121,7 +121,7 @@ private
   end
 
   def filter_params
-    params.slice(:title, :page, :per_page, :organisation_id, :dates, :unlinked_only)
+    params.slice(:title, :page, :per_page, :organisation, :dates, :unlinked_only)
           .permit!
           .to_h
           .reverse_merge(filter_defaults)
@@ -129,7 +129,7 @@ private
 
   def filter_defaults
     {
-      organisation_id: current_user.organisation.try(:id),
+      organisation: current_user.organisation.try(:id),
       dates: "future",
       user_id: current_user.id,
       per_page: 15,
@@ -149,6 +149,6 @@ private
   end
 
   def unlinked_announcements_filter
-    @unlinked_announcements_filter ||= Admin::StatisticsAnnouncementFilter.new(dates: "imminent", unlinked_only: "1", organisation_id: filter_params[:organisation_id])
+    @unlinked_announcements_filter ||= Admin::StatisticsAnnouncementFilter.new(dates: "imminent", unlinked_only: "1", organisation: filter_params[:organisation])
   end
 end

--- a/app/models/admin/statistics_announcement_filter.rb
+++ b/app/models/admin/statistics_announcement_filter.rb
@@ -12,7 +12,7 @@ module Admin
     def statistics_announcements
       scope = unfiltered_scope
       scope = scope.with_title_containing(options[:title]) if options[:title].present?
-      scope = scope.in_organisations([options[:organisation_id]]) if options[:organisation_id].present?
+      scope = scope.in_organisations([options[:organisation]]) if options[:organisation].present?
       scope = scope.merge(unlinked_scope) if unlinked_only?
       scope.merge(date_and_order_scope)
     end
@@ -34,7 +34,7 @@ module Admin
     end
 
     def organisation
-      @organisation ||= Organisation.find_by(id: options[:organisation_id])
+      @organisation ||= Organisation.find_by(id: options[:organisation])
     end
 
     def user

--- a/app/views/admin/editions/_search_results.html.erb
+++ b/app/views/admin/editions/_search_results.html.erb
@@ -1,11 +1,3 @@
-<% if @filter.show_stats %>
-    <p class="govuk-heading-s govuk-!-margin-bottom-1 "><%= pluralize(number_with_delimiter(@filter.published_count), "published document") %></p>
-    <p class="govuk-heading-s govuk-!-margin-bottom-1"><%= number_with_delimiter(@filter.force_published_count) %> force published</p>
-    <p class="govuk-heading-s govuk-!-margin-bottom-3"><%= @filter.force_published_percentage %>% force published</p>
-  <% else %>
-    <p class="govuk-heading-s govuk-!-margin-bottom-3"><%= pluralize(number_with_delimiter(@filter.editions.total_count), "document") %></p>
-<% end %>
-
 <% if filter.editions.blank? %>
   <p class="govuk-body app-view-edition-search-results__no_documents">No documents found</p>
 <% else %>
@@ -47,19 +39,4 @@
       first_cell_is_header: true,
     } %>
   </div>
-
-  <% if paginate(paginator, theme: "govuk_paginator").present? && show_export && can?(:export, Edition) %>
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-three-quarters">
-        <%= paginate(paginator, theme: "govuk_paginator") %>
-      </div>
-      <div class="govuk-grid-column-one-quarter">
-        <p class="govuk-body app-view-edition-search-results__csv-export"><%= link_to "Export as CSV", "#{confirm_export_admin_editions_path}?#{@filter.options.to_param}", class: "govuk-link" %></p>
-      </div>
-    </div>
-  <% elsif paginate(paginator, theme: "govuk_paginator").present? && !(show_export && can?(:export, Edition)) %>
-    <%= paginate(paginator, theme: "govuk_paginator") %>
-  <% elsif show_export && can?(:export, Edition) %>
-    <p class="govuk-body app-view-edition-search-results__csv-export"><%= link_to "Export as CSV", "#{confirm_export_admin_editions_path}?#{@filter.options.to_param}", class: "govuk-link" %></p>
-  <% end %>
 <% end %>

--- a/app/views/admin/editions/index.html.erb
+++ b/app/views/admin/editions/index.html.erb
@@ -2,13 +2,16 @@
 <% content_for :title, @filter.page_title %>
 <% content_for :page_full_width, true %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-one-third">
-    <%= render "admin/shared/filter_options", filter_action: admin_editions_path %>
-  </div>
-  <div class="govuk-grid-column-two-thirds">
-    <div class="app-view-edition-index__table" aria-label="Search results">
-      <%= render "search_results", filter: @filter, paginator: @filter.editions, show_export: true %>
-    </div>
-  </div>
-</div>
+<% content_for :count_display do %>
+  <% if @filter.show_stats %>
+    <p class="govuk-heading-s govuk-!-margin-bottom-1 "><%= pluralize(number_with_delimiter(@filter.published_count), "published document") %></p>
+    <p class="govuk-heading-s govuk-!-margin-bottom-1"><%= number_with_delimiter(@filter.force_published_count) %> force published</p>
+    <p class="govuk-heading-s govuk-!-margin-bottom-3"><%= @filter.force_published_percentage %>% force published</p>
+  <% else %>
+    <p class="govuk-heading-s govuk-!-margin-bottom-3"><%= pluralize(number_with_delimiter(@filter.editions.total_count), "document") %></p>
+  <% end %>
+<% end %>
+
+<%= render "admin/shared/filtered_view", show_export: can?(:export, Edition), filter_action: admin_editions_path, filter_by: [:title, :author, :organisation, :world_location, :type, :state, :date, :only_broken_links, :review_overdue], paginator: @filter.editions do %>
+  <%= render "search_results", filter: @filter %>
+<% end %>

--- a/app/views/admin/editions/index.html.erb
+++ b/app/views/admin/editions/index.html.erb
@@ -4,7 +4,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-third">
-    <%= render "filter_options", filter_action: admin_editions_path %>
+    <%= render "admin/shared/filter_options", filter_action: admin_editions_path %>
   </div>
   <div class="govuk-grid-column-two-thirds">
     <div class="app-view-edition-index__table" aria-label="Search results">

--- a/app/views/admin/featurable_editions/_search_results.html.erb
+++ b/app/views/admin/featurable_editions/_search_results.html.erb
@@ -1,46 +1,44 @@
-<p class="govuk-heading-s govuk-!-margin-bottom-3"><%= pluralize(number_with_delimiter(paginator.total_count), "document") %></p>
-
-<% if paginator.blank? %>
-  <div class="govuk-body app-view-features-search-results__no_documents">
-    No documents found
-  </div>
-<% else %>
-  <%= render "govuk_publishing_components/components/table", {
-    head: [
-      {
-        text: "Title",
-      },
-      {
-        text: "Type",
-      },
-      {
-        text: "Published",
-      },
-      {
-        text: tag.span("Actions", class: "govuk-visually-hidden"),
-      },
-    ],
-    rows:
-      featurable_editions.map do |edition|
-        [
-          {
-            text: tag.p(edition.title, class: "govuk-!-margin-0 govuk-!-font-weight-bold"),
-          },
-          {
-            text: edition.type.titleize,
-          },
-          {
-            text: localize(edition.major_change_published_at.to_date),
-          },
-          {
-            text: link_to(sanitize("View #{tag.span(edition.title, class: "govuk-visually-hidden")}"), admin_edition_path(edition), class: "govuk-link") +
-              link_to(sanitize("Feature #{tag.span(edition.title, class: "govuk-visually-hidden")}"), polymorphic_url(feature_path, edition_id: edition), class: "govuk-link govuk-!-margin-left-2"),
-            format: "numeric",
-          },
-        ]
-      end,
-    first_cell_is_header: true,
-  } %>
-
-  <%= paginate(paginator, anchor: anchor, theme: "govuk_paginator") %>
-<% end %>
+<div class="app-view-features-search-results__table">
+  <% if paginator.blank? %>
+    <div class="govuk-body app-view-features-search-results__no_documents">
+      No documents found
+    </div>
+  <% else %>
+    <%= render "govuk_publishing_components/components/table", {
+      head: [
+        {
+          text: "Title",
+        },
+        {
+          text: "Type",
+        },
+        {
+          text: "Published",
+        },
+        {
+          text: tag.span("Actions", class: "govuk-visually-hidden"),
+        },
+      ],
+      rows:
+        featurable_editions.map do |edition|
+          [
+            {
+              text: tag.p(edition.title, class: "govuk-!-margin-0 govuk-!-font-weight-bold"),
+            },
+            {
+              text: edition.type.titleize,
+            },
+            {
+              text: localize(edition.major_change_published_at.to_date),
+            },
+            {
+              text: link_to(sanitize("View #{tag.span(edition.title, class: "govuk-visually-hidden")}"), admin_edition_path(edition), class: "govuk-link") +
+                link_to(sanitize("Feature #{tag.span(edition.title, class: "govuk-visually-hidden")}"), polymorphic_url(feature_path, edition_id: edition), class: "govuk-link govuk-!-margin-left-2"),
+              format: "numeric",
+            },
+          ]
+        end,
+      first_cell_is_header: true,
+    } %>
+  <% end %>
+</div>

--- a/app/views/admin/shared/_featurable_editions.html.erb
+++ b/app/views/admin/shared/_featurable_editions.html.erb
@@ -3,13 +3,6 @@
   margin_bottom: 8,
 } %>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-one-third">
-    <%= render "admin/shared/filter_options", filter_by:, filter_action:, anchor: %>
-  </div>
-  <div class="govuk-grid-column-two-thirds">
-    <div class="app-view-features-search-results__table" aria-label="Search results">
-      <%= render "admin/featurable_editions/search_results", featurable_editions:, paginator:, anchor:, feature_path: %>
-    </div>
-  </div>
-</div>
+<%= render "admin/shared/filtered_view", filter_by:, filter_action:, anchor:, paginator: do %>
+  <%= render "admin/featurable_editions/search_results", featurable_editions:,anchor:, feature_path:, paginator: %>
+<% end %>

--- a/app/views/admin/shared/_featurable_editions.html.erb
+++ b/app/views/admin/shared/_featurable_editions.html.erb
@@ -5,7 +5,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-third">
-    <%= render "admin/editions/filter_options", filter_by:, filter_action:, anchor: %>
+    <%= render "admin/shared/filter_options", filter_by:, filter_action:, anchor: %>
   </div>
   <div class="govuk-grid-column-two-thirds">
     <div class="app-view-features-search-results__table" aria-label="Search results">

--- a/app/views/admin/shared/_filter_options.html.erb
+++ b/app/views/admin/shared/_filter_options.html.erb
@@ -43,20 +43,6 @@
       } %>
     <% end %>
 
-    <% if filter_by.include?(:organisation_id) %>
-      <%= render "components/select_with_search", {
-        label: "Organisation",
-        id: "organisation_filter",
-        name: "organisation_id",
-        heading_size: "s",
-        ga_data: {
-          document_type: "#{action_name}-#{controller_name}",
-          section: "Organisation",
-        },
-        grouped_options: admin_organisation_filter_options(@filter.options[:organisation_id]),
-    } %>
-    <% end %>
-
     <% if filter_by.include?(:organisation) %>
       <%= render "components/select_with_search", {
         label: "Organisation",

--- a/app/views/admin/shared/_filter_options.html.erb
+++ b/app/views/admin/shared/_filter_options.html.erb
@@ -4,7 +4,7 @@
   raise "filter action required" unless defined?(filter_action)
 %>
 
-<div class="app-view-filter govuk-!-margin-right-5 govuk-!-padding-5">
+<div class="app-view-filter govuk-!-padding-5">
   <%= form_with url: filter_action + anchor, method: :get do |form| %>
     <%= render "govuk_publishing_components/components/heading", {
       text: "Filter by",
@@ -41,6 +41,20 @@
           }
         end,
       } %>
+    <% end %>
+
+    <% if filter_by.include?(:organisation_id) %>
+      <%= render "components/select_with_search", {
+        label: "Organisation",
+        id: "organisation_filter",
+        name: "organisation_id",
+        heading_size: "s",
+        ga_data: {
+          document_type: "#{action_name}-#{controller_name}",
+          section: "Organisation",
+        },
+        grouped_options: admin_organisation_filter_options(@filter.options[:organisation_id]),
+    } %>
     <% end %>
 
     <% if filter_by.include?(:organisation) %>
@@ -166,6 +180,54 @@
             value: "1",
             bold: true,
             checked: params["review_overdue"],
+          },
+        ],
+      } %>
+    <% end %>
+
+    <% if filter_by.include?(:release_date) %>
+      <%= render "govuk_publishing_components/components/select", {
+        id: "release_date_filter",
+        label: "Release date",
+        name: "dates",
+        heading_size: "s",
+        full_width: true,
+        options: [
+          {
+            text: "All announcements",
+            value: nil,
+            selected: @filter.options[:dates] == nil,
+          },
+          {
+            text: "Future releases",
+            value: "future",
+            selected: @filter.options[:dates] == "future",
+          },
+          {
+            text: "Next 2 weeks",
+            value: "imminent",
+            selected: @filter.options[:dates] == "imminent",
+          },
+          {
+            text: "Past announcements",
+            value: "past",
+            selected: @filter.options[:dates] == "past",
+          },
+        ],
+      } %>
+    <% end %>
+
+    <% if filter_by.include?(:unlinked_only) %>
+      <%= render "govuk_publishing_components/components/checkboxes", {
+        name: "unlinked_only",
+        heading: "Announcements",
+        no_hint_text: true,
+        heading_size: "s",
+        items: [
+          {
+            label: "Without a linked publication",
+            value: 1,
+            checked: @filter.options[:unlinked_only],
           },
         ],
       } %>

--- a/app/views/admin/shared/_filtered_view.html.erb
+++ b/app/views/admin/shared/_filtered_view.html.erb
@@ -1,0 +1,36 @@
+<%
+  show_export ||= false
+  filter_by ||= nil
+  anchor ||= anchor || ""
+  raise "filter action required" unless defined?(filter_action)
+  heading_level ||= 0
+%>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-third">
+    <%= render "admin/shared/filter_options", filter_action:, filter_by:, anchor: %>
+  </div>
+  <div class="govuk-grid-column-two-thirds">
+    <div class="app-view-edition-index__table" aria-label="Search results">
+
+      <% unless content_for?(:count_display) %>
+        <%= render "govuk_publishing_components/components/heading", {
+            text: pluralize(number_with_delimiter(paginator.total_count), "document"),
+            font_size: "s",
+            heading_level: heading_level,
+            margin_bottom: 3,
+          } %>
+      <% else %>
+        <%= yield(:count_display) %>
+      <% end %>
+
+      <%= yield %>
+
+      <%= paginate(paginator, theme: "govuk_paginator") %>
+
+      <% if show_export %>
+        <p class="govuk-body app-view-edition-search-results__csv-export"><%= link_to "Export as CSV", "#{confirm_export_admin_editions_path}?#{@filter.options.to_param}", class: "govuk-link" %></p>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/app/views/admin/statistics_announcements/_search_results.html.erb
+++ b/app/views/admin/statistics_announcements/_search_results.html.erb
@@ -1,5 +1,3 @@
-<h2 class="govuk-heading-s govuk-!-margin-bottom-3"><%= pluralize(number_with_delimiter(paginator.total_count), "document") %></h2>
-
 <% if paginator.blank? %>
   <p class="govuk-body app-view-edition-search-results__no_documents">No <%= filter.options[:dates] %> statistics announcements found</p>
 <% else %>
@@ -52,6 +50,4 @@
       first_cell_is_header: true,
     } %>
   </div>
-
-  <%= paginate(paginator, theme: "govuk_paginator") %>
 <% end %>

--- a/app/views/admin/statistics_announcements/index.html.erb
+++ b/app/views/admin/statistics_announcements/index.html.erb
@@ -19,7 +19,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-one-third">
-    <%= render "filter_options" %>
+    <%= render "admin/shared/filter_options", filter_action: admin_statistics_announcements_path, filter_by: [ :title, :organisation_id, :release_date, :unlinked_only ] %>
   </div>
   <div class="govuk-grid-column-two-thirds">
     <div class="app-view-edition-index__table" aria-label="Search results">

--- a/app/views/admin/statistics_announcements/index.html.erb
+++ b/app/views/admin/statistics_announcements/index.html.erb
@@ -17,13 +17,6 @@
   </div>
 </div>
 
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-one-third">
-    <%= render "admin/shared/filter_options", filter_action: admin_statistics_announcements_path, filter_by: [ :title, :organisation_id, :release_date, :unlinked_only ] %>
-  </div>
-  <div class="govuk-grid-column-two-thirds">
-    <div class="app-view-edition-index__table" aria-label="Search results">
-      <%= render "search_results", filter: @filter, paginator: @statistics_announcements, show_export: true %>
-    </div>
-  </div>
-</div>
+<%= render "admin/shared/filtered_view", filter_action: admin_statistics_announcements_path, filter_by: [ :title, :organisation_id, :release_date, :unlinked_only ], paginator: @statistics_announcements, show_export: true, heading_level: 2 do %>
+    <%= render "search_results", filter: @filter, paginator: @statistics_announcements %>
+<% end %>

--- a/app/views/admin/statistics_announcements/index.html.erb
+++ b/app/views/admin/statistics_announcements/index.html.erb
@@ -17,6 +17,6 @@
   </div>
 </div>
 
-<%= render "admin/shared/filtered_view", filter_action: admin_statistics_announcements_path, filter_by: [ :title, :organisation_id, :release_date, :unlinked_only ], paginator: @statistics_announcements, show_export: true, heading_level: 2 do %>
+<%= render "admin/shared/filtered_view", filter_action: admin_statistics_announcements_path, filter_by: [ :title, :organisation, :release_date, :unlinked_only ], paginator: @statistics_announcements, show_export: true, heading_level: 2 do %>
     <%= render "search_results", filter: @filter, paginator: @statistics_announcements %>
 <% end %>

--- a/test/unit/app/models/admin/statistics_announcement_filter_test.rb
+++ b/test/unit/app/models/admin/statistics_announcement_filter_test.rb
@@ -80,7 +80,7 @@ class Admin::StatisticsAnnouncementFilterTest < ActiveSupport::TestCase
     _no_match    = create(:statistics_announcement)
 
     assert_equal [match],
-                 filter(organisation_id: organisation.id).statistics_announcements
+                 filter(organisation: organisation.id).statistics_announcements
   end
 
   test "filter eager loads the correct date for an announcement when ordered ascending" do
@@ -117,7 +117,7 @@ class Admin::StatisticsAnnouncementFilterTest < ActiveSupport::TestCase
     assert_equal "Everyone’s statistics announcements", filter.title
 
     assert_equal "Department of stuff’s statistics announcements",
-                 filter(organisation_id: organisation.id).title
+                 filter(organisation: organisation.id).title
   end
 
   test "#title reflects when the provided user belongs to the filtered organisation" do
@@ -125,14 +125,14 @@ class Admin::StatisticsAnnouncementFilterTest < ActiveSupport::TestCase
     user         = create(:writer, organisation:)
 
     assert_equal "My organisation’s statistics announcements",
-                 filter(organisation_id: organisation.id, user_id: user.id).title
+                 filter(organisation: organisation.id, user_id: user.id).title
   end
 
   test "#title handles possessive apostrophe correctly" do
     organisation = create(:organisation, name: "Department of things")
 
     assert_equal "Department of things’ statistics announcements",
-                 filter(organisation_id: organisation.id).title
+                 filter(organisation: organisation.id).title
   end
 
   test "#description describes future statistics announcements" do


### PR DESCRIPTION
## What

Reduce duplicated mark-up in `admin/editions/index.html.erb`, `admin/scheduled_announcements/index.html.erb` and `admin/shared/_featurable_editions.html.erb`.

### More details
- Move `admin/editions/filter_options` to `admin/shared/filter_options`
     - Use `admin/shared/filter_options` in `app/views/admin/shared/_filtered_view.html.erb`
- Create `app/views/admin/shared/_filtered_view.html.erb`
     - Use `filtered_view` in `admin/editions/index.html.erb`, `admin/scheduled_announcements/index.html.erb` and `admin/shared/_featurable_editions.html.erb`

## Why

We want to add analytics to search pages. The first barrier of this task was finding out where search pages existed because of duplicated code in different partials. I noted that `admin/editions/filter_options` had already been implemented as generic partial to be used in multiple places already. Therefore it didn't require a significant change to be shared in different views. Creating `app/views/admin/shared/_filtered_view.html.erb` means we can now add analytics to one partial instead of three partials.

There are further steps we could take to refine the partials further but would be more time consuming to implement and to test:
- `admin/editions/filter_options` could be a ViewComponent
- filterable attributes could be specified in the `MODELNAME_filter` or a presenter
- Move logic for building the content of each cell to a helper or presenter for each model
- Other pages that use `govuk_publishing_components/table` with `filter: true` could also use  `app/views/admin/shared/_filtered_view.html.erb`
- Adding a document to Collection could use the same search as other instances of filtering editions

Trello: https://trello.com/c/4BesXrbX/3622-search-results-page-tracking-on-whitehall-app