### PR TITLE
(CM-248) Support errors in object fields

### DIFF
--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/object_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/object_component.html.erb
@@ -12,6 +12,7 @@
         name: name_for_field(embedded_field),
         id: id_for_field(embedded_field),
         value: value_for_field(embedded_field),
+        error_items: errors_for_field(embedded_field),
       } %>
     <% end %>
   <% end %>

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/object_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/object_component.rb
@@ -9,6 +9,10 @@ private
     "#{id}_#{field.name}"
   end
 
+  def errors_for_field(field)
+    errors_for(content_block_edition.errors, "details_#{id_suffix}_#{field.name}".to_sym)
+  end
+
   def value_for_field(field)
     value&.fetch(field.name, nil)
   end

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/video_relay_service_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/video_relay_service_component.html.erb
@@ -6,14 +6,16 @@
             name: name_for_field(prefix) ,
             id: id_for_field(prefix),
             value: value_for_field(prefix) || prefix.default_value,
-          }) %>
+            error_items: errors_for_field(prefix),
+    }) %>
 
     <%= render("govuk_publishing_components/components/input", {
               label: { text: label_for("telephone_number") },
               name: name_for_field(telephone_number) ,
               id: id_for_field(telephone_number),
               value: value_for_field(telephone_number) || telephone_number.default_value,
-            }) %>
+              error_items: errors_for_field(telephone_number),
+    }) %>
   <% end %>
 
   <input type="hidden" name="<%= name_for_field(show_video_relay_service) %>" value="false">

--- a/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/object_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/object_component_test.rb
@@ -62,4 +62,31 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::ObjectComponent
       assert_selector "input[name=\"content_block/edition[details][nested][label]\"][value=\"something\"]"
     end
   end
+
+  describe "when errors are present for the object" do
+    before do
+      content_block_edition.errors.add(:details_nested_label, "Label error")
+      content_block_edition.errors.add(:details_nested_type, "Type error")
+      content_block_edition.errors.add(:details_nested_email_address, "Email address error")
+    end
+
+    it "should show errors" do
+      render_inline(component)
+
+      assert_selector ".govuk-form-group.govuk-form-group--error", text: /Label/ do |form_group|
+        form_group.assert_selector ".govuk-error-message", text: "Label error"
+        form_group.assert_selector "input.govuk-input--error"
+      end
+
+      assert_selector ".govuk-form-group.govuk-form-group--error", text: /Type/ do |form_group|
+        form_group.assert_selector ".govuk-error-message", text: "Type error"
+        form_group.assert_selector "input.govuk-input--error"
+      end
+
+      assert_selector ".govuk-form-group.govuk-form-group--error", text: /Email address/ do |form_group|
+        form_group.assert_selector ".govuk-error-message", text: "Email address error"
+        form_group.assert_selector "input.govuk-input--error"
+      end
+    end
+  end
 end

--- a/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/video_relay_service_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/video_relay_service_component_test.rb
@@ -188,4 +188,25 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::VideoRelayServi
       end
     end
   end
+
+  describe "when errors are present" do
+    before do
+      content_block_edition.errors.add(:details_video_relay_service_prefix, "Prefix error")
+      content_block_edition.errors.add(:details_video_relay_service_telephone_number, "Telephone error")
+    end
+
+    it "should show errors" do
+      render_inline(component)
+
+      assert_selector ".govuk-form-group.govuk-form-group--error", text: /Prefix/ do |form_group|
+        form_group.assert_selector ".govuk-error-message", text: "Prefix error"
+        form_group.assert_selector "textarea.govuk-textarea--error"
+      end
+
+      assert_selector ".govuk-form-group.govuk-form-group--error", text: /Telephone number/ do |form_group|
+        form_group.assert_selector ".govuk-error-message", text: "Telephone error"
+        form_group.assert_selector "input.govuk-input--error"
+      end
+    end
+  end
 end


### PR DESCRIPTION
Now we have validation for an object field (added in https://github.com/alphagov/publishing-api/pull/3468), we need a way to display errors if any nested objects are invalid.

## Screenshot

<img width="2346" height="816" alt="image" src="https://github.com/user-attachments/assets/57390d06-9809-4ee2-b223-b2c89ae6c1bc" />
