### PR TITLE
Add new `/view` route to support "View {current state} edition" action

### DIFF
--- a/app/components/admin/editions/show/sidebar_actions_component.rb
+++ b/app/components/admin/editions/show/sidebar_actions_component.rb
@@ -32,6 +32,7 @@ class Admin::Editions::Show::SidebarActionsComponent < ViewComponent::Base
       add_unpublish_action
       add_review_reminder_action
       add_view_action
+      add_view_on_website_action
       add_data_action
     end
     @actions
@@ -172,6 +173,16 @@ private
     end
   end
 
+  def add_view_action
+    if @enforcer.can?(:see) && %w[draft submitted rejected].exclude?(@edition.state)
+      actions << render("govuk_publishing_components/components/button", {
+        text: "View #{@edition.state} edition",
+        href: helpers.view_path_for_edition(@edition),
+        secondary_quiet: true,
+      })
+    end
+  end
+
   def add_review_reminder_action
     if @edition.publicly_visible? && @edition.document.latest_edition == @edition
       review_reminder = @edition.document.review_reminder
@@ -188,7 +199,7 @@ private
     end
   end
 
-  def add_view_action
+  def add_view_on_website_action
     if @edition.publicly_visible?
       actions << link_to("View on website (opens in new tab)",
                          @edition.public_url,

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -6,7 +6,7 @@ class Admin::EditionsController < Admin::BaseController
   before_action :clean_edition_parameters, only: %i[create update]
   before_action :clear_scheduled_publication_if_not_activated, only: %i[create update]
   before_action :clear_response_form_file_cache, only: %i[create update]
-  before_action :find_edition, only: %i[show edit update revise diff confirm_destroy destroy update_bypass_id update_image_display_option]
+  before_action :find_edition, only: %i[show view edit update revise diff confirm_destroy destroy update_bypass_id update_image_display_option]
   before_action :prevent_modification_of_unmodifiable_edition, only: %i[edit update]
   before_action :delete_absent_edition_organisations, only: %i[create update]
   before_action :build_national_exclusion_params, only: %i[create update]
@@ -17,7 +17,7 @@ class Admin::EditionsController < Admin::BaseController
   before_action :build_edition_dependencies, only: %i[new edit]
   before_action :forbid_editing_of_historic_content!, only: %i[create edit update destroy revise]
   before_action :enforce_permissions!
-  before_action :limit_edition_access!, only: %i[show edit update revise diff destroy]
+  before_action :limit_edition_access!, only: %i[show view edit update revise diff destroy]
   before_action :redirect_to_controller_for_type, only: [:show]
   before_action :construct_similar_slug_warning_error, only: %i[edit]
 
@@ -25,7 +25,7 @@ class Admin::EditionsController < Admin::BaseController
     case action_name
     when "index", "topics"
       enforce_permission!(:see, edition_class || Edition)
-    when "show"
+    when "show", "view"
       enforce_permission!(:see, @edition)
     when "new", "choose_type"
       enforce_permission!(:create, edition_class || Edition)
@@ -98,6 +98,11 @@ class Admin::EditionsController < Admin::BaseController
   def edit
     @edition.open_for_editing_as(current_user)
     fetch_version_and_remark_trails
+  end
+
+  def view
+    @edition.open_for_editing_as(current_user)
+    @read_only_form = true
   end
 
   def update

--- a/app/helpers/admin/editions_helper.rb
+++ b/app/helpers/admin/editions_helper.rb
@@ -107,12 +107,12 @@ module Admin::EditionsHelper
     end
   end
 
-  # Bit of a hack to stop the 'generic_editions_controller_tests' from breaking,
-  # since `view_admin_generic_edition_path` doesn't exist
   def view_path_for_edition(edition)
     route_helper = "view_admin_#{edition.type.underscore}_path"
     if respond_to?(route_helper)
       send(route_helper, edition)
+    elsif edition.is_a?(CorporateInformationPage)
+      "/government/admin/organisations/#{edition.organisation.slug}/corporate_information_pages/#{edition.id}/view"
     end
   end
 

--- a/app/views/admin/corporate_information_pages/_form.html.erb
+++ b/app/views/admin/corporate_information_pages/_form.html.erb
@@ -1,26 +1,2 @@
-<%= form_for form_url_for_edition(edition), as: :edition, html: { class: edition_form_classes(edition), multipart: true }, data: { module: "EditionForm LocaleSwitcher", "rtl-locales": Locale.right_to_left.collect(&:to_param) } do |form| %>
-  <%= render("standard_fields", form:, edition:) %>
-  <%= render("settings_fields", form:, edition:) %>
-  <div class="publishing-controls">
-    <% if edition.change_note_required? %>
-      <%= render("change_notes", form:, edition:) %>
-    <% end %>
-
-    <div class="govuk-button-group">
-      <%= render "govuk_publishing_components/components/button", {
-        text: "Save",
-        value: "save",
-        name: "save",
-      } %>
-
-      <%= render "govuk_publishing_components/components/button", {
-        text: "Save and go to document summary",
-        secondary_solid: true,
-      } %>
-
-      <% cancel_link_path = edition.new_record? ? polymorphic_path([:admin, edition.organisation, CorporateInformationPage]) : admin_edition_path(edition) %>
-      <%= link_to "Cancel", cancel_link_path, class: "govuk-link govuk-link--no-visited-state" %>
-    </div>
-
-  </div>
+<%= standard_edition_form(edition) do |form| %>
 <% end %>

--- a/app/views/admin/editions/_save_or_continue_or_cancel.html.erb
+++ b/app/views/admin/editions/_save_or_continue_or_cancel.html.erb
@@ -10,5 +10,10 @@
     secondary_solid: true,
   } %>
 
