### PR TITLE
Revert "Fix capitalisation of certain languages"

### DIFF
--- a/config/languages.yml
+++ b/config/languages.yml
@@ -65,7 +65,7 @@ fa:
 fi:
   direction: ltr
   english_name: Finnish
-  native_name: Suomi
+  native_name: suomi
 fr:
   direction: ltr
   english_name: French
@@ -153,7 +153,7 @@ nl:
 'no':
   direction: ltr
   english_name: Norwegian
-  native_name: Norsk
+  native_name: norsk
 pa:
   direction: ltr
   english_name: Punjabi Gurmukhi
@@ -205,7 +205,7 @@ sq:
 sr:
   direction: ltr
   english_name: Serbian
-  native_name: Srpski
+  native_name: srpski
 sv:
   direction: ltr
   english_name: Swedish


### PR DESCRIPTION
This reverts commit 8c388c935ec2dbf049ef7cdcd9534dcb8cf9fb48.

I had made an incorrect assumption. When refering to the language as it would be written in that language, the non-capitalised versions are correct.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
