### PR TITLE
Revert "Remove all `organisations` links for Roles"

### DIFF
--- a/app/presenters/publishing_api/role_presenter.rb
+++ b/app/presenters/publishing_api/role_presenter.rb
@@ -30,7 +30,6 @@ module PublishingApi
     def links
       {
         ordered_parent_organisations: item.organisations.pluck(:content_id).compact,
-        organisations: [],
       }
     end
 

--- a/test/unit/app/presenters/publishing_api/role_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/role_presenter_test.rb
@@ -47,7 +47,6 @@ class PublishingApi::RolePresenterTest < ActionView::TestCase
     }
     expected_links = {
       ordered_parent_organisations: [organisation.content_id],
-      organisations: [],
     }
 
     presented_item = present(role)
@@ -107,7 +106,6 @@ class PublishingApi::RolePresenterTest < ActionView::TestCase
     }
     expected_links = {
       ordered_parent_organisations: [organisation.content_id],
-      organisations: [],
     }
 
     presented_item = present(role)


### PR DESCRIPTION
Now that all roles have been republished and the `organisations` links emptied, the code to perform this operation can be removed.

This reverts commit 7dda158a31c575d2224d1d4f2d87e0e76c6876f5 (https://github.com/alphagov/whitehall/pull/10274).