### PR TITLE
(CM-115) Move calculation of value to the FormComponent

### DIFF
--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/base_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/base_component.rb
@@ -6,7 +6,7 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::BaseComponent <
   def initialize(content_block_edition:, field:, value: nil, object_id: nil)
     @content_block_edition = content_block_edition
     @field = field
-    @value = value || content_block_edition.details&.fetch(field.name, nil)
+    @value = value
     @object_id = object_id
   end
 

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/form_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/form_component.rb
@@ -20,6 +20,7 @@ private
     {
       content_block_edition:,
       field:,
+      value: content_block_edition.details&.fetch(field.name, nil),
     }
   end
 end

--- a/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/string_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/string_component_test.rb
@@ -21,17 +21,20 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::StringComponent
     assert_selector "input[type=\"text\"][name=\"#{expected_name}\"][id=\"#{expected_id}\"]"
   end
 
-  it "should show the value when present" do
-    content_block_edition.details = { "email_address": "example@example.com" }
-
+  it "should show the value when provided" do
     render_inline(
       ContentBlockManager::ContentBlockEdition::Details::Fields::StringComponent.new(
         content_block_edition:,
         field:,
+        value: "example@example.com",
       ),
     )
 
     assert_selector 'input[value="example@example.com"]'
+  end
+
+  it "should show the value from an embedded object" do
+    content_block_edition.details = { "description": "example@example.com" }
   end
 
   it "should show errors when present" do


### PR DESCRIPTION
This removes the setting of the default value from the base component to the form component. Before, if an embedded object contains a field with the same name as the parent field and the embedded object doesn’t have a value, then the value would be set to the value of the parent field, which we don’t want.