### PR TITLE
CM-185: Add UK Call Charges and Description to Telephone 

### DIFF
--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/base_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/base_component.rb
@@ -3,7 +3,7 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::BaseComponent <
 
   PARENT_CLASS = "content_block_manager_content_block_edition".freeze
 
-  def initialize(content_block_edition:, field:, value: nil, object_id: nil)
+  def initialize(content_block_edition:, field:, value: nil, object_id: nil, **_args)
     @content_block_edition = content_block_edition
     @field = field
     @value = value

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/boolean_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/boolean_component.html.erb
@@ -1,0 +1,8 @@
+<%= render "govuk_publishing_components/components/radio", {
+  heading:,
+  name:,
+  id:,
+  heading_size: "s",
+  error_items:,
+  items:,
+} %>

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/boolean_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/boolean_component.rb
@@ -1,0 +1,22 @@
+class ContentBlockManager::ContentBlockEdition::Details::Fields::BooleanComponent < ContentBlockManager::ContentBlockEdition::Details::Fields::BaseComponent
+private
+
+  def heading
+    "#{label}?"
+  end
+
+  def items
+    [
+      {
+        value: true,
+        text: "Yes",
+        checked: value.present? ? ActiveModel::Type::Boolean.new.cast(value) : false,
+      },
+      {
+        value: false,
+        text: "No",
+        checked: value.present? ? !ActiveModel::Type::Boolean.new.cast(value) : false,
+      },
+    ]
+  end
+end

--- a/lib/engines/content_block_manager/config/content_block_manager.yml
+++ b/lib/engines/content_block_manager/config/content_block_manager.yml
@@ -35,6 +35,14 @@ schemas:
         embeddable_as_block: true
         embeddable_fields:
           - telephone_numbers
+        field_order:
+          - title
+          - telephone_numbers
+          - show_uk_call_charges
+        fields:
+          show_uk_call_charges:
+            component:
+              boolean
       addresses:
         group: modes
         group_order: 3

--- a/lib/engines/content_block_manager/config/content_block_manager.yml
+++ b/lib/engines/content_block_manager/config/content_block_manager.yml
@@ -39,7 +39,11 @@ schemas:
           - title
           - telephone_numbers
           - show_uk_call_charges
+          - description
         fields:
+          description:
+            component:
+              textarea
           show_uk_call_charges:
             component:
               boolean

