### PR TITLE
Remove Nomenclature section

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,6 @@ Whitehall (also known as 'Whitehall Admin' or 'Whitehall Publisher') is used by 
 
 **Use [GOV.UK Docker](https://github.com/alphagov/govuk-docker) to run any commands that follow.**
 
-## Nomenclature
-
-- *Govspeak* A variation of [Markdown](https://daringfireball.net/projects/markdown) used throughout whitehall as the general publishing format
-
 ## Technical documentation
 
 This is a Ruby on Rails app, and should follow [our Rails app conventions](https://docs.publishing.service.gov.uk/manual/conventions-for-rails-applications.html).


### PR DESCRIPTION
GovSpeak is a widely enough spread concept across GOV.UK and Publishing that it's inappropriate for it to have a special call-out here.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
