### PR TITLE
add contact as valid schema type

### DIFF
--- a/lib/engines/content_block_manager/app/models/content_block_manager/content_block/schema.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/content_block/schema.rb
@@ -3,7 +3,7 @@ module ContentBlockManager
     class Schema
       SCHEMA_PREFIX = "content_block".freeze
 
-      VALID_SCHEMAS = %w[email_address postal_address pension].freeze
+      VALID_SCHEMAS = %w[email_address postal_address pension contact].freeze
       private_constant :VALID_SCHEMAS
 
       CONFIG_PATH = File.join(ContentBlockManager::Engine.root, "config", "content_block_manager.yml")

--- a/lib/engines/content_block_manager/config/content_block_manager.yml
+++ b/lib/engines/content_block_manager/config/content_block_manager.yml
@@ -12,3 +12,11 @@ schemas:
   content_block_email_address:
     embeddable_fields:
       - email_address
+  content_block_contact:
+    subschemas:
+      email_addresses:
+        embeddable_fields:
+          - email_address
+      telephones:
+        embeddable_fields:
+          - telephone

--- a/lib/engines/content_block_manager/test/unit/app/models/content_block_schema_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/models/content_block_schema_test.rb
@@ -202,6 +202,7 @@ class ContentBlockManager::SchemaTest < ActiveSupport::TestCase
         email_address
         postal_address
         pension
+        contact
       ]
     end
 


### PR DESCRIPTION
https://trello.com/c/Fa5E0qo6/1031-tech-task-create-basic-contact-content-block-schema

Blocked by https://github.com/alphagov/publishing-api/pull/3306 

As we are adding a Contact schema to the
Publishing API, we can enable the type here and it
will just work given our existing logic around
schemas - as we introduce more custom interaction
we can add test coverage.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
