### PR TITLE
Refactor the bulk retagging feature (WHIT-2303)

### DIFF
--- a/app/helpers/admin/base_path_helper.rb
+++ b/app/helpers/admin/base_path_helper.rb
@@ -1,0 +1,54 @@
+require "uri"
+
+module Admin::BasePathHelper
+  MAPPINGS = [
+    { "Announcement" => "/government/news" },
+    { "CallForEvidence" => "/government/calls-for-evidence" },
+    { "CaseStudy" => "/government/case-studies" },
+    { "Consultation" => "/government/consultations" },
+    { "DetailedGuide" => "/guidance" },
+    { "DocumentCollection" => "/government/collections" },
+    { "FatalityNotice" => "/government/fatalities" },
+    { "NewsArticle" => "/government/news" },
+    { "OperationalField" => "/government/fields-of-operation" },
+    { "Publication" => "/government/publications" },
+    { "Publication" => "/government/statistics" },
+    { "Speech" => "/government/speeches" },
+    { "StatisticalDataSet" => "/government/statistical-data-sets" },
+    { "StatisticsAnnouncement" => "/government/statistics/announcements" },
+  ].freeze
+
+  def url_to_document_type(url)
+    full_path = extract_path(url)
+    path_parts = full_path.split("/")
+    path_parts.pop
+    prefix = path_parts.join("/")
+
+    matches = MAPPINGS.select do |mapping|
+      prefix == mapping.values.first
+    end
+
+    raise "No document type found for #{url}" if matches.count.zero?
+
+    return Object.const_get(matches.first.keys.first) if matches.count == 1
+
+    common_superclass(matches.map(&:keys).flatten.compact.map { |klass| Object.const_get(klass) })
+  end
+
+private
+
+  def extract_path(input)
+    uri = URI.parse(input)
+    uri.path.empty? ? "/" : uri.path
+  rescue URI::InvalidURIError
+    input.start_with?("/") ? input : "/#{input}"
+  end
+
+  def common_superclass(klasses)
+    klasses.map(&:ancestors)
+          .inject(:&)
+          .select { |k| k.is_a?(Class) }
+          .reject { |k| k == BasicObject }
+          .first
+  end
+end