-  <%= link_to "Cancel", edition.new_record? ? admin_editions_path : admin_edition_path(edition), class: "govuk-link govuk-link--no-visited-state" %>
+  <% cancel_link_path = if edition.is_a?(CorporateInformationPage)
+                          edition.new_record? ? polymorphic_path([:admin, edition.organisation, CorporateInformationPage]) : admin_edition_path(edition)
+                        else
+                          edition.new_record? ? admin_editions_path : admin_edition_path(edition)
+                        end %>
+  <%= link_to "Cancel", cancel_link_path, class: "govuk-link govuk-link--no-visited-state" %>
 </div>

--- a/app/views/admin/editions/view.html.erb
+++ b/app/views/admin/editions/view.html.erb
@@ -1,0 +1,15 @@
+<% content_for :page_title, "View #{@edition.format_name}" %>
+<% content_for :title, "Viewing #{@edition.format_name}" %>
+<% content_for :context, @edition.title %>
+
+<% content_for :back_link do %>
+  <%= render "govuk_publishing_components/components/back_link", {
+    href: admin_edition_path(@edition),
+  } %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <%= render "form", edition: @edition %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -296,7 +296,9 @@ Whitehall::Application.routes.draw do
       resources :landing_pages, path: "landing-pages", except: [:index]
 
       resources :news_articles, path: "news", except: [:index]
-      resources :fatality_notices, path: "fatalities", except: [:index]
+      resources :fatality_notices, path: "fatalities", except: [:index] do
+        get :view, on: :member
+      end
       resources :consultations, except: [:index] do
         get :view, on: :member
         resource :outcome, controller: "consultation_responses", type: "ConsultationOutcome", except: %i[new destroy]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -89,6 +89,7 @@ Whitehall::Application.routes.draw do
       resources :authors, only: [:show]
 
       resources :document_collections, path: "collections", except: [:index] do
+        get :view, on: :member
         resources :document_collection_groups, as: :groups, path: "groups" do
           get :search_options, to: "document_collection_group_document_search#search_options"
           post :search_options, to: "document_collection_group_document_search#search"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -297,7 +297,9 @@ Whitehall::Application.routes.draw do
         get :view, on: :member
       end
 
-      resources :news_articles, path: "news", except: [:index]
+      resources :news_articles, path: "news", except: [:index] do
+        get :view, on: :member
+      end
       resources :fatality_notices, path: "fatalities", except: [:index] do
         get :view, on: :member
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -410,7 +410,9 @@ Whitehall::Application.routes.draw do
           post :unfeature, on: :member
         end
       end
-      resources :case_studies, path: "case-studies", except: [:index]
+      resources :case_studies, path: "case-studies", except: [:index] do
+        get :view, on: :member
+      end
       if Rails.env.test?
         resources :generic_editions, path: "generic-editions"
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -353,7 +353,9 @@ Whitehall::Application.routes.draw do
         end
       end
 
-      resources :detailed_guides, path: "detailed-guides", except: [:index]
+      resources :detailed_guides, path: "detailed-guides", except: [:index] do
+        get :view, on: :member
+      end
       resources :people do
         resources :translations, controller: "person_translations" do
           get :confirm_destroy, on: :member

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -297,6 +297,7 @@ Whitehall::Application.routes.draw do
       resources :news_articles, path: "news", except: [:index]
       resources :fatality_notices, path: "fatalities", except: [:index]
       resources :consultations, except: [:index] do
