### PR TITLE
Make URI validation rules consistent with Publishing API's

### DIFF
--- a/app/models/statistics_announcement.rb
+++ b/app/models/statistics_announcement.rb
@@ -45,7 +45,6 @@ class StatisticsAnnouncement < ApplicationRecord
   validate :redirect_not_circular, if: :unpublished?
   validates :publishing_state, inclusion: %w[published unpublished]
   validates :redirect_url, presence: { message: "must be provided when unpublishing an announcement" }, if: :unpublished?
-  validates :redirect_url, uri: true, allow_blank: true
   validates :redirect_url, gov_uk_url_format: true, allow_blank: true
   validates :title, :summary, :organisations, :creator, :statistics_announcement_dates, presence: true
   validates :cancellation_reason, presence: { message: "must be provided when cancelling an announcement" }, if: :cancelled?

--- a/app/models/unpublishing.rb
+++ b/app/models/unpublishing.rb
@@ -6,7 +6,6 @@ class Unpublishing < ApplicationRecord
   validates :edition, :unpublishing_reason, :document_type, :slug, presence: true
   validates :explanation, presence: { message: "must be provided when withdrawing", if: :withdrawn? }
   validates :alternative_url, presence: { message: "must be provided to redirect the document", if: :redirect? }
-  validates :alternative_url, uri: true, allow_blank: true
   validates :alternative_url, gov_uk_url_format: true, allow_blank: true
   validate :redirect_not_circular
 

--- a/app/validators/gov_uk_url_format_validator.rb
+++ b/app/validators/gov_uk_url_format_validator.rb
@@ -24,10 +24,15 @@ class GovUkUrlFormatValidator < ActiveModel::EachValidator
 
 private
 
+  # Expects a fully qualified URL, but anything else might be OK (e.g. for internal links).
+  # We don't need to report bad URLs here as whatever model is using the GovUkUrlFormatValidator
+  # should also be using the UriValidator.
   def matches_allow_list?(value)
     uri = URI.parse(value)
-    uri.host&.end_with?(*EXTERNAL_HOST_ALLOW_LIST)
+    return true unless uri.host
+
+    uri.host.end_with?(*EXTERNAL_HOST_ALLOW_LIST)
   rescue URI::InvalidURIError
-    false
+    true
   end
 end

--- a/app/validators/gov_uk_url_format_validator.rb
+++ b/app/validators/gov_uk_url_format_validator.rb
@@ -17,6 +17,26 @@ class GovUkUrlFormatValidator < ActiveModel::EachValidator
     end
   end
 
