### PR TITLE
Add "Only invalid editions" filter on Whitehall search (WHIT-1507)

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -419,7 +419,7 @@ private
   end
 
   def params_filters
-    params.slice(:type, :state, :organisation, :author, :page, :title, :world_location, :from_date, :to_date, :only_broken_links, :review_overdue)
+    params.slice(:type, :state, :organisation, :author, :page, :title, :world_location, :from_date, :to_date, :only_invalid_editions, :only_broken_links, :review_overdue)
           .permit!
           .to_h
   end

--- a/app/views/admin/editions/_filter_options.html.erb
+++ b/app/views/admin/editions/_filter_options.html.erb
@@ -1,5 +1,5 @@
 <%
-  filter_by ||= [:title, :author, :organisation, :world_location, :type, :state, :date, :only_broken_links, :review_overdue]
+  filter_by ||= [:title, :author, :organisation, :world_location, :type, :state, :date, :only_invalid_editions, :only_broken_links, :review_overdue]
   anchor ||= anchor || ""
   raise "filter action required" unless defined?(filter_action)
 %>
@@ -153,6 +153,25 @@
           },
         } %>
       <% end %>
+    <% end %>
+
+    <% if filter_by.include?(:only_invalid_editions) %>
+      <%= render "govuk_publishing_components/components/checkboxes", {
+        name: "only_invalid_editions",
+        small: true,
+        data_attributes: {
+          ga4_change_category: "update-filter checkbox",
+          ga4_filter_parent: true,
+        },
+        items: [
+          {
+            label: "Only invalid editions",
+            value: "1",
+            bold: true,
+            checked: params["only_invalid_editions"],
+          },
+        ],
+      } %>
     <% end %>
 
     <% if filter_by.include?(:only_broken_links) %>

--- a/test/functional/admin/editions_controller_test.rb
+++ b/test/functional/admin/editions_controller_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
+require "capybara/rails"
 
 class Admin::EditionsControllerTest < ActionController::TestCase
+  include Capybara::DSL
   include Admin::EditionRoutesHelper
 
   setup do
@@ -154,6 +156,18 @@ class Admin::EditionsControllerTest < ActionController::TestCase
   test "should remember title filter options" do
     get :index, params: { title: "test" }
     assert_equal "test", session[:document_filters]["title"]
+  end
+
+  view_test "should have an 'only invalid editions' checkbox that sets the 'only_invalid_editions' filter" do
+    visit "/government/admin/editions"
+    check "Only invalid editions"
+    click_button "Search"
+    assert_includes current_url, "only_invalid_editions=1"
+  end
+
+  test "should remember 'only invalid editions' option" do
+    get :index, params: { only_invalid_editions: "1" }
+    assert_equal "1", session[:document_filters]["only_invalid_editions"]
   end
 
   test "index should redirect to remembered filtered options if available" do


### PR DESCRIPTION
Depends on the scope added in #10392, and the end-to-end journey enabled by #10384. This will allow publishers to easily see which of their documents needs editing, and what needs editing, respectively.

New option in sidebar:

!["Only invalid editions" checkbox](https://github.com/user-attachments/assets/cdf4798d-4fb6-4a19-bc67-19f0b394962b)

Search results in action±:

![search results showing issue with `Accelerator themed competition: the future of aviation security`](https://github.com/user-attachments/assets/656fa7f4-e6c2-486d-b040-9ffae2e21699)

± after manually running `.valid?(:publish)` against an edition we know references a missing Contact.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
