### PR TITLE
Prevent deletion of translations association with published editions

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -31,8 +31,8 @@ class Admin::BaseController < ApplicationController
 
   def prevent_modification_of_unmodifiable_edition
     if @edition.unmodifiable?
-      notice = "You cannot modify a #{@edition.state} #{@edition.type.titleize}"
-      redirect_to admin_edition_path(@edition), notice:
+      alert = "You cannot modify a #{@edition.state} #{@edition.type.titleize}"
+      redirect_to admin_edition_path(@edition), alert:
     end
   end
 

--- a/app/controllers/admin/edition_translations_controller.rb
+++ b/app/controllers/admin/edition_translations_controller.rb
@@ -1,6 +1,8 @@
 class Admin::EditionTranslationsController < Admin::BaseController
   include TranslationControllerConcern
 
+  before_action :prevent_modification_of_unmodifiable_edition
+
   def new; end
 
   def edit

--- a/test/functional/admin/edition_translations_controller_test.rb
+++ b/test/functional/admin/edition_translations_controller_test.rb
@@ -224,6 +224,16 @@ class Admin::EditionTranslationsControllerTest < ActionController::TestCase
     assert_response :forbidden
   end
 
+  test "#confirm_destroy returns a redirect with a flash message for a translation associated with a published edition" do
+    edition = build(:published_edition)
+    with_locale(:fr) { edition.update!(title: "french-title", summary: "french-summary", body: "french-body") }
+
+    get :confirm_destroy, params: { edition_id: edition, id: "fr" }
+
+    assert_redirected_to @controller.admin_edition_path(edition)
+    assert_equal "You cannot modify a #{edition.state} #{edition.type.titleize}", flash[:notice]
+  end
+
   test "destroy removes translation and redirects to admin edition page" do
     edition = create(:edition)
     with_locale(:fr) { edition.update!(title: "french-title", summary: "french-summary", body: "french-body") }
@@ -244,5 +254,15 @@ class Admin::EditionTranslationsControllerTest < ActionController::TestCase
 
       assert_publishing_api_discard_draft(edition.content_id, locale: "fr")
     end
+  end
+
+  test "#destroy returns a redirect with a flash message for a translation associated with a published edition" do
+    edition = build(:published_edition)
+    with_locale(:fr) { edition.update!(title: "french-title", summary: "french-summary", body: "french-body") }
+
+    delete :destroy, params: { edition_id: edition, id: "fr" }
+
+    assert_redirected_to @controller.admin_edition_path(edition)
+    assert_equal "You cannot modify a #{edition.state} #{edition.type.titleize}", flash[:notice]
   end
 end

--- a/test/functional/admin/edition_translations_controller_test.rb
+++ b/test/functional/admin/edition_translations_controller_test.rb
@@ -231,7 +231,7 @@ class Admin::EditionTranslationsControllerTest < ActionController::TestCase
     get :confirm_destroy, params: { edition_id: edition, id: "fr" }
 
     assert_redirected_to @controller.admin_edition_path(edition)
-    assert_equal "You cannot modify a #{edition.state} #{edition.type.titleize}", flash[:notice]
+    assert_equal "You cannot modify a #{edition.state} #{edition.type.titleize}", flash[:alert]
   end
 
   test "destroy removes translation and redirects to admin edition page" do
@@ -263,6 +263,6 @@ class Admin::EditionTranslationsControllerTest < ActionController::TestCase
     delete :destroy, params: { edition_id: edition, id: "fr" }
 
     assert_redirected_to @controller.admin_edition_path(edition)
-    assert_equal "You cannot modify a #{edition.state} #{edition.type.titleize}", flash[:notice]
+    assert_equal "You cannot modify a #{edition.state} #{edition.type.titleize}", flash[:alert]
   end
 end


### PR DESCRIPTION
We've seen at least one support ticket resulting from translations remaining live on GOV.UK after they should have been removed.

To unpublish deleted translations via Publishing API, Whitehall diffs the translations for the edition being published against the translations for the published edition. If the translation has been deleted from the published edition instead of the draft edition, this doesn't work, meaning that the translation is not removed from GOV.UK.

We therefore prevent deletion of translations associated with unmodifiable editions.

Trello: https://trello.com/c/BXTGjhvi
