### PR TITLE
Fix `HtmlAttachment` reslug rake task

### DIFF
--- a/test/unit/lib/tasks/reslugging_test.rb
+++ b/test/unit/lib/tasks/reslugging_test.rb
@@ -2,15 +2,85 @@ require "test_helper"
 require "rake"
 
 class ResluggingTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
   teardown do
+    task.reenable
     Sidekiq::Job.clear_all
   end
 
-  test "it should reslug the world location" do
-    world_location_news = build(:world_location_news, content_id: SecureRandom.uuid)
-    world_location = create(:world_location, slug: "old-name", world_location_news:)
-    Rake.application.invoke_task "reslug:world_location[old-name,new-name]"
+  describe "for world location" do
+    let(:task) { Rake::Task["reslug:world_location"] }
 
-    assert_equal "new-name", world_location.reload.slug
+    test "it should reslug" do
+      world_location_news = build(:world_location_news, content_id: SecureRandom.uuid)
+      world_location = create(:world_location, slug: "old-name", world_location_news:)
+      task.invoke("old-name", "new-name")
+      Rake.application.invoke_task "reslug:world_location[old-name,new-name]"
+      assert_equal "new-name", world_location.reload.slug
+    end
+  end
+
+  describe "for HTML attachments" do
+    let(:task) { Rake::Task["reslug:html_attachment"] }
+    let(:html_attachment_title) { "HTML Attachment" }
+    let(:new_html_attachment_title) { "New #{html_attachment_title}" }
+    let(:html_attachment_slug) { html_attachment_title.to_slug.normalize.to_s }
+    let(:new_html_attachment_slug) { new_html_attachment_title.to_slug.normalize.to_s }
+
+    it "reslugs if attached to a published edition" do
+      published_edition = create(:published_edition)
+
+      existing_html_attachment = create(:html_attachment, title: html_attachment_title, body: "Some text on a published edition", attachable: published_edition)
+
+      # if attached to a published edition the
+      # attachment shouldn't be safely resluggable
+      existing_html_attachment.update!(safely_resluggable: false)
+
+      existing_html_attachment.update!(title: new_html_attachment_title)
+
+      task.invoke(published_edition.slug, existing_html_attachment.slug)
+
+      # attachment slug should have changed
+      assert_equal existing_html_attachment.reload.slug, new_html_attachment_slug
+      # attachment should not be resluggable after task
+      assert_equal existing_html_attachment.reload.safely_resluggable, false
+    end
+
+    it "reslugs if deleted attached HTML attachment with same slug" do
+      published_edition = create(:published_edition)
+      published_edition.document
+
+      deleted_html_attachment = create(:html_attachment, title: html_attachment_title, body: "Some text on a published edition", attachable: published_edition)
+
+      deleted_html_attachment.delete
+
+      existing_html_attachment = create(:html_attachment, title: html_attachment_title, body: "Some text on a published edition", attachable: published_edition)
+
+      task.invoke(published_edition.slug, existing_html_attachment.slug)
+
+      existing_html_attachment = existing_html_attachment.reload
+      new_edition = published_edition.document.editions.published.last
+
+      deleted_html_attachment_from_edition = new_edition.attachments.unscoped.deleted.where(slug: html_attachment_slug)
+
+      # there should be no deleted attachment with the slug
+      assert_empty deleted_html_attachment_from_edition
+      # attachment slug should have changed
+      assert_equal existing_html_attachment.slug, html_attachment_slug
+    end
+
+    it "does not reslug if undeleted attached HTML attachment with same slug" do
+      published_edition = create(:published_edition)
+      published_edition.document
+
+      create(:html_attachment, title: html_attachment_title, body: "Some text on a published edition", attachable: published_edition)
+
+      existing_html_attachment = create(:html_attachment, title: html_attachment_title, body: "Some text on a published edition", attachable: published_edition)
+
+      assert_raises(StandardError, match: "Attachment with slug '#{html_attachment_slug}' already exists and has been not deleted. Delete this attachment first.") do
+        task.invoke(published_edition.slug, existing_html_attachment.slug)
+      end
+    end
   end
 end


### PR DESCRIPTION
## What

Update the `HtmlAttachment` reslug rake task

## Why

In a support issue, it was revealed that the rake task does not work as expected. This was because:

- the slug of attachments is generated from the title of the attachment
  - the slug cannot be named differently from it
  - if the slug/title already exists then `--NUMBER` will be appended to it
- if another attachment associated with the edition that has been `deleted` (but not removed from the database) has the same slug, the target attachment cannot be renamed to that slug


So in this approach we don't accept a new slug as a parameter. In light of what we discovered, we could have used the 'title' of the attachment we want to reslug instead. As this can be changed within whitehall already though, personally it makes sense to me to defer to this to the user to make the process of reslugging more straightforward.

Solves: https://trello.com/c/NNssAJ4u/3668-fix-html-attachment-reslugging-rake-task

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