--- a/lib/engines/content_block_manager/features/create_contact_object.feature
+++ b/lib/engines/content_block_manager/features/create_contact_object.feature
@@ -37,7 +37,11 @@ Feature: Create a contact object
     """
     {
       "type":"object",
-      "required": ["title", "telephone_numbers"],
+      "required": [
+        "title",
+        "telephone_numbers",
+        "show_uk_call_charges"
+      ],
       "properties": {
         "telephone_numbers": {
           "type": "array",
@@ -68,6 +72,13 @@ Feature: Create a contact object
         },
         "title": {
           "type": "string"
+        },
+        "show_uk_call_charges": {
+          "type": "string",
+          "enum": [
+            "true",
+            "false"
+          ]
         }
       }
     }
@@ -100,6 +111,7 @@ Feature: Create a contact object
       | label       | telephone_number | type      |
       | Telephone 1 | 12345            | Telephone |
       | Telephone 2 | 6789             | Textphone |
+    And I choose "Yes"
     And I save and continue
     Then I should be on the "embedded_objects" step
     When I save and continue

--- a/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
@@ -480,3 +480,7 @@ Given(/^my pension content block has no rates$/) do
   @content_block.details["rates"] = {}
   @content_block.save!
 end
+
+And("I choose {string}") do |label|
+  choose label
+end

--- a/lib/engines/content_block_manager/test/components/content_block/edition/details/embedded_objects/form_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/details/embedded_objects/form_component_test.rb
@@ -10,16 +10,18 @@ class ContentBlockManager::ContentBlockEdition::Details::EmbeddedObjects::FormCo
   let(:bar_field) { stub("field", name: "bar", component_name: "string", enum_values: nil, default_value: nil) }
   let(:enum_field) { stub("field", name: "enum", component_name: "enum", enum_values: ["some value", "another value"], default_value: "some value") }
   let(:textarea_field) { stub("field", name: "enum", component_name: "textarea", enum_values: nil, default_value: nil) }
+  let(:boolean_field) { stub("field", name: "boolean", component_name: "boolean", enum_values: nil, default_value: nil) }
 
   let(:foo_stub) { stub("string_component") }
   let(:bar_stub) { stub("string_component") }
   let(:enum_stub) { stub("enum_component") }
   let(:textarea_stub) { stub("textarea_component") }
+  let(:boolean_stub) { stub("boolean_component") }
 
   let(:object_title) { "some_object" }
 
   before do
-    schema.stubs(:fields).returns([foo_field, bar_field, enum_field, textarea_field])
+    schema.stubs(:fields).returns([foo_field, bar_field, enum_field, textarea_field, boolean_field])
   end
 
   it "renders fields for each property" do
@@ -49,6 +51,12 @@ class ContentBlockManager::ContentBlockEdition::Details::EmbeddedObjects::FormCo
       object_id: object_title,
     ).returns(textarea_stub)
 
+    ContentBlockManager::ContentBlockEdition::Details::Fields::BooleanComponent.expects(:new).with(
+      content_block_edition:,
+      field: boolean_field,
+      object_id: object_title,
+    ).returns(boolean_stub)
+
     component = ContentBlockManager::ContentBlockEdition::Details::EmbeddedObjects::FormComponent.new(
       content_block_edition:,
       schema:,
@@ -60,6 +68,7 @@ class ContentBlockManager::ContentBlockEdition::Details::EmbeddedObjects::FormCo
     component.expects(:render).with(bar_stub)
     component.expects(:render).with(enum_stub)
     component.expects(:render).with(textarea_stub)
+    component.expects(:render).with(boolean_stub)
 
     render_inline(component)
   end
@@ -94,6 +103,12 @@ class ContentBlockManager::ContentBlockEdition::Details::EmbeddedObjects::FormCo
       object_id: object_title,
     ).returns(textarea_stub)
 
+    ContentBlockManager::ContentBlockEdition::Details::Fields::BooleanComponent.expects(:new).with(
+      content_block_edition:,
+      field: boolean_field,
+      object_id: object_title,
+    ).returns(boolean_stub)
+
     component = ContentBlockManager::ContentBlockEdition::Details::EmbeddedObjects::FormComponent.new(
       content_block_edition:,
       schema:,
@@ -105,6 +120,7 @@ class ContentBlockManager::ContentBlockEdition::Details::EmbeddedObjects::FormCo
     component.expects(:render).with(bar_stub)
     component.expects(:render).with(enum_stub)
     component.expects(:render).with(textarea_stub)
+    component.expects(:render).with(boolean_stub)
 
     render_inline(component)
   end

--- a/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/boolean_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/boolean_component_test.rb
@@ -1,0 +1,46 @@
+require "test_helper"
+
+class ContentBlockManager::ContentBlockEdition::Details::Fields::BooleanComponentTest < ViewComponent::TestCase
+  extend Minitest::Spec::DSL
+
+  let(:content_block_edition) { build(:content_block_edition, :pension) }
+  let(:field) { stub("field", name: "email_address", is_required?: true) }
+
+  it "should not check any radios if no value given" do
+    render_inline(
+      ContentBlockManager::ContentBlockEdition::Details::Fields::BooleanComponent.new(
+        content_block_edition:,
+        field:,
+      ),
+    )
+
+    assert_selector "input[type=\"radio\"][value=\"true\"]"
+    assert_no_selector "input[type=\"radio\"][value=\"true\"][checked=\"checked\"]"
+    assert_selector "input[type=\"radio\"][value=\"false\"]"
+    assert_no_selector "input[type=\"radio\"][value=\"false\"][checked=\"checked\"]"
+  end
+
+  it "should check Yes radio if value given is 'true'" do
+    render_inline(
+      ContentBlockManager::ContentBlockEdition::Details::Fields::BooleanComponent.new(
+        content_block_edition:,
+        field:,
+        value: "true",
+      ),
+    )
+
+    assert_selector "input[type=\"radio\"][value=\"true\"][checked=\"checked\"]"
+  end
+
+  it "should check No radio if value given is 'false'" do
+    render_inline(
+      ContentBlockManager::ContentBlockEdition::Details::Fields::BooleanComponent.new(
+        content_block_edition:,
+        field:,
+        value: "false",
+      ),
+    )
+
+    assert_selector "input[type=\"radio\"][value=\"false\"][checked=\"checked\"]"
+  end
+end


### PR DESCRIPTION
https://gov-uk.atlassian.net/jira/software/c/projects/CM/boards/134?selectedIssue=CM-167

<img width="812" alt="Screenshot 2025-06-20 at 15 56 46" src="https://github.com/user-attachments/assets/bd11d843-8bec-45e3-9e87-492142248684" />



**Call charges:**
Unfortunately because any form values get converted to a string, instead of a boolean type, and we save the `details` as a hash and it's not possible to type rails parameters (from what I can tell?) - I have had to define the boolean component as a custom one for `show_uk_call_charges`, and set it as an enum in the content schema here https://github.com/alphagov/publishing-api/pull/3411

Things not covered in this PR:
* an easy way to keep the UK as an acronym - Adding to inflections file is not possible, if it's added as an acronym it interferes with a govUKFormValidator file name, if it's added to `human`, then `humanize` gets run afterwards and removes the capitalisation. I think the best solution would be adding a custom `label` option to the `field` class, but can be done in a different PR
* how the call charges should be displayed in Review/Summary card 


----

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
