### PR TITLE
Flexible page image block

### DIFF
--- a/app/helpers/admin/flexible_page_helper.rb
+++ b/app/helpers/admin/flexible_page_helper.rb
@@ -14,8 +14,28 @@ private
 
     case property["type"]
     when "string"
-      component = property["format"] == "govspeak" ? "textarea" : "input"
-      render "govuk_publishing_components/components/#{component}", field_attrs
+      if property["format"] == "image_select"
+        render "govuk_publishing_components/components/select", {
+          id: "edition_flexible_page_content_#{path.join('_')}",
+          label: property["title"] + (schema["required"]&.include?(path.last.to_s) ? " (required)" : ""),
+          name: "edition[flexible_page_content][#{path.join('][')}]",
+          options: [
+            {
+              text: "No image selected",
+              value: "",
+            },
+          ] + edition.images.map do |image|
+            {
+              text: image.filename,
+              value: image.id,
+              selected: image.id == edition.flexible_page_content.dig(*path)&.to_i,
+            }
+          end,
+        }
+      else
+        component = property["format"] == "govspeak" ? "textarea" : "input"
+        render "govuk_publishing_components/components/#{component}", field_attrs
+      end
     when "object"
       render "govuk_publishing_components/components/fieldset", {
         legend_text: property["title"],

--- a/app/models/flexible_page.rb
+++ b/app/models/flexible_page.rb
@@ -1,5 +1,6 @@
 class FlexiblePage < Edition
   include Edition::Identifiable
+  include Edition::Images
   validates :flexible_page_type, presence: true, inclusion: { in: -> { FlexiblePageType.all_keys } }
   validate :content_conforms_to_schema
 
@@ -25,6 +26,10 @@ class FlexiblePage < Edition
 
   def previously_published
     false
+  end
+
+  def allows_image_attachments?
+    type_instance.settings["images_enabled"]
   end
 
   def base_path

--- a/app/models/flexible_page_type.rb
+++ b/app/models/flexible_page_type.rb
@@ -38,10 +38,16 @@ class FlexiblePageType
     @schema["properties"]
   end
 
+  # TODO: Separate schema validation from content validation so that we can get easier error handling and contextual validation
   def validator
     formats = {
       "govspeak" => proc do |instance|
         instance.is_a?(String) && Govspeak::HtmlValidator.new(instance).valid?
+      end,
+      "image_select" => proc do |instance|
+        next true if instance.blank?
+
+        instance.to_i.positive?
       end,
     }
     JSONSchemer.schema(@schema, formats:)

--- a/app/models/flexible_page_type.rb
+++ b/app/models/flexible_page_type.rb
@@ -53,7 +53,7 @@ class FlexiblePageType
     JSONSchemer.schema(@schema, formats:)
   end
 
-  def publishing_api_payload_builder(page_content)
-    PublishingApi::PayloadBuilder::FlexiblePageContent.new(@schema, page_content)
+  def publishing_api_payload_builder(page)
+    PublishingApi::PayloadBuilder::FlexiblePageContent.new(@schema, page)
   end
 end

--- a/app/models/flexible_page_types/history_page.json
+++ b/app/models/flexible_page_types/history_page.json
@@ -30,6 +30,12 @@
         "description": "The main content for the page",
         "type": "string",
         "format": "govspeak"
+      },
+      "sidebar_image": {
+        "title": "Sidebar image",
+        "description": "Enter the markdown code for the sidebar image",
+        "type": "string",
+        "format": "image_select"
       }
     },
     "required": ["page_title"]
@@ -38,6 +44,7 @@
     "base_path_prefix": "/government/history",
     "publishing_api_schema_name": "history",
     "publishing_api_document_type": "history",
-    "rendering_app": "government-frontend"
+    "rendering_app": "government-frontend",
+    "images_enabled": true
   }
 }

--- a/app/presenters/publishing_api/flexible_page_presenter.rb
+++ b/app/presenters/publishing_api/flexible_page_presenter.rb
@@ -15,7 +15,7 @@ module PublishingApi
       content = BaseItemPresenter.new(item, update_type:).base_attributes
       content.merge!(
         details: {
-          **type.publishing_api_payload_builder(item.flexible_page_content).call,
+          **type.publishing_api_payload_builder(item).call,
         },
         document_type: type.settings["publishing_api_document_type"],
         public_updated_at: item.public_timestamp || item.updated_at,

--- a/test/functional/admin/flexible_pages_controller_test.rb
+++ b/test/functional/admin/flexible_pages_controller_test.rb
@@ -35,6 +35,7 @@ class Admin::FlexiblePagesControllerTest < ActionController::TestCase
             },
           },
         },
+        "settings" => {},
       },
     }
     FlexiblePageType.setup_test_types(flexible_page_types)

