### PR TITLE
Correct `section` for `AddAnother` tracking [WHIT-1491]

### DIFF
--- a/app/views/admin/contacts/_form_fields.html.erb
+++ b/app/views/admin/contacts/_form_fields.html.erb
@@ -95,7 +95,7 @@
   <% end %>
 </div>
 
-<div class="govuk-!-margin-bottom-8 app-view-contacts__phone">
+<div class="govuk-!-margin-bottom-8 app-view-contacts__phone" data-ga4-section="Phone numbers">
   <%= render "govuk_publishing_components/components/fieldset", {
     legend_text: "Phone numbers",
     heading_level: 2,

--- a/app/views/admin/fatality_notices/_form.html.erb
+++ b/app/views/admin/fatality_notices/_form.html.erb
@@ -34,19 +34,21 @@
 
     <h4 class="govuk-heading-m">Casualties (required)</h4>
 
-    <%= render "govuk_publishing_components/components/add_another", {
-      fieldset_legend: "Person",
-      add_button_text: "Add another person",
-      items: form.object.fatality_notice_casualties.each_with_index.map do  |casualty, index|
-        {
-          fields: render(partial: "admin/fatality_notices/casualty_fields", locals: { form:, casualty:, index: }),
-          destroy_checkbox: render("govuk_publishing_components/components/checkboxes", { name: "edition[fatality_notice_casualties_attributes][#{index}][_destroy]", items: [{label: "Delete", value: "1" }]}),
-        }
-      end,
-      empty: render(partial: "admin/fatality_notices/casualty_fields", locals: { form:, casualty: FatalityNoticeCasualty.new, index: form.object.fatality_notice_casualties.length }),
-      data_attributes: {
-        ga4_start_index: 0,
-      },
-    } %>
+    <div data-ga4-section="Casualties (required)">
+      <%= render "govuk_publishing_components/components/add_another", {
+        fieldset_legend: "Person",
+        add_button_text: "Add another person",
+        items: form.object.fatality_notice_casualties.each_with_index.map do  |casualty, index|
+          {
+            fields: render(partial: "admin/fatality_notices/casualty_fields", locals: { form:, casualty:, index: }),
+            destroy_checkbox: render("govuk_publishing_components/components/checkboxes", { name: "edition[fatality_notice_casualties_attributes][#{index}][_destroy]", items: [{label: "Delete", value: "1" }]}),
+          }
+        end,
+        empty: render(partial: "admin/fatality_notices/casualty_fields", locals: { form:, casualty: FatalityNoticeCasualty.new, index: form.object.fatality_notice_casualties.length }),
+        data_attributes: {
+          ga4_start_index: 0,
+        },
+      } %>
+    </div>
   <% end %>
 <% end %>

--- a/app/views/admin/promotional_feature_items/_form_fields.html.erb
+++ b/app/views/admin/promotional_feature_items/_form_fields.html.erb
@@ -68,6 +68,9 @@
 <%= render "govuk_publishing_components/components/fieldset", {
   legend_text: "Feature item links",
   heading_size: "l",
+  data_attributes: {
+    ga4_section: "Feature item links",
+  },
 } do %>
   <%= render "govuk_publishing_components/components/add_another", {
     fieldset_legend: "Link",

--- a/app/views/admin/shared/_featured_links_fields.html.erb
+++ b/app/views/admin/shared/_featured_links_fields.html.erb
@@ -18,17 +18,19 @@
   } %>
 <% end %>
 
-<%= render "govuk_publishing_components/components/add_another", {
-  fieldset_legend: "Featured link",
-  add_button_text: "Add another featured link",
-  items: featured_links.each_with_index.map do  |featured_link, index|
-    {
-      fields: render(partial: "admin/shared/featured_link_fields", locals: { form:, featured_link:, index:, model: }),
-      destroy_checkbox: render("govuk_publishing_components/components/checkboxes", { name: "#{model}[featured_links_attributes][#{index}][_destroy]", items: [{label: "Delete", value: "1" }]}),
-    }
-  end,
-  empty: render(partial: "admin/shared/featured_link_fields", locals: { form:, featured_link: new_featured_link, index: featured_links.length, model: }),
-  data_attributes: {
-    ga4_start_index: 0,
-  },
-} %>
+<div data-ga4-section="Featured link">
+  <%= render "govuk_publishing_components/components/add_another", {
+    fieldset_legend: "Featured link",
+    add_button_text: "Add another featured link",
+    items: featured_links.each_with_index.map do  |featured_link, index|
+      {
+        fields: render(partial: "admin/shared/featured_link_fields", locals: { form:, featured_link:, index:, model: }),
+        destroy_checkbox: render("govuk_publishing_components/components/checkboxes", { name: "#{model}[featured_links_attributes][#{index}][_destroy]", items: [{label: "Delete", value: "1" }]}),
+      }
+    end,
+    empty: render(partial: "admin/shared/featured_link_fields", locals: { form:, featured_link: new_featured_link, index: featured_links.length, model: }),
+    data_attributes: {
+      ga4_start_index: 0,
+    },
+  } %>
+</div>

--- a/app/views/admin/topical_events/_form.html.erb
+++ b/app/views/admin/topical_events/_form.html.erb
@@ -136,6 +136,9 @@
   <%= render "govuk_publishing_components/components/fieldset", {
     legend_text: "Social media accounts",
     heading_size: "l",
+    data_attributes: {
+      ga4_section: "Social media accounts",
+    },
   } do %>
     <%= render "govuk_publishing_components/components/add_another", {
       fieldset_legend: "Account",

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/array_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/array_component.html.erb
@@ -1,4 +1,4 @@
-<div class="app-c-content-block-manager-array-component">
+<div class="app-c-content-block-manager-array-component" data-ga4-section="<%= label %>">
   <%= render "govuk_publishing_components/components/add_another", {
     fieldset_legend: label,
     add_button_text: "Add another #{label}",


### PR DESCRIPTION
## What

Add `data-ga4-section` to containers of `AddAnother` components.

## Why

So that tracked `AddAnother` interactions use the correct `section` value in fired events.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
