### PR TITLE
Rewrite `Admin::BaseControllerTest` nav testing

### DIFF
--- a/test/functional/admin/base_controller_test.rb
+++ b/test/functional/admin/base_controller_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class Admin::BaseControllerTest < ActionController::TestCase
   include GdsApi::TestHelpers::PublishingApi
 
-  view_test "renders new header component if login as a design system user" do
+  view_test "renders header component with correct links" do
     login_as :gds_editor, create(:organisation, name: "my-test-org")
     @controller = Admin::NewDocumentController.new
 
@@ -11,6 +11,11 @@ class Admin::BaseControllerTest < ActionController::TestCase
 
     assert_select ".gem-c-layout-header__logo", text: /Whitehall Publisher/
     assert_select ".govuk-service-navigation__item", text: "Dashboard"
+    assert_select ".govuk-service-navigation__item", text: "View website"
+    assert_select ".govuk-service-navigation__item", text: "Switch app"
+    assert_select ".govuk-service-navigation__item", text: "Profile"
+    assert_select ".govuk-service-navigation__item", text: "Logout"
+    assert_select ".govuk-service-navigation__item", text: "All users"
   end
 
   view_test "highlights the 'Dashboard' tab when it is the currently selected tab- Main navigation" do
@@ -20,30 +25,6 @@ class Admin::BaseControllerTest < ActionController::TestCase
     get :index
 
     assert_active_item("/government/admin")
-    assert_not_active_item("/government/admin/users")
-    assert_not_active_item("/government/admin/users/1")
-  end
-
-  view_test "highlights the 'All users' tab when it is the currently selected tab- Main navigation" do
-    login_as :gds_editor
-    @controller = Admin::UsersController.new
-
-    get :index
-
-    assert_active_item("/government/admin/users")
-    assert_not_active_item("/government/admin")
-    assert_not_active_item("/government/admin/users/1")
-  end
-
-  view_test "highlights the current user name tab when it is the currently selected tab-Main navigation" do
-    user = login_as :gds_editor
-    @controller = Admin::UsersController.new
-
-    get :show, params: { id: user.id }
-
-    assert_active_item("/government/admin/users/#{user.id}")
-    assert_not_active_item("/government/admin")
-    assert_not_active_item("/government/admin/users")
   end
 
   view_test "renders new sub-navigation header component if login as a design system user" do
@@ -61,90 +42,13 @@ class Admin::BaseControllerTest < ActionController::TestCase
     assert_select ".app-c-sub-navigation__list .app-c-sub-navigation__list-item a[href=\"/government/admin/more\"]", text: "More"
   end
 
-  view_test "highlights the 'New documents' tab when it is the currently selected tab- Sub-navigation" do
+  view_test "highlights the 'New document' tab when it is the currently selected tab- Sub-navigation" do
     login_as :gds_editor, create(:organisation, name: "my-test-org")
     @controller = Admin::NewDocumentController.new
 
     get :index
 
     assert_current_item("/government/admin/new-document")
