### PR TITLE
Change detailed_guide rendering to frontend

### DIFF
--- a/app/models/detailed_guide.rb
+++ b/app/models/detailed_guide.rb
@@ -33,7 +33,7 @@ class DetailedGuide < Edition
   validates_with HeadingHierarchyValidator
 
   def rendering_app
-    Whitehall::RenderingApp::GOVERNMENT_FRONTEND
+    Whitehall::RenderingApp::FRONTEND
   end
 
   def related_detailed_guide_ids

--- a/test/unit/app/models/detailed_guide_test.rb
+++ b/test/unit/app/models/detailed_guide_test.rb
@@ -251,8 +251,8 @@ class DetailedGuideTest < ActiveSupport::TestCase
     assert_equal [], detailed_guide.related_mainstream_content_ids
   end
 
-  test "is rendered by government-frontend" do
-    assert DetailedGuide.new.rendering_app == Whitehall::RenderingApp::GOVERNMENT_FRONTEND
+  test "is rendered by frontend" do
+    assert DetailedGuide.new.rendering_app == Whitehall::RenderingApp::FRONTEND
   end
 
   test "#all_nation_applicability_selected? false if first draft and unsaved" do

--- a/test/unit/app/presenters/publishing_api/detailed_guide_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/detailed_guide_presenter_test.rb
@@ -46,7 +46,7 @@ class PublishingApi::DetailedGuidePresenterTest < ActiveSupport::TestCase
       document_type: "detailed_guide",
       locale: "en",
       publishing_app: Whitehall::PublishingApp::WHITEHALL,
-      rendering_app: "government-frontend",
+      rendering_app: "frontend",
       routes: [
         { path: public_path, type: "exact" },
       ],


### PR DESCRIPTION
Related PR to be merged before
# https://github.com/alphagov/frontend/pull/4860

[Trello card](https://trello.com/c/8HsfHbJ6)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
