### PR TITLE
Add feature flag for flexible pages

### DIFF
--- a/app/controllers/admin/new_document_controller.rb
+++ b/app/controllers/admin/new_document_controller.rb
@@ -1,32 +1,14 @@
 class Admin::NewDocumentController < Admin::BaseController
-  def index; end
+  def index
+    @document_types = Document::View::New.types_for(current_user)
+  end
 
   def new_document_options_redirect
     if params[:new_document_options].present?
-      new_document_type = params.require(:new_document_options).to_sym
-      redirect_to redirect_path(new_document_type)
+      new_document_type = params.require(:new_document_options)
+      redirect_to send(Document::View::New.redirect_path_helper(new_document_type))
     else
       redirect_to admin_new_document_path, alert: "Please select a new document option"
     end
-  end
-
-private
-
-  def redirect_path(new_document_type)
-    redirect_options = {
-      call_for_evidence: new_admin_call_for_evidence_path,
-      case_study: new_admin_case_study_path,
-      consultation: new_admin_consultation_path,
-      detailed_guide: new_admin_detailed_guide_path,
-      document_collection: new_admin_document_collection_path,
-      fatality_notice: new_admin_fatality_notice_path,
-      news_article: new_admin_news_article_path,
-      publication: new_admin_publication_path,
-      speech: new_admin_speech_path,
-      statistical_data_set: new_admin_statistical_data_set_path,
-      worldwide_organisation: new_admin_worldwide_organisation_path,
-      landing_page: new_admin_landing_page_path,
-    }
-    redirect_options[new_document_type]
   end
 end

--- a/app/helpers/admin/new_document_helper.rb
+++ b/app/helpers/admin/new_document_helper.rb
@@ -1,36 +1,12 @@
 module Admin::NewDocumentHelper
-  NEW_DOCUMENT_LIST = [
-    Consultation,
-    Publication,
-    NewsArticle,
-    Speech,
-    DetailedGuide,
-    DocumentCollection,
-    FatalityNotice,
-    CaseStudy,
-    StatisticalDataSet,
-    CallForEvidence,
-    WorldwideOrganisation,
-    LandingPage,
-  ].freeze
-
-  def new_document_type_list(user)
-    document_list = NEW_DOCUMENT_LIST.dup
-    if Flipflop.enabled?(:flexible_pages)
-      document_list << FlexiblePage
-    end
-    document_list
-      .select { |edition_type| edition_type.enforcer(user).can?(:create) }
-      .map do |edition_type|
-      title_value = edition_type.name.underscore
-      title_label = title_value.humanize
-      {
-        value: title_value,
-        text: title_label,
-        bold: true,
-        hint_text: hint_text(title_value.to_sym),
-      }
-    end
+  def new_document_radio_item(document_type)
+    document_type_key = document_type.name.underscore
+    {
+      value: document_type_key,
+      text: document_type_key.humanize,
+      bold: true,
+      hint_text: hint_text(document_type_key.to_sym),
+    }
   end
 
 private

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -219,6 +219,39 @@ class Document < ApplicationRecord
     live_edition if live_edition&.state == "withdrawn"
   end
 
+  class View
+    class New
+      def self.all_types
+        document_types = [
+          Consultation,
+          Publication,
+          NewsArticle,
+          Speech,
+          DetailedGuide,
+          DocumentCollection,
+          FatalityNotice,
+          CaseStudy,
+          StatisticalDataSet,
+          CallForEvidence,
+          WorldwideOrganisation,
+          LandingPage,
+        ]
+
+        document_types << FlexiblePage if Flipflop.enabled?(:flexible_pages)
+        document_types
+      end
+
+      def self.types_for(user)
+        all_types.select { |type| type.enforcer(user).can?(:create) }
+      end
+
+      def self.redirect_path_helper(new_document_type)
+        redirects = all_types.each_with_object({}) { |type, hash| hash[type.name.underscore.to_sym] = "new_admin_#{type.name.underscore}_path" }
+        redirects[new_document_type.to_sym]
+      end
+    end
+  end
+
 private
 
   def destroy_all_editions

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -84,6 +84,10 @@ class Edition < ApplicationRecord
 
   validates_with UnmodifiableValidator, if: :unmodifiable?
 
