### PR TITLE
Govspeak flexible page block

### DIFF
--- a/app/helpers/admin/flexible_page_helper.rb
+++ b/app/helpers/admin/flexible_page_helper.rb
@@ -2,27 +2,42 @@ module Admin::FlexiblePageHelper
   def render_flexible_page_content_fields(schema, edition, path = [], output_html = "")
     schema["properties"].each do |key, property|
       next_path = [*path, key]
-      case property["type"]
-      when "string"
-        output_html += render "govuk_publishing_components/components/input", {
-          label: {
-            text: property["title"] + (schema["required"] ? " (required)" : ""),
-          },
-          name: "edition[flexible_page_content][#{next_path.join('][')}]",
-          value: edition.flexible_page_content&.dig(*next_path) || "",
-          id: "edition_flexible_page_content_#{next_path.join('_')}",
-          hint: property["description"],
-        }
-      when "object"
-        output_html += render "govuk_publishing_components/components/fieldset", {
-          legend_text: property["title"],
-          heading_size: "m",
-          id: "edition_flexible_page_content_#{next_path.join('_')}",
-        } do
-          render inline: render_flexible_page_content_fields(property, edition, next_path, output_html)
-        end
-      end
+      output_html += render_field(property, schema, next_path, edition)
     end
     output_html
+  end
+
+private
+
+  def render_field(property, schema, path, edition)
+    field_attrs = build_field_attributes(property, schema, path, edition)
+
+    case property["type"]
+    when "string"
+      component = property["format"] == "govspeak" ? "textarea" : "input"
+      render "govuk_publishing_components/components/#{component}", field_attrs
+    when "object"
+      render "govuk_publishing_components/components/fieldset", {
+        legend_text: property["title"],
+        heading_size: "m",
+        id: field_attrs[:id],
+      } do
+        render inline: render_flexible_page_content_fields(property, edition, path, "")
+      end
+    else
+      raise "Unsupported property type: #{property['type']}"
+    end
+  end
+
+  def build_field_attributes(property, schema, path, edition)
+    required_suffix = schema["required"]&.include?(path.last.to_s) ? " (required)" : ""
+
+    {
+      label: { text: property["title"] + required_suffix },
+      name: "edition[flexible_page_content][#{path.join('][')}]",
+      value: edition.flexible_page_content&.dig(*path) || "",
+      id: "edition_flexible_page_content_#{path.join('_')}",
+      hint: property["description"],
+    }
   end
 end

--- a/app/models/flexible_page_type.rb
+++ b/app/models/flexible_page_type.rb
@@ -41,4 +41,8 @@ class FlexiblePageType
   def validator
     JSONSchemer.schema(@schema)
   end
+
+  def publishing_api_payload_builder(page_content)
+    PublishingApi::PayloadBuilder::FlexiblePageContent.new(@schema, page_content)
+  end
 end

--- a/app/models/flexible_page_type.rb
+++ b/app/models/flexible_page_type.rb
@@ -39,7 +39,12 @@ class FlexiblePageType
   end
 
   def validator
-    JSONSchemer.schema(@schema)
+    formats = {
+      "govspeak" => proc do |instance|
+        instance.is_a?(String) && Govspeak::HtmlValidator.new(instance).valid?
+      end,
+    }
+    JSONSchemer.schema(@schema, formats:)
   end
 
   def publishing_api_payload_builder(page_content)

--- a/app/models/flexible_page_types/history_page.json
+++ b/app/models/flexible_page_types/history_page.json
@@ -24,6 +24,12 @@
           }
         },
         "required": ["heading_text"]
+      },
+      "body": {
+        "title": "Body",
+        "description": "The main content for the page",
+        "type": "string",
+        "format": "govspeak"
       }
     },
     "required": ["page_title"]

--- a/app/presenters/publishing_api/flexible_page_presenter.rb
+++ b/app/presenters/publishing_api/flexible_page_presenter.rb
@@ -15,7 +15,7 @@ module PublishingApi
       content = BaseItemPresenter.new(item, update_type:).base_attributes
       content.merge!(
         details: {
-          body: "",
+          **type.publishing_api_payload_builder(item.flexible_page_content).call,
         },
         document_type: type.settings["publishing_api_document_type"],
         public_updated_at: item.public_timestamp || item.updated_at,
@@ -40,7 +40,7 @@ module PublishingApi
   private
 
     def type
-      FlexiblePageType.find(item.flexible_page_type)
+      item.type_instance
     end
   end
 end

--- a/app/presenters/publishing_api/payload_builder/flexible_page_content.rb
+++ b/app/presenters/publishing_api/payload_builder/flexible_page_content.rb
@@ -1,0 +1,37 @@
+module PublishingApi
+  module PayloadBuilder
+    class FlexiblePageContent
+      def initialize(schema, content)
+        @schema = schema
+        @content = content
+      end
+
+      def call
+        present_content(@schema, @content)
+      end
+
+    private
+
+      def present_content(schema, content)
+        output = {}
+        schema["properties"].each do |key, property|
+          case property["type"]
+          when "object"
+            output.merge!(key.to_sym => present_content(schema["properties"][key], content[key]))
+          when "string"
+            case property["format"]
+            when "govspeak"
+              html = Whitehall::GovspeakRenderer.new.govspeak_to_html(content[key])
+              output.merge!(key.to_sym => html)
+            else
+              output.merge!(key.to_sym => content[key])
+            end
+          else
+            raise "Unknown property type #{property['type']}"
+          end
+        end
+        output
+      end
+    end
+  end
+end

--- a/features/fixtures/test_flexible_page_type.json
+++ b/features/fixtures/test_flexible_page_type.json
@@ -24,6 +24,11 @@
           }
         },
         "required": ["heading_text"]
