### PR TITLE
WIP: experimental:  Add summary component for editing/reviewing opening hours

### DIFF
--- a/lib/engines/content_block_manager/app/components/content_block_manager/shared/embedded_objects/summary_card/opening_hours_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/shared/embedded_objects/summary_card/opening_hours_component.html.erb
@@ -1,0 +1,6 @@
+<div class="app-c-content-block-manager-nested-item-component">
+  <%= render "govuk_publishing_components/components/summary_card", {
+    title:,
+    rows:,
+  } %>
+</div>

--- a/lib/engines/content_block_manager/app/components/content_block_manager/shared/embedded_objects/summary_card/opening_hours_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/shared/embedded_objects/summary_card/opening_hours_component.rb
@@ -1,0 +1,28 @@
+class ContentBlockManager::Shared::EmbeddedObjects::SummaryCard::OpeningHoursComponent < ViewComponent::Base
+  include ContentBlockManager::ContentBlock::TranslationHelper
+  with_collection_parameter :opening_hours
+
+  def initialize(opening_hours)
+    @hours = opening_hours.fetch(:opening_hours)
+  end
+
+  def title
+    "Opening hours"
+  end
+
+  def rows
+    [{ key: "Hours", value: formatted_hours }]
+  end
+
+private
+
+  def formatted_hours
+    [
+      @hours.fetch("day_from"),
+      @hours.fetch("time_from").downcase,
+      "to",
+      @hours.fetch("day_to"),
+      @hours.fetch("time_to").downcase,
+    ].join(" ")
+  end
+end

--- a/lib/engines/content_block_manager/app/components/content_block_manager/shared/embedded_objects/summary_card_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/shared/embedded_objects/summary_card_component.html.erb
@@ -17,7 +17,10 @@
     } %>
 
     <% nested_items(items).each do |key, items| %>
-      <% if items.is_a?(Array) %>
+      <% if key == "opening_hours"%>
+        <%= render ContentBlockManager::Shared::EmbeddedObjects::SummaryCard::OpeningHoursComponent.with_collection(items) %>
+
+      <% elsif items.is_a?(Array) %>
         <%= render ContentBlockManager::Shared::EmbeddedObjects::SummaryCard::NestedItemComponent.with_collection(
           items,
           title: key.singularize.titleize,


### PR DESCRIPTION
## EXPERIMENT: for comments

This new `shared/embedded_objects/summary_card/opening_hours_component.html.erb` component is rendered by `shared/embedded_objects/summary_card_component.html.erb` when:

- editing a new edition and reviewing a work in progress on the `group_modes` step at a path like:

```
/content-block-manager/content-block/editions/10/workflow/group_modes
```

- and at the `review` step at a path like:

```
content-block-manager/content-block/editions/10/workflow/review
```


<img width="1071" height="1370" alt="custom_summary_card_for_opening_hours" src="https://github.com/user-attachments/assets/1b03bd60-4b3c-4c7b-8707-595f3cd044da" />

### Notes:

- I understand that we may be stepping back from the structured approach to Opening times so this particular custom summary card component may not be needed. However, the general pattern may be useful?
- automated tests need to be backfilled
- a reflexive module or static lookup table to "constantise" potential custom components based on the value of the nested  item key (in this case `"opening_hours"` -> `ContentBlockManager::Shared::EmbeddedObjects::SummaryCard::OpeningHoursComponent`) is probably needed
