### PR TITLE
Track non-`flash` error messages when editing an edition

### DIFF
--- a/app/assets/javascripts/admin/views/broken-links-report.js
+++ b/app/assets/javascripts/admin/views/broken-links-report.js
@@ -94,6 +94,19 @@ window.GOVUK.Modules = window.GOVUK.Modules || {}
   BrokenLinksReport.prototype.replaceContents = function (html) {
     this.module.innerHTML = html
     this.module.firstChild.outerHTML = this.module.firstChild.innerHTML
+
+    // auto tracker will not track if page is already loaded
+    // but `data-ga4-auto` will have the attributes to use
+    // for the event (if it exists)
+    const autoTracker = this.module.querySelector('[data-ga4-auto]')
+
+    if (autoTracker) {
+      const autoTrackerData = autoTracker.dataset.ga4Auto
+      window.GOVUK.analyticsGa4.core.applySchemaAndSendData(
+        JSON.parse(autoTrackerData),
+        'event_data'
+      )
+    }
   }
 
   Modules.BrokenLinksReport = BrokenLinksReport

--- a/app/services/edition_publisher.rb
+++ b/app/services/edition_publisher.rb
@@ -19,6 +19,10 @@ class EditionPublisher < EditionService
     @failure_reasons = reasons
   end
 
+  def failure_reasons_plaintext
+    failure_reasons.map { |reason| ActionController::Base.helpers.strip_tags(reason).gsub(/\s+/, " ") }.join(", ")
+  end
+
   def govspeak_link_validator
     @govspeak_link_validator ||= DataHygiene::GovspeakLinkValidator.new(edition.body)
   end

--- a/app/services/edition_scheduler.rb
+++ b/app/services/edition_scheduler.rb
@@ -31,6 +31,10 @@ class EditionScheduler < EditionService
     @failure_reasons = reasons
   end
 
+  def failure_reasons_plaintext
+    failure_reasons.map { |reason| ActionController::Base.helpers.strip_tags(reason).gsub(/\s+/, " ") }.join(", ")
+  end
+
 private
 
   def govspeak_link_validator

--- a/app/views/admin/editions/show/_main_notices.html.erb
+++ b/app/views/admin/editions/show/_main_notices.html.erb
@@ -1,5 +1,19 @@
+<%
+  ga4_auto_attributes = {
+    event_name: "mid_page_error",
+    action: "error",
+  }
+%>
+
 <% if edition.rejected? %>
   <%= render "/components/inset_prompt", {
+    data_attributes: {
+      module: "ga4-auto-tracker",
+      ga4_auto: {
+        type: "rejected",
+        text: "Rejected by [author] - check the internal note in the document history for the reason.",
+      }.merge(ga4_auto_attributes).as_json,
+    },
     description: sanitize("Rejected by #{linked_author(edition.rejected_by, class: "govuk-link")} - check the internal note in the document history for the reason."),
     error: true,
   } %>
