### PR TITLE
Remove all `organisations` links for Roles

### DIFF
--- a/app/presenters/publishing_api/role_presenter.rb
+++ b/app/presenters/publishing_api/role_presenter.rb
@@ -30,6 +30,7 @@ module PublishingApi
     def links
       {
         ordered_parent_organisations: item.organisations.pluck(:content_id).compact,
+        organisations: [],
       }
     end
 

--- a/test/unit/app/presenters/publishing_api/role_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/role_presenter_test.rb
@@ -47,6 +47,7 @@ class PublishingApi::RolePresenterTest < ActionView::TestCase
     }
     expected_links = {
       ordered_parent_organisations: [organisation.content_id],
+      organisations: [],
     }
 
     presented_item = present(role)
@@ -106,6 +107,7 @@ class PublishingApi::RolePresenterTest < ActionView::TestCase
     }
     expected_links = {
       ordered_parent_organisations: [organisation.content_id],
+      organisations: [],
     }
 
     presented_item = present(role)


### PR DESCRIPTION
In b3088e5e0b7191be40c491a3dbf12c45561ae1f7, the `MinisterialRolePresenter` was removed and in 7cc776c8eb472bf291660eae1f55c663b4659864 was replaced with the `RolePresenter`.

The old presenter would include `organisations` links, whereas the new presenter did not.

When the switchover occured, the `organisations` links were never removed from content items which were already published.  As these are linkset links (not edition links), subsequent republishing of the roles has never removed them.

This means that we have out-of-date links associated with pre-2018 roles.

Additionally, these links were added prior to [Publishing API being able to support ordered links](https://github.com/alphagov/publishing-api/commit/93ff568affed13c430e15f2d48e5b28115b5400d#diff-cbf8b25d6d853acf58fa9057841f407d29ffe90649c75cf9e3f51b2d6e3aa1d3).  Therefore these links have no ordering in Publishing API as they have not been updated since this feature was added.  The links therefore appear publicly in whatever order Postgres returns them.

This commit adds `organisations` links into the `RolePresenter`, which will allow us to republish all the ministerial roles again to remove these links.  Once that republishing has been completed, this commit can be reverted.

[Trello card](https://trello.com/c/cmmioiJX)