### PR TITLE
Update document_collections documents to include body headings 

### DIFF
--- a/app/presenters/publishing_api/document_collection_presenter.rb
+++ b/app/presenters/publishing_api/document_collection_presenter.rb
@@ -64,6 +64,7 @@ module PublishingApi
       }.tap do |details_hash|
         details_hash.merge!(PayloadBuilder::PoliticalDetails.for(item))
         details_hash.merge!(PayloadBuilder::FirstPublicAt.for(item))
+        details_hash.merge!(PayloadBuilder::BodyHeadings.for(item))
       end
     end
 

--- a/test/unit/app/presenters/publishing_api/document_collection_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/document_collection_presenter_test.rb
@@ -72,6 +72,40 @@ class PublishingApi::DocumentCollectionPresenterTest < ActiveSupport::TestCase
   test "it presents the auth bypass id" do
     assert_equal [@document_collection.auth_bypass_id], @presented_content[:auth_bypass_ids]
   end
+
+  test "it includes headers when headers are present in body" do
+    document_collection = create(
+      :document_collection,
+      title: "Some document collection",
+      summary: "Some summary",
+      body: "##Some header\n\nSome content",
+    )
+
+    presented_document_collection = PublishingApi::DocumentCollectionPresenter.new(document_collection)
+
+    expected_headers = [
+      {
+        text: "Some header",
+        level: 2,
+        id: "some-header",
+      },
+    ]
+
+    assert_equal expected_headers, presented_document_collection.content[:details][:headers]
+  end
+
+  test "it does not include headers when headers are not present in body" do
+    document_collection = create(
+      :published_document_collection,
+      title: "Some document collection",
+      summary: "Some summary",
+      body: "Some content",
+    )
+
+    presented_document_collection = PublishingApi::DocumentCollectionPresenter.new(document_collection)
+
+    assert_nil presented_document_collection.content[:details][:headers]
+  end
 end
 
 class PublishingApi::DocumentCollectionPresenterWithPublicTimestampTest < ActiveSupport::TestCase


### PR DESCRIPTION
Adds parsed headings to the document_collections content item, similar to detailed_guide and corporate_information_page

https://trello.com/c/gCX6e1Kb/674-move-documentcollection-from-government-frontend-to-frontend

References:
- https://github.com/alphagov/publishing-api/pull/3426 (schema updated in publishing-api)
- https://github.com/alphagov/whitehall/pull/10210 (last similar PR)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
