### PR TITLE
Remove unnecessary "hasn't been published" prefix

### DIFF
--- a/app/validators/link_check_report_validator.rb
+++ b/app/validators/link_check_report_validator.rb
@@ -3,7 +3,7 @@ class LinkCheckReportValidator < ActiveModel::Validator
     if contains_dangerous_links?(edition)
       edition.errors.add(
         :base,
-        "This document has not been published. You need to remove dangerous links before publishing.".html_safe,
+        "You need to remove dangerous links before publishing.".html_safe,
       )
     end
   end

--- a/app/validators/taxon_validator.rb
+++ b/app/validators/taxon_validator.rb
@@ -3,7 +3,7 @@ class TaxonValidator < ActiveModel::Validator
     if missing_taxons?(edition)
       edition.errors.add(
         :base,
-        "This document has not been published. You need to add a topic before publishing.".html_safe,
+        "You need to add a topic before publishing.".html_safe,
       )
     end
   end

--- a/test/unit/app/services/edition_scheduler_test.rb
+++ b/test/unit/app/services/edition_scheduler_test.rb
@@ -40,7 +40,7 @@ class EditionSchedulerTest < ActiveSupport::TestCase
 
     scheduler = EditionScheduler.new(edition)
     assert_not scheduler.can_perform?
-    assert_equal "This edition is invalid: This document has not been published. You need to add a topic before publishing.", scheduler.failure_reason
+    assert_equal "This edition is invalid: You need to add a topic before publishing.", scheduler.failure_reason
   end
 
   test "an edition cannot be scheduled without a scheduled_publication timestamp" do

--- a/test/unit/app/validators/link_check_report_validator_test.rb
+++ b/test/unit/app/validators/link_check_report_validator_test.rb
@@ -19,7 +19,7 @@ class LinkCheckReportValidatorTest < ActiveSupport::TestCase
 
     assert_equal 1, edition.errors.count
     assert_equal(
-      "This document has not been published. You need to remove dangerous links before publishing.",
+      "You need to remove dangerous links before publishing.",
       edition.errors[:base].first,
     )
   end

--- a/test/unit/app/validators/taxon_validator_test.rb
+++ b/test/unit/app/validators/taxon_validator_test.rb
@@ -30,7 +30,7 @@ class TaxonValidatorTest < ActiveSupport::TestCase
 
     assert_equal 1, edition.errors.count
     assert_equal(
-      "This document has not been published. You need to add a topic before publishing.",
+      "You need to add a topic before publishing.",
       edition.errors[:base].first,
     )
   end


### PR DESCRIPTION
Now that we're surfacing all validation errors in the sidebar by default, the wording "This document has not been published. You need to add a topic before publishing." doesn't make sense in every context. For example, a publisher viewing their draft edition would see that message (and think, quite rightly, that they DON'T want the document to be published yet, and perhaps think - wrongly - that if they do add a topic, it will somehow automatically get published).

The fact that the document didn't publish (if the publisher tries to do so without adding a topic) should already be pretty evident from the error flash message at the top of the page, the lack of 'published' state in the sidebar, and the continued display of "Invalid edition" in the sidebar. Same applies to inclusion of dangerous links.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
