### PR TITLE
Dynamically update `revalidated_at` property (WHIT-1507)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,6 @@
 /attachment-cache
 /*_import_errors.csv
 /bulk-upload-zip-file-tmp
-.yardoc/
 /doc/
 /failures
 /node_modules

--- a/.yardopts
+++ b/.yardopts
@@ -1,1 +1,0 @@
---private --protected app/**/*.rb lib/**/*.rb - docs/misc/guidelines-for-translators.md

--- a/app/models/announcement.rb
+++ b/app/models/announcement.rb
@@ -1,4 +1,3 @@
-# @abstract
 class Announcement < Edition
   include Edition::Images
   include Edition::Organisations

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -1,5 +1,3 @@
-# The base class for almost all editoral content.
-# @abstract Using STI should not create editions directly.
 class Edition < ApplicationRecord
   include Edition::Traits
 
@@ -73,12 +71,10 @@ class Edition < ApplicationRecord
   POST_PUBLICATION_STATES = %w[published superseded withdrawn unpublished].freeze
   PUBLICLY_VISIBLE_STATES = %w[published withdrawn].freeze
 
-  # @!group Callbacks
   before_create :set_auth_bypass_id
   before_save :set_public_timestamp
   after_create :update_document_edition_references
   after_update :update_document_edition_references, if: :saved_change_to_state?
-  # @!endgroup
 
   after_update :republish_topical_event_to_publishing_api
 

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -73,6 +73,7 @@ class Edition < ApplicationRecord
 
   before_create :set_auth_bypass_id
   before_save :set_public_timestamp
+  after_create :cache_revalidation_result
   after_create :update_document_edition_references
   after_update :update_document_edition_references, if: :saved_change_to_state?
 
@@ -105,6 +106,10 @@ class Edition < ApplicationRecord
 
   def skip_main_validation?
     FROZEN_STATES.include?(state)
+  end
+
+  def cache_revalidation_result
+    self.revalidated_at = Time.zone.now if valid?
   end
 
   def unmodifiable?

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -74,7 +74,6 @@ class Edition < ApplicationRecord
   before_create :set_auth_bypass_id
   before_save :set_public_timestamp
   after_validation :update_revalidated_at, if: -> { validation_context == :publish }
-  after_commit :trigger_revalidation, on: %i[create update]
   after_create :update_document_edition_references
   after_update :update_document_edition_references, if: :saved_change_to_state?
 
@@ -117,10 +116,6 @@ class Edition < ApplicationRecord
     else
       self.revalidated_at = new_value
     end
-  end
-
-  def trigger_revalidation
-    valid?(:publish)
   end
 
   def unmodifiable?

--- a/app/models/publicationesque.rb
+++ b/app/models/publicationesque.rb
@@ -5,8 +5,6 @@
 # - Consultations
 # - Publication
 # - Statistical Data Sets
-#
-# @abstract
 class Publicationesque < Edition
   include Edition::HasDocumentCollections
   include Edition::Organisations

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,4 +1,3 @@
-# @abstract
 class Role < ApplicationRecord
   include HasContentId
   include PublishesToPublishingApi

--- a/lib/taxonomy/taxon.rb
+++ b/lib/taxonomy/taxon.rb
@@ -48,8 +48,6 @@ module Taxonomy
     end
 
     # Get ancestors of a taxon
-    #
-    # @return [Array] all taxons in the path from the root of the taxonomy to the parent taxon
     def ancestors
       if parent_node.nil?
         []
@@ -59,8 +57,6 @@ module Taxonomy
     end
 
     # Get a breadcrumb trail for a taxon
-    #
-    # @return [Array] all taxons in the path from the root of the taxonomy to this taxon
     def breadcrumb_trail
       ancestors + [self]
     end

--- a/lib/whitehall/decorators/collection_decorator.rb
+++ b/lib/whitehall/decorators/collection_decorator.rb
@@ -11,12 +11,8 @@ module Whitehall
     class CollectionDecorator
       include Enumerable
 
-      # @return [Class] the decorator class used to decorate each item, as set by
-      #   {#initialize}.
-      attr_reader :decorator_class
+      attr_reader :decorator_class, :object
 
-      # @return [Hash] extra data to be used in user-defined methods, and passed
-      #   to each item's decorator.
       attr_accessor :context
 
       extend DelegateInstanceMethodsOf
