### PR TITLE
(CM-168) Handle name collisions in object keys

### DIFF
--- a/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/documents/embedded_objects_controller.rb
+++ b/lib/engines/content_block_manager/app/controllers/content_block_manager/content_block/documents/embedded_objects_controller.rb
@@ -31,13 +31,14 @@ class ContentBlockManager::ContentBlock::Documents::EmbeddedObjectsController < 
     @content_block_edition = @content_block_document.latest_edition.clone_edition(creator: current_user)
 
     @params = object_params(@subschema).dig(:details, @subschema.block_type)
+    object_title = @content_block_edition.key_for_object(@subschema.block_type, @params&.fetch("title"))
     @content_block_edition.add_object_to_details(@subschema.block_type, @params)
     @content_block_edition.save!
 
     redirect_to content_block_manager.review_embedded_object_content_block_manager_content_block_edition_path(
       @content_block_edition,
       object_type: @subschema.block_type,
-      object_title: @content_block_edition.key_for_object(@subschema.block_type, @params),
+      object_title:,
     )
   rescue ActiveRecord::RecordInvalid
     render :new

--- a/lib/engines/content_block_manager/app/models/content_block_manager/content_block/edition.rb
+++ b/lib/engines/content_block_manager/app/models/content_block_manager/content_block/edition.rb
@@ -48,7 +48,7 @@ module ContentBlockManager
       end
 
       def add_object_to_details(object_type, body)
-        key = key_for_object(object_type, body)
+        key = key_for_object(object_type, body["title"])
 
         details[object_type] ||= {}
         details[object_type][key] = remove_destroyed body.to_h
@@ -58,13 +58,17 @@ module ContentBlockManager
         details[object_type][object_title] = remove_destroyed body.to_h
       end
 
-      def key_for_object(object_type, object)
-        if object["title"].present?
-          object["title"].parameterize
-        else
-          current_count = details[object_type]&.values&.count || 0
-          "#{object_type.parameterize}-#{current_count + 1}"
+      def key_for_object(object_type, title)
+        base_key = (title.presence || object_type).parameterize
+        key = base_key
+        counter = 1
+
+        while details.dig(object_type, key).present?
+          key = "#{base_key}-#{counter}"
+          counter += 1
         end
+
+        key
       end
 
       def has_entries_for_subschema_id?(subschema_id)


### PR DESCRIPTION
If an object has the same title, then we add a number as appropriate to prevent name collisions. Additionally, I’ve simplified the code so if a title is missing we use the object_type as the key.

I’ve had to tweak the tests, so the first time an object_type is used, a number isn’t appended, but I think this makes sense in reality.