### PR TITLE
Social media account editor permissions

### DIFF
--- a/app/components/admin/social_media_accounts/index/summary_card_component.rb
+++ b/app/components/admin/social_media_accounts/index/summary_card_component.rb
@@ -3,9 +3,10 @@
 class Admin::SocialMediaAccounts::Index::SummaryCardComponent < ViewComponent::Base
   attr_reader :socialable, :social_media_account
 
-  def initialize(socialable:, social_media_account:)
+  def initialize(socialable:, social_media_account:, user:)
     @socialable = socialable
     @social_media_account = social_media_account
+    @enforcer = Whitehall::Authority::Enforcer.new(user, @social_media_account)
   end
 
 private
@@ -73,8 +74,8 @@ private
   def summary_card_actions(translation = nil)
     actions = []
     actions << view_summary_card_action(translation)
-    actions << edit_summary_card_action
-    actions << confirm_destroy_summary_card_action
+    actions << edit_summary_card_action if @enforcer.can?(:update)
+    actions << confirm_destroy_summary_card_action if @enforcer.can?(:delete)
     actions.compact
   end
 

--- a/app/controllers/admin/social_media_accounts_controller.rb
+++ b/app/controllers/admin/social_media_accounts_controller.rb
@@ -1,6 +1,7 @@
 class Admin::SocialMediaAccountsController < Admin::BaseController
   before_action :find_socialable
   before_action :find_social_media_account, only: %i[edit update confirm_destroy destroy]
+  before_action :enforce_permissions!
   before_action :strip_whitespace_from_url
 
   def index
@@ -62,6 +63,17 @@ private
 
   def find_social_media_account
     @social_media_account = @socialable.social_media_accounts.find(params[:id])
+  end
+
+  def enforce_permissions!
+    case action_name
+    when "new", "create"
+      enforce_permission!(:create, SocialMediaAccount)
+    when "edit", "update"
+      enforce_permission!(:update, @social_media_account)
+    when "confirm_destroy", "destroy"
+      enforce_permission!(:delete, @social_media_account)
+    end
   end
 
   def strip_whitespace_from_url

--- a/app/views/admin/social_media_accounts/index.html.erb
+++ b/app/views/admin/social_media_accounts/index.html.erb
@@ -25,15 +25,17 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= render "govuk_publishing_components/components/button", {
-      text: "Create new account",
-      href: new_polymorphic_path([:admin, @socialable, SocialMediaAccount]),
-      margin_bottom: 6,
-    } %>
+    <% if can?(:create, SocialMediaAccount) %>
+      <%= render "govuk_publishing_components/components/button", {
+        text: "Create new account",
+        href: new_polymorphic_path([:admin, @socialable, SocialMediaAccount]),
+        margin_bottom: 6,
+      } %>
+    <% end %>
 
     <% if @social_media_accounts.present? %>
       <% @social_media_accounts.each do |social_media_account| %>
-        <%= render Admin::SocialMediaAccounts::Index::SummaryCardComponent.new(socialable: @socialable, social_media_account: social_media_account) %>
+        <%= render Admin::SocialMediaAccounts::Index::SummaryCardComponent.new(socialable: @socialable, social_media_account: social_media_account, user: current_user) %>
       <% end %>
     <% else %>
       <%= render "govuk_publishing_components/components/inset_text", {

--- a/lib/whitehall/authority/enforcer.rb
+++ b/lib/whitehall/authority/enforcer.rb
@@ -6,6 +6,7 @@ require "whitehall/authority/rules/ministerial_role_rules"
 require "whitehall/authority/rules/person_rules"
 require "whitehall/authority/rules/policy_group_rules"
 require "whitehall/authority/rules/miscellaneous_rules"
+require "whitehall/authority/rules/social_media_account_rules"
 
 module Whitehall::Authority
   class Enforcer
@@ -48,5 +49,6 @@ module Whitehall::Authority
     "Organisation" => Rules::OrganisationRules,
     "Government" => Rules::GovernmentRules,
     "StatisticsAnnouncement" => Rules::StatisticsAnnouncementRules,
+    "SocialMediaAccount" => Rules::SocialMediaAccountRules,
   }.freeze
 end