+  def self.enforcer(user)
+    Whitehall::Authority::Enforcer.new(user, self)
+  end
+
   def self.format_name
     @format_name ||= model_name.human.downcase
   end
@@ -434,10 +438,6 @@ private
     published_edition_date = first_public_at.try(:to_date)
     draft_edition_date = updated_at.try(:to_date)
     published_edition_date || draft_edition_date
-  end
-
-  def enforcer(user)
-    Whitehall::Authority::Enforcer.new(user, self)
   end
 
   def summary_required?

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -84,16 +84,16 @@ class Edition < ApplicationRecord
 
   validates_with UnmodifiableValidator, if: :unmodifiable?
 
-  def self.enforcer(user)
-    Whitehall::Authority::Enforcer.new(user, self)
-  end
-
   def self.format_name
     @format_name ||= model_name.human.downcase
   end
 
   def self.concrete_descendants
     descendants.reject { |model| model.descendants.any? }.sort_by(&:name)
+  end
+
+  def self.enforcer(user)
+    Whitehall::Authority::Enforcer.new(user, self)
   end
 
   def self.scheduled_for_publication_as(slug)

--- a/app/models/flexible_page.rb
+++ b/app/models/flexible_page.rb
@@ -1,0 +1,2 @@
+class FlexiblePage < Edition
+end

--- a/app/views/admin/new_document/index.html.erb
+++ b/app/views/admin/new_document/index.html.erb
@@ -8,7 +8,7 @@
         heading_level: 1,
         name: "new_document_options",
         id: "new_document_options",
