### PR TITLE
Remove `analytics-ga4` from `application.js`

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,6 +1,7 @@
 //= link_tree ../images
 //= link_tree ../builds
 //= link application.js
+//= link test-dependencies.js
 //= link admin/domain-config.js
 //= link es6-components.js
 //= link components/visual-editor.js

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,7 +1,6 @@
 //= require admin/stop-scripts-nomodule
 
 //= require govuk_publishing_components/dependencies
-//= require govuk_publishing_components/analytics-ga4
 //= require govuk_publishing_components/components/accordion
 //= require govuk_publishing_components/components/add-another
 //= require govuk_publishing_components/components/copy-to-clipboard

--- a/app/assets/javascripts/test-dependencies.js
+++ b/app/assets/javascripts/test-dependencies.js
@@ -1,0 +1,1 @@
+//= require govuk_publishing_components/analytics-ga4

--- a/spec/support/jasmine-browser.json
+++ b/spec/support/jasmine-browser.json
@@ -1,6 +1,7 @@
 {
   "srcDir": "public/assets/whitehall",
   "srcFiles": [
+    "test-dependencies-*.js",
     "application-*.js",
     "all-*.js"
   ],


### PR DESCRIPTION
## What

- Remove `analytics-ga4.js` from `application.js`
- Add `test-dependencies.js` 
- Update `manifest.js` and `jasmine-browser.json` to use `test-dependencies.js`

## Why

`analytics-ga4.js` is already included in `load-analytics.js` from `govuk_publishing_components`.

### Difference in `application.js` file size

| Before  | After |
| ------------- | ------------- |
| 298kb  | 252kb  |

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
