### PR TITLE
Fix `500` for `WorldwideOrganisation` offices [WHIT-1843]

### DIFF
--- a/app/controllers/admin/worldwide_offices_controller.rb
+++ b/app/controllers/admin/worldwide_offices_controller.rb
@@ -108,7 +108,7 @@ private
   end
 
   def find_worldwide_organisation
-    @worldwide_organisation = Edition.find(params[:worldwide_organisation_id])
+    @worldwide_organisation = WorldwideOrganisation.find(params[:worldwide_organisation_id])
   end
 
   def find_worldwide_office


### PR DESCRIPTION
## What

Use 

```
WorldwideOrganisation.find(params[:worldwide_organisation_id])
```

instead of

```
Edition.find(params[:worldwide_organisation_id])
```

## Why

This error was occurring because `find_worldwide_organisation` used `Edition.find` instead of `WorldwideOrganisation.find`. This meant that an Edition could exist with the `worldwide_organisation_id` in the param but it might be not actually be a `WorldwideOrganisation`. This would then cause an error when `offices` was called on the `Edition`.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
