### PR TITLE
Use `Ga4FinderTracker` to track search form interactions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/alphagov/select-with-search-component.git
-  revision: 3a8d7ac4afee8efaa4685ab5661ae638626aea6d
+  revision: 0bc3e506926b6fe06a25b73bde6fb3b0d5b94082
   specs:
     select_with_search_component (0.1.0)
       govuk_publishing_components

--- a/app/assets/javascripts/admin/analytics-modules/ga4-finder-setup.js
+++ b/app/assets/javascripts/admin/analytics-modules/ga4-finder-setup.js
@@ -1,0 +1,54 @@
+'use strict'
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.analyticsGa4 = window.GOVUK.analyticsGa4 || {}
+window.GOVUK.analyticsGa4.analyticsModules =
+  window.GOVUK.analyticsGa4.analyticsModules || {}
+;(function (Modules) {
+  Modules.analyticsModules = Modules.analyticsModules || {}
+
+  Modules.analyticsModules.Ga4FinderSetup = {
+    init: function () {
+      const finders = Array.from(
+        document.querySelectorAll("[data-module~='ga4-finder-tracker']")
+      )
+
+      if (finders) {
+        finders.forEach((finder) => {
+          finder.addEventListener('change', this.onFinderChange)
+        })
+
+        Modules.Ga4FinderTracker = Modules.Ga4FinderTracker || {}
+        Modules.Ga4FinderTracker.extraSupportedElements = {
+          // for select with search with multiple choice
+          'select-multiple': function (eventTarget, event) {
+            const eventValue = event.detail.value
+            const elementValue = eventTarget.querySelector(
+              `option[value="${eventValue}"]`
+            ).text
+            const selectedEventOption = eventTarget.querySelector(
+              `option[value="${eventValue}"]:checked`
+            )
+
+            return {
+              elementValue,
+              wasFilterRemoved: !selectedEventOption
+            }
+          }
+        }
+      }
+    },
+
+    onFinderChange: function (event) {
+      let ga4ChangeCategory = event.target.closest('[data-ga4-change-category]')
+      if (ga4ChangeCategory) {
+        ga4ChangeCategory = ga4ChangeCategory.getAttribute(
+          'data-ga4-change-category'
+        )
+        window.GOVUK.analyticsGa4.Ga4FinderTracker.trackChangeEvent(
+          event,
+          ga4ChangeCategory
+        )
+      }
+    }
+  }
+})(window.GOVUK.analyticsGa4)

--- a/app/assets/javascripts/admin/analytics-modules/ga4-index-section-setup.js
+++ b/app/assets/javascripts/admin/analytics-modules/ga4-index-section-setup.js
@@ -11,11 +11,39 @@ window.GOVUK.analyticsGa4.analyticsModules =
       )
 
       moduleElements.forEach(function (moduleElement) {
+        // An indexed section is either a single element
+        // or set of elements that changes one value of
+        // a form. Therefore we don't want to index:
+        //
+        // - individual radio buttons because they change
+        //   one value of a single value
+        // - individual checkboxes if they're part of a
+        //   group of checkboxes that change a single value
+        //
+        // Additionally we don't want to index:
+        // - the search within a SelectWithSearch component as it doesn't
+        //   change the value of the form
+        // - a hidden input because the user can't interact with it
         const indexedElements = moduleElement.querySelectorAll(
-          'select, input:not([data-module~="select-with-search"] input)'
+          'select, input:not([data-module~="select-with-search"] input):not([type="radio"]):not([type="hidden"]), fieldset'
         )
+
         indexedElements.forEach((element, index) => {
-          element.dataset.ga4IndexSection = index
+          if (element.tagName === 'FIELDSET' || !element.closest('fieldset')) {
+            const indexData = {
+              index_section: index,
+              index_section_count: indexedElements.length
+            }
+            element.dataset.ga4Index = JSON.stringify(indexData)
+            element.dataset.ga4IndexSection = index
+
+            if (element.closest('[data-module~="ga4-finder-tracker"]')) {
+              // required attribute for `ga4-finder-tracker`
+              // assumes that index values will come from
+              // an element with `ga4-filter-parent` set
+              element.dataset.ga4FilterParent = true
+            }
+          }
         })
       })
     }

