### PR TITLE
Add headers in payload for document_collection documents

### DIFF
--- a/app/presenters/publishing_api/statistical_data_set_presenter.rb
+++ b/app/presenters/publishing_api/statistical_data_set_presenter.rb
@@ -52,6 +52,7 @@ module PublishingApi
         details_hash.merge!(PayloadBuilder::PoliticalDetails.for(item))
         details_hash.merge!(PayloadBuilder::FirstPublicAt.for(item))
         details_hash.merge!(PayloadBuilder::Attachments.for(item))
+        details_hash.merge!(PayloadBuilder::BodyHeadings.for(item))
       end
     end
 

--- a/test/unit/app/presenters/publishing_api/statistical_data_set_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/statistical_data_set_presenter_test.rb
@@ -63,6 +63,39 @@ class PublishingApi::StatisticalDataSetPresenterTest < ActiveSupport::TestCase
   test "it presents the auth bypass id" do
     assert_equal [@statistical_data_set.auth_bypass_id], @presented_content[:auth_bypass_ids]
   end
+
+  test "it includes headers when headers are present in body" do
+    statistical_data_set = create(
+      :statistical_data_set,
+      title: "Some data set",
+      body: "##Some header\n\nSome content",
+    )
+
+    presented_statistical_data_set = PublishingApi::StatisticalDataSetPresenter.new(statistical_data_set)
+
+    expected_headers = [
+      {
+        text: "Some header",
+        level: 2,
+        id: "some-header",
+      },
+    ]
+
+    assert_equal expected_headers, presented_statistical_data_set.content[:details][:headers]
+  end
+
+  test "it does not include headers when headers are not present in body" do
+    statistical_data_set = create(
+      :published_statistical_data_set,
+      title: "Some data set",
+      summary: "Some summary",
+      body: "Some content",
+    )
+
+    presented_statistical_data_set = PublishingApi::StatisticalDataSetPresenter.new(statistical_data_set)
+
+    assert_nil presented_statistical_data_set.content[:details][:headers]
+  end
 end
 
 class PublishingApi::StatisticalDataSetWithPublicTimestampTest < ActiveSupport::TestCase


### PR DESCRIPTION
References:
- alphagov/publishing-api#3475 (schema updated in publishing-api)
- #10210, #10360 (last similar PRs)

https://trello.com/c/q60Z9Xrk/763-move-statisticaldataset-from-government-frontend-to-frontend

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