--- a/test/unit/app/models/flexible_page_test.rb
+++ b/test/unit/app/models/flexible_page_test.rb
@@ -9,6 +9,54 @@ class FlexiblePageTest < ActiveSupport::TestCase
     assert_not page.previously_published
   end
 
+  test "it allows images if the flexible page type settings permit them" do
+    test_types = {
+      "test_type_with_images" => {
+        "key" => "test_type_with_images",
+        "schema" => {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "$id": "https://www.gov.uk/schemas/test_type/v1",
+          "title": "Test type",
+          "type": "object",
+          "properties" => {
+            "test_attribute" => {
+              "title" => "Test attribute",
+              "type" => "string",
+            },
+          },
+          "required" => %w[test_attribute],
+        },
+        "settings" => {
+          "images_enabled" => true,
+        },
+      },
+      "test_type_without_images" => {
+        "key" => "test_type_without_images",
+        "schema" => {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "$id": "https://www.gov.uk/schemas/test_type/v1",
+          "title": "Test type",
+          "type": "object",
+          "properties" => {
+            "test_attribute" => {
+              "title" => "Test attribute",
+              "type" => "string",
+            },
+          },
+          "required" => %w[test_attribute],
+        },
+        "settings" => {
+          "images_enabled" => false,
+        },
+      },
+    }
+    FlexiblePageType.setup_test_types(test_types)
+    page_with_images = FlexiblePage.new(flexible_page_type: "test_type_with_images")
+    page_without_images = FlexiblePage.new(flexible_page_type: "test_type_without_images")
+    assert page_with_images.allows_image_attachments?
+    assert_not page_without_images.allows_image_attachments?
+  end
+
   test "it is invalid if the flexible page content does not conform to the flexible page type schema" do
     test_types = {
       "test_type" => {
@@ -26,6 +74,7 @@ class FlexiblePageTest < ActiveSupport::TestCase
           },
           "required" => %w[test_attribute],
         },
+        "settings" => {},
       },
     }
     FlexiblePageType.setup_test_types(test_types)
@@ -55,6 +104,7 @@ class FlexiblePageTest < ActiveSupport::TestCase
           },
           "required" => %w[test_attribute],
         },
+        "settings" => {},
       },
     }
     FlexiblePageType.setup_test_types(test_types)
@@ -66,5 +116,69 @@ class FlexiblePageTest < ActiveSupport::TestCase
     }
     page.creator = User.new
     assert page.invalid?
+  end
+
+  test "it is able to validate that image select formatted attributes are numeric strings" do
+    test_types = {
+      "test_type" => {
+        "key" => "test_type",
+        "schema" => {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "$id": "https://www.gov.uk/schemas/test_type/v1",
+          "title": "Test type",
+          "type": "object",
+          "properties" => {
+            "test_attribute" => {
+              "title" => "Test attribute",
+              "type" => "string",
+              "format" => "image_select",
+            },
+          },
+          "required" => %w[test_attribute],
+        },
+        "settings" => {},
+      },
+    }
+    FlexiblePageType.setup_test_types(test_types)
+    page = FlexiblePage.new
+    page.title = "Test Page"
+    page.flexible_page_type = "test_type"
+    page.flexible_page_content = {
+      "test_attribute" => "invalid image ID",
+    }
+    page.creator = User.new
+    assert page.invalid?
+  end
+
+  test "it allows empty values for image select formatted attributes" do
+    test_types = {
+      "test_type" => {
+        "key" => "test_type",
+        "schema" => {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "$id": "https://www.gov.uk/schemas/test_type/v1",
+          "title": "Test type",
+          "type": "object",
+          "properties" => {
+            "test_attribute" => {
+              "title" => "Test attribute",
+              "type" => "string",
+              "format" => "image_select",
+            },
+          },
+          "required" => %w[test_attribute],
+        },
+        "settings" => {},
+      },
+    }
+    FlexiblePageType.setup_test_types(test_types)
+    page = FlexiblePage.new
+    page.title = "Test Page"
+    page.flexible_page_type = "test_type"
+    page.flexible_page_content = {
+      "test_attribute" => "",
+    }
+    page.creator = User.new
+    assert page.valid?
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/kVJ6zEW1

This is a first implementation of the image flexible block.

It provides a drop down to select one of the images that has been uploaded to the edition using the images tab. We also add a setting to the flexible page config files so that the images tab can be made available to publishers on particular flexible page types.

This block required a change to some of the APIs, because it needs the entire edition as context so that the images can be loaded from the edition images association.

In a [future PR](https://github.com/alphagov/whitehall/pull/10342) I am going to factor the blocks out into separate classes so that all behaviour relating to a block is located in one place. 
