### PR TITLE
Surface fixes for link validation errors 2.0

### DIFF
--- a/app/assets/stylesheets/components/_inset-prompt.scss
+++ b/app/assets/stylesheets/components/_inset-prompt.scss
@@ -18,6 +18,8 @@
 .app-c-inset-prompt--error {
   border-color: $govuk-error-colour;
   background-color: govuk-tint($govuk-error-colour, 90%);
+  overflow-wrap: break-word;
+  word-break: break-word;
 }
 
 .app-c-inset-prompt__title {

--- a/app/services/edition_publisher.rb
+++ b/app/services/edition_publisher.rb
@@ -10,9 +10,8 @@ class EditionPublisher < EditionService
 
     reasons = []
     reasons << "This edition is invalid: #{edition.errors.full_messages.to_sentence}" unless edition.valid?
-    if govspeak_link_errors.any?
-      reasons << "This edition contains links which violate linking guidelines."
-      reasons.concat govspeak_link_errors.pluck(:fix).uniq
+    if govspeak_link_validator.errors.any?
+      reasons << "This edition contains links which violate linking guidelines: #{govspeak_link_validator.errors_to_html}"
     end
     reasons << "An edition that is #{edition.current_state} cannot be #{past_participle}" unless can_transition?
     reasons << "Scheduled editions cannot be published. This edition is scheduled for publication on #{edition.scheduled_publication}" if scheduled_for_publication?
@@ -20,8 +19,8 @@ class EditionPublisher < EditionService
     @failure_reasons = reasons
   end
 
-  def govspeak_link_errors
-    @govspeak_link_errors ||= DataHygiene::GovspeakLinkValidator.new(edition.body).errors
+  def govspeak_link_validator
+    @govspeak_link_validator ||= DataHygiene::GovspeakLinkValidator.new(edition.body)
   end
 
   def verb

--- a/app/services/edition_scheduler.rb
+++ b/app/services/edition_scheduler.rb
@@ -25,17 +25,16 @@ class EditionScheduler < EditionService
       reasons << "This edition does not have a scheduled publication date set"
     elsif scheduled_publication_is_not_within_cache_limit?
       reasons << "Scheduled publication date must be at least #{Whitehall.default_cache_max_age / 60} minutes from now"
-    elsif govspeak_link_errors.any?
-      reasons << "This edition contains links which violate linking guidelines."
-      reasons.concat govspeak_link_errors.pluck(:fix).uniq
+    elsif govspeak_link_validator.errors.any?
+      reasons << "This edition contains links which violate linking guidelines: #{govspeak_link_validator.errors_to_html}"
     end
     @failure_reasons = reasons
   end
 
 private
 
-  def govspeak_link_errors
-    @govspeak_link_errors ||= DataHygiene::GovspeakLinkValidator.new(edition.body).errors
+  def govspeak_link_validator
+    @govspeak_link_validator ||= DataHygiene::GovspeakLinkValidator.new(edition.body)
   end
 
   def fire_transition!

--- a/lib/data_hygiene/govspeak_link_validator.rb
+++ b/lib/data_hygiene/govspeak_link_validator.rb
@@ -26,6 +26,27 @@ module DataHygiene
       end
     end
 
+    def errors_to_html
+      link_violations = errors.map do |err|
+        <<~HTML
+          #{err[:link]}
+          <details class="govuk-details" data-module="govuk-details">
+            <summary class="govuk-details__summary">
+              <span class="govuk-details__summary-text">
+                See more details about this link
+              </span>
+            </summary>
+            <div class="govuk-details__text">
+              <p class="govuk-body">
+              #{err[:fix]}
+              </p>
+            </div>
+          </details>
+        HTML
+      end
+      link_violations.join("")
+    end
+
     def self.is_internal_admin_link?(href)
       return false unless href.is_a? String
 

--- a/test/unit/app/services/edition_publisher_test.rb
+++ b/test/unit/app/services/edition_publisher_test.rb
@@ -213,22 +213,24 @@ class EditionPublisherTest < ActiveSupport::TestCase
 
     assert_not publisher.perform!
     assert_not edition.reload.published?
+    # rubocop:disable Style/TrailingCommaInArrayLiteral
     assert_equal [
-      "This edition contains links which violate linking guidelines.",
-      "If you are linking to a document created within Whitehall publisher, please use the internal admin path, e.g. /government/admin/publications/3373. If you are linking to other GOV.UK links, please use full URLs.",
+      <<~HTML
+        This edition contains links which violate linking guidelines: /government/invalid/link
+        <details class="govuk-details" data-module="govuk-details">
+          <summary class="govuk-details__summary">
+            <span class="govuk-details__summary-text">
+              See more details about this link
+            </span>
+          </summary>
+          <div class="govuk-details__text">
+            <p class="govuk-body">
+            If you are linking to a document created within Whitehall publisher, please use the internal admin path, e.g. /government/admin/publications/3373. If you are linking to other GOV.UK links, please use full URLs.
+            </p>
+          </div>
+        </details>
+      HTML
     ], publisher.failure_reasons
-  end
-
-  test "#failure_reasons doesn't return duplicate fixes" do
-    edition = create(:submitted_edition)
-    edition.body = "[blah](/government/invalid/link) [blah](/government/another/invalid/link)"
-    publisher = EditionPublisher.new(edition)
-
-    assert_not publisher.perform!
-    assert_not edition.reload.published?
-    assert_equal [
-      "This edition contains links which violate linking guidelines.",
-      "If you are linking to a document created within Whitehall publisher, please use the internal admin path, e.g. /government/admin/publications/3373. If you are linking to other GOV.UK links, please use full URLs.",
-    ], publisher.failure_reasons
+    # rubocop:enable Style/TrailingCommaInArrayLiteral
   end
 end

--- a/test/unit/app/services/edition_scheduler_test.rb
+++ b/test/unit/app/services/edition_scheduler_test.rb
@@ -56,21 +56,24 @@ class EditionSchedulerTest < ActiveSupport::TestCase
     scheduler = EditionScheduler.new(edition)
 
     assert_not scheduler.can_perform?
+    # rubocop:disable Style/TrailingCommaInArrayLiteral
     assert_equal [
-      "This edition contains links which violate linking guidelines.",
-      "If you are linking to a document created within Whitehall publisher, please use the internal admin path, e.g. /government/admin/publications/3373. If you are linking to other GOV.UK links, please use full URLs.",
+      <<~HTML
+        This edition contains links which violate linking guidelines: /government/invalid/link
+        <details class="govuk-details" data-module="govuk-details">
+          <summary class="govuk-details__summary">
+            <span class="govuk-details__summary-text">
+              See more details about this link
+            </span>
+          </summary>
+          <div class="govuk-details__text">
+            <p class="govuk-body">
+            If you are linking to a document created within Whitehall publisher, please use the internal admin path, e.g. /government/admin/publications/3373. If you are linking to other GOV.UK links, please use full URLs.
+            </p>
+          </div>
+        </details>
+      HTML
     ], scheduler.failure_reasons
-  end
-
-  test "#failure_reasons doesn't return duplicate fixes" do
-    edition = create(:submitted_edition, scheduled_publication: 1.day.from_now)
-    edition.body = "[blah](/government/invalid/link) [blah](/government/another/invalid/link)"
-    scheduler = EditionScheduler.new(edition)
-
-    assert_not scheduler.can_perform?
-    assert_equal [
-      "This edition contains links which violate linking guidelines.",
-      "If you are linking to a document created within Whitehall publisher, please use the internal admin path, e.g. /government/admin/publications/3373. If you are linking to other GOV.UK links, please use full URLs.",
-    ], scheduler.failure_reasons
+    # rubocop:enable Style/TrailingCommaInArrayLiteral
   end
 end


### PR DESCRIPTION
This is the design currently used for the "link checker API" broken
links section of the sidebar, so users are already familiar with it
and it provides a nice way of hiding away the detail until needed.

Before:
![before](https://github.com/user-attachments/assets/7a9a2eb5-35a5-44cc-8d6e-8d2ff59264b7)

After (closed):
![after](https://github.com/user-attachments/assets/6870b0dd-ce3d-42e0-9660-74da15fff8b7)

After (open):
![expanded](https://github.com/user-attachments/assets/5c856a22-19b6-4254-91c9-8569e41245be)

A CSS tweak was required to ensure that long links wrap nicely
in the sidebar, as per the broken links section.

Also removes the "don't show duplicate fixes" logic, as this same
logic isn't applied to the Link Checker API equivalents and there's
no clear user need for hiding the fact that multiple links need
amending.

Unifying the UX for both 'bad links' sections paves the way
forward for consolidating these checks into Link Checker API as
a next step.

Trello: https://trello.com/c/RtFaFX2h/45-whitehall-edition-publishing-and-scheduled-publishing-error-messages-in-the-sidebar

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
