### PR TITLE
Correct attachable primary locale check

### DIFF
--- a/app/views/admin/attachments/_reference_fields.html.erb
+++ b/app/views/admin/attachments/_reference_fields.html.erb
@@ -22,7 +22,7 @@
   </div>
 <% end %>
 
-<% if attachable.respond_to?(:primary_locale) && attachable.primary_locale != :en %>
+<% if attachable.respond_to?(:primary_locale) && attachable.primary_locale != "en" %>
   <%= form.hidden_field :locale, value: attachable.primary_locale %>
 <% end %>
 


### PR DESCRIPTION
This ensures that the hidden field only appears for documents with a non-English primary locale. Setting the value of the attachment's locale has been causing errors in Publishing API for attachments on documents with translations.

We'll probably need to follow this up with a data migration to unset the locales for non-foreign-language-only attachments that have been edited since https://github.com/alphagov/whitehall/pull/10157 was merged.
