### PR TITLE
enable embed code for email_address

### DIFF
--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/summary_card_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/summary_card_component.rb
@@ -45,12 +45,46 @@ private
   end
 
   def details_items
-    content_block_edition.first_class_details.map do |key, value|
-      {
+    content_block_edition.first_class_details.map { |key, value|
+      rows = [{
         key: key.humanize,
         value:,
-      }
-    end
+        data: data_attributes_for_row(key),
+      }]
+      rows.push(embed_code_row(key)) if should_show_embed_code?(key)
+      rows
+    }.flatten
+  end
+
+  def data_attributes_for_row(key)
+    copy_embed_code(key) if should_show_embed_code?(key)
+  end
+
+  def copy_embed_code(key)
+    {
+      module: "copy-embed-code",
+      "embed-code": content_block_document.embed_code_for_field(key),
+    }
+  end
+
+  # This generates a row containing the embed code for the field above it -
+  # it will be deleted if javascript is enabled by copy-embed-code.js.
+  def embed_code_row(key)
+    {
+      key: "Embed code",
+      value: content_block_document.embed_code_for_field(key),
+      data: {
+        "embed-code-row": "true",
+      },
+    }
+  end
+
+  def should_show_embed_code?(key)
+    embeddable_fields.include?(key)
+  end
+
+  def embeddable_fields
+    @embeddable_fields = content_block_document.schema.embeddable_fields
   end
 
   def status_item

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/summary_card_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/summary_card_component.rb
@@ -1,5 +1,6 @@
 class ContentBlockManager::ContentBlock::Document::Show::SummaryCardComponent < ViewComponent::Base
   include ContentBlockManager::ContentBlock::EditionHelper
+  include ContentBlockManager::ContentBlock::EmbedCodeHelper
 
   def initialize(content_block_document:)
     @content_block_document = content_block_document
@@ -51,32 +52,13 @@ private
         value:,
         data: data_attributes_for_row(key),
       }]
-      rows.push(embed_code_row(key)) if should_show_embed_code?(key)
+      rows.push(embed_code_row(key, content_block_document)) if should_show_embed_code?(key)
       rows
     }.flatten
   end
 
   def data_attributes_for_row(key)
-    copy_embed_code(key) if should_show_embed_code?(key)
-  end
-
-  def copy_embed_code(key)
-    {
-      module: "copy-embed-code",
-      "embed-code": content_block_document.embed_code_for_field(key),
-    }
-  end
-
-  # This generates a row containing the embed code for the field above it -
-  # it will be deleted if javascript is enabled by copy-embed-code.js.
-  def embed_code_row(key)
-    {
-      key: "Embed code",
-      value: content_block_document.embed_code_for_field(key),
-      data: {
-        "embed-code-row": "true",
-      },
-    }
+    copy_embed_code_data_attributes(key, content_block_document) if should_show_embed_code?(key)
   end
 
   def should_show_embed_code?(key)

--- a/lib/engines/content_block_manager/app/helpers/content_block_manager/content_block/embed_code_helper.rb
+++ b/lib/engines/content_block_manager/app/helpers/content_block_manager/content_block/embed_code_helper.rb
@@ -1,0 +1,20 @@
+module ContentBlockManager::ContentBlock::EmbedCodeHelper
+  def copy_embed_code_data_attributes(key, content_block_document)
+    {
+      module: "copy-embed-code",
+      "embed-code": content_block_document.embed_code_for_field(key),
+    }
+  end
+
+  # This generates a row containing the embed code for the field above it -
+  # it will be deleted if javascript is enabled by copy-embed-code.js.
+  def embed_code_row(key, content_block_document)
+    {
+      key: "Embed code",
+      value: content_block_document.embed_code_for_field(key),
+      data: {
+        "embed-code-row": "true",
+      },
+    }
+  end
+end

--- a/lib/engines/content_block_manager/app/models/content_block_manager/content_block/schema.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/content_block/schema.rb
@@ -70,7 +70,7 @@ module ContentBlockManager
       end
 
       def embeddable_fields
-        config["embeddable_fields"] || fields
+        config["embeddable_fields"] || []
       end
 
       class EmbeddedSchema < Schema

--- a/lib/engines/content_block_manager/config/content_block_manager.yml
+++ b/lib/engines/content_block_manager/config/content_block_manager.yml
@@ -9,3 +9,6 @@ schemas:
           - amount
           - frequency
           - description
+  content_block_email_address:
+    embeddable_fields:
+      - email_address

--- a/lib/engines/content_block_manager/test/unit/app/models/content_block_schema_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/models/content_block_schema_test.rb
@@ -400,8 +400,8 @@ class ContentBlockManager::SchemaTest < ActiveSupport::TestCase
           .returns({})
       end
 
-      it "returns the fields" do
-        assert_equal schema.embeddable_fields, schema.fields
+      it "returns an empty array" do
+        assert_equal schema.embeddable_fields, []
       end
     end
   end


### PR DESCRIPTION
https://trello.com/c/JUwDhANf/1029-tech-task-enable-copy-embed-code-on-emails

We are user testing email addresses next week, and so we need to allow users to click a 'copy embed code' button next to the email address on the show Document page.

Changes:
* adding `email_address` as embeddable field to our schema config for emails
* look at those `embeddable_fields` on the Document summary card and render embed code stuff
* default to no `embedded_fields` on the schema level, so that if no fields are defined we don't show anything as embeddable
* add a couple of methods to shared helper

I've not added a feature test for this as we don't yet have a "real" user story for this functionality, the pension objects are covered in `view_object`, and these email address blocks are not visible in production (and may never be as we're changing the format of Contacts) -  i think the tests we have should cover us?

<img width="865" alt="Screenshot 2025-04-24 at 16 52 08" src="https://github.com/user-attachments/assets/3b72dfc0-c698-4ce6-ae29-09c6b93c08b8" />


--

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
