### PR TITLE
HMRC internal manuals finder

### DIFF
--- a/lib/finders/hmrc_internal_manuals.json
+++ b/lib/finders/hmrc_internal_manuals.json
@@ -1,0 +1,69 @@
+{
+  "base_path": "/government/hmrc-manuals-search",
+  "title": "HMRC manuals",
+  "description": "Find HMRC technical guidance.",
+  "locale": "en",
+  "document_type": "finder",
+  "schema_name": "finder",
+  "publishing_app": "whitehall",
+  "rendering_app": "finder-frontend",
+  "update_type": "major",
+  "details": {
+    "summary": [
+      {
+        "content": "These manuals contain technical guidance for HMRC staff and tax professionals and are also published in accordance with the [HMRC Publication scheme](https://www.gov.uk/government/organisations/hm-revenue-customs/about/publication-scheme).\n\nThe guidance is not comprehensive and does not provide a definitive answer in every case. It is based on the law as it stood when they were published. HMRC publishes amended or supplementary guidance if there's a change in the law or in the department's interpretation of it.\n\nFind out [how HMRC advice and information can help you](https://www.gov.uk/guidance/when-you-can-rely-on-information-or-advice-provided-by-hm-revenue-and-customs).",
+        "content_type": "text/govspeak"
+      }
+    ],
+    "filter": { "content_store_document_type": ["hmrc_manual", "hmrc_manual_section"] },
+    "facets": [
+      {
+        "allowed_values": [
+          { "label": "HMRC manual", "value": "hmrc_manual" },
+          { "label": "HMRC manual page", "value": "hmrc_manual_section" }
+        ],
+        "display_as_result_metadata": false,
+        "filterable": true,
+        "key": "content_store_document_type",
+        "name": "Page type",
+        "preposition": "of type",
+        "type": "text"
+      },
+      {
+        "name": "Last updated",
+        "key": "public_timestamp",
+        "type": "date",
+        "display_as_result_metadata": true,
+        "filterable": true,
+        "short_name": "Updated",
+        "preposition": "Updated"
+      }
+    ],
+    "sort": [
+      {"key": "title", "name": "A-Z", "default":  true},
+      {"key": "-popularity", "name": "Most viewed"},
+      {"key": "-relevance", "name": "Relevance"},
+      {"key": "-public_timestamp", "name": "Updated (newest)"},
+      {"key": "public_timestamp", "name": "Updated (oldest)"}
+    ],
+    "document_noun": "result",
+    "show_summaries": false,
+    "show_metadata_block": true,
+    "show_table_of_contents": true,
+    "default_documents_per_page": 50
+  },
+  "routes": [
+    {
+      "type": "exact",
+      "path": "/government/hmrc-manuals-search"
+    },
+    {
+      "type": "exact",
+      "path": "/government/hmrc-manuals-search.json"
+    },
+    {
+      "type": "exact",
+      "path": "/government/hmrc-manuals-search.atom"
+    }
+  ]
+}

--- a/lib/tasks/publish_finders.rake
+++ b/lib/tasks/publish_finders.rake
@@ -8,4 +8,12 @@ namespace :finders do
       PublishFinder.call(content_item)
     end
   end
+
+  desc "Publish a single finder page (by filename) to the publishing API"
+  task :publish_one, %i[filename] => [:environment] do |_, args|
+    filename = args.fetch(:filename)
+    content_item = JSON.load_file(Rails.root.join("lib/finders/#{filename}"))
+    puts "Publishing #{filename}"
+    PublishFinder.call(content_item)
+  end
 end


### PR DESCRIPTION
This is a new finder that lets users search through all HMRC manuals / manual sections.

I've been working behind the scenes with HMRC to agree the content and settings for this, which is now done. We're planning on deploying it to production as a trial, and HMRC are going to get feedback on its effectiveness from external the users of their manuals.

As this is only configuration, and I haven't had to change any code or reindex anything in search, I don't think this will add to our maintenance burden significantly. I've also done everything I can to manage down HMRC's expectations of ongoing support - they understand that there's no promise of ongoing feature improvements to this finder, and they're still keen to have it over the current situation (where it's difficult to search across HMRC manuals).

[You can currently see the finder deployed to integration here](https://www.integration.publishing.service.gov.uk/government/hmrc-manuals-search)