### PR TITLE
(CM-239) Generate object keys more intelligently

### DIFF
--- a/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/documents/embedded_objects_controller.rb
+++ b/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/documents/embedded_objects_controller.rb
@@ -37,7 +37,7 @@ class ContentBlockManager::ContentBlock::Documents::EmbeddedObjectsController < 
     redirect_to content_block_manager.review_embedded_object_content_block_manager_content_block_edition_path(
       @content_block_edition,
       object_type: @subschema.block_type,
-      object_title: @content_block_edition.key_for_object(@params),
+      object_title: @content_block_edition.key_for_object(@subschema.block_type, @params),
     )
   rescue ActiveRecord::RecordInvalid
     render :new

--- a/lib/engines/content_block_manager/app/models/content_block_manager/content_block/edition.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/content_block/edition.rb
@@ -48,7 +48,7 @@ module ContentBlockManager
       end
 
       def add_object_to_details(object_type, body)
-        key = key_for_object(body)
+        key = key_for_object(object_type, body)
 
         details[object_type] ||= {}
         details[object_type][key] = remove_destroyed body.to_h
@@ -58,8 +58,13 @@ module ContentBlockManager
         details[object_type][object_title] = remove_destroyed body.to_h
       end
 
-      def key_for_object(object)
-        object["title"]&.parameterize.presence || SecureRandom.alphanumeric.downcase
+      def key_for_object(object_type, object)
+        if object["title"].present?
+          object["title"].parameterize
+        else
+          current_count = details[object_type]&.values&.count || 0
+          "#{object_type.parameterize}-#{current_count + 1}"
+        end
       end
 
       def has_entries_for_subschema_id?(subschema_id)

--- a/lib/engines/content_block_manager/test/unit/app/models/content_block_edition_test.rb
+++ b/lib/engines/content_block_manager/test/unit/app/models/content_block_edition_test.rb
@@ -210,11 +210,16 @@ class ContentBlockManager::ContentBlockEditionTest < ActiveSupport::TestCase
       assert_equal content_block_edition.details["something"], { "another-thing" => {}, "my-thing" => { "title" => "My thing", "something" => "else" } }
     end
 
-    it "creates a random key if a title is not provided" do
-      SecureRandom.expects(:alphanumeric).returns("RANDOM-STRING")
-      content_block_edition.add_object_to_details("something", { "something" => "else" })
+    describe "when a title is not provided" do
+      it "creates a key using the object type and count of objects" do
+        content_block_edition.add_object_to_details("something", { "something" => "else" })
+        content_block_edition.add_object_to_details("something", { "something" => "additional" })
 
-      assert_equal content_block_edition.details["something"], { "random-string" => { "something" => "else" } }
+        assert_equal content_block_edition.details["something"], {
+          "something-1" => { "something" => "else" },
+          "something-2" => { "something" => "additional" },
+        }
+      end
     end
 
     it "removes deleted items from the array, as well as the `_destroy` markers" do


### PR DESCRIPTION
Up until now, we worked on the assumption that all subobjects would require a title, which we would then use to generate an object key.

For example, if we added an email object to a contact with the name “My email address”, this would be added to the `email` object with the key `my-email-address`. For example:

```
…

{
  “emails”: {
      “my-email-address”: { … }
}
…
```

We decided early on to make the titles mandatory, because otherwise we would have no way of generating a predictable identifier for an individual object.

As we’ve moved along the road, we’ve discovered that actually, mandating the use of a title causes more problems than it solves, so we’ve decided to make `title` an optional field and fall back to generating a key if a title is not present.

So, in the example above, if we were to add an email to our contact, and there was no title provided, the key would default to `email-1`.

Additionally, if there was already an email object present, we would use the count of the current number of email objects, and increment this count to generate the key `email-2`

We already did have some fallback code to generate a random identifier, but this never got hit, becuase all subobjects had mandatory titles.