### PR TITLE
(CM-187) Opening hours

### DIFF
--- a/lib/engines/content_block_manager/app/assets/stylesheets/content_block_manager/application.scss
+++ b/lib/engines/content_block_manager/app/assets/stylesheets/content_block_manager/application.scss
@@ -5,6 +5,8 @@
 @import "components/filter-options-component";
 @import "components/host-editions-rollup-component";
 @import "components/host-editions-table-component";
+@import "components/opening-hours-component";
+@import "components/opening-hours-item-component";
 @import "components/timeline-component";
 
 @import "views/content_block_manager_header";

--- a/lib/engines/content_block_manager/app/assets/stylesheets/content_block_manager/components/_opening-hours-component.scss
+++ b/lib/engines/content_block_manager/app/assets/stylesheets/content_block_manager/components/_opening-hours-component.scss
@@ -1,0 +1,13 @@
+.app-c-content-block-manager-opening-hours-component {
+  .gem-c-fieldset {
+    background-color: govuk-colour("white");
+  }
+
+  .gem-c-checkboxes > .govuk-fieldset > .govuk-fieldset__legend {
+    @extend .govuk-visually-hidden;
+  }
+
+  .js-add-another__fieldset > .govuk-fieldset > .govuk-fieldset__legend {
+    @extend .govuk-visually-hidden;
+  }
+}

--- a/lib/engines/content_block_manager/app/assets/stylesheets/content_block_manager/components/_opening-hours-item-component.scss
+++ b/lib/engines/content_block_manager/app/assets/stylesheets/content_block_manager/components/_opening-hours-item-component.scss
@@ -18,4 +18,12 @@
       }
     }
   }
+
+  &__time-group {
+    @extend .govuk-date-input__item;
+
+    &--error {
+      @extend .govuk-form-group--error;
+    }
+  }
 }

--- a/lib/engines/content_block_manager/app/assets/stylesheets/content_block_manager/components/_opening-hours-item-component.scss
+++ b/lib/engines/content_block_manager/app/assets/stylesheets/content_block_manager/components/_opening-hours-item-component.scss
@@ -1,0 +1,21 @@
+.app-c-content-block-manager-opening-hours-item-component {
+  .gem-c-fieldset {
+    margin: 0;
+    padding: 0 0 govuk-spacing(2);
+  }
+
+  &__input-group {
+    @extend .govuk-date-input;
+  }
+
+  &__input-item {
+    @extend .govuk-date-input__item;
+
+    &--time {
+      select {
+        @extend .govuk-input--width-3;
+        min-width: 0;
+      }
+    }
+  }
+}

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/array_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/array_component.rb
@@ -15,12 +15,12 @@ private
         { fields: render(component(index)) }
       end
     else
-      [{ fields: empty }]
+      [{ fields: render(component(0)) }]
     end
   end
 
   def empty
-    render component(value.count + 1)
+    render component(value.count.positive? ? value.count : 1)
   end
 
   def component(index)

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/opening_hours/item_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/opening_hours/item_component.html.erb
@@ -1,0 +1,64 @@
+<div class="app-c-content-block-manager-opening-hours-item-component">
+  <%= render "govuk_publishing_components/components/fieldset", {
+    legend_text: "Days",
+    heading_level: 3,
+    heading_size: "m",
+  } do %>
+    <% capture do %>
+      <div class="govuk-hint">
+        For example, Monday to Friday
+      </div>
+      <div class="app-c-content-block-manager-opening-hours-item-component__input-group">
+        <div class="app-c-content-block-manager-opening-hours-item-component__input-item">
+          <%= render "govuk_publishing_components/components/select", day_arguments("day_from") %>
+        </div>
+
+        <div class="app-c-content-block-manager-opening-hours-item-component__input-item">
+          <p class="govuk-body">To</p>
+        </div>
+
+        <div class="app-c-content-block-manager-opening-hours-item-component__input-item">
+          <%= render "govuk_publishing_components/components/select", day_arguments("day_to") %>
+        </div>
+      </div>
+    <% end %>
+  <% end %>
+
+  <%= render "govuk_publishing_components/components/fieldset", {
+    legend_text: "Time",
+    heading_level: 3,
+    heading_size: "m",
+  } do %>
+    <% capture do %>
+      <div class="govuk-hint">
+        For example, 8:30am to 4:30pm
+      </div>
+
+      <div class="app-c-content-block-manager-opening-hours-item-component__input-group">
+        <div class="app-c-content-block-manager-opening-hours-item-component__input-item app-c-content-block-manager-opening-hours-item-component__input-item--time">
+          <%= render "govuk_publishing_components/components/select", hour_arguments("time_from(h)") %>
+        </div>
+        <div class="app-c-content-block-manager-opening-hours-item-component__input-item app-c-content-block-manager-opening-hours-item-component__input-item--time">
+          <%= render "govuk_publishing_components/components/select", minute_arguments("time_from(m)") %>
+        </div>
+        <div class="app-c-content-block-manager-opening-hours-item-component__input-item app-c-content-block-manager-opening-hours-item-component__input-item--time">
+          <%= render "govuk_publishing_components/components/select", meridian_arguments("time_from(meridian)") %>
+        </div>
+
+        <div class="app-c-content-block-manager-opening-hours-item-component__input-item">
+          <p class="govuk-body">To</p>
+        </div>
+
+        <div class="app-c-content-block-manager-opening-hours-item-component__input-item app-c-content-block-manager-opening-hours-item-component__input-item--time">
+          <%= render "govuk_publishing_components/components/select", hour_arguments("time_to(h)") %>
+        </div>
+        <div class="app-c-content-block-manager-opening-hours-item-component__input-item app-c-content-block-manager-opening-hours-item-component__input-item--time">
+          <%= render "govuk_publishing_components/components/select", minute_arguments("time_to(m)") %>
+        </div>
+        <div class="app-c-content-block-manager-opening-hours-item-component__input-item app-c-content-block-manager-opening-hours-item-component__input-item--time">
+          <%= render "govuk_publishing_components/components/select", meridian_arguments("time_to(meridian)") %>
+        </div>
+      </div>
+    <% end %>
+  <% end %>
+</div>

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/opening_hours/item_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/opening_hours/item_component.html.erb
@@ -35,29 +35,38 @@
       </div>
 
       <div class="app-c-content-block-manager-opening-hours-item-component__input-group">
