### PR TITLE
(CM-166) Support enums within array items

### DIFF
--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/array/item_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/array/item_component.html.erb
@@ -1,21 +1,41 @@
 <% if array_items["type"] == "string" %>
-  <%= render "govuk_publishing_components/components/input", {
-    label: {
-      text: field_name.humanize,
-    },
-    name:,
-    id:,
-    value: field_value,
-  } %>
-<% elsif array_items["type"] == "object" %>
-  <% array_items["properties"].keys.each do |field| %>
+  <% if array_items["enum"] %>
+    <%= render "govuk_publishing_components/components/select", {
+      label: field_name.humanize,
+      name:,
+      id:,
+      options: select_options(array_items["enum"], value),
+    } %>
+  <% else %>
     <%= render "govuk_publishing_components/components/input", {
       label: {
-        text: field.humanize,
+        text: field_name.humanize,
       },
-      name: object_field_name(field),
-      id: object_field_id(field),
-      value: object_field_value(field),
+      name:,
+      id:,
+      value: field_value,
     } %>
+  <% end %>
+<% elsif array_items["type"] == "object" %>
+  <% array_items["properties"].keys.each do |field| %>
+    <% properties = array_items["properties"][field] %>
+    <% if properties["enum"] %>
+      <%= render "govuk_publishing_components/components/select", {
+        label: field.humanize,
+        name: object_field_name(field),
+        id: object_field_id(field),
+        options: select_options(properties["enum"], object_field_value(field)),
+        full_width: true,
+      } %>
+    <% else %>
+      <%= render "govuk_publishing_components/components/input", {
+        label: {
+          text: field.humanize,
+        },
+        name: object_field_name(field),
+        id: object_field_id(field),
+        value: object_field_value(field),
+      } %>
+    <% end %>
   <% end %>
 <% end %>

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/array/item_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/array/item_component.rb
@@ -35,4 +35,14 @@ private
   def object_field_value(field)
     value ? field_value&.fetch(field) : nil
   end
+
+  def select_options(enum, value)
+    enum.map do |item|
+      {
+        text: item.humanize,
+        value: item,
+        selected: item == value,
+      }
+    end
+  end
 end

--- a/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/array/array_item_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/array/array_item_component_test.rb
@@ -30,6 +30,41 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::Array::ItemComp
     end
   end
 
+  describe "if the array item is an enum" do
+    let(:field_name) { "Bar" }
+    let(:array_items) { { "type" => "string", "enum" => %w[foo bar baz] } }
+    let(:name_prefix) { "foo[bar]" }
+    let(:id_prefix) { "foo_bar" }
+    let(:field_value) { nil }
+    let(:index) { 1 }
+
+    it "renders a select field" do
+      render_inline(component)
+
+      assert_selector "label", text: "Bar"
+      assert_selector "select[name='foo[bar][]'][id='foo_bar_1']" do |select|
+        select.assert_selector "option[value='foo']", text: "Foo"
+        select.assert_selector "option[value='bar']", text: "Bar"
+        select.assert_selector "option[value='baz']", text: "Baz"
+      end
+    end
+
+    describe "when the value is set" do
+      let(:field_value) { "baz" }
+
+      it "marks the appropriate option as selected" do
+        render_inline(component)
+
+        assert_selector "label", text: "Bar"
+        assert_selector "select[name='foo[bar][]'][id='foo_bar_1']" do |select|
+          select.assert_selector "option[value='foo']", text: "Foo"
+          select.assert_selector "option[value='bar']", text: "Bar"
+          select.assert_selector "option[value='baz'][selected]", text: "Baz"
+        end
+      end
+    end
+  end
+
   describe "if the array item is an object" do
     let(:field_name) { "Bar" }
     let(:array_items) do
@@ -57,6 +92,43 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::Array::ItemComp
       assert_selector ".govuk-form-group", text: /Buzz/ do |form_group|
         form_group.assert_selector "label", text: "Buzz"
         form_group.assert_selector "input[type='text'][value='Else'][name='foo[bar][][buzz]'][id='foo_bar_1_buzz']"
+      end
+    end
+
+    describe "when an enum is included" do
+      let(:array_items) do
+        {
+          "type" => "object",
+          "properties" => {
+            "fizz" => { "type" => "string", "enum" => %w[foo bar baz] },
+          },
+        }
+      end
+
+      it "renders a select field" do
+        render_inline(component)
+
+        assert_selector "label", text: "Fizz"
+        assert_selector "select[name='foo[bar][][fizz]'][id='foo_bar_1_fizz']" do |select|
+          select.assert_selector "option[value='foo']", text: "Foo"
+          select.assert_selector "option[value='bar']", text: "Bar"
+          select.assert_selector "option[value='baz']", text: "Baz"
+        end
+      end
+
+      describe "when the value is set" do
+        let(:field_value) { [{}, { "fizz" => "baz" }] }
+
+        it "marks the appropriate option as selected" do
+          render_inline(component)
+
+          assert_selector "label", text: "Fizz"
+          assert_selector "select[name='foo[bar][][fizz]'][id='foo_bar_1_fizz']" do |select|
+            select.assert_selector "option[value='foo']", text: "Foo"
+            select.assert_selector "option[value='bar']", text: "Bar"
+            select.assert_selector "option[value='baz'][selected]", text: "Baz"
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
If an array item contains enum options, we should render a select component with the appropriate enum values.

## Screenshot

![image](https://github.com/user-attachments/assets/61adba03-8bed-4356-a05f-f6f319931531)
