### PR TITLE
Removed Back links from Worldwide Org pages

### DIFF
--- a/app/views/admin/worldwide_offices/index.html.erb
+++ b/app/views/admin/worldwide_offices/index.html.erb
@@ -1,8 +1,3 @@
-<% content_for :back_link do %>
-  <%= render "govuk_publishing_components/components/back_link", {
-    href: admin_worldwide_organisations_path,
-  } %>
-<% end %>
 <% content_for :page_title, "#{@worldwide_organisation.title} offices" %>
 <% content_for :title, @worldwide_organisation.title %>
 <% content_for :context, "Worldwide organisation" %>

--- a/app/views/admin/worldwide_organisation_pages/index.html.erb
+++ b/app/views/admin/worldwide_organisation_pages/index.html.erb
@@ -1,8 +1,3 @@
-<% content_for :back_link do %>
-  <%= render "govuk_publishing_components/components/back_link", {
-    href: admin_worldwide_organisations_path,
-  } %>
-<% end %>
 <% content_for :page_title, "#{@worldwide_organisation.title} offices" %>
 <% content_for :title, @worldwide_organisation.title %>
 <% content_for :context, "Worldwide organisation" %>


### PR DESCRIPTION
https://gov-uk.atlassian.net/browse/WHIT-1844 
On worldwide-organisations pages like [this](https://whitehall-admin.integration.publishing.service.gov.uk/government/admin/worldwide-organisations/1701140) , if you chose “Edit draft” from the document summary there are 5 “tabs”:

- Document
- Attachments
- Offices
- Pages
- Social media accounts

Of these tabs “Offices” and “Pages” contained a broken “Back” link. The other “tabs” had nothing. 

Back on “Organisation” pages take the user back to the Organisations list, but here “Back” should probably take the user back to the summary page (which is where they would have come from, but none of our “editionable” content-types have this button. So I removed it from those two pages.