### PR TITLE
CM-169: Add delete functionality to array component

### DIFF
--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/array_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/array_component.rb
@@ -12,7 +12,10 @@ private
   def items
     if value.count.positive?
       Array.new(value.count) do |index|
-        { fields: render(component(index)) }
+        {
+          fields: render(component(index)),
+          destroy_checkbox: destroy_checkbox(index),
+        }
       end
     else
       [{ fields: render(component(0)) }]
@@ -34,6 +37,10 @@ private
       errors:,
       error_lookup_prefix: "details_#{id_suffix}",
     )
+  end
+
+  def destroy_checkbox(index)
+    render("govuk_publishing_components/components/checkboxes", { name: "#{id}[#{index}][_destroy]", items: [{ label: "Delete", value: "1" }] })
   end
 
   def errors

--- a/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/array_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/array_component_test.rb
@@ -46,11 +46,11 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::ArrayComponentT
         component.assert_selector ".js-add-another__empty", count: 1
 
         component.assert_selector ".js-add-another__fieldset", text: /Item 1/ do |fieldset|
-          expect_form_fields(fieldset, 0, "foo")
+          expect_form_fields(fieldset, 0, "foo", 2)
         end
 
         component.assert_selector ".js-add-another__fieldset", text: /Item 2/ do |fieldset|
-          expect_form_fields(fieldset, 1, "bar")
+          expect_form_fields(fieldset, 1, "bar", 2)
         end
 
         component.assert_selector ".js-add-another__empty", text: /Item 3/ do |fieldset|
@@ -58,16 +58,21 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::ArrayComponentT
         end
       end
     end
+
+    it "renders the hidden delete checkbox for each item" do
+      render_inline component
+
+      assert_selector "input[type='checkbox'][name='content_block_manager_content_block_edition_details_items[0][_destroy]']"
+      assert_selector "input[type='checkbox'][name='content_block_manager_content_block_edition_details_items[1][_destroy]']"
+    end
   end
 
 private
 
-  def expect_form_fields(fieldset, index, value = nil)
+  def expect_form_fields(fieldset, index, value = nil, form_group_count = 1)
     fieldset.assert_selector ".govuk-fieldset__legend", text: "Item #{index + 1}"
-    fieldset.assert_selector ".govuk-form-group", count: 1
-    fieldset.assert_selector ".govuk-form-group" do |form_group|
-      form_group.assert_selector "input[value='#{value}']" unless value.nil?
-      form_group.assert_selector ".govuk-label", text: "Item"
-    end
+    fieldset.assert_selector ".govuk-form-group", count: form_group_count
+    fieldset.assert_selector "input[value='#{value}']" unless value.nil?
+    fieldset.assert_selector ".govuk-label", text: "Item"
   end
 end


### PR DESCRIPTION
The component needs a `destroy_checkbox` for its javascript to work https://components.publishing.service.gov.uk/component-guide/add_another

We do not currently want to enable the delete functionality for the 'edit' flow, so we will be making future changes to conditionally hide the delete button.


---
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
