### PR TITLE
(CM-51) Support previewing content blocks in divs

### DIFF
--- a/lib/engines/content_block_manager/app/services/content_block_manager/generate_preview_html.rb
+++ b/lib/engines/content_block_manager/app/services/content_block_manager/generate_preview_html.rb
@@ -72,20 +72,20 @@ module ContentBlockManager
     end
 
     def replace_blocks(nokogiri_html)
-      content_block_spans(nokogiri_html).each do |span|
-        embed_code = span["data-embed-code"]
-        span.replace content_block_edition.render(embed_code)
+      content_block_wrappers(nokogiri_html).each do |wrapper|
+        embed_code = wrapper["data-embed-code"]
+        wrapper.replace content_block_edition.render(embed_code)
       end
     end
 
     def style_blocks(nokogiri_html)
-      content_block_spans(nokogiri_html).each do |span|
-        span["style"] = BLOCK_STYLE
+      content_block_wrappers(nokogiri_html).each do |wrapper|
+        wrapper["style"] = BLOCK_STYLE
       end
     end
 
-    def content_block_spans(nokogiri_html)
-      nokogiri_html.css("span[data-content-id=\"#{@content_block_edition.document.content_id}\"]")
+    def content_block_wrappers(nokogiri_html)
+      nokogiri_html.css("[data-content-id=\"#{@content_block_edition.document.content_id}\"]")
     end
   end
 end

--- a/lib/engines/content_block_manager/test/unit/app/services/generate_preview_html_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/services/generate_preview_html_test.rb
@@ -99,19 +99,26 @@ class ContentBlockManager::GeneratePreviewHtmlTest < ActiveSupport::TestCase
     end
   end
 
+  describe "when the wrapper is a div" do
+    let(:fake_frontend_response) do
+      "<body class=\"govuk-body\"><p>test</p><div class=\"content-embed content-embed__content_block_email_address\" data-content-block=\"\" data-document-type=\"content_block_email_address\" data-embed-code=\"embed-code\" data-content-id=\"#{preview_content_id}\">example@example.com</div></body>"
+    end
+    let(:block_render) do
+      "<div class=\"content-embed content-embed__content_block_email_address\" data-content-block=\"\" data-document-type=\"content_block_email_address\" data-embed-code=\"embed-code\" data-content-id=\"#{preview_content_id}\"><a class=\"govuk-link\" href=\"mailto:new@new.com\">new@new.com</a></div>"
+    end
 
-    url = host_content_preview_content_block_manager_content_block_edition_path(id: block_to_preview.id, host_content_id:)
+    it "returns the preview html" do
+      actual_content = ContentBlockManager::GeneratePreviewHtml.new(
+        content_id: host_content_id,
+        content_block_edition: block_to_preview,
+        base_path: host_base_path,
+        locale: "en",
+      ).call
 