-        <div class="app-c-content-block-manager-opening-hours-item-component__input-item app-c-content-block-manager-opening-hours-item-component__input-item--time">
-          <%= render "govuk_publishing_components/components/select", hour_arguments("time_from(h)") %>
-        </div>
-        <div class="app-c-content-block-manager-opening-hours-item-component__input-item app-c-content-block-manager-opening-hours-item-component__input-item--time">
-          <%= render "govuk_publishing_components/components/select", minute_arguments("time_from(m)") %>
-        </div>
-        <div class="app-c-content-block-manager-opening-hours-item-component__input-item app-c-content-block-manager-opening-hours-item-component__input-item--time">
-          <%= render "govuk_publishing_components/components/select", meridian_arguments("time_from(meridian)") %>
+        <div class="app-c-content-block-manager-opening-hours-item-component__time-group <%= time_error_class("time_from") %>" id="<%= id_prefix %>_<%= index %>_time_from">
+          <%= time_error_message("time_from") %>
+
+          <div class="app-c-content-block-manager-opening-hours-item-component__input-item app-c-content-block-manager-opening-hours-item-component__input-item--time">
+            <%= render "govuk_publishing_components/components/select", hour_arguments("time_from(h)") %>
+          </div>
+          <div class="app-c-content-block-manager-opening-hours-item-component__input-item app-c-content-block-manager-opening-hours-item-component__input-item--time">
+            <%= render "govuk_publishing_components/components/select", minute_arguments("time_from(m)") %>
+          </div>
+          <div class="app-c-content-block-manager-opening-hours-item-component__input-item app-c-content-block-manager-opening-hours-item-component__input-item--time">
+            <%= render "govuk_publishing_components/components/select", meridian_arguments("time_from(meridian)") %>
+          </div>
         </div>
 
         <div class="app-c-content-block-manager-opening-hours-item-component__input-item">
           <p class="govuk-body">To</p>
         </div>
 
-        <div class="app-c-content-block-manager-opening-hours-item-component__input-item app-c-content-block-manager-opening-hours-item-component__input-item--time">
-          <%= render "govuk_publishing_components/components/select", hour_arguments("time_to(h)") %>
+        <div class="app-c-content-block-manager-opening-hours-item-component__time-group <%= time_error_class("time_to") %>" id="<%= id_prefix %>_<%= index %>_time_to">
+          <%= time_error_message("time_to") %>
+
+          <div class="app-c-content-block-manager-opening-hours-item-component__input-item app-c-content-block-manager-opening-hours-item-component__input-item--time">
+            <%= render "govuk_publishing_components/components/select", hour_arguments("time_to(h)") %>
+          </div>
+          <div class="app-c-content-block-manager-opening-hours-item-component__input-item app-c-content-block-manager-opening-hours-item-component__input-item--time">
+            <%= render "govuk_publishing_components/components/select", minute_arguments("time_to(m)") %>
+          </div>
+          <div class="app-c-content-block-manager-opening-hours-item-component__input-item app-c-content-block-manager-opening-hours-item-component__input-item--time">
+            <%= render "govuk_publishing_components/components/select", meridian_arguments("time_to(meridian)") %>
+          </div>
         </div>
