### PR TITLE
(CM 141) Allow attribute blocks to be hidden

### DIFF
--- a/lib/engines/content_block_manager/app/assets/stylesheets/content_block_manager/components/_embedded-objects-blocks-component.scss
+++ b/lib/engines/content_block_manager/app/assets/stylesheets/content_block_manager/components/_embedded-objects-blocks-component.scss
@@ -6,4 +6,32 @@
   &__embed-code {
     color: govuk-colour("dark-grey");
   }
+
+  &--with-block {
+    .govuk-summary-card {
+      border-bottom: none;
+      margin-bottom: 0;
+    }
+  }
+
+  &__details-text {
+    border-left: $govuk-border-width solid $govuk-border-colour;
+    padding-top: govuk-spacing(3);
+    padding-bottom: govuk-spacing(3);
+    padding-left: govuk-spacing(4);
+  }
+
+  &__details-wrapper {
+    @extend .govuk-summary-card__content;
+    border-left: 1px solid $govuk-border-colour;
+    border-right: 1px solid $govuk-border-colour;
+    border-bottom: 1px solid $govuk-border-colour;
+    margin-bottom: govuk-spacing(6);
+    padding-bottom: govuk-spacing(1);
+
+    .govuk-details__text {
+      border: none;
+      padding: 0;
+    }
+  }
 }

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/embedded_objects/blocks_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/embedded_objects/blocks_component.html.erb
@@ -1,6 +1,25 @@
-<div class="app-c-embedded-objects-blocks-component">
+<%= tag.div(class: component_classes) do %>
   <%= render "govuk_publishing_components/components/summary_card", {
     title: "Content blocks",
-    rows:,
+    rows: summary_card_rows,
   } %>
-</div>
+
+  <% if schema.embeddable_as_block? %>
+    <div class="app-c-embedded-objects-blocks-component__details-wrapper">
+      <%= render "govuk_publishing_components/components/details", {
+        title: "All #{object_name} attributes",
+      } do %>
+        <% capture do %>
+          <div class="app-c-embedded-objects-blocks-component__details-text">
+            These are all the <%= object_name %> attributes that make up the <%= object_name %>. You can use the embed code for each attribute separately in your content if required.
+          </div>
+          <div class="app-c-embedded-objects-blocks-component__details-summary-list">
+            <%= render "govuk_publishing_components/components/summary_list", {
+              items: attribute_rows(:field),
+            } %>
+          </div>
+        <% end %>
+      <% end %>
+    </div>
+  <% end %>
+<% end %>

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/embedded_objects/blocks_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/embedded_objects/blocks_component.rb
@@ -12,18 +12,33 @@ private
 
   attr_reader :items, :object_type, :object_title, :content_block_document
 
-  def rows
-    rows = schema.embeddable_as_block? ? [block_row] : []
+  def component_classes
+    [
+      "app-c-embedded-objects-blocks-component",
+      ("app-c-embedded-objects-blocks-component--with-block" if schema.embeddable_as_block?),
+    ].compact.join(" ")
+  end
 
-    items.each do |key, value|
-      rows << {
-        key: key.titleize,
+  def summary_card_rows
+    if schema.embeddable_as_block?
+      [block_row]
+    else
+      attribute_rows
+    end
+  end
+
+  def attribute_rows(key_name = :key)
+    items.map do |key, value|
+      {
+        "#{key_name}": key.titleize,
         value: content_for_row(key, value),
         data: data_attributes_for_row(key),
       }
     end
+  end
 
-    rows
+  def object_name
+    object_type.singularize.humanize.downcase
   end
 
   def block_row

--- a/lib/engines/content_block_manager/test/components/content_block/document/show/embedded_objects/blocks_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/document/show/embedded_objects/blocks_component_test.rb
@@ -11,7 +11,6 @@ class ContentBlockManager::ContentBlock::Document::Show::EmbeddedObjects::Blocks
   end
   let(:object_type) { "something" }
   let(:object_title) { "else" }
-  let(:embeddable_as_block) { false }
 
   let(:content_block_edition) { build(:content_block_edition, :pension) }
   let(:content_block_document) { build(:content_block_document, :pension) }
@@ -34,43 +33,13 @@ class ContentBlockManager::ContentBlock::Document::Show::EmbeddedObjects::Blocks
     )
   end
 
-  it "renders a summary card" do
-    render_inline component
+  describe "when the block type is not embeddable as a block" do
+    let(:embeddable_as_block) { false }
 
-    assert_selector ".app-c-embedded-objects-blocks-component [data-testid='else_foo']" do |row|
-      row.assert_selector ".govuk-summary-list__key", text: "Foo"
-      row.assert_selector ".govuk-summary-list__value" do |col|
-        col.assert_selector ".app-c-embedded-objects-blocks-component__content", text: "bar"
-        col.assert_selector ".app-c-embedded-objects-blocks-component__embed-code", text: content_block_document.embed_code_for_field("#{object_type}/#{object_title}/foo")
-      end
-    end
-
-    assert_selector ".app-c-embedded-objects-blocks-component [data-testid='else_fizz']" do |row|
-      row.assert_selector ".govuk-summary-list__key", text: "Fizz"
-      row.assert_selector ".govuk-summary-list__value" do |col|
-        col.assert_selector ".app-c-embedded-objects-blocks-component__content", text: "buzz"
-        col.assert_selector ".app-c-embedded-objects-blocks-component__embed-code", text: content_block_document.embed_code_for_field("#{object_type}/#{object_title}/fizz")
-      end
-    end
-  end
-
-  describe "when the block type is embeddable as a block" do
-    let(:embeddable_as_block) { true }
-
-    it "returns the block alongside the other fields" do
-      content_block_edition.expects(:render).with(
-        content_block_document.embed_code_for_field("#{object_type}/#{object_title}"),
-      ).returns("BLOCK_RESPONSE")
-
+    it "renders a summary card" do
       render_inline component
 
