### PR TITLE
(CM-164) Add a mode to a new contact

### DIFF
--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/workflow/group_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/workflow/group_component.html.erb
@@ -1,0 +1,3 @@
+<%= render "govuk_publishing_components/components/tabs", {
+  tabs:,
+} %>

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/workflow/group_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/workflow/group_component.rb
@@ -1,0 +1,44 @@
+class ContentBlockManager::ContentBlockEdition::Workflow::GroupComponent < ViewComponent::Base
+  def initialize(content_block_edition:, subschemas:)
+    @content_block_edition = content_block_edition
+    @subschemas = subschemas
+  end
+
+private
+
+  attr_reader :content_block_edition, :subschemas
+
+  def tabs
+    subschemas.sort_by(&:group_order).map { |subschema|
+      tab_for_subschema(subschema)
+    }.compact
+  end
+
+  def tab_for_subschema(subschema)
+    items = items_for_subschema(subschema)
+    if items.any?
+      {
+        id: subschema.id,
+        label: tab_label(subschema, items),
+        content: content_for_tab(subschema, items),
+      }
+    end
+  end
+
+  def tab_label(subschema, items)
+    "#{subschema.name.titleize} (#{items.values.count})"
+  end
+
+  def content_for_tab(subschema, items)
+    render ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponent.with_collection(
+      items.keys,
+      content_block_edition: content_block_edition,
+      object_type: subschema.block_type,
+      redirect_url: request.fullpath,
+    )
+  end
+
+  def items_for_subschema(subschema)
+    content_block_edition.details.fetch(subschema.block_type, {})
+  end
+end

--- a/lib/engines/content_block_manager/app/components/content_block_manager/shared/embedded_objects/summary_card_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/shared/embedded_objects/summary_card_component.html.erb
@@ -1,4 +1,4 @@
-<div class="govuk-summary-card">
+<%= content_tag(:div, wrapper_attributes) do %>
   <div class="govuk-summary-card__title-wrapper">
     <h2 class="govuk-summary-card__title">
       <%= title %>
@@ -21,13 +21,13 @@
         <%= render ContentBlockManager::Shared::EmbeddedObjects::SummaryCard::NestedItemComponent.with_collection(
           items,
           title: key.singularize.titleize,
-        ) %>
+          ) %>
       <% else %>
         <%= render ContentBlockManager::Shared::EmbeddedObjects::SummaryCard::NestedItemComponent.new(
           nested_items: items,
           title: key.singularize.titleize,
-        ) %>
+          ) %>
       <% end %>
     <% end %>
   </div>
-</div>
+<% end %>

--- a/lib/engines/content_block_manager/app/components/content_block_manager/shared/embedded_objects/summary_card_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/shared/embedded_objects/summary_card_component.rb
@@ -3,16 +3,19 @@ class ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponent < ViewC
 
   delegate :document, to: :content_block_edition
 
-  def initialize(content_block_edition:, object_type:, object_title:, redirect_url: nil)
+  with_collection_parameter :object_title
+
+  def initialize(content_block_edition:, object_type:, object_title:, redirect_url: nil, test_id_prefix: nil)
     @content_block_edition = content_block_edition
     @object_type = object_type
     @object_title = object_title
     @redirect_url = redirect_url
+    @test_id_prefix = test_id_prefix
   end
 
 private
 
-  attr_reader :content_block_edition, :object_type, :object_title, :redirect_url
+  attr_reader :content_block_edition, :object_type, :object_title, :redirect_url, :test_id_prefix
 
   def title
     "#{object_type.titleize.singularize} details"
@@ -60,5 +63,16 @@ private
         ),
       },
     ]
+  end
+
+  def wrapper_attributes
+    {
+      "class" => "govuk-summary-card",
+      **data_attributes,
+    }
+  end
+
+  def data_attributes
+    test_id_prefix.present? ? { "data-test-id" => [test_id_prefix, object_title].join("_") } : {}
   end
 end

--- a/lib/engines/content_block_manager/app/components/content_block_manager/shared/embedded_objects_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/shared/embedded_objects_component.html.erb
@@ -4,16 +4,13 @@
       <h2 class="govuk-heading-m"><%= subschema_name.pluralize.titleize %></h2>
     <% end %>
 
