### PR TITLE
add Content Modelling team as code owners of Content Block Manager

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+lib/engines/content_block_manager @alphagov/gov-uk-content-modelling


### PR DESCRIPTION
https://trello.com/c/7QlOgZ3F/991-add-cbm-team-to-apps-list-in-dev-docs

This should ensure that the team gets tagged in any PRs for the engine, and provides some more
documentation for any devs looking to understand the code.

This was suggested [as we want to ensure that ownership of this part of the repo is clearly defined ](https://github.com/alphagov/whitehall/pull/10136)(as we are currently a separate team to Whitehall)
 
---
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
