### PR TITLE
(CM-161) Support listing embedded objects in subschemas

### DIFF
--- a/lib/engines/content_block_manager/app/assets/stylesheets/content_block_manager/components/_embedded-objects-blocks-component.scss
+++ b/lib/engines/content_block_manager/app/assets/stylesheets/content_block_manager/components/_embedded-objects-blocks-component.scss
@@ -8,9 +8,11 @@
   }
 
   &--with-block {
-    .govuk-summary-card {
-      border-bottom: none;
-      margin-bottom: 0;
+    .app-c-embedded-objects-blocks-component__main-summary-card-wrapper {
+      .govuk-summary-card {
+        border-bottom: none;
+        margin-bottom: 0;
+      }
     }
   }
 

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/embedded_objects/blocks_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/embedded_objects/blocks_component.html.erb
@@ -4,7 +4,11 @@
     rows: summary_card_rows,
   } %>
 
-  <% if schema.embeddable_as_block? %>
+  <% if !schema.embeddable_as_block? %>
+    <% nested_blocks.each do |args| %>
+      <%= render "govuk_publishing_components/components/summary_card", **args %>
+    <% end %>
+  <% else %>
     <div class="app-c-embedded-objects-blocks-component__details-wrapper">
       <%= render "govuk_publishing_components/components/details", {
         title: "All #{object_name} attributes",
@@ -17,6 +21,10 @@
             <%= render "govuk_publishing_components/components/summary_list", {
               items: attribute_rows(:field),
             } %>
+
+            <% nested_blocks.each do |args| %>
+              <%= render "govuk_publishing_components/components/summary_card", **args %>
+            <% end %>
           </div>
         <% end %>
       <% end %>

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/embedded_objects/blocks_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/embedded_objects/blocks_component.html.erb
@@ -1,8 +1,10 @@
 <%= tag.div(class: component_classes) do %>
-  <%= render "govuk_publishing_components/components/summary_card", {
-    title: "Content blocks",
-    rows: summary_card_rows,
-  } %>
+  <div class="app-c-embedded-objects-blocks-component__main-summary-card-wrapper">
+    <%= render "govuk_publishing_components/components/summary_card", {
+      title: "Content blocks",
+      rows: summary_card_rows,
+    } %>
+  </div>
 
   <% if !schema.embeddable_as_block? %>
     <% nested_blocks.each do |args| %>

--- a/lib/engines/content_block_manager/app/components/content_block_manager/shared/embedded_objects/summary_card/nested_item_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/shared/embedded_objects/summary_card/nested_item_component.html.erb
@@ -1,0 +1,6 @@
+<div class="app-c-content-block-manager-nested-item-component">
+  <%= render "govuk_publishing_components/components/summary_card", {
+    title:,
+    rows:,
+  } %>
+</div>

--- a/lib/engines/content_block_manager/app/components/content_block_manager/shared/embedded_objects/summary_card/nested_item_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/shared/embedded_objects/summary_card/nested_item_component.rb
@@ -1,0 +1,30 @@
+class ContentBlockManager::Shared::EmbeddedObjects::SummaryCard::NestedItemComponent < ViewComponent::Base
+  with_collection_parameter :nested_items
+
+  def initialize(nested_items:, title:, nested_items_counter: nil)
+    @nested_items = nested_items
+    @title = title
+    @nested_items_counter = nested_items_counter
+  end
+
+private
+
+  attr_reader :nested_items, :nested_items_counter
+
+  def title
+    if @nested_items_counter
+      "#{@title} #{@nested_items_counter + 1}"
+    else
+      @title
+    end
+  end
+
+  def rows
+    nested_items.map do |key, value|
+      {
+        key: key.titleize,
+        value:,
+      }
+    end
+  end
+end

--- a/lib/engines/content_block_manager/app/components/content_block_manager/shared/embedded_objects/summary_card_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/shared/embedded_objects/summary_card_component.html.erb
@@ -1,5 +1,33 @@
-<%= render "govuk_publishing_components/components/summary_card", {
-  title:,
-  rows:,
-  summary_card_actions:,
-} %>
+<div class="govuk-summary-card">
+  <div class="govuk-summary-card__title-wrapper">
+    <h2 class="govuk-summary-card__title">
+      <%= title %>
+    </h2>
+    <ul class="govuk-summary-card__actions">
+      <% summary_card_actions.each do |action| %>
+        <li class="govuk-summary-card__action">
+          <a class="govuk-link" href="<%= action[:href] %>"><%= action[:label] %></a>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+  <div class="govuk-summary-card__content">
+    <%= render "govuk_publishing_components/components/summary_list", {
+      items: rows,
+    } %>
+
+    <% nested_items(items).each do |key, items| %>
+      <% if items.is_a?(Array) %>
+        <%= render ContentBlockManager::Shared::EmbeddedObjects::SummaryCard::NestedItemComponent.with_collection(
+          items,
+          title: key.singularize.titleize,
+        ) %>
+      <% else %>
+        <%= render ContentBlockManager::Shared::EmbeddedObjects::SummaryCard::NestedItemComponent.new(
+          nested_items: items,
+          title: key.singularize.titleize,
+        ) %>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/lib/engines/content_block_manager/app/components/content_block_manager/shared/embedded_objects/summary_card_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/shared/embedded_objects/summary_card_component.rb
@@ -1,16 +1,14 @@
 class ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponent < ViewComponent::Base
-  include ContentBlockManager::ContentBlock::EmbedCodeHelper
-  def initialize(content_block_edition:, object_type:, object_title:, is_editable: false, redirect_url: nil)
+  def initialize(content_block_edition:, object_type:, object_title:, redirect_url: nil)
     @content_block_edition = content_block_edition
     @object_type = object_type
     @object_title = object_title
-    @is_editable = is_editable
     @redirect_url = redirect_url
   end
 
 private
 
-  attr_reader :content_block_edition, :object_type, :object_title, :is_editable, :redirect_url
+  attr_reader :content_block_edition, :object_type, :object_title, :redirect_url
 
   def title
     "#{object_type.titleize.singularize} details"
@@ -26,7 +24,6 @@ private
           data: data_attributes_for_row(key),
         },
       ]