--- a/app/assets/javascripts/admin/analytics-modules/ga4-select-tracker.js
+++ b/app/assets/javascripts/admin/analytics-modules/ga4-select-tracker.js
@@ -12,6 +12,8 @@ window.GOVUK.analyticsGa4.analyticsModules =
 
       moduleElements.forEach(function (moduleElement) {
         moduleElement.addEventListener('change', function (event) {
+          if (event.target.dataset.ga4ChangeCategory) return
+
           const ga4DocumentType = moduleElement.dataset.ga4DocumentType
 
           if (

--- a/app/assets/javascripts/admin/analytics-modules/ga4-select-with-search-tracker.js
+++ b/app/assets/javascripts/admin/analytics-modules/ga4-select-with-search-tracker.js
@@ -11,6 +11,8 @@ window.GOVUK.analyticsGa4.analyticsModules =
       )
 
       moduleElements.forEach(function (moduleElement) {
+        if (moduleElement.dataset.ga4ChangeCategory) return
+
         moduleElement.addEventListener('addItem', function (event) {
           const eventData = {
             event: 'event_data',

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -23,6 +23,7 @@
 //= require admin/analytics-modules/ga4-select-with-search-tracker.js
 //= require admin/analytics-modules/ga4-select-tracker.js
 //= require admin/analytics-modules/ga4-search-setup.js
+//= require admin/analytics-modules/ga4-finder-setup.js
 
 //= require admin/modules/document-history-paginator
 //= require admin/modules/locale-switcher

--- a/app/views/admin/document_collection_group_document_search/add_by_title.html.erb
+++ b/app/views/admin/document_collection_group_document_search/add_by_title.html.erb
@@ -10,7 +10,7 @@
 
 <div class="govuk-grid-row" data-ga4-ecommerce data-ga4-search-query="<%= params[:title] %>" data-ga4-list-title="<%= yield(:page_title) %>" data-ga4-ecommerce-start-index="<%= page_start_index(params[:page]) %>">
   <div class="govuk-grid-column-two-thirds app-view-document-collection-document-search-bar" data-ga4-search-section="Search by title">
-    <%= form_with method: :get do |_form| %>
+    <%= form_with method: :get, data: { module: "ga4-finder-tracker" } do |_form| %>
       <%= render "govuk_publishing_components/components/search", {
         name: "title",
         value: params[:title],

--- a/app/views/admin/editions/_filter_options.html.erb
+++ b/app/views/admin/editions/_filter_options.html.erb
@@ -197,6 +197,6 @@
     } %>
 
     <p class="govuk-body">
-    <%= link_to "Reset all fields", reset_search_fields_query_string_params(current_user, filter_action, anchor), class: "govuk-link" %></p>
+    <%= link_to "Reset all fields", reset_search_fields_query_string_params(current_user, filter_action, anchor), class: "govuk-link", data: { ga4_link: { action: "remove", event_name: "select_content", type: controller_name }.to_json } %></p>
   <% end %>
 </div>

--- a/app/views/admin/editions/_filter_options.html.erb
+++ b/app/views/admin/editions/_filter_options.html.erb
@@ -34,6 +34,7 @@
           document_type: "#{action_name}-#{controller_name}",
           section: "Author",
           change_category: "update-filter select",
+          filter_parent: true,
         },
         options: admin_author_filter_options(current_user).map do |name, id|
           {
@@ -55,6 +56,7 @@
           document_type: "#{action_name}-#{controller_name}",
           section: "Organisation",
           change_category: "update-filter select",
+          filter_parent: true,
         },
         grouped_options: admin_organisation_filter_options(@filter.options[:organisation]),
       } %>
@@ -70,6 +72,7 @@
           document_type: "#{action_name}-#{controller_name}",
           section: "World location",
           change_category: "update-filter select",
+          filter_parent: true,
         },
         options: admin_world_location_filter_options(current_user).map do |name, id|
           {
@@ -91,6 +94,7 @@
           document_type: "#{action_name}-#{controller_name}",
           section: "Document type",
           change_category: "update-filter select",
+          filter_parent: true,
         },
         grouped_options: filter_edition_type_opt_groups(current_user, @filter.options[:type]),
       } %>
@@ -106,6 +110,7 @@
           document_type: "#{action_name}-#{controller_name}",
           section: "State",
           change_category: "update-filter select",
+          filter_parent: true,
         },
         options: admin_state_filter_options.map do |text, value|
           {
@@ -161,6 +166,7 @@
         small: true,
         data_attributes: {
           ga4_change_category: "update-filter checkbox",
+          ga4_filter_parent: true,
         },
         items: [
           {
@@ -179,6 +185,7 @@
         small: true,
         data_attributes: {
           ga4_change_category: "update-filter checkbox",
+          ga4_filer_parent: true,
         },
         items: [
           {

--- a/app/views/admin/editions/_filter_options.html.erb
+++ b/app/views/admin/editions/_filter_options.html.erb
@@ -5,7 +5,7 @@
 %>
 
 <div class="app-view-filter govuk-!-margin-right-5 govuk-!-padding-5">
-  <%= form_with url: filter_action + anchor, method: :get, data: { module: "ga4-finder-tracker" } do |form| %>
+  <%= form_with url: filter_action + anchor, method: :get, data: { module: "ga4-finder-tracker", ga4_section: "Filter by" } do |form| %>
     <%= render "govuk_publishing_components/components/heading", {
       text: "Filter by",
       margin_bottom: 4,
@@ -127,6 +127,9 @@
           id: "from_date",
           value: params["from_date"],
           hint: "For example, 23/07/2013",
+          data: {
+            ga4_section: "Last updated date from",
+          },
         } %>
 
         <%= render "govuk_publishing_components/components/input", {
@@ -138,6 +141,9 @@
           id: "to_date",
           value: params["to_date"],
           hint: "For example, 23/08/2013",
+          data: {
+            ga4_section: "Last updated date to",
+          },
         } %>
       <% end %>
     <% end %>

--- a/app/views/admin/editions/_filter_options.html.erb
+++ b/app/views/admin/editions/_filter_options.html.erb
@@ -5,7 +5,7 @@
 %>
 
 <div class="app-view-filter govuk-!-margin-right-5 govuk-!-padding-5">
-  <%= form_with url: filter_action + anchor, method: :get do |form| %>
+  <%= form_with url: filter_action + anchor, method: :get, data: { module: "ga4-finder-tracker" } do |form| %>
     <%= render "govuk_publishing_components/components/heading", {
       text: "Filter by",
       margin_bottom: 4,

--- a/app/views/admin/editions/_filter_options.html.erb
+++ b/app/views/admin/editions/_filter_options.html.erb
@@ -33,6 +33,7 @@
         ga_data: {
           document_type: "#{action_name}-#{controller_name}",
           section: "Author",
+          change_category: "update-filter select",
         },
         options: admin_author_filter_options(current_user).map do |name, id|
           {
@@ -53,6 +54,7 @@
         ga_data: {
           document_type: "#{action_name}-#{controller_name}",
           section: "Organisation",
+          change_category: "update-filter select",
         },
         grouped_options: admin_organisation_filter_options(@filter.options[:organisation]),
       } %>
@@ -67,6 +69,7 @@
         ga_data: {
           document_type: "#{action_name}-#{controller_name}",
           section: "World location",
+          change_category: "update-filter select",
         },
         options: admin_world_location_filter_options(current_user).map do |name, id|
           {
@@ -87,6 +90,7 @@
         ga_data: {
           document_type: "#{action_name}-#{controller_name}",
           section: "Document type",
+          change_category: "update-filter select",
         },
         grouped_options: filter_edition_type_opt_groups(current_user, @filter.options[:type]),
       } %>
@@ -101,6 +105,7 @@
         ga_data: {
           document_type: "#{action_name}-#{controller_name}",
           section: "State",
+          change_category: "update-filter select",
         },
         options: admin_state_filter_options.map do |text, value|
           {
@@ -129,6 +134,7 @@
           hint: "For example, 23/07/2013",
           data: {
             ga4_section: "Last updated date from",
+            ga4_change_category: "update-filter text",
           },
         } %>
 
@@ -143,6 +149,7 @@
           hint: "For example, 23/08/2013",
           data: {
             ga4_section: "Last updated date to",
+            ga4_change_category: "update-filter text",
           },
         } %>
       <% end %>
@@ -152,6 +159,9 @@
       <%= render "govuk_publishing_components/components/checkboxes", {
         name: "only_broken_links",
         small: true,
+        data_attributes: {
+          ga4_change_category: "update-filter checkbox",
+        },
         items: [
           {
             label: "Only broken links",
@@ -167,6 +177,9 @@
       <%= render "govuk_publishing_components/components/checkboxes", {
         name: "review_overdue",
         small: true,
+        data_attributes: {
+          ga4_change_category: "update-filter checkbox",
+        },
         items: [
           {
             label: "Review overdue",

--- a/app/views/admin/statistics_announcement_publications/index.html.erb
+++ b/app/views/admin/statistics_announcement_publications/index.html.erb
@@ -11,7 +11,7 @@
       margin_bottom: 8,
     } %>
 
-    <%= form_with url: admin_statistics_announcement_publication_index_path(@statistics_announcement), method: :get do |_form| %>
+    <%= form_with url: admin_statistics_announcement_publication_index_path(@statistics_announcement), method: :get, data: { module: "ga4-finder-tracker" } do |_form| %>
       <%= render "govuk_publishing_components/components/search", {
         name: "title",
         value: params[:title],

--- a/app/views/admin/statistics_announcements/_filter_options.html.erb
+++ b/app/views/admin/statistics_announcements/_filter_options.html.erb
@@ -25,6 +25,7 @@
         document_type: "#{action_name}-#{controller_name}",
         section: "Organisation",
         change_category: "update-filter select",
+        filter_parent: true,
       },
       grouped_options: admin_organisation_filter_options(@filter.options[:organisation_id]),
     } %>
@@ -37,6 +38,7 @@
       full_width: true,
       data_attributes: {
         ga4_change_category: "update-filter select",
+        ga4_filter_parent: true,
       },
       options: [
         {

--- a/app/views/admin/statistics_announcements/_filter_options.html.erb
+++ b/app/views/admin/statistics_announcements/_filter_options.html.erb
@@ -1,5 +1,5 @@
 <div class="app-view-filter govuk-!-padding-5">
-  <%= form_with url: admin_statistics_announcements_path, method: :get do |_form| %>
+  <%= form_with url: admin_statistics_announcements_path, method: :get, data: { module: "ga4-finder-tracker" } do |_form| %>
     <%= render "govuk_publishing_components/components/heading", {
       text: "Filter by",
       margin_bottom: 4,

--- a/app/views/admin/statistics_announcements/_filter_options.html.erb
+++ b/app/views/admin/statistics_announcements/_filter_options.html.erb
@@ -1,5 +1,5 @@
 <div class="app-view-filter govuk-!-padding-5">
-  <%= form_with url: admin_statistics_announcements_path, method: :get, data: { module: "ga4-finder-tracker" } do |_form| %>
+  <%= form_with url: admin_statistics_announcements_path, method: :get, data: { module: "ga4-finder-tracker", ga4_section: "Filter by" } do |_form| %>
     <%= render "govuk_publishing_components/components/heading", {
       text: "Filter by",
       margin_bottom: 4,
@@ -63,6 +63,9 @@
       heading: "Announcements",
       no_hint_text: true,
       heading_size: "s",
+      data_attributes: {
+        ga4_section: "Announcements",
+      },
       items: [
         {
           label: "Without a linked publication",

--- a/app/views/admin/statistics_announcements/_filter_options.html.erb
+++ b/app/views/admin/statistics_announcements/_filter_options.html.erb
@@ -86,6 +86,6 @@
       margin_bottom: 4,
     } %>
 
-    <p class="govuk-body"><%= link_to "Reset all fields", admin_statistics_announcements_path + "?state=active", class: "govuk-link" %></p>
+    <p class="govuk-body"><%= link_to "Reset all fields", admin_statistics_announcements_path + "?state=active", class: "govuk-link", data: { ga4_link: { action: "remove", event_name: "select_content", type: controller_name }.to_json } %></p>
   <% end %>
 </div>

--- a/app/views/admin/statistics_announcements/_filter_options.html.erb
+++ b/app/views/admin/statistics_announcements/_filter_options.html.erb
@@ -24,6 +24,7 @@
       ga_data: {
         document_type: "#{action_name}-#{controller_name}",
         section: "Organisation",
+        change_category: "update-filter select",
       },
       grouped_options: admin_organisation_filter_options(@filter.options[:organisation_id]),
     } %>
@@ -34,6 +35,9 @@
       name: "dates",
       heading_size: "s",
       full_width: true,
+      data_attributes: {
+        ga4_change_category: "update-filter select",
+      },
       options: [
         {
           text: "All announcements",
@@ -65,6 +69,8 @@
       heading_size: "s",
       data_attributes: {
         ga4_section: "Announcements",
+        ga4_change_category: "update-filter checkbox",
+        ga4_filter_parent: true,
       },
       items: [
         {

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -23,7 +23,7 @@
 
   <%= render partial: "shared/header" %>
 
-  <div class="govuk-width-container" data-module="ga4-event-tracker ga4-paste-tracker ga4-button-setup ga4-select-with-search-setup ga4-index-section-setup ga4-select-setup" data-ga4-search-section-type="Filter by" data-ga4-section="<%= yield(:page_title).presence || yield(:title) %>" data-ga4-document-type="<%= action_name %>-<%= controller_name %>">
+  <div class="govuk-width-container" data-module="ga4-event-tracker ga4-paste-tracker ga4-button-setup ga4-select-with-search-setup ga4-index-section-setup ga4-select-setup" data-ga4-search-section-type="Filter by" data-ga4-section="<%= yield(:page_title).presence || yield(:title) %>" data-ga4-filter-type="<%= controller_name %>" data-ga4-document-type="<%= action_name %>-<%= controller_name %>">
 
     <%= render "shared/phase_banner", {
       show_feedback_banner: t("admin.feedback.show_banner"),

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -23,7 +23,7 @@
 
   <%= render partial: "shared/header" %>
 
-  <div class="govuk-width-container" data-module="ga4-event-tracker ga4-paste-tracker ga4-button-setup ga4-select-with-search-setup ga4-index-section-setup ga4-select-setup" data-ga4-search-section-type="Filter by" data-ga4-document-type="<%= action_name %>-<%= controller_name %>">
+  <div class="govuk-width-container" data-module="ga4-event-tracker ga4-paste-tracker ga4-button-setup ga4-select-with-search-setup ga4-index-section-setup ga4-select-setup" data-ga4-search-section-type="Filter by" data-ga4-section="<%= yield(:page_title).presence || yield(:title) %>" data-ga4-document-type="<%= action_name %>-<%= controller_name %>">
 
     <%= render "shared/phase_banner", {
       show_feedback_banner: t("admin.feedback.show_banner"),

--- a/spec/javascripts/admin/analytics-modules/ga4-finder-setup.spec.js
+++ b/spec/javascripts/admin/analytics-modules/ga4-finder-setup.spec.js
@@ -1,0 +1,119 @@
+describe('GOVUK.analyticsGa4.analyticsModules.Ga4FinderSetup', function () {
+  const container = document.createElement('div')
+  const form = document.createElement('form')
+  form.dataset.module = 'ga4-finder-tracker'
+
+  const text = document.createElement('input')
+  text.type = 'text'
+
+  const date = document.createElement('div')
+  date.className = 'govuk-date-input'
+  date.innerHTML = `
+    <div class="govuk-date-input__item">
+        <div class="govuk-form-group">
+            <input class="gem-c-input govuk-input govuk-input--width-4" name="day" type="text" data-ga4-change-category="update-filter date">
+        </div>
+    </div>
+    <div class="govuk-date-input__item">
+        <div class="govuk-form-group">
+            <input class="gem-c-input govuk-input govuk-input--width-4" name="month" type="text" data-ga4-change-category="update-filter date">
+        </div>
+    </div>
+    <div class="govuk-date-input__item">
+        <div class="govuk-form-group">
+            <input class="gem-c-input govuk-input govuk-input--width-4" name="year" type="text" data-ga4-change-category="update-filter date">
+        </div>
+    </div>
+  `
+
+  const checkboxes = document.createElement('div')
+  checkboxes.innerHTML = `
+    <fieldset class="govuk-fieldset" aria-describedby="checkboxes-4d23386d-hint">
+      <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">What is your favourite colour?</legend>
+      <div id="checkboxes-4d23386d-hint" class="govuk-hint">Select all that apply</div>
+      <div class="govuk-checkboxes">
+          <div class="govuk-checkboxes__item">
+              <input type="checkbox" name="favourite_colour[]" id="checkboxes-4d23386d-0" value="red" class="govuk-checkboxes__input" data-ga4-change-category="update-filter checkbox">
+              <label for="checkboxes-4d23386d-0" class="govuk-label govuk-checkboxes__label">Red</label>
+          </div>
+      </div>
+    </fieldset>
+  `
+
+  const radios = document.createElement('div')
+  radios.innerHTML = `
+    <fieldset class="govuk-fieldset">
+      <div class="govuk-radios">
+          <input type="radio" name="radio-group" id="radio-77f4e0a5-0" value="government-gateway" class="govuk-radios__input" data-ga4-change-category="update-filter radio">
+          <label for="radio-77f4e0a5-0" class="gem-c-label govuk-label govuk-radios__label">Use Government Gateway</label>
+      </div>
+    </fieldset>
+  `
+
+  const select = document.createElement('div')
+  select.innerHTML = `
+    <select data-ga4-change-category="update-filter select">
+      <option value="1">1</option>
+      <option value="2">2</option>
+    </select>
+  `
+
+  const selectMultiple = document.querySelector('div')
+  selectMultiple.innerHTML = select.innerHTML
+  selectMultiple.dataset.ga4ChangeCategory = 'update-filter select-multiple'
+  selectMultiple.querySelector('select').setAttribute('multiple', true)
+
+  const trackedInputs = [date, radios, checkboxes, select, selectMultiple]
+
+  container.appendChild(form)
+  document.body.appendChild(container)
+
+  beforeEach(() => {
+    form.innerHTML = ''
+  })
+
+  describe('on change within tracked form', () => {
+    let trackChangeEvent
+
+    it('calls `trackChangeEvent` on tracked inputs', () => {
+      const addInputToFormAndChange = (input) => {
+        trackChangeEvent.calls.reset()
+
+        form.innerHTML = input.outerHTML
+        const field = form.querySelector('input, select')
+
+        GOVUK.analyticsGa4.analyticsModules.Ga4FinderSetup.init()
+
+        if (field.tagName === 'SELECT') {
+          field.querySelectorAll('option')[1].selected = true
+          field.dispatchEvent(new Event('change', { bubbles: true }))
+        } else {
+          field.click()
+          field.value = '123'
+          field.dispatchEvent(new Event('change', { bubbles: true }))
+        }
+      }
+
+      trackChangeEvent = spyOn(
+        GOVUK.analyticsGa4.Ga4FinderTracker,
+        'trackChangeEvent'
+      )
+
+      trackedInputs.forEach((input) => {
+        addInputToFormAndChange(input)
+        const field = form.querySelector('input, select')
+
+        expect(trackChangeEvent).toHaveBeenCalledWith(
+          new Event('change'),
+          field.dataset.ga4ChangeCategory
+        )
+
+        form.innerHTML = ''
+      })
+    })
+  })
+
+  afterAll(() => {
+    container.remove()
+  })
+})

--- a/spec/javascripts/admin/analytics-modules/ga4-index-section-setup.spec.js
+++ b/spec/javascripts/admin/analytics-modules/ga4-index-section-setup.spec.js
@@ -1,5 +1,13 @@
 describe('GOVUK.analyticsGa4.analyticsModules.GA4IndexSectionEventHandlers', function () {
-  let container, form, input, select, excludedParent, excludedInput
+  let container,
+    form,
+    input,
+    radioInput,
+    hiddenInput,
+    fieldset,
+    select,
+    excludedParent,
+    excludedInput
 
   beforeEach(function () {
     document.title = 'Document title'
@@ -16,24 +24,98 @@ describe('GOVUK.analyticsGa4.analyticsModules.GA4IndexSectionEventHandlers', fun
     excludedInput = document.createElement('input')
     excludedParent.appendChild(excludedInput)
     form.appendChild(excludedParent)
+    fieldset = document.createElement('fieldset')
+    radioInput = document.createElement('input')
+    radioInput.type = 'radio'
+    fieldset.appendChild(radioInput)
+    form.appendChild(fieldset)
+    hiddenInput = document.createElement('input')
+    hiddenInput.type = 'hidden'
+    form.appendChild(hiddenInput)
     container.appendChild(form)
     document.body.appendChild(container)
   })
 
-  it('adds a ga4-index-section data attribute to select and input fields reflecting their position in the DOM', function () {
-    const Ga4IndexSectionSetup =
-      GOVUK.analyticsGa4.analyticsModules.Ga4IndexSectionSetup
-    Ga4IndexSectionSetup.init()
+  describe('for a form not tracked by ga4-finder-tracker', function () {
+    it('adds a ga4-index-section data attribute to select and input fields reflecting their position in the DOM', function () {
+      const Ga4IndexSectionSetup =
+        GOVUK.analyticsGa4.analyticsModules.Ga4IndexSectionSetup
+      Ga4IndexSectionSetup.init()
 
-    expect(input.dataset.ga4IndexSection).toEqual('0')
-    expect(select.dataset.ga4IndexSection).toEqual('1')
+      expect(input.dataset.ga4Index).toEqual(
+        JSON.stringify({ index_section: 0, index_section_count: 3 })
+      )
+      expect(select.dataset.ga4Index).toEqual(
+        JSON.stringify({ index_section: 1, index_section_count: 3 })
+      )
+      expect(fieldset.dataset.ga4Index).toEqual(
+        JSON.stringify({ index_section: 2, index_section_count: 3 })
+      )
+    })
+
+    it('does not add ga4-filter-parent', function () {
+      const Ga4IndexSectionSetup =
+        GOVUK.analyticsGa4.analyticsModules.Ga4IndexSectionSetup
+      Ga4IndexSectionSetup.init()
+
+      expect(input.dataset.ga4FilterParent).not.toBeDefined()
+      expect(select.dataset.ga4FilterParent).not.toBeDefined()
+      expect(fieldset.dataset.ga4FilterParent).not.toBeDefined()
+    })
   })
 
-  it('does not add ga4-index-section data attributes to select and input fields in an excludedParent', function () {
-    const Ga4IndexSectionSetup =
-      GOVUK.analyticsGa4.analyticsModules.Ga4IndexSectionSetup
-    Ga4IndexSectionSetup.init()
+  describe('for a form tracked by ga4-finder-tracker', function () {
+    it('adds ga4-index-section and ga4-filter-parent data attributes to select and input fields reflecting their position in the DOM', function () {
+      form.dataset.module = 'ga4-finder-tracker'
 
-    expect(excludedInput.dataset.ga4IndexSection).not.toBeDefined()
+      const Ga4IndexSectionSetup =
+        GOVUK.analyticsGa4.analyticsModules.Ga4IndexSectionSetup
+      Ga4IndexSectionSetup.init()
+
+      expect(input.dataset.ga4Index).toEqual(
+        JSON.stringify({ index_section: 0, index_section_count: 3 })
+      )
+      expect(input.dataset.ga4FilterParent).toBeDefined()
+
+      expect(select.dataset.ga4Index).toEqual(
+        JSON.stringify({ index_section: 1, index_section_count: 3 })
+      )
+      expect(select.dataset.ga4FilterParent).toBeDefined()
+
+      expect(fieldset.dataset.ga4Index).toEqual(
+        JSON.stringify({ index_section: 2, index_section_count: 3 })
+      )
+      expect(fieldset.dataset.ga4FilterParent).toBeDefined()
+    })
+  })
+
+  describe('does not add ga4-index-section data attributes to', function () {
+    it('select and input fields in an excludedParent', function () {
+      const Ga4IndexSectionSetup =
+        GOVUK.analyticsGa4.analyticsModules.Ga4IndexSectionSetup
+      Ga4IndexSectionSetup.init()
+
+      expect(excludedInput.dataset.ga4Index).not.toBeDefined()
+    })
+
+    it('radio button within fieldset', function () {
+      const Ga4IndexSectionSetup =
+        GOVUK.analyticsGa4.analyticsModules.Ga4IndexSectionSetup
+      Ga4IndexSectionSetup.init()
+
+      expect(radioInput.dataset.ga4Index).not.toBeDefined()
+    })
+
+    it('hidden input', function () {
+      const Ga4IndexSectionSetup =
+        GOVUK.analyticsGa4.analyticsModules.Ga4IndexSectionSetup
+      Ga4IndexSectionSetup.init()
+
+      expect(hiddenInput.dataset.ga4Index).not.toBeDefined()
+    })
+  })
+
+  afterEach(function () {
+    container.remove()
   })
 })


### PR DESCRIPTION
## What

Use `Ga4FinderTracker` from `govuk_publishing_components` to track search form interactions on `whitehall`.

### More details
- Add `Ga4FinderSetup` to add change tracking to search forms and additional tracking for multiple select
- Change `Ga4IndexSetup` to make the parent `fieldset` of a radio input the index (a group radios will change one value of a form, so generally each radio isn't counted a separate input)
- Add necessary data attributes to search forms and inputs
- Change `Ga4SelectTracker` and `Ga4SelectWithSearchTracker` to not double track on finder forms

## Why

Part of the work to add GA4 tracking in `whitehall`. 

Addresses the following trello cards:

https://trello.com/c/BoARWzeD/3671-use-ga4-finder-tracker-in-whitehall
https://trello.com/c/lVFJZk1M/3715-track-reset-all-fields-button-on-select-with-search-components

Partly addresses the following trello cards:
https://trello.com/c/RAs3Yyss/3616-component-level-tracking-track-radio-button-interactions-on-whitehall
https://trello.com/c/EbHEqYtk/3627-modify-component-type-tracking-parameters
https://trello.com/c/zEY8eHbQ/803-component-level-tracking-track-checkbox-interactions-on-whitehall

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
