### PR TITLE
(Content-modelling/1020) Remove instructions for publishers on homepage

### DIFF
--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/index/summary_card_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/index/summary_card_component.rb
@@ -15,7 +15,6 @@ private
       *details_items,
       organisation_item,
       status_item,
-      (instructions_item if content_block_document.latest_edition.instructions_to_publishers.present?),
     ].compact
   end
 
@@ -59,13 +58,6 @@ private
         value: last_updated_value,
       }
     end
-  end
-
-  def instructions_item
-    {
-      key: "Instructions to publishers",
-      value: content_block_edition.instructions_to_publishers.presence || "None",
-    }
   end
 
   def title

--- a/lib/engines/content_block_manager/test/components/content_block/document/index/summary_card_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/document/index/summary_card_component_test.rb
@@ -52,24 +52,8 @@ class ContentBlockManager::ContentBlock::Document::Index::SummaryCardComponentTe
     assert_selector ".govuk-summary-list__key", text: "Lead organisation"
     assert_selector ".govuk-summary-list__value", text: content_block_edition.lead_organisation.name
 
-    assert_no_selector ".govuk-summary-list__key", text: "Instructions to publishers"
-    assert_no_selector ".govuk-summary-list__value", text: "None"
-
     assert_selector ".govuk-summary-list__key", text: "Status"
     assert_selector ".govuk-summary-list__value", text: "Published on #{strip_tags published_date(content_block_edition)} by #{content_block_edition.creator.name}"
-  end
-
-  describe "when there are instructions to publishers" do
-    it "renders them" do
-      content_block_document.latest_edition.instructions_to_publishers = "instructions"
-
-      render_inline(ContentBlockManager::ContentBlock::Document::Index::SummaryCardComponent.new(content_block_document:))
-
-      assert_selector ".govuk-summary-list__row", count: 6
-
-      assert_selector ".govuk-summary-list__key", text: "Instructions to publishers"
-      assert_selector ".govuk-summary-list__value", text: "instructions"
-    end
   end
 
   describe "when the edition is scheduled" do


### PR DESCRIPTION
https://trello.com/c/9WqJV2R5/1020-tech-task-remove-instructions-to-publishers-from-home-page-list

This is a quick PR to remove the instructions for publishers information from the Content Block Manager homepage, which is not required.