### PR TITLE
(CM-197) Auto populate the label for a telephone number

### DIFF
--- a/docs/content_block_manager/configuration.md
+++ b/docs/content_block_manager/configuration.md
@@ -32,6 +32,7 @@ And object that configures fields in a schema
 
 - [component](#schemasschema_namefieldsfield_namecomponent)
 - [field_order](#schemasschema_namefieldsfield_namefield_order)
+- [data_attributes](#schemasschema_namefieldsfield_namedata_attributes)
 
 ### `schemas.<schema_name>.fields.<field_name>.component`
 
@@ -52,6 +53,11 @@ The [Boolean](https://github.com/alphagov/whitehall/blob/main/lib/engines/conten
 
 If thew field is an array of objects, specifies an array of strings that defines the order that fields appear in when 
 rendering the subfields that can be contained in that field.
+
+### `schemas.<schema_name>.fields.<field_name>.data_attributes`
+
+A key/value list of data attributes to return in the HTML that surrounds the component for a given field. This is 
+useful for providing Javascript modules or custom selectors.
 
 ## `schemas.<schema_name>.subschemas`
 

--- a/lib/engines/content_block_manager/app/assets/javascripts/content_block_manager/application.js
+++ b/lib/engines/content_block_manager/app/assets/javascripts/content_block_manager/application.js
@@ -1,1 +1,2 @@
+//= require ./modules/auto-populate-telephone-number-label
 //= require ./modules/copy-embed-code

--- a/lib/engines/content_block_manager/app/assets/javascripts/content_block_manager/modules/auto-populate-telephone-number-label.js
+++ b/lib/engines/content_block_manager/app/assets/javascripts/content_block_manager/modules/auto-populate-telephone-number-label.js
@@ -1,0 +1,60 @@
+'use strict'
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {}
+;(function (Modules) {
+  function AutoPopulateTelephoneNumberLabel(module) {
+    this.module = module
+  }
+
+  AutoPopulateTelephoneNumberLabel.prototype.init = function () {
+    const typeSelects = this.module.querySelectorAll(
+      "select[name='content_block/edition[details][telephones][telephone_numbers][][type]']"
+    )
+
+    typeSelects.forEach(function (el) {
+      el.addEventListener('change', this.setLabelValue.bind(this))
+    }, this)
+
+    // Wait for the Add another button to be present
+    this.waitForElement('.js-add-another__add-button').then((element) => {
+      // When the add another button is clicked, reinitialize the module
+      element.addEventListener('click', this.init.bind(this))
+    })
+  }
+
+  AutoPopulateTelephoneNumberLabel.prototype.setLabelValue = function (e) {
+    const select = e.target
+    const options = select.options
+    const selectedIndex = select.selectedIndex
+    const label = select
+      .closest('fieldset')
+      .querySelector(
+        "input[name='content_block/edition[details][telephones][telephone_numbers][][label]']"
+      )
+
+    if (selectedIndex > 0) {
+      label.value = options[selectedIndex].text
+    }
+  }
+
+  AutoPopulateTelephoneNumberLabel.prototype.waitForElement = function (
+    selector
+  ) {
+    return new Promise((resolve) => {
+      const observer = new MutationObserver((mutations, observer) => {
+        const element = document.querySelector(selector)
+        if (element) {
+          observer.disconnect()
+          resolve(element)
+        }
+      })
+
+      observer.observe(this.module, {
+        childList: true,
+        subtree: true
+      })
+    })
+  }
+
+  Modules.AutoPopulateTelephoneNumberLabel = AutoPopulateTelephoneNumberLabel
+})(window.GOVUK.Modules)

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/array/item_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/array/item_component.rb
@@ -49,12 +49,20 @@ private
   end
 
   def select_options(enum, value)
-    enum.map do |item|
-      {
+    options = [{
+      text: "Select",
+      value: "",
+      selected: value.nil?,
+    }]
+
+    enum.each do |item|
+      options << {
         text: item.humanize,
         value: item,
         selected: item == value,
       }
     end
+
+    options
   end
 end

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/form_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/form_component.html.erb
@@ -1,3 +1,5 @@
-<% schema.fields.each do |attribute| %>
-  <%= render component_for_field(attribute) %>
+<% schema.fields.each do |field| %>
+  <%= content_tag :div, data: field.data_attributes do %>
+    <%= render component_for_field(field) %>
+  <% end %>
 <% end %>

--- a/lib/engines/content_block_manager/app/models/content_block_manager/content_block/schema/field.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/content_block/schema/field.rb
@@ -59,6 +59,10 @@ module ContentBlockManager
           schema.required_fields.include?(name)
         end
 
+        def data_attributes
+          @data_attributes ||= config["data_attributes"] || {}
+        end
+
       private
 
         def custom_component

--- a/lib/engines/content_block_manager/config/content_block_manager.yml
+++ b/lib/engines/content_block_manager/config/content_block_manager.yml
@@ -52,6 +52,8 @@ schemas:
             component:
               opening_hours
           telephone_numbers:
+            data_attributes:
+              module: auto-populate-telephone-number-label
             field_order:
               - type
               - label

--- a/lib/engines/content_block_manager/features/create_contact_object.feature
+++ b/lib/engines/content_block_manager/features/create_contact_object.feature
@@ -156,6 +156,12 @@ Feature: Create a contact object
     When I save and continue
     Then I should see errors for the required nested "telephone_number" fields
 
+  @javascript
+  Scenario: Telephone number label is automatically populated
+    When I click on the "telephones" subschema
+    And I choose "Textphone" from the type dropdown
+    Then the label should be set to "Textphone"
+
   Scenario: GDS editor edits answers during creation of an object
     And I click on the "email_addresses" subschema
     And I complete the "email_address" form with the following fields:

--- a/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/content_block_manager_steps.rb
@@ -484,3 +484,11 @@ end
 And("I choose {string}") do |label|
   choose label
 end
+
+When("I choose {string} from the type dropdown") do |type|
+  select type, from: "content_block_manager_content_block_edition_details_telephones_telephone_numbers_0_type"
+end
+
+Then("the label should be set to {string}") do |label|
+  expect(find("#content_block_manager_content_block_edition_details_telephones_telephone_numbers_0_label").value).to eq(label)
+end

--- a/lib/engines/content_block_manager/spec/content_block_manager/auto-populate-telephone-number-label.spec.js
+++ b/lib/engines/content_block_manager/spec/content_block_manager/auto-populate-telephone-number-label.spec.js
@@ -1,0 +1,76 @@
+describe('GOVUK.Modules.AutoPopulateTelephoneNumberLabel', function () {
+  let fixture, autoPopulateTelephoneNumberLabel
+
+  const fieldset = `<fieldset>
+          <select name="content_block/edition[details][telephones][telephone_numbers][][type]">
+             <option value="">Select</option>
+             <option value="1">1</option>
+             <option value="2">2</option>
+          </select>
+          <input name="content_block/edition[details][telephones][telephone_numbers][][label]" />
+      </fieldset>`
+
+  beforeEach(function () {
+    fixture = document.createElement('div')
+    fixture.innerHTML = `<div id="firstFieldset">${fieldset}</div>`
+
+    document.body.append(fixture)
+
+    autoPopulateTelephoneNumberLabel =
+      new GOVUK.Modules.AutoPopulateTelephoneNumberLabel(fixture)
+    autoPopulateTelephoneNumberLabel.init()
+  })
+
+  afterEach(function () {
+    fixture.innerHTML = ''
+  })
+
+  it('should auto-populate the label field when the type is selected', function () {
+    const select = document.querySelector(
+      'select[name="content_block/edition[details][telephones][telephone_numbers][][type]"]'
+    )
+    select.selectedIndex = 2
+
+    window.GOVUK.triggerEvent(select, 'change')
+
+    const valueField = document.querySelector(
+      'input[name="content_block/edition[details][telephones][telephone_numbers][][label]"]'
+    )
+
+    expect(valueField.value).toEqual('2')
+
+    select.selectedIndex = 1
+    window.GOVUK.triggerEvent(select, 'change')
+
+    expect(valueField.value).toEqual('1')
+  })
+
+  it('should work when new items are appended', function (done) {
+    const addAnotherButton = document.createElement('a')
+    addAnotherButton.classList.add('js-add-another__add-button')
+    addAnotherButton.href = '#'
+    addAnotherButton.innerText = 'Add another'
+
+    fixture.append(addAnotherButton)
+
+    const additionalFieldset = document.createElement('div')
+    additionalFieldset.id = 'additionalFieldset'
+    additionalFieldset.innerHTML = fieldset
+
+    fixture.append(additionalFieldset)
+
+    setTimeout(() => {
+      window.GOVUK.triggerEvent(addAnotherButton, 'click')
+
+      const select = document.querySelector('#additionalFieldset select')
+      select.selectedIndex = 2
+
+      window.GOVUK.triggerEvent(select, 'change')
+
+      const valueField = document.querySelector('#additionalFieldset input')
+
+      expect(valueField.value).toEqual('2')
+      done()
+    }, 10)
+  })
+})

--- a/lib/engines/content_block_manager/test/components/content_block/edition/details/embedded_objects/form_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/details/embedded_objects/form_component_test.rb
@@ -6,11 +6,11 @@ class ContentBlockManager::ContentBlockEdition::Details::EmbeddedObjects::FormCo
   let(:content_block_edition) { build(:content_block_edition) }
   let(:schema) { build(:content_block_schema) }
 
-  let(:foo_field) { stub("field", name: "foo", component_name: "string", enum_values: nil, default_value: nil) }
-  let(:bar_field) { stub("field", name: "bar", component_name: "string", enum_values: nil, default_value: nil) }
-  let(:enum_field) { stub("field", name: "enum", component_name: "enum", enum_values: ["some value", "another value"], default_value: "some value") }
-  let(:textarea_field) { stub("field", name: "enum", component_name: "textarea", enum_values: nil, default_value: nil) }
-  let(:boolean_field) { stub("field", name: "boolean", component_name: "boolean", enum_values: nil, default_value: nil) }
+  let(:foo_field) { stub("field", name: "foo", component_name: "string", enum_values: nil, default_value: nil, data_attributes: nil) }
+  let(:bar_field) { stub("field", name: "bar", component_name: "string", enum_values: nil, default_value: nil, data_attributes: nil) }
+  let(:enum_field) { stub("field", name: "enum", component_name: "enum", enum_values: ["some value", "another value"], default_value: "some value", data_attributes: nil) }
+  let(:textarea_field) { stub("field", name: "enum", component_name: "textarea", enum_values: nil, default_value: nil, data_attributes: nil) }
+  let(:boolean_field) { stub("field", name: "boolean", component_name: "boolean", enum_values: nil, default_value: nil, data_attributes: nil) }
 
   let(:foo_stub) { stub("string_component") }
   let(:bar_stub) { stub("string_component") }

--- a/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/array/array_item_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/array/array_item_component_test.rb
@@ -71,6 +71,7 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::Array::ItemComp
 
       assert_selector "label", text: "Bar"
       assert_selector "select[name='foo[bar][]'][id='foo_bar_1']" do |select|
+        select.assert_selector "option[value=''][selected]", text: "Select"
         select.assert_selector "option[value='foo']", text: "Foo"
         select.assert_selector "option[value='bar']", text: "Bar"
         select.assert_selector "option[value='baz']", text: "Baz"

--- a/lib/engines/content_block_manager/test/components/content_block/edition/details/form_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/details/form_component_test.rb
@@ -26,9 +26,9 @@ class ContentBlockManager::ContentBlockEdition::Details::FormComponentTest < Vie
   let(:content_block_edition) { build(:content_block_edition) }
   let(:schema) { build(:content_block_schema, body:) }
 
-  let(:foo_field) { stub("field", name: "foo", component_name: "string", enum_values: nil, default_value: nil) }
-  let(:bar_field) { stub("field", name: "bar", component_name: "string", enum_values: nil, default_value: nil) }
-  let(:baz_field) { stub("field", name: "baz", component_name: "enum", enum_values: %w[some enum], default_value: nil) }
+  let(:foo_field) { stub("field", name: "foo", component_name: "string", enum_values: nil, default_value: nil, data_attributes: nil) }
+  let(:bar_field) { stub("field", name: "bar", component_name: "string", enum_values: nil, default_value: nil, data_attributes: nil) }
+  let(:baz_field) { stub("field", name: "baz", component_name: "enum", enum_values: %w[some enum], default_value: nil, data_attributes: nil) }
 
   let(:foo_stub) { stub("string_component") }
   let(:bar_stub) { stub("string_component") }
@@ -43,9 +43,9 @@ class ContentBlockManager::ContentBlockEdition::Details::FormComponentTest < Vie
 
   before do
     schema.stubs(:fields).returns([foo_field, bar_field, baz_field])
-    component.expects(:render).with(foo_stub)
-    component.expects(:render).with(bar_stub)
-    component.expects(:render).with(baz_stub)
+    component.expects(:render).with(foo_stub).returns("foo_stub")
+    component.expects(:render).with(bar_stub).returns("bar_stub")
+    component.expects(:render).with(baz_stub).returns("baz_stub")
   end
 
   it "renders fields for each property" do
@@ -95,5 +95,43 @@ class ContentBlockManager::ContentBlockEdition::Details::FormComponentTest < Vie
     ).returns(baz_stub)
 
     assert render_inline(component)
+  end
+
+  describe "when data_attributes are provided" do
+    let(:foo_field) { stub("field", name: "foo", component_name: "string", enum_values: nil, default_value: nil, data_attributes: { "field" => "foo" }) }
+    let(:bar_field) { stub("field", name: "bar", component_name: "string", enum_values: nil, default_value: nil, data_attributes: { "field" => "bar" }) }
+    let(:baz_field) { stub("field", name: "baz", component_name: "enum", enum_values: %w[some enum], default_value: nil, data_attributes: { "field" => "baz" }) }
+
+    it "renders inside a div with data attributes" do
+      ContentBlockManager::ContentBlockEdition::Details::Fields::StringComponent.expects(:new).with(
+        content_block_edition:,
+        field: foo_field,
+      ).returns(foo_stub)
+
+      ContentBlockManager::ContentBlockEdition::Details::Fields::StringComponent.expects(:new).with(
+        content_block_edition:,
+        field: bar_field,
+      ).returns(bar_stub)
+
+      ContentBlockManager::ContentBlockEdition::Details::Fields::EnumComponent.expects(:new).with(
+        content_block_edition:,
+        field: baz_field,
+        enum: %w[some enum],
+      ).returns(baz_stub)
+
+      render_inline(component)
+
+      assert_selector "div[data-field='foo']" do |component|
+        component.assert_text "foo_stub"
+      end
+
+      assert_selector "div[data-field='bar']" do |component|
+        component.assert_text "bar_stub"
+      end
+
+      assert_selector "div[data-field='baz']" do |component|
+        component.assert_text "baz_stub"
+      end
+    end
   end
 end

--- a/lib/engines/content_block_manager/test/integration/content_block/workflow_test.rb
+++ b/lib/engines/content_block_manager/test/integration/content_block/workflow_test.rb
@@ -89,7 +89,7 @@ class ContentBlockManager::ContentBlock::WorkflowTest < ActionDispatch::Integrat
     describe "when subschemas are present" do
       let(:subschemas) do
         [
-          stub("subschema_1", id: "subschema_1", name: "subschema_1", block_type: "subschema_1", embeddable_fields: [], fields: [stub("field", name: "name")], group: nil),
+          stub("subschema_1", id: "subschema_1", name: "subschema_1", block_type: "subschema_1", embeddable_fields: [], fields: [stub("field", name: "name", data_attributes: nil)], group: nil),
           stub("subschema_2", id: "subschema_2", name: "subschema_2", block_type: "subschema_1", fields: [], group: nil),
         ]
       end

--- a/lib/engines/content_block_manager/test/support/integration_test_helpers.rb
+++ b/lib/engines/content_block_manager/test/support/integration_test_helpers.rb
@@ -3,8 +3,8 @@ module ContentBlockManager::IntegrationTestHelpers
     schema = stub(
       id: "content_block_type",
       fields: fields || [
-        stub(:field, name: "foo", component_name: "string", enum_values: nil, default_value: nil, is_required?: false),
-        stub(:field, name: "bar", component_name: "string", enum_values: nil, default_value: nil, is_required?: false),
+        stub(:field, name: "foo", component_name: "string", enum_values: nil, default_value: nil, is_required?: false, data_attributes: nil),
+        stub(:field, name: "bar", component_name: "string", enum_values: nil, default_value: nil, is_required?: false, data_attributes: nil),
       ],
       name: "schema",
       body: {

--- a/lib/engines/content_block_manager/test/unit/app/models/content_block_schema/field_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/models/content_block_schema/field_test.rb
@@ -229,4 +229,22 @@ class ContentBlockManager::ContentBlock::Schema::FieldTest < ActiveSupport::Test
       assert_equal false, field.is_required?
     end
   end
+
+  describe "#data_attributes" do
+    describe "when a `data_attributes` config var is set" do
+      let(:config) do
+        { "fields" => { "something" => { "data_attributes" => { "foo" => "bar" } } } }
+      end
+
+      it "returns the data attributes" do
+        assert_equal field.data_attributes, { "foo" => "bar" }
+      end
+    end
+
+    describe "when a `data_attributes` config var is not set" do
+      it "returns an empty hash" do
+        assert_equal field.data_attributes, {}
+      end
+    end
+  end
 end


### PR DESCRIPTION
When selecting a "Type" for a telephone number, the "label" will usually be the same as the type. This gives a subtle hint to the user by autopopulating the label. They will then be able to change it if they need to.

![Untitled](https://github.com/user-attachments/assets/96ce4601-75e5-4ef0-b138-cc88392dfdac)