+      },
+      "body": {
+        "title": "Body",
+        "description": "The main content of the page",
+        "type": "string"
       }
     },
     "required": ["page_title"]

--- a/features/step_definitions/flexible_page_steps.rb
+++ b/features/step_definitions/flexible_page_steps.rb
@@ -19,6 +19,7 @@ When(/^I draft a new "([^"]*)" flexible page titled "([^"]*)"$/) do |flexible_pa
   within "form" do
     fill_in "edition_title", with: title
     fill_in "edition_flexible_page_content_page_title_heading_text", with: title
+    fill_in "edition_flexible_page_content_body", with: "## Some govspeak\n\nThis is the body content"
   end
   click_button "Save and go to document summary"
 end

--- a/test/unit/app/helpers/admin/flexible_page_helper_test.rb
+++ b/test/unit/app/helpers/admin/flexible_page_helper_test.rb
@@ -101,4 +101,39 @@ class Admin::FlexiblePageHelperTest < ActionView::TestCase
     render inline: render_flexible_page_content_fields(schema, FlexiblePage.new)
     assert_dom "label", text: "One (required)"
   end
+
+  test "flexible page helper renders an input for a string property without govspeak format" do
+    schema = {
+      "type" => "object",
+      "properties" => {
+        "title" => {
+          "type" => "string",
+          "title" => "Title",
+          "description" => "A regular string field",
+        },
+      },
+    }
+
+    render inline: render_flexible_page_content_fields(schema, FlexiblePage.new)
+    assert_dom "input[name=\"edition[flexible_page_content][title]\"]"
+    refute_dom "textarea[name=\"edition[flexible_page_content][title]\"]"
+  end
+
+  test "flexible page helper renders a textarea for a string property in the govspeak format" do
+    schema = {
+      "type" => "object",
+      "properties" => {
+        "body" => {
+          "type" => "string",
+          "title" => "Body",
+          "description" => "The body content in govspeak format",
+          "format" => "govspeak",
+        },
+      },
+    }
+
+    render inline: render_flexible_page_content_fields(schema, FlexiblePage.new)
+    assert_dom "textarea[name=\"edition[flexible_page_content][body]\"]"
+    refute_dom "input[name=\"edition[flexible_page_content][body]\"]"
+  end
 end

--- a/test/unit/app/models/flexible_page_test.rb
+++ b/test/unit/app/models/flexible_page_test.rb
@@ -36,4 +36,35 @@ class FlexiblePageTest < ActiveSupport::TestCase
     page.creator = User.new
     assert page.invalid?
   end
+
+  test "it is able to validate govspeak formatted attributes" do
+    test_types = {
+      "test_type" => {
+        "key" => "test_type",
+        "schema" => {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "$id": "https://www.gov.uk/schemas/test_type/v1",
+          "title": "Test type",
+          "type": "object",
+          "properties" => {
+            "test_attribute" => {
+              "title" => "Test attribute",
+              "type" => "string",
+              "format" => "govspeak",
+            },
+          },
+          "required" => %w[test_attribute],
+        },
+      },
+    }
+    FlexiblePageType.setup_test_types(test_types)
+    page = FlexiblePage.new
+    page.title = "Test Page"
+    page.flexible_page_type = "test_type"
+    page.flexible_page_content = {
+      "test_attribute" => "<script>alert('You've been pwned!')</script>'",
+    }
+    page.creator = User.new
+    assert page.invalid?
+  end
 end

--- a/test/unit/app/presenters/publishing_api/flexible_page_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/flexible_page_presenter_test.rb
@@ -11,7 +11,8 @@ class PublishingApi::FlexiblePagePresenterTest < ActiveSupport::TestCase
       type_key => {
         "key" => type_key,
         "schema" => {
-          "type" => "string",
+          "type" => "object",
+          "properties" => [],
         },
         "settings" => {
           "base_path_prefix" => "/government/history",
@@ -31,5 +32,46 @@ class PublishingApi::FlexiblePagePresenterTest < ActiveSupport::TestCase
     assert_equal schema_name, content[:schema_name]
     assert_equal document_type, content[:document_type]
     assert_equal rendering_app, content[:rendering_app]
+  end
+
+  test "it includes the flexible page content values in the details hash" do
+    type_key = "test_type_key"
+    FlexiblePageType.setup_test_types({
+      type_key => {
+        "key" => type_key,
+        "schema" => {
+          "type" => "object",
+          "title" => "An object",
+          "properties" => {
+            "property_one" => {
+              "type" => "string",
+              "title" => "Property One",
+            },
+            "property_two" => {
+              "type" => "string",
+              "title" => "Property Two",
+            },
+          },
+        },
+        "settings" => {
+          "base_path_prefix" => "/government/test",
+          "publishing_api_schema_name" => "schema_name",
+          "publishing_api_document_type" => "document_type",
+          "rendering_app" => "rendering-app",
+        },
+      },
+    })
+    page = FlexiblePage.new
+    page.flexible_page_type = type_key
+    page.document = Document.new
+    page.document.slug = "page-title"
+    page.flexible_page_content = {
+      "property_one" => "Foo",
+      "property_two" => "Bar",
+    }
+    presenter = PublishingApi::FlexiblePagePresenter.new(page)
+    content = presenter.content
+    assert_equal page.flexible_page_content["property_one"], content[:details][:property_one]
+    assert_equal page.flexible_page_content["property_two"], content[:details][:property_two]
   end
 end

--- a/test/unit/app/presenters/publishing_api/payload_builder/flexible_page_content_test.rb
+++ b/test/unit/app/presenters/publishing_api/payload_builder/flexible_page_content_test.rb
@@ -1,0 +1,87 @@
+require "test_helper"
+class PublishingApi::PayloadBuilder::FlexiblePageContentTest < ActiveSupport::TestCase
+  test "it presents basic string fields" do
+    test_schema = {
+      "$schema" => "https://json-schema.org/draft/2020-12/schema",
+      "$id" => "https://www.gov.uk/schemas/test_type/v1",
+      "title" => "Test type",
+      "type" => "object",
+      "properties" => {
+        "test_attribute" => {
+          "title" => "Test attribute",
+          "type" => "string",
+        },
+      },
+    }
+    content = { "test_attribute" => "some text" }
+
+    payload_builder = PublishingApi::PayloadBuilder::FlexiblePageContent.new(test_schema, content)
+
+    assert_equal({ test_attribute: "some text" }, payload_builder.call)
+  end
+
+  test "it presents nested fields" do
+    test_schema = {
+      "$schema" => "https://json-schema.org/draft/2020-12/schema",
+      "$id" => "https://www.gov.uk/schemas/test_type/v1",
+      "title" => "Test type",
+      "type" => "object",
+      "properties" => {
+        "test_object_attribute" => {
+          "title" => "Test attribute",
+          "type" => "object",
+          "properties" => {
+            "test_attribute_one" => {
+              "type" => "string",
+            },
+            "test_attribute_two" => {
+              "type" => "string",
+            },
+          },
+        },
+      },
+    }
+    content = { "test_object_attribute" => {
+      "test_attribute_one" => "foo",
+      "test_attribute_two" => "bar",
+    } }
+
+    payload_builder = PublishingApi::PayloadBuilder::FlexiblePageContent.new(test_schema, content)
+
+    assert_equal({ test_object_attribute: {
+      test_attribute_one: "foo",
+      test_attribute_two: "bar",
+    } }, payload_builder.call)
+  end
+
+  test "it renders govspeak fields into html" do
+    test_schema = {
+      "$schema" => "https://json-schema.org/draft/2020-12/schema",
+      "$id" => "https://www.gov.uk/schemas/test_type/v1",
+      "title" => "Test type",
+      "type" => "object",
+      "properties" => {
+        "test_attribute" => {
+          "title" => "Test attribute",
+          "type" => "string",
+          "format" => "govspeak",
+        },
+      },
+    }
+    govspeak = "## Some Govspeak\n\n%A callout%"
+    html = "<h3>Some govspeak</h3><p class=\"govuk-callout\">A callout</p>"
+    content = {
+      "test_attribute" => govspeak,
+    }
+    govspeak_renderer = mock("Whitehall::GovspeakRenderer")
+    govspeak_renderer
+      .expects(:govspeak_to_html)
+      .with(govspeak)
+      .returns(html)
+
+    Whitehall::GovspeakRenderer.expects(:new).returns(govspeak_renderer)
+    payload_builder = PublishingApi::PayloadBuilder::FlexiblePageContent.new(test_schema, content)
+
+    assert_equal({ test_attribute: html }, payload_builder.call)
+  end
+end


### PR DESCRIPTION
## What

Add support for govspeak to flexible page schemas

## Implementation Notes

Out next move will be to create a cohesive block type abstraction so that we can keep the form input rendering and publishing API presentation behaviour for a block together. We'll put that in a separate PR.

Trello: https://trello.com/c/RLzz9VJe