-    expected_content = Nokogiri::HTML.parse("
-        <html>
-          <body class=' draft'>
-            <a href='#{url}?locale=en&base_path=/foo' target='_parent'>Internal link</a>
-            <a href='https://example.com'>External link</a>
-            <a href='//example.com'>Protocol relative link</a>
-          </body>
-        </html>
-      ").to_s
+      parsed_content = Nokogiri::HTML.parse(actual_content)
 
-    assert_equal_ignoring_whitespace actual_content.to_s, expected_content
+      assert_dom parsed_content, "body.draft"
+      assert_dom parsed_content, 'div.content-embed__content_block_email_address[style="background-color: yellow;"]'
+    end
   end
 end

--- a/lib/engines/content_block_manager/test/unit/app/services/generate_preview_html_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/services/generate_preview_html_test.rb
@@ -10,33 +10,28 @@ class ContentBlockManager::GeneratePreviewHtmlTest < ActiveSupport::TestCase
   let(:host_title) { "Test" }
   let(:host_base_path) { "/test" }
   let(:uri_mock) { mock }
+
   let(:fake_frontend_response) do
     "<body class=\"govuk-body\"><p>test</p><span class=\"content-embed content-embed__content_block_email_address\" data-content-block=\"\" data-document-type=\"content_block_email_address\" data-embed-code=\"embed-code\" data-content-id=\"#{preview_content_id}\">example@example.com</span></body>"
   end
   let(:block_render) do
     "<span class=\"content-embed content-embed__content_block_email_address\" data-content-block=\"\" data-document-type=\"content_block_email_address\" data-embed-code=\"embed-code\" data-content-id=\"#{preview_content_id}\"><a class=\"govuk-link\" href=\"mailto:new@new.com\">new@new.com</a></span>"
   end
-  let(:block_render_with_style) do
-    "<span class=\"content-embed content-embed__content_block_email_address\" data-content-block=\"\" data-document-type=\"content_block_email_address\" data-content-id=\"#{preview_content_id}\" data-embed-code=\"embed-code\" style=\"background-color: yellow;\"><a class=\"govuk-link\" href=\"mailto:new@new.com\">new@new.com</a></span>"
-  end
-  let(:expected_html) do
-    "<body class=\"govuk-body draft\"><p>test</p>#{block_render_with_style}</body>"
-  end
-  let(:error_html) do
-    "<html><body class=\" draft\"><p>Preview not found</p></body></html>"
-  end
+
   let(:document) do
     build(:content_block_document, :email_address, content_id: preview_content_id)
   end
+
   let(:block_to_preview) do
     build(:content_block_edition, :email_address, document:, details: { "email_address" => "new@new.com" }, id: 1)
   end
 
+  before do
+    Net::HTTP.stubs(:get).with(URI("#{Plek.website_root}#{host_base_path}")).returns(fake_frontend_response)
+    block_to_preview.stubs(:render).returns(block_render)
+  end
+
   it "returns the preview html" do
-    Net::HTTP.expects(:get).with(URI("#{Plek.website_root}#{host_base_path}")).returns(fake_frontend_response)
-
-    expected_content = Nokogiri::HTML.parse(expected_html).to_s
-
     actual_content = ContentBlockManager::GeneratePreviewHtml.new(
       content_id: host_content_id,
       content_block_edition: block_to_preview,
@@ -44,39 +39,66 @@ class ContentBlockManager::GeneratePreviewHtmlTest < ActiveSupport::TestCase
       locale: "en",
     ).call
 
-    assert_equal expected_content, actual_content
+    parsed_content = Nokogiri::HTML.parse(actual_content)
+
+    assert_dom parsed_content, "body.draft"
+    assert_dom parsed_content, 'span.content-embed__content_block_email_address[style="background-color: yellow;"]'
   end
 
-  it "shows an error template when the request to the frontend throws an error" do
-    exception = StandardError.new("Something went wrong")
-    Net::HTTP.expects(:get).with(URI("#{Plek.website_root}#{host_base_path}")).raises(exception)
+  describe "when the frontend throws an error" do
+    before do
+      exception = StandardError.new("Something went wrong")
+      Net::HTTP.expects(:get).with(URI("#{Plek.website_root}#{host_base_path}")).raises(exception)
+    end
 
-    expected_content = Nokogiri::HTML.parse(error_html).to_s
+    it "shows an error template" do
+      expected_content = Nokogiri::HTML.parse("<html><body class=\" draft\"><p>Preview not found</p></body></html>").to_s
 
-    actual_content = ContentBlockManager::GeneratePreviewHtml.new(
-      content_id: host_content_id,
-      content_block_edition: block_to_preview,
-      base_path: host_base_path,
-      locale: "en",
-    ).call
+      actual_content = ContentBlockManager::GeneratePreviewHtml.new(
+        content_id: host_content_id,
+        content_block_edition: block_to_preview,
+        base_path: host_base_path,
+        locale: "en",
+      ).call
 
-    assert_equal expected_content, actual_content
+      assert_equal expected_content, actual_content
+    end
   end
 
-  it "updates any link paths" do
-    fake_frontend_response = "
+  describe "when the frontend response contains links" do
+    let(:fake_frontend_response) do
+      "
         <a href='/foo'>Internal link</a>
         <a href='https://example.com'>External link</a>
         <a href='//example.com'>Protocol relative link</a>
       "
-    Net::HTTP.expects(:get).with(URI("#{Plek.website_root}#{host_base_path}")).returns(fake_frontend_response)
+    end
 
-    actual_content = ContentBlockManager::GeneratePreviewHtml.new(
-      content_id: host_content_id,
-      content_block_edition: block_to_preview,
-      base_path: host_base_path,
-      locale: "en",
-    ).call
+    it "updates any link paths" do
+      actual_content = ContentBlockManager::GeneratePreviewHtml.new(
+        content_id: host_content_id,
+        content_block_edition: block_to_preview,
+        base_path: host_base_path,
+        locale: "en",
+      ).call
+
+      url = host_content_preview_content_block_manager_content_block_edition_path(id: block_to_preview.id, host_content_id:)
+
+      parsed_content = Nokogiri::HTML.parse(actual_content)
+
+      internal_link = parsed_content.xpath("//a")[0]
+      external_link = parsed_content.xpath("//a")[1]
+      protocol_relative_link = parsed_content.xpath("//a")[2]
+
+      assert_equal internal_link.attribute("href").to_s, "#{url}?locale=en&base_path=/foo"
+      assert_equal internal_link.attribute("target").to_s, "_parent"
+
+      assert_equal external_link.attribute("href").to_s, "https://example.com"
+
+      assert_equal protocol_relative_link.attribute("href").to_s, "//example.com"
+    end
+  end
+
 
     url = host_content_preview_content_block_manager_content_block_edition_path(id: block_to_preview.id, host_content_id:)
 


### PR DESCRIPTION
This updates the HTML preview code to support block-level embeds (divs) as well as inline embeds (spans)

## Screenshots

### Before

![image](https://github.com/user-attachments/assets/f104ee39-ea48-42b1-9798-88b26d544a69)

### After

![image](https://github.com/user-attachments/assets/66f4fd6f-bde7-4e25-8e3d-67394f973857)
