### PR TITLE
(CM-159) Support objects and arrays in subschemas

### DIFF
--- a/lib/engines/content_block_manager/app/assets/stylesheets/content_block_manager/application.scss
+++ b/lib/engines/content_block_manager/app/assets/stylesheets/content_block_manager/application.scss
@@ -1,3 +1,4 @@
+@import "components/array-component";
 @import "components/embedded-objects-blocks-component";
 @import "components/embedded-objects-metadata-component";
 @import "components/default-block-component";

--- a/lib/engines/content_block_manager/app/assets/stylesheets/content_block_manager/components/_array-component.scss
+++ b/lib/engines/content_block_manager/app/assets/stylesheets/content_block_manager/components/_array-component.scss
@@ -1,0 +1,16 @@
+.app-c-content-block-manager-array-component {
+  margin-bottom: govuk-spacing(6);
+
+  .gem-c-fieldset {
+    background-color: govuk-colour("light-grey");
+    padding-left: govuk-spacing(3);
+    padding-right: govuk-spacing(3);
+
+    padding-top: govuk-spacing(6);
+    padding-bottom: govuk-spacing(6);
+
+    .govuk-fieldset__legend {
+      margin-bottom: govuk-spacing(6);
+    }
+  }
+}

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/array/item_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/array/item_component.html.erb
@@ -1,0 +1,21 @@
+<% if array_items["type"] == "string" %>
+  <%= render "govuk_publishing_components/components/input", {
+    label: {
+      text: field_name.humanize,
+    },
+    name:,
+    id:,
+    value: field_value,
+  } %>
+<% elsif array_items["type"] == "object" %>
+  <% array_items["properties"].keys.each do |field| %>
+    <%= render "govuk_publishing_components/components/input", {
+      label: {
+        text: field.humanize,
+      },
+      name: object_field_name(field),
+      id: object_field_id(field),
+      value: object_field_value(field),
+    } %>
+  <% end %>
+<% end %>

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/array/item_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/array/item_component.rb
@@ -1,0 +1,38 @@
+class ContentBlockManager::ContentBlockEdition::Details::Fields::Array::ItemComponent < ViewComponent::Base
+  def initialize(field_name:, array_items:, name_prefix:, id_prefix:, value:, index:)
+    @field_name = field_name
+    @array_items = array_items
+    @name_prefix = name_prefix
+    @id_prefix = id_prefix
+    @value = value
+    @index = index
+  end
+
+private
+
+  attr_reader :field_name, :array_items, :name_prefix, :id_prefix, :value, :index
+
+  def name
+    "#{name_prefix}[]"
+  end
+
+  def id
+    "#{id_prefix}_#{index}"
+  end
+
+  def field_value
+    value[index]
+  end
+
+  def object_field_name(field)
+    "#{name}[#{field}]"
+  end
+
+  def object_field_id(field)
+    "#{id}_#{field}"
+  end
+
+  def object_field_value(field)
+    value ? field_value&.fetch(field) : nil
+  end
+end

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/array_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/array_component.html.erb
@@ -1,6 +1,8 @@
-<%= render "govuk_publishing_components/components/add_another", {
-  fieldset_legend: label,
-  add_button_text: "Add #{helpers.add_indefinite_article label}",
-  items:,
-  empty:,
-} %>
+<div class="app-c-content-block-manager-array-component">
+  <%= render "govuk_publishing_components/components/add_another", {
+    fieldset_legend: label,
+    add_button_text: "Add #{helpers.add_indefinite_article label}",
+    items:,
+    empty:,
+  } %>
+</div>

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/array_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/array_component.html.erb
@@ -1,0 +1,6 @@
+<%= render "govuk_publishing_components/components/add_another", {
+  fieldset_legend: label,
+  add_button_text: "Add #{helpers.add_indefinite_article label}",
+  items:,
+  empty:,
+} %>

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/array_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/array_component.rb
@@ -1,0 +1,36 @@
+class ContentBlockManager::ContentBlockEdition::Details::Fields::ArrayComponent < ContentBlockManager::ContentBlockEdition::Details::Fields::BaseComponent
+private
+
+  def label
+    super.singularize
+  end
+
+  def value
+    super || []
+  end
+
+  def items
+    if value.count.positive?
+      Array.new(value.count) do |index|
+        { fields: render(component(index)) }
+      end
+    else
+      [{ fields: empty }]
+    end
+  end
+
+  def empty
+    render component(value.count + 1)
+  end
+
+  def component(index)
+    ContentBlockManager::ContentBlockEdition::Details::Fields::Array::ItemComponent.new(
+      field_name: label,
+      array_items: field.array_items,
+      name_prefix: name,
+      id_prefix: id,
+      value: value,
+      index: index,
+    )
+  end
+end

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/object_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/object_component.html.erb
@@ -1,0 +1,18 @@
+<%= render "govuk_publishing_components/components/fieldset", {
+  legend_text: label,
+  heading_level: 3,
+  heading_size: "m",
+} do %>
+  <% capture do %>
+    <% field.nested_fields.each do |embedded_field| %>
+      <%= render "govuk_publishing_components/components/input", {
+        label: {
+          text: embedded_field.name.humanize,
+        },
+        name: name_for_field(embedded_field),
+        id: id_for_field(embedded_field),
+        value: value_for_field(embedded_field),
+      } %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/object_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/object_component.rb
@@ -1,0 +1,15 @@
+class ContentBlockManager::ContentBlockEdition::Details::Fields::ObjectComponent < ContentBlockManager::ContentBlockEdition::Details::Fields::BaseComponent
+private
+
+  def name_for_field(field)
+    "#{name}[#{field.name}]"
+  end
+
+  def id_for_field(field)
+    "#{id}_#{field.name}"
+  end
+
+  def value_for_field(field)
+    value&.fetch(field.name, nil)
+  end
+end

