### PR TITLE
Add rake tasks for reporting invalid editions (WHIT-2271)

### DIFF
--- a/lib/tasks/reporting.rake
+++ b/lib/tasks/reporting.rake
@@ -117,15 +117,17 @@ def grouped_and_sorted_invalid_editions(editions)
 end
 
 def summarise_invalid_editions(prefix, scope)
-  puts "#{prefix} (#{scope.count})"
+  sum_without_duplicates = scope.flat_map { |_, data| data[:ids] }.uniq.count
+  puts "#{prefix} (#{sum_without_duplicates})"
   puts "-------------------------------"
   scope.each do |error, hash|
-    puts "#{hash[:count]} editions with error `#{error}`. Example edition IDs: #{hash[:ids].first(10).sort.join(', ')}"
+    puts "#{hash[:count]} editions have the error `#{error}`. Example edition IDs: #{hash[:ids].first(10).sort.join(', ')}"
   end
   puts "" # newline
 end
 
 def report_invalid_editions(scope)
+  puts "Found #{scope.count} invalid editions. Analysing (this could take a few minutes)..."
   editions = scope.map do |ed|
     ed.valid?(:publish)
     [ed.id, ed.state, ed.errors.map(&:full_message)]

--- a/test/unit/lib/tasks/reporting_test.rb
+++ b/test/unit/lib/tasks/reporting_test.rb
@@ -4,107 +4,154 @@ require "rake"
 class ReportingRake < ActiveSupport::TestCase
   extend Minitest::Spec::DSL
 
