### PR TITLE
Catch 404s from Publishing API taxon check (WHIT-1507)

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -168,6 +168,8 @@ class Edition < ApplicationRecord
     return false if api_response["links"].nil? || api_response["links"]["taxons"].nil?
 
     api_response["links"]["taxons"].any?
+  rescue GdsApi::HTTPNotFound
+    false
   end
 
   def create_draft(user, allow_creating_draft_from_deleted_edition: false)

--- a/test/unit/app/models/edition_test.rb
+++ b/test/unit/app/models/edition_test.rb
@@ -786,6 +786,14 @@ class EditionTest < ActiveSupport::TestCase
     assert_not edition.historic?
   end
 
+  test "#has_been_tagged? is false when request from publishing-api 404s" do
+    edition = create(:edition)
+
+    stub_any_publishing_api_call_to_return_not_found
+
+    assert_not edition.has_been_tagged?
+  end
+
   test "#has_been_tagged? is false when request from publishing-api has no taxons" do
     edition = create(:edition)
 


### PR DESCRIPTION
When checking `valid?(:publish)` against an edition that has not been tagged to a taxonomy, Publishing API returns a 404 response, resulting in an [error](https://govuk.sentry.io/issues/6745288379/?project=202259&query=is%3Aunresolved&referrer=issue-stream&stream_index=0):

> {"error":{"code":404,"message":"Could not find link set with content_id: 594aeeb0-2f7e-41a2-a9ec-9aef518d0f08"}}

We should handle this error and return false from `has_been_tagged?` instead.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
