### PR TITLE
Amendments to tracked form events [WHIT-2325]

### DIFF
--- a/app/views/admin/editions/_organisation_fields.html.erb
+++ b/app/views/admin/editions/_organisation_fields.html.erb
@@ -21,17 +21,17 @@
         <% end %>
       <% end %>
     </div>
+  <% end %>
 
-    <% if edition.can_have_supporting_organisations? %>
-      <%= render "govuk_publishing_components/components/select_with_search", {
-        id: "edition_supporting_organisation_ids",
-        name: "edition[supporting_organisation_ids][]",
-        include_blank: true,
-        label: "Supporting organisations",
-        heading_size: "m",
-        options: taggable_organisations_container(edition.edition_organisations.reject(&:lead?).map(&:organisation_id)),
-        multiple: true,
-      } %>
-    <% end %>
+  <% if edition.can_have_supporting_organisations? %>
+    <%= render "govuk_publishing_components/components/select_with_search", {
+      id: "edition_supporting_organisation_ids",
+      name: "edition[supporting_organisation_ids][]",
+      include_blank: true,
+      label: "Supporting organisations",
+      heading_size: "m",
+      options: taggable_organisations_container(edition.edition_organisations.reject(&:lead?).map(&:organisation_id)),
+      multiple: true,
+    } %>
   <% end %>
 <% end %>

--- a/app/views/components/_datetime_fields.html.erb
+++ b/app/views/components/_datetime_fields.html.erb
@@ -41,82 +41,79 @@
 %>
 <% if prefix && field_name %>
   <%= tag.div class: root_classes, data: data_attributes, id: id do %>