--- a/app/views/admin/retagging/index.html.erb
+++ b/app/views/admin/retagging/index.html.erb
@@ -32,10 +32,7 @@
     <%= render "govuk_publishing_components/components/table", {
       head: [
         {
-          text: "Slug",
-        },
-        {
-          text: "Document type",
+          text: "URL",
         },
         {
           text: "New lead organisations",
@@ -47,10 +44,7 @@
       rows: [
         [
           {
-            text: "The slug of the document.",
-          },
-          {
-            text: "The type of the document, for example DetailedGuide. This is used when more than one document is matched by the Slug.",
+            text: "The URL of the document.",
           },
           {
             text: "The slugs of the new leading organisations (separated by a comma). These will replace any existing organisations.",

--- a/features/step_definitions/retagging_content_steps.rb
+++ b/features/step_definitions/retagging_content_steps.rb
@@ -1,9 +1,9 @@
 # rubocop:disable Style/GlobalVars
 Given("the documents and organisations I am retagging exist") do
   $csv_to_submit = <<~CSV
-    Slug,New lead organisations,New supporting organisations,Document type
-    /government/publications/linked-identifier-schemes-best-practice-guide,"cabinet-office,government-digital-service",geospatial-commission,Publication
-    /government/publications/search-engine-optimisation-for-publishers-best-practice-guide,government-digital-service,"cabinet-office, geospatial-commission",Publication
+    URL,New lead organisations,New supporting organisations
+    https://www.gov.uk/government/publications/linked-identifier-schemes-best-practice-guide,"cabinet-office,government-digital-service",geospatial-commission
+    https://www.gov.uk/government/publications/search-engine-optimisation-for-publishers-best-practice-guide,government-digital-service,"cabinet-office, geospatial-commission"
   CSV
 
   create(:organisation, slug: "government-digital-service")

--- a/test/functional/admin/retagging_controller_test.rb
+++ b/test/functional/admin/retagging_controller_test.rb
@@ -25,13 +25,13 @@ class Admin::RetaggingControllerTest < ActionController::TestCase
 
   test "Submitting a CSV with invalid data should show an error message" do
     csv_to_submit = <<~CSV
-      Slug,New lead organisations,New supporting organisations,Document type
-      /made-up-slug,government-digital-service,geospatial-commission,Publication
+      URL,New lead organisations,New supporting organisations
+      https://www.gov.uk/guidance/made-up-slug,government-digital-service,geospatial-commission
     CSV
     post :preview, params: { csv_input: csv_to_submit }
 
     assert_response :ok
     assert_template :index
-    assert_equal flash[:alert], "Errors with CSV input: <br>Document not found: made-up-slug<br>Organisation not found: government-digital-service<br>Organisation not found: geospatial-commission"
+    assert_equal flash[:alert], "Errors with CSV input: <br>Document not found: https://www.gov.uk/guidance/made-up-slug<br>Organisation not found: government-digital-service<br>Organisation not found: geospatial-commission"
   end
 end

--- a/test/unit/app/helpers/admin/base_path_helper_test.rb
+++ b/test/unit/app/helpers/admin/base_path_helper_test.rb
@@ -1,0 +1,36 @@
+require "test_helper"
+
+class Admin::BasePathHelperTest < ActionView::TestCase
+  extend Minitest::Spec::DSL
+
+  include ApplicationHelper
+
+  describe "#url_to_document_type" do
+    test "it maps a URL to a document type" do
+      assert_equal Announcement, url_to_document_type("/government/news/slug") # defaults to parent, rather than e.g. NewsArticle
+      assert_equal CallForEvidence, url_to_document_type("/government/calls-for-evidence/slug")
+      assert_equal CaseStudy, url_to_document_type("/government/case-studies/slug")
+      assert_equal Consultation, url_to_document_type("/government/consultations/slug")
+      assert_equal DetailedGuide, url_to_document_type("/guidance/slug")
+      assert_equal DocumentCollection, url_to_document_type("/government/collections/slug")
+      assert_equal FatalityNotice, url_to_document_type("/government/fatalities/slug")
+      assert_equal OperationalField, url_to_document_type("/government/fields-of-operation/slug")
+      assert_equal Publication, url_to_document_type("/government/publications/slug")
+      assert_equal Publication, url_to_document_type("/government/statistics/slug")
+      assert_equal Speech, url_to_document_type("/government/speeches/slug")
+      assert_equal StatisticalDataSet, url_to_document_type("/government/statistical-data-sets/slug")
+      assert_equal StatisticsAnnouncement, url_to_document_type("/government/statistics/announcements/slug")
+    end
+
+    test "it raises exception if no document type found for slug" do
+      error = assert_raises(RuntimeError) do
+        url_to_document_type("/government/foo/slug")
+      end
+
+      assert_equal(
+        "No document type found for /government/foo/slug",
+        error.message,
+      )
+    end
+  end
+end


### PR DESCRIPTION
## What

Changes the behaviour of the [retagging feature of Whitehall](https://whitehall-admin.integration.publishing.service.gov.uk/government/admin/retagging) to take URLs rather than a slug and corresponding DocumentType.

## Why

Having to create a Slug and DocumentType creates a lot more work for the content designers, and allows a lot more room for error.

## Notes

I did consider taking this a step further and [DRYing up the base_path methods](https://github.com/alphagov/whitehall/commit/62cee0a5228cdc620f963b182594cbf53a11b954) to use the new mapping in a bidirectional way - but it felt a bit out of scope for this PR.

## Screenshots

Retagging page:

| Before | After |
|-------|-------|
|![retagging page](https://github.com/user-attachments/assets/480e683f-02f3-4e51-a8d9-46213b11a4e7)|![](https://github.com/user-attachments/assets/1853a9da-3308-492c-b680-25c82fbffba8)|

Confirmation screen:

| Before | After |
|-------|-------|
|![confirmation screen](https://github.com/user-attachments/assets/e7396cef-fe49-4e59-9b61-e8560134d492)|![](https://github.com/user-attachments/assets/886d2c77-d8ef-4a75-8c05-d26ab25e667b)|

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
