### PR TITLE
Remove references to old document hub feature flag

### DIFF
--- a/features/admin-excluded-nations.feature
+++ b/features/admin-excluded-nations.feature
@@ -3,15 +3,9 @@ Feature: Marking a publication with excluded nations
   In order to increase the relevancy of content to users
   I want to be able to exclude content from one or more nation
 
-  Scenario Outline: Creating a new draft publication that applies to multiple nations
+  Scenario: Creating a new draft publication that applies to multiple nations
     Given I am a writer
-    And the document hub feature flag is <document_hub_enabled>
     When I draft a new publication "something" that does not apply to the nations:
       | Scotland | Wales |
     Then the publication should be excluded from these nations:
       | Scotland | Wales |
-
-  Examples:
-    | document_hub_enabled |
-    | enabled |
-    | disabled |

--- a/features/admin-filtering-documents.feature
+++ b/features/admin-filtering-documents.feature
@@ -1,8 +1,7 @@
 Feature: Filtering documents by author in admin
 
-  Scenario Outline: Viewing only documents written by me
+  Scenario: Viewing only documents written by me
     Given I am a writer
-    And the document hub feature flag is <document_hub_enabled>
     And I draft a new publication "My Publication"
     And a draft publication "Another Publication" exists
     And I visit the list of draft documents
@@ -10,11 +9,6 @@ Feature: Filtering documents by author in admin
     When I filter by author "Me"
     Then I should see the publication "My Publication"
     And I should not see the publication "Another Publication"
-
-  Examples:
-    | document_hub_enabled |
-    | enabled |
-    | disabled |
 
   Scenario: Viewing only publications written by me
     Given I am a writer

--- a/features/admin-statistical-data-sets.feature
+++ b/features/admin-statistical-data-sets.feature
@@ -3,14 +3,8 @@ Feature: Adding stastical data set references to a publication
   In order to reference relevant stastics
   I want to be able to add those references to a publication
 
-  Scenario Outline: Creating a new draft publication that references statistical data sets
+  Scenario: Creating a new draft publication that references statistical data sets
     Given I am an editor
-    And the document hub feature flag is <document_hub_enabled>
     And a published statistical data set "Historical Beard Lengths"
     When I draft a new publication "Beard Lengths 2012" referencing the data set "Historical Beard Lengths"
     Then the publication should reference the "Historical Beard Lengths" data set
-
-  Examples:
-    | document_hub_enabled |
-    | enabled |
-    | disabled |

--- a/features/admin-world-locations.feature
+++ b/features/admin-world-locations.feature
@@ -3,14 +3,8 @@ Feature: Tagging world locations to publications
   In order to show which location a publication is about
   I want to be able to tag world locations to publications
 
-  Scenario Outline: The publication is about a country
+  Scenario: The publication is about a country
     Given I am an editor
-    And the document hub feature flag is <document_hub_enabled>
     And a world location "British Antarctic Territory" exists
     When I draft a new publication "Penguins have rights too" about the world location "British Antarctic Territory"
     Then the publication should be about the "British Antarctic Territory" world location
-
-  Examples:
-    | document_hub_enabled |
-    | enabled |
-    | disabled |

--- a/features/edition-attachments.feature
+++ b/features/edition-attachments.feature
@@ -4,9 +4,8 @@ Feature: Managing attachments on editions
   I want to attach files and additional HTML content to publications and consultations
   In order to support the publications and consultations with statistics and other relevant documents
 
-  Scenario Outline: Adding and reordering attachments
+  Scenario: Adding and reordering attachments
     Given I am an writer
-    And the document hub feature flag is <document_hub_enabled>
     And I start drafting a new publication "Standard Beard Lengths"
     When I start editing the attachments from the publication page
     And I upload a file attachment with the title "Beard Length Statistics 2014" and the file "dft_statistical_data_set_sample.csv"
@@ -24,14 +23,8 @@ Feature: Managing attachments on editions
       | Beard Length Statistics 2014 |
       | Beard Length Illustrations   |
 
-  Examples:
-    | document_hub_enabled |
-    | enabled |
-    | disabled |
-
-  Scenario Outline: Previewing HTML attachment
+  Scenario: Previewing HTML attachment
     Given I am an writer
-    And the document hub feature flag is <document_hub_enabled>
     And I start drafting a new publication "Standard Beard Lengths"
     When I start editing the attachments from the publication page
     And I begin editing an html attachment with the title "Beard Length Graphs 2012" and the body "Example text"
@@ -41,11 +34,6 @@ Feature: Managing attachments on editions
     And I can see the preview link to the attachment "HTML attachment"
     When I edit the attachment
     Then I can see a preview link
-
-  Examples:
-    | document_hub_enabled |
-    | enabled |
-    | disabled |
 
   Scenario: Previewing HTML attachment on consultation responses
     Given I am a writer
@@ -67,17 +55,11 @@ Feature: Managing attachments on editions
     And I upload a file attachment with the title "Beard Length Statistics 2014" and the file "dft_statistical_data_set_sample.csv"
     Then the outcome for the consultation should have the attachment "Beard Length Statistics 2014"
 
-  Scenario Outline: Attempting to save attachment after validation failure
+  Scenario: Attempting to save attachment after validation failure
     Given I am a writer
-    And the document hub feature flag is <document_hub_enabled>
     And a draft publication "Standards on Beard Grooming" exists
     When I try and upload an attachment but there are validation errors
     Then I should be able to submit the attachment without re-uploading the file
