### PR TITLE
Fix taxon validator (WHIT-2271)

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -163,11 +163,11 @@ class Edition < ApplicationRecord
   end
 
   def has_been_tagged?
-    api_response = Services.publishing_api.get_links(content_id)
+    api_response = Services.publishing_api.get_expanded_links(content_id, with_drafts: false)
 
-    return false if api_response["links"].nil? || api_response["links"]["taxons"].nil?
+    return false if api_response["expanded_links"].nil? || api_response["expanded_links"]["taxons"].nil?
 
-    api_response["links"]["taxons"].any?
+    api_response["expanded_links"]["taxons"].any?
   rescue GdsApi::HTTPNotFound
     false
   end

--- a/test/functional/admin/edition_world_tags_controller_test.rb
+++ b/test/functional/admin/edition_world_tags_controller_test.rb
@@ -14,6 +14,18 @@ class Admin::EditionWorldTagsControllerTest < ActionController::TestCase
     stub_publishing_api_expanded_links_with_taxons(@edition.content_id, [child_taxon])
   end
 
+  def stub_publishing_api_links_with_taxons(content_id, taxons)
+    stub_publishing_api_has_links(
+      {
+        "content_id" => content_id,
+        "links" => {
+          "taxons" => taxons,
+        },
+        "version" => 1,
+      },
+    )
+  end
+
   test "should return an error on a version conflict" do
     stub_publishing_api_expanded_links_with_taxons(@edition.content_id, [world_child_taxon])
 

--- a/test/functional/admin/generic_editions_controller_test.rb
+++ b/test/functional/admin/generic_editions_controller_test.rb
@@ -65,15 +65,16 @@ class Admin::GenericEditionsControllerTest < ActionController::TestCase
 
   test "PUT :update shows add tag save message when 'Save and got to document summary' button clicked and document has tags" do
     edition = create(:edition)