--- a/lib/whitehall/authority/rules/social_media_account_rules.rb
+++ b/lib/whitehall/authority/rules/social_media_account_rules.rb
@@ -1,0 +1,16 @@
+module Whitehall::Authority::Rules
+  SocialMediaAccountRules = Struct.new(:actor, :subject) do
+    def can?(action)
+      case action
+      when :create
+        actor.departmental_editor? || actor.managing_editor? || actor.gds_editor? || actor.gds_admin?
+      when :update
+        actor.departmental_editor? || actor.managing_editor? || actor.gds_editor? || actor.gds_admin?
+      when :delete
+        actor.departmental_editor? || actor.managing_editor? || actor.gds_editor? || actor.gds_admin?
+      else
+        false
+      end
+    end
+  end
+end

--- a/test/components/admin/social_media_accounts/index/summary_card_component_test.rb
+++ b/test/components/admin/social_media_accounts/index/summary_card_component_test.rb
@@ -14,6 +14,7 @@ class Admin::SocialMediaAccounts::Index::SummaryCardComponentTest < ViewComponen
     render_inline(Admin::SocialMediaAccounts::Index::SummaryCardComponent.new(
                     socialable: @socialable,
                     social_media_account: @social_media_account,
+                    user: build(:departmental_editor),
                   ))
 
     social_media_service_name = @social_media_account.social_media_service.name
@@ -32,6 +33,7 @@ class Admin::SocialMediaAccounts::Index::SummaryCardComponentTest < ViewComponen
     render_inline(Admin::SocialMediaAccounts::Index::SummaryCardComponent.new(
                     socialable: @socialable,
                     social_media_account:,
+                    user: build(:departmental_editor),
                   ))
 
     assert_selector ".govuk-summary-list__key", text: "Account"
@@ -47,6 +49,7 @@ class Admin::SocialMediaAccounts::Index::SummaryCardComponentTest < ViewComponen
     render_inline(Admin::SocialMediaAccounts::Index::SummaryCardComponent.new(
                     socialable:,
                     social_media_account: english_social_media_account,
+                    user: build(:departmental_editor),
                   ))
 
     social_media_service_name = english_social_media_account.social_media_service.name
@@ -66,5 +69,27 @@ class Admin::SocialMediaAccounts::Index::SummaryCardComponentTest < ViewComponen
     assert_selector ".govuk-summary-list__row:nth-child(3) .govuk-summary-list__value", text: french_social_media_account_translation.title
     assert_selector ".govuk-summary-list__row:nth-child(3) .govuk-summary-list__actions a[href='#{french_social_media_account_translation.url}']", text: "View French"
     assert_selector ".govuk-summary-list__row:nth-child(3) .govuk-summary-list__actions a[href='#{edit_polymorphic_path([:admin, socialable, english_social_media_account], locale: :fr)}']", text: "Edit French account"
+  end
+
+  test "omits the edit link if the user does not have permission to edit the social media account" do
+    render_inline(Admin::SocialMediaAccounts::Index::SummaryCardComponent.new(
+                    socialable: @socialable,
+                    social_media_account: @social_media_account,
+                    user: build(:writer),
+                  ))
+
+    social_media_service_name = @social_media_account.social_media_service.name
+    assert page.has_no_link?("Edit #{social_media_service_name}")
+  end
+
+  test "omits the delete link if the user does not have permission to delete the social media account" do
+    render_inline(Admin::SocialMediaAccounts::Index::SummaryCardComponent.new(
+                    socialable: @socialable,
+                    social_media_account: @social_media_account,
+                    user: build(:writer),
+                  ))
+
+    social_media_service_name = @social_media_account.social_media_service.name
+    assert page.has_no_link?("Delete #{social_media_service_name}")
   end
 end

--- a/test/functional/admin/social_media_accounts_controller_test.rb
+++ b/test/functional/admin/social_media_accounts_controller_test.rb
@@ -180,6 +180,19 @@ class Admin::SocialMediaAccountsControllerTest < ActionController::TestCase
     refute_select "a[href=?]", edit_admin_organisation_social_media_account_path(organisation_id: organisation.slug, id: social_media_account.id, params: { locale: "dk" })
   end
 
+  view_test "GET on :index includes create button for users with sufficient permission to create social media accounts" do
+    organisation = create(:organisation)
+    get :index, params: { organisation_id: organisation.id }
+    assert_select "a", text: "Create new account"
+  end
+
+  view_test "GET on :index omits create button for users without sufficient permission to create social media accounts" do
+    login_as(:writer)
+    organisation = create(:organisation)
+    get :index, params: { organisation_id: organisation.id }
+    assert_select "a", text: "Create new account", count: 0
+  end
+
   test "PUT on :update with a locale updates only the translation of the social media account" do
     organisation = create(:organisation, translated_into: [:cy])
     social_media_account = organisation.social_media_accounts.create!(social_media_service_id: @social_media_service.id, url: "http://english-url.com", title: "Title in English")

