### PR TITLE
Ensure all HTML attachments belonging to foreign language only documents have correct locale

### DIFF
--- a/db/data_migration/2025042311160000_fix_foreign_language_only_html_attachment_locales.rb
+++ b/db/data_migration/2025042311160000_fix_foreign_language_only_html_attachment_locales.rb
@@ -1,0 +1,15 @@
+# Update the locale of any HTML attachments associated with foreign language only documents to match the document's primary locale
+consultations = Consultation.joins(:attachments)
+                            .where("primary_locale != \"en\"")
+                            .where(attachments: { locale: nil, type: "HTMLAttachment" })
+
+consultations.each do |consultation|
+  consultation.html_attachments.each do |attachment|
+    attachment.locale = consultation.primary_locale
+    attachment.save!
+  end
+end
+
+consultations.pluck(:document_id).uniq.each do |document_id|
+  PublishingApiDocumentRepublishingWorker.perform_async(document_id)
+end


### PR DESCRIPTION
HTML attachments belonging to foreign language only documents should have a locale that matches the document's primary locale. Otherwise the default to English, which is a bad experience for users because the page furniture on GOV.UK will appear in English whilst the rest of the attachment is in the parent document's primary locale.

Trello: https://trello.com/c/q2C39WwA