### PR TITLE
Add only invalid editions scope (WHIT-1507)

### DIFF
--- a/app/models/admin/edition_filter.rb
+++ b/app/models/admin/edition_filter.rb
@@ -121,6 +121,7 @@ module Admin
       editions = editions.from_date(from_date) if from_date
       editions = editions.to_date(to_date) if to_date
       editions = editions.only_invalid_editions if only_invalid_editions
+      editions = editions.not_validated_since(not_validated_since) if not_validated_since
       editions = editions.only_broken_links if only_broken_links
       editions = editions.review_overdue if review_overdue
 
@@ -249,6 +250,10 @@ module Admin
 
     def topical_event
       TopicalEvent.find(options[:topical_event]) if options[:topical_event].present?
+    end
+
+    def not_validated_since
+      options[:not_validated_since].presence
     end
 
     def location_matches

--- a/app/models/admin/edition_filter.rb
+++ b/app/models/admin/edition_filter.rb
@@ -120,6 +120,7 @@ module Admin
       editions = editions.in_world_location(selected_world_locations) if selected_world_locations.any?
       editions = editions.from_date(from_date) if from_date
       editions = editions.to_date(to_date) if to_date
+      editions = editions.only_invalid_editions if only_invalid_editions
       editions = editions.only_broken_links if only_broken_links
       editions = editions.review_overdue if review_overdue
 
@@ -255,6 +256,10 @@ module Admin
         sentence = selected_world_locations.map { |l| WorldLocation.friendly.find(l).name }.to_sentence
         " about #{sentence}"
       end
+    end
+
+    def only_invalid_editions
+      options[:only_invalid_editions].present?
     end
 
     def only_broken_links

--- a/app/models/concerns/edition/scopes/filterable_by_invalid.rb
+++ b/app/models/concerns/edition/scopes/filterable_by_invalid.rb
@@ -6,5 +6,11 @@ module Edition::Scopes::FilterableByInvalid
       where(revalidated_at: nil)
         .where.not(state: %w[superseded unpublished deleted]) # We don't care if editions are invalid if they're superseded
     }
+
+    scope :not_validated_since, lambda { |from_date|
+      cutoff = Time.zone.parse(from_date.to_s)
+      where("revalidated_at IS NULL OR revalidated_at < ?", cutoff)
+        .where.not(state: %w[superseded unpublished deleted]) # We don't care if editions are invalid if they're superseded
+    }
   end
 end

--- a/app/models/concerns/edition/scopes/filterable_by_invalid.rb
+++ b/app/models/concerns/edition/scopes/filterable_by_invalid.rb
@@ -1,0 +1,10 @@
+module Edition::Scopes::FilterableByInvalid
+  extend ActiveSupport::Concern
+
+  included do
+    scope :only_invalid_editions, lambda {
+      where(revalidated_at: nil)
+        .where.not(state: %w[superseded unpublished deleted]) # We don't care if editions are invalid if they're superseded
+    }
+  end
+end

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -27,6 +27,7 @@ class Edition < ApplicationRecord
   include Edition::Scopes::Orderable
   include Edition::Scopes::SearchableByTitle
   include Edition::Scopes::FilterableByAuthor
+  include Edition::Scopes::FilterableByInvalid
   include Edition::Scopes::FilterableByBrokenLinks
   include Edition::Scopes::FilterableByDate
   include Edition::Scopes::FilterableByTopicalEvent

--- a/test/unit/app/models/admin/edition_filter_test.rb
+++ b/test/unit/app/models/admin/edition_filter_test.rb
@@ -240,6 +240,19 @@ class Admin::EditionFilterTest < ActiveSupport::TestCase
     )
   end
 
+  test "should filter by editions not validated since X" do
+    # rubocop:disable Lint/UselessAssignment
+    edition_validated_recently = create(:draft_edition, revalidated_at: Time.zone.now)
+    edition_validated_ages_ago = create(:published_edition, revalidated_at: 1.year.ago)
+    edition_never_validated = create(:draft_edition, revalidated_at: nil)
+    # rubocop:enable Lint/UselessAssignment
+
+    assert_equal(
+      [edition_validated_ages_ago, edition_never_validated],
+      Admin::EditionFilter.new(Edition, @current_user, not_validated_since: 1.week.ago.strftime("%d/%m/%Y")).editions.sort_by(&:id),
+    )
+  end
+
   test "should filter by broken links" do
     edition_with_broken_link = create(
       :published_publication,

--- a/test/unit/app/models/admin/edition_filter_test.rb
+++ b/test/unit/app/models/admin/edition_filter_test.rb
@@ -225,6 +225,21 @@ class Admin::EditionFilterTest < ActiveSupport::TestCase
     assert_equal [tagged_news], filter.editions
   end
 
+  test "should filter by invalid, non-superseded editions" do
+    # rubocop:disable Lint/UselessAssignment
+    valid_draft_edition = create(:draft_edition, revalidated_at: Time.zone.now)
+    valid_published_edition = create(:published_edition, revalidated_at: Time.zone.now)
+    invalid_draft_edition = create(:draft_edition, revalidated_at: nil)
+    invalid_published_edition = create(:published_edition, revalidated_at: nil)
+    invalid_superseded_edtion = create(:superseded_edition, revalidated_at: nil)
+    # rubocop:enable Lint/UselessAssignment
+
+    assert_equal(
+      [invalid_draft_edition, invalid_published_edition],
+      Admin::EditionFilter.new(Edition, @current_user, only_invalid_editions: true).editions.sort_by(&:id),
+    )
+  end
+
   test "should filter by broken links" do
     edition_with_broken_link = create(
       :published_publication,


### PR DESCRIPTION
Adds a scope (`Edition.only_invalid_editions` / `Edition.not_validated_since("01/01/1970")`) to easily filter only the editions considered to be 'invalid' - see property added in #10391.

This surfaces any edition that has a `nil` value for `revalidated_at`. Initially, all editions will have a `nil` value, but in #10382 we're going to bulk-revalidate all the editions, so that will no longer be the case. It should also not be possible to create a new edition that is valid but has a `revalidated_at` nil value, once #10384 is merged.

The purpose of this scope is twofold:

1. Initially, for dev use only (not exposed to publishers at this point) - to have a figure we can use for reporting system health. And the `not_validated_since` scope will be used for the bulk-revalidation, as we'll want to grab editions that have not been revalidated since a certain date (e.g. 1 week ago)
2. In #10383, expose the scope via the Whitehall search UI, so that publishers can easily find the editions they need to patch.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