+        get :view, on: :member
         resource :outcome, controller: "consultation_responses", type: "ConsultationOutcome", except: %i[new destroy]
         resource :public_feedback, controller: "consultation_responses", type: "ConsultationPublicFeedback", except: %i[new destroy]
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -115,6 +115,7 @@ Whitehall::Application.routes.draw do
       resources :organisations do
         resources :groups, except: [:show]
         resources :corporate_information_pages do
+          get :view, on: :member
           resources :translations, controller: "corporate_information_pages_translations"
         end
         resources :contacts do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -205,6 +205,7 @@ Whitehall::Application.routes.draw do
         member do
           post :submit, to: "edition_workflow#submit"
           post :revise
+          get  :view
           get  :diff
           get  :confirm_approve_retrospectively, to: "edition_workflow#confirm_approve_retrospectively"
           post :approve_retrospectively, to: "edition_workflow#approve_retrospectively"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -328,7 +328,9 @@ Whitehall::Application.routes.draw do
         get :reorder, on: :collection
       end
 
-      resources :speeches, except: [:index]
+      resources :speeches, except: [:index] do
+        get :view, on: :member
+      end
       resources :statistical_data_sets, path: "statistical-data-sets", except: [:index]
       resources :worldwide_organisations, path: "worldwide-organisations", except: [:index] do
         resources :pages, controller: "worldwide_organisation_pages" do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -293,7 +293,9 @@ Whitehall::Application.routes.draw do
       resources :flexible_pages, path: "flexible-pages", except: [:index] do
         get :choose_type, on: :collection, as: :choose_type
       end
-      resources :landing_pages, path: "landing-pages", except: [:index]
+      resources :landing_pages, path: "landing-pages", except: [:index] do
+        get :view, on: :member
+      end
 
       resources :news_articles, path: "news", except: [:index]
       resources :fatality_notices, path: "fatalities", except: [:index] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -288,7 +288,9 @@ Whitehall::Application.routes.draw do
         end
       end
 
-      resources :publications, except: [:index]
+      resources :publications, except: [:index] do
+        get :view, on: :member
+      end
 
       resources :flexible_pages, path: "flexible-pages", except: [:index] do
         get :choose_type, on: :collection, as: :choose_type

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -335,6 +335,7 @@ Whitehall::Application.routes.draw do
         get :view, on: :member
       end
       resources :worldwide_organisations, path: "worldwide-organisations", except: [:index] do
+        get :view, on: :member
         resources :pages, controller: "worldwide_organisation_pages" do
           get :confirm_destroy, on: :member
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -308,6 +308,7 @@ Whitehall::Application.routes.draw do
       end
 
       resources :calls_for_evidence, path: "calls-for-evidence", except: [:index] do
+        get :view, on: :member
         resource :outcome, controller: "call_for_evidence_responses", type: "CallForEvidenceOutcome", except: %i[new destroy]
       end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -331,7 +331,9 @@ Whitehall::Application.routes.draw do
       resources :speeches, except: [:index] do
         get :view, on: :member
       end
-      resources :statistical_data_sets, path: "statistical-data-sets", except: [:index]
+      resources :statistical_data_sets, path: "statistical-data-sets", except: [:index] do
+        get :view, on: :member
+      end
       resources :worldwide_organisations, path: "worldwide-organisations", except: [:index] do
         resources :pages, controller: "worldwide_organisation_pages" do
           get :confirm_destroy, on: :member

--- a/test/components/admin/editions/show/sidebar_actions_component_test.rb
+++ b/test/components/admin/editions/show/sidebar_actions_component_test.rb
@@ -19,8 +19,9 @@ class Admin::Editions::Show::SidebarActionsComponentTest < ViewComponent::TestCa
     edition = create(:published_edition)
     render_inline(Admin::Editions::Show::SidebarActionsComponent.new(edition:, current_user:))
 
-    assert_selector "li", count: 4
+    assert_selector "li", count: 5
     assert_selector "button", text: "Create new edition"
+    assert_selector "button", text: "View published edition"
     assert_selector "a", text: "Set review date"
     assert_selector "a", text: "View data about page"
     assert_selector "a[href='https://www.test.gov.uk/government/generic-editions/#{edition.title}']", text: "View on website (opens in new tab)"
@@ -32,8 +33,9 @@ class Admin::Editions::Show::SidebarActionsComponentTest < ViewComponent::TestCa
     create(:review_reminder, :reminder_due, document: edition.document)
     render_inline(Admin::Editions::Show::SidebarActionsComponent.new(edition:, current_user:))
 
-    assert_selector "li", count: 5
+    assert_selector "li", count: 6
     assert_selector "button", text: "Create new edition"
