### PR TITLE
Change rendering app for Call For Evidence pages from government-frontend to frontend

### DIFF
--- a/app/models/call_for_evidence.rb
+++ b/app/models/call_for_evidence.rb
@@ -64,7 +64,7 @@ class CallForEvidence < Publicationesque
   end
 
   def rendering_app
-    Whitehall::RenderingApp::GOVERNMENT_FRONTEND
+    Whitehall::RenderingApp::FRONTEND
   end
 
   def allows_inline_attachments?

--- a/app/presenters/publishing_api/call_for_evidence_presenter.rb
+++ b/app/presenters/publishing_api/call_for_evidence_presenter.rb
@@ -24,7 +24,7 @@ module PublishingApi
           details:,
           document_type:,
           public_updated_at:,
-          rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
+          rendering_app: Whitehall::RenderingApp::FRONTEND,
           schema_name: SCHEMA_NAME,
           links: edition_links,
           auth_bypass_ids: [call_for_evidence.auth_bypass_id],

--- a/test/unit/app/models/call_for_evidence_test.rb
+++ b/test/unit/app/models/call_for_evidence_test.rb
@@ -401,4 +401,8 @@ class CallForEvidenceTest < ActiveSupport::TestCase
     assert_not call_for_evidence.valid?
     assert_includes call_for_evidence.errors[:call_for_evidence_response_form], "must have finished uploading"
   end
+
+  test "is rendered by frontend" do
+    assert CallForEvidence.new.rendering_app == Whitehall::RenderingApp::FRONTEND
+  end
 end

--- a/test/unit/app/presenters/publishing_api/call_for_evidence_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/call_for_evidence_presenter_test.rb
@@ -162,7 +162,7 @@ module PublishingApi::CallForEvidencePresenterTest
     end
 
     test "rendering app" do
-      assert_attribute :rendering_app, "government-frontend"
+      assert_attribute :rendering_app, "frontend"
     end
 
     test "schema name" do


### PR DESCRIPTION
Do not merge until:

- [x] https://github.com/alphagov/frontend/pull/4855 has been merged and deployed

[Trello card](https://trello.com/c/GzNmv0Ag/647-move-callforevidence-from-government-frontend-to-frontend)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