-      rows.push(embed_code_row("#{object_type}/#{object_title}/#{key}", content_block_edition.document)) if should_show_embed_code?(key)
       rows
     }.flatten
   end
@@ -35,20 +32,12 @@ private
     attributes = {
       testid: (object_title.parameterize + "_#{key}").underscore,
     }
-    attributes.merge!(copy_embed_code_data_attributes("#{object_type}/#{object_title}/#{key}", content_block_edition.document)) if should_show_embed_code?(key)
     attributes
   end
-
-  def should_show_embed_code?(key)
-    !is_editable && is_embeddable?(key)
   end
 
   def embeddable_fields
     @embeddable_fields = schema.embeddable_fields
-  end
-
-  def is_embeddable?(key)
-    embeddable_fields.include?(key)
   end
 
   def object
@@ -60,20 +49,16 @@ private
   end
 
   def summary_card_actions
-    if is_editable
-      [
-        {
-          label: "Edit",
-          href: helpers.content_block_manager.edit_embedded_object_content_block_manager_content_block_edition_path(
-            content_block_edition,
-            object_type:,
-            object_title:,
-            redirect_url:,
-          ),
-        },
-      ]
-    else
-      []
-    end
+    [
+      {
+        label: "Edit",
+        href: helpers.content_block_manager.edit_embedded_object_content_block_manager_content_block_edition_path(
+          content_block_edition,
+          object_type:,
+          object_title:,
+          redirect_url:,
+        ),
+      },
+    ]
   end
 end

--- a/lib/engines/content_block_manager/app/components/content_block_manager/shared/embedded_objects_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/shared/embedded_objects_component.html.erb
@@ -10,7 +10,6 @@
           content_block_edition: content_block_edition,
           object_type: subschema.block_type,
           object_title: k,
-          is_editable: true,
           redirect_url:,
         ) %>
       </div>

--- a/lib/engines/content_block_manager/app/helpers/content_block_manager/content_block/summary_list_helper.rb
+++ b/lib/engines/content_block_manager/app/helpers/content_block_manager/content_block/summary_list_helper.rb
@@ -1,0 +1,33 @@
+module ContentBlockManager::ContentBlock::SummaryListHelper
+  def first_class_items(input)
+    result = {}
+
+    input.each do |key, value|
+      case value
+      when String
+        result[key] = value
+      when Array
+        value.each_with_index do |item, index|
+          result["#{key}/#{index}"] = item if item.is_a?(String)
+        end
+      end
+    end
+
+    result
+  end
+
+  def nested_items(input)
+    input.select do |_key, value|
+      value.is_a?(Hash) || value.is_a?(Array) && value.all? { |item| item.is_a?(Hash) }
+    end
+  end
+
+  def key_to_title(key)
+    subject, count = key.split("/")
+    if count
+      "#{subject.singularize} #{count.to_i + 1}".titleize
+    else
+      subject.titleize
+    end
+  end
+end

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/embedded_objects/review.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/embedded_objects/review.html.erb
@@ -24,7 +24,6 @@
       content_block_edition: @content_block_edition,
       object_type: @subschema.block_type,
       object_title: @object_title,
