### PR TITLE
(1014) Enable line breaks in instructions to publishers

### DIFF
--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/summary_card_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/summary_card_component.rb
@@ -40,7 +40,7 @@ private
   def instructions_item
     {
       key: "Instructions to publishers",
-      value: content_block_edition.instructions_to_publishers.presence || "None",
+      value: formatted_instructions_to_publishers(content_block_edition),
     }
   end
 

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/show/confirm_summary_card_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/show/confirm_summary_card_component.rb
@@ -1,4 +1,6 @@
 class ContentBlockManager::ContentBlockEdition::Show::ConfirmSummaryCardComponent < ViewComponent::Base
+  include ContentBlockManager::ContentBlock::EditionHelper
+
   def initialize(content_block_edition:)
     @content_block_edition = content_block_edition
   end
@@ -46,7 +48,7 @@ private
   def instructions_item
     {
       key: "Instructions to publishers",
-      value: content_block_edition.instructions_to_publishers.presence || "None",
+      value: formatted_instructions_to_publishers(content_block_edition),
     }
   end
 

--- a/lib/engines/content_block_manager/app/helpers/content_block_manager/content_block/edition_helper.rb
+++ b/lib/engines/content_block_manager/app/helpers/content_block_manager/content_block/edition_helper.rb
@@ -16,4 +16,16 @@ module ContentBlockManager::ContentBlock::EditionHelper
       lang: "en",
     )
   end
+
+  def formatted_instructions_to_publishers(content_block_edition)
+    if content_block_edition.instructions_to_publishers.present?
+      simple_format(
+        auto_link(content_block_edition.instructions_to_publishers, html: { class: "govuk-link", target: "_blank", rel: "noopener" }),
+        { class: "govuk-!-margin-top-0" },
+        { sanitize_options: { attributes: %w[href class target rel] } },
+      )
+    else
+      "None"
+    end
+  end
 end

--- a/lib/engines/content_block_manager/test/components/content_block/document/show/summary_card_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/document/show/summary_card_component_test.rb
@@ -70,7 +70,7 @@ class ContentBlockManager::ContentBlock::Document::Show::SummaryCardComponentTes
       render_inline(ContentBlockManager::ContentBlock::Document::Show::SummaryCardComponent.new(content_block_document:))
 
       assert_selector ".govuk-summary-list__key", text: "Instructions to publishers"
-      assert_selector ".govuk-summary-list__value", text: "instructions"
+      assert_selector ".govuk-summary-list__value p", text: "instructions"
     end
   end
 end

--- a/lib/engines/content_block_manager/test/components/content_block/edition/show/confirm_summary_card_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/show/confirm_summary_card_component_test.rb
@@ -16,7 +16,7 @@ class ContentBlockManager::ContentBlockEdition::Show::ConfirmSummaryCardComponen
                   ))
 
     assert_selector ".govuk-summary-list__key", text: "Instructions to publishers"
-    assert_selector ".govuk-summary-list__value", text: "some instructions"
+    assert_selector ".govuk-summary-list__value p", text: "some instructions"
   end
 
   it "renders a summary card component with the edition details to confirm" do

--- a/lib/engines/content_block_manager/test/unit/app/helpers/content_block_manager/content_block/edition_helper_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/helpers/content_block_manager/content_block/edition_helper_test.rb
@@ -3,6 +3,7 @@ require "test_helper"
 class ContentBlockManager::ContentBlock::EditionHelperTest < ActionView::TestCase
   extend Minitest::Spec::DSL
 
+  include ERB::Util
   include ContentBlockManager::ContentBlock::EditionHelper
 
   let(:content_block_edition) do
@@ -34,6 +35,25 @@ class ContentBlockManager::ContentBlock::EditionHelperTest < ActionView::TestCas
       ).returns("STUB")
 
       assert_equal "STUB", scheduled_date(content_block_edition)
+    end
+  end
+
+  describe "#formatted_instructions_to_publishers" do
+    test "it adds line breaks and links to instructions to publishers" do
+      content_block_edition.instructions_to_publishers = "
+        Hello
+        There
+        Here is a link: https://example.com
+      "
+      expected = "
+      <p class=\"govuk-!-margin-top-0\">
+        Hello <br />
+        There <br />
+        Here is a link: <a href=\"https://example.com\" class=\"govuk-link\" target=\"_blank\" rel=\"noopener\">https://example.com</a> <br />
+      </p>
+      "
+
+      assert_equal expected.squish, formatted_instructions_to_publishers(content_block_edition).squish
     end
   end
 end


### PR DESCRIPTION
Trello card: https://trello.com/c/ggVAML1f/1014-enable-line-breaks-in-instructions-to-publishers

This allows instructions to publishers to be lightly formatted, turning URLs into links and replacing line breaks with HTML `<br />` tags.

## Screenshots

### Before

![image](https://github.com/user-attachments/assets/cc554f8c-8e6b-4e71-80f2-94008c2c0886)

![image](https://github.com/user-attachments/assets/5ca9f73d-3c6e-4cbf-847d-1c02b6e752ee)

### After

![image](https://github.com/user-attachments/assets/e38ee9e5-a8f5-4681-896a-f8c6036df35e)

![image](https://github.com/user-attachments/assets/d0279922-49f8-4dc0-bb59-c0406a2531ce)

