### PR TITLE
feat: change rendering app from government-frontend to frontend

### DIFF
--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -2,7 +2,7 @@
 #
 # There are many types of publications - see `PublicationType`.
 #
-# Publication pages are rendered by Whitehall.
+# Publication pages are rendered by Frontend.
 #
 # Note that `Publicationesque` inherits from `Edition`
 class Publication < Publicationesque
@@ -69,7 +69,7 @@ class Publication < Publicationesque
   end
 
   def rendering_app
-    Whitehall::RenderingApp::GOVERNMENT_FRONTEND
+    Whitehall::RenderingApp::FRONTEND
   end
 
   def allows_inline_attachments?

--- a/test/unit/app/presenters/publishing_api/publication_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/publication_presenter_test.rb
@@ -27,7 +27,7 @@ class PublishingApi::PublicationPresenterTest < ActiveSupport::TestCase
       locale: "en",
       public_updated_at: publication.public_timestamp,
       publishing_app: Whitehall::PublishingApp::WHITEHALL,
-      rendering_app: "government-frontend",
+      rendering_app: "frontend",
       routes: [
         { path: public_path, type: "exact" },
       ],


### PR DESCRIPTION
https://trello.com/c/utYFvGDW/781-move-publication-from-government-frontend-to-frontend

Do not merge before:
- [ ] https://github.com/alphagov/frontend/pull/4927

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
