### PR TITLE
Add clarifying help text RE draft editions

### DIFF
--- a/app/views/admin/republishing/confirm_document.html.erb
+++ b/app/views/admin/republishing/confirm_document.html.erb
@@ -7,6 +7,7 @@
   <section class="govuk-grid-column-two-thirds">
     <p class="govuk-body govuk-!-margin-bottom-7">
       This will republish the following editions.
+      Any editions with a "State" of "Draft" will only have their draft content updated and will <strong>not</strong> be published.
     </p>
 
     <%= render "govuk_publishing_components/components/table", {


### PR DESCRIPTION
This came up as a support question earlier:
https://gds.slack.com/archives/C02L13S214K/p1746185637855279

The current interface isn't very clear and could be taken to mean that any affected Draft editions will be published, which is not the case (nor would it be desirable).
![Image](https://github.com/user-attachments/assets/ce67abf6-e8c9-4eb5-87e9-8a5109e207bd)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