-        <div class="app-c-content-block-manager-opening-hours-item-component__input-item app-c-content-block-manager-opening-hours-item-component__input-item--time">
-          <%= render "govuk_publishing_components/components/select", minute_arguments("time_to(m)") %>
-        </div>
-        <div class="app-c-content-block-manager-opening-hours-item-component__input-item app-c-content-block-manager-opening-hours-item-component__input-item--time">
-          <%= render "govuk_publishing_components/components/select", meridian_arguments("time_to(meridian)") %>
-        </div>
+
       </div>
     <% end %>
   <% end %>

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/opening_hours/item_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/opening_hours/item_component.rb
@@ -1,0 +1,94 @@
+class ContentBlockManager::ContentBlockEdition::Details::Fields::OpeningHours::ItemComponent < ViewComponent::Base
+  DAYS = Date::DAYNAMES.rotate(1)
+  HOURS = (1..12).to_a
+  MINUTES = (0..59).map { |i| sprintf("%02d", i) }
+  MERIDIAN = %w[AM PM].freeze
+
+  def initialize(name_prefix:, id_prefix:, value:, index:, field:)
+    @name_prefix = name_prefix
+    @id_prefix = id_prefix
+    @value = value
+    @index = index
+    @field = field
+  end
+
+private
+
+  attr_reader :name_prefix, :id_prefix, :value, :index, :field
+
+  def day_arguments(field_name)
+    select_arguments(field_name).merge(
+      options: options(field_name, DAYS)
+    )
+  end
+
+  def hour_arguments(field_name)
+    select_arguments(field_name).merge(
+      options: options(field_name, HOURS),
+    )
+  end
+
+  def minute_arguments(field_name)
+    select_arguments(field_name).merge(
+      options: options(field_name, MINUTES),
+    )
+  end
+
+  def meridian_arguments(field_name)
+    select_arguments(field_name).merge(
+      options: options(field_name, %w[AM PM]),
+    )
+  end
+
+  def select_arguments(field_name)
+    {
+      label: I18n.t("content_block_edition.details.labels.contacts.telephones.opening_hours.#{field_name}"),
+      name: "#{name_prefix}[][#{field_name}]",
+      id: "#{id_prefix}_#{index}_#{field_name.parameterize.underscore}",
+    }
+  end
+
+  def options(field_name, items)
+    options = [{
+      text: "Select",
+      value: "",
+      selected: value_for_field(field_name).nil?,
+    }]
+
+    items.each do |item|
+      options << {
+        text: item,
+        value: item,
+        selected: value_for_field(field_name) == item.to_s,
+      }
+    end
+
+    options
+  end
+
+  def value_for_field(field_name)
+    return nil if value.blank?
+
+    if field_name =~ /([a-z_]+)\((h|m|meridian)\)/
+      time = value_for_field(::Regexp.last_match(1)) || ""
+      value_for_time_field(time, ::Regexp.last_match(2))
+    else
+      field_value&.fetch(field_name, nil)
+    end
+  end
+
+  def value_for_time_field(time, part)
+    case part
+    when "h"
+      time.split(":").first
+    when "m"
+      time.split(":").last.try { |val| val[0..1] }
+    else
+      time[-2..]
+    end
+  end
+
+  def field_value
+    value[index]
+  end
+end

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/opening_hours_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/opening_hours_component.html.erb
@@ -1,0 +1,19 @@
+<div class="app-c-content-block-manager-opening-hours-component">
+  <%= render "govuk_publishing_components/components/checkboxes", {
+    name: "hours_available",
+    id: "hours_available",
+    heading: "Opening hours",
+    no_hint_text: true,
+    small: true,
+    items: [
+      {
+        label: "Hours available",
+        value: "1",
+        checked: value.any?,
+        conditional: capture do
+          render_parent
+        end,
+      },
+    ],
+  } %>
+</div>

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/opening_hours_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/opening_hours_component.rb
@@ -1,0 +1,17 @@
+class ContentBlockManager::ContentBlockEdition::Details::Fields::OpeningHoursComponent < ContentBlockManager::ContentBlockEdition::Details::Fields::ArrayComponent
+private
+
+  def label
+    "Opening Hours"
+  end
+
+  def component(index)
+    ContentBlockManager::ContentBlockEdition::Details::Fields::OpeningHours::ItemComponent.new(
+      name_prefix: name,
+      id_prefix: id,
+      value: value,
+      index:,
+      field:,
+    )
+  end
+end

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/opening_hours_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/opening_hours_component.rb
@@ -2,7 +2,7 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::OpeningHoursCom
 private
 
   def label
-    "Opening Hours"
+    "Opening Hour"
   end
 
   def component(index)

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/opening_hours_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/opening_hours_component.rb
@@ -12,6 +12,7 @@ private
       value: value,
       index:,
       field:,
+      errors:,
     )
   end
 end