--- a/lib/engines/content_block_manager/app/models/content_block_manager/content_block/edition.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/content_block/edition.rb
@@ -30,6 +30,9 @@ module ContentBlockManager
           details:,
           embed_code:,
         ).render
+      rescue TypeError
+        # TODO: Remove this when we've updated Content Block Tools to support an array of telephones
+        nil
       end
 
       def clone_edition(creator:)

--- a/lib/engines/content_block_manager/app/models/content_block_manager/content_block/schema/embedded_schema.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/content_block/schema/embedded_schema.rb
@@ -28,6 +28,12 @@ module ContentBlockManager
           @group_order ||= config["group_order"]&.to_i || Float::INFINITY
         end
 
+        def permitted_params
+          fields.map do |field|
+            field.nested_fields.present? ? { field.name => field.nested_fields.map(&:name) } : field.name
+          end
+        end
+
       private
 
         def field_names

--- a/lib/engines/content_block_manager/app/models/content_block_manager/content_block/schema/embedded_schema.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/content_block/schema/embedded_schema.rb
@@ -30,7 +30,13 @@ module ContentBlockManager
 
         def permitted_params
           fields.map do |field|
-            field.nested_fields.present? ? { field.name => field.nested_fields.map(&:name) } : field.name
+            if field.nested_fields.present?
+              { field.name => field.nested_fields.map(&:name) }
+            elsif field.format == "array"
+              { field.name => field.array_items["properties"]&.keys || [] }
+            else
+              field.name
+            end
           end
         end
 

--- a/lib/engines/content_block_manager/app/models/content_block_manager/content_block/schema/field.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/content_block/schema/field.rb
@@ -45,6 +45,10 @@ module ContentBlockManager
           end
         end
 
+        def array_items
+          properties.fetch("items", nil)
+        end
+
       private
 
         def custom_component

--- a/lib/engines/content_block_manager/app/models/content_block_manager/content_block/schema/field.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/content_block/schema/field.rb
@@ -4,6 +4,8 @@ module ContentBlockManager
       class Field
         attr_reader :name, :schema
 