@@ -29,21 +25,12 @@ module Whitehall
                                    without_methods_of: Array,
                                    with_default_methods: false
 
-      # @param [Enumerable] object
-      #   collection to decorate.
-      # @param [Class] decorator_class
-      #   the decorator class used to decorate each item. When `nil`, each item's
-      #   {Decoratable#decorate decorate} method will be used.
-      # @param [Object] context
-      #   extra data to be stored in the collection decorator and used in
-      #   user-defined methods, and passed to each item's decorator.
       def initialize(object, decorator_class, context)
         @object = object
         @decorator_class = decorator_class
         @context = context
       end
 
-      # @return [Array] the decorated items.
       def decorated_collection
         @decorated_collection ||= object.map { |item| decorate_item(item) }
       end
@@ -73,9 +60,6 @@ module Whitehall
         decorated_collection.replace(other)
         self
       end
-
-      # @return the collection being decorated.
-      attr_reader :object
 
       # Decorates the given item.
       def decorate_item(item)

--- a/test/support/view_rendering.rb
+++ b/test/support/view_rendering.rb
@@ -25,7 +25,6 @@ module ViewRendering
     end
   end
 
-  # @private
   class EmptyTemplateResolver
     def self.build(path)
       if path.is_a?(::ActionView::Resolver)
@@ -51,8 +50,6 @@ module ViewRendering
     # Delegates all methods to the submitted resolver and for all methods
     # that return a collection of `ActionView::Template` instances, return
     # templates with modified source
-    #
-    # @private
     class ResolverDecorator < ::ActionView::Resolver
       (::ActionView::Resolver.instance_methods - Object.instance_methods).each do |method|
         undef_method method
@@ -87,8 +84,6 @@ module ViewRendering
 
     # Delegates find_templates to the submitted path set and then returns
     # templates with modified source
-    #
-    # @private
     class FileSystemResolver < ::ActionView::FileSystemResolver
     private
 
@@ -99,7 +94,6 @@ module ViewRendering
     end
   end
 
-  # @private
   class EmptyTemplateHandler
     def self.call(_template, _source = nil)
       ::Rails.logger.info("  Template rendering was prevented by rspec-rails. Use `render_views` to verify rendered view contents if necessary.")
@@ -109,8 +103,6 @@ module ViewRendering
   end
 
   # Used to null out view rendering in controller specs.
-  #
-  # @private
   module EmptyTemplates
     def prepend_view_path(new_path)
       super(_path_decorator(*new_path))
@@ -127,7 +119,6 @@ module ViewRendering
     end
   end
 
-  # @private
   RESOLVER_CACHE = Hash.new do |hash, path|
     hash[path] = EmptyTemplateResolver.build(path)
   end

--- a/test/unit/app/models/edition_test.rb
+++ b/test/unit/app/models/edition_test.rb
@@ -961,6 +961,23 @@ class EditionTest < ActiveSupport::TestCase
     assert_not edition.valid?
   end
 
+  test "should set 'revalidated_at' value correctly on create" do
+    Timecop.freeze "2025-07-08" do
+      edition = create(:edition)
+      assert edition.revalidated_at
+      assert_equal Time.zone.parse("2025-07-08 00:00:00.000000000 BST +01:00"), edition.revalidated_at
+    end
+  end
+
+  test "should set null 'revalidated_at' if we somehow create an invalid record" do
+    edition = build(:edition)
+    # invalid without summary
+    edition.update(summary: nil) # rubocop:disable Rails/SaveBang
+    edition.save!(validate: false)
+
+    assert_nil edition.revalidated_at
+  end
+
   def decoded_token_payload(token)
     payload, _header = JWT.decode(
       token,


### PR DESCRIPTION
Dependent on #10391. With that PR safely merged and the DB migration run, we are free to start referring to the new table property in application code. Spreading this across two PRs as we don't want to accidentally deploy code that refers to DB properties that don't yet exist - [we've been bitten by that before](https://docs.google.com/document/d/1GsLZTyuFBaAyt-VNFk2guV2XIzCoui1KNfe2_gN0lX4/edit?tab=t.0#heading=h.p99426yo0rbv).

This will cause the `revalidated_at` to be set to a timestamp if `valid?(:publish)` returns `true`, indicating whether or not the edition is considered valid to publish. We'll be able to query editions via this value, in a separate PR.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
