### PR TITLE
Fix `VALID_YOUTUBE_URLS` regex to not capture unwanted query strings in YouTube URLs [WHIT-2076]

### DIFF
--- a/app/models/promotional_feature_item.rb
+++ b/app/models/promotional_feature_item.rb
@@ -1,5 +1,5 @@
 class PromotionalFeatureItem < ApplicationRecord
-  VALID_YOUTUBE_URL_FORMAT = /\A(?:(?:https:\/\/youtu\.be\/)(.+)|(?:https:\/\/www\.youtube\.com\/watch\?v=)(.*?)(?:&|#|$).*)\Z/
+  VALID_YOUTUBE_URL_FORMAT = /\A(?:https:\/\/youtu\.be\/|https:\/\/www\.youtube\.com\/watch\?v=)([0-9A-Za-z_-]*)(?:$|(?:\?|&).*$)/
 
   include ImageKind
 

--- a/test/unit/app/models/promotional_feature_item_test.rb
+++ b/test/unit/app/models/promotional_feature_item_test.rb
@@ -3,7 +3,9 @@ require "test_helper"
 class PromotionalFeatureItemTest < ActiveSupport::TestCase
   VALID_YOUTUBE_URLS = [
     "https://youtu.be/fFmDQn9Lbl4",
+    "https://youtu.be/fFmDQn9Lbl4?si=9638MLETxOvSfmSw",
     "https://www.youtube.com/watch?v=fFmDQn9Lbl4",
+    "https://youtu.be/fFmDQn9Lbl4?feature=shared&t=2",
   ].freeze
 
   test "invalid without a summary" do


### PR DESCRIPTION
## What

Update the `VALID_YOUTUBE_URLS` regex to not capture unwanted query strings in YouTube URLs.

## Why

For URLs of the format `https://youtu.be/fFmDQn9Lbl4?si=9638MLETxOvSfmSw`, the regex would capture `fFmDQn9Lbl4?si=9638MLETxOvSfmSw` as the video ID which would result in YouTube embeds not working.


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