-    <% subschema_keys.each do |k| %>
-      <div data-test-id="embedded_<%= k %>">
-        <%= render ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponent.new(
-          content_block_edition: content_block_edition,
-          object_type: subschema.block_type,
-          object_title: k,
-          redirect_url:,
-        ) %>
-      </div>
-    <% end %>
+    <%= render ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponent.with_collection(
+      subschema_keys,
+      content_block_edition: content_block_edition,
+      object_type: subschema.block_type,
+      redirect_url:,
+      test_id_prefix: "embedded",
+    ) %>
 
     <% if show_add_button? %>
       <%= render "govuk_publishing_components/components/button", {

--- a/lib/engines/content_block_manager/app/controllers/concerns/workflow.rb
+++ b/lib/engines/content_block_manager/app/controllers/concerns/workflow.rb
@@ -1,6 +1,7 @@
 module Workflow
   class Step < Data.define(:name, :show_action, :update_action, :included_in_create_journey)
     SUBSCHEMA_PREFIX = "embedded_".freeze
+    GROUP_PREFIX = "group_".freeze
 
     ALL = [
       Step.new(:edit_draft, :edit_draft, :update_draft, true),

--- a/lib/engines/content_block_manager/app/controllers/concerns/workflow.rb
+++ b/lib/engines/content_block_manager/app/controllers/concerns/workflow.rb
@@ -1,8 +1,9 @@
 module Workflow
   class Step < Data.define(:name, :show_action, :update_action, :included_in_create_journey)
+    SUBSCHEMA_PREFIX = "embedded_".freeze
+
     ALL = [
       Step.new(:edit_draft, :edit_draft, :update_draft, true),
-      Step.new(:embedded_objects, :embedded_objects, :redirect_to_next_step, true),
       Step.new(:review_links, :review_links, :redirect_to_next_step, false),
       Step.new(:internal_note, :internal_note, :update_internal_note, false),
       Step.new(:change_note, :change_note, :update_change_note, false),
@@ -10,5 +11,9 @@ module Workflow
       Step.new(:review, :review, :validate_review_page, true),
       Step.new(:confirmation, :confirmation, nil, true),
     ].freeze
+
+    def is_subschema?
+      name.to_s.start_with?(SUBSCHEMA_PREFIX)
+    end
   end
 end

--- a/lib/engines/content_block_manager/app/controllers/concerns/workflow/show_methods.rb
+++ b/lib/engines/content_block_manager/app/controllers/concerns/workflow/show_methods.rb
@@ -12,12 +12,17 @@ module Workflow::ShowMethods
     render :edit_draft
   end
 
-  def embedded_objects
-    @subschemas = @schema.subschemas
-    @content_block_edition = ContentBlockManager::ContentBlock::Edition.find(params[:id])
-    @title = @content_block_edition.document.is_new_block? ? "Add to #{@schema.name}" : "Change #{@schema.name}"
+  # This handles the optional embedded objects in the flow, delegating to `embedded_objects`
+  def method_missing(method_name, *arguments, &block)
+    if method_name.to_s =~ /#{Workflow::Step::SUBSCHEMA_PREFIX}(.*)/
+      embedded_objects(::Regexp.last_match(1))
+    else
+      super
+    end
+  end
 
-    render :embedded_objects
+  def respond_to_missing?(method_name, include_private = false)
+    method_name.to_s.start_with?(Workflow::Step::SUBSCHEMA_PREFIX) || super
   end
 
   def review_links
@@ -86,6 +91,19 @@ module Workflow::ShowMethods
   end
 
 private
+
+  def embedded_objects(subschema_name)
+    @subschema = @schema.subschema(subschema_name)
+    @step_name = current_step.name
+    @action = @content_block_edition.document.is_new_block? ? "Add" : "Edit"
+    @add_button_text = has_embedded_objects ? "Add another #{subschema_name.humanize.singularize.downcase}" : "Add #{helpers.add_indefinite_article @subschema.name.humanize.singularize.downcase}"
+
+    if @subschema
+      render :embedded_objects
+    else
+      raise ActionController::RoutingError, "Subschema #{subschema_name} does not exist"
+    end
+  end
 
   def has_embedded_objects
     @content_block_edition.details[@subschema.block_type].present?

--- a/lib/engines/content_block_manager/app/controllers/concerns/workflow/show_methods.rb
+++ b/lib/engines/content_block_manager/app/controllers/concerns/workflow/show_methods.rb
@@ -115,13 +115,22 @@ private
     @action = @content_block_edition.document.is_new_block? ? "Add" : "Edit"
 
     if @subschemas.any?
-      render :group_objects
+      if @subschemas.none? { |subschema| has_embedded_objects(subschema) }
+        @group = group_name
+        @back_link = back_path
+        @redirect_path = content_block_manager.new_embedded_objects_options_redirect_content_block_manager_content_block_edition_path(@content_block_edition)
+        @context = @content_block_edition.title
+
+        render "content_block_manager/content_block/shared/embedded_objects/select_subschema"
+      else
+        render :group_objects
+      end
     else
       raise ActionController::RoutingError, "Subschema group #{group_name} does not exist"
     end
   end
 
-  def has_embedded_objects
-    @content_block_edition.details[@subschema.block_type].present?
+  def has_embedded_objects(subschema = @subschema)
+    @content_block_edition.details[subschema.block_type].present?
   end
 end

--- a/lib/engines/content_block_manager/app/controllers/concerns/workflow/steps.rb
+++ b/lib/engines/content_block_manager/app/controllers/concerns/workflow/steps.rb
@@ -6,11 +6,26 @@ module Workflow::Steps
   end
 
   def steps
-    @steps ||= should_show_subschema_steps? ? all_steps : all_steps.reject { |s| s.name == :embedded_objects }
+    @steps ||= if @schema.subschemas.any?
+                 standard_steps = all_steps.map(&:dup)
+                 extra_steps = @schema.subschemas.map { |subschema|
+                   next if skip_subschema?(subschema)
+
+                   Workflow::Step.new(
+                     "#{Workflow::Step::SUBSCHEMA_PREFIX}#{subschema.id}".to_sym,
+                     "#{Workflow::Step::SUBSCHEMA_PREFIX}#{subschema.id}".to_sym,
+                     :redirect_to_next_step,
+                     true,
+                   )
+                 }.compact
+                 standard_steps.insert(1, extra_steps).flatten!
+               else
+                 all_steps
+               end
   end
 
   def current_step
-    Workflow::Step::ALL.find { |step| step.name == params[:step].to_sym }
+    steps.find { |step| step.name == params[:step].to_sym }
   end
 
   def previous_step
@@ -31,14 +46,6 @@ private
     end
   end
 
-  def should_show_subschema_steps?
-    if @content_block_edition.document.is_new_block?
-      @schema.subschemas.any?
-    else
-      @schema.subschemas.any? && @schema.subschemas.any? { |subschema| @content_block_edition.has_entries_for_subschema_id?(subschema.id) }
-    end
-  end
-
   def initialize_edition_and_schema
     @content_block_edition = ContentBlockManager::ContentBlock::Edition.find(params[:id])
     @schema = ContentBlockManager::ContentBlock::Schema.find_by_block_type(@content_block_edition.document.block_type)
@@ -46,5 +53,10 @@ private
 
   def index
     steps.find_index { |step| step.name == params[:step]&.to_sym } || 0
+  end
+
+  def skip_subschema?(subschema)
+    !@content_block_edition.document.is_new_block? &&
+      !@content_block_edition.has_entries_for_subschema_id?(subschema.id)
   end
 end

--- a/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/documents/embedded_objects_controller.rb
+++ b/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/documents/embedded_objects_controller.rb
@@ -15,11 +15,13 @@ class ContentBlockManager::ContentBlock::Documents::EmbeddedObjectsController < 
       @group = params[:group]
       @subschemas = @schema.subschemas_for_group(@group)
       @back_link = content_block_manager.content_block_manager_content_block_document_path(@content_block_document)
+      @redirect_path = content_block_manager.new_embedded_objects_options_redirect_content_block_manager_content_block_document_embedded_objects_path(@content_block_document)
+      @context = @content_block_document.title
 
       if @subschemas.blank?
         render "admin/errors/not_found", status: :not_found
       else
-        render :select_subschema
+        render "content_block_manager/content_block/shared/embedded_objects/select_subschema"
       end
     end
   end

--- a/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/editions/embedded_objects_controller.rb
+++ b/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/editions/embedded_objects_controller.rb
@@ -35,10 +35,12 @@ class ContentBlockManager::ContentBlock::Editions::EmbeddedObjectsController < C
     @content_block_edition.add_object_to_details(@subschema.block_type, @object)
     @content_block_edition.save!
 
+    object_or_group = @subschema.group ? @subschema.group.humanize.singularize : @subschema.name.singularize
+
     flash[:notice] = I18n.t(
       "content_block_edition.create.embedded_objects.added_confirmation",
-      name_capitalized: @subschema.name.singularize,
-      name_downcase: @subschema.name.singularize.downcase,
+      object_name: @subschema.name.singularize,
+      object_or_group: object_or_group.downcase,
       schema_name: @schema.name.singularize.downcase,
     )
     redirect_to embedded_objects_path
@@ -63,10 +65,12 @@ class ContentBlockManager::ContentBlock::Editions::EmbeddedObjectsController < C
     @content_block_edition.save!
 
     if params[:redirect_url].present?
+      object_or_group = @subschema.group ? @subschema.group.humanize.singularize : @subschema.name.singularize
+
       flash[:notice] = I18n.t(
         "content_block_edition.create.embedded_objects.edited_confirmation",
-        name_capitalized: @subschema.name.singularize,
-        name_downcase: @subschema.name.singularize.downcase,
+        object_name: @subschema.name.singularize,
+        object_or_group: object_or_group.downcase,
         schema_name: @schema.name.singularize.downcase,
       )
       redirect_to params[:redirect_url], allow_other_host: false

--- a/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/editions/embedded_objects_controller.rb
+++ b/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/editions/embedded_objects_controller.rb
@@ -1,13 +1,36 @@
 class ContentBlockManager::ContentBlock::Editions::EmbeddedObjectsController < ContentBlockManager::BaseController
   include EmbeddedObjects
 
-  before_action :initialize_edition_and_schema
+  before_action :initialize_edition
 
   def new
-    @back_link = embedded_objects_path
+    @schema = get_schema(@content_block_edition.document.block_type)
+
+    if params[:object_type]
+      @subschema = get_subschema(@schema, params[:object_type])
+      @back_link = embedded_objects_path
+
+      render :new
+    else
+      @group = params[:group]
+      @subschemas = @schema.subschemas_for_group(@group)
+      @back_link = content_block_manager.content_block_manager_content_block_workflow_path(
+        @content_block_edition,
+        step: "#{Workflow::Step::GROUP_PREFIX}#{@group}",
+      )
+      @redirect_path = content_block_manager.new_embedded_objects_options_redirect_content_block_manager_content_block_edition_path(@content_block_edition)
+      @context = @content_block_edition.title
+
+      if @subschemas.blank?
+        render "admin/errors/not_found", status: :not_found
+      else
+        render "content_block_manager/content_block/shared/embedded_objects/select_subschema"
+      end
+    end
   end
 
   def create
+    @schema, @subschema = get_schema_and_subschema(@content_block_edition.document.block_type, params[:object_type])
     @object = object_params(@subschema).dig(:details, @subschema.block_type)
     @content_block_edition.add_object_to_details(@subschema.block_type, @object)
     @content_block_edition.save!
@@ -25,6 +48,7 @@ class ContentBlockManager::ContentBlock::Editions::EmbeddedObjectsController < C
   end
 
   def edit
+    @schema, @subschema = get_schema_and_subschema(@content_block_edition.document.block_type, params[:object_type])
     @redirect_url = params[:redirect_url]
     @object_title = params[:object_title]
     @object = @content_block_edition.details.dig(params[:object_type], params[:object_title])
@@ -33,6 +57,7 @@ class ContentBlockManager::ContentBlock::Editions::EmbeddedObjectsController < C
   end
 
   def update
+    @schema, @subschema = get_schema_and_subschema(@content_block_edition.document.block_type, params[:object_type])
     @object = object_params(@subschema).dig(:details, @subschema.block_type)
     @content_block_edition.update_object_with_details(params[:object_type], params[:object_title], @object)
     @content_block_edition.save!
@@ -59,10 +84,12 @@ class ContentBlockManager::ContentBlock::Editions::EmbeddedObjectsController < C
   end
 
   def review
+    @schema, @subschema = get_schema_and_subschema(@content_block_edition.document.block_type, params[:object_type])
     @object_title = params[:object_title]
   end
 
   def publish
+    @schema, @subschema = get_schema_and_subschema(@content_block_edition.document.block_type, params[:object_type])
     if params[:is_confirmed].blank?
       flash[:error] = I18n.t("content_block_edition.review_page.errors.confirm")
       redirect_path = content_block_manager.review_embedded_object_content_block_manager_content_block_edition_path(
@@ -81,11 +108,22 @@ class ContentBlockManager::ContentBlock::Editions::EmbeddedObjectsController < C
     redirect_to redirect_path
   end
 
+  def new_embedded_objects_options_redirect
+    if params[:object_type].present?
+      flash[:back_link] = content_block_manager.new_embedded_objects_options_redirect_content_block_manager_content_block_edition_path(
+        @content_block_edition,
+        group: params.require(:group),
+      )
+      redirect_to content_block_manager.new_embedded_object_content_block_manager_content_block_edition_path(@content_block_edition, object_type: params.require(:object_type))
+    else
+      redirect_to content_block_manager.new_embedded_object_content_block_manager_content_block_edition_path(@content_block_edition, group: params.require(:group)), flash: { error: I18n.t("activerecord.errors.models.content_block_manager/content_block/document.attributes.block_type.blank") }
+    end
+  end
+
 private
 
-  def initialize_edition_and_schema
+  def initialize_edition
     @content_block_edition = ContentBlockManager::ContentBlock::Edition.find(params[:id])
-    @schema, @subschema = get_schema_and_subschema(@content_block_edition.document.block_type, params[:object_type])
   end
 
   def embedded_objects_path

--- a/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/editions/embedded_objects_controller.rb
+++ b/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/editions/embedded_objects_controller.rb
@@ -89,7 +89,7 @@ private
   end
 
   def embedded_objects_path
-    step = "#{Workflow::Step::SUBSCHEMA_PREFIX}#{@subschema.id}"
+    step = @subschema.group ? "#{Workflow::Step::GROUP_PREFIX}#{@subschema.group}" : "#{Workflow::Step::SUBSCHEMA_PREFIX}#{@subschema.id}"
     content_block_manager.content_block_manager_content_block_workflow_path(@content_block_edition, step:)
   end
 end

--- a/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/editions/embedded_objects_controller.rb
+++ b/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/editions/embedded_objects_controller.rb
@@ -89,6 +89,7 @@ private
   end
 
   def embedded_objects_path
-    content_block_manager.content_block_manager_content_block_workflow_path(@content_block_edition, step: :embedded_objects)
+    step = "#{Workflow::Step::SUBSCHEMA_PREFIX}#{@subschema.id}"
+    content_block_manager.content_block_manager_content_block_workflow_path(@content_block_edition, step:)
   end
 end

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/embedded_objects/shared/_form.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/embedded_objects/shared/_form.html.erb
@@ -18,7 +18,7 @@
   } %>
   <%= render "govuk_publishing_components/components/button", {
     text: "Cancel",
-    href: @redirect_url.presence || content_block_manager.content_block_manager_content_block_workflow_path(id: @content_block_edition.id, step: "embedded_objects"),
+    href: @redirect_url.presence || content_block_manager.content_block_manager_content_block_workflow_path(id: @content_block_edition.id, step: "embedded_#{@subschema.block_type}"),
     secondary_solid: true,
   } %>
 </div>

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/embedded_objects.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/embedded_objects.html.erb
@@ -15,16 +15,14 @@
       ), method: :put, id: "embedded_objects" do %>
 
       <% if @content_block_edition.details[@subschema.block_type] %>
-        <% @content_block_edition.details[@subschema.block_type].keys.each do |k| %>
-          <div data-test-id="embedded_<%= k %>">
-            <%= render ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponent.new(
-              content_block_edition: @content_block_edition,
-              object_type: @subschema.block_type,
-              object_title: k,
-              redirect_url: request.fullpath,
-              ) %>
-          </div>
-          <% end %>
+        <%= render ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponent.with_collection(
+          @content_block_edition.details[@subschema.block_type].keys,
+          content_block_edition: @content_block_edition,
+          object_type: @subschema.block_type,
+          object_title: k,
+          redirect_url: request.fullpath,
+          test_id_prefix: "embedded",
+        ) %>
       <% else %>
         <% if I18n.exists?("content_block_edition.create.embedded_objects.#{@subschema.id}") %>
           <%= render "govuk_publishing_components/components/hint", {

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/embedded_objects.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/embedded_objects.html.erb
@@ -1,5 +1,5 @@
 <% content_for :context, context %>
-<% content_for :title, @title %>
+<% content_for :title, "#{@action} #{@subschema.name.humanize(capitalize: false)}" %>
 <% content_for :title_margin_bottom, 4 %>
 <% content_for :back_link do %>
   <%= render "govuk_publishing_components/components/back_link", {
@@ -7,25 +7,48 @@
   } %>
 <% end %>
 
-<% if flash[:error] %>
-  <%= render ContentBlockManager::ContentBlockEdition::New::ErrorSummaryComponent.new(
-    error_message: flash[:error],
-    ) %>
-<% end %>
-<%= form_with url: content_block_manager.content_block_manager_content_block_workflow_path(
-  @content_block_edition,
-  step: "embedded_objects",
-  ), method: :put, id: "embedded_objects" do %>
-  <% @subschemas.each do |subschema| %>
-    <%= render ContentBlockManager::Shared::EmbeddedObjectsComponent.new(
-      content_block_edition: @content_block_edition,
-      subschema:,
-      redirect_url: request.fullpath,
-    ) %>
-  <% end %>
-<% end %>
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= form_with url: content_block_manager.content_block_manager_content_block_workflow_path(
+      @content_block_edition,
+      step: @step_name,
+      ), method: :put, id: "embedded_objects" do %>
 
-<%= render ContentBlockManager::Shared::ContinueOrCancelButtonGroup.new(
-    form_id: "embedded_objects",
-    content_block_edition: @content_block_edition,
-    ) %>
+      <% if @content_block_edition.details[@subschema.block_type] %>
+        <% @content_block_edition.details[@subschema.block_type].keys.each do |k| %>
+          <div data-test-id="embedded_<%= k %>">
+            <%= render ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponent.new(
+              content_block_edition: @content_block_edition,
+              object_type: @subschema.block_type,
+              object_title: k,
+              redirect_url: request.fullpath,
+              ) %>
+          </div>
+          <% end %>
+      <% else %>
+        <% if I18n.exists?("content_block_edition.create.embedded_objects.#{@subschema.id}") %>
+          <%= render "govuk_publishing_components/components/hint", {
+            text: t("content_block_edition.create.embedded_objects.#{@subschema.id}", block_type: @subschema.name.humanize(capitalize: false)),
+          } %>
+        <% end %>
+      <% end %>
+
+      <% if @content_block_edition.document.is_new_block? %>
+        <%= render "govuk_publishing_components/components/button", {
+          text: @add_button_text,
+          href: content_block_manager.new_embedded_object_content_block_manager_content_block_edition_path(
+            @content_block_edition,
+            object_type: @subschema.block_type,
+          ),
+          secondary_solid: true,
+          margin_bottom: 6,
+        } %>
+      <% end %>
+    <% end %>
+
+    <%= render ContentBlockManager::Shared::ContinueOrCancelButtonGroup.new(
+      form_id: "embedded_objects",
+      content_block_edition: @content_block_edition,
+      ) %>
+  </div>
+</div>

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/embedded_objects.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/embedded_objects.html.erb
@@ -19,7 +19,6 @@
           @content_block_edition.details[@subschema.block_type].keys,
           content_block_edition: @content_block_edition,
           object_type: @subschema.block_type,
-          object_title: k,
           redirect_url: request.fullpath,
           test_id_prefix: "embedded",
         ) %>

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/group_objects.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/group_objects.html.erb
@@ -25,6 +25,16 @@
       ) %>
     <% end %>
 
