### PR TITLE
allow embedded objects to render if no changes

### DIFF
--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/document_timeline/timeline_item_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/document_timeline/timeline_item_component.rb
@@ -56,7 +56,7 @@ private
 
   def embedded_object_diffs
     schema.subschemas.map { |subschema|
-      version.field_diffs.dig("details", subschema.id).map do |object_id, field_diff|
+      version.field_diffs.dig("details", subschema.id)&.map do |object_id, field_diff|
         { object_id:, field_diff:, subschema_id: subschema.id }
       end
     }.flatten
@@ -85,11 +85,13 @@ private
   end
 
   def embedded_object_field_changes
-    embedded_object_diffs.map do |item|
-      render ContentBlockManager::ContentBlock::Document::Show::DocumentTimeline::EmbeddedObject::FieldChangesTableComponent.new(
-        **item,
-        content_block_edition: version.item,
-      )
+    if embedded_object_diffs.any?
+      embedded_object_diffs.map do |item|
+        render ContentBlockManager::ContentBlock::Document::Show::DocumentTimeline::EmbeddedObject::FieldChangesTableComponent.new(
+          **item,
+          content_block_edition: version.item,
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
https://trello.com/c/UJgdT5Gg/1016-bug-allow-pensionss-without-rates-to-be-edited

if a block with a schema that has embedded objects does not have any embedded objects and is edited,
then we need to be able to render the timeline component.

This change checks `for field_diffs` on any subschemas before trying to map through them.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