@@ -8,6 +22,13 @@
 <% if edition.force_published? %>
   <%= render "/components/inset_prompt", {
     title: "This edition was force published and has not yet been reviewed by a second pair of eyes",
+    data_attributes: {
+      module: "ga4-auto-tracker",
+      ga4_auto: {
+        type: "rejected",
+        text: "This edition was force published and has not yet been reviewed by a second pair of eyes",
+      }.merge(ga4_auto_attributes).as_json,
+    },
     description: capture do %>
       <% if can?(:approve, edition) %>
         <p class="govuk-body"><%= link_to "View this on the website", edition.public_url(draft: true), class: "govuk-link", target: "_blank", rel: "noopener" %> and check everything thoroughly.</p>

--- a/app/views/admin/editions/show/_sidebar_history_state.html.erb
+++ b/app/views/admin/editions/show/_sidebar_history_state.html.erb
@@ -20,6 +20,15 @@
   <% else %>
     <%= render "components/inset_prompt", {
       title: "This edition has been superseded",
+      data_attributes: {
+        module: "ga4-auto-tracker",
+        ga4_auto: {
+          type: "edition superseded",
+          text: "This edition has been superseded",
+          event_name: "side_bar_error",
+          action: "error",
+        }
+      },
       description: capture do %>
         <%= render "govuk_publishing_components/components/button", {
           text: "Go to most recent edition",

--- a/app/views/admin/editions/show/_sidebar_notices.html.erb
+++ b/app/views/admin/editions/show/_sidebar_notices.html.erb
@@ -1,8 +1,22 @@
+<%
+  ga4_auto_attributes = {
+    event_name: "side_bar_error",
+    action: "error",
+  }
+%>
+
 <div class="app-view-summary__sidebar-notices">
   <% if @edition.scheduled_publication %>
     <% if force_scheduler.can_transition? && !force_scheduler.can_perform? %>
       <%= render "components/inset_prompt", {
         title: "This edition cannot be scheduled",
+        data_attributes: {
+          module: "ga4-auto-tracker",
+          ga4_auto: {
+            type: "scheduled",
+            text: force_scheduler.failure_reasons_plaintext,
+          }.merge(ga4_auto_attributes).as_json,
+        },
         description: render("govuk_publishing_components/components/list", {
           visible_counters: true,
           items: force_scheduler.failure_reasons,
@@ -14,6 +28,14 @@
     <% if force_publisher.can_transition? && !force_publisher.can_perform? %>
       <%= render "components/inset_prompt", {
         title: "This edition cannot be force-published",
+        module: "ga4-auto-tracker",
+        data_attributes: {
+          module: "ga4-auto-tracker",
+          ga4_auto: {
+            type: "force published",
+            text: force_scheduler.failure_reasons_plaintext,
+          }.merge(ga4_auto_attributes).as_json,
+        },
         description: render("govuk_publishing_components/components/list", {
           visible_counters: true,
           items: force_publisher.failure_reasons,
@@ -24,6 +46,13 @@
   <% end %>
   <% if show_similar_slugs_warning?(@edition) %>
     <%= render "components/inset_prompt", {
+      data_attributes: {
+        module: "ga4-auto-tracker",
+        ga4_auto: {
+          type: "show similar slugs warning",
+          text: "This title has been used before on GOV.UK, although the page may no longer exist. Please use another title.",
+        }.merge(ga4_auto_attributes).as_json,
+      },
       description: "This title has been used before on GOV.UK, although the page may no longer exist. Please use another title.",
       error: true,
     } %>

--- a/app/views/admin/link_check_reports/_link_check_report.html.erb
+++ b/app/views/admin/link_check_reports/_link_check_report.html.erb
@@ -24,56 +24,68 @@
       <% end
     } %>
   <% elsif report.danger_links.any? || report.broken_links.any? || report.caution_links.any? %>
+
+    <% description = capture do %>
+      <%
+        status_order = { "danger" => 1, "broken" => 2, "caution" => 3 }
+        report.links.sort_by { |link| status_order[link.status] || 9999 }.group_by(&:status).each do |status, links|
+      %>
+        <% next unless %w(danger broken caution).include? status %>
+
+        <p class="govuk-body"><%= t "broken_links.#{status}.subheading" %></p>
+
+        <ul class="govuk-list app-view-summary__broken-links-report">
+          <% links.each do |link| %>
+            <li>
+              <% if link.status == "danger" %>
+                <%= link.uri %>
+              <% else %>
+                <%= link_to link.uri.truncate(50), link.uri, title: link.uri, class: "govuk-link" %>
+              <% end %>
+              <details class="govuk-details" data-module="govuk-details">
+                <summary class="govuk-details__summary">
+                  <span class="govuk-details__summary-text">
+                    See more details about this link
+                  </span>
+                </summary>
+                <div class="govuk-details__text">
+                  <p class="govuk-body">
+                    <%= link.problem_summary %>: <%= link.check_details %>
+                  </p>
+                  <% if link.suggested_fix %>
+                    <p class="govuk-body">Suggested fix: <%= link.suggested_fix %></p>
+                  <% end %>
+                </div>
+              </details>
+            </li>
+          <% end %>
+        </ul>
+      <% end %>
+      <% if LinkCheckerApiService.has_admin_draft_links?(report.edition) %>
+        <p class="govuk-body">It also contains links to draft documents that weren't checked.</p>
+      <% end %>
+      <% unless hide_button_to_create_new_report %>
+        <%= render partial: "admin/link_check_reports/form", locals: {
+          edition: report.edition,
+          button_text: "Check again",
+        } %>
+      <% end %>
+      <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-top-5">Last checked: <%= l(report.updated_at, format: :long_ordinal) %></p>
+    <% end %>
+
     <%= render "components/inset_prompt", {
       title: t("broken_links.title"),
-      description: capture do %>
-        <%
-          status_order = { "danger" => 1, "broken" => 2, "caution" => 3 }
-          report.links.sort_by { |link| status_order[link.status] || 9999 }.group_by(&:status).each do |status, links|
-        %>
-          <% next unless %w(danger broken caution).include? status %>
-
-          <p class="govuk-body"><%= t "broken_links.#{status}.subheading" %></p>
-
-          <ul class="govuk-list app-view-summary__broken-links-report">
-            <% links.each do |link| %>
-              <li>
-                <% if link.status == "danger" %>
-                  <%= link.uri %>
-                <% else %>
-                  <%= link_to link.uri.truncate(50), link.uri, title: link.uri, class: "govuk-link" %>
-                <% end %>
-                <details class="govuk-details" data-module="govuk-details">
-                  <summary class="govuk-details__summary">
-                    <span class="govuk-details__summary-text">
-                      See more details about this link
-                    </span>
-                  </summary>
-                  <div class="govuk-details__text">
-                    <p class="govuk-body">
-                      <%= link.problem_summary %>: <%= link.check_details %>
-                    </p>
-                    <% if link.suggested_fix %>
-                      <p class="govuk-body">Suggested fix: <%= link.suggested_fix %></p>
-                    <% end %>
-                  </div>
-                </details>
-              </li>
-            <% end %>
-          </ul>
-        <% end %>
-        <% if LinkCheckerApiService.has_admin_draft_links?(report.edition) %>
-          <p class="govuk-body">It also contains links to draft documents that weren't checked.</p>
-        <% end %>
-        <% unless hide_button_to_create_new_report %>
-          <%= render partial: "admin/link_check_reports/form", locals: {
-            edition: report.edition,
-            button_text: "Check again",
-          } %>
-        <% end %>
-        <p class="govuk-body govuk-!-font-size-16 govuk-!-margin-top-5">Last checked: <%= l(report.updated_at, format: :long_ordinal) %></p>
-      <% end,
-      error: true
+      data_attributes: {
+        module: "ga4-auto-tracker",
+        ga4_auto: {
+          type: "broken links",
+          text: strip_tags(description).gsub(/\s+/, " "),
+          event_name: "side_bar_error",
+          action: "error",
+        }.as_json,
+      },
+      description:,
+      error: true,
     } %>
   <% else %>
     <%= render "components/inset_prompt", {


### PR DESCRIPTION
## What

- Add `ga4-auto-tracker` to instances of `inset_prompt` that display error messages to the user when viewing or editing an edition
- Add event tracking to when `BrokenLinksReport` calls `replaceContents`

## Why

As part of adding GA4 Tracking to whitehall.

https://trello.com/c/lC82z7co/3760-add-tracking-to-insetprompt-error-messages

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
