### PR TITLE
Bump govspeak from 10.3.0 to 10.4.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -294,7 +294,7 @@ GEM
       rake (>= 13)
     googleapis-common-protos-types (1.20.0)
       google-protobuf (>= 3.18, < 5.a)
-    govspeak (10.3.0)
+    govspeak (10.4.0)
       actionview (>= 6, < 8.0.3)
       addressable (>= 2.3.8, < 2.8.8)
       govuk_publishing_components (>= 43)


### PR DESCRIPTION
This is needed for republishing a document with an abbreviation in an informational Govspeak component for a support ticket