### PR TITLE
Fix draft creation to check for clone attachment validity

### DIFF
--- a/app/models/concerns/attachable.rb
+++ b/app/models/concerns/attachable.rb
@@ -35,8 +35,9 @@ module Attachable
       add_trait do
         def process_associations_after_save(edition)
           @edition.attachments.each do |attachment|
-            edition.attachments << attachment.deep_clone
-            raise "Your edition failed to create successfully. Please contact GOV.UK support." unless attachment.save!
+            draft_attachment = attachment.deep_clone
+            edition.attachments << draft_attachment
+            raise "Your edition failed to create successfully. Please contact GOV.UK support." unless draft_attachment.save!
           end
         end
       end

--- a/test/integration/workers/publishing_api_document_republishing_worker_integration_test.rb
+++ b/test/integration/workers/publishing_api_document_republishing_worker_integration_test.rb
@@ -107,7 +107,7 @@ class PublishingApiDocumentRepublishingWorkerIntegrationTest < ActiveSupport::Te
     end
 
     test "Should only publish live edition when document is published with invalid draft" do
-      edition = build(:published_publication)
+      edition = create(:published_publication)
       draft_edition = edition.create_draft(build(:user))
       draft_edition.title = nil
       draft_edition.save!(validate: false)
@@ -181,7 +181,7 @@ class PublishingApiDocumentRepublishingWorkerIntegrationTest < ActiveSupport::Te
     end
 
     test "Should unpublish live edition and update draft when document is unpublished with new draft" do
-      unpublishing = build(:unpublishing, redirect: false)
+      unpublishing = create(:unpublishing, redirect: false)
       edition = build(:unpublished_publication, unpublishing:)
       with_locale(:es) { edition.title = "spanish-title" }
       edition.save!
@@ -226,8 +226,8 @@ class PublishingApiDocumentRepublishingWorkerIntegrationTest < ActiveSupport::Te
     end
 
     test "Should only unpublish live edition when document is unpublished with invalid draft" do
-      unpublishing = build(:unpublishing, redirect: false)
-      edition = build(:unpublished_publication, unpublishing:)
+      unpublishing = create(:unpublishing, redirect: false)
+      edition = create(:unpublished_publication, unpublishing:)
       draft_edition = edition.create_draft(build(:user))
       draft_edition.title = nil
       draft_edition.save!(validate: false)


### PR DESCRIPTION
Previously we seem to be checking for existing attachment save! as opposed to the newly cloned attachment for the new draft. Whilst debugging a ZenDesk ticket: https://govuk.zendesk.com/agent/tickets/6122813 we find that original attachment can return valid, but the newly cloned attachment fails validation and does not save. The save fails silently and the attachment is removed from the edition.

In doing this, some integration tests are failing because editions are `built` in the tests, not `created`. With the previous code, since we are saving the original edition attachment, that saves the edition to the database and commits the document. With this no longer there, document does not exist for the presenter to read content_id out of, hence the test fail. We need to create the editions for tests to run.

It is now surfacing an error when you try to create a new edition and html attachments fail to clone
<img width="1199" alt="image" src="https://github.com/user-attachments/assets/4ec51d85-0abb-4695-8984-73f269e02765" />


https://trello.com/c/DICxbdzx/3730-html-attachment-gets-lost-when-creating-new-edition

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
