### PR TITLE
Revert "Stop scheduling daily Sidekiq workers in local environment"

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -13,11 +13,9 @@
   - edition_revalidation
 :scheduler:
   :schedule:
-<% unless Rails.env.development? || Rails.env.test? %>
     revalidate_old_link_check_reports:
       cron: '0 4 * * *' # Runs at 4 a.m every day
       class: RevalidateOldLinkCheckReportsWorker
     revalidate_all_editions:
       cron: '45 5 * * *' # Runs at 5:45am every day
       class: RevalidateEditionsSchedulerWorker
-<% end %>


### PR DESCRIPTION
This reverts commit 782fb4be041cc8713467e233c46d01639e63d26a. This failed when deploying to staging because the Rails constant is not defined when siedkiq.yml is evaluated.
