### PR TITLE
`create` instead of `new` for `Ga4FormTracker`

### DIFF
--- a/app/assets/javascripts/admin/analytics-modules/ga4-form-setup.js
+++ b/app/assets/javascripts/admin/analytics-modules/ga4-form-setup.js
@@ -45,7 +45,7 @@ window.GOVUK.analyticsGa4.analyticsModules =
 
             eventData = {
               ...eventData,
-              type,
+              type: type === 'create' ? 'new' : type,
               tool_name: toolName
             }
           }

--- a/spec/javascripts/admin/analytics-modules/ga4-form-setup.spec.js
+++ b/spec/javascripts/admin/analytics-modules/ga4-form-setup.spec.js
@@ -52,6 +52,18 @@ describe('GOVUK.analyticsGa4.analyticsModules.Ga4FormSetup', function () {
       expect(JSON.parse(ga4Form)).toEqual(expectedDefaults)
     })
 
+    it('uses new instead of create as action', () => {
+      container.dataset.ga4DocumentType = 'create-toolName'
+
+      GOVUK.analyticsGa4.analyticsModules.Ga4FormSetup.init()
+
+      const { ga4Form } = form.dataset
+
+      expect(ga4Form).toBeDefined()
+
+      expect(JSON.parse(ga4Form)).toEqual({ ...expectedDefaults, type: 'new' })
+    })
+
     it('adds the `data-ga4-form-change-tracking` attribute if no tracked components', () => {
       GOVUK.analyticsGa4.analyticsModules.Ga4FormSetup.init()
 


### PR DESCRIPTION
## What

If `create` passed the `type` of form to `Ga4FormTracker` then use `new` instead. 

## Why

The `type` is derived from the controller action of the rendered page and using `new` consistently is easier to understand and track (and doesn't have a different view from `create` either).

This is a requested change from the Publishing PAs.

Solves: https://trello.com/c/lMzQdGQu/1035-tracked-form-action-for-new-documents-should-consistently-use-new-instead-of-sometimes-create

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
