### PR TITLE
CM-154: Adding default value logic to enum component

### DIFF
--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/enum_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/enum_component.rb
@@ -1,6 +1,7 @@
 class ContentBlockManager::ContentBlockEdition::Details::Fields::EnumComponent < ContentBlockManager::ContentBlockEdition::Details::Fields::BaseComponent
-  def initialize(enum:, **args)
+  def initialize(enum:, default: "", **args)
     @enum = enum
+    @default = default
     super(**args)
   end
 
@@ -11,12 +12,16 @@ private
       {
         text: item,
         value: item,
-        selected: item == value,
+        selected: selected?(item),
       }
     end
   end
 
   def error_message
     error_items&.first&.fetch(:text)
+  end
+
+  def selected?(item)
+    item == (value.presence || @default)
   end
 end

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/enum_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/enum_component.rb
@@ -8,7 +8,7 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::EnumComponent <
 private
 
   def options
-    ["", @enum].flatten.map do |item|
+    [blank_option, @enum].flatten.compact.map do |item|
       {
         text: item,
         value: item,
@@ -23,5 +23,9 @@ private
 
   def selected?(item)
     item == (value.presence || @default)
+  end
+
+  def blank_option
+    @default.empty? ? "" : nil
   end
 end

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/form_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/form_component.rb
@@ -11,7 +11,7 @@ private
   def component_for_field(field)
     component_name = field.component_name
     component_class = "ContentBlockManager::ContentBlockEdition::Details::Fields::#{component_name.camelize}Component".constantize
-    args = component_args(field).merge(enum: field.enum_values)
+    args = component_args(field).merge(enum: field.enum_values, default: field.default_value)
 
     component_class.new(**args.compact)
   end

--- a/lib/engines/content_block_manager/app/models/content_block_manager/content_block/schema/field.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/content_block/schema/field.rb
@@ -29,6 +29,10 @@ module ContentBlockManager
           @enum_values ||= schema.body.dig("properties", name, "enum")
         end
 
+        def default_value
+          @default_value ||= schema.body.dig("properties", name, "default")
+        end
+
       private
 
         def custom_component

--- a/lib/engines/content_block_manager/test/components/content_block/edition/details/embedded_objects/form_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/details/embedded_objects/form_component_test.rb
@@ -6,16 +6,18 @@ class ContentBlockManager::ContentBlockEdition::Details::EmbeddedObjects::FormCo
   let(:content_block_edition) { build(:content_block_edition) }
   let(:schema) { build(:content_block_schema) }
 
-  let(:foo_field) { stub("field", name: "foo", component_name: "string", enum_values: nil) }
-  let(:bar_field) { stub("field", name: "bar", component_name: "string", enum_values: nil) }
+  let(:foo_field) { stub("field", name: "foo", component_name: "string", enum_values: nil, default_value: nil) }
+  let(:bar_field) { stub("field", name: "bar", component_name: "string", enum_values: nil, default_value: nil) }
+  let(:enum_field) { stub("field", name: "enum", component_name: "enum", enum_values: ["some value", "another value"], default_value: "some value") }
 
   let(:foo_stub) { stub("string_component") }
   let(:bar_stub) { stub("string_component") }
+  let(:enum_stub) { stub("enum_component") }
 
   let(:object_title) { "some_object" }
 
   before do
-    schema.stubs(:fields).returns([foo_field, bar_field])
+    schema.stubs(:fields).returns([foo_field, bar_field, enum_field])
   end
 
   it "renders fields for each property" do
@@ -31,6 +33,14 @@ class ContentBlockManager::ContentBlockEdition::Details::EmbeddedObjects::FormCo
       object_id: object_title,
     ).returns(bar_stub)
 
+    ContentBlockManager::ContentBlockEdition::Details::Fields::EnumComponent.expects(:new).with(
+      content_block_edition:,
+      field: enum_field,
+      object_id: object_title,
+      enum: ["some value", "another value"],
+      default: "some value",
+    ).returns(enum_stub)
+
     component = ContentBlockManager::ContentBlockEdition::Details::EmbeddedObjects::FormComponent.new(
       content_block_edition:,
       schema:,
@@ -40,6 +50,7 @@ class ContentBlockManager::ContentBlockEdition::Details::EmbeddedObjects::FormCo
 
     component.expects(:render).with(foo_stub)
     component.expects(:render).with(bar_stub)
+    component.expects(:render).with(enum_stub)
 
     render_inline(component)
   end
@@ -60,6 +71,14 @@ class ContentBlockManager::ContentBlockEdition::Details::EmbeddedObjects::FormCo
       object_id: object_title,
     ).returns(bar_stub)
 
