### PR TITLE
Remove legacy (unused) thumbnail assets (WHIT-1507)

### DIFF
--- a/db/data_migration/20250708070143_remove_thumbnail_assets.rb
+++ b/db/data_migration/20250708070143_remove_thumbnail_assets.rb
@@ -27,7 +27,7 @@
 # 1048455, 1048463, 1048467, 1048469, 1048473, 1048475, 1048479, 1048481, 1048487, 1048491, 1048493, 1048497, 1048501, 1048507, 1048509, 1048511, 1049303, 1049639, 1050990, 1051019, 1051041, 1051043, 1751104
 #
 # On closer inspection (https://github.com/alphagov/whitehall/pull/10388#discussion_r2192532605),
-#these are all also unused thumbnails, but just happen not to follow the filename pattern for some reason.
+# these are all also unused thumbnails, but just happen not to follow the filename pattern for some reason.
 # So they can be deleted too.
 non_conforming_thumbnail_assets = [1_048_455, 1_048_463, 1_048_467, 1_048_469, 1_048_473, 1_048_475, 1_048_479, 1_048_481, 1_048_487, 1_048_491, 1_048_493, 1_048_497, 1_048_501, 1_048_507, 1_048_509, 1_048_511, 1_049_303, 1_049_639, 1_050_990, 1_051_019, 1_051_041, 1_051_043, 1_751_104]
 

--- a/db/data_migration/20250708070143_remove_thumbnail_assets.rb
+++ b/db/data_migration/20250708070143_remove_thumbnail_assets.rb
@@ -26,11 +26,15 @@
 # IDs of the non-matching rows (safe-delete sanity check):
 # 1048455, 1048463, 1048467, 1048469, 1048473, 1048475, 1048479, 1048481, 1048487, 1048491, 1048493, 1048497, 1048501, 1048507, 1048509, 1048511, 1049303, 1049639, 1050990, 1051019, 1051041, 1051043, 1751104
 #
-assets_to_look_at_later = [1_048_455, 1_048_463, 1_048_467, 1_048_469, 1_048_473, 1_048_475, 1_048_479, 1_048_481, 1_048_487, 1_048_491, 1_048_493, 1_048_497, 1_048_501, 1_048_507, 1_048_509, 1_048_511, 1_049_303, 1_049_639, 1_050_990, 1_051_019, 1_051_041, 1_051_043, 1_751_104]
+# On closer inspection (https://github.com/alphagov/whitehall/pull/10388#discussion_r2192532605),
+#these are all also unused thumbnails, but just happen not to follow the filename pattern for some reason.
+# So they can be deleted too.
+non_conforming_thumbnail_assets = [1_048_455, 1_048_463, 1_048_467, 1_048_469, 1_048_473, 1_048_475, 1_048_479, 1_048_481, 1_048_487, 1_048_491, 1_048_493, 1_048_497, 1_048_501, 1_048_507, 1_048_509, 1_048_511, 1_049_303, 1_049_639, 1_050_990, 1_051_019, 1_051_041, 1_051_043, 1_751_104]
 
 valid_variants = Asset.defined_enums["variant"].keys
 
 Asset.where.not(variant: valid_variants)
      .where("filename REGEXP ?", '^thumbnail_.*\\.png$')
-     .where.not(id: assets_to_look_at_later)
      .delete_all
+
+Asset.where(id: non_conforming_thumbnail_assets).delete_all

--- a/db/data_migration/20250708070143_remove_thumbnail_assets.rb
+++ b/db/data_migration/20250708070143_remove_thumbnail_assets.rb
@@ -1,0 +1,36 @@
+# **SCRIPT TO CHECK WHICH ASSETS TO DELETE**
+#
+# # 0.  Get the list of enum strings that ARE valid
+# valid_variants = Asset.defined_enums["variant"].keys
+# # => ["original", "s960", "s712", …]
+
+# # Grab every Asset whose stored variant is NOT one of those
+# invalid_assets = Asset.where.not(variant: valid_variants)
+# total = invalid_assets.count
+# # Split them on the filename pattern
+# non_matching = invalid_assets.where.not("filename REGEXP ?", '^thumbnail_.*\\.png$')
+
+# puts <<~MSG
+#   --- Asset variant audit ---
+#   Total records with 'variant' shown as nil: #{total}
+#   Of those, filenames NOT matching thumbnail_*.png: #{non_matching.count}
+#   IDs of the non-matching rows (safe-delete sanity check):
+#   #{non_matching.pluck(:id).join(', ')}
+# MSG
+#
+# **OUTPUT OF THE RUN**
+#
+# --- Asset variant audit ---
+# Total records with 'variant' shown as nil: 782232
+# Of those, filenames NOT matching thumbnail_*.png: 23
+# IDs of the non-matching rows (safe-delete sanity check):
+# 1048455, 1048463, 1048467, 1048469, 1048473, 1048475, 1048479, 1048481, 1048487, 1048491, 1048493, 1048497, 1048501, 1048507, 1048509, 1048511, 1049303, 1049639, 1050990, 1051019, 1051041, 1051043, 1751104
+#
+assets_to_look_at_later = [1_048_455, 1_048_463, 1_048_467, 1_048_469, 1_048_473, 1_048_475, 1_048_479, 1_048_481, 1_048_487, 1_048_491, 1_048_493, 1_048_497, 1_048_501, 1_048_507, 1_048_509, 1_048_511, 1_049_303, 1_049_639, 1_050_990, 1_051_019, 1_051_041, 1_051_043, 1_751_104]
+
+valid_variants = Asset.defined_enums["variant"].keys
+
+Asset.where.not(variant: valid_variants)
+     .where("filename REGEXP ?", '^thumbnail_.*\\.png$')
+     .where.not(id: assets_to_look_at_later)
+     .delete_all


