### PR TITLE
Add Publishing API settings for flexible page type configuration

### DIFF
--- a/app/models/flexible_page.rb
+++ b/app/models/flexible_page.rb
@@ -1,4 +1,5 @@
 class FlexiblePage < Edition
+  include Edition::Identifiable
   validates :flexible_page_type, presence: true, inclusion: { in: -> { FlexiblePageType.all_keys } }
   validate :content_conforms_to_schema
 
@@ -26,12 +27,15 @@ class FlexiblePage < Edition
     false
   end
 
-  def rendering_app
-    Whitehall::RenderingApp::FRONTEND
+  def base_path
+    "#{type_instance.settings['base_path_prefix']}/#{slug}"
+  end
+
+  def type_instance
+    FlexiblePageType.find(flexible_page_type)
   end
 
   def content_conforms_to_schema
-    type_instance = FlexiblePageType.find(flexible_page_type)
     unless type_instance.validator.valid?(flexible_page_content)
       errors.add(:flexible_page_content, "does not conform to schema for the #{type_instance.label}.")
     end

--- a/app/models/flexible_page_type.rb
+++ b/app/models/flexible_page_type.rb
@@ -1,5 +1,5 @@
 class FlexiblePageType
-  attr_reader :key, :schema
+  attr_reader :key, :schema, :settings
 
   def self.types
     @types ||= Dir.glob("app/models/flexible_page_types/*.json").each_with_object({}) do |filename, hash|
@@ -27,6 +27,7 @@ class FlexiblePageType
   def initialize(type)
     @key = type["key"]
     @schema = type["schema"]
+    @settings = type["settings"]
   end
 
   def label

--- a/app/models/flexible_page_types/history_page.json
+++ b/app/models/flexible_page_types/history_page.json
@@ -27,5 +27,11 @@
       }
     },
     "required": ["page_title"]
+  },
+  "settings": {
+    "base_path_prefix": "/government/history",
+    "publishing_api_schema_name": "history",
+    "publishing_api_document_type": "history",
+    "rendering_app": "government-frontend"
   }
 }

--- a/app/presenters/publishing_api/flexible_page_presenter.rb
+++ b/app/presenters/publishing_api/flexible_page_presenter.rb
@@ -14,11 +14,13 @@ module PublishingApi
     def content
       content = BaseItemPresenter.new(item, update_type:).base_attributes
       content.merge!(
-        details: {},
-        document_type:,
+        details: {
+          body: "",
+        },
+        document_type: type.settings["publishing_api_document_type"],
         public_updated_at: item.public_timestamp || item.updated_at,
-        rendering_app: item.rendering_app,
-        schema_name: "flexible_page",
+        rendering_app: type.settings["rendering_app"],
+        schema_name: type.settings["publishing_api_schema_name"],
         links: edition_links,
         auth_bypass_ids: [item.auth_bypass_id],
       )
@@ -28,15 +30,17 @@ module PublishingApi
     end
 
     def links
-      edition_links
+      {}
     end
 
     def edition_links
-      []
+      {}
     end
 
-    def document_type
-      "history_page"
+  private
+
+    def type
+      FlexiblePageType.find(item.flexible_page_type)
     end
   end
 end

--- a/features/fixtures/test_flexible_page_type.json
+++ b/features/fixtures/test_flexible_page_type.json
@@ -27,5 +27,11 @@
       }
     },
     "required": ["page_title"]
+  },
+  "settings": {
+    "base_path_prefix": "/government/test-type",
+    "publishing_api_schema_name": "test_type",
+    "publishing_api_document_type": "test_type",
+    "rendering_app": "government-frontend"
   }
 }

--- a/test/unit/app/presenters/publishing_api/flexible_page_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/flexible_page_presenter_test.rb
@@ -1,0 +1,35 @@
+require "test_helper"
+
+class PublishingApi::FlexiblePagePresenterTest < ActiveSupport::TestCase
+  test "it sets the schema name, document type, base path and rendering app based on the flexible page type settings" do
+    schema_name = "test_type_schema"
+    document_type = "test_type"
+    rendering_app = "government-frontend"
+    base_path_prefix = "/government/history"
+    type_key = "test_type_key"
+    FlexiblePageType.setup_test_types({
+      type_key => {
+        "key" => type_key,
+        "schema" => {
+          "type" => "string",
+        },
+        "settings" => {
+          "base_path_prefix" => "/government/history",
+          "publishing_api_schema_name" => schema_name,
+          "publishing_api_document_type" => document_type,
+          "rendering_app" => rendering_app,
+        },
+      },
+    })
+    page = FlexiblePage.new
+    page.flexible_page_type = type_key
+    page.document = Document.new
+    page.document.slug = "page-title"
+    presenter = PublishingApi::FlexiblePagePresenter.new(page)
+    content = presenter.content
+    assert_equal "#{base_path_prefix}/#{page.document.slug}", content[:base_path]
+    assert_equal schema_name, content[:schema_name]
+    assert_equal document_type, content[:document_type]
+    assert_equal rendering_app, content[:rendering_app]
+  end
+end


### PR DESCRIPTION
This commit adds a settings section so that we can control the payload sent to Publishing API for the flexible page type. We do not know what the preferred rendering app, base path, schema name or document type are going to be for flexible pages, so it is useful to be able to configure them. This allows us to leverage existing schemas, in this case the history schema for the history pages. This will be important if we decide we would like to migrate existing Whitehall content to flexible pages at a later date.

I decided not to add a flexible page schema to Publishing API in the end (which was the original intention of the [Trello card](https://trello.com/c/rCRfSVGk)). It isn't currently possible to create a truly "flexible" schema in Publishing API at present because every document type has to be added to the allowed [document type configuration](https://github.com/alphagov/publishing-api/blob/main/content_schemas/allowed_document_types.yml), so I decided to use the existing history schema for now.

The existing history schema requires a body value. This will be added when we work on the govspeak block, for now I have set an empty string for a default.