+    ContentBlockManager::ContentBlockEdition::Details::Fields::EnumComponent.expects(:new).with(
+      content_block_edition:,
+      field: enum_field,
+      object_id: object_title,
+      enum: ["some value", "another value"],
+      default: "some value",
+    ).returns(enum_stub)
+
     component = ContentBlockManager::ContentBlockEdition::Details::EmbeddedObjects::FormComponent.new(
       content_block_edition:,
       schema:,
@@ -69,6 +88,7 @@ class ContentBlockManager::ContentBlockEdition::Details::EmbeddedObjects::FormCo
 
     component.expects(:render).with(foo_stub)
     component.expects(:render).with(bar_stub)
+    component.expects(:render).with(enum_stub)
 
     render_inline(component)
   end

--- a/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/enum_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/enum_component_test.rb
@@ -63,7 +63,6 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::EnumComponentTe
 
       assert_selector "label", text: "Something"
       assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"]"
-      assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"] option[value=\"\"]"
       assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"] option[value=\"a week\"]", text: "a week"
       assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"] option[value=\"a month\"][selected]", text: "a month"
     end
@@ -84,7 +83,6 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::EnumComponentTe
 
       assert_selector "label", text: "Something"
       assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"]"
-      assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"] option[value=\"\"]"
       assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"] option[value=\"a week\"][selected]", text: "a week"
       assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"] option[value=\"a month\"]", text: "a month"
     end

--- a/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/enum_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/enum_component_test.rb
@@ -6,43 +6,88 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::EnumComponentTe
   let(:content_block_edition) { build(:content_block_edition, :pension) }
   let(:field) { stub("field", name: "something") }
 
-  it "should render an select field with default parameters" do
-    render_inline(
-      ContentBlockManager::ContentBlockEdition::Details::Fields::EnumComponent.new(
-        content_block_edition:,
-        field:,
-        enum: ["a week", "a month"],
-      ),
-    )
+  describe "when there is no default value" do
+    it "should render a select field with given parameters" do
+      render_inline(
+        ContentBlockManager::ContentBlockEdition::Details::Fields::EnumComponent.new(
+          content_block_edition:,
+          field:,
+          enum: ["a week", "a month"],
+        ),
+      )
 
-    expected_name = "content_block/edition[details][something]"
-    expected_id = "#{ContentBlockManager::ContentBlockEdition::Details::Fields::BaseComponent::PARENT_CLASS}_details_something"
+      expected_name = "content_block/edition[details][something]"
+      expected_id = "#{ContentBlockManager::ContentBlockEdition::Details::Fields::BaseComponent::PARENT_CLASS}_details_something"
 
-    assert_selector "label", text: "Something"
-    assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"]"
-    assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"] option[value=\"\"]"
-    assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"] option[value=\"a week\"]", text: "a week"
-    assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"] option[value=\"a month\"]", text: "a month"
+      assert_selector "label", text: "Something"
+      assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"]"
+      assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"] option[value=\"\"]"
+      assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"] option[value=\"a week\"]", text: "a week"
+      assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"] option[value=\"a month\"]", text: "a month"
+    end
+
+    it "should show an option as selected when value is given" do
+      render_inline(
+        ContentBlockManager::ContentBlockEdition::Details::Fields::EnumComponent.new(
+          content_block_edition:,
+          field:,
+          enum: ["a week", "a month"],
+          value: "a week",
+        ),
+      )
+
+      expected_name = "content_block/edition[details][something]"
+      expected_id = "#{ContentBlockManager::ContentBlockEdition::Details::Fields::BaseComponent::PARENT_CLASS}_details_something"
+
+      assert_selector "label", text: "Something"
+      assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"]"
+      assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"] option[value=\"\"]"
+      assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"] option[value=\"a week\"][selected]", text: "a week"
+      assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"] option[value=\"a month\"]", text: "a month"
+    end
   end
 
-  it "should show an option as selected when value is given" do
-    render_inline(
-      ContentBlockManager::ContentBlockEdition::Details::Fields::EnumComponent.new(
-        content_block_edition:,
-        field:,
-        enum: ["a week", "a month"],
-        value: "a week",
-      ),
-    )
+  describe "when there is a default value" do
+    it "should render a select field with given parameters" do
+      render_inline(
+        ContentBlockManager::ContentBlockEdition::Details::Fields::EnumComponent.new(
+          content_block_edition:,
+          field:,
+          enum: ["a week", "a month"],
+          default: "a month",
+        ),
+      )
 
-    expected_name = "content_block/edition[details][something]"
-    expected_id = "#{ContentBlockManager::ContentBlockEdition::Details::Fields::BaseComponent::PARENT_CLASS}_details_something"
+      expected_name = "content_block/edition[details][something]"
+      expected_id = "#{ContentBlockManager::ContentBlockEdition::Details::Fields::BaseComponent::PARENT_CLASS}_details_something"
 
-    assert_selector "label", text: "Something"
-    assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"]"
-    assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"] option[value=\"\"]"
-    assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"] option[value=\"a week\"][selected]", text: "a week"
-    assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"] option[value=\"a month\"]", text: "a month"
+      assert_selector "label", text: "Something"
+      assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"]"
+      assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"] option[value=\"\"]"
+      assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"] option[value=\"a week\"]", text: "a week"
+      assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"] option[value=\"a month\"][selected]", text: "a month"
+    end
+
+    it "should show an option as selected when value is given" do
+      render_inline(
+        ContentBlockManager::ContentBlockEdition::Details::Fields::EnumComponent.new(
+          content_block_edition:,
+          field:,
+          enum: ["a week", "a month"],
+          value: "a week",
+          default: "a month",
+        ),
+      )
+
+      expected_name = "content_block/edition[details][something]"
+      expected_id = "#{ContentBlockManager::ContentBlockEdition::Details::Fields::BaseComponent::PARENT_CLASS}_details_something"
+
+      assert_selector "label", text: "Something"
+      assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"]"
+      assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"] option[value=\"\"]"
+      assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"] option[value=\"a week\"][selected]", text: "a week"
+      assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"] option[value=\"a month\"]", text: "a month"
+    end
   end
 
   it "should show errors when present" do

--- a/lib/engines/content_block_manager/test/components/content_block/edition/details/form_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/details/form_component_test.rb
@@ -26,9 +26,9 @@ class ContentBlockManager::ContentBlockEdition::Details::FormComponentTest < Vie
   let(:content_block_edition) { build(:content_block_edition) }
   let(:schema) { build(:content_block_schema, body:) }
 
-  let(:foo_field) { stub("field", name: "foo", component_name: "string", enum_values: nil) }
-  let(:bar_field) { stub("field", name: "bar", component_name: "string", enum_values: nil) }
-  let(:baz_field) { stub("field", name: "baz", component_name: "enum", enum_values: %w[some enum]) }
+  let(:foo_field) { stub("field", name: "foo", component_name: "string", enum_values: nil, default_value: nil) }
+  let(:bar_field) { stub("field", name: "bar", component_name: "string", enum_values: nil, default_value: nil) }
+  let(:baz_field) { stub("field", name: "baz", component_name: "enum", enum_values: %w[some enum], default_value: nil) }
 
   let(:foo_stub) { stub("string_component") }
   let(:bar_stub) { stub("string_component") }

--- a/lib/engines/content_block_manager/test/support/integration_test_helpers.rb
+++ b/lib/engines/content_block_manager/test/support/integration_test_helpers.rb
@@ -3,8 +3,8 @@ module ContentBlockManager::IntegrationTestHelpers
     schema = stub(
       id: "content_block_type",
       fields: fields || [
-        stub(:field, name: "foo", component_name: "string", enum_values: nil),
-        stub(:field, name: "bar", component_name: "string", enum_values: nil),
+        stub(:field, name: "foo", component_name: "string", enum_values: nil, default_value: nil),
+        stub(:field, name: "bar", component_name: "string", enum_values: nil, default_value: nil),
       ],
       name: "schema",
       body: {

--- a/lib/engines/content_block_manager/test/unit/app/models/content_block_schema/field_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/models/content_block_schema/field_test.rb
@@ -73,4 +73,26 @@ class ContentBlockManager::ContentBlock::Schema::FieldTest < ActiveSupport::Test
       end
     end
   end
+
+  describe "#default_value" do
+    describe "when the field has a default value" do
+      let(:body) do
+        { "properties" => { "something" => { "type" => "string", "default" => "bar" } } }
+      end
+
+      it "returns enum" do
+        assert_equal "bar", field.default_value
+      end
+    end
+
+    describe "when the field has no defaut value" do
+      let(:body) do
+        { "properties" => { "something" => { "type" => "string" } } }
+      end
+
+      it "returns enum" do
+        assert_nil field.default_value
+      end
+    end
+  end
 end


### PR DESCRIPTION
With the [introduction of a Contact type enum](https://github.com/alphagov/publishing-api/pull/3389) which has a default value, we can introduce handling of a default on the enum component 



---
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
