### PR TITLE
CM-249: Order "Opening times" nested object's properties in summary card

### DIFF
--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/embedded_objects/blocks_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block/document/show/embedded_objects/blocks_component.rb
@@ -61,12 +61,22 @@ private
   end
 
   def rows_for_nested_items(items, nested_name, index)
-    items.map do |key, value|
+    rows = items.map do |key, value|
       {
         key: key_to_title(key),
         value: content_for_row(embed_code_identifier(nested_name, index, key), value),
         data: data_attributes_for_row(embed_code_identifier(nested_name, index, key)),
       }
+    end
+    ordered_by_field_order(rows, nested_name)
+  end
+
+  def ordered_by_field_order(rows, nested_object_name)
+    field_order = schema.config.dig("fields", nested_object_name, "field_order")
+    return rows unless field_order
+
+    rows.sort_by do |row|
+      field_order.index(row.fetch(:key).parameterize(separator: "_")) || Float::INFINITY
     end
   end
 

--- a/lib/engines/content_block_manager/config/content_block_manager.yml
+++ b/lib/engines/content_block_manager/config/content_block_manager.yml
@@ -68,6 +68,11 @@ schemas:
           opening_hours:
             component:
               opening_hours
+            field_order:
+              - day_from
+              - time_from
+              - day_to
+              - time_to
           call_charges:
             component:
               call_charges


### PR DESCRIPTION
See [Jira CM-249](https://gov-uk.atlassian.net/browse/CM-249)

In this PR we:

### 1) extend `Document::Show::EmbeddedObjects::BlocksComponent`
to  order the rows in the summary cards rendered according to the `field_order`
setting, if present.

### 2) define 'field_order' for "Opening times" nested object
within the "telephones" sub-schema of the "Contact" content block

<img width="539" height="630" alt="ordering_of_opening_hours_properties" src="https://github.com/user-attachments/assets/4f18f8e1-d73b-40f4-8796-67d7260bf7b3" />

