### PR TITLE
Add strong_migrations gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,7 @@ gem "select_with_search_component", github: "alphagov/select-with-search-compone
 gem "sentry-sidekiq"
 gem "sidekiq-scheduler"
 gem "sprockets-rails"
+gem "strong_migrations"
 gem "terser"
 gem "transitions", require: ["transitions", "active_record/transitions"]
 gem "validates_email_format_of"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -995,6 +995,8 @@ GEM
     string_pattern (2.3.0)
       regexp_parser (~> 2.5, >= 2.5.0)
     stringio (3.1.7)
+    strong_migrations (2.3.0)
+      activerecord (>= 7)
     sync (0.5.0)
     sys-uname (1.3.1)
       ffi (~> 1.1)
@@ -1138,6 +1140,7 @@ DEPENDENCIES
   sidekiq-scheduler
   simplecov
   sprockets-rails
+  strong_migrations
   terser
   timecop
   transitions

--- a/config/initializers/strong_migrations.rb
+++ b/config/initializers/strong_migrations.rb
@@ -1,0 +1,2 @@
+StrongMigrations.lock_timeout = 10.seconds
+StrongMigrations.statement_timeout = 1.hour


### PR DESCRIPTION
Following the precedent set in https://github.com/alphagov/publishing-api/pull/3251, this PR adds the strong_migrations gem.

From the README:

>  Catch unsafe migrations in development
>
>    ✓  Detects potentially dangerous operations
>    ✓  Prevents them from running by default
>    ✓  Provides instructions on safer ways to do what you want

This should help prevent accidents like adding indexes non-concurrently,
which can lock tables and cause incidents.

Lots of information about what this tool does in the README:

https://github.com/ankane/strong_migrations/blob/master/README.md

--

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
