### PR TITLE
Return an empty map if there are no headings in body

### DIFF
--- a/app/presenters/publishing_api/payload_builder/body_headings.rb
+++ b/app/presenters/publishing_api/payload_builder/body_headings.rb
@@ -12,7 +12,11 @@ module PublishingApi
       end
 
       def call
-        { headers: body_headings }
+        headers = body_headings
+
+        return {} if headers.empty?
+
+        { headers: }
       end
 
     private

--- a/test/unit/app/presenters/publishing_api/payload_builder/body_headings_test.rb
+++ b/test/unit/app/presenters/publishing_api/payload_builder/body_headings_test.rb
@@ -36,10 +36,10 @@ module PublishingApi
         assert_equal BodyHeadings.for(item), expected_headers
       end
 
-      test "returns an empty array of headers if none are found in the body" do
+      test "returns empty map if there are no headers in the body" do
         item = stub(body: "Some stuff")
 
-        assert_equal 0, BodyHeadings.for(item)[:headers].count
+        assert_equal BodyHeadings.for(item), {}
       end
     end
   end


### PR DESCRIPTION
We're currently returning an empty array in the `headers` details, but instead we should be returning an empty map as there are no headings present in the body.

Related PR - https://github.com/alphagov/whitehall/pull/10143

Trello card: https://trello.com/c/EKDXTDsm/398-move-document-type-corporateinformationpage-from-government-frontend-to-frontend

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
