### PR TITLE
(CM-148) Send change type and notes depending on major change

### DIFF
--- a/lib/engines/content_block_manager/app/services/content_block_manager/publish_edition_service.rb
+++ b/lib/engines/content_block_manager/app/services/content_block_manager/publish_edition_service.rb
@@ -33,7 +33,10 @@ module ContentBlockManager
     end
 
     def create_publishing_api_edition(content_id:, content_id_alias:, schema_id:, content_block_edition:)
-      Services.publishing_api.put_content(content_id, publishing_api_payload(schema_id, content_id_alias, content_block_edition))
+      Services.publishing_api.put_content(
+        content_id,
+        publishing_api_payload(schema_id, content_id_alias, content_block_edition),
+      )
     end
 
     def publishing_api_payload(schema_id, content_id_alias, content_block_edition)
@@ -50,7 +53,8 @@ module ContentBlockManager
             content_block_edition.lead_organisation.content_id,
           ],
         },
-        update_type: "major",
+        update_type: content_block_edition.major_change ? "major" : "minor",
+        change_note: content_block_edition.major_change ? content_block_edition.change_note : nil,
       }
     end
 

--- a/lib/engines/content_block_manager/app/services/content_block_manager/publish_edition_service.rb
+++ b/lib/engines/content_block_manager/app/services/content_block_manager/publish_edition_service.rb
@@ -20,14 +20,7 @@ module ContentBlockManager
         content_id:,
         content_id_alias:,
         schema_id: schema.id,
-        title: content_block_edition.title,
-        details: content_block_edition.details,
-        instructions_to_publishers: content_block_edition.instructions_to_publishers,
-        links: {
-          primary_publishing_organisation: [
-            content_block_edition.lead_organisation.content_id,
-          ],
-        },
+        content_block_edition:,
       )
       dequeue_all_previously_queued_editions(content_block_edition)
       publish_publishing_api_edition(content_id:)
@@ -39,18 +32,26 @@ module ContentBlockManager
       raise e
     end
 
-    def create_publishing_api_edition(content_id:, content_id_alias:, schema_id:, title:, instructions_to_publishers:, details:, links:)
-      Services.publishing_api.put_content(content_id, {
+    def create_publishing_api_edition(content_id:, content_id_alias:, schema_id:, content_block_edition:)
+      Services.publishing_api.put_content(content_id, publishing_api_payload(schema_id, content_id_alias, content_block_edition))
+    end
+
+    def publishing_api_payload(schema_id, content_id_alias, content_block_edition)
+      {
         schema_name: schema_id,
         document_type: schema_id,
         publishing_app: Whitehall::PublishingApp::WHITEHALL,
-        title:,
-        instructions_to_publishers:,
+        title: content_block_edition.title,
+        instructions_to_publishers: content_block_edition.instructions_to_publishers,
         content_id_alias:,
-        details:,
-        links:,
+        details: content_block_edition.details,
+        links: {
+          primary_publishing_organisation: [
+            content_block_edition.lead_organisation.content_id,
+          ],
+        },
         update_type: "major",
-      })
+      }
     end
 
     def publish_publishing_api_edition(content_id:)

--- a/lib/engines/content_block_manager/test/integration/content_block/workflow_test.rb
+++ b/lib/engines/content_block_manager/test/integration/content_block/workflow_test.rb
@@ -632,6 +632,7 @@ def assert_edition_is_published(&block)
         primary_publishing_organisation: [organisation.content_id],
       },
       update_type: "major",
+      change_note: edition.change_note,
     },
   ]
   publishing_api_mock.expect :publish, fake_publish_content_response, [


### PR DESCRIPTION
This updates the `PublishEditionService` to send a `major` change type and the change note ONLY if the update type has been set to major.

This will allow us to trigger email alerts for dependent content downstream in the Publishing API.