### PR TITLE
(CM-196) Specify the order of an array field

### DIFF
--- a/docs/content_block_manager/configuration.md
+++ b/docs/content_block_manager/configuration.md
@@ -20,6 +20,39 @@ An object that defines a schema
 
 This defines if a subschema is embeddable as an entire block.
 
+## `schemas.<schema_name>.field_order`
+
+An array of strings that defines the order that fields appear in when rendering the form.
+
+## `schemas.<schema_name>.fields`
+
+And object that configures fields in a schema
+
+## Properties
+
+- [component](#schemasschema_namefieldsfield_namecomponent)
+- [field_order](#schemasschema_namefieldsfield_namefield_order)
+
+### `schemas.<schema_name>.fields.<field_name>.component`
+
+Allows the component used for the field to be overridden. For example, when specifying:
+
+```yaml
+...
+fields:
+  my_field:
+    component:
+      boolean
+...
+```
+
+The [Boolean](https://github.com/alphagov/whitehall/blob/main/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/boolean_component.rb) component will be used.
+
+### `schemas.<schema_name>.fields.<field_name>.field_order`
+
+If thew field is an array of objects, specifies an array of strings that defines the order that fields appear in when 
+rendering the subfields that can be contained in that field.
+
 ## `schemas.<schema_name>.subschemas`
 
 A list of [subschemas](#schemasschema_namesubschemassubschema_name) for a specific object

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/embedded_objects/blocks_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/embedded_objects/blocks_component.rb
@@ -83,7 +83,7 @@ private
   end
 
   def content_for_row(key, value)
-    content = content_tag(:p, value, class: "app-c-embedded-objects-blocks-component__content")
+    content = content_tag(:p, value, class: "app-c-embedded-objects-blocks-component__content govspeak")
     content << content_tag(:p, content_block_document.embed_code_for_field("#{object_type}/#{object_title}/#{key}"), class: "app-c-embedded-objects-blocks-component__embed-code")
     content
   end
@@ -98,7 +98,7 @@ private
   def content_for_block_row
     content = content_tag(:div,
                           content_block_edition.render(content_block_document.embed_code_for_field("#{object_type}/#{object_title}")),
-                          class: "app-c-embedded-objects-blocks-component__content")
+                          class: "app-c-embedded-objects-blocks-component__content govspeak")
     content << content_tag(:p, content_block_document.embed_code_for_field("#{object_type}/#{object_title}"), class: "app-c-embedded-objects-blocks-component__embed-code")
     content
   end

--- a/lib/engines/content_block_manager/app/models/content_block_manager/content_block/schema/field.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/content_block/schema/field.rb
@@ -46,7 +46,13 @@ module ContentBlockManager
         end
 
         def array_items
-          properties.fetch("items", nil)
+          properties.fetch("items", nil)&.tap do |array_items|
+            if array_items["type"] == "object"
+              array_items["properties"] = array_items["properties"].sort_by { |k, _v|
+                field_ordering_rule.find_index(k) || Float::INFINITY
+              }.to_h
+            end
+          end
         end
 
         def is_required?
@@ -65,6 +71,10 @@ module ContentBlockManager
 
         def config
           @config ||= schema.config.dig("fields", name) || {}
+        end
+
+        def field_ordering_rule
+          @field_ordering_rule ||= config["field_order"] || []
         end
       end
     end

--- a/lib/engines/content_block_manager/config/content_block_manager.yml
+++ b/lib/engines/content_block_manager/config/content_block_manager.yml
@@ -51,6 +51,11 @@ schemas:
           opening_hours:
             component:
               opening_hours
+          telephone_numbers:
+            field_order:
+              - type
+              - label
+              - telephone_number
       addresses:
         group: modes
         group_order: 3

--- a/lib/engines/content_block_manager/test/components/content_block/document/show/embedded_objects/blocks_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/document/show/embedded_objects/blocks_component_test.rb
@@ -278,7 +278,7 @@ class ContentBlockManager::ContentBlock::Document::Show::EmbeddedObjects::Blocks
     parent_container.assert_selector "[data-testid='#{test_id}']", visible: visible do |row|
       row.assert_selector ".govuk-summary-list__key", text: key, visible: visible
       row.assert_selector ".govuk-summary-list__value", visible: visible do |col|
-        col.assert_selector ".app-c-embedded-objects-blocks-component__content", text: value, visible: visible
+        col.assert_selector ".app-c-embedded-objects-blocks-component__content.govspeak", text: value, visible: visible
         col.assert_selector ".app-c-embedded-objects-blocks-component__embed-code", text: content_block_document.embed_code_for_field([object_type, object_title, embed_code_suffix].compact.join("/")), visible: visible
       end
     end

--- a/lib/engines/content_block_manager/test/unit/app/models/content_block_schema/field_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/models/content_block_schema/field_test.rb
@@ -159,17 +159,59 @@ class ContentBlockManager::ContentBlock::Schema::FieldTest < ActiveSupport::Test
             "something" => {
               "type" => "array",
               "items" => {
-                "type" => "string",
+                "properties" => {
+                  "foo" => { "type" => "string" },
+                  "bar" => { "type" => "string", "enum" => %w[foo bar] },
+                },
               },
             },
           },
         }
       end
 
-      it "returns nil" do
+      it "returns the array items" do
         assert_equal field.array_items, {
-          "type" => "string",
+          "properties" => {
+            "foo" => { "type" => "string" },
+            "bar" => { "type" => "string", "enum" => %w[foo bar] },
+          },
         }
+      end
+
+      describe "when an order is specified" do
+        let(:config) do
+          {
+            "field_order" => %w[bar foo],
+          }
+        end
+
+        it "returns the array items with the specified order" do
+          assert_equal field.array_items, {
+            "properties" => {
+              "bar" => { "type" => "string", "enum" => %w[foo bar] },
+              "foo" => { "type" => "string" },
+            },
+          }
+        end
+      end
+
+      describe "when the array type is a string" do
+        let(:body) do
+          {
+            "properties" => {
+              "something" => {
+                "type" => "array",
+                "items" => {
+                  "type" => "string",
+                },
+              },
+            },
+          }
+        end
+
+        it "returns successfully" do
+          assert_equal field.array_items, { "type" => "string" }
+        end
       end
     end
   end


### PR DESCRIPTION
This allows the order of objects in an array field to be specified. This is useful in the case of Telephone Numbers where we want the `type` to be first in the list.

## Screenshots

### Before

![image](https://github.com/user-attachments/assets/8ea27316-6bee-4df4-8749-bce0fcd769a2)

### After

![image](https://github.com/user-attachments/assets/097285e1-f31d-40b2-9637-237830eef4b5)
