### PR TITLE
Create the basic edition workflow for flexible pages.

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -304,6 +304,7 @@ private
             ],
           },
         ],
+        flexible_page_content: {},
       },
       :auth_bypass_id,
     ]

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -27,7 +27,7 @@ class Admin::EditionsController < Admin::BaseController
       enforce_permission!(:see, edition_class || Edition)
     when "show"
       enforce_permission!(:see, @edition)
-    when "new"
+    when "new", "choose_type"
       enforce_permission!(:create, edition_class || Edition)
     when "create"
       enforce_permission!(:create, @edition)
@@ -307,6 +307,7 @@ private
         flexible_page_content: {},
       },
       :auth_bypass_id,
+      :flexible_page_type,
     ]
   end
 

--- a/app/controllers/admin/flexible_pages_controller.rb
+++ b/app/controllers/admin/flexible_pages_controller.rb
@@ -1,8 +1,6 @@
 class Admin::FlexiblePagesController < Admin::EditionsController
   before_action :prevent_access_when_disabled
-  def new
-    render "admin/editions/new" if params.include? :flexible_page_type
-  end
+  def choose_type; end
 
 private
 
@@ -12,5 +10,9 @@ private
 
   def prevent_access_when_disabled
     head :not_found unless Flipflop.flexible_pages?
+  end
+
+  def new_edition_params
+    super[:flexible_page_type].blank? ? super.merge(flexible_page_type: params[:flexible_page_type]) : super
   end
 end

--- a/app/controllers/admin/flexible_pages_controller.rb
+++ b/app/controllers/admin/flexible_pages_controller.rb
@@ -1,0 +1,16 @@
+class Admin::FlexiblePagesController < Admin::EditionsController
+  before_action :prevent_access_when_disabled
+  def new
+    render "admin/editions/new" if params.include? :flexible_page_type
+  end
+
+private
+
+  def edition_class
+    FlexiblePage
+  end
+
+  def prevent_access_when_disabled
+    head :not_found unless Flipflop.flexible_pages?
+  end
+end

--- a/app/helpers/admin/editions_helper.rb
+++ b/app/helpers/admin/editions_helper.rb
@@ -156,7 +156,7 @@ module Admin::EditionsHelper
   end
 
   def edition_is_a_novel?(edition)
-    edition.body.split.size > 99_999
+    edition.body.present? && edition.body.split.size > 99_999
   end
 
   def edition_has_links?(edition)

--- a/app/helpers/admin/flexible_page_helper.rb
+++ b/app/helpers/admin/flexible_page_helper.rb
@@ -1,12 +1,12 @@
 module Admin::FlexiblePageHelper
-  def render_flexible_page_content_fields(schema_properties, edition, path = "", output_html = "")
-    schema_properties.each do |key, property|
+  def render_flexible_page_content_fields(schema, edition, path = "", output_html = "")
+    schema["properties"].each do |key, property|
       next_path = path.empty? ? key : "#{path}.#{key}"
       case property["type"]
       when "string"
         output_html += render "govuk_publishing_components/components/input", {
           label: {
-            text: property["title"],
+            text: property["title"] + (schema["required"] ? " (required)" : ""),
           },
           name: "edition[flexible_page_content][#{next_path.split('.').join('][')}]",
           value: edition.flexible_page_content&.dig(*next_path.split(".")) || "",
@@ -19,7 +19,7 @@ module Admin::FlexiblePageHelper
           heading_size: "m",
           id: "edition_flexible_page_content_#{next_path.split('.').join('_')}",
         } do
-          render inline: render_flexible_page_content_fields(property["properties"], edition, next_path, output_html)
+          render inline: render_flexible_page_content_fields(property, edition, next_path, output_html)
         end
       end
     end

--- a/app/helpers/admin/flexible_page_helper.rb
+++ b/app/helpers/admin/flexible_page_helper.rb
@@ -1,0 +1,28 @@
+module Admin::FlexiblePageHelper
+  def render_flexible_page_content_fields(schema_properties, edition, path = "", output_html = "")
+    schema_properties.each do |key, property|
+      next_path = path.empty? ? key : "#{path}.#{key}"
+      case property["type"]
+      when "string"
+        output_html += render "govuk_publishing_components/components/input", {
+          label: {
+            text: property["title"],
+          },
+          name: "edition[flexible_page_content][#{next_path.split('.').join('][')}]",
+          value: edition.flexible_page_content&.dig(*next_path.split(".")) || "",
+          id: "edition_flexible_page_content_#{next_path.split('.').join('_')}",
+          hint: property["description"],
+        }
+      when "object"
+        output_html += render "govuk_publishing_components/components/fieldset", {
+          legend_text: property["title"],
+          heading_size: "m",
+          id: "edition_flexible_page_content_#{next_path.split('.').join('_')}",
+        } do
+          render inline: render_flexible_page_content_fields(property["properties"], edition, next_path, output_html)
+        end
+      end
+    end
+    output_html
+  end
+end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -222,23 +222,7 @@ class Document < ApplicationRecord
   class View
     class New
       def self.all_types
-        document_types = [
-          Consultation,
-          Publication,
-          NewsArticle,
-          Speech,
-          DetailedGuide,
-          DocumentCollection,
-          FatalityNotice,
-          CaseStudy,
-          StatisticalDataSet,
-          CallForEvidence,
-          WorldwideOrganisation,
-          LandingPage,
-        ]
-
-        document_types << FlexiblePage if Flipflop.enabled?(:flexible_pages)
-        document_types
+        types_hash.values
       end
 
       def self.types_for(user)
@@ -246,8 +230,28 @@ class Document < ApplicationRecord
       end
 
       def self.redirect_path_helper(new_document_type)
-        redirects = all_types.each_with_object({}) { |type, hash| hash[type.name.underscore.to_sym] = "new_admin_#{type.name.underscore}_path" }
-        redirects[new_document_type.to_sym]
+        types_hash[new_document_type].choose_document_type_form_action
+      end
+
+      private
+
+      def self.types_hash
+        types = {
+          "consultation" => Consultation,
+          "publication" => Publication,
+          "news_article" => NewsArticle,
+          "speech" => Speech,
+          "detailed_guide" => DetailedGuide,
+          "document_collection" => DocumentCollection,
+          "fatality_notice" => FatalityNotice,
+          "case_study" => CaseStudy,
+          "statistical_data_set" => StatisticalDataSet,
+          "call_for_evidence" => CallForEvidence,
+          "worldwide_organisation" => WorldwideOrganisation,
+          "landing_page" => LandingPage,
+        }
+        types["flexible_page"] = FlexiblePage if Flipflop.enabled?(:flexible_pages)
+        types
       end
     end
   end

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -101,6 +101,10 @@ class Edition < ApplicationRecord
     document&.scheduled_edition
   end
 
+  def self.choose_document_type_form_action
+    "new_admin_#{name.underscore}_path"
+  end
+
   def skip_main_validation?
     FROZEN_STATES.include?(state)
   end

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -299,6 +299,10 @@ class Edition < ApplicationRecord
     true
   end
 
+  def summary_required?
+    true
+  end
+
   def body_required?
     true
   end
@@ -438,10 +442,6 @@ private
     published_edition_date = first_public_at.try(:to_date)
     draft_edition_date = updated_at.try(:to_date)
     published_edition_date || draft_edition_date
-  end
-
-  def summary_required?
-    true
   end
 
   def republish_topical_event_to_publishing_api

--- a/app/models/flexible_page.rb
+++ b/app/models/flexible_page.rb
@@ -1,4 +1,11 @@
 class FlexiblePage < Edition
+  validates :flexible_page_type, presence: true, inclusion: { in: -> { FlexiblePageType.all_keys } }
+  validate :content_conforms_to_schema
+
+  def self.choose_document_type_form_action
+    "choose_type_admin_flexible_pages_path"
+  end
+
   def publishing_api_presenter
     PublishingApi::FlexiblePagePresenter
   end
@@ -21,5 +28,12 @@ class FlexiblePage < Edition
 
   def rendering_app
     Whitehall::RenderingApp::FRONTEND
+  end
+
+  def content_conforms_to_schema
+    type_instance = FlexiblePageType.find(flexible_page_type)
+    unless type_instance.validator.valid?(flexible_page_content)
+      errors.add(:flexible_page_content, "does not conform to schema for the #{type_instance.label}.")
+    end
   end
 end

--- a/app/models/flexible_page.rb
+++ b/app/models/flexible_page.rb
@@ -1,2 +1,25 @@
 class FlexiblePage < Edition
