### PR TITLE
Simplify worker

### DIFF
--- a/app/sidekiq/revalidate_editions_scheduler_worker.rb
+++ b/app/sidekiq/revalidate_editions_scheduler_worker.rb
@@ -2,11 +2,8 @@ class RevalidateEditionsSchedulerWorker
   include Sidekiq::Job
   sidekiq_options queue: "edition_revalidation", retry: 0
 
-  BATCH_SIZE  = ENV.fetch("REVALIDATE_BATCH_SIZE", 100).to_i
-  MAX_BATCHES = ENV.fetch("REVALIDATE_MAX_BATCHES", 1000).to_i # 1000 × 100 = 100 000 editions/run
-  def self.stale_after
-    1.week.ago
-  end
+  BATCH_SIZE  = 100
+  MAX_BATCHES = 1000 # 1000 × 100 = 100 000 editions/run
 
   def perform
     scope = Edition.not_validated_since(1.week.ago.strftime("%d/%m/%Y"))


### PR DESCRIPTION
As spotted by @lauraghiorghisor-tw:
https://github.com/alphagov/whitehall/pull/10382/files#r2205248698

We don't ever expect these to be set in ENV vars, and we don't use the `stale_after` method.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
