### PR TITLE
Define constants for the maxlength magic numbers

### DIFF
--- a/app/views/admin/corporate_information_pages/_standard_fields.html.erb
+++ b/app/views/admin/corporate_information_pages/_standard_fields.html.erb
@@ -35,7 +35,7 @@
       error_items: errors_for(form.object.errors, :summary),
     },
     id: "edition_summary",
-    maxlength: 160,
+    maxlength: MaxLengths::SUMMARY,
   } %>
 
   <%= render "components/govspeak_editor", {

--- a/app/views/admin/editions/_standard_fields.html.erb
+++ b/app/views/admin/editions/_standard_fields.html.erb
@@ -24,7 +24,7 @@
         rows: 1,
       },
       id: "edition_title",
-      maxlength: 65,
+      maxlength: MaxLengths::TITLE,
     } %>
   </div>
 
@@ -59,7 +59,7 @@
         margin_bottom: 8,
       },
       id: "edition_summary",
-      maxlength: 160,
+      maxlength: MaxLengths::SUMMARY,
     } %>
   </div>
 

--- a/app/views/admin/flexible_pages/_form.html.erb
+++ b/app/views/admin/flexible_pages/_form.html.erb
@@ -17,7 +17,7 @@
           rows: 1,
         },
         id: "edition_title",
-        maxlength: 65,
+        maxlength: MaxLengths::TITLE,
       } %>
     </div>
 

--- a/app/views/admin/historical_accounts/_form.html.erb
+++ b/app/views/admin/historical_accounts/_form.html.erb
@@ -13,7 +13,7 @@
           error_items: errors_for(historical_account.errors, :summary),
         },
         id: "historical_account_summary",
-        maxlength: 160,
+        maxlength: MaxLengths::SUMMARY,
       } %>
 
       <%= render "components/select_with_search", {

--- a/app/views/admin/topical_events/_form.html.erb
+++ b/app/views/admin/topical_events/_form.html.erb
@@ -21,7 +21,7 @@
       rows: 4,
       error_items: errors_for(topical_event.errors, :summary),
     },
-    maxlength: 160,
+    maxlength: MaxLengths::SUMMARY,
     id: "topical_event_summary",
   } %>
 

--- a/app/views/admin/worldwide_organisation_pages/_form.html.erb
+++ b/app/views/admin/worldwide_organisation_pages/_form.html.erb
@@ -37,7 +37,7 @@
       error_items: errors_for(form.object.errors, :summary),
     },
     id: "worldwide_organisation_page_summary",
-    maxlength: 160,
+    maxlength: MaxLengths::SUMMARY,
   } %>
 
   <%= render "components/govspeak_editor", {

--- a/config/initializers/max_lengths.rb
+++ b/config/initializers/max_lengths.rb
@@ -1,0 +1,4 @@
+module MaxLengths
+  SUMMARY = 160
+  TITLE = 65
+end


### PR DESCRIPTION
These were repeated in several places and probably ought to be consistent by design.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
