### PR TITLE
Set `use_es6_components` to true

### DIFF
--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -5,7 +5,6 @@
     <meta name="govuk:components_gem_version" content="<%= GovukPublishingComponents::VERSION %>">
     <%= javascript_include_tag "admin/domain-config" %>
     <%= javascript_include_tag "govuk_publishing_components/load-analytics" %>
-    <%= javascript_include_tag "es6-components", type: "module" %>
   <% end %>
 <% end %>
 

--- a/config/initializers/govuk_publishing_components.rb
+++ b/config/initializers/govuk_publishing_components.rb
@@ -1,0 +1,3 @@
+GovukPublishingComponents.configure do |config|
+  config.use_es6_components = true
+end


### PR DESCRIPTION
## What

- Remove `es6-components` javascript tag from `design_system.html.erb`.
- Add initializer to set `use_es6_components` in `GovukPublishingComponents`

## Why 

This option adds this javascript tag to `layout_for_admin`. This script comes from `govuk_publishing_components` and could be renamed. So using the config is more maintainable.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
