### PR TITLE
EPIC: Constantly revalidate Whitehall editions (WHIT-1507)

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -419,7 +419,7 @@ private
   end
 
   def params_filters
-    params.slice(:type, :state, :organisation, :author, :page, :title, :world_location, :from_date, :to_date, :only_broken_links, :review_overdue)
+    params.slice(:type, :state, :organisation, :author, :page, :title, :world_location, :from_date, :to_date, :only_invalid_editions, :only_broken_links, :review_overdue)
           .permit!
           .to_h
   end

--- a/app/models/admin/edition_filter.rb
+++ b/app/models/admin/edition_filter.rb
@@ -121,6 +121,7 @@ module Admin
       editions = editions.from_date(from_date) if from_date
       editions = editions.to_date(to_date) if to_date
       editions = editions.only_invalid_editions if only_invalid_editions
+      editions = editions.not_validated_since(not_validated_since) if not_validated_since
       editions = editions.only_broken_links if only_broken_links
       editions = editions.review_overdue if review_overdue
 
@@ -249,6 +250,10 @@ module Admin
 
     def topical_event
       TopicalEvent.find(options[:topical_event]) if options[:topical_event].present?
+    end
+
+    def not_validated_since
+      options[:not_validated_since].presence
     end
 
     def location_matches

--- a/app/models/admin/edition_filter.rb
+++ b/app/models/admin/edition_filter.rb
@@ -120,6 +120,7 @@ module Admin
       editions = editions.in_world_location(selected_world_locations) if selected_world_locations.any?
       editions = editions.from_date(from_date) if from_date
       editions = editions.to_date(to_date) if to_date
+      editions = editions.only_invalid_editions if only_invalid_editions
       editions = editions.only_broken_links if only_broken_links
       editions = editions.review_overdue if review_overdue
 
@@ -255,6 +256,10 @@ module Admin
         sentence = selected_world_locations.map { |l| WorldLocation.friendly.find(l).name }.to_sentence
         " about #{sentence}"
       end
+    end
+
+    def only_invalid_editions
+      options[:only_invalid_editions].present?
     end
 
     def only_broken_links

--- a/app/models/concerns/edition/scopes/filterable_by_invalid.rb
+++ b/app/models/concerns/edition/scopes/filterable_by_invalid.rb
@@ -6,5 +6,11 @@ module Edition::Scopes::FilterableByInvalid
       where(revalidated_at: nil)
         .where.not(state: %w[superseded unpublished deleted]) # We don't care if editions are invalid if they're superseded
     }
+
+    scope :not_validated_since, lambda { |from_date|
+      cutoff = Time.zone.parse(from_date.to_s)
+      where("revalidated_at IS NULL OR revalidated_at < ?", cutoff)
+        .where.not(state: %w[superseded unpublished deleted]) # We don't care if editions are invalid if they're superseded
+    }
   end
 end

--- a/app/models/concerns/edition/scopes/filterable_by_invalid.rb
+++ b/app/models/concerns/edition/scopes/filterable_by_invalid.rb
@@ -1,0 +1,10 @@
+module Edition::Scopes::FilterableByInvalid
+  extend ActiveSupport::Concern
+
+  included do
+    scope :only_invalid_editions, lambda {
+      where(revalidated_at: nil)
+        .where.not(state: %w[superseded unpublished deleted]) # We don't care if editions are invalid if they're superseded
+    }
+  end
+end

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -75,6 +75,7 @@ class Edition < ApplicationRecord
 
   before_create :set_auth_bypass_id
   before_save :set_public_timestamp
+  after_create :cache_revalidation_result
   after_create :update_document_edition_references
   after_update :update_document_edition_references, if: :saved_change_to_state?
 
@@ -107,6 +108,10 @@ class Edition < ApplicationRecord
 
   def skip_main_validation?
     FROZEN_STATES.include?(state)
+  end
+
+  def cache_revalidation_result
+    self.revalidated_at = Time.zone.now if valid?
   end
 
   def unmodifiable?

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -73,12 +73,10 @@ class Edition < ApplicationRecord
   POST_PUBLICATION_STATES = %w[published superseded withdrawn unpublished].freeze
   PUBLICLY_VISIBLE_STATES = %w[published withdrawn].freeze
 
-  # @!group Callbacks
   before_create :set_auth_bypass_id
   before_save :set_public_timestamp
   after_create :update_document_edition_references
   after_update :update_document_edition_references, if: :saved_change_to_state?
-  # @!endgroup
 
   after_update :republish_topical_event_to_publishing_api
 

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -111,13 +111,18 @@ class Edition < ApplicationRecord
   end
 
   def cache_revalidation_result