-    <% unless date_only && !date_heading %>
-      <%= render "govuk_publishing_components/components/heading", {
-        text: date_heading || "Date (required)",
-        heading_level: heading_level || 3,
-        font_size: heading_size || "m",
-        padding: true,
+    <% date_input = capture do %>
+      <%= render "govuk_publishing_components/components/date_input", {
+        id: date_id,
+        hint: date_hint,
+        error_items: error_items,
+        items: date_input_items,
       } %>
     <% end %>
 
-    <%= render "govuk_publishing_components/components/date_input", {
-      id: date_id,
-      hint: date_hint,
-      error_items: error_items,
-      items: date_input_items,
+    <%= render "govuk_publishing_components/components/fieldset", {
+      heading_level: heading_level || 3,
+      heading_size: heading_size || "m",
+      legend_text: date_heading || "Date (required)",
+      text: date_input,
     } %>
 
     <% unless date_only %>
-      <div class="govuk-!-margin-top-3">
-        <%= render "govuk_publishing_components/components/heading", {
-          text: "Time",
-          heading_level: heading_level || 3,
-          font_size: heading_size || "m",
-          padding: true,
-        } %>
-      </div>
-
-      <% if time_hint %>
-        <%= render "govuk_publishing_components/components/hint", {
-          text: time_hint,
-          id: time_hint_id,
-        } %>
-      <% end %>
-
-      <div class="app-c-datetime-fields__date-time-wrapper">
-        <div class="app-c-datetime-fields__date-time">
-          <%= render "govuk_publishing_components/components/label", {
-            text: "Hour",
-            html_for: hour_select_id,
-            id: hour_label_id,
+      <%= render "govuk_publishing_components/components/fieldset", {
+        legend_text: "Time",
+        heading_level: heading_level || 3,
+        heading_size: heading_size || "m",
+      } do %>
+        <% if time_hint %>
+          <%= render "govuk_publishing_components/components/hint", {
+            text: time_hint,
+            id: time_hint_id,
           } %>
+        <% end %>
 
-          <%= select_hour hour_value,
-                          {
-                            include_blank: true,
-                            prefix: prefix,
-                            field_name: "#{field_name}(4i)",
-                          },
-                          {
-                            id: hour_select_id,
-                            class: "govuk-select app-c-datetime-fields__date-time-input",
-                            "aria-describedby": "#{hour_label_id} #{time_hint_id if time_hint.present?}".strip,
-                          } %>
-        </div>
+        <div class="app-c-datetime-fields__date-time-wrapper">
+          <div class="app-c-datetime-fields__date-time">
+            <%= render "govuk_publishing_components/components/label", {
+              text: "Hour",
+              html_for: hour_select_id,
+              id: hour_label_id,
+            } %>
 
-        <p class="govuk-body app-c-datetime-fields__time-separator">:</p>
-
-        <div class="app-c-datetime-fields__date-time">
-          <%= render "govuk_publishing_components/components/label", {
-            text: "Minute",
-            html_for: minute_select_id,
-            id: minute_label_id,
-          } %>
-
-          <%= select_minute minute_value,
+            <%= select_hour hour_value,
                             {
                               include_blank: true,
                               prefix: prefix,
-                              field_name: "#{field_name}(5i)",
+                              field_name: "#{field_name}(4i)",
                             },
                             {
-                              id: minute_select_id,
+                              id: hour_select_id,
                               class: "govuk-select app-c-datetime-fields__date-time-input",
-                              "aria-describedby": "#{minute_label_id} #{time_hint_id if time_hint.present?}".strip,
+                              "aria-describedby": "#{hour_label_id} #{time_hint_id if time_hint.present?}".strip,
                             } %>
+          </div>
+
+          <p class="govuk-body app-c-datetime-fields__time-separator">:</p>
+
+          <div class="app-c-datetime-fields__date-time">
+            <%= render "govuk_publishing_components/components/label", {
+              text: "Minute",
+              html_for: minute_select_id,
+              id: minute_label_id,
+            } %>
+
+            <%= select_minute minute_value,
+                              {
+                                include_blank: true,
+                                prefix: prefix,
+                                field_name: "#{field_name}(5i)",
+                              },
+                              {
+                                id: minute_select_id,
+                                class: "govuk-select app-c-datetime-fields__date-time-input",
+                                "aria-describedby": "#{minute_label_id} #{time_hint_id if time_hint.present?}".strip,
+                              } %>
+          </div>
         </div>
-      </div>
+      <% end %>
     <% end %>
   <% end %>
 <% end %>

--- a/spec/javascripts/admin/analytics-modules/ga4-form-tracker.spec.js
+++ b/spec/javascripts/admin/analytics-modules/ga4-form-tracker.spec.js
@@ -76,7 +76,7 @@ describe('GOVUK.analyticsGa4.analyticsModules.Ga4FormTracker', function () {
       expect(mockGa4SendData).toHaveBeenCalledWith(
         {
           ...expectedAttributes,
-          section: `${Form.formDefaultOptions.legend} - ${Form.formDefaultOptions.label}`,
+          section: `${Form.formDefaultOptions.label}`,
           ...JSON.parse(index.dataset.ga4Index),
           action: 'select'
         },

--- a/spec/javascripts/admin/analytics-modules/ga4-index-section-setup.spec.js
+++ b/spec/javascripts/admin/analytics-modules/ga4-index-section-setup.spec.js
@@ -1,45 +1,27 @@
 describe('GOVUK.analyticsGa4.analyticsModules.GA4IndexSectionEventHandlers', function () {
-  let container,
-    form,
-    input,
-    radioInput,
-    hiddenInput,
-    fieldset,
-    select,
-    excludedParent,
-    excludedInput
+  const Form = window.GOVUK.Modules.JasmineHelpers.Form
+
+  const Ga4IndexSectionSetup =
+    window.GOVUK.analyticsGa4.analyticsModules.Ga4IndexSectionSetup
+
+  let container, form, input, fieldset, select
 
   beforeEach(function () {
-    document.title = 'Document title'
-
     container = document.createElement('div')
     container.setAttribute('data-module', 'ga4-index-section-setup')
-    form = document.createElement('form')
-    input = document.createElement('input')
-    form.appendChild(input)
-    select = document.createElement('select')
-    form.appendChild(select)
-    excludedParent = document.createElement('div')
-    excludedParent.setAttribute('data-module', 'select-with-search')
-    excludedInput = document.createElement('input')
-    excludedParent.appendChild(excludedInput)
-    form.appendChild(excludedParent)
-    fieldset = document.createElement('fieldset')
-    radioInput = document.createElement('input')
-    radioInput.type = 'radio'
-    fieldset.appendChild(radioInput)
-    form.appendChild(fieldset)
-    hiddenInput = document.createElement('input')
-    hiddenInput.type = 'hidden'
-    form.appendChild(hiddenInput)
-    container.appendChild(form)
+
+    form = new Form(['text', 'select', 'radio'])
+
+    form.appendToParent(container)
     document.body.appendChild(container)
+
+    input = form.querySelector('input')
+    select = form.querySelector('select')
+    fieldset = form.querySelector('fieldset')
   })
 
   describe('for a form not tracked by ga4-finder-tracker', function () {
     it('adds a ga4-index-section data attribute to select and input fields reflecting their position in the DOM', function () {
-      const Ga4IndexSectionSetup =
-        GOVUK.analyticsGa4.analyticsModules.Ga4IndexSectionSetup
       Ga4IndexSectionSetup.init()
 
       expect(input.dataset.ga4Index).toEqual(
@@ -54,8 +36,6 @@ describe('GOVUK.analyticsGa4.analyticsModules.GA4IndexSectionEventHandlers', fun
     })
 
     it('does not add ga4-filter-parent', function () {
-      const Ga4IndexSectionSetup =
-        GOVUK.analyticsGa4.analyticsModules.Ga4IndexSectionSetup
       Ga4IndexSectionSetup.init()
 
       expect(input.dataset.ga4FilterParent).not.toBeDefined()
@@ -68,8 +48,6 @@ describe('GOVUK.analyticsGa4.analyticsModules.GA4IndexSectionEventHandlers', fun
     it('adds ga4-index-section and ga4-filter-parent data attributes to select and input fields reflecting their position in the DOM', function () {
       form.dataset.module = 'ga4-finder-tracker'
 
-      const Ga4IndexSectionSetup =
-        GOVUK.analyticsGa4.analyticsModules.Ga4IndexSectionSetup
       Ga4IndexSectionSetup.init()
 
       expect(input.dataset.ga4Index).toEqual(
@@ -90,26 +68,36 @@ describe('GOVUK.analyticsGa4.analyticsModules.GA4IndexSectionEventHandlers', fun
   })
 
   describe('does not add ga4-index-section data attributes to', function () {
+    let excludedParent, excludedInput, radioInput, hiddenInput
+
     it('select and input fields in an excludedParent', function () {
-      const Ga4IndexSectionSetup =
-        GOVUK.analyticsGa4.analyticsModules.Ga4IndexSectionSetup
+      excludedParent = document.createElement('div')
+      excludedParent.setAttribute('data-module', 'select-with-search')
+      excludedInput = document.createElement('input')
+      excludedParent.appendChild(excludedInput)
+      form.appendChild(excludedParent)
+
       Ga4IndexSectionSetup.init()
 
       expect(excludedInput.dataset.ga4Index).not.toBeDefined()
     })
 
     it('radio button within fieldset', function () {
-      const Ga4IndexSectionSetup =
-        GOVUK.analyticsGa4.analyticsModules.Ga4IndexSectionSetup
       Ga4IndexSectionSetup.init()
+
+      radioInput = form.querySelector('input[type=radio]')
 
       expect(radioInput.dataset.ga4Index).not.toBeDefined()
     })
 
     it('hidden input', function () {
-      const Ga4IndexSectionSetup =
-        GOVUK.analyticsGa4.analyticsModules.Ga4IndexSectionSetup
+      hiddenInput = document.createElement('input')
+      hiddenInput.type = 'hidden'
+      form.appendChild(hiddenInput)
+
       Ga4IndexSectionSetup.init()
+
+      hiddenInput = form.querySelector('input[type=hidden]')
 
       expect(hiddenInput.dataset.ga4Index).not.toBeDefined()
     })

--- a/spec/javascripts/helpers/helpers.js
+++ b/spec/javascripts/helpers/helpers.js
@@ -24,19 +24,19 @@ window.GOVUK.Modules = window.GOVUK.Modules || {}
       <div class="govuk-date-input__item">
         <div class="govuk-form-group">
           <label for="day" class="gem-c-label govuk-label">Day</label>
-          <input class="gem-c-input govuk-input govuk-input--width-4" id="day" name="day" type="text">
+          <input class="gem-c-input govuk-input govuk-input--width-4" name="date(1i)" id="date_1i" type="text">
         </div>
       </div>
       <div class="govuk-date-input__item">
         <div class="govuk-form-group">
           <label for="month" class="gem-c-label govuk-label">Month</label>
-          <input class="gem-c-input govuk-input govuk-input--width-4" name="month" id="month" type="text">
+          <input class="gem-c-input govuk-input govuk-input--width-4" name="date(2i)" id="date_2i" type="text">
         </div>
       </div>
       <div class="govuk-date-input__item">
         <div class="govuk-form-group">
           <label for="year" class="gem-c-label govuk-label">Year</label>
-          <input class="gem-c-input govuk-input govuk-input--width-4" name="year" id="year" type="text">
+          <input class="gem-c-input govuk-input govuk-input--width-4" name="date(3i)" id="date_3i" type="text">
         </div>
       </div>
       </fieldset>
@@ -88,8 +88,12 @@ window.GOVUK.Modules = window.GOVUK.Modules || {}
       <fieldset class="govuk-fieldset">
         <legend>${legend}</legend>
         <div class="govuk-radios">
-            <input type="radio" name="radio-group" id="radio" value="1">
-            <label for="radio">${value}</label>
+            <input type="radio" name="radio(1i)" id="radio_1i" value="1">
+            <label for="radio_1i">${value}</label>
+        </div>
+        <div class="govuk-radios">
+            <input type="radio" name="radio(2i)" id="radio_2i" value="2">
+            <label for="radio_2i">${value} 2</label>
         </div>
       </fieldset>
     `

--- a/test/components/datetime_fields_test.rb
+++ b/test/components/datetime_fields_test.rb
@@ -16,11 +16,11 @@ class DatetimefieldsComponentTest < ComponentTestCase
     })
 
     assert_select ".app-c-datetime-fields"
-    assert_select "h3.govuk-heading-m", text: "Date (required)"
+    assert_select "h3.govuk-fieldset__heading", text: "Date (required)"
     assert_select ".govuk-input[name='day']"
     assert_select ".govuk-input[name='month']"
     assert_select ".govuk-input[name='year']"
-    assert_select "h3.govuk-heading-m", text: "Time"
+    assert_select "h3.govuk-fieldset__heading", text: "Time"
     assert_select ".govuk-label", text: "Hour"
     assert_select ".govuk-label", text: "Minute"
   end
@@ -45,8 +45,8 @@ class DatetimefieldsComponentTest < ComponentTestCase
       heading_size: "l",
     })
 
-    assert_select "h1.govuk-heading-l", text: "i am heading"
-    assert_select "h1.govuk-heading-l", text: "Time"
+    assert_select "h1.govuk-fieldset__heading", text: "i am heading"
+    assert_select "h1.govuk-fieldset__heading", text: "Time"
   end
 
   test "shows hint text" do


### PR DESCRIPTION
## What

- Use `fieldset` for `datetime_fields`
- Move "Support organisations" select outside of "Lead Organisation" `fieldset`
- Updates to `Ga4IndexSectionSetup` to take into account multiple choice fields and split fields
- Updates to `Ga4FormTracker` to use correct `section` for fields within fieldsets

## Why

Addresses indexing issues that have occurred within forms in the previous implementation, which based the index on if the field was a child of `fieldset` and not on what the field actually controlled within the form. Using `name` and `id` as a basis for the indexing will allow more accurate generation of index sections.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