+    <%= render("govuk_publishing_components/components/button", {
+      text: "Add another #{@group_name.singularize.downcase}",
+      href: content_block_manager.new_embedded_object_content_block_manager_content_block_edition_path(
+        @content_block_edition,
+        group: @group_name,
+      ),
+      margin_bottom: 6,
+      secondary_solid: true,
+    }) %>
+
     <%= render ContentBlockManager::Shared::ContinueOrCancelButtonGroup.new(
       form_id: @step_name,
       content_block_edition: @content_block_edition,

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/group_objects.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/group_objects.html.erb
@@ -1,0 +1,36 @@
+<% content_for :context, context %>
+<% content_for :title, "#{@action} #{@group_name.humanize(capitalize: false)}" %>
+<% content_for :title_margin_bottom, 4 %>
+<% content_for :back_link do %>
+  <%= render "govuk_publishing_components/components/back_link", {
+    href: back_path,
+  } %>
+<% end %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <% if flash[:error] %>
+      <%= render ContentBlockManager::ContentBlockEdition::New::ErrorSummaryComponent.new(
+        error_message: flash[:error],
+        ) %>
+    <% end %>
+
+    <%= form_with url: content_block_manager.content_block_manager_content_block_workflow_path(
+      @content_block_edition,
+      step: @step_name,
+      ), method: :put, id: @step_name do %>
+      <% @subschemas.each do |subschema| %>
+        <%= render ContentBlockManager::Shared::EmbeddedObjectsComponent.new(
+          content_block_edition: @content_block_edition,
+          subschema:,
+          redirect_url: request.fullpath,
+          ) %>
+      <% end %>
+    <% end %>
+
+    <%= render ContentBlockManager::Shared::ContinueOrCancelButtonGroup.new(
+      form_id: @step_name,
+      content_block_edition: @content_block_edition,
+      ) %>
+  </div>
+</div>

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/group_objects.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/group_objects.html.erb
@@ -19,13 +19,10 @@
       @content_block_edition,
       step: @step_name,
       ), method: :put, id: @step_name do %>
-      <% @subschemas.each do |subschema| %>
-        <%= render ContentBlockManager::Shared::EmbeddedObjectsComponent.new(
-          content_block_edition: @content_block_edition,
-          subschema:,
-          redirect_url: request.fullpath,
-          ) %>
-      <% end %>
+      <%= render ContentBlockManager::ContentBlockEdition::Workflow::GroupComponent.new(
+        content_block_edition: @content_block_edition,
+        subschemas: @subschemas,
+      ) %>
     <% end %>
 
     <%= render ContentBlockManager::Shared::ContinueOrCancelButtonGroup.new(

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/review.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/review.html.erb
@@ -29,7 +29,7 @@
             content_block_edition: @content_block_edition,
             object_type: subschema.id,
             object_title: k,
-            redirect_url: content_block_manager.content_block_manager_content_block_workflow_path(@content_block_edition, step: :embedded_objects),
+            redirect_url: content_block_manager.content_block_manager_content_block_workflow_path(@content_block_edition, step: "#{Workflow::Step::SUBSCHEMA_PREFIX}#{subschema.id}"),
             ) %>
         </div>
       <% end %>

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/review.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/editions/workflow/review.html.erb
@@ -23,15 +23,14 @@
           ) %>
 
     <% @schema.subschemas.each do |subschema| %>
-      <% @content_block_edition.details[subschema.id]&.keys&.each do |k| %>
-        <div data-test-id="review_embedded_<%= k %>">
-          <%= render ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponent.new(
-            content_block_edition: @content_block_edition,
-            object_type: subschema.id,
-            object_title: k,
-            redirect_url: content_block_manager.content_block_manager_content_block_workflow_path(@content_block_edition, step: "#{Workflow::Step::SUBSCHEMA_PREFIX}#{subschema.id}"),
-            ) %>
-        </div>
+      <% if @content_block_edition.details[subschema.id] %>
+        <%= render ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponent.with_collection(
+          @content_block_edition.details[subschema.id].keys,
+          content_block_edition: @content_block_edition,
+          object_type: subschema.id,
+          redirect_url: content_block_manager.content_block_manager_content_block_workflow_path(@content_block_edition, step: "#{Workflow::Step::SUBSCHEMA_PREFIX}#{subschema.id}"),
+          test_id_prefix: "review_embedded",
+        ) %>
       <% end %>
     <% end %>
 

--- a/lib/engines/content_block_manager/app/views/content_block_manager/content_block/shared/embedded_objects/select_subschema.html.erb
+++ b/lib/engines/content_block_manager/app/views/content_block_manager/content_block/shared/embedded_objects/select_subschema.html.erb
@@ -1,5 +1,5 @@
-<% content_for :context, @content_block_document.title %>
-<% content_for :title, "Add a #{@group.singularize}" %>
+<% content_for :context, @context %>
+<% content_for :title, "Add #{add_indefinite_article @group.singularize}" %>
 
 <% content_for :back_link do %>
   <%= render "govuk_publishing_components/components/back_link", {
@@ -13,7 +13,7 @@
     ) %>
 <% end %>
 
-<%= form_with url: content_block_manager.new_embedded_objects_options_redirect_content_block_manager_content_block_document_embedded_objects_path(@content_block_document), method: :post do %>
+<%= form_with url: @redirect_path, method: :post do %>
   <%= hidden_field_tag :object_type, "" %>
   <%= hidden_field_tag :group, @group %>
 
