### PR TITLE
Use the new /csv-preview url for previewing CSV attachments 

### DIFF
--- a/app/helpers/attachments_helper.rb
+++ b/app/helpers/attachments_helper.rb
@@ -15,7 +15,7 @@ module AttachmentsHelper
 
   def preview_path_for_attachment(attachment)
     if attachment.attachment_data.all_asset_variants_uploaded?
-      "/media/#{attachment.attachment_data.assets.first.asset_manager_id}/#{attachment.attachment_data.assets.first.filename}/preview"
+      "/csv-preview/#{attachment.attachment_data.assets.first.asset_manager_id}/#{attachment.attachment_data.assets.first.filename}"
     end
   end
 

--- a/test/unit/app/helpers/attachments_helper_test.rb
+++ b/test/unit/app/helpers/attachments_helper_test.rb
@@ -161,7 +161,7 @@ class AttachmentsHelperTest < ActionView::TestCase
       content_type: "text/csv",
       filename: attachment.filename,
       file_size: attachment.file_size,
-      preview_url: "/media/asset_manager_id/sample.csv/preview",
+      preview_url: "/csv-preview/asset_manager_id/sample.csv",
     }
     assert_equal expect_params, attachment_component_params(attachment)
   end


### PR DESCRIPTION
We changed the preview functionality to use a new url that is served from gov.uk domain rather than the assets domain.
At the moment, the /media route redirects to the new url. The documents created using govspeak still use the old format, so we want to update the preview_url for attachments added using govspeak.

Trello board: https://trello.com/c/LkrcutJb

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
