### PR TITLE
Content Modelling: Tidy: extract call_charges label copy to locale file

### DIFF
--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/call_charges_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/call_charges_component.html.erb
@@ -3,7 +3,7 @@
   <% call_charges_url_input = capture do %>
     <%= render("govuk_publishing_components/components/input", {
               label: {
-              text: "Label",
+              text: label_for("label"),
             },
             name: name_for_field(label) ,
             id: id_for_field(label),
@@ -12,7 +12,7 @@
 
     <%= render("govuk_publishing_components/components/input", {
                 label: {
-                text: "URL to find out about call charges",
+                text: label_for("call_charges_info_url"),
               },
               name: name_for_field(call_charges_info_url) ,
               id: id_for_field(call_charges_info_url),
@@ -25,13 +25,13 @@
   <%= render "govuk_publishing_components/components/checkboxes", {
     name: name_for_field(show_call_charges_info_url),
     id: id_for_field(show_call_charges_info_url),
-    heading: "Show call charges info link?",
+    heading: label_for("show_call_charges_info_url"),
     visually_hide_heading: true,
     no_hint_text: true,
     small: true,
     items: [
       {
-        label: "Show hyperlink to 'Find out about call charges'",
+        label: label_for("show_call_charges_info_url"),
         value: "true",
         checked: value_for_field(show_call_charges_info_url) == true,
         conditional: call_charges_url_input,

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/call_charges_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/call_charges_component.rb
@@ -10,4 +10,8 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::CallChargesComp
   def label
     field.nested_field("label")
   end
+
+  def label_for(field_name)
+    humanized_label(relative_key: field_name, root_object: "telephones.call_charges")
+  end
 end

--- a/lib/engines/content_block_manager/config/locales/en.yml
+++ b/lib/engines/content_block_manager/config/locales/en.yml
@@ -92,11 +92,6 @@ en:
               time_to(h): Hours
               time_to(m): Minutes
               time_to(meridian): AM/PM
-        video_relay_service:
-          show_video_relay_service: "Show video relay service information"
-          telephone_number_prefix: "Prefix to telephone number"
-          telephone_number: "Telephone number"
-          information: "Information"
       values:
         true: "Yes"
         false: "No"

--- a/lib/engines/content_block_manager/config/locales/en.yml
+++ b/lib/engines/content_block_manager/config/locales/en.yml
@@ -68,7 +68,6 @@ en:
             For example: 'The body of the email must include your name, date of birth, passport number and mobile phone number.'"
       labels:
         telephones:
-          show_uk_call_charges: "Show hyperlink to 'Find out about call charges'"
           bsl_guidance:
             show: Show BSL guidance?
             value: Value
@@ -76,6 +75,10 @@ en:
             show: Include Relay UK?
             prefix: Prefix
             telephone_number: Telephone number
+          call_charges:
+            show_call_charges_info_url: "Show hyperlink to 'Find out about call charges'"
+            label: "Label"
+            call_charges_info_url: "URL to find out about call charges"
         addresses:
           title: Recipient
         contacts:


### PR DESCRIPTION
We extract all label text from the `CallChargesComponent` to the local file. We'll try to keep components free of "copy".


