### PR TITLE
(CM-52) Create an embed code for an entire contact

### DIFF
--- a/docs/content_block_manager/configuration.md
+++ b/docs/content_block_manager/configuration.md
@@ -11,6 +11,15 @@ Made up of one or more schemas, as defined by [`schemas.<schema_name>`](#schemas
 
 An object that defines a schema
 
+## Properties
+
+- [embeddable_as_block](#schemasschema_nameembeddable_as_block)
+- [subschemas](#schemasschema_namesubschemas)
+
+## `schemas.<schema_name>.embeddable_as_block`
+
+This defines if a subschema is embeddable as an entire block.
+
 ## `schemas.<schema_name>.subschemas`
 
 A list of [subschemas](#schemasschema_namesubschemassubschema_name) for a specific object

--- a/lib/engines/content_block_manager/app/assets/stylesheets/content_block_manager/application.scss
+++ b/lib/engines/content_block_manager/app/assets/stylesheets/content_block_manager/application.scss
@@ -1,5 +1,6 @@
 @import "components/embedded-objects-blocks-component";
 @import "components/embedded-objects-metadata-component";
+@import "components/default-block-component";
 @import "components/filter-options-component";
 @import "components/host-editions-rollup-component";
 @import "components/host-editions-table-component";

--- a/lib/engines/content_block_manager/app/assets/stylesheets/content_block_manager/components/_default-block-component.scss
+++ b/lib/engines/content_block_manager/app/assets/stylesheets/content_block_manager/components/_default-block-component.scss
@@ -1,0 +1,20 @@
+.app-c-content-block-manager-default-block {
+  .govuk-summary-list__row {
+    border: none;
+
+    .govuk-summary-list__key {
+      // Hide the key in the summary list, while keeping it readable for screen reader users
+      @include govuk-visually-hidden;
+      width: 0;
+      position: relative !important;
+    }
+
+    .govuk-summary-list__value {
+      padding: 0;
+    }
+  }
+
+  &__embed_code {
+    color: $govuk-secondary-text-colour;
+  }
+}

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/default_block_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/default_block_component.html.erb
@@ -1,0 +1,16 @@
+<div class="app-c-content-block-manager-default-block">
+  <%= render "govuk_publishing_components/components/summary_card", {
+    title: "Default block",
+    rows: [
+      {
+        key: "Block content",
+        value: block_content,
+        data: data_attributes,
+      },
+      {
+        key: "Embed code",
+        value: embed_code_row_value,
+      },
+    ],
+  } %>
+</div>

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/default_block_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/default_block_component.rb
@@ -1,0 +1,34 @@
+class ContentBlockManager::ContentBlock::Document::Show::DefaultBlockComponent < ViewComponent::Base
+  def initialize(content_block_document:)
+    @content_block_document = content_block_document
+  end
+
+private
+
+  attr_reader :content_block_document
+
+  def content_block_edition
+    @content_block_edition = content_block_document.latest_edition
+  end
+
+  def block_content
+    content_tag(:div, class: "govspeak") do
+      content_block_edition.render(embed_code)
+    end
+  end
+
+  def embed_code_row_value
+    content_tag(:p, embed_code, class: "app-c-content-block-manager-default-block__embed_code")
+  end
+
+  def embed_code
+    @embed_code ||= content_block_document.embed_code
+  end
+
+  def data_attributes
+    {
+      module: "copy-embed-code",
+      "embed-code": embed_code,
+    }
+  end
+end

--- a/lib/engines/content_block_manager/app/models/content_block_manager/content_block/schema.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/content_block/schema.rb
@@ -77,6 +77,10 @@ module ContentBlockManager
         config["embeddable_fields"] || []
       end
 
+      def embeddable_as_block?
+        config["embeddable_as_block"].present?
+      end
+
       def config
         @config ||= self.class.schema_settings.dig("schemas", @id) || {}
       end

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/documents/show.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/documents/show.html.erb
@@ -46,6 +46,18 @@
   </div>
 </div>
 
+<% if @schema.embeddable_as_block? %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <%= render(
+            ContentBlockManager::ContentBlock::Document::Show::DefaultBlockComponent.new(
+              content_block_document: @content_block_document,
+              ),
+            ) %>
+    </div>
+  </div>
+<% end %>
+
 <% grouped_subschemas(@schema).each do |group, subschemas| %>
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/lib/engines/content_block_manager/config/content_block_manager.yml
+++ b/lib/engines/content_block_manager/config/content_block_manager.yml
@@ -10,6 +10,7 @@ schemas:
           - frequency
           - description
   content_block_contact:
+    embeddable_as_block: true
     subschemas:
       email_addresses:
         group: modes

--- a/lib/engines/content_block_manager/test/components/content_block/edition/show/default_block_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/show/default_block_component_test.rb
@@ -1,0 +1,26 @@
+require "test_helper"
+
+class ContentBlockManager::ContentBlockEdition::Show::DefaultBlockComponentTest < ViewComponent::TestCase
+  extend Minitest::Spec::DSL
+
+  let(:content_block_edition) { build(:content_block_edition, :pension) }
+  let(:content_block_document) { build(:content_block_document, :pension) }
+
+  let(:embed_code) { "EMBED_CODE" }
+  let(:default_block_output) { "DEFAULT_BLOCK_OUTPUT" }
+
+  before do
+    content_block_document.stubs(:latest_edition).returns(content_block_edition)
+    content_block_document.stubs(:embed_code).returns(embed_code)
+    content_block_edition.stubs(:render).with(embed_code).returns(default_block_output)
+  end
+
+  it "renders the default block" do
+    render_inline(
+      ContentBlockManager::ContentBlock::Document::Show::DefaultBlockComponent.new(content_block_document:),
+    )
+
+    assert_selector ".govuk-summary-list__row[data-module=\"copy-embed-code\"][data-embed-code=\"#{embed_code}\"] .govuk-summary-list__value .govspeak", text: default_block_output
+    assert_selector ".govuk-summary-list__value .app-c-content-block-manager-default-block__embed_code", text: embed_code
+  end
+end

--- a/lib/engines/content_block_manager/test/support/integration_test_helpers.rb
+++ b/lib/engines/content_block_manager/test/support/integration_test_helpers.rb
@@ -17,6 +17,7 @@ module ContentBlockManager::IntegrationTestHelpers
       permitted_params: %i[foo bar],
       subschemas:,
       embeddable_fields: [],
+      embeddable_as_block?: false,
     )
     subschemas.each do |subschema|
       schema.stubs(:subschema).with(subschema.id).returns(subschema)

--- a/lib/engines/content_block_manager/test/unit/app/models/content_block_schema_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/models/content_block_schema_test.rb
@@ -360,4 +360,40 @@ class ContentBlockManager::SchemaTest < ActiveSupport::TestCase
       assert_equal schema.subschemas_for_group("group_2"), []
     end
   end
+
+  describe "#embeddable_as_block?" do
+    describe "when the embeddable_as_block config value is set" do
+      before do
+        ContentBlockManager::ContentBlock::Schema
+          .stubs(:schema_settings)
+          .returns({
+            "schemas" => {
+              schema.id => {
+                "embeddable_as_block" => true,
+              },
+            },
+          })
+      end
+
+      it "returns true" do
+        assert schema.embeddable_as_block?
+      end
+    end
+
+    describe "when the embeddable_as_block config value is not set" do
+      before do
+        ContentBlockManager::ContentBlock::Schema
+          .stubs(:schema_settings)
+          .returns({
+            "schemas" => {
+              schema.id => {},
+            },
+          })
+      end
+
+      it "returns false" do
+        assert_not schema.embeddable_as_block?
+      end
+    end
+  end
 end


### PR DESCRIPTION
This allows us to show a summary card for an entire content block, if a config var is set

## Screenshot

![image](https://github.com/user-attachments/assets/d3e08657-074e-44ef-b217-ae2555a0e608)
