### PR TITLE
Stop scheduling daily Sidekiq workers in local environment

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -13,9 +13,11 @@
   - edition_revalidation
 :scheduler:
   :schedule:
+<% unless Rails.env.development? || Rails.env.test? %>
     revalidate_old_link_check_reports:
       cron: '0 4 * * *' # Runs at 4 a.m every day
       class: RevalidateOldLinkCheckReportsWorker
     revalidate_all_editions:
       cron: '45 5 * * *' # Runs at 5:45am every day
       class: RevalidateEditionsSchedulerWorker
+<% end %>


### PR DESCRIPTION
I'd occasionally see a lot of Link Checker API activity locally, and it seems to stem from this (in combination with me keeping a `govuk-docker-up` shell running overnight).
We should avoid actioning this cronjob anywhere but on the remote environments (integration, staging, production).

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
