### PR TITLE
Fix schedule-publishing loophole that leads to missing taxon (WHIT-2304)

### DIFF
--- a/app/services/edition_publisher.rb
+++ b/app/services/edition_publisher.rb
@@ -7,7 +7,7 @@ class EditionPublisher < EditionService
     return @failure_reasons if @failure_reasons
 
     reasons = []
-    reasons << "This edition is invalid: #{edition.errors.full_messages.to_sentence}" unless edition.valid?
+    reasons << "This edition is invalid: #{edition.errors.full_messages.to_sentence}" unless edition.valid?(:publish)
     reasons << "An edition that is #{edition.current_state} cannot be #{past_participle}" unless can_transition?
     reasons << "Scheduled editions cannot be published. This edition is scheduled for publication on #{edition.scheduled_publication}" if scheduled_for_publication?
 
@@ -16,10 +16,6 @@ class EditionPublisher < EditionService
 
   def failure_reasons_plaintext
     failure_reasons.map { |reason| ActionController::Base.helpers.strip_tags(reason).gsub(/\s+/, " ") }.join(", ")
-  end
-
-  def govspeak_link_validator
-    @govspeak_link_validator ||= DataHygiene::GovspeakLinkValidator.new(edition.body)
   end
 
   def verb

--- a/app/services/edition_scheduler.rb
+++ b/app/services/edition_scheduler.rb
@@ -15,8 +15,8 @@ class EditionScheduler < EditionService
     return @failure_reasons if @failure_reasons
 
     reasons = []
-    if !edition.valid?
-      reasons << "This edition is invalid: #{edition.errors.full_messages.to_sentence}" unless edition.valid?
+    if !edition.valid?(:publish)
+      reasons << "This edition is invalid: #{edition.errors.full_messages.to_sentence}"
     elsif !can_transition?
       reasons << "An edition that is #{edition.current_state} cannot be #{past_participle}"
     elsif edition.scheduled_publication.blank?
@@ -32,10 +32,6 @@ class EditionScheduler < EditionService
   end
 
 private
-
-  def govspeak_link_validator
-    @govspeak_link_validator ||= DataHygiene::GovspeakLinkValidator.new(edition.body)
-  end
 
   def fire_transition!
     super

--- a/test/functional/admin/edition_workflow_controller_test.rb
+++ b/test/functional/admin/edition_workflow_controller_test.rb
@@ -56,6 +56,7 @@ class Admin::EditionWorkflowControllerTest < ActionController::TestCase
   end
 
   test "GET #confirm_force_publish redirects when edition must tagged be taxons but is not" do
+    TaxonValidator.any_instance.unstub(:validate)
     stub_publishing_api_links_with_taxons(draft_edition.content_id, [])
 
     get :confirm_force_publish, params: { id: draft_edition, lock_version: draft_edition.lock_version }

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -75,6 +75,7 @@ class ActiveSupport::TestCase
     stub_publishing_api_publish_intent
     Services.publishing_api.stubs(:get_events_for_content_id).returns([])
     Services.stubs(:asset_manager).returns(stub_everything("asset-manager"))
+    TaxonValidator.any_instance.stubs(:validate)
   end
 
   teardown do
@@ -240,8 +241,8 @@ class ActionController::TestCase
     # header.
     stub_request(:get, %r{.*content-store.*/content/.*}).to_return(status: 404)
     stub_publishing_api_has_linkables([], document_type: "topic")
-
     stub_request(:get, %r{\A#{Plek.find('publishing-api')}/v2/links/}).to_return(body: { links: {} }.to_json)
+    TaxonValidator.any_instance.stubs(:validate)
   end
 
   def login_as(role_or_user, organisation = nil)

--- a/test/unit/app/services/edition_scheduler_test.rb
+++ b/test/unit/app/services/edition_scheduler_test.rb
@@ -31,6 +31,18 @@ class EditionSchedulerTest < ActiveSupport::TestCase
     assert_equal "This edition is invalid: Title cannot be blank", scheduler.failure_reason
   end
 
+  test "an edition that is invalid in the 'publish' context cannot be scheduled" do
+    TaxonValidator.any_instance.unstub(:validate)
+    stub_any_publishing_api_call_to_return_not_found
+    edition = create(:submitted_edition, scheduled_publication: 1.day.from_now)
+
+    assert_not edition.has_been_tagged?
+
+    scheduler = EditionScheduler.new(edition)
+    assert_not scheduler.can_perform?
+    assert_equal "This edition is invalid: This document has not been published. You need to add a topic before publishing.", scheduler.failure_reason
+  end
+
   test "an edition cannot be scheduled without a scheduled_publication timestamp" do
     edition = create(:submitted_edition)
     scheduler = EditionScheduler.new(edition)

--- a/test/unit/app/validators/taxon_validator_test.rb
+++ b/test/unit/app/validators/taxon_validator_test.rb
@@ -6,6 +6,7 @@ class TaxonValidatorTest < ActiveSupport::TestCase
   end
 
   test "is invalid when edition has not been tagged to a taxon" do
+    TaxonValidator.any_instance.unstub(:validate)
     edition = create(:draft_edition)
 
     stub_publishing_api_has_links(


### PR DESCRIPTION
Whitehall doesn't allow publishers to publish documents that have not been tagged to a topic taxonomy. The 'publish' and 'force publish' actions don't succeed.

But a workaround has been to schedule a document for publishing. Publishers are duly told "Your document has been saved. You need to add topic tags before you can publish this document." in the subsequent 'success' flash message upon successfully saving or scheduling their document, but there are no further checks made before the edition is published. Consequently we have a number of live editions without a topic taxonomy. This isn't great as it affects users ability to navigate to content outside of using the search bar, and also limits their ability to subscribe to email alerts about a topic.

The issue seems to stem from us calling the more forgiving `valid?` method in the edition publisher / scheduler, where we should really be calling `valid?(:publish)` to check that the edition is valid in a published context. The latter has more stringent checks such as checking that a document has been tagged to a topic taxonomy, that all of its Contact embed codes refer to contacts that actually exist, etc.

Also removes some straggling code that should have been removed in #10284, the last time we were in this area.

IMPACT ON THE TESTS:

We're now doing a full `valid?(:publish)` call on the edition schedule/publish workflows. This more comprehensive validity check uses the TaxonValidator to ensure that the document has been tagged to a topic taxonomy. We therefore have to  ock that a document has had its pre-requisite tagging done, in order to not break all the tests.

I did explore a few approaches, e.g. stubbing `Services.publishing_api.get_links` to return a links hash with taxons hash with an array of links, but then that causes a lot of test failures where we're expecting NO links (directly, or indirectly). So my eventual solution, which requires minimal changes, is to stub a successful response from TaxonValidator except in the very few cases where its behaviour is being directly tested (in which case we 'unstub' it).

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