+    assert_selector "button", text: "View published edition"
     assert_selector "a", text: "Edit review date"
     assert_selector "a", text: "Delete review date"
     assert_selector "a", text: "View data about page"
@@ -45,8 +47,9 @@ class Admin::Editions::Show::SidebarActionsComponentTest < ViewComponent::TestCa
     edition = create(:non_english_published_edition)
     render_inline(Admin::Editions::Show::SidebarActionsComponent.new(edition:, current_user:))
 
-    assert_selector "li", count: 4
+    assert_selector "li", count: 5
     assert_selector "button", text: "Create new edition"
+    assert_selector "button", text: "View published edition"
     assert_selector "a", text: "Set review date"
     assert_selector "a", text: "View data about page"
     assert_selector "a[href='https://www.test.gov.uk/government/generic-editions/#{edition.document.id}.cy']", text: "View on website (opens in new tab)"
@@ -86,8 +89,9 @@ class Admin::Editions::Show::SidebarActionsComponentTest < ViewComponent::TestCa
     edition = create(:scheduled_edition)
     render_inline(Admin::Editions::Show::SidebarActionsComponent.new(edition:, current_user:))
 
-    assert_selector "li", count: 1
+    assert_selector "li", count: 2
     assert_selector "a", text: "Unschedule"
+    assert_selector "button", text: "View scheduled edition"
   end
 
   test "actions for unpublished edition" do
@@ -95,8 +99,9 @@ class Admin::Editions::Show::SidebarActionsComponentTest < ViewComponent::TestCa
     edition = create(:unpublished_edition)
     render_inline(Admin::Editions::Show::SidebarActionsComponent.new(edition:, current_user:))
 
-    assert_selector "li", count: 1
+    assert_selector "li", count: 2
     assert_selector "button", text: "Create new edition"
+    assert_selector "button", text: "View unpublished edition"
   end
 
   test "actions for withdrawn edition" do
@@ -104,8 +109,9 @@ class Admin::Editions::Show::SidebarActionsComponentTest < ViewComponent::TestCa
     edition = create(:withdrawn_edition)
     render_inline(Admin::Editions::Show::SidebarActionsComponent.new(edition:, current_user:))
 
-    assert_selector "li", count: 3
+    assert_selector "li", count: 4
     assert_selector "a", text: "Set review date"
+    assert_selector "button", text: "View withdrawn edition"
     assert_selector "a", text: "View data about page"
     assert_selector "a", text: "View on website (opens in new tab)"
   end
@@ -139,8 +145,9 @@ class Admin::Editions::Show::SidebarActionsComponentTest < ViewComponent::TestCa
     edition = create(:published_edition)
     render_inline(Admin::Editions::Show::SidebarActionsComponent.new(edition:, current_user:))
 
-    assert_selector "li", count: 5
+    assert_selector "li", count: 6
     assert_selector "button", text: "Create new edition"
+    assert_selector "button", text: "View published edition"
     assert_selector "a", text: "Set review date"
     assert_selector "a", text: "Withdraw or unpublish"
     assert_selector "a", text: "View data about page"
@@ -195,8 +202,9 @@ class Admin::Editions::Show::SidebarActionsComponentTest < ViewComponent::TestCa
     edition = create(:scheduled_edition)
     render_inline(Admin::Editions::Show::SidebarActionsComponent.new(edition:, current_user:))
 
-    assert_selector "li", count: 1
+    assert_selector "li", count: 2
     assert_selector "a", text: "Unschedule"
+    assert_selector "button", text: "View scheduled edition"
   end
 
   test "actions for unpublished edition as managing editor" do
@@ -204,8 +212,9 @@ class Admin::Editions::Show::SidebarActionsComponentTest < ViewComponent::TestCa
     edition = create(:edition, :published_in_error_no_redirect)
     render_inline(Admin::Editions::Show::SidebarActionsComponent.new(edition:, current_user:))
 
-    assert_selector "li", count: 2
+    assert_selector "li", count: 3
     assert_selector "button", text: "Create new edition"
+    assert_selector "button", text: "View unpublished edition"
     assert_selector "a", text: "Edit unpublishing explanation"
   end
 
@@ -214,8 +223,9 @@ class Admin::Editions::Show::SidebarActionsComponentTest < ViewComponent::TestCa
     edition = create(:withdrawn_edition)
     render_inline(Admin::Editions::Show::SidebarActionsComponent.new(edition:, current_user:))
 
-    assert_selector "li", count: 5
+    assert_selector "li", count: 6
     assert_selector "a", text: "Unwithdraw"