-    # Set `nil` if invalid edition, otherwise use current timestamp
-    value_to_set = errors.empty? ? Time.zone.now : nil
+    return unless new_record? || changed? || validation_context == :publish
 
-    if new_record?
-      self.revalidated_at = value_to_set
+    # If there were no errors, the edition passed re-validation
+    new_timestamp = errors.empty? ? Time.current : nil
+
+    if validation_context == :publish && !changed?
+      # Someone called valid?(:publish) on an already-saved record
+      # There may be no subsequent save, so hit the DB directly
+      update_column(:revalidated_at, new_timestamp)
     else
-      update_column(:revalidated_at, value_to_set)
+      # We’re inside a create/update flow; assigning is enough:
+      self.revalidated_at = new_timestamp # will be persisted with the save
     end
   end
 

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -75,7 +75,7 @@ class Edition < ApplicationRecord
 
   before_create :set_auth_bypass_id
   before_save :set_public_timestamp
-  after_create :cache_revalidation_result
+  after_validation :cache_revalidation_result
   after_create :update_document_edition_references
   after_update :update_document_edition_references, if: :saved_change_to_state?
 
@@ -111,7 +111,14 @@ class Edition < ApplicationRecord
   end
 
   def cache_revalidation_result
-    self.revalidated_at = Time.zone.now if valid?
+    # Set `nil` if invalid edition, otherwise use current timestamp
+    value_to_set = errors.empty? ? Time.zone.now : nil
+
+    if new_record?
+      self.revalidated_at = value_to_set
+    else
+      update_column(:revalidated_at, value_to_set)
+    end
   end
 
   def unmodifiable?

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -27,6 +27,7 @@ class Edition < ApplicationRecord
   include Edition::Scopes::Orderable
   include Edition::Scopes::SearchableByTitle
   include Edition::Scopes::FilterableByAuthor
+  include Edition::Scopes::FilterableByInvalid
   include Edition::Scopes::FilterableByBrokenLinks
   include Edition::Scopes::FilterableByDate
   include Edition::Scopes::FilterableByTopicalEvent

--- a/app/sidekiq/revalidate_edition_batch_worker.rb
+++ b/app/sidekiq/revalidate_edition_batch_worker.rb
@@ -1,0 +1,10 @@
+class RevalidateEditionBatchWorker
+  include Sidekiq::Job
+  sidekiq_options retry: 0, backtrace: false
+
+  def perform(edition_ids)
+    Edition.where(id: edition_ids).find_each do |edition|
+      edition.valid?(:publish) # revalidates the edition and updates `revalidated_at`
+    end
+  end
+end

--- a/app/sidekiq/revalidate_editions_scheduler_worker.rb
+++ b/app/sidekiq/revalidate_editions_scheduler_worker.rb
@@ -1,0 +1,24 @@
+class RevalidateEditionsSchedulerWorker
+  include Sidekiq::Job
+  sidekiq_options retry: 0
+
+  BATCH_SIZE  = ENV.fetch("REVALIDATE_BATCH_SIZE", 100).to_i
+  MAX_BATCHES = ENV.fetch("REVALIDATE_MAX_BATCHES", 1000).to_i # 1000 × 100 = 100 000 editions/run
+  def self.stale_after
+    1.week.ago
+  end
+
+  def perform
+    scope = Edition.not_validated_since(1.week.ago.strftime("%d/%m/%Y"))
+    logger.info("[RevalidateEditionsSchedulerWorker] #{scope.count} editions need revalidating")
+
+    # Pull batches in random order so permanently invalid editions
+    # don't prevent us from revalidating 'old' revalidated editions
+    scope.order(Arel.sql("RAND()")) # MySQL / MariaDB
+         .limit(BATCH_SIZE * MAX_BATCHES)
+         .pluck(:id)
+         .each_slice(BATCH_SIZE) do |ids|
+      RevalidateEditionBatchWorker.perform_async(ids)
+    end
+  end
+end

--- a/app/views/admin/editions/_filter_options.html.erb
+++ b/app/views/admin/editions/_filter_options.html.erb
@@ -1,5 +1,5 @@
 <%
-  filter_by ||= [:title, :author, :organisation, :world_location, :type, :state, :date, :only_broken_links, :review_overdue]
+  filter_by ||= [:title, :author, :organisation, :world_location, :type, :state, :date, :only_invalid_editions, :only_broken_links, :review_overdue]
   anchor ||= anchor || ""
   raise "filter action required" unless defined?(filter_action)
 %>