-    stub_publishing_api_has_links(
+    stub_publishing_api_has_expanded_links(
       {
         "content_id" => edition.content_id,
-        "links" => {
+        "expanded_links" => {
           "organisations" => %w[569a9ee5-c195-4b7f-b9dc-edc17a09113f],
           "taxons" => %w[7754ae52-34aa-499e-a6dd-88f04633b8ab],
         },
         "version" => 1,
       },
+      with_drafts: false,
     )
 
     put :update, params: { id: edition, edition: { title: "New title" }, save_and_continue: "Save and continue editing" }

--- a/test/support/taxonomy_helper.rb
+++ b/test/support/taxonomy_helper.rb
@@ -82,14 +82,15 @@ module TaxonomyHelper
   end
 
   def stub_publishing_api_links_with_taxons(content_id, taxons)
-    stub_publishing_api_has_links(
+    stub_publishing_api_has_expanded_links(
       {
         "content_id" => content_id,
-        "links" => {
+        "expanded_links" => {
           "taxons" => taxons,
         },
         "version" => 1,
       },
+      with_drafts: false,
     )
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -242,6 +242,7 @@ class ActionController::TestCase
     stub_request(:get, %r{.*content-store.*/content/.*}).to_return(status: 404)
     stub_publishing_api_has_linkables([], document_type: "topic")
     stub_request(:get, %r{\A#{Plek.find('publishing-api')}/v2/links/}).to_return(body: { links: {} }.to_json)
+    stub_request(:get, %r{\A#{Plek.find('publishing-api')}/v2/expanded-links/}).to_return(body: { links: {} }.to_json)
     TaxonValidator.any_instance.stubs(:validate)
   end
 

--- a/test/unit/app/models/edition_test.rb
+++ b/test/unit/app/models/edition_test.rb
@@ -797,14 +797,15 @@ class EditionTest < ActiveSupport::TestCase
   test "#has_been_tagged? is false when request from publishing-api has no taxons" do
     edition = create(:edition)
 
-    stub_publishing_api_has_links(
+    stub_publishing_api_has_expanded_links(
       {
         "content_id" => edition.content_id,
-        "links" => {
+        "expanded_links" => {
           "organisations" => %w[569a9ee5-c195-4b7f-b9dc-edc17a09113f],
         },
         "version" => 1,
       },
+      with_drafts: false,
     )
 
     assert_not edition.has_been_tagged?
@@ -813,15 +814,16 @@ class EditionTest < ActiveSupport::TestCase
   test "#has_been_tagged? is true when request from publishing-api has taxons" do
     edition = create(:edition)
 
-    stub_publishing_api_has_links(
+    stub_publishing_api_has_expanded_links(
       {
         "content_id" => edition.content_id,
-        "links" => {
+        "expanded_links" => {
           "organisations" => %w[569a9ee5-c195-4b7f-b9dc-edc17a09113f],
-          "taxons" => %w[7754ae52-34aa-499e-a6dd-88f04633b8ab],
+          "taxons" => ["something goes here"],
         },
         "version" => 1,
       },
+      with_drafts: false,
     )
 
     assert edition.has_been_tagged?

--- a/test/unit/app/validators/taxon_validator_test.rb
+++ b/test/unit/app/validators/taxon_validator_test.rb
@@ -9,21 +9,15 @@ class TaxonValidatorTest < ActiveSupport::TestCase
     TaxonValidator.any_instance.unstub(:validate)
     edition = create(:draft_edition)
 
-    stub_publishing_api_has_links(
+    stub_publishing_api_has_expanded_links(
       {
         "content_id" => edition.content_id,
-        "links" => {
+        "expanded_links" => {
           "organisations" => %w[569a9ee5-c195-4b7f-b9dc-edc17a09113f],
         },
         "version" => 1,
       },
-    )
-
-    stub_publishing_api_has_expanded_links(
-      {
-        content_id: edition.content_id,
-        expanded_links: {},
-      },
+      with_drafts: false,
     )
 
     @validator.validate(edition)


### PR DESCRIPTION
A number of editions were reporting `.valid?(:publish) => true` despite having no visibly tagged topics in the UI. On further investigation, they appear to have been tagged to taxonomies that have either been deleted or made draft. Examples:

* Admin link 1: https://whitehall-admin.publishing.service.gov.uk/government/admin/consultations/234676
* Admin link 2: https://whitehall-admin.publishing.service.gov.uk/government/admin/publications/289739

Sure enough, they seem valid, looking in Rails console, despite definitely requring being tagged to a taxon:

```
Edition.find(234676).valid?(:publish)
=> true
Edition.find(289739).valid?(:publish)
=> true

Edition.find(234676).requires_taxon?
=> true
Edition.find(289739).requires_taxon?
=> true
```

However, the [actual validation](https://github.com/alphagov/whitehall/blob/41fdd08c086289d40f7e0a1c89cd53186e99c1f4/app/validators/taxon_validator.rb#L13-L15) checks `edition.has_been_tagged?`, rather than `edition.requires_taxon?`. And in these cases, they have apparently been tagged:

```Edition.find(234676).has_been_tagged?
=> true
Edition.find(289739).has_been_tagged?
=> true
```

The [has_been_tagged? definition](https://github.com/alphagov/whitehall/blob/e6680abcdcf3f1ddc89355bdc84ef66cf7b45988/app/models/edition.rb#L165-L173)
checks the `links.taxons` property. Let’s look at those in the content items:

* [Content item 1](https://www.gov.uk/api/content/government/consultations/consultation-on-changes-to-immigration-related-home-office-statistical-outputs)
* [Content item 2](https://www.gov.uk/api/content/government/publications/agreement-between-the-uk-and-india-for-the-promotion-and-protection-of-investments)

No `links.taxons` property in either content item - suspicious.

But calling the same code as in `has_been_tagged?`, for each content item respectively, there IS a `taxons` property:

```
api_response = Services.publishing_api.get_links("5e8cd219-7631-11e4-a3cb-005056011aef") => #<GdsApi::Response:0x0000ffff737b2730 @http_response=<RestClient::Response 200 "{\"content_i...">, @web_urls_relative_to=nil> api_response["links"]
=>
{"government"=>["591c83aa-3b74-437d-a342-612bddd97572"],
 "organisations"=>["06056197-bc69-4147-aa28-070bca132178"],
 "original_primary_publishing_organisation"=>["06056197-bc69-4147-aa28-070bca132178"],
 "primary_publishing_organisation"=>["06056197-bc69-4147-aa28-070bca132178"],
 "taxons"=>["ca58fbb7-432d-4d51-918c-c1667639723f"]}

api_response = Services.publishing_api.get_links("5ef958f3-7631-11e4-a3cb-005056011aef") => #<GdsApi::Response:0x0000ffff71813ff0 @http_response=<RestClient::Response 200 "{\"content_i...">, @web_urls_relative_to=nil>

api_response["links"]
=>
{"government"=>["ee4de459-0941-40dd-ba36-f23eec0585cb"],
 "organisations"=>["9adfc4ed-9f6c-4976-a6d8-18d34356367c"],
 "original_primary_publishing_organisation"=>["9adfc4ed-9f6c-4976-a6d8-18d34356367c"],
 "primary_publishing_organisation"=>["9adfc4ed-9f6c-4976-a6d8-18d34356367c"],
 "suggested_ordered_related_items"=>["5e8ebd51-7631-11e4-a3cb-005056011aef", "4062dc67-fe9b-4f3e-96b3-5404e299123f", "ee9f2427-b1c3-4bd1-85b8-eeab7e58d92e", "c3f9367f-0451-4426-99d9-dce7d672cddc"],
 "taxons"=>["06ad07f7-1e79-462f-a192-6b2c9d92089c"],
 "world_locations"=>["5e9f047a-7706-11e4-a3cb-005056011aef"]}
```

I wondered why the taxon links are somehow dropped from the content item
(where all the other links make it through unscathed). Looking in Content
Tagger, the first taxon [does exist](https://content-tagger.publishing.service.gov.uk/taxons/ca58fbb7-432d-4d51-918c-c1667639723f)
and I can see “Consultation on changes to immigration-related Home Office statistical outputs”
on its [list of tagged content](https://content-tagger.publishing.service.gov.uk/taxons/ca58fbb7-432d-4d51-918c-c1667639723f/tagged_content).
But I note that its state is `draft` (although its ‘phase’ is `live`),
and thus the taxonomy page itself 404s.
The second taxon doesn't appear to exist even in Content Tagger - I can
only assume it was deleted.

All this to say, Whitehall knows when its content has been tagged to
a taxon, and thus passes validation. But if that tag is later
deleted or turned into a draft, the page is no longer publicly
tagged to a taxonomy, and Whitehall is unaware that it is linked to
a taxonomy that is no longer publicly reachable (and should thus
fail validation).

The workaround is to use `get_expanded_links` rather than
`get_links`. The link expansion drops the missing taxon (and drops
the draft taxon, provided we pass `with_drafts: false`), and so we
can confirm that the Edition still requires tagging to a taxonomy
and thus should not be considered valid.

JIRA: WHIT-2271

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