+    assert_selector "button", text: "View withdrawn edition"
     assert_selector "a", text: "Edit withdrawal explanation"
     assert_selector "a", text: "Set review date"
     assert_selector "a", text: "View data about page"

--- a/test/functional/admin/calls_for_evidence_controller_test.rb
+++ b/test/functional/admin/calls_for_evidence_controller_test.rb
@@ -162,6 +162,29 @@ class Admin::CallsForEvidenceControllerTest < ActionController::TestCase
     end
   end
 
+  view_test "view displays call_for_evidence fields" do
+    response_form = create(:call_for_evidence_response_form)
+    participation = create(:call_for_evidence_participation, call_for_evidence_response_form: response_form)
+    call_for_evidence = create(:call_for_evidence, call_for_evidence_participation: participation)
+
+    get :view, params: { id: call_for_evidence }
+
+    assert_select "form#edit_edition fieldset[disabled='disabled']" do
+      assert_select "textarea[name='edition[summary]']"
+      assert_select "input[name*='edition[opening_at']", count: 3
+      assert_select "select[name*='edition[opening_at']", count: 2
+      assert_select "input[name*='edition[closing_at']", count: 3
+      assert_select "select[name*='edition[closing_at']", count: 2
+      assert_select "input[type='text'][name='edition[call_for_evidence_participation_attributes][link_url]']"
+      assert_select "input[type='text'][name='edition[call_for_evidence_participation_attributes][email]']"
+      assert_select "textarea[name='edition[call_for_evidence_participation_attributes][postal_address]']"
+      assert_select "input[type='hidden'][name='edition[call_for_evidence_participation_attributes][call_for_evidence_response_form_attributes][id]'][value='#{response_form.id}']"
+      assert_select "input[type='text'][name='edition[call_for_evidence_participation_attributes][call_for_evidence_response_form_attributes][title]']"
+      assert_select "input[type='hidden'][name='edition[call_for_evidence_participation_attributes][call_for_evidence_response_form_attributes][call_for_evidence_response_form_data_attributes][id]'][value='#{response_form.call_for_evidence_response_form_data.id}']"
+      assert_select "input[type='file'][name='edition[call_for_evidence_participation_attributes][call_for_evidence_response_form_attributes][call_for_evidence_response_form_data_attributes][file]']"
+    end
+  end
+
   test "update should save modified call_for_evidence attributes" do
     call_for_evidence = create(:call_for_evidence)
 

--- a/test/functional/admin/case_studies_controller_test.rb
+++ b/test/functional/admin/case_studies_controller_test.rb
@@ -28,4 +28,13 @@ class Admin::CaseStudiesControllerTest < ActionController::TestCase
     assert_equal "no_image", edition.reload.image_display_option
     assert_nil edition.lead_image
   end
+
+  view_test "viewing a readonly representation of this case study" do
+    case_study = create(:published_case_study)
+    get :view, params: { id: case_study }
+
+    assert_select "form#edit_edition fieldset[disabled='disabled']" do
+      assert_select "textarea[name='edition[body]']"
+    end
+  end
 end

--- a/test/functional/admin/consultations_controller_test.rb
+++ b/test/functional/admin/consultations_controller_test.rb
@@ -183,6 +183,29 @@ class Admin::ConsultationsControllerTest < ActionController::TestCase
     end
   end
 
+  view_test "view displays consultation fields" do
+    response_form = create(:consultation_response_form)
+    participation = create(:consultation_participation, consultation_response_form: response_form)
+    consultation = create(:consultation, consultation_participation: participation)
+
+    get :view, params: { id: consultation }
+
+    assert_select "form#edit_edition fieldset[disabled='disabled']" do
+      assert_select "textarea[name='edition[summary]']"
+      assert_select "input[name*='edition[opening_at']", count: 3
+      assert_select "select[name*='edition[opening_at']", count: 2
+      assert_select "input[name*='edition[closing_at']", count: 3
+      assert_select "select[name*='edition[closing_at']", count: 2
+      assert_select "input[type='text'][name='edition[consultation_participation_attributes][link_url]']"
+      assert_select "input[type='text'][name='edition[consultation_participation_attributes][email]']"
+      assert_select "textarea[name='edition[consultation_participation_attributes][postal_address]']"
+      assert_select "input[type='hidden'][name='edition[consultation_participation_attributes][consultation_response_form_attributes][id]'][value='#{response_form.id}']"
+      assert_select "input[type='text'][name='edition[consultation_participation_attributes][consultation_response_form_attributes][title]']"
+      assert_select "input[type='hidden'][name='edition[consultation_participation_attributes][consultation_response_form_attributes][consultation_response_form_data_attributes][id]'][value='#{response_form.consultation_response_form_data.id}']"
+      assert_select "input[type='file'][name='edition[consultation_participation_attributes][consultation_response_form_attributes][consultation_response_form_data_attributes][file]']"
+    end
+  end
+
   test "update should save modified consultation attributes" do
     consultation = create(:consultation)
 

