### PR TITLE
Send only the English version in world_location_names

### DIFF
--- a/app/presenters/publishing_api/worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/worldwide_organisation_presenter.rb
@@ -166,7 +166,7 @@ module PublishingApi
       item.world_locations.map do |world_location|
         {
           content_id: world_location.content_id,
-          name: world_location.name,
+          name: world_location.translations.find_by(locale: "en")&.name || world_location.name,
         }
       end
     end


### PR DESCRIPTION
On non-english worldwide organisation pages, the link that should send the user to the world location news page is not working. For example,  see Česká republika on this [embassy page](https://www.gov.uk/world/organisations/british-embassy-prague.cs), that links to `/world/ceska-republika/news` , but it should be `/world/czechia/news`.
This is because in government-frontend we are using the country name from world_location_names, and content data returns the native country name for translated pages, and not the English version, which is the one we need.

Because `world_locations` doesn't return only the English version for location name, this issue is affecting links on Woldwide Organisation, News Articles, Case Studies and Speech pages.

Trello card: https://trello.com/c/dXfX6R0o/3433-fix-the-broken-link-in-the-head-of-some-non-english-worldwide-organisation-pages-that-links-to-the-world-location-news-page

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
