### PR TITLE
Change field_of_operation rendering app to frontend

### DIFF
--- a/app/presenters/publishing_api/operational_field_presenter.rb
+++ b/app/presenters/publishing_api/operational_field_presenter.rb
@@ -21,7 +21,7 @@ module PublishingApi
           document_type: "field_of_operation",
           locale: "en",
           publishing_app: Whitehall::PublishingApp::WHITEHALL,
-          rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
+          rendering_app: Whitehall::RenderingApp::FRONTEND,
           schema_name: "field_of_operation",
           title: operational_field.name,
           update_type:,

--- a/test/unit/app/presenters/publishing_api/operational_field_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/operational_field_presenter_test.rb
@@ -32,7 +32,7 @@ class PublishingApi::OperationalFieldPresenterTest < ActiveSupport::TestCase
       base_path: "/government/fields-of-operation/operational-field-name",
       details: {},
       document_type: "field_of_operation",
-      rendering_app: "government-frontend",
+      rendering_app: "frontend",
       schema_name: "field_of_operation",
       description: Whitehall::GovspeakRenderer.new.govspeak_to_html(@operational_field.description),
       routes: [


### PR DESCRIPTION
As part of app consolidation. See https://github.com/alphagov/frontend/pull/4742