### PR TITLE
Use `options_for_locales` in `Attachment` [WHIT-2327]

### DIFF
--- a/app/views/admin/attachments/_reference_fields.html.erb
+++ b/app/views/admin/attachments/_reference_fields.html.erb
@@ -7,11 +7,11 @@
 <% if attachable.respond_to?(:translated_locales) && attachable.translated_locales.many? %>
   <%
     locale_options = [{text: "All languages", value: ""}]
-    locale_options.concat(attachable.translated_locales.map do |locale|
+    locale_options.concat(options_for_locales(attachable.translated_locales).map do |language, value|
       {
-        text: native_language_name_for(locale),
-        value: locale,
-        selected: attachment.locale == locale.to_s,
+        text: language,
+        value: value,
+        selected: attachment.locale == value,
       }
     end)
   %>


### PR DESCRIPTION
## What

Use `options_for_locales` in `Attachment` forms.

### Visual Differences

| Before | After |
| ------------- | ------------- |
| <img width="773" height="212" alt="Screenshot 2025-08-04 at 11 14 15" src="https://github.com/user-attachments/assets/577a23d5-8310-4e28-8552-7bf02fe446b3" />  | <img width="789" height="212" alt="Screenshot 2025-08-04 at 11 13 49" src="https://github.com/user-attachments/assets/6ed9e08a-cf29-446e-899d-892c71e8bb39" /> |

## Why

Request that the English language name be added to the dropdown for selecting a translation when creating/editing an HTML Attachment (like when the user selects a translation for an edition). This was because the `admin/attachments/_reference_fields.html.erb` was not using the same helper as `admin/edition_translations/new.html.erb`.



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