+  def publishing_api_presenter
+    PublishingApi::FlexiblePagePresenter
+  end
+
+  def summary_required?
+    false
+  end
+
+  def body_required?
+    false
+  end
+
+  def can_set_previously_published?
+    false
+  end
+
+  def previously_published
+    false
+  end
+
+  def rendering_app
+    Whitehall::RenderingApp::FRONTEND
+  end
 end

--- a/app/models/flexible_page_type.rb
+++ b/app/models/flexible_page_type.rb
@@ -2,6 +2,8 @@
 class FlexiblePageType
   @types = {}
 
+  attr_reader :key, :schema
+
   class << self
     attr_accessor :types
   end
@@ -46,6 +48,4 @@ class FlexiblePageType
   def validator
     JSONSchemer.schema(@schema)
   end
-
-  attr_reader :key
 end

--- a/app/models/flexible_page_type.rb
+++ b/app/models/flexible_page_type.rb
@@ -1,0 +1,51 @@
+# require 'json_schemer'
+class FlexiblePageType
+  @types = {}
+
+  class << self
+    attr_accessor :types
+  end
+
+  def self.boot
+    filenames = Dir.glob("app/models/flexible_page_types/*.json")
+    @types = filenames.each_with_object({}) do |filename, types|
+      type = JSON.parse(File.read(filename))
+      types[type["key"]] = type
+    end
+  end
+
+  def self.setup_test_types(types)
+    @types = types
+  end
+
+  def self.find(type_key)
+    new(@types[type_key])
+  end
+
+  def self.all
+    @types.values.map { |type| new(type) }
+  end
+
+  def self.all_keys
+    @types.keys
+  end
+
+  def initialize(type)
+    @key = type["key"]
+    @schema = type["schema"]
+  end
+
+  def label
+    @schema["title"]
+  end
+
+  def properties
+    @schema["properties"]
+  end
+
+  def validator
+    JSONSchemer.schema(@schema)
+  end
+
+  attr_reader :key
+end

--- a/app/models/flexible_page_types/history_page.json
+++ b/app/models/flexible_page_types/history_page.json
@@ -1,0 +1,31 @@
+{
+  "key": "history_page",
+  "schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://www.gov.uk/schemas/history_page/v1",
+    "title": "History page",
+    "description": "A history page on GOV.UK",
+    "type": "object",
+    "properties": {
+      "page_title": {
+        "title": "Page title",
+        "description": "The title of the history page",
+        "type": "object",
+        "properties": {
+          "heading_text": {
+            "title": "Heading text",
+            "description": "The main heading text for the page title",
+            "type": "string"
+          },
+          "context": {
+            "title": "Context",
+            "description": "Some additional context for the page title",
+            "type": "string"
+          }
+        },
+        "required": ["heading_text"]
+      }
+    },
+    "required": ["page_title"]
+  }
+}

--- a/app/presenters/publishing_api/flexible_page_presenter.rb
+++ b/app/presenters/publishing_api/flexible_page_presenter.rb
@@ -1,0 +1,50 @@
+module PublishingApi
+  class FlexiblePagePresenter
+    include Presenters::PublishingApi::UpdateTypeHelper
+
+    attr_accessor :item, :update_type
+
+    def initialize(item, update_type: nil)
+      self.item = item
+      self.update_type = update_type || default_update_type(item)
+    end
+
+    delegate :content_id, :flexible_page_content, to: :item
+
+    def content
+      content = BaseItemPresenter.new(item, update_type:).base_attributes
+      content.merge!(
+        details:,
+        document_type:,
+        public_updated_at: item.public_timestamp || item.updated_at,
+        rendering_app: item.rendering_app,
+        schema_name: "flexible_page",
+        links: edition_links,
+        auth_bypass_ids: [item.auth_bypass_id],
+      )
+      content.merge!(PayloadBuilder::PublicDocumentPath.for(item))
+      content.merge!(PayloadBuilder::AccessLimitation.for(item))
+      content.merge!(PayloadBuilder::FirstPublishedAt.for(item))
+    end
+
+    def links
+      edition_links
+    end
+
+    def edition_links
+      []
+    end
+
+    def document_type
+      "history_page"
+    end
+
+  private
+
+    def details
+      {
+        flexible_page_content:,
+      }
+    end
+  end
+end

--- a/app/views/admin/editions/new.html.erb
+++ b/app/views/admin/editions/new.html.erb
@@ -16,7 +16,6 @@
         } %>
       </div>
     <% end %>
-
     <%= render "form", edition: @edition %>
   </div>
 

--- a/app/views/admin/flexible_pages/_form.html.erb
+++ b/app/views/admin/flexible_pages/_form.html.erb
@@ -1,0 +1,55 @@
+<%= form_for form_url_for_edition(edition), as: :edition, html: { class: edition_form_classes(edition), multipart: true }, data: { module: "EditionForm LocaleSwitcher", "rtl-locales": Locale.right_to_left.collect(&:to_param) } do |form| %>
+  <div class="<%= "right-to-left" if edition.rtl? %>">
+    <%= form.hidden_field :lock_version %>
+
+    <div class="govuk-!-margin-bottom-6 js-locale-switcher-field">
+      <%= render "govuk_publishing_components/components/character_count", {
+        textarea: {
+          label: {
+            text: "Admin Title (required)",
+            heading_size: "m",
+          },
+          name: "edition[title]",
+          value: edition.title,
+          error_items: errors_for(edition.errors, :title),
+          right_to_left: form.object.translation_rtl?,
+          right_to_left_help: false,
+          rows: 1,
+        },
+        id: "edition_title",
+        maxlength: 65,
+      } %>
+    </div>
+
+    <% if edition.document&.slug.present? %>
+      <div class="app-view-edit-edition__page-address govuk-!-margin-bottom-6">
+        <%= render "govuk_publishing_components/components/heading", {
+          text: "Page address",
+          heading_level: 3,
+          font_size: "m",
+          margin_bottom: 2,
+        } %>
+
+        <%= render "govuk_publishing_components/components/hint", {
+          text: edition.public_url,
+        } %>
+      </div>
+    <% end %>
+
+    <%= render "govuk_publishing_components/components/heading", {
+      text: "Content",
+      font_size: "l",
+      margin_bottom: 6,
+    } %>
+
+    <%= render "govuk_publishing_components/components/input", {
+        label: {
+        text: "Heading Text",
+      },
+      name: "edition[flexible_page_content][title][heading_text]",
+      id: "edition_flexible_page_content_title_heading_text",
+    } %>
+    <%= render("settings_fields", form:, edition:) %>
+    <%= standard_edition_publishing_controls(form, edition) %>
+  </div>
+<% end %>

--- a/app/views/admin/flexible_pages/_form.html.erb
+++ b/app/views/admin/flexible_pages/_form.html.erb
@@ -43,7 +43,7 @@
     } %>
 
     <%= form.hidden_field :flexible_page_type, value: @edition.flexible_page_type %>
-    <%= render inline: render_flexible_page_content_fields(FlexiblePageType.find(@edition.flexible_page_type).properties, @edition) %>
+    <%= render inline: render_flexible_page_content_fields(FlexiblePageType.find(@edition.flexible_page_type).schema, @edition) %>
     <%= render("settings_fields", form:, edition:) %>
     <%= standard_edition_publishing_controls(form, edition) %>
   </div>

--- a/app/views/admin/flexible_pages/_form.html.erb
+++ b/app/views/admin/flexible_pages/_form.html.erb
@@ -42,13 +42,8 @@
       margin_bottom: 6,
     } %>
 
-    <%= render "govuk_publishing_components/components/input", {
-        label: {
-        text: "Heading Text",
-      },
-      name: "edition[flexible_page_content][title][heading_text]",
-      id: "edition_flexible_page_content_title_heading_text",
-    } %>
+    <%= form.hidden_field :flexible_page_type, value: @edition.flexible_page_type %>
+    <%= render inline: render_flexible_page_content_fields(FlexiblePageType.find(@edition.flexible_page_type).properties, @edition) %>
     <%= render("settings_fields", form:, edition:) %>
     <%= standard_edition_publishing_controls(form, edition) %>
   </div>

--- a/app/views/admin/flexible_pages/choose_type.html.erb
+++ b/app/views/admin/flexible_pages/choose_type.html.erb
@@ -8,10 +8,7 @@
         heading_level: 1,
         name: "flexible_page_type",
         id: "flexible_page_type",
-        items: [
-          "text": "History page",
-          "value": "history_page",
-        ],
+        items: FlexiblePageType.all.map { |type| { text: type.label, value: type.key }},
       } %>
       <div class="govuk-button-group">
         <%= render "govuk_publishing_components/components/button", { text: "Next" } %>