-
-  Examples:
-    | document_hub_enabled |
-    | enabled |
-    | disabled |
 
   Scenario: Attempting to publish attachment which is still being uploaded to the asset manager
     Given I am an editor
@@ -87,16 +69,10 @@ Feature: Managing attachments on editions
     And I try to publish the draft edition
     Then I see a validation error for uploading attachments
 
-  Scenario Outline: Editing metadata on attachments
+  Scenario: Editing metadata on attachments
     Given I am an writer
-    And the document hub feature flag is <document_hub_enabled>
     And I start drafting a new publication "Standard Beard Lengths"
     When I start editing the attachments from the publication page
     And I upload an html attachment with the title "Beard Length Graphs 2012" and the isbn "9781474127783"
     And I publish the draft edition for publication "Standard Beard Lengths"
     Then the html attachment "Beard Length Graphs 2012" includes the isbn "9781474127783"
-
-  Examples:
-    | document_hub_enabled |
-    | enabled |
-    | disabled |

--- a/features/force-publishing-editions.feature
+++ b/features/force-publishing-editions.feature
@@ -4,25 +4,13 @@ Feature: Force Publishing editions
     Given I am an editor
 
   @not-quite-as-fake-search
-  Scenario Outline: Force-publishing a submitted edition
+  Scenario: Force-publishing a submitted edition
     Given I draft a new publication "Ban Beards"
-    And the document hub feature flag is <document_hub_enabled>
     When I force publish the publication "Ban Beards"
     Then the publication "Ban Beards" should have a force publish reason
 
-  Examples:
-    | document_hub_enabled |
-    | enabled |
-    | disabled |
-
-  Scenario Outline: Retrospective second-pair of eyes
+  Scenario: Retrospective second-pair of eyes
     Given I draft a new publication "Ban Beards"
-    And the document hub feature flag is <document_hub_enabled>
     And I force publish the publication "Ban Beards"
     When another editor retrospectively approves the "Ban Beards" publication
     Then the "Ban Beards" publication should not be flagged as force-published any more
-
-  Examples:
-    | document_hub_enabled |
-    | enabled |
-    | disabled |

--- a/features/preview-unpublished-editions.feature
+++ b/features/preview-unpublished-editions.feature
@@ -1,24 +1,12 @@
 Feature: Previewing unpublished editions
 
-  Scenario Outline: Unpublished editions link to preview
+  Scenario: Unpublished editions link to preview
     Given I am an editor
-    And the document hub feature flag is <document_hub_enabled>
     When I draft a new publication "Test publication"
     Then I should see a link to the preview version of the publication "Test publication"
 
-    Examples:
-      | document_hub_enabled |
-      | enabled |
-      | disabled |
-
-  Scenario Outline: Unpublished editions link to preview from the edit page
+  Scenario: Unpublished editions link to preview from the edit page
     Given I am an editor
-    And the document hub feature flag is <document_hub_enabled>
     When I draft a new publication "Test publication"
     When I am on the edit page for publication "Test publication"
     Then I should see a link to the preview version of the publication "Test publication"
-
-    Examples:
-      | document_hub_enabled |
-      | enabled |
-      | disabled |

--- a/features/publications.feature
+++ b/features/publications.feature
@@ -6,33 +6,21 @@ Feature: Publications
   Background:
     Given I am a writer
 
-  Scenario Outline: Creating a new draft publication
+  Scenario: Creating a new draft publication
     When I draft a new publication "Standard Beard Lengths"
-    And the document hub feature flag is <document_hub_enabled>
     Then I should see the publication "Standard Beard Lengths" in the list of draft documents
-
-    Examples:
-      | document_hub_enabled |
-      | enabled |
-      | disabled |
 
   Scenario: Submitting a draft publication to a second pair of eyes
     Given a draft publication "Standard Beard Lengths" exists
     When I submit the publication "Standard Beard Lengths"
     Then I should see the publication "Standard Beard Lengths" in the list of submitted documents
 
-  Scenario Outline: Publishing an edition I submitted is forbidden
+  Scenario: Publishing an edition I submitted is forbidden
     Given I am an editor
-    And the document hub feature flag is <document_hub_enabled>
     And there is a user called "Beardy"
     And "Beardy" drafts a new publication "Britain's Hairiest Ministers"
     When I submit the publication "Britain's Hairiest Ministers"
     Then I should not be able to publish the publication "Britain's Hairiest Ministers"
-
-    Examples:
-      | document_hub_enabled |
-      | enabled |
-      | disabled |
 
   @not-quite-as-fake-search
   Scenario: Publishing an edition I created but did not submit

--- a/features/step_definitions/document_steps.rb
+++ b/features/step_definitions/document_steps.rb
@@ -158,8 +158,3 @@ When(/^I check "([^"]*)" adheres to the consultation principles$/) do |title|
   edition.read_consultation_principles = true
   edition.save!
 end
-
-When(/^the document hub feature flag is (enabled|disabled)$/) do |document_hub_enabled|
-  @test_strategy ||= Flipflop::FeatureSet.current.test!
-  @test_strategy.switch!(:document_hub_enabled, document_hub_enabled == "enabled")
-end


### PR DESCRIPTION
This feature flag was removed some time ago, so I'm quite surprised these tests were still passing. Obviously flipflop doesn't enforce that a feature flag actually exists when you attempt to switch it on 🤔 
