### PR TITLE
Add 'revalidated_at' property to editions table (WHIT-1507)

### DIFF
--- a/db/migrate/20250708124941_add_revalidated_at_timestamp_to_editions.rb
+++ b/db/migrate/20250708124941_add_revalidated_at_timestamp_to_editions.rb
@@ -1,0 +1,7 @@
+class AddRevalidatedAtTimestampToEditions < ActiveRecord::Migration[8.0]
+  def change
+    change_table :editions, bulk: true do |t|
+      t.datetime :revalidated_at
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_08_124941) do
   create_table "assets", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.string "variant", null: false
@@ -455,6 +455,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_10_095041) do
     t.boolean "visual_editor"
     t.integer "government_id"
     t.string "flexible_page_type"
+    t.datetime "revalidated_at"
     t.index ["alternative_format_provider_id"], name: "index_editions_on_alternative_format_provider_id"
     t.index ["closing_at"], name: "index_editions_on_closing_at"
     t.index ["document_id"], name: "index_editions_on_document_id"


### PR DESCRIPTION
We are going to introduce a background worker that cycles through all published editions and checks whether they're still considered 'valid'. This is to catch cases where published editions are no longer valid, such as using legacy GovSpeak or referring to a Contact embed that no longer exists.

Running the `valid?` checks at runtime, across all editions, is _very_ slow - so we need to pre-compute the outputs ahead of time if we want to be able to surface invalid editions in search. We're therefore introducing a cache field, and in a future PR, we will:

1. Update the timestamp on a per-edition basis, at the point of validation (so we can slowly build up a better picture of the number of invalid editions just through normal publisher interaction).
2. Update the property in bulk by looping through all editions.

The 'invalid editions' count will be useful in reporting on Whitehall system health

NB we [initially considered](https://github.com/alphagov/whitehall/pull/10380) adding a `revalidation_passed` boolean (true for valid editions, false for invalid) but then that limits our ability to know how recently something was revalidated, which hampers our ability to intelligently batch editions for revalidation. So following the advice of <https://changelog.com/posts/you-might-as-well-timestamp-it>

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