--- a/test/functional/admin/social_media_accounts_controller_test.rb
+++ b/test/functional/admin/social_media_accounts_controller_test.rb
@@ -8,6 +8,17 @@ class Admin::SocialMediaAccountsControllerTest < ActionController::TestCase
 
   should_be_an_admin_controller
 
+  test "GET on :new returns forbidden response when user does not have correct permissions" do
+    login_as :writer
+    organisation = create(:organisation)
+    get :new,
+        params: {
+          organisation_id: organisation,
+        }
+
+    assert_response :forbidden
+  end
+
   test "POST on :create creates social media account" do
     organisation = create(:organisation)
     post :create,
@@ -25,6 +36,34 @@ class Admin::SocialMediaAccountsControllerTest < ActionController::TestCase
     assert_equal "#{@social_media_service.name} account created successfully", flash[:notice]
     assert_equal 1, organisation.social_media_accounts.count
     assert_equal @social_media_service, organisation.social_media_accounts.first.social_media_service
+  end
+
+  test "POST on :create returns forbidden response when user does not have correct permissions" do
+    login_as :writer
+    organisation = create(:organisation)
+    post :create,
+         params: {
+           social_media_account: {
+             social_media_service_id: @social_media_service.id,
+             url: "http://foo",
+           },
+           organisation_id: organisation,
+         }
+
+    assert_response :forbidden
+  end
+
+  test "GET on :edit returns forbidden response when user does not have correct permissions" do
+    login_as :writer
+    organisation = create(:organisation)
+    social_media_account = organisation.social_media_accounts.create!(social_media_service_id: @social_media_service.id, url: "http://foo")
+    get :edit,
+        params: {
+          id: social_media_account,
+          organisation_id: organisation,
+        }
+
+    assert_response :forbidden
   end
 
   test "PUT on :update updates a social media account" do
@@ -46,6 +85,23 @@ class Admin::SocialMediaAccountsControllerTest < ActionController::TestCase
 
     organisation.reload
     assert_equal ["http://bar"], organisation.social_media_accounts.map(&:url)
+  end
+
+  test "PUT on :update returns forbidden response when user does not have correct permissions" do
+    login_as :writer
+    organisation = create(:organisation)
+    social_media_account = organisation.social_media_accounts.create!(social_media_service_id: @social_media_service.id, url: "http://foo")
+    post :update,
+         params: {
+           id: social_media_account,
+           social_media_account: {
+             social_media_service_id: @social_media_service.id,
+             url: "http://bar",
+           },
+           organisation_id: organisation,
+         }
+
+    assert_response :forbidden
   end
 
   test ":create and :update strip whitespace from urls" do
@@ -72,6 +128,16 @@ class Admin::SocialMediaAccountsControllerTest < ActionController::TestCase
     assert_equal "http://bar", social_media_account.reload.url
   end
 
+  test "GET on :confirm_destroy returns forbidden if user has insufficient permissions" do
+    login_as :writer
+    organisation = create(:organisation)
+    social_media_account = create(:social_media_account, socialable: organisation)
+
+    get :confirm_destroy, params: { organisation_id: organisation, id: social_media_account }
+
+    assert_response :forbidden
+  end
+
   view_test "GET on :confirm_destroy has the correct action and cancel links when socialable is an organisation" do
     organisation = create(:organisation)
     social_media_account = create(:social_media_account, socialable: organisation)
@@ -92,6 +158,16 @@ class Admin::SocialMediaAccountsControllerTest < ActionController::TestCase
     assert_redirected_to admin_organisation_social_media_accounts_url(organisation)
     assert_equal "#{social_media_account.service_name} account deleted successfully", flash[:notice]
     assert_not SocialMediaAccount.exists?(social_media_account.id)
+  end
+
+  test "DELETE on :destroy returns forbidden when user has insufficient permissions" do
+    login_as :writer
+    organisation = create(:organisation)
+    social_media_account = create(:social_media_account, socialable: organisation)
+
+    delete :destroy, params: { organisation_id: organisation, id: social_media_account }
+
+    assert_response :forbidden
   end
 
   view_test "GET on :index displays edit button only for languages the organisation is translated in" do

