### PR TITLE
Bulk update `revalidated_at` for all applicable Editions (WHIT-1507)

### DIFF
--- a/app/sidekiq/revalidate_edition_batch_worker.rb
+++ b/app/sidekiq/revalidate_edition_batch_worker.rb
@@ -1,0 +1,10 @@
+class RevalidateEditionBatchWorker
+  include Sidekiq::Job
+  sidekiq_options queue: "edition_revalidation", retry: 0, backtrace: false
+
+  def perform(edition_ids)
+    Edition.where(id: edition_ids).find_each do |edition|
+      edition.valid?(:publish) # revalidates the edition and updates `revalidated_at`
+    end
+  end
+end

--- a/app/sidekiq/revalidate_editions_scheduler_worker.rb
+++ b/app/sidekiq/revalidate_editions_scheduler_worker.rb
@@ -1,0 +1,24 @@
+class RevalidateEditionsSchedulerWorker
+  include Sidekiq::Job
+  sidekiq_options queue: "edition_revalidation", retry: 0
+
+  BATCH_SIZE  = ENV.fetch("REVALIDATE_BATCH_SIZE", 100).to_i
+  MAX_BATCHES = ENV.fetch("REVALIDATE_MAX_BATCHES", 1000).to_i # 1000 × 100 = 100 000 editions/run
+  def self.stale_after
+    1.week.ago
+  end
+
+  def perform
+    scope = Edition.not_validated_since(1.week.ago.strftime("%d/%m/%Y"))
+    logger.info("[RevalidateEditionsSchedulerWorker] #{scope.count} editions need revalidating")
+
+    # Pull batches in random order so permanently invalid editions
+    # don't prevent us from revalidating 'old' revalidated editions
+    scope.order(Arel.sql("RAND()")) # MySQL / MariaDB
+         .limit(BATCH_SIZE * MAX_BATCHES)
+         .pluck(:id)
+         .each_slice(BATCH_SIZE) do |ids|
+      RevalidateEditionBatchWorker.perform_async(ids)
+    end
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -10,8 +10,12 @@
   - bulk_republishing
   - link_checks
   - asset_migration
+  - edition_revalidation
 :scheduler:
   :schedule:
     revalidate_old_link_check_reports:
       cron: '0 4 * * *' # Runs at 4 a.m every day
       class: RevalidateOldLinkCheckReportsWorker
+    revalidate_all_editions:
+      cron: '45 5 * * *' # Runs at 5:45am every day
+      class: RevalidateEditionsSchedulerWorker

--- a/test/factories/editions.rb
+++ b/test/factories/editions.rb
@@ -183,6 +183,7 @@ FactoryBot.define do
   factory :superseded_edition, parent: :edition, traits: [:superseded]
   factory :scheduled_edition, parent: :edition, traits: [:scheduled]
   factory :force_scheduled_edition, parent: :edition, traits: [:force_scheduled]
+  factory :force_published_edition, parent: :edition, traits: [:force_published]
   factory :unpublished_edition, parent: :edition, traits: [:unpublished]
   factory :withdrawn_edition, parent: :edition, traits: [:withdrawn]
   factory :protected_edition, parent: :edition, traits: [:access_limited]

--- a/test/unit/app/sidekiq/revalidate_edition_batch_worker_test.rb
+++ b/test/unit/app/sidekiq/revalidate_edition_batch_worker_test.rb
@@ -1,0 +1,12 @@
+require "test_helper"
+
+class RevalidateEditionBatchWorkerTest < ActiveSupport::TestCase
+  test "calls `valid?(:publish)` on the given editions" do
+    edition1 = create(:edition)
+    edition2 = create(:edition)
+
+    Edition.any_instance.expects(:valid?).with(:publish).twice
+
+    RevalidateEditionBatchWorker.new.perform([edition1.id, edition2.id])
+  end
+end

