### PR TITLE
Update detailed guide to include body headings

### DIFF
--- a/app/presenters/publishing_api/detailed_guide_presenter.rb
+++ b/app/presenters/publishing_api/detailed_guide_presenter.rb
@@ -73,6 +73,7 @@ module PublishingApi
       details_hash.merge!(PayloadBuilder::TagDetails.for(item))
       details_hash.merge!(PayloadBuilder::FirstPublicAt.for(item))
       details_hash.merge!(PayloadBuilder::Attachments.for(item))
+      details_hash.merge!(PayloadBuilder::BodyHeadings.for(item))
     end
 
     def body

--- a/test/unit/app/presenters/publishing_api/detailed_guide_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/detailed_guide_presenter_test.rb
@@ -88,6 +88,42 @@ class PublishingApi::DetailedGuidePresenterTest < ActiveSupport::TestCase
     assert_equal detailed_guide.document.content_id, presented_item.content_id
   end
 
+  test "DetailedGuide includes headers when headers are present in body" do
+    detailed_guide = create(
+      :detailed_guide,
+      title: "Some detailed guide",
+      summary: "Some summary",
+      body: "##Some header\n\nSome content",
+    )
+
+    presented_item = present(detailed_guide)
+    details = presented_item.content[:details]
+
+    expected_headers = [
+      {
+        text: "Some header",
+        level: 2,
+        id: "some-header",
+      },
+    ]
+
+    assert_equal expected_headers, details[:headers]
+  end
+
+  test "DetailedGuide does not include headers when headers are not present in body" do
+    detailed_guide = create(
+      :published_detailed_guide,
+      title: "Some detailed guide",
+      summary: "Some summary",
+      body: "Some content",
+    )
+
+    presented_item = present(detailed_guide)
+    details = presented_item.content[:details]
+
+    assert_nil details[:headers]
+  end
+
   test "DetailedGuide presents related mainstream in links and details" do
     lookup_hash = {
       "/mainstream-content" => "9dd9e077-ae45-45f6-ad9d-2a484e5ff312",


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## What

To include `BodyHeadings` as part of payload in `detailed_guide_presenter`.

[Related PR in publishing-api](https://github.com/alphagov/publishing-api/pull/3320) which introduces this change and updates `detailed_guide` schemas.

## Why

As part of app consolidation, `detailed_guide` is being migrated from Government-frontend to Frontend. To present the headers in the contents list , we implement this approach as already done in [corporate information pages](https://github.com/alphagov/whitehall/pull/10143). 

Trello card: https://trello.com/c/8HsfHbJ6