### PR TITLE
(553) Support friendly IDs in embed codes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,7 +133,7 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.3.4)
     connection_pool (2.5.0)
-    content_block_tools (0.4.6)
+    content_block_tools (0.5.0)
       actionview (>= 6)
     crack (1.0.0)
       bigdecimal

--- a/config/features.rb
+++ b/config/features.rb
@@ -28,4 +28,7 @@ Flipflop.configure do
   feature :show_all_content_block_types,
           description: "Show all applicable content block types in Content Block Manager",
           default: Whitehall.integration_or_staging? || !Rails.env.production?
+  feature :use_friendly_embed_codes,
+          description: "Use embed codes with friendly IDs in Content Block Manager",
+          default: Whitehall.integration_or_staging? || !Rails.env.production?
 end

--- a/lib/engines/content_block_manager/app/models/content_block_manager/content_block/document.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/content_block/document.rb
@@ -28,12 +28,12 @@ module ContentBlockManager
 
       scope :live, -> { where.not(latest_edition_id: nil) }
 
-      def embed_code
-        "#{embed_code_prefix}}}"
+      def embed_code(use_friendly_id: Flipflop.use_friendly_embed_codes?)
+        "#{embed_code_prefix(use_friendly_id)}}}"
       end
 
-      def embed_code_for_field(field_path)
-        "#{embed_code_prefix}/#{field_path}}}"
+      def embed_code_for_field(field_path, use_friendly_id: Flipflop.use_friendly_embed_codes?)
+        "#{embed_code_prefix(use_friendly_id)}/#{field_path}}}"
       end
 
       def title
@@ -58,8 +58,8 @@ module ContentBlockManager
 
     private
 
-      def embed_code_prefix
-        "{{embed:content_block_#{block_type}:#{content_id}"
+      def embed_code_prefix(use_friendly_id)
+        "{{embed:content_block_#{block_type}:#{use_friendly_id ? content_id_alias : content_id}"
       end
     end
   end

--- a/lib/engines/content_block_manager/test/unit/app/services/find_and_replace_embed_codes_service_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/services/find_and_replace_embed_codes_service_test.rb
@@ -4,28 +4,28 @@ class ContentBlockManager::FindAndReplaceEmbedCodesServiceTest < ActiveSupport::
   extend Minitest::Spec::DSL
 
   it "finds and replaces embed codes" do
-    document_1 = create(:content_block_document, :email_address)
+    document_1 = create(:content_block_document, :email_address, content_id_alias: "something")
     edition_1 = create(:content_block_edition, :email_address, state: "published", document: document_1)
     document_1.latest_edition = edition_1
     document_1.save!
 
-    document_2 = create(:content_block_document, :email_address)
+    document_2 = create(:content_block_document, :email_address, content_id_alias: "something-else")
     edition_2 = create(:content_block_edition, :email_address, state: "published", document: document_2)
     document_2.latest_edition = edition_2
     document_2.save!
 
     html = "
       <p>Hello there</p>
-      <p>#{edition_2.document.embed_code}</p>
-      <p>#{edition_1.document.embed_code}</p>
-      <p>#{edition_2.document.embed_code}</p>
+      <p>#{edition_2.document.embed_code(use_friendly_id: false)}</p>
+      <p>#{edition_1.document.embed_code(use_friendly_id: true)}</p>
+      <p>#{edition_2.document.embed_code(use_friendly_id: false)}</p>
     "
 
     expected = "
       <p>Hello there</p>
-      <p>#{edition_2.render(edition_2.document.embed_code)}</p>
-      <p>#{edition_1.render(edition_1.document.embed_code)}</p>
-      <p>#{edition_2.render(edition_2.document.embed_code)}</p>
+      <p>#{edition_2.render(edition_2.document.embed_code(use_friendly_id: false))}</p>
+      <p>#{edition_1.render(edition_1.document.embed_code(use_friendly_id: true))}</p>
+      <p>#{edition_2.render(edition_2.document.embed_code(use_friendly_id: false))}</p>
     "
 
     result = ContentBlockManager::FindAndReplaceEmbedCodesService.call(html)


### PR DESCRIPTION
Trello card: https://trello.com/c/fdJtXlmL/553-tech-spike-investigate-friendly-names-for-content-blocks-embed-codes

This updates the content block tools gem to the latest version to allow support for embed codes with friendly IDs. It also adds a feature flag to generate content blocks using the content ID aliases. We then update the FindAndReplaceEmbedCodesService class used in preview to support both types of embed code.