### PR TITLE
Set HTML attachment locale to the same as the attachable's primary locale if the primary locale is not English

### DIFF
--- a/app/views/admin/attachments/_reference_fields.html.erb
+++ b/app/views/admin/attachments/_reference_fields.html.erb
@@ -22,6 +22,10 @@
   </div>
 <% end %>
 
+<% if attachable.respond_to?(:primary_locale) && attachable.primary_locale != :en %>
+  <%= form.hidden_field :locale, value: attachable.primary_locale %>
+<% end %>
+
 <div class="govuk-!-margin-bottom-8">
   <%= render "govuk_publishing_components/components/input", {
     label: {

--- a/test/functional/admin/attachments_controller_test.rb
+++ b/test/functional/admin/attachments_controller_test.rb
@@ -292,6 +292,13 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
     assert_select ".govspeak-help", visible: false, count: 1
   end
 
+  view_test "GET :new for a consultation includes hidden locale field with value set to consultation primary locale" do
+    consultation = create(:consultation, primary_locale: "cy")
+    get :new, params: { edition_id: consultation, type: "file" }
+
+    assert_select "input[type='hidden'][name='attachment[locale]'][value='#{consultation.primary_locale}']"
+  end
+
   test "POST :create with bad data does not save the attachment and re-renders the new template" do
     post :create, params: { edition_id: @edition, attachment: { attachment_data_attributes: {} } }
     assert_template :new


### PR DESCRIPTION
This fixes a bug with foreign language only consultations and calls for evidence which results in non-English HTML attachments rendering on GOV.UK with English page furniture.

If the locale isn't set for an HTML attachment, Whitehall sends English to the Publishing API for the locale value as the default.

This isn't a great solution, because if we subsequently choose to have translated documents that have a primary locale other than English, then this will cause problems. Ideally we would check if the attachable was a "foreign language only" content item and only render the hidden field if that is the case. However, because we don't persist the information about whether an attachable is foreign language only, the only way to know when to set the attachment locale is to check if the attachable has a non-English primary locale. I did try to use the `locale_can_be_changed?` method in the condition, but this doesn't work for consultations/calls for evidence that aren't foreign language only. In that case we don't want to override the attachment locale, because it will stop the attachment appearing on the English translation.

Trello: https://trello.com/c/q2C39WwA
