### PR TITLE
Add a feature test for publishing a flexible page

### DIFF
--- a/features/flexible-pages.feature
+++ b/features/flexible-pages.feature
@@ -6,3 +6,10 @@ Feature: Flexible pages
     And the test flexible page type is defined
     When I draft a new "Test flexible page type" flexible page titled "The history of GOV.UK"
     Then I am on the summary page of the draft titled "The history of GOV.UK"
+
+  Scenario: Force publishing an existing draft flexible page
+    Given I am a editor in the organisation "Department of Examples"
+    And the flexible pages feature flag is enabled
+    And the test flexible page type is defined
+    When I publish a submitted draft of a test flexible page titled "The history of GOV.UK"
+    Then I can see that the draft edition of "The history of GOV.UK" was published successfully


### PR DESCRIPTION
The existing flexible page test only covered saving a draft flexible page. I felt it would be reassuring to have a feature covering publishing too, because the flexible page presenter is a reasonably likely source of bugs. Only having unit test coverage of the presenter felt a little bit risky.

Not directly linked to a particular Trello ticket.

I'm going to need to think about how to create a factory bot factory for these at some point, because setting us test flexible page editions is a little bit painful.
