### PR TITLE
Drop 'take_part_pages' table

### DIFF
--- a/db/migrate/20250508154529_drop_take_part_pages_table.rb
+++ b/db/migrate/20250508154529_drop_take_part_pages_table.rb
@@ -1,0 +1,24 @@
+class DropTakePartPagesTable < ActiveRecord::Migration[8.0]
+  def up
+    drop_table :take_part_pages
+  end
+
+  def down
+    create_table "take_part_pages", id: :integer, options: "DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci" do |t|
+      t.string "title", null: false
+      t.string "slug", null: false
+      t.string "summary", null: false
+      t.text "body", limit: 4_294_967_295, null: false # :long corresponds to `longtext` in MySQL
+      t.string "image_alt_text"
+      t.integer "ordering", null: false
+      t.datetime "created_at"
+      t.datetime "updated_at"
+      t.string "content_id"
+    end
+
+    change_table :take_part_pages, bulk: true do |t|
+      t.index :ordering, name: "index_take_part_pages_on_ordering"
+      t.index :slug, name: "index_take_part_pages_on_slug", unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_19_130617) do
+ActiveRecord::Schema[8.0].define(version: 2025_05_08_154529) do
   create_table "assets", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.string "variant", null: false
@@ -1069,20 +1069,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_19_130617) do
     t.index ["slug"], name: "index_statistics_announcements_on_slug"
     t.index ["title"], name: "index_statistics_announcements_on_title"
     t.index ["topic_id"], name: "index_statistics_announcements_on_topic_id"
-  end
-
-  create_table "take_part_pages", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.string "title", null: false
-    t.string "slug", null: false
-    t.string "summary", null: false
-    t.text "body", size: :long, null: false
-    t.string "image_alt_text"
-    t.integer "ordering", null: false
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
-    t.string "content_id"
-    t.index ["ordering"], name: "index_take_part_pages_on_ordering"
-    t.index ["slug"], name: "index_take_part_pages_on_slug", unique: true
   end
 
   create_table "topical_event_about_pages", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|


### PR DESCRIPTION
Dependent on #10188.

Trello: https://trello.com/c/HwMcJkmn/3682-remove-get-involved-section-from-whitehall

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