--- a/app/views/admin/flexible_pages/new.html.erb
+++ b/app/views/admin/flexible_pages/new.html.erb
@@ -1,0 +1,23 @@
+<% content_for :page_title, "New flexible page" %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= form_with method: "get", url: new_admin_flexible_page_path do %>
+      <%= render "govuk_publishing_components/components/radio", {
+        heading: "New flexible page",
+        heading_level: 1,
+        name: "flexible_page_type",
+        id: "flexible_page_type",
+        items: [
+          "text": "History page",
+          "value": "history_page",
+        ],
+      } %>
+      <div class="govuk-button-group">
+        <%= render "govuk_publishing_components/components/button", { text: "Next" } %>
+
+        <%= link_to("Cancel", root_path, class: "govuk-link govuk-link--no-visited-state") %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/config/initializers/flexible_page_types.rb
+++ b/config/initializers/flexible_page_types.rb
@@ -1,0 +1,4 @@
+# Load the flexible page schemas when the Rails application boots
+Rails.application.config.after_initialize do
+  FlexiblePageType.boot
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -207,6 +207,9 @@ en:
       fatality_notice:
         one: Fatality notice
         other: Fatality notices
+      flexible_page:
+        one: Flexible page
+        other: Flexible Pages
       foi_release:
         one: FOI release
         other: FOI releases

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -290,7 +290,9 @@ Whitehall::Application.routes.draw do
 
       resources :publications, except: [:index]
 
-      resources :flexible_pages, path: "flexible-pages", except: [:index]
+      resources :flexible_pages, path: "flexible-pages", except: [:index] do
+        get :choose_type, on: :collection, as: :choose_type
+      end
       resources :landing_pages, path: "landing-pages", except: [:index]
 
       resources :news_articles, path: "news", except: [:index]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -290,6 +290,7 @@ Whitehall::Application.routes.draw do
 
       resources :publications, except: [:index]
 
+      resources :flexible_pages, path: "flexible-pages", except: [:index]
       resources :landing_pages, path: "landing-pages", except: [:index]
 
       resources :news_articles, path: "news", except: [:index]

--- a/db/migrate/20250610095041_add_flexible_page_content_to_editions.rb
+++ b/db/migrate/20250610095041_add_flexible_page_content_to_editions.rb
@@ -1,0 +1,5 @@
+class AddFlexiblePageContentToEditions < ActiveRecord::Migration[8.0]
+  def change
+    add_column :editions, :flexible_page_content, :json, default: nil
+  end
+end

--- a/db/migrate/20250610095041_add_flexible_page_content_to_editions.rb
+++ b/db/migrate/20250610095041_add_flexible_page_content_to_editions.rb
@@ -1,5 +1,6 @@
 class AddFlexiblePageContentToEditions < ActiveRecord::Migration[8.0]
   def change
+    add_column :editions, :flexible_page_type, :string, default: nil
     add_column :editions, :flexible_page_content, :json, default: nil
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 20_250_610_095_041) do
+ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
   create_table "assets", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.string "variant", null: false
@@ -453,6 +453,7 @@ ActiveRecord::Schema[8.0].define(version: 20_250_610_095_041) do
     t.integer "main_office_id"
     t.boolean "visual_editor"
     t.integer "government_id"
+    t.string "flexible_page_type"
     t.json "flexible_page_content"
     t.index ["alternative_format_provider_id"], name: "index_editions_on_alternative_format_provider_id"
     t.index ["closing_at"], name: "index_editions_on_closing_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_05_08_154529) do
+ActiveRecord::Schema[8.0].define(version: 20_250_610_095_041) do
   create_table "assets", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.string "variant", null: false
@@ -453,6 +453,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_08_154529) do
     t.integer "main_office_id"
     t.boolean "visual_editor"
     t.integer "government_id"
+    t.json "flexible_page_content"
     t.index ["alternative_format_provider_id"], name: "index_editions_on_alternative_format_provider_id"
     t.index ["closing_at"], name: "index_editions_on_closing_at"
     t.index ["document_id"], name: "index_editions_on_document_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
-  create_table "assets", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "assets", charset: "utf8mb3", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.string "variant", null: false
     t.datetime "created_at", null: false
@@ -23,7 +23,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["assetable_type", "assetable_id"], name: "index_assets_on_assetable"
   end
 
-  create_table "attachment_data", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "attachment_data", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.string "carrierwave_file"
     t.string "content_type"
     t.integer "file_size"
@@ -34,13 +34,13 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["replaced_by_id"], name: "index_attachment_data_on_replaced_by_id"
   end
 
-  create_table "attachment_sources", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "attachment_sources", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "attachment_id"
     t.string "url"
     t.index ["attachment_id"], name: "index_attachment_sources_on_attachment_id"
   end
 
-  create_table "attachments", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "attachments", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.string "title"
@@ -71,32 +71,32 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["ordering"], name: "index_attachments_on_ordering"
   end
 
-  create_table "call_for_evidence_participations", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "call_for_evidence_participations", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "edition_id"
     t.string "link_url"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.string "email"
     t.integer "call_for_evidence_response_form_id"
-    t.text "postal_address", size: :medium
+    t.text "postal_address"
     t.index ["call_for_evidence_response_form_id"], name: "index_cfes_participations_on_cfes_response_form_id"
     t.index ["edition_id"], name: "index_call_for_evidence_participations_on_edition_id"
   end
 
-  create_table "call_for_evidence_response_form_data", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "call_for_evidence_response_form_data", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.string "carrierwave_file"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
   end
 
-  create_table "call_for_evidence_response_forms", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "call_for_evidence_response_forms", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.string "title"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.integer "call_for_evidence_response_form_data_id"
   end
 
-  create_table "call_for_evidence_responses", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "call_for_evidence_responses", charset: "utf8mb3", force: :cascade do |t|
     t.integer "edition_id"
     t.text "summary"
     t.datetime "created_at", precision: nil
@@ -107,34 +107,34 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["edition_id"], name: "index_call_for_evidence_responses_on_edition_id"
   end
 
-  create_table "consultation_participations", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "consultation_participations", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "edition_id"
     t.string "link_url"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.string "email"
     t.integer "consultation_response_form_id"
-    t.text "postal_address", size: :medium
+    t.text "postal_address"
     t.index ["consultation_response_form_id"], name: "index_cons_participations_on_cons_response_form_id"
     t.index ["edition_id"], name: "index_consultation_participations_on_edition_id"
   end
 
-  create_table "consultation_response_form_data", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "consultation_response_form_data", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.string "carrierwave_file"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
   end
 
-  create_table "consultation_response_forms", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "consultation_response_forms", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.string "title"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.integer "consultation_response_form_data_id"
   end
 
-  create_table "consultation_responses", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "consultation_responses", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "edition_id"
-    t.text "summary", size: :medium
+    t.text "summary"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.date "published_on"
@@ -143,7 +143,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["edition_id"], name: "index_consultation_responses_on_edition_id"
   end
 
-  create_table "contact_number_translations", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "contact_number_translations", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "contact_number_id"
     t.string "locale"
     t.datetime "created_at", precision: nil, null: false
@@ -154,7 +154,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["locale"], name: "index_contact_number_translations_on_locale"
   end
 
-  create_table "contact_numbers", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "contact_numbers", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "contact_id"
     t.string "label"
     t.string "number"
@@ -163,15 +163,15 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["contact_id"], name: "index_contact_numbers_on_contact_id"
   end
 
-  create_table "contact_translations", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "contact_translations", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "contact_id"
     t.string "locale"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.string "title"
-    t.text "comments", size: :medium
+    t.text "comments"
     t.string "recipient"
-    t.text "street_address", size: :medium
+    t.text "street_address"
     t.string "locality"
     t.string "region"
     t.string "email"
@@ -180,7 +180,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["locale"], name: "index_contact_translations_on_locale"
   end
 
-  create_table "contacts", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "contacts", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "contactable_id"
     t.string "contactable_type"
     t.string "postal_code"
@@ -191,7 +191,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["contactable_id", "contactable_type"], name: "index_contacts_on_contactable_id_and_contactable_type"
   end
 
-  create_table "content_block_documents", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "content_block_documents", charset: "utf8mb3", force: :cascade do |t|
     t.string "content_id"
     t.string "sluggable_string"
     t.string "block_type"
@@ -206,7 +206,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["live_edition_id"], name: "index_content_block_documents_on_live_edition_id"
   end
 
