### PR TITLE
Add labeler action

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,4 @@
+# Add 'Content Modelling' label to any changes within the content_block_manager engine
+Content Modelling:
+- changed-files:
+    - any-glob-to-any-file: lib/engines/content_block_manager/**

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,14 @@
+name: "Pull Request Labeler"
+on:
+  - pull_request_target
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          repo-token: ${{ secrets.GOVUK_CI_GITHUB_API_TOKEN }}


### PR DESCRIPTION
This automatically labels any PRs that have changes to files in the content_block_manager engine with the `Content Modelling` label using the [official Github Labeler action](https://github.com/actions/labeler)