--- a/lib/engines/content_block_manager/app/controllers/concerns/embedded_objects.rb
+++ b/lib/engines/content_block_manager/app/controllers/concerns/embedded_objects.rb
@@ -1,5 +1,6 @@
 module EmbeddedObjects
   extend ActiveSupport::Concern
+  include ParamsPreprocessor
 
   def get_schema_and_subschema(block_type, object_type)
     schema = get_schema(block_type)
@@ -17,7 +18,7 @@ module EmbeddedObjects
   end
 
   def object_params(subschema)
-    params.require("content_block/edition").permit(
+    processed_params.require("content_block/edition").permit(
       details: {
         subschema.block_type.to_s => subschema.permitted_params,
       },

--- a/lib/engines/content_block_manager/app/controllers/concerns/params_preprocessor.rb
+++ b/lib/engines/content_block_manager/app/controllers/concerns/params_preprocessor.rb
@@ -1,0 +1,18 @@
+module ParamsPreprocessor
+  extend ActiveSupport::Concern
+
+  PREPROCESSORS = {
+    "telephones" => ParamsPreprocessors::TelephonePreprocessor,
+  }.freeze
+
+  def processed_params
+    @processed_params ||= begin
+      preprocessor = PREPROCESSORS[params[:object_type]]
+      if preprocessor
+        preprocessor.new(params).processed_params
+      else
+        params
+      end
+    end
+  end
+end

--- a/lib/engines/content_block_manager/app/controllers/concerns/params_preprocessors/telephone_preprocessor.rb
+++ b/lib/engines/content_block_manager/app/controllers/concerns/params_preprocessors/telephone_preprocessor.rb
@@ -1,0 +1,42 @@
+class ParamsPreprocessors::TelephonePreprocessor
+  def initialize(params)
+    @params = params
+  end
+
+  def processed_params
+    process!
+    params
+  end
+
+  def process!
+    if params.dig("content_block/edition", "details", "telephones", "opening_hours")
+      params["hours_available"] ? format_opening_hours : strip_opening_hours
+    end
+  end
+
+private
+
+  attr_accessor :params
+
+  def format_opening_hours
+    params["content_block/edition"]["details"]["telephones"]["opening_hours"].map! do |hours|
+      {
+        "day_from" => hours["day_from"],
+        "day_to" => hours["day_to"],
+        "time_from" => format_time(hours, "time_from"),
+        "time_to" => format_time(hours, "time_to"),
+      }
+    end
+  end
+
+  def strip_opening_hours
+    params["content_block/edition"]["details"]["telephones"]["opening_hours"] = []
+  end
+
+  def format_time(hours, prefix)
+    h = hours["#{prefix}(h)"]
+    m = hours["#{prefix}(m)"]
+    meridian = hours["#{prefix}(meridian)"]
+    "#{h}:#{m}#{meridian}"
+  end
+end

--- a/lib/engines/content_block_manager/app/validators/content_block_manager/details_validator.rb
+++ b/lib/engines/content_block_manager/app/validators/content_block_manager/details_validator.rb
@@ -28,7 +28,7 @@ class ContentBlockManager::DetailsValidator < ActiveModel::Validator
     data_pointer = error["data_pointer"].delete_prefix("/")
     field_items = data_pointer.split("/")
     attribute = field_items.last
-    key = field_items.count > 1 ? "#{field_items.first}_#{attribute}" : attribute
+    key = key_with_optional_prefix(error, nil)
     edition.errors.add(
       "details_#{key}",
       I18n.t("activerecord.errors.models.content_block_manager/content_block/edition.invalid", attribute: attribute.humanize),

--- a/lib/engines/content_block_manager/config/content_block_manager.yml
+++ b/lib/engines/content_block_manager/config/content_block_manager.yml
@@ -38,6 +38,7 @@ schemas:
         field_order:
           - title
           - telephone_numbers
+          - opening_hours
           - show_uk_call_charges
           - description
         fields:
@@ -47,6 +48,9 @@ schemas:
           show_uk_call_charges:
             component:
               boolean
+          opening_hours:
+            component:
+              opening_hours
       addresses:
         group: modes
         group_order: 3

--- a/lib/engines/content_block_manager/config/locales/en.yml
+++ b/lib/engines/content_block_manager/config/locales/en.yml
@@ -62,3 +62,14 @@ en:
       labels:
         telephones:
           show_uk_call_charges: "Show UK call charges"
+        contacts:
+          telephones:
+            opening_hours:
+              day_from: From
+              day_to: To
+              time_from(h): Hours
+              time_from(m): Minutes
+              time_from(meridian): AM/PM
+              time_to(h): Hours
+              time_to(m): Minutes
+              time_to(meridian): AM/PM

--- a/lib/engines/content_block_manager/features/create_contact_object.feature
+++ b/lib/engines/content_block_manager/features/create_contact_object.feature
@@ -79,6 +79,34 @@ Feature: Create a contact object
             "true",
             "false"
           ]
+        },
+        "opening_hours": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "day_from",
+              "day_to",
+              "time_from",
+              "time_to"
+            ],
+            "properties": {
+              "day_from": {
+                "type": "string"
+              },
+              "day_to": {
+                "type": "string"
+              },
+              "time_from": {
+                "type": "string",
+                "pattern": "^[0-9]{1,2}:[0-9]{2}AM|PM$"
+              },
+              "time_to": {
+                "type": "string",
+                "pattern": "^[0-9]{1,2}:[0-9]{2}AM|PM$"
+              }
+            }
+          }
         }
       }
     }
