### PR TITLE
Move 255 URL maxlength limit into the UriValidator

### DIFF
--- a/app/models/nation_inapplicability.rb
+++ b/app/models/nation_inapplicability.rb
@@ -10,7 +10,6 @@ class NationInapplicability < ApplicationRecord
 
   validates :nation_id, inclusion: { in: Nation.potentially_inapplicable.map(&:id) }
   validates :alternative_url, uri: true, allow_blank: true
-  validates :alternative_url, length: { maximum: 255 }
 
   attr_accessor :excluded
 

--- a/app/validators/uri_validator.rb
+++ b/app/validators/uri_validator.rb
@@ -3,8 +3,15 @@ require "addressable/uri"
 
 # Accepts options[:message] and options[:allowed_protocols]
 class UriValidator < ActiveModel::EachValidator
+  MAX_LENGTH = 255
+
   def validate_each(record, attribute, value)
     return if value.nil?
+
+    if value.length > MAX_LENGTH
+      record.errors.add(attribute, "is too long. Please shorten the URL to less than #{MAX_LENGTH} characters.")
+      return
+    end
 
     uri = URI.parse(value)
 

--- a/test/unit/app/models/nation_inapplicability_test.rb
+++ b/test/unit/app/models/nation_inapplicability_test.rb
@@ -1,37 +1,9 @@
 require "test_helper"
 
 class NationInapplicabilityTest < ActiveSupport::TestCase
-  test "should be invalid with a malformed alternative url" do
-    inapplicability = build(:nation_inapplicability, alternative_url: "invalid-url")
-    assert_not inapplicability.valid?
-  end
-
-  test "should be valid with an alternative url with HTTP protocol" do
-    inapplicability = build(:nation_inapplicability, alternative_url: "http://example.com")
-    assert inapplicability.valid?
-  end
-
-  test "should be valid with an alternative url with HTTPS protocol" do
-    inapplicability = build(:nation_inapplicability, alternative_url: "https://example.com")
-    assert inapplicability.valid?
-  end
-
-  test "should be valid without an alternative url" do
-    inapplicability = build(:nation_inapplicability, alternative_url: nil)
-    assert inapplicability.valid?
-  end
-
-  test "should be valid with 255 character alternative url" do
-    alternative_url_255_character = "https://1HHGPav0JgJ6r1rJR34wO2Tksnimp6DjWIrJU02iQgcUK6H7he4aWZ5wrtNGOifEHoLO9afMMfNIZxoOTj6BkQE7NcBwY4fvYpCXwCFaBjnXkRqyl3LfFAIJc5GUXz64LGwQvHQHiOkFdP2fk43HkM2Dx6aHoHxdgRHRB7jVzGNLNwUBQtFdjlLv4CBHRTFMnHBtSsskEXhSGlv0TubV2uouqlUkoLSOwC3AJHa4XN1bcD23112.com"
-    inapplicability = build(:nation_inapplicability, alternative_url: alternative_url_255_character)
-    assert inapplicability.valid?
-  end
-
-  test "should error with more than 255 character alternative url" do
-    alternative_url_256_character = "https://1HHGPav0JgJ6r1rJR34wO2Tksnimp6DjWIrJU02iQgcUK6H7he4aWZ5wrtNGOifEHoLO9afMMfNIZxoOTj6BkQE7NcBwY4fvYpCXwCFaBjnXkRqyl3LfFAIJc5GUXz64LGwQvHQHiOkFdP2fk43HkM2Dx6aHoHxdgRHRB7jVzGNLNwUBQtFdjlLv4CBHRTFMnHBtSsskEXhSGlv0TubV2uouqlUkoLSOwC3AJHa4XN1bcD231125.com"
-    inapplicability = build(:nation_inapplicability, alternative_url: alternative_url_256_character)
-    assert_not inapplicability.valid?
-    assert_includes inapplicability.errors.messages[:alternative_url], I18n.t("activerecord.errors.models.nation_inapplicability.attributes.alternative_url.too_long")
+  test "uses UriValidator on :alternative_url" do
+    validators = NationInapplicability.validators_on(:alternative_url)
+    assert validators.any? { |v| v.is_a?(UriValidator) }, "UriValidator not found on :alternative_url"
   end
 
   test "has a virtual attribute to indicate exclusion" do

--- a/test/unit/app/validators/uri_validator_test.rb
+++ b/test/unit/app/validators/uri_validator_test.rb
@@ -56,6 +56,18 @@ class UriValidatorTest < ActiveSupport::TestCase
     assert_equal ["is not valid."], feature_link.errors[:url]
   end
 
+  test "should be valid with 255 character alternative url" do
+    alternative_url_255_character = "https://1HHGPav0JgJ6r1rJR34wO2Tksnimp6DjWIrJU02iQgcUK6H7he4aWZ5wrtNGOifEHoLO9afMMfNIZxoOTj6BkQE7NcBwY4fvYpCXwCFaBjnXkRqyl3LfFAIJc5GUXz64LGwQvHQHiOkFdP2fk43HkM2Dx6aHoHxdgRHRB7jVzGNLNwUBQtFdjlLv4CBHRTFMnHBtSsskEXhSGlv0TubV2uouqlUkoLSOwC3AJHa4XN1bcD23112.com"
+    feature_link = validate(PromotionalFeatureLink.new(url: alternative_url_255_character))
+    assert feature_link.errors.empty?
+  end
+
+  test "should error with more than 255 character alternative url" do
+    alternative_url_256_character = "https://1HHGPav0JgJ6r1rJR34wO2Tksnimp6DjWIrJU02iQgcUK6H7he4aWZ5wrtNGOifEHoLO9afMMfNIZxoOTj6BkQE7NcBwY4fvYpCXwCFaBjnXkRqyl3LfFAIJc5GUXz64LGwQvHQHiOkFdP2fk43HkM2Dx6aHoHxdgRHRB7jVzGNLNwUBQtFdjlLv4CBHRTFMnHBtSsskEXhSGlv0TubV2uouqlUkoLSOwC3AJHa4XN1bcD231125.com"
+    feature_link = validate(PromotionalFeatureLink.new(url: alternative_url_256_character))
+    assert_includes feature_link.errors[:url], I18n.t("activerecord.errors.models.nation_inapplicability.attributes.alternative_url.too_long")
+  end
+
 private
 
   def validate(record)


### PR DESCRIPTION
There's no reason this should have been applied only to the Nation Applicability 'alternative URL' validation. It should be encapsulated in the UriValidator for everything to benefit from.

I've also removed the duplicate tests for the inapplicability file. It is enough to test that the model calls the uri_validator, and not to repeat the assertions.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
