### PR TITLE
Surface validation errors in the sidebar (WHIT-1507)

### DIFF
--- a/app/views/admin/editions/show/_sidebar_notices.html.erb
+++ b/app/views/admin/editions/show/_sidebar_notices.html.erb
@@ -6,6 +6,23 @@
 %>
 
 <div class="app-view-summary__sidebar-notices">
+  <% unless @edition.valid?(:publish) %>
+    <%= render "components/inset_prompt", {
+      data_attributes: {
+        module: "ga4-auto-tracker",
+        ga4_auto: {
+          type: "show invalid edition warning",
+          text: @edition.errors.map(&:full_message).join(", "),
+        }.merge(ga4_auto_attributes).as_json,
+      },
+      title: "This edition is invalid",
+      description: render("govuk_publishing_components/components/list", {
+        visible_counters: true,
+        items:  @edition.errors.map(&:full_message),
+      }),
+      error: true,
+    } %>
+  <% end %>
   <% if @edition.scheduled_publication %>
     <% if force_scheduler.can_transition? && !force_scheduler.can_perform? %>
       <%= render "components/inset_prompt", {

--- a/app/views/admin/editions/show/_sidebar_notices.html.erb
+++ b/app/views/admin/editions/show/_sidebar_notices.html.erb
@@ -23,44 +23,6 @@
       error: true,
     } %>
   <% end %>
-  <% if @edition.scheduled_publication %>
-    <% if force_scheduler.can_transition? && !force_scheduler.can_perform? %>
-      <%= render "components/inset_prompt", {
-        title: "This edition cannot be scheduled",
-        data_attributes: {
-          module: "ga4-auto-tracker",
-          ga4_auto: {
-            type: "scheduled",
-            text: force_scheduler.failure_reasons_plaintext,
-          }.merge(ga4_auto_attributes).as_json,
-        },
-        description: render("govuk_publishing_components/components/list", {
-          visible_counters: true,
-          items: force_scheduler.failure_reasons,
-        }),
-        error: true,
-      } %>
-    <% end %>
-  <% else %>
-    <% if force_publisher.can_transition? && !force_publisher.can_perform? %>
-      <%= render "components/inset_prompt", {
-        title: "This edition cannot be force-published",
-        module: "ga4-auto-tracker",
-        data_attributes: {
-          module: "ga4-auto-tracker",
-          ga4_auto: {
-            type: "force published",
-            text: force_scheduler.failure_reasons_plaintext,
-          }.merge(ga4_auto_attributes).as_json,
-        },
-        description: render("govuk_publishing_components/components/list", {
-          visible_counters: true,
-          items: force_publisher.failure_reasons,
-        }),
-        error: true,
-      } %>
-    <% end %>
-  <% end %>
   <% if show_similar_slugs_warning?(@edition) %>
     <%= render "components/inset_prompt", {
       data_attributes: {

--- a/test/functional/admin/generic_editions_controller_test.rb
+++ b/test/functional/admin/generic_editions_controller_test.rb
@@ -1,6 +1,7 @@
 require "test_helper"
 
 class Admin::GenericEditionsControllerTest < ActionController::TestCase
+  include TaxonomyHelper
   should_be_an_admin_controller
 
   setup do
@@ -110,5 +111,21 @@ class Admin::GenericEditionsControllerTest < ActionController::TestCase
 
     assert_select ".govuk-link", text: "Preview on website (opens in new tab)", href: draft_edition.public_url(draft: true), count: 0
     assert_select ".govuk-inset-text", text: "To see the changes and share a document preview link, add a change note or mark the change type to minor."
+  end
+
+  view_test "visiting an invalid edition should show the validation errors" do
+    bad_id = "9999999999999"
+    edition = create(:draft_edition, body: "[Contact:#{bad_id}]")
+    edition.save!(validate: false)
+    stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+
+    get :show, params: { id: edition }
+
+    assert_select ".app-view-summary__sidebar .app-c-inset-prompt--error" do |elements|
+      expected_message = "This edition is invalid"
+      assert elements.text.include?(expected_message), "Could not find \"#{expected_message}\" in #{elements.text}"
+      expected_message = "Contact ID #{bad_id} doesn't exist"
+      assert elements.text.include?(expected_message), "Could not find \"#{expected_message}\" in #{elements.text}"
+    end
   end
 end


### PR DESCRIPTION
This PR adds a new "This edition is invalid" section to the sidebar, surfacing any and all± validation errors that would prevent publishing of the content. This section is also surfaced on earlier editions on the document (e.g. superseded ones) which provides a useful audit trail of whether or not past editions were considered 'valid'.

± Where validation fails on a dependency, such as an attachment (or attachment's attachment_data, or the attachment_data's asset), these are surfaced as a high level "Attachments is invalid" as per Rails' default. We're hoping to explore this further in https://gov-uk.atlassian.net/browse/WHIT-1517 to see if we can surface more specific validation messages in these cases at the Edition level.

It's worth noting that Whitehall did already have "This edition cannot be force-published" / "This edition cannot be scheduled" sections, which our new "This edition is invalid" section would now be duplicating. The former weren't backed up by any tests, were only visible in specific circumstances, and ultimately didn't flag all the publisher-blocking issues (see screenshots), so have been removed.

The context for this change is that in #10383, we're offering publishers a way of seeing all their 'invalid' editions directly from the search screen, but then it would be all too common for them to click through to an edition and see no issues until they try to edit or publish the content. We need a better journey for them to actually find out what the validation issues are, so we now run the `valid?(:publish)` checks on page render, and surface any validation issues in the sidebar.

## Screenshots

| Before | After |
|--------|------|
|![whitehall-admin integration publishing service gov uk_government_admin_collections_502122](https://github.com/user-attachments/assets/969f4843-b03e-41c9-977a-4dcdf06efe4b)|![whitehall-admin dev gov uk_government_admin_collections_502122](https://github.com/user-attachments/assets/d904feab-0a85-4bb7-9d22-0b901f32c25d)|
| No visible issues | Validation error now surfaced on the main screen, in the sidebar 🎉  |
|![whitehall-admin integration publishing service gov uk_government_admin_news_505814](https://github.com/user-attachments/assets/2c35ba47-e763-45fb-86c9-e5b94c4ce00a)|![whitehall-admin dev gov uk_government_admin_news_505814](https://github.com/user-attachments/assets/fee31080-b9d1-4deb-9719-ea046cd8e8dd)|
| Visible issues ✅ | Visible issues, but now with proper tests 🎉  |

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