-  create_table "content_block_edition_authors", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "content_block_edition_authors", charset: "utf8mb3", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "edition_id", null: false
     t.datetime "created_at", precision: nil, null: false
@@ -215,7 +215,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["user_id"], name: "index_content_block_edition_authors_on_user_id"
   end
 
-  create_table "content_block_edition_organisations", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "content_block_edition_organisations", charset: "utf8mb3", force: :cascade do |t|
     t.bigint "content_block_edition_id", null: false
     t.integer "organisation_id", null: false
     t.datetime "created_at", precision: nil, null: false
@@ -224,11 +224,12 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["organisation_id"], name: "index_content_block_edition_organisations_on_organisation_id"
   end
 
-  create_table "content_block_editions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "content_block_editions", charset: "utf8mb3", force: :cascade do |t|
     t.json "details", null: false
     t.bigint "document_id", null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
+    t.bigint "user_id"
     t.string "state", default: "draft", null: false
     t.datetime "scheduled_publication", precision: nil
     t.text "instructions_to_publishers"
@@ -239,9 +240,10 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.virtual "details_for_indexing", type: :text, as: "json_unquote(`details`)", stored: true
     t.index ["document_id"], name: "index_content_block_editions_on_document_id"
     t.index ["title", "details_for_indexing", "instructions_to_publishers"], name: "title_details_instructions_to_publishers", type: :fulltext
+    t.index ["user_id"], name: "index_content_block_editions_on_user_id"
   end
 
-  create_table "content_block_versions", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "content_block_versions", charset: "utf8mb3", force: :cascade do |t|
     t.string "item_type", null: false
     t.integer "item_id", null: false
     t.integer "event", null: false
@@ -255,12 +257,12 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["item_type"], name: "index_content_block_versions_on_item_type"
   end
 
-  create_table "data_migration_records", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "data_migration_records", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.string "version"
     t.index ["version"], name: "index_data_migration_records_on_version", unique: true
   end
 
-  create_table "document_collection_group_memberships", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "document_collection_group_memberships", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "document_id"
     t.integer "document_collection_group_id"
     t.integer "ordering"
@@ -272,26 +274,26 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["non_whitehall_link_id"], name: "index_document_collection_non_whitehall_link"
   end
 
-  create_table "document_collection_groups", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "document_collection_groups", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "document_collection_id"
     t.string "heading"
-    t.text "body", size: :medium
+    t.text "body"
     t.integer "ordering"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.index ["document_collection_id", "ordering"], name: "index_dc_groups_on_dc_id_and_ordering"
   end
 
-  create_table "document_collection_non_whitehall_links", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "document_collection_non_whitehall_links", charset: "utf8mb3", force: :cascade do |t|
     t.string "content_id", null: false
     t.string "title", null: false
-    t.text "base_path", size: :medium, null: false
+    t.text "base_path", null: false
     t.string "publishing_app", null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
   end
 
-  create_table "documents", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "documents", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.string "slug"
@@ -306,7 +308,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["slug", "document_type"], name: "index_documents_on_slug_and_document_type", unique: true
   end
 
-  create_table "edition_authors", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "edition_authors", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "edition_id"
     t.integer "user_id"
     t.datetime "created_at", precision: nil
@@ -315,14 +317,14 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["user_id"], name: "index_edition_authors_on_user_id"
   end
 
-  create_table "edition_dependencies", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "edition_dependencies", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "edition_id"
     t.integer "dependable_id"
     t.string "dependable_type"
     t.index ["dependable_id", "dependable_type", "edition_id"], name: "index_edition_dependencies_on_dependable_and_edition", unique: true
   end
 
-  create_table "edition_lead_images", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "edition_lead_images", charset: "utf8mb3", force: :cascade do |t|
     t.integer "edition_id"
     t.integer "image_id"
     t.datetime "created_at", null: false
@@ -330,7 +332,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["edition_id"], name: "index_lead_image_on_edition_id", unique: true
   end
 
-  create_table "edition_organisations", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "edition_organisations", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "edition_id"
     t.integer "organisation_id"
     t.datetime "created_at", precision: nil
@@ -341,7 +343,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["organisation_id"], name: "index_edition_organisations_on_organisation_id"
   end
 
-  create_table "edition_relations", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "edition_relations", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "edition_id", null: false
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
@@ -350,40 +352,40 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["edition_id"], name: "index_edition_relations_on_edition_id"
   end
 
-  create_table "edition_role_appointments", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "edition_role_appointments", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "edition_id"
     t.integer "role_appointment_id"
     t.index ["edition_id"], name: "index_edition_role_appointments_on_edition_id"
     t.index ["role_appointment_id"], name: "index_edition_role_appointments_on_role_appointment_id"
   end
 
-  create_table "edition_roles", id: false, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "edition_roles", id: false, charset: "utf8mb3", force: :cascade do |t|
     t.bigint "edition_id", null: false
     t.bigint "role_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "edition_statistical_data_sets", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "edition_statistical_data_sets", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "edition_id"
     t.integer "document_id"
     t.index ["document_id"], name: "index_edition_statistical_data_sets_on_document_id"
     t.index ["edition_id"], name: "index_edition_statistical_data_sets_on_edition_id"
   end
 
-  create_table "edition_translations", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "edition_translations", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "edition_id"
     t.string "locale"
     t.string "title"
-    t.text "summary", size: :medium
-    t.text "body", size: :long
+    t.text "summary"
+    t.text "body", size: :medium
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.index ["edition_id"], name: "index_edition_translations_on_edition_id"
     t.index ["locale"], name: "index_edition_translations_on_locale"
   end
 
-  create_table "edition_world_locations", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "edition_world_locations", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "edition_id"
     t.integer "world_location_id"
     t.datetime "created_at", precision: nil
@@ -393,7 +395,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["world_location_id"], name: "index_edition_world_locations_on_world_location_id"
   end
 
-  create_table "edition_worldwide_organisations", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "edition_worldwide_organisations", charset: "utf8mb3", force: :cascade do |t|
     t.integer "edition_id"
     t.integer "document_id"
     t.datetime "created_at", null: false
@@ -402,7 +404,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["edition_id"], name: "index_edition_worldwide_organisations_on_edition_id"
   end
 
-  create_table "editions", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "editions", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.integer "lock_version", default: 0
@@ -416,7 +418,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.datetime "first_published_at", precision: nil
     t.integer "speech_type_id"
     t.boolean "stub", default: false
-    t.text "change_note", size: :medium
+    t.text "change_note"
     t.boolean "force_published"
     t.boolean "minor_change", default: false
     t.integer "publication_type_id"
@@ -432,7 +434,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.integer "published_major_version"
     t.integer "published_minor_version"
     t.integer "operational_field_id"
-    t.text "roll_call_introduction", size: :medium
+    t.text "roll_call_introduction"
     t.integer "news_article_type_id"
     t.string "person_override"
     t.boolean "external", default: false
@@ -448,9 +450,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.string "image_display_option"
     t.string "auth_bypass_id", null: false
     t.string "taxonomy_topic_email_override"
+    t.integer "main_office_id"
     t.string "logo_formatted_name"
     t.string "analytics_identifier"
-    t.integer "main_office_id"
     t.boolean "visual_editor"
     t.integer "government_id"
     t.string "flexible_page_type"
@@ -474,8 +476,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["updated_at"], name: "index_editions_on_updated_at"
   end
 
-  create_table "editorial_remarks", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.text "body", size: :medium
+  create_table "editorial_remarks", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.text "body"
     t.integer "edition_id"
     t.integer "author_id"
     t.datetime "created_at", precision: nil
@@ -484,26 +486,26 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["edition_id"], name: "index_editorial_remarks_on_edition_id"
   end
 
-  create_table "fact_check_requests", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "fact_check_requests", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "edition_id"
     t.string "key"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.string "email_address"
-    t.text "comments", size: :medium
-    t.text "instructions", size: :medium
+    t.text "comments"
+    t.text "instructions"
     t.integer "requestor_id"
     t.index ["edition_id"], name: "index_fact_check_requests_on_edition_id"
     t.index ["key"], name: "index_fact_check_requests_on_key", unique: true
     t.index ["requestor_id"], name: "index_fact_check_requests_on_requestor_id"
   end
 
-  create_table "fatality_notice_casualties", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "fatality_notice_casualties", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "fatality_notice_id"
-    t.text "personal_details", size: :medium
+    t.text "personal_details"
   end
 
-  create_table "feature_lists", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "feature_lists", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "featurable_id"
     t.string "featurable_type"
     t.string "locale"
