### PR TITLE
(CM-66) Remove nils from `embedded_object_diffs`

### DIFF
--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/document_timeline/timeline_item_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/document_timeline/timeline_item_component.rb
@@ -59,7 +59,7 @@ private
       version.field_diffs.dig("details", subschema.id)&.map do |object_id, field_diff|
         { object_id:, field_diff:, subschema_id: subschema.id }
       end
-    }.flatten
+    }.flatten.compact
   end
 
   def show_details_of_changes?

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/documents/show.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/documents/show.html.erb
@@ -54,7 +54,7 @@
       </div>
       <div class="govuk-grid-column-one-half subschema-listing__create-button-wrapper">
         <%= render "govuk_publishing_components/components/button", {
-          text: "Add a #{subschema.name.singularize.downcase}",
+          text: "Add #{add_indefinite_article subschema.name.singularize.downcase}",
           href: content_block_manager.new_content_block_manager_content_block_document_embedded_object_path(
             @content_block_document,
             object_type: subschema.id,

--- a/lib/engines/content_block_manager/test/components/content_block/document/show/document_timeline/timeline_item_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/document/show/document_timeline/timeline_item_component_test.rb
@@ -165,8 +165,9 @@ class ContentBlockManager::ContentBlock::Document::Show::DocumentTimeline::Timel
   end
 
   describe "when there are embedded objects" do
-    let(:subschema) { stub(:subschema, id: "embedded_schema") }
-    let(:schema) { stub(:schema, subschemas: [subschema]) }
+    let(:subschema1) { stub(:subschema, id: "embedded_schema") }
+    let(:subschema2) { stub(:subschema, id: "other_embedded_schema") }
+    let(:schema) { stub(:schema, subschemas: [subschema1, subschema2]) }
 
     describe "when there are field diffs" do
       let(:field_diffs) do


### PR DESCRIPTION
If there are multiple subschemas for an object, and only one object type has been updated, there is no entry for that subschema in the diff, and we end up trying to cast a `nil` to a hash when initializing the `FieldChangesTableComponent` in line 90.

Simply adding `.compact` to the end of the `map` call removes any nils from the resulting array and allows us to continue error free.

I’ve added multiple subschemas to the tests to reflect this behaviour.