@@ -107,6 +135,10 @@ Feature: Create a contact object
       | label       | telephone_number | type      |
       | Telephone 1 | 12345            | Telephone |
       | Telephone 2 | 6789             | Textphone |
+    And I add the following "opening_hours" to the form:
+      | day_from | day_to | time_from | time_to |
+      | Monday   | Friday | 9:00AM    | 5:00PM  |
+      | Saturday | Sunday  | 10:00AM   | 3:00PM  |
     And I choose "Yes"
     And I save and continue
     Then I should be on the "add_group_modes" step

--- a/lib/engines/content_block_manager/features/step_definitions/embedded_object_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/embedded_object_steps.rb
@@ -28,6 +28,26 @@ end
 
 And("I add the following {string} to the form:") do |item_type, table|
   fields = table.hashes
+
+  if item_type == "opening_hours"
+    fields.map! do |item|
+      time_from = item.delete("time_from")
+      time_to = item.delete("time_to")
+
+      item["time_from(h)"] = time_from.split(":")[0]
+      item["time_from(m)"] = time_from.split(":")[1][0..1]
+      item["time_from(meridian)"] = time_from[-2..]
+
+      item["time_to(h)"] = time_to.split(":")[0]
+      item["time_to(m)"] = time_to.split(":")[1][0..1]
+      item["time_to(meridian)"] = time_to[-2..]
+
+      item
+    end
+
+    check "Hours available"
+  end
+
   fields.each do |row|
     field_prefix = "content_block/edition[details][#{@object_type.pluralize}][#{item_type}][]"
 
@@ -42,7 +62,9 @@ And("I add the following {string} to the form:") do |item_type, table|
       end
     end
 
-    click_on "Add a #{item_type.humanize.singularize}" unless row == fields.last
+    page.driver.with_playwright_page do |page|
+      page.get_by_text("Add #{add_indefinite_article item_type.humanize.singularize}").click unless row == fields.last
+    end
   end
 end
 

--- a/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/array_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/array_component_test.rb
@@ -25,11 +25,11 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::ArrayComponentT
         component.assert_selector ".js-add-another__empty", count: 1
 
         component.assert_selector ".js-add-another__fieldset", text: /Item 1/ do |fieldset|
-          expect_form_fields(fieldset, 1)
+          expect_form_fields(fieldset, 0)
         end
 
         component.assert_selector ".js-add-another__empty", text: /Item 2/ do |fieldset|
-          expect_form_fields(fieldset, 2)
+          expect_form_fields(fieldset, 1)
         end
       end
     end
@@ -46,15 +46,15 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::ArrayComponentT
         component.assert_selector ".js-add-another__empty", count: 1
 
         component.assert_selector ".js-add-another__fieldset", text: /Item 1/ do |fieldset|
-          expect_form_fields(fieldset, 1, "foo")
+          expect_form_fields(fieldset, 0, "foo")
         end
 
         component.assert_selector ".js-add-another__fieldset", text: /Item 2/ do |fieldset|
-          expect_form_fields(fieldset, 2, "bar")
+          expect_form_fields(fieldset, 1, "bar")
         end
 
         component.assert_selector ".js-add-another__empty", text: /Item 3/ do |fieldset|
-          expect_form_fields(fieldset, 3)
+          expect_form_fields(fieldset, 2)
         end
       end
     end
@@ -63,7 +63,7 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::ArrayComponentT
 private
 
   def expect_form_fields(fieldset, index, value = nil)
-    fieldset.assert_selector ".govuk-fieldset__legend", text: "Item #{index}"
+    fieldset.assert_selector ".govuk-fieldset__legend", text: "Item #{index + 1}"
     fieldset.assert_selector ".govuk-form-group", count: 1
     fieldset.assert_selector ".govuk-form-group" do |form_group|
       form_group.assert_selector "input[value='#{value}']" unless value.nil?