@@ -512,7 +514,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["featurable_id", "featurable_type", "locale"], name: "featurable_lists_unique_locale_per_featurable", unique: true
   end
 
-  create_table "featured_image_data", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "featured_image_data", charset: "utf8mb3", force: :cascade do |t|
     t.string "carrierwave_image"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -520,9 +522,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.integer "featured_imageable_id"
   end
 
-  create_table "featured_link_translations", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.text "url", size: :medium
-    t.text "title", size: :medium
+  create_table "featured_link_translations", charset: "utf8mb3", force: :cascade do |t|
+    t.text "url"
+    t.text "title"
     t.string "locale", null: false
     t.integer "featured_link_id", null: false
     t.datetime "created_at", null: false
@@ -531,14 +533,14 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["locale"], name: "index_on_locale"
   end
 
-  create_table "featured_links", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "featured_links", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "linkable_id"
     t.string "linkable_type"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
   end
 
-  create_table "features", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "features", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "document_id"
     t.integer "feature_list_id"
     t.string "alt_text"
@@ -554,14 +556,14 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["ordering"], name: "index_features_on_ordering"
   end
 
-  create_table "flipflop_features", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "flipflop_features", charset: "utf8mb3", force: :cascade do |t|
     t.string "key", null: false
     t.boolean "enabled", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "force_publication_attempts", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "force_publication_attempts", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "import_id"
     t.integer "total_documents"
     t.integer "successful_documents"
@@ -574,7 +576,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["import_id"], name: "index_force_publication_attempts_on_import_id"
   end
 
-  create_table "governments", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "governments", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.string "slug"
     t.string "name"
     t.date "start_date"
@@ -589,16 +591,16 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["start_date"], name: "index_governments_on_start_date"
   end
 
-  create_table "govspeak_contents", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "govspeak_contents", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "html_attachment_id"
-    t.text "body", size: :long
+    t.text "body", size: :medium
     t.boolean "manually_numbered_headings"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.index ["html_attachment_id"], name: "index_govspeak_contents_on_html_attachment_id"
   end
 
-  create_table "group_memberships", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "group_memberships", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "group_id"
     t.integer "person_id"
     t.datetime "created_at", precision: nil
@@ -607,18 +609,18 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["person_id"], name: "index_group_memberships_on_person_id"
   end
 
-  create_table "groups", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "groups", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "organisation_id"
     t.string "name"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.string "slug"
-    t.text "description", size: :medium
+    t.text "description"
     t.index ["organisation_id"], name: "index_groups_on_organisation_id"
     t.index ["slug"], name: "index_groups_on_slug"
   end
 
-  create_table "historical_account_roles", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "historical_account_roles", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "role_id"
     t.integer "historical_account_id"
     t.datetime "created_at", precision: nil
@@ -627,14 +629,14 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["role_id"], name: "index_historical_account_roles_on_role_id"
   end
 
-  create_table "historical_accounts", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "historical_accounts", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "person_id"
-    t.text "summary", size: :medium
-    t.text "body", size: :medium
+    t.text "summary"
+    t.text "body"
     t.string "born"
     t.string "died"
-    t.text "major_acts", size: :medium
-    t.text "interesting_facts", size: :medium
+    t.text "major_acts"
+    t.text "interesting_facts"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.string "political_party_ids"
@@ -642,7 +644,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["person_id"], name: "index_historical_accounts_on_person_id"
   end
 
-  create_table "home_page_list_items", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "home_page_list_items", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "home_page_list_id", null: false
     t.integer "item_id", null: false
     t.string "item_type", null: false
@@ -654,7 +656,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["item_id", "item_type"], name: "index_home_page_list_items_on_item_id_and_item_type"
   end
 
-  create_table "home_page_lists", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "home_page_lists", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "owner_id", null: false
     t.string "owner_type", null: false
     t.string "name"
@@ -663,41 +665,41 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["owner_id", "owner_type", "name"], name: "index_home_page_lists_on_owner_id_and_owner_type_and_name", unique: true
   end
 
-  create_table "image_data", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "image_data", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "carrierwave_image"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.string "image_kind", default: "default", null: false
   end
 
-  create_table "images", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "images", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "image_data_id"
     t.integer "edition_id"
     t.string "alt_text"
-    t.text "caption", size: :medium
+    t.text "caption"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.index ["edition_id"], name: "index_images_on_edition_id"
     t.index ["image_data_id"], name: "index_images_on_image_data_id"
   end
 
-  create_table "link_checker_api_report_links", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "link_checker_api_report_links", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "link_checker_api_report_id"
-    t.text "uri", size: :medium, null: false
+    t.text "uri", null: false
     t.string "status", null: false
     t.datetime "checked", precision: nil
-    t.text "check_warnings", size: :medium
-    t.text "check_errors", size: :medium
+    t.text "check_warnings"
+    t.text "check_errors"
     t.integer "ordering", null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
-    t.text "problem_summary", size: :medium
-    t.text "suggested_fix", size: :medium
+    t.text "problem_summary"
+    t.text "suggested_fix"
     t.text "check_dangers", size: :medium
     t.index ["link_checker_api_report_id"], name: "index_link_checker_api_report_id"
   end
 
-  create_table "link_checker_api_reports", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "link_checker_api_reports", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "batch_id"
     t.string "status", null: false
     t.datetime "completed_at", precision: nil
@@ -708,7 +710,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["edition_id"], name: "index_link_checker_api_reports_on_edition_id", unique: true
   end
 
-  create_table "nation_inapplicabilities", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "nation_inapplicabilities", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "nation_id"
     t.integer "edition_id"
     t.datetime "created_at", precision: nil
@@ -718,7 +720,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["nation_id"], name: "index_nation_inapplicabilities_on_nation_id"
   end
 
-  create_table "offsite_links", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "offsite_links", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.string "title"
     t.string "summary"
     t.string "url"
@@ -730,17 +732,17 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.datetime "updated_at", precision: nil, null: false
   end
 
-  create_table "operational_fields", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "operational_fields", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
-    t.text "description", size: :medium
+    t.text "description"
     t.string "slug"
     t.string "content_id"
     t.index ["slug"], name: "index_operational_fields_on_slug"
   end
 
-  create_table "organisation_roles", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "organisation_roles", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "organisation_id"
     t.integer "role_id"
     t.datetime "created_at", precision: nil
@@ -750,17 +752,17 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["role_id"], name: "index_organisation_roles_on_role_id"
   end
 
-  create_table "organisation_supersedings", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "organisation_supersedings", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "superseded_organisation_id"
     t.integer "superseding_organisation_id"
     t.index ["superseded_organisation_id"], name: "index_organisation_supersedings_on_superseded_organisation_id"
   end
 
-  create_table "organisation_translations", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "organisation_translations", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "organisation_id"
     t.string "locale"
     t.string "name"
-    t.text "logo_formatted_name", size: :medium
+    t.text "logo_formatted_name"
     t.string "acronym"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
@@ -769,7 +771,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["organisation_id"], name: "index_organisation_translations_on_organisation_id"
   end
 
-  create_table "organisational_relationships", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "organisational_relationships", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "parent_organisation_id"
     t.integer "child_organisation_id"
     t.datetime "created_at", precision: nil
@@ -778,7 +780,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["parent_organisation_id"], name: "index_organisational_relationships_on_parent_organisation_id"
   end
 
-  create_table "organisations", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "organisations", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.string "slug", null: false
@@ -800,7 +802,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.boolean "foi_exempt", default: false, null: false
     t.string "organisation_chart_url"
     t.string "govuk_closed_status"
-    t.text "custom_jobs_url", size: :medium
+    t.text "custom_jobs_url"
     t.string "content_id"
     t.string "homepage_type", default: "news"
     t.boolean "political", default: false
@@ -811,7 +813,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["slug"], name: "index_organisations_on_slug", unique: true
   end
 
-  create_table "people", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "people", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "title"
     t.string "forename"
     t.string "surname"
@@ -824,17 +826,17 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["slug"], name: "index_people_on_slug", unique: true
   end
 
-  create_table "person_translations", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "person_translations", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "person_id"
     t.string "locale"
-    t.text "biography", size: :medium
+    t.text "biography"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.index ["locale"], name: "index_person_translations_on_locale"
     t.index ["person_id"], name: "index_person_translations_on_person_id"
   end
 
-  create_table "policy_group_dependencies", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "policy_group_dependencies", charset: "utf8mb3", force: :cascade do |t|
     t.bigint "policy_group_id"
     t.string "dependable_type"
     t.bigint "dependable_id"
