### PR TITLE
Requested amendments to analytics [WHIT-2323] [WHIT-2306]

### DIFF
--- a/app/assets/javascripts/admin/analytics-modules/ga4-form-setup.js
+++ b/app/assets/javascripts/admin/analytics-modules/ga4-form-setup.js
@@ -28,7 +28,6 @@ window.GOVUK.analyticsGa4.analyticsModules =
 
           const sectionContainer = form.closest('[data-ga4-section]')
           const documentTypeContainer = form.closest('[data-ga4-document-type]')
-          const contentIdContainer = form.closest('[data-ga4-content-id]')
 
           let eventData = {
             event_name: 'form_response',
@@ -38,12 +37,6 @@ window.GOVUK.analyticsGa4.analyticsModules =
           if (sectionContainer) {
             eventData.section =
               sectionContainer.getAttribute('data-ga4-section')
-          }
-
-          if (contentIdContainer) {
-            eventData.content_id = contentIdContainer.getAttribute(
-              'data-ga4-content-id'
-            )
           }
 
           if (documentTypeContainer) {

--- a/app/assets/javascripts/admin/analytics-modules/ga4-form-tracker.js
+++ b/app/assets/javascripts/admin/analytics-modules/ga4-form-tracker.js
@@ -39,7 +39,7 @@ window.GOVUK.Modules.Ga4FormTracker = window.GOVUK.Modules.Ga4FormTracker || {}
     const fieldset = target.closest('fieldset')
     const legend = fieldset && fieldset.querySelector('legend')
     const sectionContainer = form.closest('[data-ga4-section]')
-    const label = form.querySelector(`label[for='${id}']`)
+    const label = form.querySelector(`label[for='${CSS.escape(id)}']`)
     const dateTimeComponent = this.dateTimeComponent(target)
 
     let section = sectionContainer && sectionContainer.dataset.ga4Section
@@ -109,7 +109,7 @@ window.GOVUK.Modules.Ga4FormTracker = window.GOVUK.Modules.Ga4FormTracker || {}
     // a radio or check input with a `name` and `value`
     // or an option of `value` within a `select` with `name`
     const checkableValue = form.querySelector(
-      `#${id}[value="${value}"], #${id} [value="${value}"]`
+      `#${CSS.escape(id)}[value="${CSS.escape(value)}"], #${CSS.escape(id)} [value="${CSS.escape(value)}"]`
     )
 
     let action = 'select'
@@ -125,7 +125,7 @@ window.GOVUK.Modules.Ga4FormTracker = window.GOVUK.Modules.Ga4FormTracker || {}
 
       if (!text) {
         // it's not an option so has no innerText
-        text = form.querySelector(`label[for='${id}']`).innerText
+        text = form.querySelector(`label[for='${CSS.escape(id)}']`).innerText
       }
     } else if (!text) {
       // it's a free form text field

--- a/app/assets/javascripts/admin/analytics-modules/ga4-index-section-setup.js
+++ b/app/assets/javascripts/admin/analytics-modules/ga4-index-section-setup.js
@@ -35,7 +35,7 @@ window.GOVUK.analyticsGa4.analyticsModules =
             // field could have a hidden element if it is
             // a checkbox so need to exclude hidden
             const multipleElements = moduleElement.querySelectorAll(
-              `[name='${element.name}']:not([type="hidden"])`
+              `[name='${CSS.escape(element.name)}']:not([type="hidden"])`
             )
             // if name is split then `name` will be of format
             // `name[Ni]` where `N` is index of split field

--- a/app/assets/javascripts/admin/analytics-modules/ga4-index-section-setup.js
+++ b/app/assets/javascripts/admin/analytics-modules/ga4-index-section-setup.js
@@ -32,10 +32,9 @@ window.GOVUK.analyticsGa4.analyticsModules =
 
         Array.from(indexedElements)
           .map((element) => {
-            const form = element.form
             // field could have a hidden element if it is
             // a checkbox so need to exclude hidden
-            const multipleElements = form.querySelectorAll(
+            const multipleElements = moduleElement.querySelectorAll(
               `[name='${element.name}']:not([type="hidden"])`
             )
             // if name is split then `name` will be of format

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -7,7 +7,7 @@
     <meta name="govuk:user-organisation-name" content="<%= current_user&.organisation_name %>">
     <meta name="govuk:user-role" content="<%= current_user&.role %>">
     <meta name="govuk:format" content="<%= "#{action_name}-#{controller_name}" %>">
-    <meta name="govuk:format" content="<%= "#{action_name}-#{controller_name}" %>">
+    <meta name="govuk:user-id" content="">
     <% if get_content_id(@edition) %>
       <meta name="govuk:content-id" content="<%= get_content_id(@edition) %>">
     <% end %>

--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -7,6 +7,10 @@
     <meta name="govuk:user-organisation-name" content="<%= current_user&.organisation_name %>">
     <meta name="govuk:user-role" content="<%= current_user&.role %>">
     <meta name="govuk:format" content="<%= "#{action_name}-#{controller_name}" %>">
+    <meta name="govuk:format" content="<%= "#{action_name}-#{controller_name}" %>">
+    <% if get_content_id(@edition) %>
+      <meta name="govuk:content-id" content="<%= get_content_id(@edition) %>">
+    <% end %>
     <%= javascript_include_tag "admin/domain-config" %>
     <%= javascript_include_tag "govuk_publishing_components/load-analytics" %>
   <% end %>
@@ -32,7 +36,6 @@
       ga4_section: yield(:page_title).presence || yield(:title),
       ga4_filter_type: controller_name,
       ga4_document_type: "#{action_name}-#{controller_name}",
-      ga4_content_id: get_content_id(@edition),
     },
   ) do %>
     <%= render "shared/phase_banner", {


### PR DESCRIPTION
## What

- Add `govuk:content-id` to metatags
  - Remove `data-ga4-content-id` from root container
  - Remove logic for getting `content-id` from container from `GA4FormTracker`
- Add `govuk:user-id` to metatags
- Use `document` in `Ga4IndexSectionSetup`
- Add `CSS.escape` to programmatic CSS selectors

## Why

- If `content-id` is present in `pageview` event on load, then it will be present in subsequent events. We want to send the `content-id` in different scenarios, so it makes sense to have in the `pageview` event.
- `user-id` has been requested to be added to `pageview` events.
- Issue in which `Ga4IndexSectionSetup` would `error` if element was not part of a form (such as copy-and-paste embed code components)
- Issue in which programmatic CSS selectors were invalid as the name or id of an element contained characters that need to be escaped in queries. This has been fixed using `CSS.escape`.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
