### PR TITLE
Fix 'native name' of each non-English language

### DIFF
--- a/config/languages.yml
+++ b/config/languages.yml
@@ -1,11 +1,11 @@
 ar:
   direction: rtl
   english_name: Arabic
-  native_name: العربية
+  native_name: العربيَّة
 az:
   direction: ltr
   english_name: Azeri
-  native_name: Azərbaycanca
+  native_name: Azeri
 be:
   direction: ltr
   english_name: Belarusian
@@ -13,7 +13,7 @@ be:
 bg:
   direction: ltr
   english_name: Bulgarian
-  native_name: Български
+  native_name: Bulgarian
 bn:
   direction: ltr
   english_name: Bangla
@@ -65,7 +65,7 @@ fa:
 fi:
   direction: ltr
   english_name: Finnish
-  native_name: Suomi
+  native_name: suomi
 fr:
   direction: ltr
   english_name: French
@@ -77,7 +77,7 @@ gd:
 gu:
   direction: ltr
   english_name: Gujarati
-  native_name: ગુજરાતી
+  native_name: જોર્જિયન
 he:
   direction: rtl
   english_name: Hebrew
@@ -85,7 +85,7 @@ he:
 hi:
   direction: ltr
   english_name: Hindi
-  native_name: हिन्दी
+  native_name: हिंदी
 hr:
   direction: ltr
   english_name: Croatian
@@ -153,15 +153,15 @@ nl:
 'no':
   direction: ltr
   english_name: Norwegian
-  native_name: Norsk
+  native_name: norsk
 pa:
   direction: ltr
   english_name: Punjabi Gurmukhi
-  native_name: ਪੰਜਾਬੀ
+  native_name: ਪੰਜਾਬੀ ਗੁਰਮੁਖੀ
 pa-pk:
   direction: rtl
   english_name: Punjabi Shahmukhi
-  native_name: پنجابی
+  pa-native_name: پنجابی شاہ مُکھی
 pl:
   direction: ltr
   english_name: Polish
@@ -169,7 +169,7 @@ pl:
 ps:
   direction: rtl
   english_name: Pashto
-  native_name: پښتو
+  native_name: جرمني
 pt:
   direction: ltr
   english_name: Portuguese
@@ -189,7 +189,7 @@ si:
 sk:
   direction: ltr
   english_name: Slovak
-  native_name: Slovenčina
+  native_name: Slovensky
 sl:
   direction: ltr
   english_name: Slovene
@@ -205,11 +205,11 @@ sq:
 sr:
   direction: ltr
   english_name: Serbian
-  native_name: Српски
+  native_name: srpski
 sv:
   direction: ltr
   english_name: Swedish
-  native_name: Svenska
+  native_name: Svensk
 sw:
   direction: ltr
   english_name: Swahili
@@ -241,7 +241,7 @@ ur:
 uz:
   direction: ltr
   english_name: Uzbek
-  native_name: Oʻzbek
+  native_name: Ўзбекча
 vi:
   direction: ltr
   english_name: Vietnamese
@@ -249,7 +249,7 @@ vi:
 yi:
   direction: rtl
   english_name: Yiddish
-  native_name: ייִדיש
+  native_name: יידיש
 zh:
   direction: ltr
   english_name: Chinese
@@ -257,7 +257,7 @@ zh:
 zh-hk:
   direction: ltr
   english_name: Cantonese
-  native_name: 粵語
+  native_name: 中文
 zh-tw:
   direction: ltr
   english_name: Traditional Chinese

--- a/config/languages.yml
+++ b/config/languages.yml
@@ -13,7 +13,7 @@ be:
 bg:
   direction: ltr
   english_name: Bulgarian
-  native_name: Bulgarian
+  native_name: български
 bn:
   direction: ltr
   english_name: Bangla

--- a/config/languages.yml
+++ b/config/languages.yml
@@ -65,7 +65,7 @@ fa:
 fi:
   direction: ltr
   english_name: Finnish
-  native_name: suomi
+  native_name: Suomi
 fr:
   direction: ltr
   english_name: French
@@ -153,7 +153,7 @@ nl:
 'no':
   direction: ltr
   english_name: Norwegian
-  native_name: norsk
+  native_name: Norsk
 pa:
   direction: ltr
   english_name: Punjabi Gurmukhi
@@ -205,7 +205,7 @@ sq:
 sr:
   direction: ltr
   english_name: Serbian
-  native_name: srpski
+  native_name: Srpski
 sv:
   direction: ltr
   english_name: Swedish


### PR DESCRIPTION
These values were set in PR #9845, where we can see what the values used to be in the `language_names: {locale}` property of the corresponding file (e.g. [ar.yml](https://github.com/alphagov/whitehall/blob/10b15007275cce466b33ac14020c59381c617867/config/locales/ar.yml#L730)).

From memory, I think I used Copilot to perform the laborious task of copying the correct value from the old locale file to the new `languages.yml` file, and evidently, it hallucinated some translations. So I've manually patched these back to the values they were prior to the change, even if that meant lowercasing them when we probably shouldn't(!) - and then fixed up the lowercasing in the next commit, just so we have a full audit trail.

Thanks to @yndajas for spotting the issue.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
