### PR TITLE
CM-185: Introduce value translation for details on an edition

### DIFF
--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/embedded_objects/metadata_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/embedded_objects/metadata_component.rb
@@ -13,7 +13,7 @@ private
     items.map do |key, value|
       {
         field: humanized_label(key, @object_type),
-        value: value,
+        value: translated_value(value),
       }
     end
   end

--- a/lib/engines/content_block_manager/app/components/content_block_manager/shared/embedded_objects/summary_card_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/shared/embedded_objects/summary_card_component.rb
@@ -1,5 +1,6 @@
 class ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponent < ViewComponent::Base
   include ContentBlockManager::ContentBlock::SummaryListHelper
+  include ContentBlockManager::ContentBlock::TranslationHelper
 
   delegate :document, to: :content_block_edition
 
@@ -31,7 +32,7 @@ private
     first_class_items(items).map do |key, value|
       {
         field: key_to_title(key, object_type),
-        value:,
+        value: translated_value(value),
         data: {
           testid: [object_title.parameterize, key].compact.join("_").underscore,
         },

--- a/lib/engines/content_block_manager/app/helpers/content_block_manager/content_block/translation_helper.rb
+++ b/lib/engines/content_block_manager/app/helpers/content_block_manager/content_block/translation_helper.rb
@@ -3,4 +3,9 @@ module ContentBlockManager::ContentBlock::TranslationHelper
     translation_path = object_type ? "#{object_type}.#{label}" : label
     I18n.t("content_block_edition.details.labels.#{translation_path}", default: label.humanize.gsub("-", " "))
   end
+
+  def translated_value(value)
+    translation_path = "content_block_edition.details.values.#{value}"
+    I18n.t(translation_path, default: value)
+  end
 end

--- a/lib/engines/content_block_manager/config/locales/en.yml
+++ b/lib/engines/content_block_manager/config/locales/en.yml
@@ -73,3 +73,6 @@ en:
               time_to(h): Hours
               time_to(m): Minutes
               time_to(meridian): AM/PM
+      values:
+        true: "Yes"
+        false: "No"

--- a/lib/engines/content_block_manager/test/components/content_block/document/show/embedded_objects/metadata_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/document/show/embedded_objects/metadata_component_test.rb
@@ -45,6 +45,9 @@ class ContentBlockManager::ContentBlock::Document::Show::EmbeddedObjects::Metada
       I18n.expects(:t).with("content_block_edition.details.labels.telephone.foo", default: "Foo").returns("Foo translated")
       I18n.expects(:t).with("content_block_edition.details.labels.telephone.fizz", default: "Fizz").returns("Fizz translated")
 
+      I18n.expects(:t).with("content_block_edition.details.values.bar", default: "bar").returns("bar")
+      I18n.expects(:t).with("content_block_edition.details.values.buzz", default: "buzz").returns("buzz")
+
       component.expects(:render).with(
         "govuk_publishing_components/components/summary_list", {
           items: [
@@ -55,6 +58,35 @@ class ContentBlockManager::ContentBlock::Document::Show::EmbeddedObjects::Metada
             {
               field: "Fizz translated",
               value: "buzz",
+            },
+          ],
+        }
+      ).returns("STUB_RESPONSE")
+
+      render_inline component
+
+      assert_text "STUB_RESPONSE"
+    end
+  end
+
+  describe "when there is a translated field value" do
+    it "uses translated label" do
+      I18n.expects(:t).with("content_block_edition.details.labels.telephone.foo", default: "Foo").returns("Foo")
+      I18n.expects(:t).with("content_block_edition.details.labels.telephone.fizz", default: "Fizz").returns("Fizz")
+
+      I18n.expects(:t).with("content_block_edition.details.values.bar", default: "bar").returns("Bar translated")
+      I18n.expects(:t).with("content_block_edition.details.values.buzz", default: "buzz").returns("Buzz translated")
+
+      component.expects(:render).with(
+        "govuk_publishing_components/components/summary_list", {
+          items: [
+            {
+              field: "Foo",
+              value: "Bar translated",
+            },
+            {
+              field: "Fizz",
+              value: "Buzz translated",
             },
           ],
         }

--- a/lib/engines/content_block_manager/test/components/shared/embedded_objects/summary_card_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/shared/embedded_objects/summary_card_component_test.rb
@@ -72,6 +72,39 @@ class ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponentTest < V
     assert_selector ".govuk-summary-card[data-test-id='prefix_my-embedded-object']"
   end
 
+  describe "when there is a translated value" do
+    it "returns a translated value" do
+      I18n.expects(:t).with("content_block_edition.details.labels.embedded-objects.name", default: "Name").returns("Name")
+      I18n.expects(:t).with("content_block_edition.details.labels.embedded-objects.field-1", default: "Field 1").returns("Field 1")
+      I18n.expects(:t).with("content_block_edition.details.labels.embedded-objects.field-2", default: "Field 2").returns("Field 2")
+
+      I18n.expects(:t).with("content_block_edition.details.values.My Embedded Object", default: "My Embedded Object").returns("My Embedded Object translated")
+      I18n.expects(:t).with("content_block_edition.details.values.Value 2", default: "Value 2").returns("Value 2 translated")
+      I18n.expects(:t).with("content_block_edition.details.values.Value 1", default: "Value 1").returns("Value 1 translated")
+
+      component = ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponent.new(
+        content_block_edition:,
+        object_type: "embedded-objects",
+        object_title: "my-embedded-object",
+        test_id_prefix: "prefix",
+      )
+
+      render_inline component
+
+      assert_selector ".govuk-summary-list__row[data-testid='my_embedded_object_name']", text: /Name/ do
+        assert_selector ".govuk-summary-list__value", text: "My Embedded Object translated"
+      end
+
+      assert_selector ".govuk-summary-list__row[data-testid='my_embedded_object_field_1']", text: /Field 1/ do
+        assert_selector ".govuk-summary-list__value", text: "Value 1 translated"
+      end
+
+      assert_selector ".govuk-summary-list__row[data-testid='my_embedded_object_field_2']", text: /Field 2/ do
+        assert_selector ".govuk-summary-list__value", text: "Value 2 translated"
+      end
+    end
+  end
+
   it "renders a summary list with a collection" do
     component = ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponent.with_collection(
       %w[my-embedded-object],
@@ -242,6 +275,8 @@ class ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponentTest < V
         I18n.expects(:t).with("content_block_edition.details.labels.embedded-objects.name", default: "Name").returns("Name translated")
         I18n.expects(:t).with("content_block_edition.details.labels.item", default: "Item").returns("Item translated")
         I18n.expects(:t).with("content_block_edition.details.labels.item", default: "Item").returns("Item translated")
+
+        I18n.expects(:t).with("content_block_edition.details.values.My Embedded Object", default: "My Embedded Object").returns("My Embedded Object")
 
         component = ContentBlockManager::Shared::EmbeddedObjects::SummaryCardComponent.new(
           content_block_edition:,

--- a/lib/engines/content_block_manager/test/unit/app/helpers/content_block_manager/content_block/translation_helper_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/helpers/content_block_manager/content_block/translation_helper_test.rb
@@ -33,4 +33,14 @@ class ContentBlockManager::ContentBlock::TranslationHelperTest < ActiveSupport::
       assert_equal "Field name", humanized_label("field-name", nil)
     end
   end
+
+  describe "translated_value" do
+    it "calls translation config with value" do
+      I18n.expects(:t)
+          .with("content_block_edition.details.values.field value", default: "field value")
+          .returns("field value")
+
+      assert_equal "field value", translated_value("field value")
+    end
+  end
 end


### PR DESCRIPTION
This is to be used for simple single-word translations, like
turning `true` to `Yes`, so I've kept the path to the translation
pretty generic. If more complex or field-specific translations
are needed in the future it could be expanded/iterated

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
