### PR TITLE
Make 'dangerous' links unclickable in the Link Check Report UI

### DIFF
--- a/app/views/admin/link_check_reports/_link_check_report.html.erb
+++ b/app/views/admin/link_check_reports/_link_check_report.html.erb
@@ -38,7 +38,11 @@
           <ul class="govuk-list app-view-summary__broken-links-report">
             <% links.each do |link| %>
               <li>
-                <%= link_to link.uri.truncate(50), link.uri, title: link.uri, class: "govuk-link" %>
+                <% if link.status == "danger" %>
+                  <%= link.uri %>
+                <% else %>
+                  <%= link_to link.uri.truncate(50), link.uri, title: link.uri, class: "govuk-link" %>
+                <% end %>
                 <details class="govuk-details" data-module="govuk-details">
                   <summary class="govuk-details__summary">
                     <span class="govuk-details__summary-text">


### PR DESCRIPTION
For broken and warning links, we create a clickable link in the sidebar so that editors can click on the links and reproduce any of the reported issues.

For 'dangerous' links that may have been taken over by a malicious third party and could be distributing malware etc, we should take a more cautious approach and just render the link as text, so that editors don't accidentally click on a dangerous link.

Before:
> ![clickable link](https://github.com/user-attachments/assets/1c538365-30a8-41bc-8a32-8e5a8b97e546)

After:
> ![plain text](https://github.com/user-attachments/assets/724886c9-ece9-432f-a9c0-0e08a65805c1)

Trello: https://trello.com/c/PLcGoXXf

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