--- a/test/functional/admin/corporate_information_pages_controller_test.rb
+++ b/test/functional/admin/corporate_information_pages_controller_test.rb
@@ -65,6 +65,17 @@ class Admin::CorporateInformationPagesControllerTest < ActionController::TestCas
     end
   end
 
+  view_test "GET :view should display read-only form for existing corporate information page" do
+    corporate_information_page = create(:corporate_information_page, organisation: @organisation)
+    get :view, params: { organisation_id: @organisation, id: corporate_information_page }
+
+    assert_select "form fieldset[disabled='disabled']" do
+      assert_select "textarea[name='edition[body]']", corporate_information_page.body
+      assert_select "textarea[name='edition[summary]']", corporate_information_page.summary
+      assert_select "select[name='edition[corporate_information_page_type_id]']", count: 0
+    end
+  end
+
   test "PUT :update should update an existing corporate information page and redirect on success" do
     corporate_information_page = create(:corporate_information_page, organisation: @organisation)
     new_attributes = { body: "New body", summary: "New summary" }

--- a/test/functional/admin/detailed_guides_controller_test.rb
+++ b/test/functional/admin/detailed_guides_controller_test.rb
@@ -83,6 +83,15 @@ class Admin::DetailedGuidesControllerTest < ActionController::TestCase
     end
   end
 
+  view_test "viewing a readonly representation of this detailed guide" do
+    detailed_guide = create(:published_detailed_guide)
+    get :view, params: { id: detailed_guide }
+
+    assert_select "form#edit_edition fieldset[disabled='disabled']" do
+      assert_select "textarea[name='edition[body]']"
+    end
+  end
+
 private
 
   def controller_attributes_for(edition_type, attributes = {})

--- a/test/functional/admin/document_collections_controller_test.rb
+++ b/test/functional/admin/document_collections_controller_test.rb
@@ -78,6 +78,19 @@ class Admin::DocumentCollectionsControllerTest < ActionController::TestCase
     end
   end
 
+  view_test "GET #view renders the a disabled form showing the document collection contents" do
+    document_collection = create(:document_collection)
+
+    get :view, params: { id: document_collection }
+
+    assert_select "form[action=?] fieldset[disabled='disabled']", admin_document_collection_path(document_collection) do
+      assert_select ".app-view-edit-edition__page-address .govuk-hint", document_collection.public_url
+      assert_select "textarea[name='edition[title]']", document_collection.title
+      assert_select "textarea[name='edition[summary]']", text: document_collection.summary
+      assert_select "textarea[name='edition[body]']", text: document_collection.body
+    end
+  end
+
   test "PUT #update updates the document collection" do
     document_collection = create(:document_collection, title: "old-title")
 

--- a/test/functional/admin/editions_controller_test.rb
+++ b/test/functional/admin/editions_controller_test.rb
@@ -30,6 +30,15 @@ class Admin::EditionsControllerTest < ActionController::TestCase
     get :index, params: { type: :publication }
   end
 
+  test "viewing a readonly representation of this edition" do
+    publication = create(:published_publication)
+    get :view, params: { id: publication }
+
+    assert_response :success
+    assert_template :view
+    assert_equal true, assigns(:read_only_form)
+  end
+
   test "diffing against a previous version" do
     publication = create(:draft_publication)
     editor = create(:departmental_editor)

--- a/test/functional/admin/fatality_notices_controller_test.rb
+++ b/test/functional/admin/fatality_notices_controller_test.rb
@@ -50,6 +50,17 @@ class Admin::FatalityNoticesControllerTest < ActionController::TestCase
     end
   end
 
+  view_test "when viewing shows the saved fields" do
+    field = create(:operational_field)
+    edition = create(:fatality_notice, operational_field: field)
+
+    get :view, params: { id: edition }
+
+    assert_select "form#edit_edition fieldset[disabled='disabled']" do
+      assert_select "select[name='edition[operational_field_id]']"
+    end
+  end
+
   view_test "should display fields for new fatality notice casualties" do
     get :new
 

--- a/test/functional/admin/landing_pages_controller_test.rb
+++ b/test/functional/admin/landing_pages_controller_test.rb
@@ -58,6 +58,17 @@ class Admin::LandingPagesControllerTest < ActionController::TestCase
     assert_template "edit"
   end
 
