### PR TITLE
Document increased scope of content block 'field_order'

### DIFF
--- a/docs/content_block_manager/configuration.md
+++ b/docs/content_block_manager/configuration.md
@@ -22,7 +22,10 @@ This defines if a subschema is embeddable as an entire block.
 
 ## `schemas.<schema_name>.field_order`
 
-An array of strings that defines the order that fields appear in when rendering the form.
+An array of strings that defines the order in which:
+
+- fields appear when rendering the form
+- properties are listed when viewing an embedded object in a summary list
 
 ## `schemas.<schema_name>.fields`
 


### PR DESCRIPTION
Since [582f9d36a8fda56b048c896f911b1ac920867a5a][] `field_order` is also used to sort the rows of the metadata component's summary list.

[582f9d36a8fda56b048c896f911b1ac920867a5a]:
https://github.com/alphagov/whitehall/pull/10374/commits/582f9d36a8fda56b048c896f911b1ac920867a5a