-  teardown do
-    Rake::Task["reporting:matching_docs"].reenable
+  describe "rake reporting:matching_docs" do
+    teardown do
+      Rake::Task["reporting:matching_docs"].reenable
+    end
+
+    context "for editions" do
+      setup do
+        @document_1 = create(:published_edition, body: "Some text 1")
+        @document_2 = create(:draft_edition, body: "Some text 2")
+        @document_3 = create(:published_edition, body: "Some other text 1")
+      end
+
+      test "it prints the content IDs of the matching documents from published editions" do
+        assert_output(/#{@document_1.document.content_id},#{@document_1.base_path}/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
+      end
+
+      test "it does not print the content IDs of the matching documents from draft editions" do
+        refute_output(/#{@document_2.document.content_id},#{@document_2.base_path}/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
+      end
+
+      test "it does not print the content IDs of the non-matching documents from published editions" do
+        refute_output(/#{@document_3.document.content_id},#{@document_3.base_path}/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
+      end
+    end
+
+    context "for HTML attachments" do
+      setup do
+        @html_attachment_1 = create(:html_attachment, body: "Some text on a published edition", attachable: create(:published_edition))
+        @html_attachment_2 = create(:html_attachment, body: "Some other text on a published edition", attachable: create(:published_edition))
+        @html_attachment_3 = create(:html_attachment, body: "Some text on a draft edition", attachable: create(:draft_edition))
+      end
+
+      test "it prints the content IDs of the matching documents from published HTML attachments" do
+        assert_output(/#{@html_attachment_1.content_id},#{@html_attachment_1.base_path}/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
+      end
+
+      test "it does not print the content IDs of the non-matching documents from published HTML attachments" do
+        refute_output(/#{@html_attachment_2.content_id},#{@html_attachment_2.base_path}/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
+      end
+
+      test "it does not print the content IDs of the matching documents from draft HTML attachments" do
+        refute_output(/#{@html_attachment_3.content_id},#{@html_attachment_3.base_path}/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
+      end
+    end
+
+    context "for people" do
+      setup do
+        @person_1 = create(:person, biography: "Some text")
+        @person_2 = create(:person, biography: "Some other text")
+      end
+
+      test "it prints the content IDs of the matching documents from people" do
+        assert_output(/#{@person_1.content_id},#{@person_1.base_path}/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
+      end
+
+      test "it does not print the content IDs of the non-matching documents from people" do
+        refute_output(/#{@person_2.content_id},#{@person_2.base_path}/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
+      end
+    end
+
+    context "for policy groups" do
+      setup do
+        @policy_group_1 = create(:policy_group, description: "Some text")
+        @policy_group_2 = create(:policy_group, description: "Some other text")
+      end
+
+      test "it prints the content IDs of the matching documents from policy groups" do
+        assert_output(/#{@policy_group_1.content_id},#{@policy_group_1.base_path}/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
+      end
+
+      test "it does not print the content IDs of the non-matching documents from policy groups" do
+        refute_output(/#{@policy_group_2.content_id},#{@policy_group_2.base_path}/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
+      end
+    end
+
+    context "for world location news" do
+      setup do
+        @world_location_news_1 = create(:world_location_news, mission_statement: "Some text", world_location: create(:world_location))
+        @world_location_news_2 = create(:world_location_news, mission_statement: "Some other text", world_location: create(:world_location))
+      end
+
+      test "it prints the content IDs of the matching documents from world location news" do
+        assert_output(/#{@world_location_news_1.content_id},#{@world_location_news_1.base_path}/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
+      end
+
+      test "it does not print the content IDs of the non-matching documents from world location news" do
+        refute_output(/#{@world_location_news_2.content_id},#{@world_location_news_2.base_path}/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
+      end
+    end
+
+    context "for worldwide offices" do
+      setup do
+        @worldwide_office_1 = create(:worldwide_office, access_and_opening_times: "Some text")
+        @worldwide_office_2 = create(:worldwide_office, access_and_opening_times: "Some other text")
+      end
+
+      test "it prints the content IDs of the matching documents from worldwide offices" do
+        assert_output(/#{@worldwide_office_1.content_id},#{@worldwide_office_1.base_path}/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
+      end
+
+      test "it does not print the content IDs of the non-matching documents from worldwide offices" do
+        refute_output(/#{@worldwide_office_2.content_id},#{@worldwide_office_2.base_path}/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
+      end
+    end
   end
 
-  context "for editions" do
-    setup do
-      @document_1 = create(:published_edition, body: "Some text 1")
-      @document_2 = create(:draft_edition, body: "Some text 2")
-      @document_3 = create(:published_edition, body: "Some other text 1")
+  describe "rake reporting:invalid_editions" do
+    teardown do
+      Rake::Task["reporting:invalid_editions"].reenable
     end
 
-    test "it prints the content IDs of the matching documents from published editions" do
-      assert_output(/#{@document_1.document.content_id},#{@document_1.base_path}/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
-    end
+    test "it groups and summarises all of the invalid editions" do
+      edition_with_missing_contact = create(:published_edition)
+      edition_with_missing_contact.translations.first.update_columns(body: "[Contact:9999999]")
+      edition_with_bad_link_1 = create(:withdrawn_edition, body: "[bad link](http:::::://gov.uk)")
+      edition_with_bad_link_2 = create(:edition, body: "[another bad link](http:::::://gov.uk)")
+      blank_edition = create(:edition)
+      blank_edition.translations.first.update_columns(body: "")
 
-    test "it does not print the content IDs of the matching documents from draft editions" do
-      refute_output(/#{@document_2.document.content_id},#{@document_2.base_path}/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
-    end
+      invalid_editions = [
+        edition_with_missing_contact,
+        edition_with_bad_link_1,
+        edition_with_bad_link_2,
+        blank_edition,
+      ]
 
-    test "it does not print the content IDs of the non-matching documents from published editions" do
-      refute_output(/#{@document_3.document.content_id},#{@document_3.base_path}/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
-    end
-  end
+      invalid_editions.each { |edition| edition.valid?(:publish) }
 
-  context "for HTML attachments" do
-    setup do
-      @html_attachment_1 = create(:html_attachment, body: "Some text on a published edition", attachable: create(:published_edition))
-      @html_attachment_2 = create(:html_attachment, body: "Some other text on a published edition", attachable: create(:published_edition))
-      @html_attachment_3 = create(:html_attachment, body: "Some text on a draft edition", attachable: create(:draft_edition))
-    end
+      expected_output = <<~OUTPUT
+        All invalid editions (3)
+        -------------------------------
+        2 editions with error `Invalid external link structure`. Example edition IDs: #{edition_with_bad_link_1.id}, #{edition_with_bad_link_2.id}
+        1 editions with error `Body cannot be blank`. Example edition IDs: #{blank_edition.id}
+        1 editions with error `Invalid Contact ID`. Example edition IDs: #{edition_with_missing_contact.id}
 
-    test "it prints the content IDs of the matching documents from published HTML attachments" do
-      assert_output(/#{@html_attachment_1.content_id},#{@html_attachment_1.base_path}/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
-    end
+        Invalid published editions (1)
+        -------------------------------
+        1 editions with error `Invalid Contact ID`. Example edition IDs: #{edition_with_missing_contact.id}
 
-    test "it does not print the content IDs of the non-matching documents from published HTML attachments" do
-      refute_output(/#{@html_attachment_2.content_id},#{@html_attachment_2.base_path}/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
-    end
+        Invalid withdrawn editions (1)
+        -------------------------------
+        1 editions with error `Invalid external link structure`. Example edition IDs: #{edition_with_bad_link_1.id}
 
-    test "it does not print the content IDs of the matching documents from draft HTML attachments" do
-      refute_output(/#{@html_attachment_3.content_id},#{@html_attachment_3.base_path}/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
-    end
-  end
+      OUTPUT
 
-  context "for people" do
-    setup do
-      @person_1 = create(:person, biography: "Some text")
-      @person_2 = create(:person, biography: "Some other text")
-    end
-
-    test "it prints the content IDs of the matching documents from people" do
-      assert_output(/#{@person_1.content_id},#{@person_1.base_path}/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
-    end
-
-    test "it does not print the content IDs of the non-matching documents from people" do
-      refute_output(/#{@person_2.content_id},#{@person_2.base_path}/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
-    end
-  end
-
-  context "for policy groups" do
-    setup do
-      @policy_group_1 = create(:policy_group, description: "Some text")
-      @policy_group_2 = create(:policy_group, description: "Some other text")
-    end
-
-    test "it prints the content IDs of the matching documents from policy groups" do
-      assert_output(/#{@policy_group_1.content_id},#{@policy_group_1.base_path}/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
-    end
-
-    test "it does not print the content IDs of the non-matching documents from policy groups" do
-      refute_output(/#{@policy_group_2.content_id},#{@policy_group_2.base_path}/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
-    end
-  end
-
-  context "for world location news" do
-    setup do
-      @world_location_news_1 = create(:world_location_news, mission_statement: "Some text", world_location: create(:world_location))
-      @world_location_news_2 = create(:world_location_news, mission_statement: "Some other text", world_location: create(:world_location))
-    end
-
-    test "it prints the content IDs of the matching documents from world location news" do
-      assert_output(/#{@world_location_news_1.content_id},#{@world_location_news_1.base_path}/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
-    end
-
-    test "it does not print the content IDs of the non-matching documents from world location news" do
-      refute_output(/#{@world_location_news_2.content_id},#{@world_location_news_2.base_path}/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
-    end
-  end
-
-  context "for worldwide offices" do
-    setup do
-      @worldwide_office_1 = create(:worldwide_office, access_and_opening_times: "Some text")
-      @worldwide_office_2 = create(:worldwide_office, access_and_opening_times: "Some other text")
-    end
-
-    test "it prints the content IDs of the matching documents from worldwide offices" do
-      assert_output(/#{@worldwide_office_1.content_id},#{@worldwide_office_1.base_path}/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
-    end
-
-    test "it does not print the content IDs of the non-matching documents from worldwide offices" do
-      refute_output(/#{@worldwide_office_2.content_id},#{@worldwide_office_2.base_path}/) { Rake.application.invoke_task "reporting:matching_docs[Some text]" }
+      assert_output(expected_output) do
+        Rake.application.invoke_task "reporting:invalid_editions"
+      end
     end
   end
 end


### PR DESCRIPTION
(Best reviewed commit by commit with `?w=1` added to the end of the URL to suppress whitespace changes).

Adds two new rake tasks for reporting the 'invalid' editions in Whitehall, broken down by state and error type.

We're planning to use these metrics as part of our system health reporting. We're interested in global numbers, and particularly in published and withdrawn editions, since these are live and user-facing. We're somewhat less interested in invalid draft (or rejected or submitted) editions, since publishers would need to fix the validation issues in order to publish the content anyway.

But beyond looking at all invalid editions globally, we're also interested in surfacing just the invalid editions created from a certain cut-off point. Since #10384 was merged, 'invalid' editions are more obviously flagged to the publisher, and we wouldn't really expect any invalid editions to go live from this date. So this is a metric we're keen on tracking separately.

Usage (all invalid editions):

```
rake reporting:invalid_editions
```

Usage (invalid editions from a certain date):

```
rake reporting:invalid_editions_created_since['2025-07-17']
```

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
