### PR TITLE
Bump govspeak from 10.2.5 to 10.3.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -294,7 +294,7 @@ GEM
       rake (>= 13)
     googleapis-common-protos-types (1.20.0)
       google-protobuf (>= 3.18, < 5.a)
-    govspeak (10.2.5)
+    govspeak (10.3.0)
       actionview (>= 6, < 8.0.3)
       addressable (>= 2.3.8, < 2.8.8)
       govuk_publishing_components (>= 43)


### PR DESCRIPTION
This is needed for republishing a document with a Welsh translation for a support ticket

[Trello](https://trello.com/c/MGfVI5Dq/1714-investigate-a-support-ticket-the-word-footnote-on-a-footnote-isnt-translated-into-welsh)