### PR TITLE
CM-155: Add optional label to optional fields

### DIFF
--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/base_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/base_component.rb
@@ -15,7 +15,11 @@ private
   attr_reader :content_block_edition, :field, :object_id, :value
 
   def label
-    field.name.humanize
+    "#{field.name.humanize}#{field.is_required? ? nil : optional_label}"
+  end
+
+  def optional_label
+    " (optional)"
   end
 
   def name

--- a/lib/engines/content_block_manager/app/models/content_block_manager/content_block/schema.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/content_block/schema.rb
@@ -95,6 +95,10 @@ module ContentBlockManager
         end
       end
 
+      def required_fields
+        @body["required"] || []
+      end
+
     private
 
       def field_names

--- a/lib/engines/content_block_manager/app/models/content_block_manager/content_block/schema/field.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/content_block/schema/field.rb
@@ -49,6 +49,10 @@ module ContentBlockManager
           properties.fetch("items", nil)
         end
 
+        def is_required?
+          schema.required_fields.include?(name)
+        end
+
       private
 
         def custom_component

--- a/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/array_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/array_component_test.rb
@@ -4,7 +4,7 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::ArrayComponentT
   extend Minitest::Spec::DSL
 
   let(:content_block_edition) { build(:content_block_edition, :pension) }
-  let(:field) { stub("field", name: "items", array_items:) }
+  let(:field) { stub("field", name: "items", array_items:, is_required?: true) }
   let(:array_items) { { "type" => "string" } }
   let(:field_value) { nil }
 

--- a/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/country_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/country_component_test.rb
@@ -4,7 +4,7 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::CountryComponen
   extend Minitest::Spec::DSL
 
   let(:content_block_edition) { build(:content_block_edition, :pension) }
-  let(:field) { stub("field", name: "country") }
+  let(:field) { stub("field", name: "country", is_required?: true) }
 
   let(:world_locations) { build_list(:world_location, 5) }
 

--- a/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/enum_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/enum_component_test.rb
@@ -4,7 +4,7 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::EnumComponentTe
   extend Minitest::Spec::DSL
 
   let(:content_block_edition) { build(:content_block_edition, :pension) }
-  let(:field) { stub("field", name: "something") }
+  let(:field) { stub("field", name: "something", is_required?: true) }
 
   describe "when there is no default value" do
     it "should render a select field with given parameters" do

--- a/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/object_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/object_component_test.rb
@@ -12,7 +12,7 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::ObjectComponent
     ]
   end
   let(:schema) { stub("schema", id: "root") }
-  let(:field) { stub("field", name: "nested", nested_fields:, schema:) }
+  let(:field) { stub("field", name: "nested", nested_fields:, schema:, is_required?: true) }
 
   let(:label_stub) { stub("string_component") }
   let(:type_stub) { stub("enum_component") }

--- a/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/string_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/string_component_test.rb
@@ -4,7 +4,7 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::StringComponent
   extend Minitest::Spec::DSL
 
   let(:content_block_edition) { build(:content_block_edition, :pension) }
-  let(:field) { stub("field", name: "email_address") }
+  let(:field) { stub("field", name: "email_address", is_required?: true) }
 
   it "should render an input field with default parameters" do
     render_inline(
@@ -19,6 +19,19 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::StringComponent
 
     assert_selector "label", text: "Email address"
     assert_selector "input[type=\"text\"][name=\"#{expected_name}\"][id=\"#{expected_id}\"]"
+  end
+
+  it "should show optional label when field is optional" do
+    optional_field = stub("field", name: "email_address", is_required?: false)
+
+    render_inline(
+      ContentBlockManager::ContentBlockEdition::Details::Fields::StringComponent.new(
+        content_block_edition:,
+        field: optional_field,
+      ),
+    )
+
+    assert_selector "label", text: "Email address (optional)"
   end
 
   it "should show the value when provided" do

--- a/lib/engines/content_block_manager/test/support/integration_test_helpers.rb
+++ b/lib/engines/content_block_manager/test/support/integration_test_helpers.rb
@@ -3,8 +3,8 @@ module ContentBlockManager::IntegrationTestHelpers
     schema = stub(
       id: "content_block_type",
       fields: fields || [
-        stub(:field, name: "foo", component_name: "string", enum_values: nil, default_value: nil),
-        stub(:field, name: "bar", component_name: "string", enum_values: nil, default_value: nil),
+        stub(:field, name: "foo", component_name: "string", enum_values: nil, default_value: nil, is_required?: false),
+        stub(:field, name: "bar", component_name: "string", enum_values: nil, default_value: nil, is_required?: false),
       ],
       name: "schema",
       body: {

--- a/lib/engines/content_block_manager/test/unit/app/models/content_block_schema/field_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/models/content_block_schema/field_test.rb
@@ -173,4 +173,18 @@ class ContentBlockManager::ContentBlock::Schema::FieldTest < ActiveSupport::Test
       end
     end
   end
+
+  describe "#is_required?" do
+    it "returns true when in the schema's required fields" do
+      schema.stubs(:required_fields).returns(%w[something])
+
+      assert_equal true, field.is_required?
+    end
+
+    it "returns false when note in the schema's required fields" do
+      schema.stubs(:required_fields).returns(%w[else])
+
+      assert_equal false, field.is_required?
+    end
+  end
 end

--- a/lib/engines/content_block_manager/test/unit/app/models/content_block_schema_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/models/content_block_schema_test.rb
@@ -62,6 +62,21 @@ class ContentBlockManager::SchemaTest < ActiveSupport::TestCase
     end
   end
 
+  describe "#required_fields" do
+    describe "when there are no required fields" do
+      it "returns an empty array" do
+        assert_equal [], schema.required_fields
+      end
+    end
+
+    describe "when there are required fields" do
+      it "returns them as an array" do
+        body["required"] = %w[foo]
+        assert_equal %w[foo], schema.required_fields
+      end
+    end
+  end
+
   describe "when a schema has embedded objects" do
     let(:body) do
       {


### PR DESCRIPTION
- **add required fields to schema and field**
- **add (optional) to field labels if optional in schema**

Based on this slack convo https://gds.slack.com/archives/C078ZA4308N/p1749829308951879?thread_ts=1749825824.640709&cid=C078ZA4308N

Every field that is optional should be labelled as such. this introduces logic for that based on schema.

![Screenshot 2025-06-13 at 17 13 03](https://github.com/user-attachments/assets/96a4ecc5-3463-48e4-af81-005489d8013c)
![Screenshot 2025-06-13 at 17 12 33](https://github.com/user-attachments/assets/61c424db-d18b-4e51-8456-6948441fca82)



--

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
