### PR TITLE
Prevent deleting actively used contacts

### DIFF
--- a/app/controllers/admin/worldwide_offices_controller.rb
+++ b/app/controllers/admin/worldwide_offices_controller.rb
@@ -54,6 +54,15 @@ class Admin::WorldwideOfficesController < Admin::BaseController
   def confirm_destroy; end
 
   def destroy
+    editions_embedding_this_contact = EditionDependency
+      .where(dependable_type: "Contact", dependable_id: @worldwide_office.contact.id)
+      .map { |edition_dependency| Edition.find(edition_dependency.edition_id) }
+
+    if editions_embedding_this_contact.count > 0
+      edition_summaries = editions_embedding_this_contact.map { |ed| "Edition ID #{ed.id} (#{ed.document.slug})" }
+      raise "Cannot delete: contact is embedded in #{edition_summaries.join(',')}" 
+    end
+
     title = @worldwide_office.title
 
     if @worldwide_office.destroy

--- a/app/models/contact.rb
+++ b/app/models/contact.rb
@@ -20,6 +20,8 @@ class Contact < ApplicationRecord
   after_update :republish_dependent_policy_groups
   after_update :republish_organisation_to_publishing_api
 
+  # before_destroy :ensure_no_editions_are_embedding_the_contact
+
   after_create :republish_organisation_to_publishing_api
   after_destroy :republish_organisation_to_publishing_api
 
@@ -106,4 +108,10 @@ class Contact < ApplicationRecord
       errors.add(:base, "Translations '#{non_existent_translations.map(&:code).join(', ')}' do not exist for this worldwide organisation")
     end
   end
+
+  # This doesn't work - the EditionDependency gets deleted before we reach this bit of code
+  # def ensure_no_editions_are_embedding_the_contact
+  #   editions_embedding_this_contact = EditionDependency.where(dependable_type: "Contact", dependable_id: id)
+  #   raise "Cannot delete: contact is embedded in #{editions_embedding_this_contact.join(',')}" if editions_embedding_this_contact.count > 0
+  # end
 end

--- a/app/models/edition_dependency.rb
+++ b/app/models/edition_dependency.rb
@@ -1,4 +1,12 @@
 class EditionDependency < ApplicationRecord
   belongs_to :edition
   belongs_to :dependable, polymorphic: true
+
+  # before_destroy :foo
+
+  # EditionDependency seems to get destroyed by the `if @worldwide_office.destroy` in the controller
+  # before we get a chance to intercept it :( 
+  # def foo
+  #   puts Thread.current.backtrace.join("\n")
+  # end
 end

--- a/app/models/worldwide_office.rb
+++ b/app/models/worldwide_office.rb
@@ -5,6 +5,8 @@ class WorldwideOffice < ApplicationRecord
   has_many :services, through: :worldwide_office_worldwide_services, source: :worldwide_service
   validates :contact, :edition, :worldwide_office_type_id, presence: true
 
+  # before_destroy :ensure_no_editions_are_embedding_the_contact
+
   accepts_nested_attributes_for :contact
 
   extend FriendlyId
@@ -73,4 +75,16 @@ class WorldwideOffice < ApplicationRecord
   def publishing_api_presenter
     PublishingApi::WorldwideOfficePresenter
   end
+
+  # EditionDependency already deleted by this point - too late
+  # def ensure_no_editions_are_embedding_the_contact
+  #   editions_embedding_this_contact = EditionDependency
+  #     .where(dependable_type: "Contact", dependable_id: contact.id)
+  #     .map { |edition_dependency| Edition.find(edition_dependency.edition_id) }
+
+  #   if editions_embedding_this_contact.count > 0
+  #     edition_summaries = editions_embedding_this_contact.map { |ed| "Edition ID #{ed.id} (#{ed.document.slug})" }
+  #     raise "Cannot delete: contact is embedded in #{edition_summaries.join(',')}" 
+  #   end
+  # end
 end

--- a/features/step_definitions/worldwide_organisation_steps.rb
+++ b/features/step_definitions/worldwide_organisation_steps.rb
@@ -116,6 +116,19 @@ When(/^I add an worldwide organisation "([^"]*)" office for the home page with a
   click_on "Save"
 end
 
+Given(/^it has an office contact that is embedded on other \(published\) pages$/) do
+  worldwide_organisation = WorldwideOrganisation.last
+  worldwide_office = WorldwideOffice.last
+
+  publication = create(:publication, attachments: [])
+  create(:html_attachment, attachable: publication, body: "[Contact:#{worldwide_office.contact.id}]")
+  EditionDependency.create!(
+    edition_id: publication.id,
+    dependable_id: worldwide_office.contact.id,
+    dependable_type: "Contact"
+  )
+end
+
 When(/^I delete the "([^"]*)" office for the worldwide organisation$/) do |_office|
   visit admin_worldwide_organisation_path(WorldwideOrganisation.last)
   click_link "Edit draft"
@@ -125,6 +138,10 @@ When(/^I delete the "([^"]*)" office for the worldwide organisation$/) do |_offi
   expect(page).to have_text("Are you sure you want to delete \"Main office for Test Worldwide Organisation\"")
 
   click_button "Delete"
+end
+
+Then(/^I should see (.+) and the office contact should not be deleted$/) do |string|
+  expect(page).to have_text("Unable to delete office as it is embedded on other pages.")
 end
 
 When(/^I visit the pages tab for the worldwide organisation$/) do

--- a/features/worldwide-organisations.feature
+++ b/features/worldwide-organisations.feature
@@ -84,7 +84,13 @@ Feature: Worldwide organisations
     Given an worldwide organisation "Test Worldwide Organisation"
     When I delete the "Main office for Test Worldwide Organisation" office for the worldwide organisation
     Then I should see that the list of offices for the worldwide organisation is empty
-    And The "Test Worldwide Organisation" worldwide organisation should have no offices
+    And The "Test Worldwide Organisation" worldwide organisation should have no officestion
+
+  Scenario: Deleting an office for a worldwide organisation, where that contact is embedded in other pages
+    Given an worldwide organisation "Test Worldwide Organisation"
+    And it has an office contact that is embedded on other (published) pages
+    When I delete the "Main office for Test Worldwide Organisation" office for the worldwide organisation
+    Then I should see "Unable to delete office" and the office contact should not be deleted
 
   Scenario: Adding a page to a worldwide organisation
     Given an worldwide organisation "Test Worldwide Organisation"


### PR DESCRIPTION
Trello: https://trello.com/c/qqwUXCFB/3806-prevent-deletion-of-contacts-that-are-still-referenced-on-govuk

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