-      assert_selector ".app-c-embedded-objects-blocks-component [data-testid='else']" do |row|
-        row.assert_selector ".govuk-summary-list__key", text: "Something"
-        row.assert_selector ".govuk-summary-list__value" do |col|
-          col.assert_selector ".app-c-embedded-objects-blocks-component__content", text: "BLOCK_RESPONSE"
-          col.assert_selector ".app-c-embedded-objects-blocks-component__embed-code", text: content_block_document.embed_code_for_field("#{object_type}/#{object_title}")
-        end
-      end
+      assert_selector ".app-c-embedded-objects-blocks-component .govuk-summary-list__row", count: 2
 
       assert_selector ".app-c-embedded-objects-blocks-component [data-testid='else_foo']" do |row|
         row.assert_selector ".govuk-summary-list__key", text: "Foo"
@@ -87,6 +56,85 @@ class ContentBlockManager::ContentBlock::Document::Show::EmbeddedObjects::Blocks
           col.assert_selector ".app-c-embedded-objects-blocks-component__embed-code", text: content_block_document.embed_code_for_field("#{object_type}/#{object_title}/fizz")
         end
       end
+    end
+
+    it "adds the correct class to the wrapper" do
+      render_inline component
+
+      assert_selector ".app-c-embedded-objects-blocks-component"
+      refute_selector ".app-c-embedded-objects-blocks-component.app-c-embedded-objects-blocks-component--with-block"
+    end
+
+    it "does not render the details" do
+      render_inline component
+
+      refute_selector ".app-c-embedded-objects-blocks-component__details-wrapper"
+    end
+  end
+
+  describe "when the block type is embeddable as a block" do
+    let(:embeddable_as_block) { true }
+
+    before do
+      content_block_edition.expects(:render).with(
+        content_block_document.embed_code_for_field("#{object_type}/#{object_title}"),
+      ).returns("BLOCK_RESPONSE")
+    end
+
+    it "returns the block inside the summary card" do
+      render_inline component
+
+      assert_selector ".app-c-embedded-objects-blocks-component .govuk-summary-card" do |wrapper|
+        wrapper.assert_selector ".govuk-summary-list__row", count: 1
+        wrapper.assert_selector ".govuk-summary-list__row[data-testid='else']" do |row|
+          row.assert_selector ".govuk-summary-list__key", text: "Something"
+          row.assert_selector ".govuk-summary-list__value" do |col|
+            col.assert_selector ".app-c-embedded-objects-blocks-component__content", text: "BLOCK_RESPONSE"
+            col.assert_selector ".app-c-embedded-objects-blocks-component__embed-code", text: content_block_document.embed_code_for_field("#{object_type}/#{object_title}")
+          end
+        end
+      end
+    end
+
+    it "shows the details component with the attributes in a summary list" do
+      render_inline component
+
+      assert_selector ".app-c-embedded-objects-blocks-component__details-wrapper" do |wrapper|
+        wrapper.assert_selector ".govuk-details__summary-text", text: "All #{object_type} attributes"
+        wrapper.assert_selector ".govuk-details__text", visible: false do |details|
+          details.assert_selector ".app-c-embedded-objects-blocks-component__details-text",
+                                  text: "These are all the #{object_type} attributes that make up the #{object_type}. You can use the embed code for each attribute separately in your content if required.",
+                                  visible: false
+
+          details.assert_selector ".app-c-embedded-objects-blocks-component__details-summary-list", visible: false do |summary_list|
+            summary_list.assert_selector ".govuk-summary-list__row", count: 2, visible: false
+
+            summary_list.assert_selector ".govuk-summary-list__row[data-testid='else_foo']", visible: false do |row|
+              row.assert_selector ".govuk-summary-list__key", text: "Foo", visible: false
+
+              row.assert_selector ".govuk-summary-list__value", visible: false do |col|
+                col.assert_selector ".app-c-embedded-objects-blocks-component__content", text: "bar", visible: false
+                col.assert_selector ".app-c-embedded-objects-blocks-component__embed-code", text: content_block_document.embed_code_for_field("#{object_type}/#{object_title}/foo"), visible: false
+              end
+            end
+
+            summary_list.assert_selector ".govuk-summary-list__row[data-testid='else_fizz']", visible: false do |row|
+              row.assert_selector ".govuk-summary-list__key", text: "Fizz", visible: false
+
+              row.assert_selector ".govuk-summary-list__value", visible: false do |col|
+                col.assert_selector ".app-c-embedded-objects-blocks-component__content", text: "buzz", visible: false
+                col.assert_selector ".app-c-embedded-objects-blocks-component__embed-code", text: content_block_document.embed_code_for_field("#{object_type}/#{object_title}/fizz"), visible: false
+              end
+            end
+          end
+        end
+      end
+    end
+
+    it "adds the correct class to the wrapper" do
+      render_inline component
+
+      assert_selector ".app-c-embedded-objects-blocks-component.app-c-embedded-objects-blocks-component--with-block"
     end
   end
 end


### PR DESCRIPTION
If an object is embeddable as a block, we want to show this front and centre, but also give the user the opportunity to use the individual attributes that make up the block if they want.

If an object has a block-level representation, we render a `details` component with a further summary list inside. The user can then expand the details element to see the other blocks.

I’ve altered the styling a bit to make the component look like one unified component, whilst still keeping the HTML neat

## Screenshot

![image](https://github.com/user-attachments/assets/a78d0cbb-5e14-4755-9710-7ab79d963814)