@@ -845,21 +847,21 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["policy_group_id"], name: "index_policy_group_dependencies_on_policy_group_id"
   end
 
-  create_table "policy_groups", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "policy_groups", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "email"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.string "name"
-    t.text "description", size: :medium
-    t.text "summary", size: :medium
+    t.text "description"
+    t.text "summary"
     t.string "slug"
     t.string "content_id", null: false
     t.index ["slug"], name: "index_policy_groups_on_slug"
   end
 
-  create_table "promotional_feature_items", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "promotional_feature_items", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "promotional_feature_id"
-    t.text "summary", size: :medium
+    t.text "summary"
     t.string "image"
     t.string "image_alt_text"
     t.string "title"
@@ -871,7 +873,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["promotional_feature_id"], name: "index_promotional_feature_items_on_promotional_feature_id"
   end
 
-  create_table "promotional_feature_links", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "promotional_feature_links", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "promotional_feature_item_id"
     t.string "url"
     t.string "text"
@@ -880,7 +882,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["promotional_feature_item_id"], name: "index_promotional_feature_links_on_promotional_feature_item_id"
   end
 
-  create_table "promotional_features", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "promotional_features", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "organisation_id"
     t.string "title"
     t.datetime "created_at", precision: nil
@@ -889,14 +891,14 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["organisation_id"], name: "index_promotional_features_on_organisation_id"
   end
 
-  create_table "recent_edition_openings", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "recent_edition_openings", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "edition_id", null: false
     t.integer "editor_id", null: false
     t.datetime "created_at", precision: nil, null: false
     t.index ["edition_id", "editor_id"], name: "index_recent_edition_openings_on_edition_id_and_editor_id", unique: true
   end
 
-  create_table "related_mainstreams", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "related_mainstreams", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "edition_id"
     t.string "content_id"
     t.boolean "additional", default: false
@@ -905,7 +907,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["edition_id"], name: "index_related_mainstreams_on_edition_id"
   end
 
-  create_table "republishing_events", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "republishing_events", charset: "utf8mb3", force: :cascade do |t|
     t.text "action", null: false
     t.text "reason", null: false
     t.bigint "user_id", null: false
@@ -920,7 +922,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["user_id"], name: "index_republishing_events_on_user_id"
   end
 
-  create_table "review_reminders", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "review_reminders", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "document_id"
     t.integer "creator_id"
     t.string "email_address"
@@ -933,7 +935,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["review_at", "reminder_sent_at"], name: "index_review_reminders_on_review_at_and_reminder_sent_at"
   end
 
-  create_table "role_appointments", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "role_appointments", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "role_id"
     t.integer "person_id"
     t.datetime "created_at", precision: nil
@@ -947,11 +949,11 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["role_id"], name: "index_role_appointments_on_role_id"
   end
 
-  create_table "role_translations", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "role_translations", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "role_id"
     t.string "locale"
     t.string "name"
-    t.text "responsibilities", size: :medium
+    t.text "responsibilities"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.index ["locale"], name: "index_role_translations_on_locale"
@@ -959,7 +961,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["role_id"], name: "index_role_translations_on_role_id"
   end
 
-  create_table "roles", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "roles", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.string "type", null: false
@@ -979,18 +981,18 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["supports_historical_accounts"], name: "index_roles_on_supports_historical_accounts"
   end
 
-  create_table "sitewide_settings", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "sitewide_settings", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.string "key"
-    t.text "description", size: :medium
+    t.text "description"
     t.boolean "on"
-    t.text "govspeak", size: :medium
+    t.text "govspeak"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
   end
 
-  create_table "social_media_account_translations", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.text "url", size: :medium
-    t.text "title", size: :medium
+  create_table "social_media_account_translations", charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
+    t.text "url"
+    t.text "title"
     t.string "locale", null: false
     t.integer "social_media_account_id", null: false
     t.datetime "created_at", null: false
@@ -999,7 +1001,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["social_media_account_id"], name: "index_on_social_media_account"
   end
 
-  create_table "social_media_accounts", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "social_media_accounts", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "socialable_id"
     t.integer "social_media_service_id"
     t.datetime "created_at", precision: nil
@@ -1010,18 +1012,18 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["socialable_id"], name: "index_social_media_accounts_on_organisation_id"
   end
 
-  create_table "social_media_services", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "social_media_services", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
   end
 
-  create_table "statistics_announcement_dates", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "statistics_announcement_dates", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "statistics_announcement_id"
     t.datetime "release_date", precision: nil
     t.integer "precision"
     t.boolean "confirmed"
-    t.text "change_note", size: :medium
+    t.text "change_note"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.integer "creator_id"
@@ -1029,7 +1031,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["statistics_announcement_id", "created_at"], name: "statistics_announcement_release_date"
   end
 
-  create_table "statistics_announcement_organisations", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "statistics_announcement_organisations", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "statistics_announcement_id"
     t.integer "organisation_id"
     t.datetime "created_at", precision: nil, null: false
@@ -1038,7 +1040,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["statistics_announcement_id", "organisation_id"], name: "index_on_statistics_announcement_id_and_organisation_id"
   end
 
-  create_table "statistics_announcement_topics", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "statistics_announcement_topics", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "statistics_announcement_id"
     t.integer "topic_id"
     t.datetime "created_at", precision: nil, null: false
@@ -1047,17 +1049,17 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["topic_id"], name: "index_statistics_announcement_topics_on_topic_id"
   end
 
-  create_table "statistics_announcements", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "statistics_announcements", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.string "title"
     t.string "slug"
-    t.text "summary", size: :medium
+    t.text "summary"
     t.integer "publication_type_id"
     t.integer "topic_id"
     t.integer "creator_id"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.integer "publication_id"
-    t.text "cancellation_reason", size: :medium
+    t.text "cancellation_reason"
     t.datetime "cancelled_at", precision: nil
     t.integer "cancelled_by_id"
     t.string "publishing_state", default: "published", null: false
@@ -1073,24 +1075,24 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["topic_id"], name: "index_statistics_announcements_on_topic_id"
   end
 
-  create_table "topical_event_about_pages", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "topical_event_about_pages", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "topical_event_id"
     t.string "name"
-    t.text "summary", size: :medium
-    t.text "body", size: :medium
+    t.text "summary"
+    t.text "body"
     t.string "read_more_link_text"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.string "content_id"
   end
 
-  create_table "topical_event_featuring_image_data", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "topical_event_featuring_image_data", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.string "carrierwave_image"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
   end
 
-  create_table "topical_event_featurings", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "topical_event_featurings", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "edition_id"
     t.integer "topical_event_id"
     t.datetime "created_at", precision: nil
@@ -1105,7 +1107,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["topical_event_id"], name: "index_topical_event_feat_on_topical_event_id"
   end
 
-  create_table "topical_event_memberships", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "topical_event_memberships", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "topical_event_id"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
@@ -1115,7 +1117,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["topical_event_id"], name: "index_topical_event_memberships_on_topical_event_id"
   end
 
-  create_table "topical_event_organisations", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "topical_event_organisations", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "organisation_id", null: false
     t.integer "topical_event_id", null: false
     t.datetime "created_at", precision: nil
@@ -1128,26 +1130,26 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["topical_event_id"], name: "index_topical_event_org_on_topical_event_id"
   end
 
-  create_table "topical_events", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "topical_events", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
-    t.text "description", size: :medium
+    t.text "description"
     t.string "slug"
     t.string "state"
     t.string "logo_alt_text"
     t.date "start_date"
     t.date "end_date"
     t.string "content_id"
-    t.text "summary", size: :medium
+    t.text "summary"
     t.index ["slug"], name: "index_topical_events_on_slug"
   end
 
-  create_table "unpublishings", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "unpublishings", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "edition_id"
     t.integer "unpublishing_reason_id"
-    t.text "explanation", size: :medium
-    t.text "alternative_url", size: :medium
+    t.text "explanation"
+    t.text "alternative_url"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.string "document_type"
@@ -1159,20 +1161,20 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["unpublishing_reason_id"], name: "index_unpublishings_on_unpublishing_reason_id"
   end
 
-  create_table "user_world_locations", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "user_world_locations", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "user_id"
     t.integer "world_location_id"
     t.index ["user_id", "world_location_id"], name: "index_user_world_locations_on_user_id_and_world_location_id", unique: true
   end
 
-  create_table "users", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "users", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.string "email"
     t.string "uid"
     t.integer "version"
-    t.text "permissions", size: :medium
+    t.text "permissions"
     t.boolean "remotely_signed_out", default: false
     t.string "organisation_slug"
     t.boolean "disabled", default: false