+        NestedField = Data.define(:name, :format, :enum_values)
+
         def initialize(name, schema)
           @name = name
           @schema = schema
@@ -31,6 +33,14 @@ module ContentBlockManager
 
         def default_value
           @default_value ||= properties["default"]
+        end
+
+        def nested_fields
+          if format == "object"
+            properties.fetch("properties", {}).map do |key, value|
+              NestedField.new(name: key, format: value["type"], enum_values: value["enum"])
+            end
+          end
         end
 
       private

--- a/lib/engines/content_block_manager/app/models/content_block_manager/content_block/schema/field.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/content_block/schema/field.rb
@@ -22,21 +22,29 @@ module ContentBlockManager
         end
 
         def format
-          @format ||= schema.body.dig("properties", name, "type")
+          @format ||= properties["type"]
         end
 
         def enum_values
-          @enum_values ||= schema.body.dig("properties", name, "enum")
+          @enum_values ||= properties["enum"]
         end
 
         def default_value
-          @default_value ||= schema.body.dig("properties", name, "default")
+          @default_value ||= properties["default"]
         end
 
       private
 
         def custom_component
-          @custom_component ||= schema.config.dig("fields", name, "component")
+          @custom_component ||= config["component"]
+        end
+
+        def properties
+          @properties ||= schema.body.dig("properties", name) || {}
+        end
+
+        def config
+          @config ||= schema.config.dig("fields", name) || {}
         end
       end
     end

--- a/lib/engines/content_block_manager/app/models/content_block_manager/content_block/schema/field.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/content_block/schema/field.rb
@@ -18,8 +18,10 @@ module ContentBlockManager
         def component_name
           if custom_component
             custom_component
-          elsif format == "string"
-            enum_values ? "enum" : "string"
+          elsif enum_values
+            "enum"
+          else
+            format
           end
         end
 

--- a/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/array/array_item_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/array/array_item_component_test.rb
@@ -1,0 +1,63 @@
+require "test_helper"
+
+class ContentBlockManager::ContentBlockEdition::Details::Fields::Array::ItemComponentTest < ViewComponent::TestCase
+  extend Minitest::Spec::DSL
+
+  let(:component) do
+    ContentBlockManager::ContentBlockEdition::Details::Fields::Array::ItemComponent.new(
+      field_name:,
+      array_items:,
+      name_prefix:,
+      id_prefix:,
+      value: field_value,
+      index:,
+    )
+  end
+
+  describe "if the array item is a string" do
+    let(:field_name) { "Bar" }
+    let(:array_items) { { "type" => "string" } }
+    let(:name_prefix) { "foo[bar]" }
+    let(:id_prefix) { "foo_bar" }
+    let(:field_value) { ["", "Some text"] }
+    let(:index) { 1 }
+
+    it "renders a text field" do
+      render_inline(component)
+
+      assert_selector "label", text: "Bar"
+      assert_selector "input[type='text'][value='Some text'][name='foo[bar][]'][id='foo_bar_1']"
+    end
+  end
+
+  describe "if the array item is an object" do
+    let(:field_name) { "Bar" }
+    let(:array_items) do
+      {
+        "type" => "object",
+        "properties" => {
+          "fizz" => { "type" => "string" },
+          "buzz" => { "type" => "string" },
+        },
+      }
+    end
+    let(:name_prefix) { "foo[bar]" }
+    let(:id_prefix) { "foo_bar" }
+    let(:field_value) { [{}, { "fizz" => "Something", "buzz" => "Else" }] }
+    let(:index) { 1 }
+
+    it "renders a text field for each item" do
+      render_inline(component)
+
+      assert_selector ".govuk-form-group", text: /Fizz/ do |form_group|
+        form_group.assert_selector "label", text: "Fizz"
+        form_group.assert_selector "input[type='text'][value='Something'][name='foo[bar][][fizz]'][id='foo_bar_1_fizz']"
+      end
+
+      assert_selector ".govuk-form-group", text: /Buzz/ do |form_group|
+        form_group.assert_selector "label", text: "Buzz"
+        form_group.assert_selector "input[type='text'][value='Else'][name='foo[bar][][buzz]'][id='foo_bar_1_buzz']"
+      end
+    end
+  end
+end