-    assert_not_current_item("/government/admin/editions")
-    assert_not_current_item("/government/admin/statistics_announcements")
-    assert_not_current_item("/government/admin/organisations/my-test-org/features")
-    assert_not_current_item("/government/admin/organisations/my-test-org/corporate_information_pages")
-    assert_not_current_item("/government/admin/more")
-  end
-
-  view_test "highlights the 'Documents' tab when it is the currently selected tab- Sub-navigation" do
-    login_as :gds_editor, create(:organisation, name: "my-test-org")
-    @controller = Admin::EditionsController.new
-
-    get :index, params: { type: 1 }
-
-    assert_current_item("/government/admin/editions")
-    assert_not_current_item("/government/admin/new-document")
-    assert_not_current_item("/government/admin/statistics_announcements")
-    assert_not_current_item("/government/admin/organisations/my-test-org/features")
-    assert_not_current_item("/government/admin/organisations/my-test-org/corporate_information_pages")
-    assert_not_current_item("/government/admin/more")
-  end
-
-  view_test "highlights the 'Statistics announcements' tab when it is the currently selected tab- Sub-navigation" do
-    login_as :gds_editor, create(:organisation, name: "my-test-org")
-    @controller = Admin::StatisticsAnnouncementsController.new
-
-    get :index
-
-    assert_current_item("/government/admin/statistics_announcements")
-    assert_not_current_item("/government/admin/new-document")
-    assert_not_current_item("/government/admin/editions")
-    assert_not_current_item("/government/admin/organisations/my-test-org/features")
-    assert_not_current_item("/government/admin/organisations/my-test-org/corporate_information_pages")
-    assert_not_current_item("/government/admin/more")
-  end
-
-  view_test "highlights the 'Features' tab when it is the currently selected tab- Sub-navigation" do
-    my_test_org = create(:organisation, name: "my-test-org")
-    login_as :gds_editor, my_test_org
-    @controller = Admin::OrganisationsController.new
-
-    get :features, params: { id: my_test_org }
-
-    assert_current_item("/government/admin/organisations/my-test-org/features")
-    assert_not_current_item("/government/admin/new-document")
-    assert_not_current_item("/government/admin/editions")
-    assert_not_current_item("/government/admin/statistics_announcements")
-    assert_not_current_item("/government/admin/organisations/my-test-org/corporate_information_pages")
-    assert_not_current_item("/government/admin/more")
-  end
-
-  view_test "highlights the 'Corporate information pages' tab when it is the currently selected tab- Sub-navigation" do
-    my_test_org = create(:organisation, name: "my-test-org")
-    login_as :gds_editor, my_test_org
-    @controller = Admin::CorporateInformationPagesController.new
-
-    get :index, params: { organisation_id: my_test_org }
-
-    assert_current_item("/government/admin/organisations/my-test-org/corporate_information_pages")
-    assert_not_current_item("/government/admin/new-document")
-    assert_not_current_item("/government/admin/editions")
-    assert_not_current_item("/government/admin/statistics_announcements")
-    assert_not_current_item("/government/admin/organisations/my-test-org/features")
-    assert_not_current_item("/government/admin/more")
-  end
-
-  view_test "highlights the 'More' tab when it is the currently selected tab- Sub-navigation" do
-    login_as :gds_editor, create(:organisation, name: "my-test-org")
-    @controller = Admin::MoreController.new
-
-    get :index
-
-    assert_current_item("/government/admin/more")
-    assert_not_current_item("/government/admin/new-document")
-    assert_not_current_item("/government/admin/editions")
-    assert_not_current_item("/government/admin/statistics_announcements")
-    assert_not_current_item("/government/admin/organisations/my-test-org/corporate_information_pages")
-    assert_not_current_item("/government/admin/organisations/my-test-org/features")
   end
 
   view_test "dashboard page is inaccessible when maintenance mode is enabled" do
@@ -161,19 +65,13 @@ class Admin::BaseControllerTest < ActionController::TestCase
 
 private
 
-  def assert_not_current_item(path)
-    assert_select ".app-c-sub-navigation__list-item--current a[href=\"#{path}\"]", false
-  end
-
   def assert_current_item(path)
+    assert_select ".app-c-sub-navigation__list-item--current", count: 1
     assert_select ".app-c-sub-navigation__list-item--current a[href=\"#{path}\"]"
   end
 
-  def assert_not_active_item(path)
-    assert_select ".govuk-service-navigation__item--active a[href=\"#{path}\"]", false
-  end
-
   def assert_active_item(path)
+    assert_select ".govuk-service-navigation__item--active", count: 1
     assert_select ".govuk-service-navigation__item--active a[href=\"#{path}\"]"
   end
 end


### PR DESCRIPTION
## What

- Rewrite the test scenarios to reflect the fact that the design system is now used across `whitehall`
- Rewrite test to check that navigation renders all of the intended links
- Remove extraneous tests to check if each link within the navigation is `active`
 
## Why

If the navigation renders all the correct links then we can assume that the active class will be correctly applied to each link (as the components used for navigation are independently tested).

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