+  view_test "GET :view fetches the supplied instance for readonly mode" do
+    document = create(:document, slug: "/some-slug-starting-with-slash")
+    page = create(:landing_page, organisations: [@organisation], document:)
+
+    get :view, params: { id: page }
+
+    assert_select "form#edit_edition fieldset[disabled='disabled']" do
+      assert_select "textarea[name='edition[body]']"
+    end
+  end
+
   test "PUT :update changes the supplied instance with the supplied params" do
     attrs = attributes_for(:landing_page, title: "Hello there")
     document = create(:document, slug: "/some-slug-starting-with-slash")

--- a/test/functional/admin/news_articles_controller_test.rb
+++ b/test/functional/admin/news_articles_controller_test.rb
@@ -41,6 +41,17 @@ class Admin::NewsArticlesControllerTest < ActionController::TestCase
     end
   end
 
+  view_test "view displays news article field and guidance" do
+    news_article = create(:news_article)
+
+    get :view, params: { id: news_article }
+
+    assert_select "form#edit_edition fieldset[disabled='disabled']" do
+      assert_select "select[name*='edition[news_article_type_id']"
+      assert_select ".js-app-view-edition-form__subtype-format-advice", disabled: true, text: "Use this subformat for… Unedited press releases as sent to the media, and official statements from the organisation or a minister.Do not use for: statements to Parliament. Use the “Speech” format for those."
+    end
+  end
+
   view_test "show renders the summary" do
     draft_news_article = create(:draft_news_article, summary: "a-simple-summary")
     stub_publishing_api_expanded_links_with_taxons(draft_news_article.content_id, [])

--- a/test/functional/admin/publications_controller_test.rb
+++ b/test/functional/admin/publications_controller_test.rb
@@ -103,6 +103,18 @@ class Admin::PublicationsControllerTest < ActionController::TestCase
     end
   end
 
+  view_test "view displays publication fields and guidance" do
+    publication = create(:publication)
+
+    get :view, params: { id: publication }
+
+    assert_select "form#edit_edition fieldset[disabled='disabled']" do
+      assert_select "select[name='edition[publication_type_id]']"
+      assert_select "input[name*='edition[first_published_at']", count: 3
+      assert_select ".js-app-view-edition-form__subtype-format-advice", text: "Use this subformat for… A policy paper explains the government’s position on something. It doesn’t include instructions on how to carry out a task, only the policy itself and how it’ll be implemented.Read the policy papers guidance in full."
+    end
+  end
+
   test "update should save modified publication attributes" do
     publication = create(:publication)
 

--- a/test/functional/admin/speeches_controller_test.rb
+++ b/test/functional/admin/speeches_controller_test.rb
@@ -45,6 +45,22 @@ class Admin::SpeechesControllerTest < ActionController::TestCase
     end
   end
 
+  view_test "view renders subtype guidance" do
+    speech = create(:speech)
+
+    get :view, params: { id: speech }
+
+    assert_select "form#edit_edition fieldset[disabled='disabled']" do
+      assert_select "select[name='edition[speech_type_id]']"
+      assert_select "select[name='edition[role_appointment_id]']"
+      assert_select "input[name='edition[person_override]']"
+      assert_select "input[name*='edition[delivered_on']", count: 3
+      assert_select "select[name*='edition[delivered_on']", count: 2
+      assert_select "input[name='edition[location]'][type='text']"
+      assert_select ".js-app-view-edition-form__subtype-format-advice", text: "Use this subformat for… A verbatim report of exactly what the speaker said (checked against delivery)."
+    end
+  end
+
   test "create should create a new speech" do
     role_appointment = create(:role_appointment)
     speech_type = SpeechType::Transcript

--- a/test/functional/admin/statistical_data_sets_controller_test.rb
+++ b/test/functional/admin/statistical_data_sets_controller_test.rb
@@ -18,6 +18,15 @@ class Admin::StatisticalDataSetsControllerTest < ActionController::TestCase
   should_allow_scheduled_publication_of :statistical_data_set
   should_allow_access_limiting_of :statistical_data_set
 
