### PR TITLE
Use `button` instead of `input` for `Add` document

### DIFF
--- a/app/views/admin/document_collection_group_document_search/add_by_title.html.erb
+++ b/app/views/admin/document_collection_group_document_search/add_by_title.html.erb
@@ -35,16 +35,17 @@
                        rows: @editions.map do |edition|
                          title_span = tag.span(index_table_title_row(edition), class: "govuk-!-font-weight-bold")
                          view_link = link_to(sanitize("View #{tag.span(edition.title, class: "govuk-visually-hidden")}"), edition.public_url, class: "govuk-link",data: { "ga4-ecommerce-content-id": edition.document.content_id })
-                         add_button = button_to("Add",
-                                                admin_document_collection_new_whitehall_member_path(@collection),
-                                                method: :post,
-                                                params: {
-                                                  group_id: @group.id,
-                                                  document_id: edition.document.id,
-                                                },
-                                                aria: { label: "Add document to the document collection group" },
-                                                class: "gem-c-button govuk-button govuk-button--secondary",
-                         )
+                         add_button = button_to admin_document_collection_new_whitehall_member_path(@collection), {
+                            method: :post,
+                            params: {
+                              group_id: @group.id,
+                              document_id: edition.document.id,
+                            },
+                            aria: { label: "Add document to the document collection group" },
+                            class: "gem-c-button govuk-button govuk-button--secondary",
+                          } do
+                            "Add"
+                          end
 
                          [{ text: title_span }, { text: view_link + add_button }]
                        end,


### PR DESCRIPTION
## What

Use a block for `button_to` in `add_by_title.html.erb` to ensure that the form uses a `button type='submit' ` and not an `input type='submit'`.

## Why

Ed identified this instance of an `input type='submit'` being generated by `button_to`. Interestingly, [this shouldn't be happening as of Rails 7](https://github.com/rails/rails/pull/40747) but changing this to a block instead of an 

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
