### PR TITLE
Raise an error when duplicate content id's are fed to bulk republish

### DIFF
--- a/app/controllers/admin/bulk_republishing_controller.rb
+++ b/app/controllers/admin/bulk_republishing_controller.rb
@@ -109,6 +109,8 @@ class Admin::BulkRepublishingController < Admin::BaseController
     content_ids = content_ids_string_to_array(@content_ids_string)
     return if redirect_if_no_requested_content_ids(content_ids)
 
+    return if redirect_if_duplicated_content_ids(content_ids)
+
     @matching_documents = Document.where(content_id: content_ids)
     return if redirect_if_unfound_content_ids(@matching_documents.pluck(:content_id), content_ids)
 

--- a/test/functional/admin/bulk_republishing_controller_test.rb
+++ b/test/functional/admin/bulk_republishing_controller_test.rb
@@ -380,6 +380,13 @@ class Admin::BulkRepublishingControllerTest < ActionController::TestCase
     assert_equal "No content IDs provided", flash[:alert]
   end
 
+  test "GDS Admin users should be redirected back to :new_documents_by_content_ids when trying to POST :republish_documents_by_content_ids with duplicate content IDs" do
+    post :republish_documents_by_content_ids, params: { content_ids: "abc-123, abc-123, def-456", reason: "this needs republishing" }
+
+    assert_redirected_to admin_bulk_republishing_documents_by_content_ids_new_path
+    assert_equal "Duplicated content IDs ('abc-123') provided. Please remove these from the input.", flash[:alert]
+  end
+
   test "GDS Admin users should be redirected back to :new_documents_by_content_ids when trying to POST :republish_documents_by_content_ids with invalid content IDs" do
     post :republish_documents_by_content_ids, params: { content_ids: "this is not valid", reason: "this needs republishing" }
 


### PR DESCRIPTION
This caused an issue recently which was initially misdiagnosed as an issue with providing a large list of content id's.

Only after someone had a proper look at the list was it realised the problem was a duplicate and nothing to do with the size. So this PR adds similar functionality to what is present is `search_documents_by_content_ids` to prevent this happening again.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