-        items: new_document_type_list(current_user),
+        items: @document_types.map { |type| new_document_radio_item(type) },
       } %>
       <%= render "govuk_publishing_components/components/inset_text", {
         text: sanitize("Check the #{link_to("content types guidance", "#{Plek.website_root}/guidance/content-design/content-types", class: "govuk-link")}" +

--- a/app/views/admin/new_document/index.html.erb
+++ b/app/views/admin/new_document/index.html.erb
@@ -8,7 +8,7 @@
         heading_level: 1,
         name: "new_document_options",
         id: "new_document_options",
-        items: new_document_type_list,
+        items: new_document_type_list(current_user),
       } %>
       <%= render "govuk_publishing_components/components/inset_text", {
         text: sanitize("Check the #{link_to("content types guidance", "#{Plek.website_root}/guidance/content-design/content-types", class: "govuk-link")}" +

--- a/config/features.rb
+++ b/config/features.rb
@@ -31,4 +31,7 @@ Flipflop.configure do
   feature :use_friendly_embed_codes,
           description: "Use embed codes with friendly IDs in Content Block Manager",
           default: Whitehall.integration_or_staging? || !Rails.env.production?
+  feature :flexible_pages,
+          description: "Enable flexible pages functionality",
+          default: Rails.env.development?
 end

--- a/test/unit/app/helpers/admin/new_document_helper_test.rb
+++ b/test/unit/app/helpers/admin/new_document_helper_test.rb
@@ -1,64 +1,12 @@
 require "test_helper"
 
 class Admin::NewDocumentHelperTest < ActionView::TestCase
-  test "new_document_type_list returns a list of document type list items" do
-    enforcer = Minitest::Mock.new
-    NEW_DOCUMENT_LIST.each do |edition_type|
-      enforcer.expect :can?, true, [:create]
-      edition_type.stubs(:enforcer).returns(enforcer)
-    end
-
-    result = new_document_type_list(User.new)
-
-    assert result.is_a?(Array)
-    assert result.size == NEW_DOCUMENT_LIST.size
-    NEW_DOCUMENT_LIST.each do |edition_type|
-      assert_includes result, {
-        value: edition_type.name.underscore,
-        text: edition_type.name.underscore.humanize,
-        bold: true,
-        hint_text: hint_text(edition_type.name.underscore.to_sym),
-      }
-    end
-  end
-
-  test "new_document_type_list includes flexible page if flip flop is enabled" do
-    enforcer = Minitest::Mock.new
-    NEW_DOCUMENT_LIST.each do |edition_type|
-      enforcer.expect :can?, true, [:create]
-      edition_type.stubs(:enforcer).returns(enforcer)
-    end
-
-    test_strategy = Flipflop::FeatureSet.current.test!
-    test_strategy.switch!(:flexible_pages, true)
-    enforcer.expect :can?, true, [:create]
-    FlexiblePage.stubs(:enforcer).returns(enforcer)
-
-    result = new_document_type_list(User.new)
-
-    assert_includes result, {
-      value: "flexible_page",
-      text: "Flexible page",
+  test "new_document_radio_item returns a hash representation of the document type" do
+    assert_equal new_document_radio_item(NewsArticle), {
+      value: "news_article",
+      text: "News article",
       bold: true,
-      hint_text: nil,
+      hint_text: "Use this for news story, press release, government response, and world news story.",
     }
-  end
-
-  def hint_text(new_document_type)
-    hint_text = {
-      call_for_evidence: "Use this to request people's views when it is not a consultation.",
-      case_study: "Use this to share real examples that help users understand a process or an important aspect of government policy covered on GOV.UK.",
-      consultation: "Use this for documents requiring a collective agreement across government, and requests for people's view on a question with an outcome.",
-      detailed_guide: "Use this to tell users the steps they need to take to complete a clearly defined task. They are usually aimed at specialist or professional audiences.",
-      document_collection: "Use this to group related documents on a single page for a specific audience or around a specific theme.",
-      fatality_notice: "Use this to provide official confirmation of the death of a member of the armed forces while on deployment. Ministry of Defence only.",
-      news_article: "Use this for news story, press release, government response, and world news story.",
-      publication: "Use this for standalone government documents, white papers, strategy documents, and reports.",
-      speech: "Use this for speeches by ministers or other named spokespeople, and ministerial statements to Parliament.",
-      statistical_data_set: "Use this for data that you publish monthly or more often without analysis.",
-      worldwide_organisation: "Use this to create a new worldwide organisation page. Do not create a worldwide organisation unless you have permission from your managing editor or GOV.UK department lead.",
-      landing_page: "EXPERIMENTAL Use this to create landing pages.",
-    }
-    hint_text[new_document_type]
   end
 end

--- a/test/unit/app/helpers/admin/republishing_helper_test.rb
+++ b/test/unit/app/helpers/admin/republishing_helper_test.rb
@@ -5,7 +5,7 @@ class Admin::RepublishingHelperTest < ActionView::TestCase
     Rails.application.eager_load!
 
     # Ignore "abstract" Edition descendants
-    unexpected_content_types = %w[Announcement GenericEdition Publicationesque SearchableEdition]
+    unexpected_content_types = %w[Announcement FlexiblePage GenericEdition Publicationesque SearchableEdition]
 
     expected_content_types = (
       Edition.descendants.map(&:to_s) + non_editionable_content_types - unexpected_content_types


### PR DESCRIPTION
## What

Add a feature flag for the flexible pages feature and use it to toggle the appearance of the "Flexible Page" option on the new document form.

This PR also includes a substantial refactor of the new document controller and helper.

## Why

We want to be able to safely deploy the flexible page feature to production before it is finished, so that we don't have a long lived feature branch to merge or a large, risky deployment.

## Why the refactor?

We wanted to add a test to cover the flexible pages feature flag, but we didn't want to test it using a controller test as trying to interpret the DOM seemed a very inefficient way of testing the condition.

We therefore tried to push the test down the stack into the new document helper, but that didn't work because the helper depends on the `can?` method on the base application controller, which wasn't available in the helper test. This was a clear signal that the helper had taken on responsibilities beyond what a Rails view helper should have.

We therefore refactored some of the helper behaviour, such as the feature flag check and the authorisation check, on to the document model. However, because the behaviour was very specific to the new document page, we decided that a view model for that page was the most appropriate solution. We did consider a view component, but felt that testing this logic via the DOM again did not make sense.

The refactor has allowed us to safely remove some of the tests from the new document controller, becausewe have a test on the view model which confirms that authorisation has been performed. We have unit tests in the authorisation layer which check that authorisation of fatality notice creation is enforced correctly. We can therefore safely remove those tests from the controller.

## Screenshots

Feature flag off
![Screenshot 2025-05-29 at 10 02 58](https://github.com/user-attachments/assets/647767ce-f0e9-4240-92a3-1fce6e0222da)

Feature flag on
![Screenshot 2025-05-29 at 10 03 24](https://github.com/user-attachments/assets/6a5cdec6-5253-4c17-a6f8-03f649ff9935)