+  # def validate_each(record, attribute, value)
+  #   return if value.blank?                # let presence validators handle blank
+  #   return if internal_path?(value)       # accept internal paths like "/foo"
+
+  #   # Reuse UriValidator to surface its exact messages (length, scheme, etc.)
+  #   # Don't pass our :message option through, so UriValidator uses its own copy.
+  #   before = record.errors[attribute].length
+  #   UriValidator.new(options.except(:message)).validate_each(record, attribute, value)
+  #   added_uri_errors = record.errors[attribute].length > before
+  #   return if added_uri_errors             # if syntax invalid, show those errors and stop
+
+  #   # Syntax is OK — now enforce allow-list
+  #   unless allowed_host?(value)
+  #     record.errors.add(
+  #       attribute,
+  #       options[:message] || "must be an allowed external URL (or use an internal path like /foo)"
+  #     )
+  #   end
+  # end
+
   def self.matches_gov_uk?(value)
     %r{\A#{Whitehall.public_protocol}://#{Whitehall.public_host}/}.match?(value)
   end

--- a/app/validators/gov_uk_url_format_validator.rb
+++ b/app/validators/gov_uk_url_format_validator.rb
@@ -1,4 +1,3 @@
-# Accepts options[:message] and options[:allowed_protocols]
 class GovUkUrlFormatValidator < ActiveModel::EachValidator
   EXTERNAL_HOST_ALLOW_LIST = %w[
     .caa.co.uk

--- a/app/validators/gov_uk_url_format_validator.rb
+++ b/app/validators/gov_uk_url_format_validator.rb
@@ -24,15 +24,10 @@ class GovUkUrlFormatValidator < ActiveModel::EachValidator
 
 private
 
-  # Expects a fully qualified URL, but anything else might be OK (e.g. for internal links).
-  # We don't need to report bad URLs here as whatever model is using the GovUkUrlFormatValidator
-  # should also be using the UriValidator.
   def matches_allow_list?(value)
     uri = URI.parse(value)
-    return true unless uri.host
-
-    uri.host.end_with?(*EXTERNAL_HOST_ALLOW_LIST)
+    uri.host&.end_with?(*EXTERNAL_HOST_ALLOW_LIST)
   rescue URI::InvalidURIError
-    true
+    false
   end
 end

--- a/app/validators/uri_validator.rb
+++ b/app/validators/uri_validator.rb
@@ -1,7 +1,7 @@
 # Modified from https://gist.github.com/timocratic/5113293
 require "addressable/uri"
 
-# Accepts options[:message] and options[:allowed_protocols]
+# Accepts options[:message]
 class UriValidator < ActiveModel::EachValidator
   MAX_LENGTH = 255
 
@@ -17,7 +17,7 @@ class UriValidator < ActiveModel::EachValidator
 
     if uri.blank?
       record.errors.add(attribute, failure_message)
-    elsif allowed_protocols.exclude?(uri.scheme)
+    elsif %w[http https].exclude?(uri.scheme)
       record.errors.add(attribute, "is not valid. Make sure it starts with http(s)")
     end
   rescue URI::Error
@@ -28,9 +28,5 @@ private
 
   def failure_message
     options[:message] || "is not valid."
-  end
-
-  def allowed_protocols
-    @allowed_protocols ||= [options[:allowed_protocols] || %w[http https]].flatten
   end
 end

--- a/app/validators/uri_validator.rb
+++ b/app/validators/uri_validator.rb
@@ -1,7 +1,6 @@
 # Modified from https://gist.github.com/timocratic/5113293
 require "addressable/uri"
 
-# Accepts options[:message]
 class UriValidator < ActiveModel::EachValidator
   MAX_LENGTH = 255
 
@@ -16,17 +15,11 @@ class UriValidator < ActiveModel::EachValidator
     uri = URI.parse(value)
 
     if uri.blank?
-      record.errors.add(attribute, failure_message)
+      record.errors.add(attribute, "is not valid.")
     elsif %w[http https].exclude?(uri.scheme)
       record.errors.add(attribute, "is not valid. Make sure it starts with http(s)")
     end
   rescue URI::Error
-    record.errors.add(attribute, failure_message)
-  end
-
-private
-
-  def failure_message
-    options[:message] || "is not valid."
+    record.errors.add(attribute, "is not valid.")
   end
 end

--- a/app/validators/uri_validator.rb
+++ b/app/validators/uri_validator.rb
@@ -17,14 +17,8 @@ class UriValidator < ActiveModel::EachValidator
 
     if uri.blank?
       record.errors.add(attribute, failure_message)
-    elsif uri.host&.end_with?("gov.uk")
-      record.errors.add(attribute, "is not valid. A redirect to a page on GOV.UK should not be specified with a full url (e.g. use '/example' rather than 'https://www.gov.uk/example')")
     elsif allowed_protocols.exclude?(uri.scheme)
-      if uri.scheme.nil? && value[0] == "/"
-        # Internal GOV.UK link - this is valid.
-      else
-        record.errors.add(attribute, "is not valid. Make sure it starts with http(s)")
-      end
+      record.errors.add(attribute, "is not valid. Make sure it starts with http(s)")
     end
   rescue URI::Error
     record.errors.add(attribute, failure_message)

--- a/app/validators/uri_validator.rb
+++ b/app/validators/uri_validator.rb
@@ -17,8 +17,14 @@ class UriValidator < ActiveModel::EachValidator
 
     if uri.blank?
       record.errors.add(attribute, failure_message)
+    elsif uri.host&.end_with?("gov.uk")
+      record.errors.add(attribute, "is not valid. A redirect to a page on GOV.UK should not be specified with a full url (e.g. use '/example' rather than 'https://www.gov.uk/example')")
     elsif allowed_protocols.exclude?(uri.scheme)
-      record.errors.add(attribute, "is not valid. Make sure it starts with http(s)")
+      if uri.scheme.nil? && value[0] == "/"
+        # Internal GOV.UK link - this is valid.
+      else
+        record.errors.add(attribute, "is not valid. Make sure it starts with http(s)")
+      end
     end
   rescue URI::Error
     record.errors.add(attribute, failure_message)

--- a/app/views/admin/edition_workflow/_alternative_url_constraints.html.erb
+++ b/app/views/admin/edition_workflow/_alternative_url_constraints.html.erb
@@ -1,5 +1,5 @@
 <div>
-  <p class="govuk-body">Must be a GOV.UK URL or a link ending in:</p>
+  <p class="govuk-body">Must be an internal GOV.UK path (e.g. `/browse/benefits`) or a full URL to one of the sites on the allowlist below:</p>
 
   <%= render "govuk_publishing_components/components/list", {
     visible_counters: true,

--- a/test/functional/admin/edition_workflow_controller_test.rb
+++ b/test/functional/admin/edition_workflow_controller_test.rb
@@ -240,24 +240,15 @@ class Admin::EditionWorkflowControllerTest < ActionController::TestCase
     assert_equal publication, assigns(:edition)
   end
 
-  # TODO: consolidate gov_uk_url_format_validator tests
   view_test "confirm_unpublish describes the constraints of the alternative URL" do
     login_as(create(:managing_editor))
     publication = create(:published_publication)
     get :confirm_unpublish, params: { id: publication, lock_version: publication.lock_version }
 
     alternative_uris_constraints = <<~CONSTRAINTS
-      Must be a GOV.UK URL or a link ending in:
+      Must be an internal GOV.UK path (e.g. `/browse/benefits`) or a full URL to one of the sites on the allowlist below:
 
-        .caa.co.uk
-        .gov.uk
-        .independent-inquiry.uk
-        .judiciary.uk
-        .nationalhighways.co.uk
-        .nhs.uk
-        .police.uk
-        .pubscodeadjudicator.org.uk
-        .ukri.org
+        #{GovUkUrlFormatValidator::EXTERNAL_HOST_ALLOW_LIST.join(" ")}
     CONSTRAINTS
     alternative_uris_constraints = alternative_uris_constraints.strip.gsub(/\s+/, " ")
 

--- a/test/functional/admin/edition_workflow_controller_test.rb
+++ b/test/functional/admin/edition_workflow_controller_test.rb
@@ -240,6 +240,7 @@ class Admin::EditionWorkflowControllerTest < ActionController::TestCase
     assert_equal publication, assigns(:edition)
   end
 
+  # TODO: consolidate gov_uk_url_format_validator tests
   view_test "confirm_unpublish describes the constraints of the alternative URL" do
     login_as(create(:managing_editor))
     publication = create(:published_publication)

--- a/test/unit/app/models/unpublishing_test.rb
+++ b/test/unit/app/models/unpublishing_test.rb
@@ -1,7 +1,10 @@
 require "test_helper"
 
-# TODO: consolidate gov_uk_url_format_validator tests
 class UnpublishingTest < ActiveSupport::TestCase
+  setup do
+    @valid_alternative_url = "#{Whitehall.public_protocol}://#{Whitehall.public_host}/example"
+  end
+
   test "#unpublished_at is automatically populated if left blank" do
     unpublishing = create(:unpublishing)
     assert_equal Time.zone.now, unpublishing.unpublished_at
@@ -13,7 +16,6 @@ class UnpublishingTest < ActiveSupport::TestCase
     assert_equal unpublished_at, unpublishing.unpublished_at
   end
 
-  # moved from duplicate file
   test "is not valid without an unpublishing reason" do
     unpublishing = build(:unpublishing, unpublishing_reason: nil)
     assert_not unpublishing.valid?
@@ -44,10 +46,10 @@ class UnpublishingTest < ActiveSupport::TestCase
     unpublishing = build(:unpublishing, redirect: true)
     assert_not unpublishing.valid?
 
-    unpublishing = build(:unpublishing, redirect: true, alternative_url: "#{Whitehall.public_protocol}://#{Whitehall.public_host}/example")
+    unpublishing = build(:unpublishing, redirect: true, alternative_url: @valid_alternative_url)
     assert unpublishing.valid?
 
-    unpublishing = build(:unpublishing, redirect: false, alternative_url: "#{Whitehall.public_protocol}://#{Whitehall.public_host}/example")
+    unpublishing = build(:unpublishing, redirect: false, alternative_url: @valid_alternative_url)
     assert unpublishing.valid?
   end
 
@@ -60,12 +62,10 @@ class UnpublishingTest < ActiveSupport::TestCase
     assert unpublishing.errors[:alternative_url].include?("cannot redirect to itself")
   end
 
+  # TODO: consolidate gov_uk_url_format_validator tests
   test "alternative_url must be internal (www.gov.uk) or present on the allowed list" do
     unpublishing = build(:unpublishing, redirect: true, alternative_url: "http://example.com")
     assert_not unpublishing.valid?
-
-    unpublishing = build(:unpublishing, redirect: true, alternative_url: "#{Whitehall.public_protocol}://#{Whitehall.public_host}/example")
-    assert unpublishing.valid?
 
     unpublishing = build(:unpublishing, redirect: true, alternative_url: "https://www.independent-inquiry.uk/about-the-independent-inquiry/")
     assert unpublishing.valid?
@@ -121,6 +121,7 @@ class UnpublishingTest < ActiveSupport::TestCase
     unpublishing = build(:unpublishing, redirect: true, alternative_url: "https://www.test.gov.uk/guidance/document-path#part-one")
     assert_includes unpublishing.alternative_path, "#part-one"
   end
+  # UP TO HERE
 
   test "returns an unpublishing reason" do
     unpublishing = build(:unpublishing, unpublishing_reason: reason)

--- a/test/unit/app/models/unpublishing_test.rb
+++ b/test/unit/app/models/unpublishing_test.rb
@@ -1,5 +1,6 @@
 require "test_helper"
 
+# TODO: consolidate gov_uk_url_format_validator tests
 class UnpublishingTest < ActiveSupport::TestCase
   test "#unpublished_at is automatically populated if left blank" do
     unpublishing = create(:unpublishing)

--- a/test/unit/app/validators/gov_uk_url_format_validator_test.rb
+++ b/test/unit/app/validators/gov_uk_url_format_validator_test.rb
@@ -1,0 +1,78 @@
+require "test_helper"
+
+# TODO: consolidate gov_uk_url_format_validator tests
+class GovUkUrlFormatValidatorTest < ActiveSupport::TestCase
+#   setup do
+#     @validator = UriValidator.new(attributes: [:url])
+#   end
+
+#   test "validates nil urls" do
+#     feature_link = validate(PromotionalFeatureLink.new(url: nil))
+#     assert feature_link.errors.empty?
+#   end
+
+#   test "validates http urls" do
+#     feature_link = validate(PromotionalFeatureLink.new(url: "http://example.com"))
+#     assert feature_link.errors.empty?
+#   end
+
+#   test "validates https urls" do
+#     feature_link = validate(PromotionalFeatureLink.new(url: "https://example.com"))
+#     assert feature_link.errors.empty?
+#   end
+
+#   test "non-http(s) URLs are not valid" do
+#     feature_link = validate(PromotionalFeatureLink.new(url: "ftp://example.com"))
+#     assert_equal ["is not valid. Make sure it starts with http(s)"], feature_link.errors[:url]
+
+#     feature_link = validate(PromotionalFeatureLink.new(url: "gopher://example.com"))
+#     assert_equal ["is not valid. Make sure it starts with http(s)"], feature_link.errors[:url]
+
+#     feature_link = validate(PromotionalFeatureLink.new(url: "mailto:name@example.com"))
+#     assert_equal ["is not valid. Make sure it starts with http(s)"], feature_link.errors[:url]
+#   end
+
+#   test "invalid urls get an error if they aren't https/http and are poorly formatted" do
+#     feature_link = validate(PromotionalFeatureLink.new(url: "mailto://example.com"))
+#     assert_equal ["is not valid."], feature_link.errors[:url]
+#   end
+
+#   test "invalid urls get an error if they include whitespace" do
+#     feature_link = validate(PromotionalFeatureLink.new(url: "https://example.come/guidance/inspire-index-polygons-spatial-data blah blah"))
+#     assert_equal ["is not valid."], feature_link.errors[:url]
+#   end
+
+#   test "invalid urls get an error, without http" do
+#     feature_link = validate(PromotionalFeatureLink.new(url: "example.com"))
+#     assert_equal ["is not valid. Make sure it starts with http(s)"], feature_link.errors[:url]
+#   end
+
+#   test "invalid urls get an error, with http" do
+#     feature_link = validate(PromotionalFeatureLink.new(url: "http ://example.com"))
+#     assert_equal ["is not valid."], feature_link.errors[:url]
+#   end
+
+#   test "invalid urls get an error, with http without a space" do
+#     feature_link = validate(PromotionalFeatureLink.new(url: "http://abc</option%3E"))
+#     assert_equal ["is not valid."], feature_link.errors[:url]
+#   end
+
+#   test "should be valid with 255 character alternative url" do
+#     alternative_url_255_character = "https://1HHGPav0JgJ6r1rJR34wO2Tksnimp6DjWIrJU02iQgcUK6H7he4aWZ5wrtNGOifEHoLO9afMMfNIZxoOTj6BkQE7NcBwY4fvYpCXwCFaBjnXkRqyl3LfFAIJc5GUXz64LGwQvHQHiOkFdP2fk43HkM2Dx6aHoHxdgRHRB7jVzGNLNwUBQtFdjlLv4CBHRTFMnHBtSsskEXhSGlv0TubV2uouqlUkoLSOwC3AJHa4XN1bcD23112.com"
+#     feature_link = validate(PromotionalFeatureLink.new(url: alternative_url_255_character))
+#     assert feature_link.errors.empty?
+#   end
+
+#   test "should error with more than 255 character alternative url" do
+#     alternative_url_256_character = "https://1HHGPav0JgJ6r1rJR34wO2Tksnimp6DjWIrJU02iQgcUK6H7he4aWZ5wrtNGOifEHoLO9afMMfNIZxoOTj6BkQE7NcBwY4fvYpCXwCFaBjnXkRqyl3LfFAIJc5GUXz64LGwQvHQHiOkFdP2fk43HkM2Dx6aHoHxdgRHRB7jVzGNLNwUBQtFdjlLv4CBHRTFMnHBtSsskEXhSGlv0TubV2uouqlUkoLSOwC3AJHa4XN1bcD231125.com"
+#     feature_link = validate(PromotionalFeatureLink.new(url: alternative_url_256_character))
+#     assert_includes feature_link.errors[:url], I18n.t("activerecord.errors.models.nation_inapplicability.attributes.alternative_url.too_long")
+#   end
+
+# private
+
+#   def validate(record)
+#     @validator.validate(record)
+#     record
+#   end
+end

--- a/test/unit/app/validators/gov_uk_url_format_validator_test.rb
+++ b/test/unit/app/validators/gov_uk_url_format_validator_test.rb
@@ -1,15 +1,19 @@
 require "test_helper"
 
-# TODO: consolidate gov_uk_url_format_validator tests
 class GovUkUrlFormatValidatorTest < ActiveSupport::TestCase
-#   setup do
-#     @validator = UriValidator.new(attributes: [:url])
-#   end
+  setup do
+    @validator = GovUkUrlFormatValidator.new(attributes: [:alternative_url])
+  end
 
-#   test "validates nil urls" do
-#     feature_link = validate(PromotionalFeatureLink.new(url: nil))
-#     assert feature_link.errors.empty?
-#   end
+  # test "validates https urls on the allowlist" do
+  #   redirect_link = validate(Unpublishing.new(alternative_url: "https://nhs.uk/bar"))
+  #   assert redirect_link.errors.empty?
+  # end
+
+  test "validates https subdomain / wildcard urls on the allowlist" do
+    redirect_link = validate(Unpublishing.new(alternative_url: "https://foo.nhs.uk/bar"))
+    assert redirect_link.errors.empty?
+  end
 
 #   test "validates http urls" do
 #     feature_link = validate(PromotionalFeatureLink.new(url: "http://example.com"))
@@ -69,10 +73,10 @@ class GovUkUrlFormatValidatorTest < ActiveSupport::TestCase
 #     assert_includes feature_link.errors[:url], I18n.t("activerecord.errors.models.nation_inapplicability.attributes.alternative_url.too_long")
 #   end
 
-# private
+private
 
-#   def validate(record)
-#     @validator.validate(record)
-#     record
-#   end
+  def validate(record)
+    @validator.validate(record)
+    record
+  end
 end

--- a/test/unit/app/validators/uri_validator_test.rb
+++ b/test/unit/app/validators/uri_validator_test.rb
@@ -20,6 +20,17 @@ class UriValidatorTest < ActiveSupport::TestCase
     assert feature_link.errors.empty?
   end
 
+  test "validates internal GOV.UK URLs" do
+    feature_link = validate(PromotionalFeatureLink.new(url: "/foo"))
+    assert feature_link.errors.empty?
+  end
+
+  # See https://github.com/alphagov/publishing-api/blob/537a4d62960e6fc7ea7ffa4e245dba006172b5df/app/validators/routes_and_redirects_validator.rb#L201-L202
+  test "absolute GOV.UK URLs are not valid (they're rejected by Publishing API)" do
+    feature_link = validate(PromotionalFeatureLink.new(url: "https://www.gov.uk/foo"))
+    assert_equal ["is not valid. A redirect to a page on GOV.UK should not be specified with a full url (e.g. use '/example' rather than 'https://www.gov.uk/example')"], feature_link.errors[:url]
+  end
+
   test "non-http(s) URLs are not valid" do
     feature_link = validate(PromotionalFeatureLink.new(url: "ftp://example.com"))
     assert_equal ["is not valid. Make sure it starts with http(s)"], feature_link.errors[:url]

--- a/test/unit/app/validators/uri_validator_test.rb
+++ b/test/unit/app/validators/uri_validator_test.rb
@@ -20,17 +20,6 @@ class UriValidatorTest < ActiveSupport::TestCase
     assert feature_link.errors.empty?
   end
 
-  test "validates internal GOV.UK URLs" do
-    feature_link = validate(PromotionalFeatureLink.new(url: "/foo"))
-    assert feature_link.errors.empty?
-  end
-
-  # See https://github.com/alphagov/publishing-api/blob/537a4d62960e6fc7ea7ffa4e245dba006172b5df/app/validators/routes_and_redirects_validator.rb#L201-L202
-  test "absolute GOV.UK URLs are not valid (they're rejected by Publishing API)" do
-    feature_link = validate(PromotionalFeatureLink.new(url: "https://www.gov.uk/foo"))
-    assert_equal ["is not valid. A redirect to a page on GOV.UK should not be specified with a full url (e.g. use '/example' rather than 'https://www.gov.uk/example')"], feature_link.errors[:url]
-  end
-
   test "non-http(s) URLs are not valid" do
     feature_link = validate(PromotionalFeatureLink.new(url: "ftp://example.com"))
     assert_equal ["is not valid. Make sure it starts with http(s)"], feature_link.errors[:url]


### PR DESCRIPTION
Publishing API does not allow redirect values to fully qualified GOV.UK URLs. The resulting UX is very poor - Whitehall happily reports that the document has redirected as it should, whereas in reality, Publishing API has responded with a 422 and not processed the redirect.

See Sentry error:
https://govuk.sentry.io/issues/6340746667/?project=202259&query=&referrer=issue-stream

So now we enforce the same rule as Publishing API: that redirects to GOV.UK URLs should be given absolute paths rather than fully qualified URLs. Host-less URLs, such as `example.com`, continue to fail as they should.

JIRA: https://gov-uk.atlassian.net/browse/WHIT-2401

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