--- a/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/opening_hours_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/opening_hours_component_test.rb
@@ -1,0 +1,150 @@
+require "test_helper"
+
+class ContentBlockManager::ContentBlockEdition::Details::Fields::OpeningHoursComponentTest < ViewComponent::TestCase
+  extend Minitest::Spec::DSL
+
+  let(:content_block_edition) { build(:content_block_edition, :pension) }
+  let(:field) { stub("field", name: "items", is_required?: true) }
+  let(:field_value) { nil }
+
+  let(:days) { ContentBlockManager::ContentBlockEdition::Details::Fields::OpeningHours::ItemComponent::DAYS }
+  let(:hours) { ContentBlockManager::ContentBlockEdition::Details::Fields::OpeningHours::ItemComponent::HOURS }
+  let(:minutes) { ContentBlockManager::ContentBlockEdition::Details::Fields::OpeningHours::ItemComponent::MINUTES }
+  let(:meridian) { ContentBlockManager::ContentBlockEdition::Details::Fields::OpeningHours::ItemComponent::MERIDIAN }
+
+  let(:component) do
+    ContentBlockManager::ContentBlockEdition::Details::Fields::OpeningHoursComponent.new(
+      content_block_edition:,
+      field:,
+      value: field_value,
+    )
+  end
+
+  describe "when there are no items present" do
+    it "renders with one empty item and a template" do
+      render_inline component
+
+      assert_selector ".govuk-checkboxes__conditional" do |conditional|
+        conditional.assert_selector ".gem-c-add-another" do |component|
+          component.assert_selector ".js-add-another__fieldset", count: 1
+          component.assert_selector ".js-add-another__empty", count: 1
+
+          component.assert_selector ".js-add-another__fieldset", text: /Opening Hour 1/ do |fieldset|
+            expect_form_fields(fieldset, 0)
+          end
+
+          component.assert_selector ".js-add-another__empty", text: /Opening Hour 2/ do |fieldset|
+            expect_form_fields(fieldset, 1)
+          end
+        end
+      end
+    end
+  end
+
+  describe "when there are items present" do
+    let(:field_value) do
+      [
+        {
+          "day_from" => "Tuesday",
+          "day_to" => "Friday",
+          "time_from" => "9:30AM",
+          "time_to" => "5:45PM",
+        },
+        {
+          "day_from" => "Saturday",
+          "day_to" => "Sunday",
+          "time_from" => "12:00PM",
+          "time_to" => "3:00PM",
+        },
+      ]
+    end
+
+    it "renders a fieldset for each item and a template" do
+      render_inline component
+
+      assert_selector ".govuk-checkboxes__conditional" do |conditional|
+        conditional.assert_selector ".gem-c-add-another" do |component|
+          component.assert_selector ".js-add-another__fieldset", count: 2
+          component.assert_selector ".js-add-another__empty", count: 1
+
+          component.assert_selector ".js-add-another__fieldset", text: "Opening Hour 1" do |fieldset|
+            expect_form_fields(fieldset, 0)
+
+            fieldset.assert_selector "select[name='content_block/edition[details][items][][day_from]'] option[value='Tuesday'][selected]"
+            fieldset.assert_selector "select[name='content_block/edition[details][items][][day_to]'] option[value='Friday'][selected]"
+
+            fieldset.assert_selector "select[name='content_block/edition[details][items][][time_from(h)]'] option[value='9'][selected]"
+            fieldset.assert_selector "select[name='content_block/edition[details][items][][time_from(m)]'] option[value='30'][selected]"
+            fieldset.assert_selector "select[name='content_block/edition[details][items][][time_from(meridian)]'] option[value='AM'][selected]"
+
+            fieldset.assert_selector "select[name='content_block/edition[details][items][][time_to(h)]'] option[value='5'][selected]"
+            fieldset.assert_selector "select[name='content_block/edition[details][items][][time_to(m)]'] option[value='45'][selected]"
+            fieldset.assert_selector "select[name='content_block/edition[details][items][][time_to(meridian)]'] option[value='PM'][selected]"
+          end
+
+          component.assert_selector ".js-add-another__fieldset", text: "Opening Hour 2" do |fieldset|
+            expect_form_fields(fieldset, 1)
+
+            fieldset.assert_selector "select[name='content_block/edition[details][items][][day_from]'] option[value='Saturday'][selected]"
+            fieldset.assert_selector "select[name='content_block/edition[details][items][][day_to]'] option[value='Sunday'][selected]"
+
+            fieldset.assert_selector "select[name='content_block/edition[details][items][][time_from(h)]'] option[value='12'][selected]"
+            fieldset.assert_selector "select[name='content_block/edition[details][items][][time_from(m)]'] option[value='00'][selected]"
+            fieldset.assert_selector "select[name='content_block/edition[details][items][][time_from(meridian)]'] option[value='PM'][selected]"
+
+            fieldset.assert_selector "select[name='content_block/edition[details][items][][time_to(h)]'] option[value='3'][selected]"
+            fieldset.assert_selector "select[name='content_block/edition[details][items][][time_to(m)]'] option[value='00'][selected]"
+            fieldset.assert_selector "select[name='content_block/edition[details][items][][time_to(meridian)]'] option[value='PM'][selected]"
+          end
+
+          component.assert_selector ".js-add-another__empty", text: "Opening Hour 3" do |fieldset|
+            expect_form_fields(fieldset, 2)
+          end
+        end
+      end
+    end
+  end
+
+private
+
+  def expect_form_fields(fieldset, index)
+    fieldset.assert_selector ".govuk-fieldset__legend", text: "Opening Hour #{index + 1}"
+    fieldset.assert_selector ".app-c-content-block-manager-opening-hours-item-component" do |component|
+      component.assert_selector ".govuk-fieldset", text: "Days" do |days_fieldset|
+        days_fieldset.assert_selector "select#content_block_manager_content_block_edition_details_items_#{index}_day_from" do |select|
+          days.each do |day|
+            select.assert_selector "option[value='#{day}']", text: day
+          end
+        end
+
+        days_fieldset.assert_selector "select#content_block_manager_content_block_edition_details_items_#{index}_day_to" do |select|
+          days.each do |day|
+            select.assert_selector "option[value='#{day}']", text: day
+          end
+        end
+      end
+
+      component.assert_selector ".govuk-fieldset", text: "Time" do |time_fieldset|
+        %w[from to].each do |from_to|
+          time_fieldset.assert_selector "select#content_block_manager_content_block_edition_details_items_#{index}_time_#{from_to}_h" do |select|
+            hours.each do |hour|
+              select.assert_selector "option[value='#{hour}']", text: hour
+            end
+          end
+
+          time_fieldset.assert_selector "select#content_block_manager_content_block_edition_details_items_#{index}_time_#{from_to}_m" do |select|
+            minutes.each do |minute|
+              select.assert_selector "option[value='#{minute}']", text: minute
+            end
+          end
+
+          time_fieldset.assert_selector "select#content_block_manager_content_block_edition_details_items_#{index}_time_#{from_to}_meridian" do |select|
+            meridian.each do |am_pm|
+              select.assert_selector "option[value='#{am_pm}']", text: am_pm
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/opening_hours_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/opening_hours_component_test.rb
@@ -103,6 +103,52 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::OpeningHoursCom
         end
       end
     end
