### PR TITLE
[WHIT-2392] Revert "Move 255 URL maxlength limit into the UriValidator"

### DIFF
--- a/app/models/nation_inapplicability.rb
+++ b/app/models/nation_inapplicability.rb
@@ -10,6 +10,7 @@ class NationInapplicability < ApplicationRecord
 
   validates :nation_id, inclusion: { in: Nation.potentially_inapplicable.map(&:id) }
   validates :alternative_url, uri: true, allow_blank: true
+  validates :alternative_url, length: { maximum: 255 }
 
   attr_accessor :excluded
 

--- a/app/validators/uri_validator.rb
+++ b/app/validators/uri_validator.rb
@@ -3,15 +3,8 @@ require "addressable/uri"
 
 # Accepts options[:message] and options[:allowed_protocols]
 class UriValidator < ActiveModel::EachValidator
-  MAX_LENGTH = 255
-
   def validate_each(record, attribute, value)
     return if value.nil?
-
-    if value.length > MAX_LENGTH
-      record.errors.add(attribute, "is too long. Please shorten the URL to less than #{MAX_LENGTH} characters.")
-      return
-    end
 
     uri = URI.parse(value)
 

--- a/test/unit/app/models/nation_inapplicability_test.rb
+++ b/test/unit/app/models/nation_inapplicability_test.rb
@@ -1,9 +1,37 @@
 require "test_helper"
 
 class NationInapplicabilityTest < ActiveSupport::TestCase
-  test "uses UriValidator on :alternative_url" do
-    validators = NationInapplicability.validators_on(:alternative_url)
-    assert validators.any? { |v| v.is_a?(UriValidator) }, "UriValidator not found on :alternative_url"
+  test "should be invalid with a malformed alternative url" do
+    inapplicability = build(:nation_inapplicability, alternative_url: "invalid-url")
+    assert_not inapplicability.valid?
+  end
+
+  test "should be valid with an alternative url with HTTP protocol" do
+    inapplicability = build(:nation_inapplicability, alternative_url: "http://example.com")
+    assert inapplicability.valid?
+  end
+
+  test "should be valid with an alternative url with HTTPS protocol" do
+    inapplicability = build(:nation_inapplicability, alternative_url: "https://example.com")
+    assert inapplicability.valid?
+  end
+
+  test "should be valid without an alternative url" do
+    inapplicability = build(:nation_inapplicability, alternative_url: nil)
+    assert inapplicability.valid?
+  end
+
+  test "should be valid with 255 character alternative url" do
+    alternative_url_255_character = "https://1HHGPav0JgJ6r1rJR34wO2Tksnimp6DjWIrJU02iQgcUK6H7he4aWZ5wrtNGOifEHoLO9afMMfNIZxoOTj6BkQE7NcBwY4fvYpCXwCFaBjnXkRqyl3LfFAIJc5GUXz64LGwQvHQHiOkFdP2fk43HkM2Dx6aHoHxdgRHRB7jVzGNLNwUBQtFdjlLv4CBHRTFMnHBtSsskEXhSGlv0TubV2uouqlUkoLSOwC3AJHa4XN1bcD23112.com"
+    inapplicability = build(:nation_inapplicability, alternative_url: alternative_url_255_character)
+    assert inapplicability.valid?
+  end
+
+  test "should error with more than 255 character alternative url" do
+    alternative_url_256_character = "https://1HHGPav0JgJ6r1rJR34wO2Tksnimp6DjWIrJU02iQgcUK6H7he4aWZ5wrtNGOifEHoLO9afMMfNIZxoOTj6BkQE7NcBwY4fvYpCXwCFaBjnXkRqyl3LfFAIJc5GUXz64LGwQvHQHiOkFdP2fk43HkM2Dx6aHoHxdgRHRB7jVzGNLNwUBQtFdjlLv4CBHRTFMnHBtSsskEXhSGlv0TubV2uouqlUkoLSOwC3AJHa4XN1bcD231125.com"
+    inapplicability = build(:nation_inapplicability, alternative_url: alternative_url_256_character)
+    assert_not inapplicability.valid?
+    assert_includes inapplicability.errors.messages[:alternative_url], I18n.t("activerecord.errors.models.nation_inapplicability.attributes.alternative_url.too_long")
   end
 
   test "has a virtual attribute to indicate exclusion" do

--- a/test/unit/app/validators/uri_validator_test.rb
+++ b/test/unit/app/validators/uri_validator_test.rb
@@ -56,18 +56,6 @@ class UriValidatorTest < ActiveSupport::TestCase
     assert_equal ["is not valid."], feature_link.errors[:url]
   end
 
-  test "should be valid with 255 character alternative url" do
-    alternative_url_255_character = "https://1HHGPav0JgJ6r1rJR34wO2Tksnimp6DjWIrJU02iQgcUK6H7he4aWZ5wrtNGOifEHoLO9afMMfNIZxoOTj6BkQE7NcBwY4fvYpCXwCFaBjnXkRqyl3LfFAIJc5GUXz64LGwQvHQHiOkFdP2fk43HkM2Dx6aHoHxdgRHRB7jVzGNLNwUBQtFdjlLv4CBHRTFMnHBtSsskEXhSGlv0TubV2uouqlUkoLSOwC3AJHa4XN1bcD23112.com"
-    feature_link = validate(PromotionalFeatureLink.new(url: alternative_url_255_character))
-    assert feature_link.errors.empty?
-  end
-
-  test "should error with more than 255 character alternative url" do
-    alternative_url_256_character = "https://1HHGPav0JgJ6r1rJR34wO2Tksnimp6DjWIrJU02iQgcUK6H7he4aWZ5wrtNGOifEHoLO9afMMfNIZxoOTj6BkQE7NcBwY4fvYpCXwCFaBjnXkRqyl3LfFAIJc5GUXz64LGwQvHQHiOkFdP2fk43HkM2Dx6aHoHxdgRHRB7jVzGNLNwUBQtFdjlLv4CBHRTFMnHBtSsskEXhSGlv0TubV2uouqlUkoLSOwC3AJHa4XN1bcD231125.com"
-    feature_link = validate(PromotionalFeatureLink.new(url: alternative_url_256_character))
-    assert_includes feature_link.errors[:url], I18n.t("activerecord.errors.models.nation_inapplicability.attributes.alternative_url.too_long")
-  end
-
 private
 
   def validate(record)


### PR DESCRIPTION
## What

Reverts alphagov/whitehall#10491

## Why

We got a zendesk ticket relating to this, because we have now made organisations invalid (due to the `custom_jobs_url` being too long) https://govuk.zendesk.com/agent/tickets/6192793.

URI character limit validation was introduced in #10491, extending the validation to all URIs in the codebase. Previously, it was set per model, e.g. for `alternative_url` on `nation_inapplicabilities`.

We investigated what data types the various urls we use are. Here's a list:
```
external_url - all string
link_url - all string
contact_form_url - all string
alternative_url - string for nation_inapplicabilities but a text for unpublishings
organisation_chart_url - all string
url - some string, some text for social_media_account_translations, featured_link_translations
redirect_url - all string
custom_jobs_url - text for organisations
other fields named `<>_url` are all string type
```

So there are only a few outliers that are of `text` type and should thus not be limited to a 255 character limit. 
It seems we should not proceed with applying the validation universally. If we do so,  we should correct the data before applying the validation. 

[Jira](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-2392)