--- a/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/array_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/array_component_test.rb
@@ -1,0 +1,73 @@
+require "test_helper"
+
+class ContentBlockManager::ContentBlockEdition::Details::Fields::ArrayComponentTest < ViewComponent::TestCase
+  extend Minitest::Spec::DSL
+
+  let(:content_block_edition) { build(:content_block_edition, :pension) }
+  let(:field) { stub("field", name: "items", array_items:) }
+  let(:array_items) { { "type" => "string" } }
+  let(:field_value) { nil }
+
+  let(:component) do
+    ContentBlockManager::ContentBlockEdition::Details::Fields::ArrayComponent.new(
+      content_block_edition:,
+      field:,
+      value: field_value,
+    )
+  end
+
+  describe "when there are no items present" do
+    it "renders with one empty item and a template" do
+      render_inline component
+
+      assert_selector ".gem-c-add-another" do |component|
+        component.assert_selector ".js-add-another__fieldset", count: 1
+        component.assert_selector ".js-add-another__empty", count: 1
+
+        component.assert_selector ".js-add-another__fieldset", text: /Item 1/ do |fieldset|
+          expect_form_fields(fieldset, 1)
+        end
+
+        component.assert_selector ".js-add-another__empty", text: /Item 2/ do |fieldset|
+          expect_form_fields(fieldset, 2)
+        end
+      end
+    end
+  end
+
+  describe "when there are items present" do
+    let(:field_value) { %w[foo bar] }
+
+    it "renders a fieldset for each item and a template" do
+      render_inline component
+
+      assert_selector ".gem-c-add-another" do |component|
+        component.assert_selector ".js-add-another__fieldset", count: 2
+        component.assert_selector ".js-add-another__empty", count: 1
+
+        component.assert_selector ".js-add-another__fieldset", text: /Item 1/ do |fieldset|
+          expect_form_fields(fieldset, 1, "foo")
+        end
+
+        component.assert_selector ".js-add-another__fieldset", text: /Item 2/ do |fieldset|
+          expect_form_fields(fieldset, 2, "bar")
+        end
+
+        component.assert_selector ".js-add-another__empty", text: /Item 3/ do |fieldset|
+          expect_form_fields(fieldset, 3)
+        end
+      end
+    end
+  end
+
+private
+
+  def expect_form_fields(fieldset, index, value = nil)
+    fieldset.assert_selector ".govuk-fieldset__legend", text: "Item #{index}"
+    fieldset.assert_selector ".govuk-form-group", count: 1
+    fieldset.assert_selector ".govuk-form-group" do |form_group|
+      form_group.assert_selector "input[value='#{value}']" unless value.nil?
+      form_group.assert_selector ".govuk-label", text: "Item"
+    end
+  end
+end

