### PR TITLE
(CM-176) Update country component

### DIFF
--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/country_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/country_component.rb
@@ -1,6 +1,18 @@
 class ContentBlockManager::ContentBlockEdition::Details::Fields::CountryComponent < ContentBlockManager::ContentBlockEdition::Details::Fields::EnumComponent
+  BLANK_OPTION = "United Kingdom".freeze
+
   def initialize(**args)
     countries = WorldLocation.geographical.map(&:name)
     super(**args.merge(enum: countries))
+  end
+
+private
+
+  def enum
+    @enum.excluding(blank_option)
+  end
+
+  def blank_option
+    BLANK_OPTION
   end
 end

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/country_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/country_component.rb
@@ -1,6 +1,6 @@
 class ContentBlockManager::ContentBlockEdition::Details::Fields::CountryComponent < ContentBlockManager::ContentBlockEdition::Details::Fields::EnumComponent
   def initialize(**args)
-    countries = WorldLocation.all.map(&:name)
+    countries = WorldLocation.geographical.map(&:name)
     super(**args.merge(enum: countries))
   end
 end

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/enum_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/enum_component.rb
@@ -5,17 +5,29 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::EnumComponent <
     super(**args)
   end
 
-private
-
   def options
-    [blank_option, @enum].flatten.compact.map do |item|
+    options = [
       {
+        text: blank_option,
+        value: "",
+        selected: selected?(blank_option),
+      },
+    ]
+
+    enum.each do |item|
+      options.push({
         text: item,
         value: item,
         selected: selected?(item),
-      }
+      })
     end
+
+    options
   end
+
+private
+
+  attr_reader :enum
 
   def error_message
     error_items&.first&.fetch(:text)

--- a/lib/engines/content_block_manager/config/content_block_manager.yml
+++ b/lib/engines/content_block_manager/config/content_block_manager.yml
@@ -91,6 +91,10 @@ schemas:
           - region
           - postal_code
           - country
+        fields:
+          country:
+            component:
+              country
       contact_forms:
         group: modes
         embeddable_as_block: true

--- a/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/country_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/country_component_test.rb
@@ -9,7 +9,7 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::CountryComponen
   let(:world_locations) { build_list(:world_location, 5) }
 
   before do
-    WorldLocation.stubs(:all).returns(world_locations)
+    WorldLocation.stubs(:geographical).returns(world_locations)
   end
 
   it "should render an select field populated with WorldLocations" do

--- a/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/country_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/country_component_test.rb
@@ -6,13 +6,16 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::CountryComponen
   let(:content_block_edition) { build(:content_block_edition, :pension) }
   let(:field) { stub("field", name: "country", is_required?: true) }
 
-  let(:world_locations) { build_list(:world_location, 5) }
+  let(:world_locations) { 5.times.map { |i| build(:world_location, name: "World location #{i}") } }
+  let(:uk) { build(:world_location, name: "United Kingdom") }
+
+  let(:all_locations) { [world_locations, uk].flatten }
 
   before do
-    WorldLocation.stubs(:geographical).returns(world_locations)
+    WorldLocation.stubs(:geographical).returns(all_locations)
   end
 
-  it "should render an select field populated with WorldLocations" do
+  it "should render an select field populated with WorldLocations with the UK as the blank option" do
     render_inline(
       ContentBlockManager::ContentBlockEdition::Details::Fields::CountryComponent.new(
         content_block_edition:,
@@ -25,7 +28,10 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::CountryComponen
 
     assert_selector "label", text: "Country"
     assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"]"
-    assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"] option[value=\"\"]"
+
+    assert_selector "select option", count: all_locations.count
+
+    assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"] option[value=\"\"]", text: uk.name
 
     world_locations.each do |location|
       assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"] option[value=\"#{location.name}\"]", text: location.name
@@ -46,7 +52,7 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::CountryComponen
 
     assert_selector "label", text: "Country"
     assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"]"
-    assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"] option[value=\"\"]"
+    assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"] option[value=\"\"]", text: uk.name
 
     world_locations.each do |location|
       assert_selector "select[name=\"#{expected_name}\"][id=\"#{expected_id}\"] option[value=\"#{location.name}\"]", text: location.name
@@ -69,5 +75,44 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::CountryComponen
     assert_selector ".govuk-form-group--error"
     assert_selector ".govuk-error-message", text: "Some error goes here"
     assert_selector "select.govuk-select--error"
+  end
+
+  describe "#options" do
+    it "returns a list of countries" do
+      component = ContentBlockManager::ContentBlockEdition::Details::Fields::CountryComponent.new(
+        content_block_edition:,
+        field:,
+      )
+
+      expected = [
+        { text: "United Kingdom", value: "", selected: false },
+        { text: world_locations[0].name, value: world_locations[0].name, selected: false },
+        { text: world_locations[1].name, value: world_locations[1].name, selected: false },
+        { text: world_locations[2].name, value: world_locations[2].name, selected: false },
+        { text: world_locations[3].name, value: world_locations[3].name, selected: false },
+        { text: world_locations[4].name, value: world_locations[4].name, selected: false },
+      ]
+
+      assert_equal component.options, expected
+    end
+
+    it "sets an option as selected when value is provided" do
+      component = ContentBlockManager::ContentBlockEdition::Details::Fields::CountryComponent.new(
+        content_block_edition:,
+        field:,
+        value: world_locations.first.name,
+      )
+
+      expected = [
+        { text: "United Kingdom", value: "", selected: false },
+        { text: world_locations[0].name, value: world_locations[0].name, selected: true },
+        { text: world_locations[1].name, value: world_locations[1].name, selected: false },
+        { text: world_locations[2].name, value: world_locations[2].name, selected: false },
+        { text: world_locations[3].name, value: world_locations[3].name, selected: false },
+        { text: world_locations[4].name, value: world_locations[4].name, selected: false },
+      ]
+
+      assert_equal component.options, expected
+    end
   end
 end

--- a/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/enum_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/enum_component_test.rb
@@ -103,4 +103,35 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::EnumComponentTe
     assert_selector ".govuk-error-message", text: "Some error goes here"
     assert_selector "select.govuk-select--error"
   end
+
+  describe "#options" do
+    it "returns a list of options" do
+      component = ContentBlockManager::ContentBlockEdition::Details::Fields::EnumComponent.new(
+        content_block_edition:,
+        field:,
+        enum: ["a week", "a month"],
+      )
+
+      assert_equal component.options, [
+        { text: "", value: "", selected: true },
+        { text: "a week", value: "a week", selected: false },
+        { text: "a month", value: "a month", selected: false },
+      ]
+    end
+
+    it "sets an option as selected when value is provided" do
+      component = ContentBlockManager::ContentBlockEdition::Details::Fields::EnumComponent.new(
+        content_block_edition:,
+        field:,
+        enum: ["a week", "a month"],
+        value: "a week",
+      )
+
+      assert_equal component.options, [
+        { text: "", value: "", selected: false },
+        { text: "a week", value: "a week", selected: true },
+        { text: "a month", value: "a month", selected: false },
+      ]
+    end
+  end
 end


### PR DESCRIPTION
This updates the address mode to use the previously added country component, which inherits from the Enum component. I've also made some updates to ensure only geographical countries are included, and the default (blank) option is the United Kingdom.