@@ -1180,25 +1182,25 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["organisation_slug"], name: "index_users_on_organisation_slug"
   end
 
-  create_table "versions", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "versions", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.string "item_type", null: false
     t.integer "item_id", null: false
     t.string "event", null: false
     t.string "whodunnit"
-    t.text "object", size: :medium
+    t.text "object"
     t.datetime "created_at", precision: nil
-    t.text "state", size: :medium
+    t.text "state"
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
-  create_table "world_location_news", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "world_location_news", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "world_location_id"
     t.string "content_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "world_location_news_translations", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "world_location_news_translations", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "world_location_news_id"
     t.string "locale"
     t.string "title"
@@ -1207,7 +1209,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "world_location_translations", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "world_location_translations", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.integer "world_location_id"
     t.string "locale"
     t.string "name"
@@ -1217,7 +1219,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["world_location_id"], name: "index_world_location_translations_on_world_location_id"
   end
 
-  create_table "world_locations", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "world_locations", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.string "slug"
@@ -1231,26 +1233,26 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["world_location_type"], name: "index_world_locations_on_world_location_type"
   end
 
-  create_table "worldwide_office_worldwide_services", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "worldwide_office_worldwide_services", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.integer "worldwide_office_id", null: false
     t.integer "worldwide_service_id", null: false
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
   end
 
-  create_table "worldwide_offices", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "worldwide_offices", id: :integer, charset: "utf8mb3", collation: "utf8mb3_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.integer "worldwide_office_type_id", null: false
     t.string "slug"
-    t.text "access_and_opening_times", size: :medium
+    t.text "access_and_opening_times"
     t.string "content_id"
     t.integer "edition_id"
     t.index ["edition_id"], name: "index_worldwide_offices_on_edition_id"
     t.index ["slug"], name: "index_worldwide_offices_on_slug"
   end
 
-  create_table "worldwide_organisation_page_translations", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "worldwide_organisation_page_translations", charset: "utf8mb3", force: :cascade do |t|
     t.bigint "worldwide_organisation_page_id", null: false
     t.string "locale", null: false
     t.datetime "created_at", null: false
@@ -1262,7 +1264,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["worldwide_organisation_page_id"], name: "index_bbd0fc4436b2d97c8b36796e9089468751fc0f2e"
   end
 
-  create_table "worldwide_organisation_pages", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "worldwide_organisation_pages", charset: "utf8mb3", force: :cascade do |t|
     t.integer "corporate_information_page_type_id", null: false
     t.integer "edition_id", null: false
     t.datetime "created_at", null: false
@@ -1271,7 +1273,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.index ["edition_id"], name: "index_worldwide_organisation_pages_on_edition_id"
   end
 
-  create_table "worldwide_services", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
+  create_table "worldwide_services", id: :integer, charset: "utf8mb3", force: :cascade do |t|
     t.string "name", default: "", null: false
     t.integer "service_type_id", null: false
     t.datetime "created_at", precision: nil

--- a/features/fixtures/test_flexible_page_type.json
+++ b/features/fixtures/test_flexible_page_type.json
@@ -1,0 +1,31 @@
+{
+  "key": "test",
+  "schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://www.gov.uk/schemas/history_page/v1",
+    "title": "Test flexible page type",
+    "description": "A test flexible page on GOV.UK",
+    "type": "object",
+    "properties": {
+      "page_title": {
+        "title": "Page title",
+        "description": "The title of the page",
+        "type": "object",
+        "properties": {
+          "heading_text": {
+            "title": "Heading text",
+            "description": "The main heading text for the page title",
+            "type": "string"
+          },
+          "context": {
+            "title": "Context",
+            "description": "Some additional context for the page title",
+            "type": "string"
+          }
+        },
+        "required": ["heading_text"]
+      }
+    },
+    "required": ["page_title"]
+  }
+}

--- a/features/flexible-pages.feature
+++ b/features/flexible-pages.feature
@@ -1,0 +1,7 @@
+Feature: Flexible pages
+
+  Scenario: Creating a new draft flexible page
+    Given I am a writer in the organisation "Department of Examples"
+    And the flexible pages feature flag is enabled
+    When I draft a new "History page" flexible page titled "The history of GOV.UK"
+    Then I can see a preview link

--- a/features/flexible-pages.feature
+++ b/features/flexible-pages.feature
@@ -3,5 +3,6 @@ Feature: Flexible pages
   Scenario: Creating a new draft flexible page
     Given I am a writer in the organisation "Department of Examples"
     And the flexible pages feature flag is enabled
-    When I draft a new "History page" flexible page titled "The history of GOV.UK"
-    Then I can see a preview link
+    And the test flexible page type is defined
+    When I draft a new "Test flexible page type" flexible page titled "The history of GOV.UK"
+    Then I am on the summary page of the draft titled "The history of GOV.UK"

--- a/features/step_definitions/flexible_page_steps.rb
+++ b/features/step_definitions/flexible_page_steps.rb
@@ -1,0 +1,19 @@
+Given(/^the flexible pages feature flag is (enabled|disabled)$/) do |enabled|
+  @test_strategy ||= Flipflop::FeatureSet.current.test!
+  @test_strategy.switch!(:flexible_pages, enabled == "enabled")
+end
+
+When(/^I draft a new "([^"]*)" flexible page titled "([^"]*)"$/) do |flexible_page_type, title|
+  create(:organisation) if Organisation.count.zero?
+  visit admin_root_path
+  find("li.app-c-sub-navigation__list-item a", text: "New document").click
+  page.choose("Flexible page")
+  click_button("Next")
+  page.choose(flexible_page_type)
+  click_button("Next")
+  within "form" do
+    fill_in "edition_title", with: title
+    fill_in "edition_flexible_page_content_title_heading_text", with: title
+  end
+  click_button "Save and go to document summary"
+end

--- a/features/step_definitions/flexible_page_steps.rb
+++ b/features/step_definitions/flexible_page_steps.rb
@@ -3,6 +3,11 @@ Given(/^the flexible pages feature flag is (enabled|disabled)$/) do |enabled|
   @test_strategy.switch!(:flexible_pages, enabled == "enabled")
 end
 
+Given(/^the test flexible page type is defined$/) do
+  type_definition = JSON.parse(File.read(Rails.root.join("features/fixtures/test_flexible_page_type.json")))
+  FlexiblePageType.setup_test_types({ "test" => type_definition })
+end
+
 When(/^I draft a new "([^"]*)" flexible page titled "([^"]*)"$/) do |flexible_page_type, title|
   create(:organisation) if Organisation.count.zero?
   visit admin_root_path
@@ -13,7 +18,13 @@ When(/^I draft a new "([^"]*)" flexible page titled "([^"]*)"$/) do |flexible_pa
   click_button("Next")
   within "form" do
     fill_in "edition_title", with: title
-    fill_in "edition_flexible_page_content_title_heading_text", with: title
+    fill_in "edition_flexible_page_content_page_title_heading_text", with: title
   end
   click_button "Save and go to document summary"
+end
+
+# TODO
+Then(/^I am on the summary page of the draft titled "([^"]*)"$/) do |title|
+  expect(page.find("h1")).to have_content(title)
+  expect(page).to have_content("Your document has been saved.")
 end

--- a/test/functional/admin/flexible_pages_controller_test.rb
+++ b/test/functional/admin/flexible_pages_controller_test.rb
@@ -1,0 +1,14 @@
+require "test_helper"
+
+class Admin::FlexiblePagesControllerTest < ActionController::TestCase
+  should_be_an_admin_controller
+
+  setup do
+    login_as :writer
+  end
+
+  test "GET new returns a not found response when the flexible pages feature flag is disabled" do
+    get :new
+    assert_response :not_found
+  end
+end

--- a/test/functional/admin/flexible_pages_controller_test.rb
+++ b/test/functional/admin/flexible_pages_controller_test.rb
@@ -5,10 +5,28 @@ class Admin::FlexiblePagesControllerTest < ActionController::TestCase
 
   setup do
     login_as :writer
+
+    @test_strategy ||= Flipflop::FeatureSet.current.test!
+    @test_strategy.switch!(:flexible_pages, true)
+  end
+
+  teardown do
+    @test_strategy.switch!(:flexible_pages, false)
   end
 
   test "GET new returns a not found response when the flexible pages feature flag is disabled" do
+    @test_strategy.switch!(:flexible_pages, false)
     get :new
     assert_response :not_found
