### PR TITLE
Delete unused helpers from `EditionActionsHelper`

### DIFF
--- a/app/helpers/admin/edition_actions_helper.rb
+++ b/app/helpers/admin/edition_actions_helper.rb
@@ -1,8 +1,4 @@
 module Admin::EditionActionsHelper
-  def filter_edition_type_options_for_select(user, selected)
-    options_for_select([["All types", ""]]) + edition_type_options_for_select(user, selected) + edition_sub_type_options_for_select(selected)
-  end
-
   def filter_edition_type_opt_groups(user, selected)
     [
       [
@@ -63,10 +59,6 @@ module Admin::EditionActionsHelper
 
 private
 
-  def edition_type_options_for_select(user, selected)
-    options_for_select(type_options_container(user), selected)
-  end
-
   def type_options_container(user)
     Whitehall.edition_classes.map { |edition_type|
       next if edition_type == FatalityNotice && !user.can_handle_fatalities?
@@ -74,33 +66,5 @@ private
 
       [edition_type.format_name.humanize.pluralize, edition_type.model_name.singular]
     }.compact
-  end
-
-  def edition_sub_type_options_for_select(selected)
-    subtype_options_hash = {
-      "Publication sub-types" => PublicationType.ordered_by_prevalence.map { |sub_type| [sub_type.plural_name, "publication_#{sub_type.id}"] },
-      "News article sub-types" => NewsArticleType.all.map { |sub_type| [sub_type.plural_name, "news_article_#{sub_type.id}"] },
-      "Speech sub-types" => SpeechType.all.map { |sub_type| [sub_type.plural_name, "speech_#{sub_type.id}"] },
-    }
-    grouped_options_for_select(subtype_options_hash, selected)
-  end
-
-  def root_taxon_paths(edition_taxons)
-    edition_taxons
-      .map(&method(:get_root))
-      .map(&:base_path)
-      .uniq
-      .map(&method(:delete_leading_slash))
-      .sort.join(", ")
-  end
-
-  def delete_leading_slash(str)
-    str.delete_prefix("/")
-  end
-
-  def get_root(taxon)
-    return taxon if taxon.parent_node.nil?
-
-    get_root(taxon.parent_node)
   end
 end


### PR DESCRIPTION
## What

Delete from `EditionActionsHelper`

- edition_type_options_for_select
- edition_sub_type_options_for_select
- root_taxon_paths
- delete_leading_slash
- get_root


## Why

In https://github.com/alphagov/whitehall/pull/10271, [Minno highlighted some other helpers](https://github.com/alphagov/whitehall/pull/10271) from `EditionActionsHelper` that could be removed. I agreed they should be removed but as these weren't directly connected to the main change of #10271, I thought it made sense to put them in a different PR.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