@@ -35,7 +35,7 @@
       text: "Cancel",
       name: "cancel",
       value: "cancel",
-      href: content_block_manager.content_block_manager_content_block_documents_path,
+      href: @back_link,
       secondary_solid: true,
     } %>
   </div>

--- a/lib/engines/content_block_manager/config/locales/en.yml
+++ b/lib/engines/content_block_manager/config/locales/en.yml
@@ -40,8 +40,8 @@ en:
       title: "Create %{block_type}"
       embedded_objects:
         rates: "Enter %{block_type} details. You can do this now or later."
-        added_confirmation: "%{name_capitalized} added. You can add another %{name_downcase} or finish creating the %{schema_name} block."
-        edited_confirmation: "%{name_capitalized} edited. You can add another %{name_downcase} or finish creating the %{schema_name} block."
+        added_confirmation: "%{object_name} added. You can add another %{object_or_group} or finish creating the %{schema_name} block."
+        edited_confirmation: "%{object_name} edited. You can add another %{object_or_group} or finish creating the %{schema_name} block."
     confirmation_page:
       scheduled:
         banner: "%{block_type} scheduled to publish on %{date}"

--- a/lib/engines/content_block_manager/config/locales/en.yml
+++ b/lib/engines/content_block_manager/config/locales/en.yml
@@ -40,8 +40,8 @@ en:
       title: "Create %{block_type}"
       embedded_objects:
         rates: "Enter %{block_type} details. You can do this now or later."
-        added_confirmation: "%{name_capitalized} added. You can add more items or finish creating the %{schema_name} block."
-        edited_confirmation: "%{name_capitalized} edited. You can edit more items or finish creating the %{schema_name} block."
+        added_confirmation: "%{name_capitalized} added. You can add another %{name_downcase} or finish creating the %{schema_name} block."
+        edited_confirmation: "%{name_capitalized} edited. You can add another %{name_downcase} or finish creating the %{schema_name} block."
     confirmation_page:
       scheduled:
         banner: "%{block_type} scheduled to publish on %{date}"

--- a/lib/engines/content_block_manager/config/routes.rb
+++ b/lib/engines/content_block_manager/config/routes.rb
@@ -27,7 +27,8 @@ ContentBlockManager::Engine.routes.draw do
               get :cancel, to: "editions/workflow#cancel"
             end
           end
-          get "embedded-objects/:object_type/new", to: "editions/embedded_objects#new", as: :new_embedded_object
+          get "embedded-objects/(:object_type)/new", to: "editions/embedded_objects#new", as: :new_embedded_object
+          post "embedded-objects", to: "editions/embedded_objects#new_embedded_objects_options_redirect", as: :new_embedded_objects_options_redirect
           post "embedded-objects/:object_type", to: "editions/embedded_objects#create", as: :create_embedded_object
           get "embedded-objects/:object_type/:object_title/edit", to: "editions/embedded_objects#edit", as: :edit_embedded_object
           put "embedded-objects/:object_type/:object_title", to: "editions/embedded_objects#update", as: :embedded_object

--- a/lib/engines/content_block_manager/features/create_contact_object.feature
+++ b/lib/engines/content_block_manager/features/create_contact_object.feature
@@ -81,6 +81,7 @@ Feature: Create a contact object
 
   Scenario: GDS editor creates a Contact without any embedded objects
     When I save and continue
+    And I save and continue
     Then I am asked to review my answers for a "contact"
     And I review and confirm my answers are correct
     Then the edition should have been created successfully
@@ -92,6 +93,7 @@ Feature: Create a contact object
     And I complete the "email_address" form with the following fields:
       | title     | email_address          |
       | New email | foo@example.com        |
+    And I save and continue
     When I click to add a new "telephone"
     And I fill in the "telephone" form with the following fields:
       | title            |
@@ -111,8 +113,9 @@ Feature: Create a contact object
 
   @javascript
   Scenario: GDS editor sees errors for invalid telephone objects
-    When I click to add a new "telephone"
-    And I save and continue
+    When I save and continue
+    And I click to add a new "telephone"
+    When I save and continue
     Then I should see errors for the required nested "telephone_number" fields
 
   Scenario: GDS editor edits answers during creation of an object
@@ -121,10 +124,12 @@ Feature: Create a contact object
       | title     | email_address          |
       | New email | foo@example.com        |
     And I save and continue
+    And I save and continue
     When I click the first edit link
     And I complete the form with the following fields:
       | title            |
       | New email 2 |
+    And I save and continue
     And I save and continue
     Then I am asked to review my answers
     And I confirm my answers are correct