+  end
+
+  test "POST create re-renders the new edition template with the submitted flexible page content if the form is invalid" do
+    flexible_page_content = {
+      "page_title" => {
+        "heading_text" => "foo",
+      },
+    }
+    post :create, params: { edition: { flexible_page_type: "history_page", flexible_page_content: } }
+    assert_template "admin/editions/new"
   end
 end

--- a/test/unit/app/helpers/admin/flexible_page_helper_test.rb
+++ b/test/unit/app/helpers/admin/flexible_page_helper_test.rb
@@ -2,64 +2,73 @@ require "test_helper"
 
 class Admin::FlexiblePageHelperTest < ActionView::TestCase
   test "flexible page helper outputs a fieldset for each object property" do
-    properties = {
-      "one" => {
-        "type" => "object",
-        "title" => "One",
-        "properties" => {
-          "one_a" => {
-            "type" => "string",
-            "title" => "One A",
+    schema = {
+      "type" => "object",
+      "properties" => {
+        "one" => {
+          "type" => "object",
+          "title" => "One",
+          "properties" => {
+            "one_a" => {
+              "type" => "string",
+              "title" => "One A",
+            },
           },
         },
-      },
-      "two" => {
-        "type" => "object",
-        "title" => "Two",
-        "properties" => {
-          "two_a" => {
-            "type" => "string",
-            "title" => "Two A",
+        "two" => {
+          "type" => "object",
+          "title" => "Two",
+          "properties" => {
+            "two_a" => {
+              "type" => "string",
+              "title" => "Two A",
+            },
           },
         },
       },
     }
 
-    render inline: render_flexible_page_content_fields(properties, FlexiblePage.new)
-    properties.values.each do |property|
+    render inline: render_flexible_page_content_fields(schema, FlexiblePage.new)
+    schema["properties"].values.each do |property|
       assert_dom "legend", text: property["title"]
     end
   end
 
   test "flexible page helper outputs the description for the field as hint text" do
-    properties = {
-      "property_with_description" => {
-        "type" => "string",
-        "title" => "Property with description",
-        "description" => "A property with a description",
-      },
+    schema = {
+      "type" => "object",
+      "properties" => {
+        "property_with_description" => {
+          "type" => "string",
+          "title" => "Property with description",
+          "description" => "A property with a description",
+        },
+      }
     }
 
-    render inline: render_flexible_page_content_fields(properties, FlexiblePage.new)
-    assert_dom ".govuk-hint", text: properties["property_with_description"]["description"]
+    render inline: render_flexible_page_content_fields(schema, FlexiblePage.new)
+    assert_dom ".govuk-hint", text: schema["properties"]["property_with_description"]["description"]
   end
 
   test "flexible page helper sets the value of the input" do
-    properties = {
-      "test" => {
-        "type" => "object",
-        "title" => "Test property",
-        "properties" => {
-          "test_one" => {
-            "type" => "string",
-            "title" => "test one",
-          },
-          "test_two" => {
-            "type" => "string",
-            "title" => "test two",
+    schema = {
+      "type" => "object",
+      "properties" => {
+        "test" => {
+          "type" => "object",
+          "title" => "Test property",
+          "properties" => {
+            "test_one" => {
+              "type" => "string",
+              "title" => "test one",
+            },
+            "test_two" => {
+              "type" => "string",
+              "title" => "test two",
+            },
           },
         },
-      },
+      }
     }
     page = FlexiblePage.new
     page.flexible_page_content = {
@@ -68,12 +77,28 @@ class Admin::FlexiblePageHelperTest < ActionView::TestCase
         "test_two" => "bar",
       },
     }
-    render inline: render_flexible_page_content_fields(properties, page)
+    render inline: render_flexible_page_content_fields(schema, page)
     assert_dom "input[name=\"edition[flexible_page_content][test][test_one]\"][value=\"foo\"]"
     assert_dom "input[name=\"edition[flexible_page_content][test][test_two]\"][value=\"bar\"]"
   end
 
   test "flexible page helper appends a required hint to the field label for required fields" do
-    assert false
+    schema = {
+      "type" => "object",
+      "properties" => {
+        "one" => {
+          "type" => "string",
+          "title" => "One",
+          },
+        "two" => {
+          "type" => "string",
+          "title" => "Two",
+          },
+      },
+      "required" => ["one"],
+    }
+
+    render inline: render_flexible_page_content_fields(schema, FlexiblePage.new)
+    assert_dom "label", text: "One (required)"
   end
 end

--- a/test/unit/app/helpers/admin/flexible_page_helper_test.rb
+++ b/test/unit/app/helpers/admin/flexible_page_helper_test.rb
@@ -1,0 +1,79 @@
+require "test_helper"
+
+class Admin::FlexiblePageHelperTest < ActionView::TestCase
+  test "flexible page helper outputs a fieldset for each object property" do
+    properties = {
+      "one" => {
+        "type" => "object",
+        "title" => "One",
+        "properties" => {
+          "one_a" => {
+            "type" => "string",
+            "title" => "One A",
+          },
+        },
+      },
+      "two" => {
+        "type" => "object",
+        "title" => "Two",
+        "properties" => {
+          "two_a" => {
+            "type" => "string",
+            "title" => "Two A",
+          },
+        },
+      },
+    }
+
+    render inline: render_flexible_page_content_fields(properties, FlexiblePage.new)
+    properties.values.each do |property|
+      assert_dom "legend", text: property["title"]
+    end
+  end
+
+  test "flexible page helper outputs the description for the field as hint text" do
+    properties = {
+      "property_with_description" => {
+        "type" => "string",
+        "title" => "Property with description",
+        "description" => "A property with a description",
+      },
+    }
+
+    render inline: render_flexible_page_content_fields(properties, FlexiblePage.new)
+    assert_dom ".govuk-hint", text: properties["property_with_description"]["description"]
+  end
+
+  test "flexible page helper sets the value of the input" do
+    properties = {
+      "test" => {
+        "type" => "object",
+        "title" => "Test property",
+        "properties" => {
+          "test_one" => {
+            "type" => "string",
+            "title" => "test one",
+          },
+          "test_two" => {
+            "type" => "string",
+            "title" => "test two",
+          },
+        },
+      },
+    }
+    page = FlexiblePage.new
+    page.flexible_page_content = {
+      "test" => {
+        "test_one" => "foo",
+        "test_two" => "bar",
+      },
+    }
+    render inline: render_flexible_page_content_fields(properties, page)
+    assert_dom "input[name=\"edition[flexible_page_content][test][test_one]\"][value=\"foo\"]"
+    assert_dom "input[name=\"edition[flexible_page_content][test][test_two]\"][value=\"bar\"]"
+  end
+
+  test "flexible page helper appends a required hint to the field label for required fields" do
+    assert false
+  end
+end

--- a/test/unit/app/models/flexible_page_test.rb
+++ b/test/unit/app/models/flexible_page_test.rb
@@ -8,4 +8,32 @@ class FlexiblePageTest < ActiveSupport::TestCase
     assert_not page.can_set_previously_published?
     assert_not page.previously_published
   end
+
+  test "it is invalid if the flexible page content does not conform to the flexible page type schema" do
+    test_types = {
+      "test_type" => {
+        "key" => "test_type",
+        "schema" => {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "$id": "https://www.gov.uk/schemas/test_type/v1",
+          "title": "Test type",
+          "type": "object",
+          "properties" => {
+            "test_attribute" => {
+              "title" => "Test attribute",
+              "type" => "string",
+            },
+          },
+          "required" => %w[test_attribute],
+        },
+      },
+    }
+    FlexiblePageType.setup_test_types(test_types)
+    page = FlexiblePage.new
+    page.title = "Test Page"
+    page.flexible_page_type = "test_type"
+    page.flexible_page_content = {}
+    page.creator = User.new
+    assert page.invalid?
+  end
 end

--- a/test/unit/app/models/flexible_page_test.rb
+++ b/test/unit/app/models/flexible_page_test.rb
@@ -1,0 +1,11 @@
+require "test_helper"
+
+class FlexiblePageTest < ActiveSupport::TestCase
+  test "does not require some of the standard edition fields" do
+    page = FlexiblePage.new
+    assert_not page.summary_required?
+    assert_not page.body_required?
+    assert_not page.can_set_previously_published?
+    assert_not page.previously_published
+  end
+end


### PR DESCRIPTION
This includes an additional flexible page type selection step. Currently we're just hardcoding the single history page flexible content type.

Flexible page content will be stored as JSON.

Flexible pages will not use the default summary and body fields, but it will use a title field for admin purposes. The title will appear on thje document search page in Whitehall and also provide the slug for the page.

Trello: https://trello.com/c/t3Hosesy