+
+    describe "when errors are present" do
+      let(:errors) do
+        [
+          stub(:error, attribute: :details_items_0_day_from, full_message: "Day from can't be blank"),
+          stub(:error, attribute: :details_items_0_day_to, full_message: "Day to can't be blank"),
+          stub(:error, attribute: :details_items_0_time_from, full_message: "Time from is invalid"),
+          stub(:error, attribute: :details_items_0_time_to, full_message: "Time to is invalid"),
+        ]
+      end
+
+      before do
+        content_block_edition.stubs(:errors).returns(errors)
+      end
+
+      it "displays the errors" do
+        render_inline component
+
+        assert_selector ".govuk-checkboxes__conditional" do |conditional|
+          conditional.assert_selector ".gem-c-add-another" do |component|
+            component.assert_selector ".js-add-another__fieldset", count: 2
+            component.assert_selector ".js-add-another__empty", count: 1
+
+            component.assert_selector ".js-add-another__fieldset", text: "Opening Hour 1" do |fieldset|
+              fieldset.assert_selector ".govuk-form-group--error", text: "Day from can't be blank" do |form_group|
+                form_group.assert_selector ".govuk-error-message", text: "Day from can't be blank"
+                form_group.assert_selector "#content_block_manager_content_block_edition_details_items_0_day_from.govuk-select--error"
+              end
+
+              fieldset.assert_selector ".govuk-form-group--error", text: "Day to can't be blank" do |form_group|
+                form_group.assert_selector ".govuk-error-message", text: "Day to can't be blank"
+                form_group.assert_selector "#content_block_manager_content_block_edition_details_items_0_day_to.govuk-select--error"
+              end
+
+              fieldset.assert_selector ".app-c-content-block-manager-opening-hours-item-component__time-group--error", text: "Time from is invalid" do |form_group|
+                form_group.assert_selector ".govuk-error-message", text: "Time from is invalid"
+              end
+
+              fieldset.assert_selector ".app-c-content-block-manager-opening-hours-item-component__time-group--error", text: "Time to is invalid" do |form_group|
+                form_group.assert_selector ".govuk-error-message", text: "Time to is invalid"
+              end
+            end
+          end
+        end
+      end
+    end
   end
 
 private