-      is_editable: true,
     ) %>
   </div>
 </div>

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/review.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/review.html.erb
@@ -29,7 +29,6 @@
             content_block_edition: @content_block_edition,
             object_type: subschema.id,
             object_title: k,
-            is_editable: true,
             redirect_url: content_block_manager.content_block_manager_content_block_workflow_path(@content_block_edition, step: :embedded_objects),
             ) %>
         </div>

--- a/lib/engines/content_block_manager/config/content_block_manager.yml
+++ b/lib/engines/content_block_manager/config/content_block_manager.yml
@@ -20,8 +20,9 @@ schemas:
       telephones:
         group: modes
         group_order: 2
+        embeddable_as_block: true
         embeddable_fields:
-          - telephone
+          - telephone_numbers
       addresses:
         group: modes
         group_order: 3

--- a/lib/engines/content_block_manager/test/components/shared/embedded_objects/summary_card_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/shared/embedded_objects/summary_card_component_test.rb
@@ -59,7 +59,7 @@ class ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponentTest < V
     end
   end
 
-  it "renders copy code buttons" do
+  it "renders a summary list with edit link" do
     component = ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponent.new(
       content_block_edition:,
       object_type: "embedded-objects",
@@ -68,149 +68,192 @@ class ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponentTest < V
 
     render_inline component
 
-    assert_selector ".govuk-summary-list__row[data-embed-code='#{content_block_edition.document.embed_code_for_field('embedded-objects/my-embedded-object/name')}']", text: "Name"
-    assert_selector ".govuk-summary-list__row[data-embed-code='#{content_block_edition.document.embed_code_for_field('embedded-objects/my-embedded-object/field-1')}']", text: "Field 1"
-    assert_selector ".govuk-summary-list__row[data-embed-code='#{content_block_edition.document.embed_code_for_field('embedded-objects/my-embedded-object/field-2')}']", text: "Field 2"
-  end
+    assert_selector ".govuk-summary-card__title", text: "Embedded Object details"
 
-  it "renders an embed code row for each field" do
-    component = ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponent.new(
-      content_block_edition:,
+    expected_edit_path = edit_embedded_object_content_block_manager_content_block_edition_path(
+      content_block_edition,
       object_type: "embedded-objects",
       object_title: "my-embedded-object",
     )
 
+    assert_selector ".govuk-summary-list__row", count: 3
+
+    assert_selector ".govuk-summary-card__actions .govuk-summary-card__action:nth-child(1) a[href='#{expected_edit_path}']", text: "Edit"
+
+    assert_selector ".govuk-summary-list__row", text: /Name/ do
+      assert_selector ".govuk-summary-list__key", text: "Name"
+      assert_selector ".govuk-summary-list__value", text: "My Embedded Object"
+    end
+
+    assert_selector ".govuk-summary-list__row", text: /Field 1/ do
+      assert_selector ".govuk-summary-list__key", text: "Field 1"
+      assert_selector ".govuk-summary-list__value", text: "Value 1"
+    end
+
+    assert_selector ".govuk-summary-list__row", text: /Field 2/ do
+      assert_selector ".govuk-summary-list__key", text: "Field 2"
+      assert_selector ".govuk-summary-list__value", text: "Value 2"
+    end
+  end
+
+  it "renders a summary list with edit link and redirect url if provided" do
+    component = ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponent.new(
+      content_block_edition:,
+      object_type: "embedded-objects",
+      object_title: "my-embedded-object",
+      redirect_url: "https://example.com",
+    )
+
     render_inline component
 
-    assert_selector ".govuk-summary-list__row[data-embed-code-row='true']", text: content_block_edition.document.embed_code_for_field("embedded-objects/my-embedded-object/name")
-    assert_selector ".govuk-summary-list__row[data-embed-code-row='true']", text: content_block_edition.document.embed_code_for_field("embedded-objects/my-embedded-object/field-1")
-    assert_selector ".govuk-summary-list__row[data-embed-code-row='true']", text: content_block_edition.document.embed_code_for_field("embedded-objects/my-embedded-object/field-2")
+    assert_selector ".govuk-summary-card__title", text: "Embedded Object details"
+
+    expected_edit_path = edit_embedded_object_content_block_manager_content_block_edition_path(
+      content_block_edition,
+      object_type: "embedded-objects",
+      object_title: "my-embedded-object",
+      redirect_url: "https://example.com",
+    )
+
+    assert_selector ".govuk-summary-card__actions .govuk-summary-card__action:nth-child(1) a[href='#{expected_edit_path}']", text: "Edit"
   end
 
-  describe "when only some fields are embeddable" do
-    let(:subschema) { stub(:subschema, embeddable_fields: %w[field-1], fields:) }
-
-    it "only renders copy code buttons for embeddable fields" do
-      component = ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponent.new(
-        content_block_edition:,
-        object_type: "embedded-objects",
-        object_title: "my-embedded-object",
-      )
-
-      render_inline component
-
-      assert_no_selector ".govuk-summary-list__row[data-embed-code='#{content_block_edition.document.embed_code_for_field('embedded-objects/my-embedded-object/name')}']", text: "Name"
-      assert_no_selector ".govuk-summary-list__row[data-embed-code='#{content_block_edition.document.embed_code_for_field('embedded-objects/my-embedded-object/field-2')}']", text: "Field 2"
-
-      assert_selector ".govuk-summary-list__row[data-embed-code='#{content_block_edition.document.embed_code_for_field('embedded-objects/my-embedded-object/field-1')}']", text: "Field 1"
+  describe "when arrays are present" do
+    let(:fields) do
+      [
+        stub("field", name: "name"),
+        stub("field", name: "field"),
+      ]
     end
 
-    it "only renders an embed code row for embeddable fields" do
-      component = ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponent.new(
-        content_block_edition:,
-        object_type: "embedded-objects",
-        object_title: "my-embedded-object",
-      )
-
-      render_inline component
-
-      assert_no_selector ".govuk-summary-list__row[data-embed-code-row='true']", text: content_block_edition.document.embed_code_for_field("embedded-objects/my-embedded-object/name")
-      assert_no_selector ".govuk-summary-list__row[data-embed-code-row='true']", text: content_block_edition.document.embed_code_for_field("embedded-objects/my-embedded-object/field-2")
-
-      assert_selector ".govuk-summary-list__row[data-embed-code-row='true']", text: content_block_edition.document.embed_code_for_field("embedded-objects/my-embedded-object/field-1")
+    let(:details) do
+      {
+        "embedded-objects" => {
+          "my-embedded-object" => {
+            "name" => "My Embedded Object",
+            "field" => %w[Foo Bar],
+          },
+        },
+      }
     end
-  end
 
-  describe "when card is editable" do
-    it "renders a summary list with edit link" do
+    it "renders a summary list" do
       component = ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponent.new(
         content_block_edition:,
         object_type: "embedded-objects",
         object_title: "my-embedded-object",
-        is_editable: true,
       )
 
       render_inline component
 
       assert_selector ".govuk-summary-card__title", text: "Embedded Object details"
 
-      expected_edit_path = edit_embedded_object_content_block_manager_content_block_edition_path(
-        content_block_edition,
-        object_type: "embedded-objects",
-        object_title: "my-embedded-object",
-      )
-
-      assert_selector ".govuk-summary-list__row", count: 3
-
-      assert_selector ".govuk-summary-card__actions .govuk-summary-card__action:nth-child(1) a[href='#{expected_edit_path}']", text: "Edit"
-
-      assert_selector ".govuk-summary-list__row", text: /Name/ do
+      assert_selector ".govuk-summary-list__row[data-testid='my_embedded_object_name']", text: /Name/ do
         assert_selector ".govuk-summary-list__key", text: "Name"
         assert_selector ".govuk-summary-list__value", text: "My Embedded Object"
       end
 
-      assert_selector ".govuk-summary-list__row", text: /Field 1/ do
+      assert_selector ".govuk-summary-list__row[data-testid='my_embedded_object_field/0']", text: /Field 1/ do
         assert_selector ".govuk-summary-list__key", text: "Field 1"
-        assert_selector ".govuk-summary-list__value", text: "Value 1"
+        assert_selector ".govuk-summary-list__value", text: "Foo"
       end
 
-      assert_selector ".govuk-summary-list__row", text: /Field 2/ do
+      assert_selector ".govuk-summary-list__row[data-testid='my_embedded_object_field/1']", text: /Field 2/ do
         assert_selector ".govuk-summary-list__key", text: "Field 2"
-        assert_selector ".govuk-summary-list__value", text: "Value 2"
+        assert_selector ".govuk-summary-list__value", text: "Bar"
       end
     end
 
-    it "renders a summary list with edit link and redirect url if provided" do
-      component = ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponent.new(
-        content_block_edition:,
-        object_type: "embedded-objects",
-        object_title: "my-embedded-object",
-        is_editable: true,
-        redirect_url: "https://example.com",
-      )
+    describe "when arrays are present with hashes" do
+      let(:fields) do
+        [
+          stub("field", name: "name"),
+          stub("field", name: "field"),
+        ]
+      end
 
-      render_inline component
+      let(:details) do
+        {
+          "embedded-objects" => {
+            "my-embedded-object" => {
+              "name" => "My Embedded Object",
+              "field" => [{ item: "Foo" }, { item: "Bar" }],
+            },
+          },
+        }
+      end
 
-      assert_selector ".govuk-summary-card__title", text: "Embedded Object details"
+      it "renders a nested summary card" do
+        component = ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponent.new(
+          content_block_edition:,
+          object_type: "embedded-objects",
+          object_title: "my-embedded-object",
+        )
 
-      expected_edit_path = edit_embedded_object_content_block_manager_content_block_edition_path(
-        content_block_edition,
-        object_type: "embedded-objects",
-        object_title: "my-embedded-object",
-        redirect_url: "https://example.com",
-      )
+        render_inline component
 
-      assert_selector ".govuk-summary-card__actions .govuk-summary-card__action:nth-child(1) a[href='#{expected_edit_path}']", text: "Edit"
+        assert_selector ".govuk-summary-card__title", text: "Embedded Object details"
+
+        assert_selector ".govuk-summary-list__row[data-testid='my_embedded_object_name']", text: /Name/ do
+          assert_selector ".govuk-summary-list__key", text: "Name"
+          assert_selector ".govuk-summary-list__value", text: "My Embedded Object"
+        end
+
+        assert_selector ".app-c-content-block-manager-nested-item-component", text: /Field 1/ do |nested_block|
+          nested_block.assert_selector ".govuk-summary-card__title", text: "Field 1"
+          nested_block.assert_selector ".govuk-summary-list__key", text: "Item"
+          nested_block.assert_selector ".govuk-summary-list__value", text: "Foo"
+        end
+
+        assert_selector ".app-c-content-block-manager-nested-item-component", text: /Field 2/ do |nested_block|
+          nested_block.assert_selector ".govuk-summary-card__title", text: "Field 2"
+          nested_block.assert_selector ".govuk-summary-list__key", text: "Item"
+          nested_block.assert_selector ".govuk-summary-list__value", text: "Bar"
+        end
+      end
     end
 
-    it "does not render copy code button" do
-      component = ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponent.new(
-        content_block_edition:,
-        object_type: "embedded-objects",
-        object_title: "my-embedded-object",
-        is_editable: true,
-      )
+    describe "when hashes are present" do
+      let(:fields) do
+        [
+          stub("field", name: "name"),
+          stub("field", name: "field"),
+        ]
+      end
 
-      render_inline component
+      let(:details) do
+        {
+          "embedded-objects" => {
+            "my-embedded-object" => {
+              "name" => "My Embedded Object",
+              "field" => { item: "Foo" },
+            },
+          },
+        }
+      end
 
-      assert_no_selector ".govuk-summary-list__row[data-embed-code='#{content_block_edition.document.embed_code_for_field('embedded-objects/my-embedded-object/name')}']", text: "Name"
-      assert_no_selector ".govuk-summary-list__row[data-embed-code='#{content_block_edition.document.embed_code_for_field('embedded-objects/my-embedded-object/field-1')}']", text: "Field 1"
-      assert_no_selector ".govuk-summary-list__row[data-embed-code='#{content_block_edition.document.embed_code_for_field('embedded-objects/my-embedded-object/field-2')}']", text: "Field 2"
-    end
+      it "renders a nested summary card" do
+        component = ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponent.new(
+          content_block_edition:,
+          object_type: "embedded-objects",
+          object_title: "my-embedded-object",
+        )
 
-    it "does not embed code row" do
-      component = ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponent.new(
-        content_block_edition:,
-        object_type: "embedded-objects",
-        object_title: "my-embedded-object",
-        is_editable: true,
-      )
+        render_inline component
 
-      render_inline component
+        assert_selector ".govuk-summary-card__title", text: "Embedded Object details"
 
-      assert_no_selector ".govuk-summary-list__row[data-embed-code-row='true']", text: content_block_edition.document.embed_code_for_field("embedded-objects/my-embedded-object/name")
-      assert_no_selector ".govuk-summary-list__row[data-embed-code-row='true']", text: content_block_edition.document.embed_code_for_field("embedded-objects/my-embedded-object/field-1")
-      assert_no_selector ".govuk-summary-list__row[data-embed-code-row='true']", text: content_block_edition.document.embed_code_for_field("embedded-objects/my-embedded-object/field-2")
+        assert_selector ".govuk-summary-list__row[data-testid='my_embedded_object_name']", text: /Name/ do
+          assert_selector ".govuk-summary-list__key", text: "Name"
+          assert_selector ".govuk-summary-list__value", text: "My Embedded Object"
+        end
+
+        assert_selector ".app-c-content-block-manager-nested-item-component", text: /Field/ do |nested_block|
+          nested_block.assert_selector ".govuk-summary-card__title", text: "Field"
+          nested_block.assert_selector ".govuk-summary-list__key", text: "Item"
+          nested_block.assert_selector ".govuk-summary-list__value", text: "Foo"
+        end
+      end
     end
   end
 end

--- a/lib/engines/content_block_manager/test/components/shared/embedded_objects_test.rb
+++ b/lib/engines/content_block_manager/test/components/shared/embedded_objects_test.rb
@@ -52,7 +52,6 @@ class ContentBlockManager::Shared::EmbeddedObjectsTest < ViewComponent::TestCase
     default_args = {
       content_block_edition: content_block_edition,
       object_type: subschema.block_type,
-      is_editable: true,
       redirect_url:,
     }
 

--- a/lib/engines/content_block_manager/test/unit/app/helpers/content_block_manager/content_block/summary_list_helper_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/helpers/content_block_manager/content_block/summary_list_helper_test.rb
@@ -1,0 +1,72 @@
+require "test_helper"
+
+class ContentBlockManager::ContentBlock::SummaryListHelperTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+  include ContentBlockManager::ContentBlock::SummaryListHelper
+
+  let(:input) do
+    {
+      "string_item" => "Item",
+      "array_items" => ["Item 1", "Item 2"],
+      "array_of_objects_items" => [
+        {
+          "title" => "Item 1 Title",
+          "description" => "Item 1 Description",
+        },
+        {
+          "title" => "Item 2 Title",
+          "description" => "Item 2 Description",
+        },
+      ],
+      "object_item" => {
+        "title" => "Object Title",
+        "description" => "Object Description",
+      },
+    }
+  end
+
+  describe "#first_class_items" do
+    it "returns any string items and flattens out non-nested arrays" do
+      expected = {
+        "string_item" => "Item",
+        "array_items/0" => "Item 1",
+        "array_items/1" => "Item 2",
+      }
+
+      assert_equal first_class_items(input), expected
+    end
+  end
+
+  describe "#nested_items" do
+    it "returns nested items" do
+      expected = {
+        "array_of_objects_items" => [
+          {
+            "title" => "Item 1 Title",
+            "description" => "Item 1 Description",
+          },
+          {
+            "title" => "Item 2 Title",
+            "description" => "Item 2 Description",
+          },
+        ],
+        "object_item" => {
+          "title" => "Object Title",
+          "description" => "Object Description",
+        },
+      }
+
+      assert_equal nested_items(input), expected
+    end
+  end
+
+  describe "#key_to_title" do
+    it "returns a titlelized version of a key without an index" do
+      assert_equal key_to_title("item"), "Item"
+    end
+
+    it "returns a titleized version with a count when an index is present" do
+      assert_equal key_to_title("items/1"), "Item 2"
+    end
+  end
+end


### PR DESCRIPTION
This adds functionality to support embedded objects when they are listed in Summary Lists. It's a bit of a complex beast, but hopefully is fairly understandable!

## Screenshots

![image](https://github.com/user-attachments/assets/84fdd763-f77d-4912-9bcf-2568c919ed51)

![image](https://github.com/user-attachments/assets/0d3767d5-044f-4159-bdcc-2d3e109364b4)

![image](https://github.com/user-attachments/assets/ee255b7d-07db-4f2f-be4e-c86319050bdc)
