### PR TITLE
Remove temporary rake task to remove Topical Events finder

### DIFF
--- a/lib/tasks/publish_finders.rake
+++ b/lib/tasks/publish_finders.rake
@@ -8,18 +8,4 @@ namespace :finders do
       PublishFinder.call(content_item)
     end
   end
-
-  desc "Unpublish topical events finder to the publishing API"
-  task unpublish: :environment do
-    Services.publishing_api.unpublish(
-      "b39c6645-c85f-44e4-b581-dbca52c59c70",
-      type: "redirect",
-      alternative_path: "/",
-      discard_drafts: true,
-    )
-
-    puts "Finder unpublished"
-  rescue GdsApi::HTTPServerError => e
-    puts "Error unpublishing finder: #{e.inspect}"
-  end
 end


### PR DESCRIPTION
## What
Remove the temporary rake task which removes the Topical Events finder - reverts https://github.com/alphagov/whitehall/pull/10215/commits/ec623a37fac0fd040ef8277dd1a78e43839e50a8

## Why
This rake task has been successfully run in production and is no longer needed.

Trello card: https://trello.com/c/UIgbls0C/486-retire-topical-events-finder

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
