### PR TITLE
Change header title from ‘Dashboard’ to ‘Blocks’

### DIFF
--- a/lib/engines/content_block_manager/app/views/shared/_header.html.erb
+++ b/lib/engines/content_block_manager/app/views/shared/_header.html.erb
@@ -5,7 +5,7 @@
   environment: environment,
   logo_link: content_block_manager.content_block_manager_root_path,
   navigation_items: [
-    main_nav_item("Dashboard", content_block_manager.content_block_manager_root_path),
+    main_nav_item("Blocks", content_block_manager.content_block_manager_root_path),
     {
       text: "View website",
       href: Whitehall.public_root,

--- a/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
@@ -443,7 +443,7 @@ Then(/^I should see the object store's home page title$/) do
 end
 
 And(/^I should see the object store's navigation$/) do
-  expect(page).to have_selector("a.govuk-header__link[href='#{content_block_manager.content_block_manager_root_path}']", text: "Dashboard")
+  expect(page).to have_selector("a.govuk-header__link[href='#{content_block_manager.content_block_manager_root_path}']", text: "Blocks")
 end
 
 And("I should see the object store's phase banner") do


### PR DESCRIPTION
https://trello.com/c/lV6zTglR/805-change-copy-in-heading-from-dashboard-to-blocks-s

As per design decision.

--

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