--- a/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/object_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/object_component_test.rb
@@ -1,0 +1,65 @@
+require "test_helper"
+
+class ContentBlockManager::ContentBlockEdition::Details::Fields::ObjectComponentTest < ViewComponent::TestCase
+  extend Minitest::Spec::DSL
+
+  let(:content_block_edition) { build(:content_block_edition, :pension) }
+  let(:nested_fields) do
+    [
+      stub("field", name: "label", enum_values: nil),
+      stub("field", name: "type", enum_values: %w[enum_1 enum_2 enum_3]),
+      stub("field", name: "email_address", enum_values: nil),
+    ]
+  end
+  let(:schema) { stub("schema", id: "root") }
+  let(:field) { stub("field", name: "nested", nested_fields:, schema:) }
+
+  let(:label_stub) { stub("string_component") }
+  let(:type_stub) { stub("enum_component") }
+  let(:email_address_stub) { stub("string_component") }
+
+  let(:form_value) { nil }
+
+  let(:component) do
+    ContentBlockManager::ContentBlockEdition::Details::Fields::ObjectComponent.new(
+      content_block_edition:,
+      field:,
+      value: form_value,
+    )
+  end
+
+  it "renders fields for each property" do
+    render_inline(component)
+
+    assert_selector(".govuk-fieldset") do |fieldset|
+      fieldset.assert_selector ".govuk-fieldset__legend--m h3", text: field.name.humanize
+      fieldset.assert_selector ".govuk-form-group", count: 3
+
+      fieldset.assert_selector ".govuk-form-group", text: /Label/ do |form_group|
+        form_group.assert_selector "input[name=\"content_block/edition[details][nested][label]\"]"
+      end
+
+      fieldset.assert_selector ".govuk-form-group", text: /Type/ do |form_group|
+        form_group.assert_selector "input[name=\"content_block/edition[details][nested][type]\"]"
+      end
+
+      fieldset.assert_selector ".govuk-form-group", text: /Email address/ do |form_group|
+        form_group.assert_selector "input[name=\"content_block/edition[details][nested][email_address]\"]"
+      end
+    end
+  end
+
+  describe "when values are present for the object" do
+    let(:form_value) do
+      {
+        "label" => "something",
+      }
+    end
+
+    it "renders the field with the value" do
+      render_inline(component)
+
+      assert_selector "input[name=\"content_block/edition[details][nested][label]\"][value=\"something\"]"
+    end
+  end
+end

--- a/lib/engines/content_block_manager/test/unit/app/models/content_block_schema/embedded_schema_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/models/content_block_schema/embedded_schema_test.rb
@@ -9,21 +9,24 @@ class ContentBlockManager::ContentBlock::Schema::EmbeddedSchemaTest < ActiveSupp
       "patternProperties" => {
         "*" => {
           "type" => "object",
-          "properties" => {
-            "amount" => {
-              "type" => "string",
-            },
-            "description" => {
-              "type" => "string",
-            },
-            "frequency" => {
-              "type" => "string",
-            },
-            "title" => {
-              "type" => "string",
-            },
-          },
+          "properties" => properties,
         },
+      },
+    }
+  end
+  let(:properties) do
+    {
+      "amount" => {
+        "type" => "string",
+      },
+      "description" => {
+        "type" => "string",
+      },
+      "frequency" => {
+        "type" => "string",
+      },
+      "title" => {
+        "type" => "string",
       },
     }
   end
@@ -214,6 +217,35 @@ class ContentBlockManager::ContentBlock::Schema::EmbeddedSchemaTest < ActiveSupp
 
       it "returns infinity to put the item at the end of the group" do
         assert_equal schema.group_order, Float::INFINITY
+      end
+    end
+  end
+
+  describe "#permitted_params" do
+    it "returns permitted params" do
+      assert_equal schema.permitted_params, %w[title amount description frequency]
+    end
+
+    describe "when some fields have nested fields" do
+      let(:properties) do
+        {
+          "title" => {
+            "type" => "string",
+          },
+          "foo" => {
+            "type" => "object",
+            "properties" => {
+              "my_string" => {},
+            },
+          },
+          "bar" => {
+            "type" => "string",
+          },
+        }
+      end
+
+      it "returns permitted params" do
+        assert_equal schema.permitted_params, ["title", { "foo" => %w[my_string] }, "bar"]
       end
     end
   end

--- a/lib/engines/content_block_manager/test/unit/app/models/content_block_schema/embedded_schema_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/models/content_block_schema/embedded_schema_test.rb
@@ -248,5 +248,34 @@ class ContentBlockManager::ContentBlock::Schema::EmbeddedSchemaTest < ActiveSupp
         assert_equal schema.permitted_params, ["title", { "foo" => %w[my_string] }, "bar"]
       end
     end