### PR DESCRIPTION
The context for this change is that we're introducing a 'revalidation' check across all Editions (see #10379), which will allow us to quickly surface all Editions that have issues that need rectifying.

An early look at the affected Editions showed a lot of false positives regarding thumbnail assets. An Edition would have an "Attachments is invalid" error, and digging deeper, the real reason appears to be that we have an invalid 'variant' of the asset, i.e. the thumbnail PNG, which now serve no purpose. Indeed, we removed thumbnail generation in #9163 and legacy thumbnail references in #9682 now that the frontend no longer uses them, but it looks as though the legacy data itself was left untouched. (Annoyingly this was [picked up on](https://github.com/alphagov/whitehall/pull/9682#pullrequestreview-2484728705) by @lauraghiorghisor-tw but I think we had an offline conversation about it and never documented the conclusion in the PR!)

A very unscientific set of numbers on this: my (only partially concluded) run of revalidation surfaced ~12150 'invalid' Editions. With the thumbnail asset variant removed from all editions, this dropped the number of invalid editions down to ~3550 - so thumbnail assets were the root cause of 70% of all 'invalid' Editions.

## Details of the issue

```
ed6 = Edition.find(183846)
ed6.valid?(:publish)

ed6.errors
=> #<ActiveModel::Errors [#<ActiveModel::Error attribute=attachments, type=invalid, options={}>]>
```

Digging into the dodgy attachments property more deeply:

```
ed6.attachments.first.attachment_data.assets
=> [#<Asset:0x0000ffff7f7fa510
  id: 112570,
  asset_manager_id: "5a79f566e5274a319e776d3b",
  variant: "original",
  created_at: "2023-09-22 15:01:12.783866000 +0100",
  updated_at: "2023-09-22 15:01:12.783866000 +0100",
  assetable_type: "AttachmentData",
  assetable_id: 186978,
  filename: "IndiaPolicyOptionsCarbonReduction101212.pdf">,
 #<Asset:0x0000ffff7f7fa3d0
  id: 112571,
  asset_manager_id: "5a79f55940f0b66a2fbfedfc",
  variant: nil,
  created_at: "2023-09-22 15:01:12.816944000 +0100",
  updated_at: "2023-09-22 15:01:12.816944000 +0100",
  assetable_type: "AttachmentData",
  assetable_id: 186978,
  filename: "thumbnail_IndiaPolicyOptionsCarbonReduction101212....">]
```

...and now the attachments' attachment data's assets:

```
ed6.attachments.first.attachment_data.assets.map do |asset|
  is_valid = asset.valid?(:publish)
  [is_valid, asset.filename, asset.asset_manager_id, asset.errors.map(&:full_message)]
end

=>

[
  [
    true,
    "IndiaPolicyOptionsCarbonReduction101212.pdf",
    "5a79f566e5274a319e776d3b",
    [],
  ],
  [
    false,
    "thumbnail_IndiaPolicyOptionsCarbonReduction101212.pdf.png",
    "5a79f55940f0b66a2fbfedfc",
    ["Variant cannot be blank"],
  ],
]
```

Looking at the [code](https://github.com/alphagov/whitehall/blob/f7caf78af3c415d9224f83f53dab7f8b493318f5/app/models/asset.rb#L19-L25), we [defer](https://github.com/alphagov/whitehall/blob/f90eac26c4aa17472a9f4643462408053f36e925/lib/whitehall.rb#L137) to a [build_image_kinds](https://github.com/alphagov/whitehall/blob/e0ade76f0b549390930dbb48113f544956e42fc8/lib/whitehall/image_kinds.rb#L46-L49) method which looks for matching versions in the [image_kinds.yml](https://github.com/alphagov/whitehall/blob/b7b11b5b00baafdf7db2bf5e7c2d9a28b82e2d8d/config/image_kinds.yml#L8) config file. Given the legacy variant was called "thumbnail", this doesn't match any of the variant enums (e.g. s960), so Rails map these to `nil` (as per the output of the `ed6.attachments.first.attachment_data.assets` command above) and we fail the `presence` validation check on the asset.

In the commented out code in the data migration script in this commit, we can see that there are almost 800k such assets, with just two dozen that have a non-matching enum that _aren't_ thumbnail assets (we'll deal with these later). The rest can be safely deleted.

## To delete or not to delete from Asset Manager?

I've decided only to remove the assets from Whitehall's DB - not to make calls to Asset Manager to delete the files from S3, for a few reasons:

1. Risk management: if we decide we need to get the thumbnails back, or if there is a bug in the code and we accidentally delete something we shouldn't, we can always get the asset references back from a Whitehall backup. The assets themselves are still safe in S3.
2. Simpler data migration: can just drop the records, no need to rate-limit them because we're making calls to Asset Manager, etc.
3. Minimal cost. The cost of storing approximately 800,000 small images in S3 is just over $20 per *year* (assuming a very generous average of 100 KB per image): https://www.nops.io/blog/how-much-do-aws-s3-storage-classes-cost/. Additionally, internal transfers between S3 buckets within the same AWS region are free, so maintaining our nightly backups to Staging/Integration shouldn't incur any additional costs: https://aws.amazon.com/s3/pricing/

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
