### PR TITLE
(CM-224) Make email and contact forms embeddable as a block

### DIFF
--- a/lib/engines/content_block_manager/config/content_block_manager.yml
+++ b/lib/engines/content_block_manager/config/content_block_manager.yml
@@ -27,6 +27,7 @@ schemas:
       email_addresses:
         group: modes
         group_order: 1
+        embeddable_as_block: true
         embeddable_fields:
           - email_address
       telephones:
@@ -78,6 +79,7 @@ schemas:
           - country
       contact_forms:
         group: modes
+        embeddable_as_block: true
         group_order: 4
         embeddable_fields:
           - url


### PR DESCRIPTION
This makes the email and contact form elements embeddable as blocks, so the titles and items can be embedded as blocks, in the same way as telephone / addresses.

## Before

![image](https://github.com/user-attachments/assets/91fdeed4-7839-446a-b3b7-1df2cd087acd)

![image](https://github.com/user-attachments/assets/829e9eca-cfb1-4fea-91b5-a0c9c8e1a0aa)

## After

![image](https://github.com/user-attachments/assets/fa94602c-c59b-42eb-abcd-37043286430d)

![image](https://github.com/user-attachments/assets/9748eb73-c303-4426-bf3d-becd54481007)