--- a/lib/engines/content_block_manager/features/create_contact_object.feature
+++ b/lib/engines/content_block_manager/features/create_contact_object.feature
@@ -72,6 +72,8 @@ Feature: Create a contact object
       }
     }
     """
+    And the schema "contact" has a group "modes" with the following subschemas:
+      | email_addresses | telephones |
     And I visit the Content Block Manager home page
     And I click to create an object
     And I click on the "contact" schema
@@ -79,22 +81,14 @@ Feature: Create a contact object
       | title            | description   | organisation        | instructions_to_publishers |
       | my basic contact | this is basic | Ministry of Example | this is important  |
 
-  Scenario: GDS editor creates a Contact without any embedded objects
-    When I save and continue
-    And I save and continue
-    Then I am asked to review my answers for a "contact"
-    And I review and confirm my answers are correct
-    Then the edition should have been created successfully
-    And I should be taken to the confirmation page for a new "contact"
-
   @javascript
   Scenario: GDS editor creates a Contact with an email address and a telephone
-    When I click to add a new "email_address"
+    And I click on the "email_addresses" subschema
     And I complete the "email_address" form with the following fields:
       | title     | email_address          |
       | New email | foo@example.com        |
-    And I save and continue
-    When I click to add a new "telephone"
+    And I click to add another "mode"
+    And I click on the "telephones" subschema
     And I fill in the "telephone" form with the following fields:
       | title            |
       | New phone number |
@@ -103,7 +97,7 @@ Feature: Create a contact object
       | Telephone 1 | 12345            | Telephone |
       | Telephone 2 | 6789             | Textphone |
     And I save and continue
-    Then I should be on the "embedded_objects" step
+    Then I should be on the "add_group_modes" step
     When I save and continue
     And I review and confirm my answers are correct
     Then I should be taken to the confirmation page for a new "contact"
@@ -114,22 +108,20 @@ Feature: Create a contact object
   @javascript
   Scenario: GDS editor sees errors for invalid telephone objects
     When I save and continue
-    And I click to add a new "telephone"
+    And I click on the "telephones" subschema
     When I save and continue
     Then I should see errors for the required nested "telephone_number" fields
 
   Scenario: GDS editor edits answers during creation of an object
-    When I click to add a new "email_address"
+    And I click on the "email_addresses" subschema
     And I complete the "email_address" form with the following fields:
       | title     | email_address          |
       | New email | foo@example.com        |
-    And I save and continue
     And I save and continue
     When I click the first edit link
     And I complete the form with the following fields:
       | title            |
       | New email 2 |
-    And I save and continue
     And I save and continue
     Then I am asked to review my answers
     And I confirm my answers are correct

--- a/lib/engines/content_block_manager/features/create_pension_object.feature
+++ b/lib/engines/content_block_manager/features/create_pension_object.feature
@@ -51,7 +51,7 @@ Feature: Create a content object
     When I complete the form with the following fields:
       | title            | description   | organisation        | instructions_to_publishers |
       | my basic pension | this is basic | Ministry of Example | this is important  |
-    Then I should be on the "embedded_objects" step
+    Then I should be on the "add_embedded_rates" step
     When I save and continue
     Then I am asked to review my answers for a "pension"
     And I review and confirm my answers are correct
@@ -68,11 +68,11 @@ Feature: Create a content object
       | title            | description   | organisation        | instructions_to_publishers |
       | my basic pension | this is basic | Ministry of Example | this is important  |
     When I click to add a new "rate"
-    Then I should see a back link to the "embedded_objects" step
+    Then I should see a back link to the "embedded_rates" step
     And I complete the "rate" form with the following fields:
       | title    | amount  | frequency |
       | New rate | £127.91 | a month  |
-    Then I should be on the "embedded_objects" step
+    Then I should be on the "add_embedded_rates" step
     When I save and continue
     And I review and confirm my answers are correct
     Then I should be taken to the confirmation page for a new "pension"
@@ -88,7 +88,7 @@ Feature: Create a content object
       | my basic pension | this is basic | Ministry of Example | this is important  |
     When I click to add a new "rate"
     And I click the cancel link
-    Then I should be on the "embedded_objects" step
+    Then I should be on the "add_embedded_rates" step
 
   Scenario: GDS editor creates a Pension and sees validation errors for new rate
     When I visit the Content Block Manager home page
@@ -100,7 +100,7 @@ Feature: Create a content object
     When I click to add a new "rate"
     And I click save
     Then I should see errors for the required "rate" fields
-    And I should see a back link to the "embedded_objects" step
+    And I should see a back link to the "embedded_rates" step
 
   Scenario: GDS editor clicks back and is taken back to rates
     When I visit the Content Block Manager home page
@@ -111,5 +111,5 @@ Feature: Create a content object
       | my basic pension | this is basic | Ministry of Example | this is important  |
     And I click the back link
     And I click save
-    Then I should be on the "embedded_objects" step
+    Then I should be on the "add_embedded_rates" step
 

--- a/lib/engines/content_block_manager/features/edit_pension_object.feature
+++ b/lib/engines/content_block_manager/features/edit_pension_object.feature
@@ -65,7 +65,7 @@ Feature: Edit a pension object
     And I should see the updated rates for that block
     When I save and continue
     Then I should be on the "review_links" step
-    And I should see a back link to the "embedded_objects" step
+    And I should see a back link to the "embedded_rates" step
     When I continue after reviewing the links
     Then I should be on the "internal_note" step
     And I should see a back link to the "review_links" step

--- a/lib/engines/content_block_manager/features/step_definitions/embedded_object_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/embedded_object_steps.rb
@@ -95,6 +95,11 @@ And("I click to add a new {string}") do |object_type|
   click_on "Add #{add_indefinite_article object_type.humanize.downcase}"
 end
 
+And("I click to add another {string}") do |object_type|
+  @object_type = object_type
+  click_on "Add another #{object_type.humanize.downcase}"
+end
+
 And("I review and confirm my {string} is correct") do |_object_type|
   check "is_confirmed"
   click_on "Create"

--- a/lib/engines/content_block_manager/features/step_definitions/form_step_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/form_step_steps.rb
@@ -12,9 +12,9 @@ Then(/^I should be on the "([^"]*)" step$/) do |step|
     should_be_on_review_step(object_type: @content_block.document.block_type)
   when "change_note"
     should_be_on_change_note_step
-  when "add_embedded_objects"
-    assert_text "Add to #{@schema.name}"
-  when "edit_embedded_objects"
-    assert_text "Change #{@schema.name}"
+  when /add_#{Workflow::Step::SUBSCHEMA_PREFIX}(.*)/
+    should_be_on_subschema_step(::Regexp.last_match(1), "Add")
+  when /edit_#{Workflow::Step::SUBSCHEMA_PREFIX}(.*)/
+    should_be_on_subschema_step(::Regexp.last_match(1), "Edit")
   end
 end

--- a/lib/engines/content_block_manager/features/step_definitions/form_step_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/form_step_steps.rb
@@ -16,5 +16,7 @@ Then(/^I should be on the "([^"]*)" step$/) do |step|
     should_be_on_subschema_step(::Regexp.last_match(1), "Add")
   when /edit_#{Workflow::Step::SUBSCHEMA_PREFIX}(.*)/
     should_be_on_subschema_step(::Regexp.last_match(1), "Edit")
+  when /add_#{Workflow::Step::GROUP_PREFIX}(.*)/
+    assert_text "Add #{::Regexp.last_match(1).humanize(capitalize: false)}"
   end
 end

--- a/lib/engines/content_block_manager/features/step_definitions/schema_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/schema_steps.rb
@@ -9,6 +9,7 @@ When("I click on the {string} subschema") do |schema_id|
   schema = @schemas.values.last
   subschema = schema.subschema(schema_id)
   choose subschema.name.singularize
+  @object_type = schema_id
   click_save_and_continue
 end
 

--- a/lib/engines/content_block_manager/features/support/form_step_helpers.rb
+++ b/lib/engines/content_block_manager/features/support/form_step_helpers.rb
@@ -56,3 +56,7 @@ def fill_in_embedded_object_form(object_type, table)
     end
   end
 end
+
+def should_be_on_subschema_step(subschema, prefix)
+  assert_text "#{prefix} #{subschema.humanize(capitalize: false)}"
+end

--- a/lib/engines/content_block_manager/test/components/content_block/edition/workflow/group_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/workflow/group_component_test.rb
@@ -1,0 +1,85 @@
+require "test_helper"
+
+class ContentBlockManager::ContentBlockEdition::Workflow::GroupComponentTest < ViewComponent::TestCase
+  extend Minitest::Spec::DSL
+
+  let(:details) do
+    {
+      "embedded-type-1" => {
+        "embedded-type-1-item-1" => {},
+        "embedded-type-1-item-2" => {},
+      },
+      "embedded-type-2" => {
+        "embedded-type-2-item-1" => {},
+        "embedded-type-2-item-2" => {},
+        "embedded-type-2-item-3" => {},
+      },
+      "embedded-type-3" => {},
+    }
+  end
+  let(:content_block_edition) { build(:content_block_edition, :pension, details:) }
+
+  let(:subschema_1) { stub("subschema_1", id: "embedded-type-1", block_type: "embedded-type-1", name: "embedded type 1", group_order: 1) }
+  let(:subschema_2) { stub("subschema_2", id: "embedded-type-1", block_type: "embedded-type-2", name: "embedded type 2", group_order: 0) }
+  let(:subschema_3) { stub("subschema_3", id: "embedded-type-3", block_type: "embedded-type-3", name: "embedded type 3", group_order: 2) }
+
+  let(:subschemas) do
+    [
+      subschema_1,
+      subschema_2,
+      subschema_3,
+    ]
+  end
+
+  let(:component) do
+    ContentBlockManager::ContentBlockEdition::Workflow::GroupComponent.new(
+      content_block_edition:,
+      subschemas:,
+    )
+  end
+
+  let(:request) { stub(:request, fullpath: "/foo/bar") }
+
+  before do
+    component.stubs(:request).returns(request)
+  end
+
+  it "should render a tab for each subschema that has content" do
+    summary_card_stub_1 = stub("SummaryCard")
+    summary_card_stub_2 = stub("SummaryCard")
+
+    ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponent.expects(:with_collection).with(
+      %w[embedded-type-1-item-1 embedded-type-1-item-2],
+      content_block_edition: content_block_edition,
+      object_type: subschema_1.block_type,
+      redirect_url: request.fullpath,
+    ).returns(summary_card_stub_1)
+
+    ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponent.expects(:with_collection).with(
+      %w[embedded-type-2-item-1 embedded-type-2-item-2 embedded-type-2-item-3],
+      content_block_edition: content_block_edition,
+      object_type: subschema_2.block_type,
+      redirect_url: request.fullpath,
+    ).returns(summary_card_stub_2)
+
+    component.expects(:render).with(summary_card_stub_1).returns("summary_card_1_body")
+    component.expects(:render).with(summary_card_stub_2).returns("summary_card_2_body")
+
+    component.expects(:render).with("govuk_publishing_components/components/tabs", {
+      tabs: [
+        {
+          id: subschema_2.id,
+          label: "#{subschema_2.name.titleize} (3)",
+          content: "summary_card_2_body",
+        },
+        {
+          id: subschema_1.id,
+          label: "#{subschema_1.name.titleize} (2)",
+          content: "summary_card_1_body",
+        },
+      ],
+    })
+
+    render_inline component
+  end
+end

--- a/lib/engines/content_block_manager/test/components/shared/embedded_objects/summary_card_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/shared/embedded_objects/summary_card_component_test.rb
@@ -59,6 +59,32 @@ class ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponentTest < V
     end
   end
 
+  it "adds a data attribute if test_id_prefix is set" do
+    component = ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponent.new(
+      content_block_edition:,
+      object_type: "embedded-objects",
+      object_title: "my-embedded-object",
+      test_id_prefix: "prefix",
+    )
+
+    render_inline component
+
+    assert_selector ".govuk-summary-card[data-test-id='prefix_my-embedded-object']"
+  end
+
+  it "renders a summary list with a collection" do
+    component = ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponent.with_collection(
+      %w[my-embedded-object],
+      content_block_edition:,
+      object_type: "embedded-objects",
+    )
+
+    render_inline component
+
+    assert_selector ".govuk-summary-card__title", text: "Embedded Object details"
+    assert_selector ".govuk-summary-list__row", count: 3
+  end
+
   it "renders a summary list with edit link" do
     component = ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponent.new(
       content_block_edition:,

--- a/lib/engines/content_block_manager/test/components/shared/embedded_objects_test.rb
+++ b/lib/engines/content_block_manager/test/components/shared/embedded_objects_test.rb
@@ -46,25 +46,17 @@ class ContentBlockManager::Shared::EmbeddedObjectsTest < ViewComponent::TestCase
   end
 
   it "renders all embedded objects of a particular type" do
-    object1_double = stub("summary_card_1")
-    object2_double = stub("summary_card_2")
+    summary_card_double = stub("summary_card")
 
-    default_args = {
+    ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponent.expects(:with_collection).with(
+      %w[my-embedded-object another-embedded-object],
       content_block_edition: content_block_edition,
       object_type: subschema.block_type,
       redirect_url:,
-    }
+      test_id_prefix: "embedded",
+    ).returns(summary_card_double)
 
-    ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponent.expects(:new).with(
-      **default_args.merge(object_title: "my-embedded-object"),
-    ).returns(object1_double)
-
-    ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponent.expects(:new).with(
-      **default_args.merge(object_title: "another-embedded-object"),
-    ).returns(object2_double)
-
-    component.expects(:render).with(object1_double)
-    component.expects(:render).with(object2_double)
+    component.expects(:render).with(summary_card_double)
 
     render_inline(component)
   end

--- a/lib/engines/content_block_manager/test/integration/content_block/documents/embedded_objects_test.rb
+++ b/lib/engines/content_block_manager/test/integration/content_block/documents/embedded_objects_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 require "capybara/rails"
 
-class ContentBlockManager::ContentBlock::Editions::EmbeddedObjectsTest < ActionDispatch::IntegrationTest
+class ContentBlockManager::ContentBlock::Documents::EmbeddedObjectsTest < ActionDispatch::IntegrationTest
   include Capybara::DSL
   extend Minitest::Spec::DSL
   include ContentBlockManager::Engine.routes.url_helpers

--- a/lib/engines/content_block_manager/test/integration/content_block/editions/embedded_objects_test.rb
+++ b/lib/engines/content_block_manager/test/integration/content_block/editions/embedded_objects_test.rb
@@ -42,7 +42,7 @@ class ContentBlockManager::ContentBlock::Editions::EmbeddedObjectsTest < ActionD
       }
 
       assert_redirected_to content_block_manager.content_block_manager_content_block_workflow_path(
-        edition, step: :embedded_objects
+        edition, step: "#{Workflow::Step::SUBSCHEMA_PREFIX}#{object_type}"
       )
 
       updated_edition = edition.reload
@@ -57,7 +57,7 @@ class ContentBlockManager::ContentBlock::Editions::EmbeddedObjectsTest < ActionD
           },
         },
       }
-      assert_equal "Something added. You can add more items or finish creating the schema block.", flash[:notice]
+      assert_equal "Something added. You can add another something or finish creating the schema block.", flash[:notice]
     end
   end
 
@@ -158,7 +158,7 @@ class ContentBlockManager::ContentBlock::Editions::EmbeddedObjectsTest < ActionD
       }
 
       assert_redirected_to content_block_manager.content_block_manager_content_block_documents_path
-      assert_equal "Something edited. You can edit more items or finish creating the schema block.", flash[:notice]
+      assert_equal "Something edited. You can add another something or finish creating the schema block.", flash[:notice]
     end
 
     it "should not rename the object if a new title is given" do

--- a/lib/engines/content_block_manager/test/integration/content_block/editions/embedded_objects_test.rb
+++ b/lib/engines/content_block_manager/test/integration/content_block/editions/embedded_objects_test.rb
@@ -180,6 +180,7 @@ class ContentBlockManager::ContentBlock::Editions::EmbeddedObjectsTest < ActionD
         assert_redirected_to content_block_manager.content_block_manager_content_block_workflow_path(
           edition, step: "#{Workflow::Step::GROUP_PREFIX}#{group}"
         )
+        assert_equal "Something added. You can add another some group or finish creating the schema block.", flash[:notice]
       end
     end
   end
@@ -282,6 +283,31 @@ class ContentBlockManager::ContentBlock::Editions::EmbeddedObjectsTest < ActionD
 
       assert_redirected_to content_block_manager.content_block_manager_content_block_documents_path
       assert_equal "Something edited. You can add another something or finish creating the schema block.", flash[:notice]
+    end
+
+    describe "when the subschema belongs to a group" do
+      let(:group) { "some_group" }
+
+      it "should redirect if a redirect_url is given" do
+        put content_block_manager.embedded_object_content_block_manager_content_block_edition_path(
+          edition,
+          object_type:,
+          object_title: "embedded",
+        ), params: {
+          redirect_url: content_block_manager.content_block_manager_content_block_documents_path,
+          "content_block/edition" => {
+            details: {
+              object_type => {
+                "title" => "Embedded",
+                "is" => "different",
+              },
+            },
+          },
+        }
+
+        assert_redirected_to content_block_manager.content_block_manager_content_block_documents_path
+        assert_equal "Something edited. You can add another some group or finish creating the schema block.", flash[:notice]
+      end
     end
 
     it "should not rename the object if a new title is given" do

--- a/lib/engines/content_block_manager/test/integration/content_block/editions/embedded_objects_test.rb
+++ b/lib/engines/content_block_manager/test/integration/content_block/editions/embedded_objects_test.rb
@@ -14,9 +14,10 @@ class ContentBlockManager::ContentBlock::Editions::EmbeddedObjectsTest < ActionD
   end
 
   let(:edition) { create(:content_block_edition, :pension, details: { "something" => { "embedded" => { "title" => "Embedded", "is" => "here" } } }) }
+  let(:group) { nil }
 
   let(:stub_schema) { stub("schema", body: [], name: "Schema") }
-  let(:stub_subschema) { stub("subschema", name: "Something", block_type: object_type, fields: [], permitted_params: %w[title is], id: "something") }
+  let(:stub_subschema) { stub("subschema", name: "Something", block_type: object_type, fields: [], permitted_params: %w[title is], id: "something", group:) }
 
   let(:object_type) { "something" }
 
@@ -58,6 +59,30 @@ class ContentBlockManager::ContentBlock::Editions::EmbeddedObjectsTest < ActionD
         },
       }
       assert_equal "Something added. You can add another something or finish creating the schema block.", flash[:notice]
+    end
+
+    describe "when the subschema belongs to a group" do
+      let(:group) { "some_group" }
+
+      it "should redirect to the group step" do
+        post content_block_manager.create_embedded_object_content_block_manager_content_block_edition_path(
+          edition,
+          object_type:,
+        ), params: {
+          "content_block/edition" => {
+            details: {
+              object_type => {
+                "title" => "New Thing",
+                "is" => "something",
+              },
+            },
+          },
+        }
+
+        assert_redirected_to content_block_manager.content_block_manager_content_block_workflow_path(
+          edition, step: "#{Workflow::Step::GROUP_PREFIX}#{group}"
+        )
+      end
     end
   end
 

--- a/lib/engines/content_block_manager/test/integration/content_block/editions_test.rb
+++ b/lib/engines/content_block_manager/test/integration/content_block/editions_test.rb
@@ -137,7 +137,7 @@ class ContentBlockManager::ContentBlock::EditionsTest < ActionDispatch::Integrat
         end
 
         it "redirects to the first subschema step when successful" do
-          redirects_to_step(:embedded_objects) do
+          redirects_to_step(:embedded_my_subschema_name) do
             post content_block_manager.content_block_manager_content_block_document_editions_path(content_block_document), params: {
               "content_block/edition": {
                 document_attributes: {
@@ -215,8 +215,8 @@ class ContentBlockManager::ContentBlock::EditionsTest < ActionDispatch::Integrat
         let(:subschemas) { [stub("subschema", id: "my_subschema_name")] }
         let!(:schema) { stub_request_for_schema("pension", subschemas:) }
 
-        it "redirects to the first embedded objects step when successful" do
-          redirects_to_step(:embedded_objects) do
+        it "redirects to the first subschema step when successful" do
+          redirects_to_step(:embedded_my_subschema_name) do
             post content_block_manager.content_block_manager_content_block_editions_path, params: {
               something: "else",
               "content_block/edition": {

--- a/lib/engines/content_block_manager/test/integration/content_block/editions_test.rb
+++ b/lib/engines/content_block_manager/test/integration/content_block/editions_test.rb
@@ -129,7 +129,8 @@ class ContentBlockManager::ContentBlock::EditionsTest < ActionDispatch::Integrat
       end
 
       describe "when subschemas are present" do
-        let(:subschemas) { [stub("subschema", id: "my_subschema_name")] }
+        let(:group) { nil }
+        let(:subschemas) { [stub("subschema", id: "my_subschema_name", group:)] }
         let!(:schema) { stub_request_for_schema("pension", subschemas:) }
 
         before do
@@ -145,6 +146,22 @@ class ContentBlockManager::ContentBlock::EditionsTest < ActionDispatch::Integrat
                 },
               },
             }
+          end
+        end
+
+        describe "when a subschema has a group" do
+          let(:group) { "group" }
+
+          it "redirects to the group step when successful" do
+            redirects_to_step(:group_group) do
+              post content_block_manager.content_block_manager_content_block_document_editions_path(content_block_document), params: {
+                "content_block/edition": {
+                  document_attributes: {
+                    block_type: "pension",
+                  },
+                },
+              }
+            end
           end
         end
       end
@@ -212,7 +229,8 @@ class ContentBlockManager::ContentBlock::EditionsTest < ActionDispatch::Integrat
       end
 
       describe "when subschemas are present" do
-        let(:subschemas) { [stub("subschema", id: "my_subschema_name")] }
+        let(:group) { nil }
+        let(:subschemas) { [stub("subschema", id: "my_subschema_name", group:)] }
         let!(:schema) { stub_request_for_schema("pension", subschemas:) }
 
         it "redirects to the first subschema step when successful" do
@@ -225,6 +243,23 @@ class ContentBlockManager::ContentBlock::EditionsTest < ActionDispatch::Integrat
                 organisation_id: organisation.id,
               },
             }
+          end
+        end
+
+        describe "when a subschema has a group" do
+          let(:group) { "group" }
+
+          it "redirects to the group step when successful" do
+            redirects_to_step(:group_group) do
+              post content_block_manager.content_block_manager_content_block_editions_path, params: {
+                something: "else",
+                "content_block/edition": {
+                  document_attributes:,
+                  details:,
+                  organisation_id: organisation.id,
+                },
+              }
+            end
           end
         end
       end

--- a/lib/engines/content_block_manager/test/integration/content_block/workflow_test.rb
+++ b/lib/engines/content_block_manager/test/integration/content_block/workflow_test.rb
@@ -407,8 +407,8 @@ class ContentBlockManager::ContentBlock::WorkflowTest < ActionDispatch::Integrat
         let(:group) { nil }
         let(:subschemas) do
           [
-            stub("subschema", id: "subschema_1", name: "subschema_1", block_type: "subschema_1", group:),
-            stub("subschema", id: "subschema_2", name: "subschema_2", block_type: "subschema_2", group:),
+            stub("subschema", id: "subschema_1", name: "subschema_1", block_type: "subschema_1", group:, group_order: 0, fields: []),
+            stub("subschema", id: "subschema_2", name: "subschema_2", block_type: "subschema_2", group:, group_order: 1, fields: []),
           ]
         end
 
@@ -454,10 +454,30 @@ class ContentBlockManager::ContentBlock::WorkflowTest < ActionDispatch::Integrat
           end
 
           describe "#show" do
-            it "shows the form for the group" do
-              get content_block_manager.content_block_manager_content_block_workflow_path(id: edition.id, step: "group_some_group")
+            describe "when content exists for at least some of the subschemas" do
+              let(:details) do
+                {
+                  subschemas[0].block_type.to_s => {
+                    "item" => {
+                      "key" => "value",
+                    },
+                  },
+                }
+              end
 
-              assert_template "content_block_manager/content_block/editions/workflow/group_objects"
+              it "shows the form for the group" do
+                get content_block_manager.content_block_manager_content_block_workflow_path(id: edition.id, step: "group_some_group")
+
+                assert_template "content_block_manager/content_block/editions/workflow/group_objects"
+              end
+            end
+
+            describe "when content does not exist for any of the subschemas" do
+              it "renders the select subschema group" do
+                get content_block_manager.content_block_manager_content_block_workflow_path(id: edition.id, step: "group_some_group")
+
+                assert_template "content_block_manager/content_block/shared/embedded_objects/select_subschema"
+              end
             end
           end
 

--- a/lib/engines/content_block_manager/test/integration/content_block/workflow_test.rb
+++ b/lib/engines/content_block_manager/test/integration/content_block/workflow_test.rb
@@ -97,8 +97,14 @@ class ContentBlockManager::ContentBlock::WorkflowTest < ActionDispatch::Integrat
       let!(:schema) { stub_request_for_schema("pension", subschemas:) }
 
       describe "#show" do
-        it "shows the embedded_objects step" do
-          get content_block_manager.content_block_manager_content_block_workflow_path(id: edition.id, step: "embedded_objects")
+        it "shows the form for the first subschema" do
+          get content_block_manager.content_block_manager_content_block_workflow_path(id: edition.id, step: "embedded_subschema_1")
+
+          assert_template "content_block_manager/content_block/editions/workflow/embedded_objects"
+        end
+
+        it "shows the form for the second subschema" do
+          get content_block_manager.content_block_manager_content_block_workflow_path(id: edition.id, step: "embedded_subschema_2")
 
           assert_template "content_block_manager/content_block/editions/workflow/embedded_objects"
         end
@@ -107,19 +113,24 @@ class ContentBlockManager::ContentBlock::WorkflowTest < ActionDispatch::Integrat
           let(:details) { { subschema_1: { existing_subschema: { name: "existing subschema" } } } }
           let(:edition) { create(:content_block_edition, document:, details:, organisation:, instructions_to_publishers: "instructions", title: "Some Edition Title") }
 
-          it "shows the existing block and how to add other embedded blocks" do
-            visit content_block_manager.content_block_manager_content_block_workflow_path(id: edition.id, step: "embedded_objects")
+          it "shows the existing block and how to add another embedded block" do
+            visit content_block_manager.content_block_manager_content_block_workflow_path(id: edition.id, step: "embedded_subschema_1")
 
             assert_text "existing subschema"
             assert_text "Add another subschema 1"
-            assert_text "Add another subschema 2"
           end
         end
       end
 
       describe "#update" do
+        it "redirects to the second subschema" do
+          put content_block_manager.content_block_manager_content_block_workflow_path(id: edition.id, step: "embedded_subschema_1")
+
+          assert_redirected_to content_block_manager_content_block_workflow_path(id: edition.id, step: :embedded_subschema_2)
+        end
+
         it "redirects to the review page" do
-          put content_block_manager.content_block_manager_content_block_workflow_path(id: edition.id, step: "embedded_objects")
+          put content_block_manager.content_block_manager_content_block_workflow_path(id: edition.id, step: "embedded_subschema_2")
 
           assert_redirected_to content_block_manager_content_block_workflow_path(id: edition.id, step: :review)
         end
@@ -364,16 +375,28 @@ class ContentBlockManager::ContentBlock::WorkflowTest < ActionDispatch::Integrat
         end
 
         describe "#show" do
-          it "renders the embedded objects template" do
-            get content_block_manager.content_block_manager_content_block_workflow_path(id: edition.id, step: "embedded_objects")
+          it "shows the form for the first subschema" do
+            get content_block_manager.content_block_manager_content_block_workflow_path(id: edition.id, step: "embedded_subschema_1")
+
+            assert_template "content_block_manager/content_block/editions/workflow/embedded_objects"
+          end
+
+          it "shows the form for the second subschema" do
+            get content_block_manager.content_block_manager_content_block_workflow_path(id: edition.id, step: "embedded_subschema_2")
 
             assert_template "content_block_manager/content_block/editions/workflow/embedded_objects"
           end
         end
 
         describe "#update" do
+          it "redirects to the second subschema" do
+            put content_block_manager.content_block_manager_content_block_workflow_path(id: edition.id, step: "embedded_subschema_1")
+
+            assert_redirected_to content_block_manager_content_block_workflow_path(id: edition.id, step: :embedded_subschema_2)
+          end
+
           it "redirects to review links" do
-            put content_block_manager.content_block_manager_content_block_workflow_path(id: edition.id, step: "embedded_objects")
+            put content_block_manager.content_block_manager_content_block_workflow_path(id: edition.id, step: "embedded_subschema_2")
 
             assert_redirected_to content_block_manager_content_block_workflow_path(id: edition.id, step: :review_links)
           end

--- a/lib/engines/content_block_manager/test/integration/content_block/workflow_test.rb
+++ b/lib/engines/content_block_manager/test/integration/content_block/workflow_test.rb
@@ -89,8 +89,8 @@ class ContentBlockManager::ContentBlock::WorkflowTest < ActionDispatch::Integrat
     describe "when subschemas are present" do
       let(:subschemas) do
         [
-          stub("subschema_1", id: "subschema_1", name: "subschema_1", block_type: "subschema_1", embeddable_fields: [], fields: [stub("field", name: "name")]),
-          stub("subschema_2", id: "subschema_2", name: "subschema_2", block_type: "subschema_1", fields: []),
+          stub("subschema_1", id: "subschema_1", name: "subschema_1", block_type: "subschema_1", embeddable_fields: [], fields: [stub("field", name: "name")], group: nil),
+          stub("subschema_2", id: "subschema_2", name: "subschema_2", block_type: "subschema_1", fields: [], group: nil),
         ]
       end
 
@@ -363,8 +363,8 @@ class ContentBlockManager::ContentBlock::WorkflowTest < ActionDispatch::Integrat
       describe "when subschemas are present" do
         let(:subschemas) do
           [
-            stub("subschema", id: "subschema_1", name: "subschema_1", block_type: "subschema_1"),
-            stub("subschema", id: "subschema_2", name: "subschema_2", block_type: "subschema_2"),
+            stub("subschema", id: "subschema_1", name: "subschema_1", block_type: "subschema_1", group: nil),
+            stub("subschema", id: "subschema_2", name: "subschema_2", block_type: "subschema_2", group: nil),
           ]
         end
 
@@ -399,6 +399,74 @@ class ContentBlockManager::ContentBlock::WorkflowTest < ActionDispatch::Integrat
             put content_block_manager.content_block_manager_content_block_workflow_path(id: edition.id, step: "embedded_subschema_2")
 
             assert_redirected_to content_block_manager_content_block_workflow_path(id: edition.id, step: :review_links)
+          end
+        end
+      end
+
+      describe "when subschemas are present" do
+        let(:group) { nil }
+        let(:subschemas) do
+          [
+            stub("subschema", id: "subschema_1", name: "subschema_1", block_type: "subschema_1", group:),
+            stub("subschema", id: "subschema_2", name: "subschema_2", block_type: "subschema_2", group:),
+          ]
+        end
+
+        let!(:schema) { stub_request_for_schema("pension", subschemas:) }
+
+        before do
+          ContentBlockManager::ContentBlock::Edition.any_instance.stubs(:has_entries_for_subschema_id?).returns(true)
+        end
+
+        describe "#show" do
+          it "shows the form for the first subschema" do
+            get content_block_manager.content_block_manager_content_block_workflow_path(id: edition.id, step: "embedded_subschema_1")
+
+            assert_template "content_block_manager/content_block/editions/workflow/embedded_objects"
+          end
+
+          it "shows the form for the second subschema" do
+            get content_block_manager.content_block_manager_content_block_workflow_path(id: edition.id, step: "embedded_subschema_2")
+
+            assert_template "content_block_manager/content_block/editions/workflow/embedded_objects"
+          end
+        end
+
+        describe "#update" do
+          it "redirects to the second subschema" do
+            put content_block_manager.content_block_manager_content_block_workflow_path(id: edition.id, step: "embedded_subschema_1")
+
+            assert_redirected_to content_block_manager_content_block_workflow_path(id: edition.id, step: :embedded_subschema_2)
+          end
+
+          it "redirects to review links" do
+            put content_block_manager.content_block_manager_content_block_workflow_path(id: edition.id, step: "embedded_subschema_2")
+
+            assert_redirected_to content_block_manager_content_block_workflow_path(id: edition.id, step: :review_links)
+          end
+        end
+
+        describe "when the subschemas are in a group" do
+          let(:group) { "some_group" }
+
+          before do
+            schema.stubs(:subschemas_for_group).with(group).returns(subschemas)
+          end
+
+          describe "#show" do
+            it "shows the form for the group" do
+              get content_block_manager.content_block_manager_content_block_workflow_path(id: edition.id, step: "group_some_group")
+
+              assert_template "content_block_manager/content_block/editions/workflow/group_objects"
+            end
+          end
+
+          describe "#update" do
+            it "redirects to review links" do
+              put content_block_manager.content_block_manager_content_block_workflow_path(id: edition.id, step: "group_some_group")
+
+              assert_redirected_to content_block_manager_content_block_workflow_path(id: edition.id, step: :review_links)
+            end
           end
         end
       end
@@ -499,8 +567,18 @@ class ContentBlockManager::ContentBlock::WorkflowTest < ActionDispatch::Integrat
 
   describe "when an unknown subschema step is provided" do
     describe "#show" do
-      it "shows the new edition for review" do
+      it "returns a 404" do
         get content_block_manager.content_block_manager_content_block_workflow_path(id: edition.id, step: "embedded_something")
+
+        assert_response :missing
+      end
+    end
+  end
+
+  describe "when an unknown group step is provided" do
+    describe "#show" do
+      it "returns a 404" do
+        get content_block_manager.content_block_manager_content_block_workflow_path(id: edition.id, step: "group_something")
 
         assert_response :missing
       end

--- a/lib/engines/content_block_manager/test/unit/app/controllers/concerns/workflow/steps_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/controllers/concerns/workflow/steps_test.rb
@@ -263,4 +263,158 @@ class Workflow::StepsTest < ActionDispatch::IntegrationTest
       end
     end
   end
+
+  describe "when a schema has grouped subschemas" do
+    let(:subschemas) do
+      [
+        stub("subschema", id: "something", group: "my_group"),
+        stub("subschema", id: "something_else", group: "my_group"),
+        stub("subschema", id: "ungrouped", group: nil),
+      ]
+    end
+
+    let!(:schema) { stub_request_for_schema(content_block_document.block_type, subschemas:) }
+
+    let(:step) { "something" }
+
+    before do
+      content_block_edition.stubs(:has_entries_for_subschema_id?).with("something").returns(true)
+      content_block_edition.stubs(:has_entries_for_subschema_id?).with("something_else").returns(true)
+      content_block_edition.stubs(:has_entries_for_subschema_id?).with("ungrouped").returns(true)
+    end
+
+    describe "#steps" do
+      it "inserts the subschemas into the flow" do
+        assert_equal workflow.steps, [
+          Workflow::Step::ALL[0],
+          Workflow::Step.new(:group_my_group, :group_my_group, :redirect_to_next_step, true),
+          Workflow::Step.new(:embedded_ungrouped, :embedded_ungrouped, :redirect_to_next_step, true),
+          Workflow::Step::ALL[1..],
+        ].flatten
+      end
+
+      describe "when there are entries missing for a given subschema" do
+        before do
+          content_block_edition.stubs(:has_entries_for_subschema_id?).with("something").returns(false)
+          content_block_edition.stubs(:has_entries_for_subschema_id?).with("something_else").returns(false)
+          content_block_edition.stubs(:has_entries_for_subschema_id?).with("ungrouped").returns(true)
+        end
+
+        it "skips the subschemas without data" do
+          assert_equal workflow.steps, [
+            Workflow::Step::ALL[0],
+            Workflow::Step.new(:embedded_ungrouped, :embedded_ungrouped, :redirect_to_next_step, true),
+            Workflow::Step::ALL[1..],
+          ].flatten
+        end
+
+        describe "when there are entries missing for only some subschemas in a group" do
+          before do
+            content_block_edition.stubs(:has_entries_for_subschema_id?).with("something").returns(false)
+            content_block_edition.stubs(:has_entries_for_subschema_id?).with("something_else").returns(true)
+            content_block_edition.stubs(:has_entries_for_subschema_id?).with("ungrouped").returns(true)
+          end
+
+          it "retains the group" do
+            assert_equal workflow.steps, [
+              Workflow::Step::ALL[0],
+              Workflow::Step.new(:group_my_group, :group_my_group, :redirect_to_next_step, true),
+              Workflow::Step.new(:embedded_ungrouped, :embedded_ungrouped, :redirect_to_next_step, true),
+              Workflow::Step::ALL[1..],
+            ].flatten
+          end
+        end
+      end
+    end
+
+    describe "#next_step" do
+      [
+        %i[edit_draft group_my_group],
+        %i[group_my_group embedded_ungrouped],
+        %i[embedded_ungrouped review_links],
+        %i[review_links internal_note],
+        %i[internal_note change_note],
+        %i[change_note schedule_publishing],
+        %i[schedule_publishing review],
+        %i[review confirmation],
+      ].each do |current_step, expected_step|
+        describe "when current_step is #{current_step}" do
+          let(:step) { current_step }
+
+          it "returns #{expected_step} step" do
+            assert_equal workflow.next_step.name, expected_step
+          end
+        end
+      end
+    end
+
+    describe "#previous_step" do
+      [
+        %i[group_my_group edit_draft],
+        %i[embedded_ungrouped group_my_group],
+        %i[review_links embedded_ungrouped],
+        %i[internal_note review_links],
+        %i[change_note internal_note],
+        %i[schedule_publishing change_note],
+        %i[review schedule_publishing],
+      ].each do |current_step, expected_step|
+        describe "when current_step is #{current_step}" do
+          let(:step) { current_step }
+
+          it "returns #{expected_step} step" do
+            assert_equal workflow.previous_step.name, expected_step
+          end
+        end
+      end
+    end
+
+    describe "and the content block is new" do
+      before do
+        content_block_document.expects(:is_new_block?).at_least_once.returns(true)
+      end
+
+      it "removes steps not included in the create journey" do
+        assert_equal workflow.steps, [
+          Workflow::Step.new(:edit_draft, :edit_draft, :update_draft, true),
+          Workflow::Step.new(:group_my_group, :group_my_group, :redirect_to_next_step, true),
+          Workflow::Step.new(:embedded_ungrouped, :embedded_ungrouped, :redirect_to_next_step, true),
+          Workflow::Step.new(:review, :review, :validate_review_page, true),
+          Workflow::Step.new(:confirmation, :confirmation, nil, true),
+        ].flatten
+      end
+
+      describe "#next_step" do
+        [
+          %i[edit_draft group_my_group],
+          %i[group_my_group embedded_ungrouped],
+          %i[embedded_ungrouped review],
+          %i[review confirmation],
+        ].each do |current_step, expected_step|
+          describe "when current_step is #{current_step}" do
+            let(:step) { current_step }
+
+            it "returns #{expected_step} step" do
+              assert_equal workflow.next_step.name, expected_step
+            end
+          end
+        end
+      end
+
+      describe "#previous_step" do
+        [
+          %i[group_my_group edit_draft],
+          %i[embedded_ungrouped group_my_group],
+          %i[review embedded_ungrouped],
+        ].each do |current_step, expected_step|
+          describe "when current_step is #{current_step}" do
+            let(:step) { current_step }
+
+            it "returns #{expected_step} step" do
+              assert_equal workflow.previous_step.name, expected_step
+            end
+          end
+        end
+      end
+    end
+  end
 end

--- a/lib/engines/content_block_manager/test/unit/app/controllers/concerns/workflow/steps_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/controllers/concerns/workflow/steps_test.rb
@@ -148,26 +148,36 @@ class Workflow::StepsTest < ActionDispatch::IntegrationTest
     end
 
     describe "#steps" do
-      it "returns all the steps" do
-        assert_equal workflow.steps, Workflow::Step::ALL
+      it "inserts the subschemas into the flow" do
+        assert_equal workflow.steps, [
+          Workflow::Step::ALL[0],
+          Workflow::Step.new(:embedded_something, :embedded_something, :redirect_to_next_step, true),
+          Workflow::Step.new(:embedded_something_else, :embedded_something_else, :redirect_to_next_step, true),
+          Workflow::Step::ALL[1..],
+        ].flatten
       end
 
-      describe "when no subschemas are present" do
+      describe "when there are entries missing for a given subschema" do
         before do
           content_block_edition.stubs(:has_entries_for_subschema_id?).with("something").returns(false)
-          content_block_edition.stubs(:has_entries_for_subschema_id?).with("something_else").returns(false)
+          content_block_edition.stubs(:has_entries_for_subschema_id?).with("something_else").returns(true)
         end
 
-        it "removes the embedded_objects step" do
-          assert_equal(workflow.steps, Workflow::Step::ALL.reject { |step| step.name == :embedded_objects })
+        it "skips the subschemas without data" do
+          assert_equal workflow.steps, [
+            Workflow::Step::ALL[0],
+            Workflow::Step.new(:embedded_something_else, :embedded_something_else, :redirect_to_next_step, true),
+            Workflow::Step::ALL[1..],
+          ].flatten
         end
       end
     end
 
     describe "#next_step" do
       [
-        %i[edit_draft embedded_objects],
-        %i[embedded_objects review_links],
+        %i[edit_draft embedded_something],
+        %i[embedded_something embedded_something_else],
+        %i[embedded_something_else review_links],
         %i[review_links internal_note],
         %i[internal_note change_note],
         %i[change_note schedule_publishing],
@@ -186,8 +196,9 @@ class Workflow::StepsTest < ActionDispatch::IntegrationTest
 
     describe "#previous_step" do
       [
-        %i[embedded_objects edit_draft],
-        %i[review_links embedded_objects],
+        %i[embedded_something edit_draft],
+        %i[embedded_something_else embedded_something],
+        %i[review_links embedded_something_else],
         %i[internal_note review_links],
         %i[change_note internal_note],
         %i[schedule_publishing change_note],
@@ -211,16 +222,18 @@ class Workflow::StepsTest < ActionDispatch::IntegrationTest
       it "removes steps not included in the create journey" do
         assert_equal workflow.steps, [
           Workflow::Step.new(:edit_draft, :edit_draft, :update_draft, true),
-          Workflow::Step.new(:embedded_objects, :embedded_objects, :redirect_to_next_step, true),
+          Workflow::Step.new(:embedded_something, :embedded_something, :redirect_to_next_step, true),
+          Workflow::Step.new(:embedded_something_else, :embedded_something_else, :redirect_to_next_step, true),
           Workflow::Step.new(:review, :review, :validate_review_page, true),
           Workflow::Step.new(:confirmation, :confirmation, nil, true),
-        ]
+        ].flatten
       end
 
       describe "#next_step" do
         [
-          %i[edit_draft embedded_objects],
-          %i[embedded_objects review],
+          %i[edit_draft embedded_something],
+          %i[embedded_something embedded_something_else],
+          %i[embedded_something_else review],
           %i[review confirmation],
         ].each do |current_step, expected_step|
           describe "when current_step is #{current_step}" do
@@ -235,8 +248,9 @@ class Workflow::StepsTest < ActionDispatch::IntegrationTest
 
       describe "#previous_step" do
         [
-          %i[embedded_objects edit_draft],
-          %i[review embedded_objects],
+          %i[embedded_something edit_draft],
+          %i[embedded_something_else embedded_something],
+          %i[review embedded_something_else],
         ].each do |current_step, expected_step|
           describe "when current_step is #{current_step}" do
             let(:step) { current_step }

--- a/lib/engines/content_block_manager/test/unit/app/controllers/concerns/workflow/steps_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/controllers/concerns/workflow/steps_test.rb
@@ -133,8 +133,8 @@ class Workflow::StepsTest < ActionDispatch::IntegrationTest
   describe "when a schema has subschemas" do
     let(:subschemas) do
       [
-        stub("subschema", id: "something"),
-        stub("subschema", id: "something_else"),
+        stub("subschema", id: "something", group: nil),
+        stub("subschema", id: "something_else", group: nil),
       ]
     end
 


### PR DESCRIPTION
This updates the journey when creating a new block to take into account grouped subschemas. To do this, I needed to undo some of the work we did earlier to unify the embedded objects into one page, and instead only unify embedded objects if they're part of a group.

## Screenshots

![image](https://github.com/user-attachments/assets/050c8e5d-71bb-4728-8835-2008921f8ce0)

![image](https://github.com/user-attachments/assets/9747c40d-513a-4014-bd31-dc245a169206)

![image](https://github.com/user-attachments/assets/aeeb9a33-895f-45ac-a13e-4177889c715c)

![image](https://github.com/user-attachments/assets/77e30bfd-bf13-4065-b5cb-178a2c4fb103)