+  view_test "viewing a readonly representation of this edition" do
+    statistical_data_set = create(:published_statistical_data_set)
+    get :view, params: { id: statistical_data_set }
+
+    assert_select "form#edit_edition fieldset[disabled='disabled']" do
+      assert_select "textarea[name='edition[body]']"
+    end
+  end
+
   def controller_attributes_for(edition_type, attributes = {})
     super.except(:alternative_format_provider).reverse_merge(
       alternative_format_provider_id: create(:alternative_format_provider).id,

--- a/test/functional/admin/worldwide_organisations_controller_test.rb
+++ b/test/functional/admin/worldwide_organisations_controller_test.rb
@@ -53,6 +53,17 @@ class Admin::WorldwideOrganisationsControllerTest < ActionController::TestCase
     assert_redirected_to admin_worldwide_organisation_path(worldwide_organisation)
   end
 
+  view_test "viewing a readonly representation of this worldwide organisation" do
+    worldwide_organisation = create(:published_worldwide_organisation)
+    get :view, params: { id: worldwide_organisation }
+
+    assert_select "form#edit_edition fieldset[disabled='disabled']" do
+      assert_select "textarea[name='edition[logo_formatted_name]']"
+      assert_select "select[name='edition[world_location_ids][]']"
+      assert_select "select[name='edition[role_ids][]']"
+    end
+  end
+
 private
 
   def controller_attributes_for(edition_type, attributes = {})

--- a/test/unit/app/helpers/admin/editions_helper_test.rb
+++ b/test/unit/app/helpers/admin/editions_helper_test.rb
@@ -101,4 +101,24 @@ class Admin::EditionsHelperTest < ActionView::TestCase
 
     assert_equal "It's my title!", edition_title_link_or_edition_title(edition)
   end
+
+  test "#view_path_for_edition returns view path for standard edition types" do
+    edition = create(:publication)
+
+    assert_equal "/government/admin/publications/#{edition.id}/view", view_path_for_edition(edition)
+  end
+
+  test "#view_path_for_edition returns view path for Corporate Information Pages" do
+    edition = create(:corporate_information_page)
+
+    assert_equal "/government/admin/organisations/#{edition.organisation.slug}/corporate_information_pages/#{edition.id}/view", view_path_for_edition(edition)
+  end
+
+  # Bit of a hack to stop the 'generic_editions_controller_tests' from breaking,
+  # since `view_admin_generic_edition_path` doesn't exist
+  test "#view_path_for_edition returns nil for Generic Edition" do
+    edition = build(:published_edition)
+
+    assert_equal nil, view_path_for_edition(edition)
+  end
 end


### PR DESCRIPTION
## What

Adds a "View {current state} edition" button in the sidebar, so that:

1. We can see the contents of a published Edition without creating a new edition(!).
2. We can easily see what the contents of superseded editions used to be.

See individual commits for details of which document type has this "View {state} edition" feature. Note that the Flexible Page type has been omitted, for now, as its implementation is liable to change quite rapidly in the coming weeks. 

The view reuses all the same partials as the "Edit" action, but with the publish/settings actions removed and with an overall `<fieldset>` wrapping the form inputs to force every input to be disabled / readonly. It does require some duplicate route definitions in routes.rb, because we can't use the `edition/{id}/view` slug because the form itself relies on knowing the content type, so the content type has to be part of the URL. The standard new/edit/show RESTful routes are included in Rails by default, so aren't explicitly defined in routes.rb, but the 'view' route needs defining manually.

Notably absent is the ability to view HTML attachments (or indeed any attachments) from this screen, but I figure that's something that can be added later in response to publisher demand.

NB, we don't add the button to the sidebar of _draft_ editions, since the publisher would just press the "Edit draft" button.

Trello: https://trello.com/c/wCnq2kT4/3836-add-view-current-edition-feature

## Why

Not being able to see an edition's GovSpeak contents impedes our ability to troubleshoot when responding to support requests. We have to go through the somewhat arduous process of switching to integration, so that we can take the non-idempotent action of creating a new edition.

Even worse is the experience of trying to find out the GovSpeak contents of past editions, which either means trying to construct the correct [diff url](https://github.com/alphagov/whitehall/blob/3aa1268058476ddfd04b135cc53cd342db51cdec/config/routes.rb#L210) to compare the superseded edition with the latest edition, or else fire up a Rails console to dig out the details manually. There is surely a tonne of benefit to more easily surfacing this information for publishers.

## Screenshots

Sidebar on superseded editions:
> ![sidebar on superseded editions](https://github.com/user-attachments/assets/825dae06-f7f7-4014-b4e3-9f2a98e004a4)

Sidebar on 'current' editions:
> ![sidebar on 'current' editions](https://github.com/user-attachments/assets/d51bcab8-f2ee-4ceb-8b02-6ee4da3eb573)

Sidebar on draft/submitted/rejected editions (unchanged):
> ![sidebar on draft editions](https://github.com/user-attachments/assets/db7a066c-394a-4851-8df1-2946a4044612)

Read-only form:
> ![read-only form)](https://github.com/user-attachments/assets/b22858b6-aea5-479e-bd63-8bcdf92d3241)

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