--- a/test/unit/app/sidekiq/revalidate_editions_scheduler_worker_test.rb
+++ b/test/unit/app/sidekiq/revalidate_editions_scheduler_worker_test.rb
@@ -1,0 +1,36 @@
+require "test_helper"
+
+class RevalidateEditionsSchedulerWorkerTest < ActiveSupport::TestCase
+  test "enqueues RevalidateEditionBatchWorker for editions that haven't been revalidated and aren't unpublished, superseded or deleted" do
+    Sidekiq::Testing.fake! do
+      # Editions that SHOULD trigger a worker
+      draft = create(:draft_edition, title: "Draft")
+      submitted = create(:submitted_edition, title: "Submitted")
+      rejected = create(:rejected_edition, title: "Rejected")
+      published = create(:published_edition, title: "Published")
+      scheduled = create(:scheduled_edition, title: "Scheduled")
+      force_published = create(:force_published_edition, title: "Force published")
+      withdrawn = create(:withdrawn_edition, title: "Withdrawn")
+
+      # Editions that SHOULD NOT trigger a worker
+      unpublished = create(:unpublished_edition, title: "Unpublished")
+      superseded = create(:superseded_edition, title: "Superseded")
+
+      RevalidateEditionsSchedulerWorker.new.perform
+
+      # Flatten all batch args (each job's arg is an array of IDs)
+      enqueued_ids = RevalidateEditionBatchWorker.jobs.flat_map { |job| job["args"].first }
+
+      expected_ids = [draft, submitted, rejected, published, scheduled, force_published, withdrawn].map(&:id)
+      unexpected_ids = [unpublished.id, superseded.id]
+
+      expected_ids.each do |id|
+        assert_includes enqueued_ids, id, "Expected edition #{id} to be enqueued"
+      end
+
+      unexpected_ids.each do |id|
+        assert_not_includes enqueued_ids, id, "Did not expect edition #{id} to be enqueued"
+      end
+    end
+  end
+end


### PR DESCRIPTION
## What

Every edition has a `revalidated_at` timestamp, which is currently nil, as the property was added in #10391. In #10381, we added logic to overwrite the property with the current timestamp whenever `valid?(:publish)` is called (and succeeds). We now want to revalidate all of Whitehall's editions (except for deleted, superseded and unpublished editions) in bulk, via a worker running on a cron. This PR adds that worker and cron configuration.

## Why

This will accommodate changing circumstances in future (e.g. a more strict GovSpeak validator, or a situation where an embedded Contact has been deleted): it would revalidate all of the relevant Whitehall editions within roughly one week.

We'll then be able to easily grab all the invalid editions (`Edition.only_invalid_editions`) and report on that as a system health metric. We'll also be able to surface invalid editions for publishers, for them to fix up (in #10383).

## Testing on Integration

```
$ RevalidateEditionsSchedulerWorker.new.perform
# enqueues lots of workers...

$ puts Sidekiq::Queue.new("edition_revalidation").size; puts Edition.only_invalid_editions.count
1000 # jobs
398974 # editions where `revalidated_at` is `nil` - i.e. all of them

# a bit later... (and after running `RevalidateEditionsSchedulerWorker.new.perform` a couple more times)
$ puts Sidekiq::Queue.new("edition_revalidation").size; puts Edition.only_invalid_editions.count
0
213841

# and finally...
$ puts Sidekiq::Queue.new("edition_revalidation").size; puts Edition.only_invalid_editions.count
0
48045
```

Publishing API seemed to cope fine with this bulk-enqueuing:

<img width="1581" height="341" alt="Screenshot 2025-07-14 at 10 25 38" src="https://github.com/user-attachments/assets/c30fafba-5bed-4161-9866-07aa40954239" />
<img width="1604" height="780" alt="Screenshot 2025-07-14 at 10 26 00" src="https://github.com/user-attachments/assets/2b942428-4771-40ad-ba07-0e51cd8d317d" />

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