--- a/test/unit/lib/whitehall/authority/department_editor_test.rb
+++ b/test/unit/lib/whitehall/authority/department_editor_test.rb
@@ -179,4 +179,16 @@ class DepartmentEditorTest < ActiveSupport::TestCase
   test "cannot publish historic editions" do
     assert_not enforcer_for(department_editor, historic_edition).can?(:publish)
   end
+
+  test "can create social media accounts" do
+    assert enforcer_for(department_editor, build(:social_media_account)).can?(:create)
+  end
+
+  test "can update social media accounts" do
+    assert enforcer_for(department_editor, build(:social_media_account)).can?(:update)
+  end
+
+  test "can delete social media accounts" do
+    assert enforcer_for(department_editor, build(:social_media_account)).can?(:delete)
+  end
 end

--- a/test/unit/lib/whitehall/authority/department_writer_test.rb
+++ b/test/unit/lib/whitehall/authority/department_writer_test.rb
@@ -154,4 +154,16 @@ class DepartmentWriterTest < ActiveSupport::TestCase
   test "cannot modify historic editions" do
     assert_not enforcer_for(department_writer, historic_edition).can?(:modify)
   end
+
+  test "cannot create social media accounts" do
+    assert_not enforcer_for(department_writer, build(:social_media_account)).can?(:create)
+  end
+
+  test "cannot update social media accounts" do
+    assert_not enforcer_for(department_writer, build(:social_media_account)).can?(:update)
+  end
+
+  test "cannot delete social media accounts" do
+    assert_not enforcer_for(department_writer, build(:social_media_account)).can?(:delete)
+  end
 end

--- a/test/unit/lib/whitehall/authority/gds_admin_test.rb
+++ b/test/unit/lib/whitehall/authority/gds_admin_test.rb
@@ -38,4 +38,16 @@ class GDSAdminTest < ActiveSupport::TestCase
   test "can modify historic editions" do
     assert enforcer_for(gds_admin, historic_edition).can?(:modify)
   end
+
+  test "can create social media accounts" do
+    assert enforcer_for(gds_admin, build(:social_media_account)).can?(:create)
+  end
+
+  test "can update social media accounts" do
+    assert enforcer_for(gds_admin, build(:social_media_account)).can?(:update)
+  end
+
+  test "can delete social media accounts" do
+    assert enforcer_for(gds_admin, build(:social_media_account)).can?(:delete)
+  end
 end

--- a/test/unit/lib/whitehall/authority/gds_editor_test.rb
+++ b/test/unit/lib/whitehall/authority/gds_editor_test.rb
@@ -184,4 +184,16 @@ class GDSEditorTest < ActiveSupport::TestCase
   test "can modify historic editions" do
     assert enforcer_for(gds_editor, historic_edition).can?(:modify)
   end
+
+  test "can create social media accounts" do
+    assert enforcer_for(gds_editor, build(:social_media_account)).can?(:create)
+  end
+
+  test "can update social media accounts" do
+    assert enforcer_for(gds_editor, build(:social_media_account)).can?(:update)
+  end
+
+  test "can delete social media accounts" do
+    assert enforcer_for(gds_editor, build(:social_media_account)).can?(:delete)
+  end
 end

--- a/test/unit/lib/whitehall/authority/managing_editor_test.rb
+++ b/test/unit/lib/whitehall/authority/managing_editor_test.rb
@@ -189,4 +189,16 @@ class ManagingEditorTest < ActiveSupport::TestCase
   test "cannot publish historic editions" do
     assert_not enforcer_for(managing_editor, historic_edition).can?(:publish)
   end
+
+  test "can create social media accounts" do
+    assert enforcer_for(managing_editor, build(:social_media_account)).can?(:create)
+  end
+
+  test "can update social media accounts" do
+    assert enforcer_for(managing_editor, build(:social_media_account)).can?(:update)
+  end
+
+  test "can delete social media accounts" do
+    assert enforcer_for(managing_editor, build(:social_media_account)).can?(:delete)
+  end
 end


### PR DESCRIPTION
This PR ensures that users which only have the basic Whitehall permissions are unable to create, update or delete social media accounts.

We're looking to provide a basic level of authorisation for unprotected resources in Whitehall, ahead of a planned overhaul of the authorisation system.

I have tried as far as possible to remain consistent with existing authorisation implementations within Whitehall.

Trello: https://trello.com/c/RevqdALn