### PR TITLE
Improvements to "offsite link" and "alternative URL" forms/error messages

### DIFF
--- a/app/models/offsite_link.rb
+++ b/app/models/offsite_link.rb
@@ -1,6 +1,15 @@
 class OffsiteLink < ApplicationRecord
   include DateValidation
 
+  PERMITTED_HOSTS = [
+    "flu-lab-net.eu",
+    "tse-lab-net.eu",
+    "beisgovuk.citizenspace.com",
+    "nhs.uk",
+    "royal.uk",
+    "victimandwitnessinformation.org.uk",
+  ].freeze
+
   module LinkTypes
     def self.all
       @all ||= %w[
@@ -99,16 +108,7 @@ private
   end
 
   def url_is_permitted?(host)
-    permitted_hosts = [
-      "flu-lab-net.eu",
-      "tse-lab-net.eu",
-      "beisgovuk.citizenspace.com",
-      "nhs.uk",
-      "royal.uk",
-      "victimandwitnessinformation.org.uk",
-    ]
-
-    permitted_hosts.any? { |permitted_host| host =~ /(?:^|\.)#{permitted_host}$/ }
+    PERMITTED_HOSTS.any? { |permitted_host| host =~ /(?:^|\.)#{permitted_host}$/ }
   end
 
   def republish_parent_to_publishing_api

--- a/app/models/offsite_link.rb
+++ b/app/models/offsite_link.rb
@@ -71,10 +71,10 @@ class OffsiteLink < ApplicationRecord
     end
 
     unless government_or_permitted_url?(host)
-      errors.add(:url, "Please enter a valid government URL, such as https://www.gov.uk/jobsearch")
+      errors.add(:url, "Please enter a valid URL")
     end
   rescue URI::InvalidURIError
-    errors.add(:url, "Please enter a valid URL, such as https://www.gov.uk/jobsearch")
+    errors.add(:url, "Please enter a valid URL")
   end
 
   def humanized_link_type

--- a/app/validators/gov_uk_url_format_validator.rb
+++ b/app/validators/gov_uk_url_format_validator.rb
@@ -14,7 +14,7 @@ class GovUkUrlFormatValidator < ActiveModel::EachValidator
 
   def validate_each(record, attribute, value)
     unless self.class.matches_gov_uk?(value) || matches_allow_list?(value)
-      record.errors.add(attribute, message: failure_message)
+      record.errors.add(attribute)
     end
   end
 
@@ -23,10 +23,6 @@ class GovUkUrlFormatValidator < ActiveModel::EachValidator
   end
 
 private
-
-  def failure_message
-    options[:message] || "must be in the form of #{Whitehall.public_protocol}://#{Whitehall.public_host}/example"
-  end
 
   def matches_allow_list?(value)
     uri = URI.parse(value)

--- a/app/views/admin/edition_workflow/_alternative_url_constraints.html.erb
+++ b/app/views/admin/edition_workflow/_alternative_url_constraints.html.erb
@@ -1,0 +1,8 @@
+<div>
+  <p class="govuk-body">Must be a GOV.UK URL or a link ending in:</p>
+
+  <%= render "govuk_publishing_components/components/list", {
+    visible_counters: true,
+    items: GovUkUrlFormatValidator::EXTERNAL_HOST_ALLOW_LIST,
+  } %>
+</div>

--- a/app/views/admin/edition_workflow/confirm_unpublish.html.erb
+++ b/app/views/admin/edition_workflow/confirm_unpublish.html.erb
@@ -132,6 +132,7 @@
           value: @unpublishing.alternative_url,
           error_items: errors_for(@unpublishing.errors, :alternative_url),
         } %>
+        <%= render "alternative_url_constraints" %>
         <%= render "govuk_publishing_components/components/checkboxes", {
           name: "unpublishing[redirect]",
           items: [
@@ -186,6 +187,7 @@
           value: @unpublishing.alternative_url,
           error_items: errors_for(@unpublishing.errors, :alternative_url),
         } %>
+        <%= render "alternative_url_constraints" %>
 
         <div class="govuk-button-group govuk-!-margin-bottom-6">
           <%= render "govuk_publishing_components/components/button", {

--- a/app/views/admin/offsite_links/_form.html.erb
+++ b/app/views/admin/offsite_links/_form.html.erb
@@ -68,10 +68,12 @@
     },
   } %>
 
+  <% permitted_hosts_snippet = OffsiteLink::PERMITTED_HOSTS.map { |host| "<br>- #{host}" }.join %>
   <%= render "govuk_publishing_components/components/input", {
     label: {
       text: "URL (required)",
     },
+    hint: sanitize("Must be a GOV.UK URL or a link ending in: #{permitted_hosts_snippet}"),
     heading_size: "l",
     id: "offsite_link_url",
     name: "offsite_link[url]",

--- a/test/functional/admin/edition_workflow_controller_test.rb
+++ b/test/functional/admin/edition_workflow_controller_test.rb
@@ -239,6 +239,36 @@ class Admin::EditionWorkflowControllerTest < ActionController::TestCase
     assert_equal publication, assigns(:edition)
   end
 
+  view_test "confirm_unpublish describes the constraints of the alternative URL" do
+    login_as(create(:managing_editor))
+    publication = create(:published_publication)
+    get :confirm_unpublish, params: { id: publication, lock_version: publication.lock_version }
+
+    alternative_uris_constraints = <<~CONSTRAINTS
+      Must be a GOV.UK URL or a link ending in:
+
+        .caa.co.uk
+        .gov.uk
+        .independent-inquiry.uk
+        .judiciary.uk
+        .nationalhighways.co.uk
+        .nhs.uk
+        .police.uk
+        .pubscodeadjudicator.org.uk
+        .ukri.org
+    CONSTRAINTS
+    alternative_uris_constraints = alternative_uris_constraints.strip.gsub(/\s+/, " ")
+
+    assert_includes(
+      css_select("div:has(> label[for='published_in_error_alternative_url']) + div").text.strip.gsub(/\s+/, " "),
+      alternative_uris_constraints,
+    )
+    assert_includes(
+      css_select("div:has(> label[for='consolidated_alternative_url']) + div").text.strip.gsub(/\s+/, " "),
+      alternative_uris_constraints,
+    )
+  end
+
   test "confirm_unpublish loads up to the last 50 previous withdrawals" do
     # arbitrary limit to protect against unexpectedly large result sets that could cause performance issues
     login_as(create(:managing_editor))

--- a/test/functional/admin/offsite_links_controller_test.rb
+++ b/test/functional/admin/offsite_links_controller_test.rb
@@ -18,6 +18,8 @@ class Admin::OffsiteLinksControllerTest < ActionController::TestCase
     assert_offsite_links_form(
       admin_world_location_news_offsite_links_path,
     )
+
+    assert_select "label[for='offsite_link_url'] + .govuk-hint", text: "Must be a GOV.UK URL or a link ending in: - flu-lab-net.eu- tse-lab-net.eu- beisgovuk.citizenspace.com- nhs.uk- royal.uk- victimandwitnessinformation.org.uk"
   end
 
   view_test "GET :edit should render existing offside links form" do

--- a/test/unit/app/models/statistics_announcement_test.rb
+++ b/test/unit/app/models/statistics_announcement_test.rb
@@ -28,7 +28,7 @@ class StatisticsAnnouncementTest < ActiveSupport::TestCase
     announcement = build(:unpublished_statistics_announcement, redirect_url: "https://www.youtube.com")
     assert_not announcement.valid?
 
-    assert_match %r{must be in the form of https://www.test.gov.uk/example}, announcement.errors[:redirect_url].first
+    assert_match "is invalid", announcement.errors[:redirect_url].first
   end
 
   test "when unpublished, it cannot redirect to itself" do


### PR DESCRIPTION
See commits for details.

Trello: https://trello.com/c/sXJ2WLi7/3635-various-error-message-tweaks

## Screenshots

### Offsite links

![Image](https://github.com/user-attachments/assets/64047cfa-609a-4ff3-8840-41169318bdb0)

### Alternative URLs

"Unpublish: published in error" option:

> ![Image](https://github.com/user-attachments/assets/23559656-632b-4640-8ab7-d2bc2406b673)

"Unpublish: consolidated into another GOV.UK page" option:

> ![Image](https://github.com/user-attachments/assets/4573569e-b6d1-4a6b-87ee-5f83885cbccf)

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