@@ -153,6 +153,25 @@
           },
         } %>
       <% end %>
+    <% end %>
+
+    <% if filter_by.include?(:only_invalid_editions) %>
+      <%= render "govuk_publishing_components/components/checkboxes", {
+        name: "only_invalid_editions",
+        small: true,
+        data_attributes: {
+          ga4_change_category: "update-filter checkbox",
+          ga4_filter_parent: true,
+        },
+        items: [
+          {
+            label: "Only invalid editions",
+            value: "1",
+            bold: true,
+            checked: params["only_invalid_editions"],
+          },
+        ],
+      } %>
     <% end %>
 
     <% if filter_by.include?(:only_broken_links) %>

--- a/app/views/admin/editions/show/_sidebar_notices.html.erb
+++ b/app/views/admin/editions/show/_sidebar_notices.html.erb
@@ -24,44 +24,6 @@
       error: true,
     } %>
   <% end %>
-  <% if @edition.scheduled_publication %>
-    <% if force_scheduler.can_transition? && !force_scheduler.can_perform? %>
-      <%= render "components/inset_prompt", {
-        title: "This edition cannot be scheduled",
-        data_attributes: {
-          module: "ga4-auto-tracker",
-          ga4_auto: {
-            type: "scheduled",
-            text: force_scheduler.failure_reasons_plaintext,
-          }.merge(ga4_auto_attributes).as_json,
-        },
-        description: render("govuk_publishing_components/components/list", {
-          visible_counters: true,
-          items: force_scheduler.failure_reasons,
-        }),
-        error: true,
-      } %>
-    <% end %>
-  <% else %>
-    <% if force_publisher.can_transition? && !force_publisher.can_perform? %>
-      <%= render "components/inset_prompt", {
-        title: "This edition cannot be force-published",
-        module: "ga4-auto-tracker",
-        data_attributes: {
-          module: "ga4-auto-tracker",
-          ga4_auto: {
-            type: "force published",
-            text: force_scheduler.failure_reasons_plaintext,
-          }.merge(ga4_auto_attributes).as_json,
-        },
-        description: render("govuk_publishing_components/components/list", {
-          visible_counters: true,
-          items: force_publisher.failure_reasons,
-        }),
-        error: true,
-      } %>
-    <% end %>
-  <% end %>
   <% if show_similar_slugs_warning?(@edition) %>
     <%= render "components/inset_prompt", {
       data_attributes: {

--- a/app/views/admin/editions/show/_sidebar_notices.html.erb
+++ b/app/views/admin/editions/show/_sidebar_notices.html.erb
@@ -6,6 +6,24 @@
 %>
 
 <div class="app-view-summary__sidebar-notices">
+  <% unless @edition.valid?(:publish) %>
+    <% error_message = "This edition is invalid: #{}" %>
+    <%= render "components/inset_prompt", {
+      data_attributes: {
+        module: "ga4-auto-tracker",
+        ga4_auto: {
+          type: "show invalid edition warning",
+          text: @edition.errors.map(&:full_message).join(", "),
+        }.merge(ga4_auto_attributes).as_json,
+      },
+      title: "This edition is invalid",
+      description: render("govuk_publishing_components/components/list", {
+        visible_counters: true,
+        items:  @edition.errors.map(&:full_message),
+      }),
+      error: true,
+    } %>
+  <% end %>
   <% if @edition.scheduled_publication %>
     <% if force_scheduler.can_transition? && !force_scheduler.can_perform? %>
       <%= render "components/inset_prompt", {

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -15,3 +15,6 @@
     revalidate_old_link_check_reports:
       cron: '0 4 * * *' # Runs at 4 a.m every day
       class: RevalidateOldLinkCheckReportsWorker
+    revalidate_all_editions:
+      cron: '45 5 * * *' # Runs at 5:45am every day
+      class: RevalidateEditionsSchedulerWorker

--- a/db/migrate/20250708124941_add_revalidated_at_timestamp_to_editions.rb
+++ b/db/migrate/20250708124941_add_revalidated_at_timestamp_to_editions.rb
@@ -1,0 +1,7 @@
+class AddRevalidatedAtTimestampToEditions < ActiveRecord::Migration[8.0]
+  def change
+    change_table :editions, bulk: true do |t|
+      t.datetime :revalidated_at
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_08_124941) do
   create_table "assets", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.string "variant", null: false
@@ -455,6 +455,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.boolean "visual_editor"
     t.integer "government_id"
     t.string "flexible_page_type"
+    t.datetime "revalidated_at"
     t.index ["alternative_format_provider_id"], name: "index_editions_on_alternative_format_provider_id"
     t.index ["closing_at"], name: "index_editions_on_closing_at"
     t.index ["document_id"], name: "index_editions_on_document_id"

--- a/test/factories/editions.rb
+++ b/test/factories/editions.rb
@@ -183,6 +183,7 @@ FactoryBot.define do
   factory :superseded_edition, parent: :edition, traits: [:superseded]
   factory :scheduled_edition, parent: :edition, traits: [:scheduled]
   factory :force_scheduled_edition, parent: :edition, traits: [:force_scheduled]
+  factory :force_published_edition, parent: :edition, traits: [:force_published]
   factory :unpublished_edition, parent: :edition, traits: [:unpublished]
   factory :withdrawn_edition, parent: :edition, traits: [:withdrawn]
   factory :protected_edition, parent: :edition, traits: [:access_limited]

--- a/test/functional/admin/generic_editions_controller_test.rb
+++ b/test/functional/admin/generic_editions_controller_test.rb
@@ -1,6 +1,7 @@
 require "test_helper"
 
 class Admin::GenericEditionsControllerTest < ActionController::TestCase
+  include TaxonomyHelper
   should_be_an_admin_controller
 
   setup do
@@ -110,5 +111,21 @@ class Admin::GenericEditionsControllerTest < ActionController::TestCase
 
     assert_select ".govuk-link", text: "Preview on website (opens in new tab)", href: draft_edition.public_url(draft: true), count: 0
     assert_select ".govuk-inset-text", text: "To see the changes and share a document preview link, add a change note or mark the change type to minor."
+  end
+
+  view_test "visiting an invalid edition should show the validation errors" do
+    bad_id = "9999999999999"
+    edition = create(:draft_edition, body: "[Contact:#{bad_id}]")
+    edition.save!(validate: false)
+    stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+
+    get :show, params: { id: edition }
+
+    assert_select ".app-view-summary__sidebar .app-c-inset-prompt--error" do |elements|
+      expected_message = "This edition is invalid"
+      assert elements.text.include?(expected_message), "Could not find \"#{expected_message}\" in #{elements.text}"
+      expected_message = "Contact ID #{bad_id} doesn't exist"
+      assert elements.text.include?(expected_message), "Could not find \"#{expected_message}\" in #{elements.text}"
+    end
   end
 end

--- a/test/unit/app/models/admin/edition_filter_test.rb
+++ b/test/unit/app/models/admin/edition_filter_test.rb
@@ -240,6 +240,19 @@ class Admin::EditionFilterTest < ActiveSupport::TestCase
     )
   end
 
+  test "should filter by editions not validated since X" do
+    # rubocop:disable Lint/UselessAssignment
+    edition_validated_recently = create(:draft_edition, revalidated_at: Time.zone.now)
+    edition_validated_ages_ago = create(:published_edition, revalidated_at: 1.year.ago)
+    edition_never_validated = create(:draft_edition, revalidated_at: nil)
+    # rubocop:enable Lint/UselessAssignment
+
+    assert_equal(
+      [edition_validated_ages_ago, edition_never_validated],
+      Admin::EditionFilter.new(Edition, @current_user, not_validated_since: 1.week.ago.strftime("%d/%m/%Y")).editions.sort_by(&:id),
+    )
+  end
+
   test "should filter by broken links" do
     edition_with_broken_link = create(
       :published_publication,

--- a/test/unit/app/models/admin/edition_filter_test.rb
+++ b/test/unit/app/models/admin/edition_filter_test.rb
@@ -225,6 +225,21 @@ class Admin::EditionFilterTest < ActiveSupport::TestCase
     assert_equal [tagged_news], filter.editions
   end
 
+  test "should filter by invalid, non-superseded editions" do
+    # rubocop:disable Lint/UselessAssignment
+    valid_draft_edition = create(:draft_edition, revalidated_at: Time.zone.now)
+    valid_published_edition = create(:published_edition, revalidated_at: Time.zone.now)
+    invalid_draft_edition = create(:draft_edition, revalidated_at: nil)
+    invalid_published_edition = create(:published_edition, revalidated_at: nil)
+    invalid_superseded_edtion = create(:superseded_edition, revalidated_at: nil)
+    # rubocop:enable Lint/UselessAssignment
+
+    assert_equal(
+      [invalid_draft_edition, invalid_published_edition],
+      Admin::EditionFilter.new(Edition, @current_user, only_invalid_editions: true).editions.sort_by(&:id),
+    )
+  end
+
   test "should filter by broken links" do
     edition_with_broken_link = create(
       :published_publication,

--- a/test/unit/app/models/edition_test.rb
+++ b/test/unit/app/models/edition_test.rb
@@ -961,6 +961,23 @@ class EditionTest < ActiveSupport::TestCase
     assert_not edition.valid?
   end
 
+  test "should set 'revalidated_at' value correctly on create" do
+    Timecop.freeze "2025-07-08" do
+      edition = create(:edition)
+      assert edition.revalidated_at
+      assert_equal Time.zone.parse("2025-07-08 00:00:00.000000000 BST +01:00"), edition.revalidated_at
+    end
+  end
+
+  test "should set null 'revalidated_at' if we somehow create an invalid record" do
+    edition = build(:edition)
+    # invalid without summary
+    edition.update(summary: nil) # rubocop:disable Rails/SaveBang
+    edition.save!(validate: false)
+
+    assert_nil edition.revalidated_at
+  end
+
   def decoded_token_payload(token)
     payload, _header = JWT.decode(
       token,

--- a/test/unit/app/sidekiq/revalidate_edition_batch_worker_test.rb
+++ b/test/unit/app/sidekiq/revalidate_edition_batch_worker_test.rb
@@ -1,0 +1,12 @@
+require "test_helper"
+
+class RevalidateEditionBatchWorkerTest < ActiveSupport::TestCase
+  test "calls `valid?(:publish)` on the given editions" do
+    edition1 = create(:edition)
+    edition2 = create(:edition)
+
+    Edition.any_instance.expects(:valid?).with(:publish).twice
+
+    RevalidateEditionBatchWorker.new.perform([edition1.id, edition2.id])
+  end
+end

--- a/test/unit/app/sidekiq/revalidate_editions_scheduler_worker_test.rb
+++ b/test/unit/app/sidekiq/revalidate_editions_scheduler_worker_test.rb
@@ -1,0 +1,36 @@
+require "test_helper"
+
+class RevalidateEditionsSchedulerWorkerTest < ActiveSupport::TestCase
+  test "enqueues RevalidateEditionBatchWorker for editions that haven't been revalidated and aren't unpublished, superseded or deleted" do
+    Sidekiq::Testing.fake! do
+      # Editions that SHOULD trigger a worker
+      draft = create(:draft_edition, title: "Draft")
+      submitted = create(:submitted_edition, title: "Submitted")
+      rejected = create(:rejected_edition, title: "Rejected")
+      published = create(:published_edition, title: "Published")
+      scheduled = create(:scheduled_edition, title: "Scheduled")
+      force_published = create(:force_published_edition, title: "Force published")
+      withdrawn = create(:withdrawn_edition, title: "Withdrawn")
+
+      # Editions that SHOULD NOT trigger a worker
+      unpublished = create(:unpublished_edition, title: "Unpublished")
+      superseded = create(:superseded_edition, title: "Superseded")
+
+      RevalidateEditionsSchedulerWorker.new.perform
+
+      # Flatten all batch args (each job's arg is an array of IDs)
+      enqueued_ids = RevalidateEditionBatchWorker.jobs.flat_map { |job| job["args"].first }
+
+      expected_ids = [draft, submitted, rejected, published, scheduled, force_published, withdrawn].map(&:id)
+      unexpected_ids = [unpublished.id, superseded.id]
+
+      expected_ids.each do |id|
+        assert_includes enqueued_ids, id, "Expected edition #{id} to be enqueued"
+      end
+
+      unexpected_ids.each do |id|
+        assert_not_includes enqueued_ids, id, "Did not expect edition #{id} to be enqueued"
+      end
+    end
+  end
+end


### PR DESCRIPTION
EDIT - have split this out into multiple PRs:

Phase 1: clean up DB and add new property:

- [x] https://github.com/alphagov/whitehall/pull/10388
- [x] https://github.com/alphagov/whitehall/pull/10391

Phase 2: add logic for updating the new property, and scopes for filtering by the new property:

- [x] https://github.com/alphagov/whitehall/pull/10381
- [x] https://github.com/alphagov/whitehall/pull/10392

Phase 3: roll out bulk updating:

- [x] https://github.com/alphagov/whitehall/pull/10401
- [x] https://github.com/alphagov/whitehall/pull/10382

Phase 4: surface the results for users:

- [ ] https://github.com/alphagov/whitehall/pull/10384
- [ ] https://github.com/alphagov/whitehall/pull/10383

JIRA: https://gov-uk.atlassian.net/browse/WHIT-1507

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