+
+    describe "when some fields have an array type" do
+      let(:properties) do
+        {
+          "title" => {
+            "type" => "string",
+          },
+          "foo" => {
+            "type" => "array",
+            "items" => {
+              "type" => "string",
+            },
+          },
+          "bar" => {
+            "type" => "array",
+            "items" => {
+              "type" => "object",
+              "properties" => {
+                "my_string" => {},
+              },
+            },
+          },
+        }
+      end
+
+      it "returns permitted params" do
+        assert_equal schema.permitted_params, ["title", { "foo" => [] }, { "bar" => %w[my_string] }]
+      end
+    end
   end
 end

--- a/lib/engines/content_block_manager/test/unit/app/models/content_block_schema/field_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/models/content_block_schema/field_test.rb
@@ -95,4 +95,43 @@ class ContentBlockManager::ContentBlock::Schema::FieldTest < ActiveSupport::Test
       end
     end
   end
+
+  describe "#nested fields" do
+    describe "when there are no nested fields present" do
+      it "returns nil" do
+        assert_equal nil, field.nested_fields
+      end
+    end
+
+    describe "when there are nested fields present" do
+      let(:body) do
+        {
+          "properties" => {
+            "something" => {
+              "type" => "object",
+              "properties" => {
+                "foo" => { "type" => "string" },
+                "bar" => { "type" => "string", "enum" => %w[foo bar] },
+              },
+            },
+          },
+        }
+      end
+
+      it "returns nested fields" do
+        nested_fields = field.nested_fields
+
+        assert_equal nested_fields.count, 2
+
+        assert_equal nested_fields[0].name, "foo"
+        assert_equal nested_fields[1].name, "bar"
+
+        assert_equal nested_fields[0].format, "string"
+        assert_equal nested_fields[1].format, "string"
+
+        assert_equal nested_fields[0].enum_values, nil
+        assert_equal nested_fields[1].enum_values, %w[foo bar]
+      end
+    end
+  end
 end

--- a/lib/engines/content_block_manager/test/unit/app/models/content_block_schema/field_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/models/content_block_schema/field_test.rb
@@ -144,4 +144,33 @@ class ContentBlockManager::ContentBlock::Schema::FieldTest < ActiveSupport::Test
       end
     end
   end
+
+  describe "#array_items" do
+    describe "when there are no properties present" do
+      it "returns nil" do
+        assert_nil field.array_items
+      end
+    end
+
+    describe "when there are properties present" do
+      let(:body) do
+        {
+          "properties" => {
+            "something" => {
+              "type" => "array",
+              "items" => {
+                "type" => "string",
+              },
+            },
+          },
+        }
+      end
+
+      it "returns nil" do
+        assert_equal field.array_items, {
+          "type" => "string",
+        }
+      end
+    end
+  end
 end

--- a/lib/engines/content_block_manager/test/unit/app/models/content_block_schema/field_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/models/content_block_schema/field_test.rb
@@ -50,6 +50,16 @@ class ContentBlockManager::ContentBlock::Schema::FieldTest < ActiveSupport::Test
         assert_equal "custom", field.component_name
       end
     end
+
+    describe "when the field is an object" do
+      let(:body) do
+        { "properties" => { "something" => { "type" => "object" } } }
+      end
+
+      it "returns object" do
+        assert_equal "object", field.component_name
+      end
+    end
   end
 
   describe "#enum_values" do


### PR DESCRIPTION
Telephones need multiple “telephone numbers”, so we need a way for CBM to support arrays of objects using the “Add another” pattern.

This adds new components for both objects and arrays, as well as updating the `permitted_params` helpers for subschemas, so Rails will recognise the fields and allow them to be passed through.

The next step is getting these array items to display correctly in the summary lists, but I'll handle this in a separate PR.

## Screenshots

![image](https://github.com/user-attachments/assets/cb434ae8-92f1-4674-ae2e-04509c954c41)

![image](https://github.com/user-attachments/assets/60f8b340-d533-44b0-a625-d6cb6fb4f9d5)