--- a/lib/engines/content_block_manager/test/unit/app/controllers/concerns/params_preprocessor_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/controllers/concerns/params_preprocessor_test.rb
@@ -1,0 +1,34 @@
+require "test_helper"
+
+class ParamsPreprocessorClass
+  include ParamsPreprocessor
+
+  attr_reader :params
+
+  def initialize(params)
+    @params = params
+  end
+end
+
+class ContentBlockManager::ContentBlock::ParamsPreprocessorClassTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
+  let(:params) { { object_type:, "something" => "else" } }
+
+  let(:object) { ParamsPreprocessorClass.new(params) }
+
+  describe "when object type is `telephones`" do
+    let(:object_type) { "telephones" }
+
+    it "should call the TelephonePreprocessor" do
+      processed_params = stub(:processed_params)
+      preprocessor = stub(:preprocessor, processed_params:)
+
+      ParamsPreprocessors::TelephonePreprocessor.expects(:new)
+                                                .with(params)
+                                                .returns(preprocessor)
+
+      assert_equal object.processed_params, processed_params
+    end
+  end
+end

--- a/lib/engines/content_block_manager/test/unit/app/controllers/concerns/params_preprocessors/telephone_preprocessor_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/controllers/concerns/params_preprocessors/telephone_preprocessor_test.rb
@@ -1,0 +1,84 @@
+require "test_helper"
+
+class ParamsPreprocessors::TelephonePreprocessorTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
+  let(:opening_hours) do
+    [
+      {
+        "day_from" => "Monday",
+        "day_to" => "Friday",
+        "time_from(h)" => "9",
+        "time_from(m)" => "00",
+        "time_from(meridian)" => "AM",
+        "time_to(h)" => "5",
+        "time_to(m)" => "30",
+        "time_to(meridian)" => "PM",
+      },
+    ]
+  end
+
+  let(:details) do
+    {
+      "telephones" => {
+        "opening_hours" => opening_hours,
+      },
+    }
+  end
+
+  let(:params) do
+    {
+      "hours_available" => hours_available,
+      "content_block/edition" => {
+        "details" => details,
+      },
+    }
+  end
+
+  describe "when hours_available is set" do
+    let(:hours_available) { "1" }
+
+    it "formats the opening hours correctly" do
+      result = ParamsPreprocessors::TelephonePreprocessor.new(params).processed_params
+      expected_result = {
+        "hours_available" => "1",
+        "content_block/edition" => {
+          "details" => {
+            "telephones" => {
+              "opening_hours" => [
+                {
+                  "day_from" => "Monday",
+                  "day_to" => "Friday",
+                  "time_from" => "9:00AM",
+                  "time_to" => "5:30PM",
+                },
+              ],
+            },
+          },
+        },
+      }
+
+      assert_equal result, expected_result
+    end
+  end
+
+  describe "when hours_available is not set" do
+    let(:hours_available) { nil }
+
+    it "clears the opening_hours array" do
+      result = ParamsPreprocessors::TelephonePreprocessor.new(params).processed_params
+      expected_result = {
+        "hours_available" => nil,
+        "content_block/edition" => {
+          "details" => {
+            "telephones" => {
+              "opening_hours" => [],
+            },
+          },
+        },
+      }
+
+      assert_equal result, expected_result
+    end
+  end
+end

--- a/lib/engines/content_block_manager/test/unit/app/validators/details_validator_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/validators/details_validator_test.rb
@@ -179,6 +179,7 @@ class ContentBlockManager::DetailsValidatorTest < ActiveSupport::TestCase
                       "properties" => {
                         "foo" => {
                           "type" => "string",
+                          "pattern" => "valid",
                         },
                         "bar" => {
                           "type" => "string",
@@ -222,6 +223,36 @@ class ContentBlockManager::DetailsValidatorTest < ActiveSupport::TestCase
       assert_equal content_block_edition.valid?, false
       errors = content_block_edition.errors
       assert_error errors:, key: :details_things_array_of_objects_1_foo, type: "blank", attribute: "Foo"
+    end
+
+    it "returns an error if an item is invalid in an array of objects" do
+      content_block_edition = build(
+        :content_block_edition,
+        :pension,
+        details: {
+          foo: "foo@example.com",
+          bar: "2022-01-01",
+          things: {
+            "something-else": {
+              array_of_objects: [
+                {
+                  foo: "not correct",
+                  bar: "something",
+                },
+                {
+                  foo: "",
+                  bar: "something",
+                },
+              ],
+            },
+          },
+        },
+        schema:,
+      )
+
+      assert_equal content_block_edition.valid?, false
+      errors = content_block_edition.errors
+      assert_error errors:, key: :details_things_array_of_objects_0_foo, type: "invalid", attribute: "Foo"
     end
   end
 


### PR DESCRIPTION
This adds a custom component to allow opening hours to be added to a telephone object. This was a bit tricky as we expect the times to be presented as select boxes, rather than fields. After a few false starts, I decided that we should store the start and end times as single strings, using a preprocessor to join them when they are submitted. The schema has a regex to check the times are in the correct format, so if any part of the time(s) are missing, the data will not validate against the schema.

## Screenshots

![image](https://github.com/user-attachments/assets/056ae1e1-d28a-4552-93f6-a2530af48667)

![image](https://github.com/user-attachments/assets/2716152b-e00c-4240-97a8-32ba46b837e0)
