### PR TITLE
feat: change rendering app for statistical_data_set to Frontend

### DIFF
--- a/app/models/statistical_data_set.rb
+++ b/app/models/statistical_data_set.rb
@@ -19,7 +19,7 @@ class StatisticalDataSet < Publicationesque
   end
 
   def rendering_app
-    Whitehall::RenderingApp::GOVERNMENT_FRONTEND
+    Whitehall::RenderingApp::FRONTEND
   end
 
   def base_path

--- a/test/unit/app/models/statistical_data_set_test.rb
+++ b/test/unit/app/models/statistical_data_set_test.rb
@@ -22,8 +22,8 @@ class StatisticalDataSetTest < ActiveSupport::TestCase
     assert data_set.access_limited?
   end
 
-  test "specifies rendering app to be government frontend" do
+  test "specifies rendering app to be frontend" do
     statistical_data_set = StatisticalDataSet.new
-    assert statistical_data_set.rendering_app.include?(Whitehall::RenderingApp::GOVERNMENT_FRONTEND)
+    assert statistical_data_set.rendering_app.include?(Whitehall::RenderingApp::FRONTEND)
   end
 end

--- a/test/unit/app/presenters/publishing_api/statistical_data_set_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/statistical_data_set_presenter_test.rb
@@ -44,8 +44,8 @@ class PublishingApi::StatisticalDataSetPresenterTest < ActiveSupport::TestCase
     assert_equal Whitehall::PublishingApp::WHITEHALL, @presented_content[:publishing_app]
   end
 
-  test "it presents the rendering_app as government-frontend" do
-    assert_equal "government-frontend", @presented_content[:rendering_app]
+  test "it presents the rendering_app as frontend" do
+    assert_equal "frontend", @presented_content[:rendering_app]
   end
 
   test "it presents the schema_name as statistical_data_set" do


### PR DESCRIPTION

https://trello.com/c/q60Z9Xrk/763-move-statisticaldataset-from-government-frontend-to-frontend

Do not merge before:
- [ ] https://trello.com/c/q60Z9Xrk/763-move-statisticaldataset-from-government-frontend-to-frontend


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
