### PR TITLE
[WHIT-2257] Surface nested validation errors

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -146,15 +146,4 @@ module ApplicationHelper
   def get_content_id(edition)
     edition&.content_id
   end
-
-  def filtered_validation_errors(edition)
-    all_messages = edition.errors.map(&:full_message)
-    has_contact_errors = all_messages.any? { |msg| msg.include?("Contact ID") || msg.include?("contact reference") }
-
-    if has_contact_errors
-      all_messages.reject { |msg| msg.match?(/\A(Attachments|Html attachments) is invalid\z/) }
-    else
-      all_messages
-    end
-  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -144,10 +144,17 @@ module ApplicationHelper
   end
 
   def get_content_id(edition)
-    return if edition.nil?
+    edition&.content_id
+  end
 
-    return unless edition.respond_to?("content_id")
+  def filtered_validation_errors(edition)
+    all_messages = edition.errors.map(&:full_message)
+    has_contact_errors = all_messages.any? { |msg| msg.include?("Contact ID") || msg.include?("contact reference") }
 
-    edition.content_id
+    if has_contact_errors
+      all_messages.reject { |msg| msg.match?(/\A(Attachments|Html attachments) is invalid\z/) }
+    else
+      all_messages
+    end
   end
 end

--- a/app/models/html_attachment.rb
+++ b/app/models/html_attachment.rb
@@ -104,12 +104,6 @@ class HtmlAttachment < Attachment
     PublishingApi::HtmlAttachmentPresenter
   end
 
-  def invalid_contact_messages
-    errors.details[:base]
-      .select { |detail| detail[:error] == :invalid_contact }
-      .map { |detail| "Contact #{detail[:contact_id]} doesn't exist" }
-  end
-
 private
 
   def skip_contact_validation?

--- a/app/models/html_attachment.rb
+++ b/app/models/html_attachment.rb
@@ -10,6 +10,7 @@ class HtmlAttachment < Attachment
   before_save :ensure_slug_is_valid
 
   validates :govspeak_content, presence: true
+  validates_with GovspeakContactEmbedValidator
 
   accepts_nested_attributes_for :govspeak_content
   delegate :body,

--- a/app/models/html_attachment.rb
+++ b/app/models/html_attachment.rb
@@ -10,7 +10,7 @@ class HtmlAttachment < Attachment
   before_save :ensure_slug_is_valid
 
   validates :govspeak_content, presence: true
-  validates_with GovspeakContactEmbedValidator
+  validates_with GovspeakContactEmbedValidator, unless: :skip_contact_validation?
 
   accepts_nested_attributes_for :govspeak_content
   delegate :body,
@@ -104,7 +104,22 @@ class HtmlAttachment < Attachment
     PublishingApi::HtmlAttachmentPresenter
   end
 
+  def invalid_contact_messages
+    errors.details[:base]
+      .select { |detail| detail[:error] == :invalid_contact }
+      .map { |detail| "Contact #{detail[:contact_id]} doesn't exist" }
+  end
+
 private
+
+  def skip_contact_validation?
+    return false if persisted? && !@created_during_draft
+
+    @created_during_draft ||
+      (attachable.respond_to?(:draft?) && attachable.draft? &&
+       attachable.respond_to?(:document) && attachable.document.present? &&
+       !attachable.document.editions.published.empty?)
+  end
 
   def public_path(options = {})
     append_url_options(base_path, options)

--- a/app/models/html_attachment.rb
+++ b/app/models/html_attachment.rb
@@ -107,12 +107,12 @@ class HtmlAttachment < Attachment
 private
 
   def skip_contact_validation?
-    return false if persisted? && !@created_during_draft
+    @created_during_draft || draft_of_previously_published_document?
+  end
 
-    @created_during_draft ||
-      (attachable.respond_to?(:draft?) && attachable.draft? &&
-       attachable.respond_to?(:document) && attachable.document.present? &&
-       !attachable.document.editions.published.empty?)
+  def draft_of_previously_published_document?
+    attachable.draft? &&
+      attachable.document&.editions&.published&.any?
   end
 
   def public_path(options = {})

--- a/app/validators/govspeak_contact_embed_validator.rb
+++ b/app/validators/govspeak_contact_embed_validator.rb
@@ -4,14 +4,5 @@ class GovspeakContactEmbedValidator < ActiveModel::Validator
       contact = Contact.find_by(id: contact_id)
       record.errors.add(:base, "Contact ID #{contact_id} doesn't exist") unless contact
     end
-
-    if record.respond_to?(:html_attachments)
-      record.html_attachments.each do |html_attachment|
-        Govspeak::ContactsExtractor.new(html_attachment.body).extracted_contact_ids.each do |contact_id|
-          contact = Contact.find_by(id: contact_id)
-          html_attachment.errors.add(:base, "Contact ID #{contact_id} doesn't exist") unless contact
-        end
-      end
-    end
   end
 end

--- a/app/validators/govspeak_contact_embed_validator.rb
+++ b/app/validators/govspeak_contact_embed_validator.rb
@@ -1,8 +1,10 @@
 class GovspeakContactEmbedValidator < ActiveModel::Validator
   def validate(record)
-    Govspeak::ContactsExtractor.new(record.body).extracted_contact_ids.each do |contact_id|
-      contact = Contact.find_by(id: contact_id)
-      record.errors.add(:base, "Contact ID #{contact_id} doesn't exist") unless contact
+    contact_ids = Govspeak::ContactsExtractor.new(record.body).extracted_contact_ids
+    invalid_contact_ids = contact_ids.reject { |id| Contact.exists?(id: id) }
+
+    invalid_contact_ids.each do |contact_id|
+      record.errors.add(:base, "Body contains invalid contact reference: Contact ID #{contact_id} doesn't exist", contact_id: contact_id.to_s, error: :invalid_contact)
     end
   end
 end

--- a/app/views/admin/editions/show/_sidebar_notices.html.erb
+++ b/app/views/admin/editions/show/_sidebar_notices.html.erb
@@ -18,7 +18,7 @@
       title: "This edition is invalid",
       description: render("govuk_publishing_components/components/list", {
         visible_counters: true,
-        items:  @edition.errors.map(&:full_message),
+        items: @edition.errors.map(&:full_message),
       }),
       error: true,
     } %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -119,6 +119,10 @@ en:
         minister: Minister
         speaker: Speaker
       written_on: 'Written on:'
+    errors:
+      messages:
+        attachment_error: "error: %{msg}"
+        invalid_contact_reference: "contains invalid contact reference. Contact %{contact_id} doesn't exist"
     type:
       about:
         one: About

--- a/test/functional/admin/editions_sidebar_notices_test.rb
+++ b/test/functional/admin/editions_sidebar_notices_test.rb
@@ -1,0 +1,57 @@
+require "test_helper"
+
+class Admin::EditionsSidebarNoticesTest < ActionController::TestCase
+  include Admin::EditionRoutesHelper
+
+  setup do
+    login_as :writer
+    @controller = Admin::NewsArticlesController.new
+    @bad_contact_id = "99999"
+  end
+
+  view_test "sidebar notices handles editions with no validation errors" do
+    edition = create(:draft_news_article, title: "Valid title", body: "Valid body content")
+    stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+
+    get :show, params: { id: edition }
+
+    assert_response :success
+    assert_select ".app-view-summary__sidebar .app-c-inset-prompt--error", count: 0
+  end
+
+  view_test "sidebar notices shows validation errors from edition" do
+    edition = create(:draft_news_article, body: "[Contact:#{@bad_contact_id}]")
+    edition.save!(validate: false)
+    stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+
+    get :show, params: { id: edition }
+
+    assert_select ".app-view-summary__sidebar .app-c-inset-prompt--error" do |elements|
+      error_text = elements.text
+      assert_includes error_text, "This edition is invalid"
+    end
+  end
+
+  view_test "sidebar notices shows specific validation errors without generic association messages" do
+    edition = create(:draft_news_article, body: "[Contact:#{@bad_contact_id}]")
+    stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+
+    get :show, params: { id: edition }
+
+    assert_select ".app-view-summary__sidebar .app-c-inset-prompt--error" do |elements|
+      error_text = elements.text
+      assert_includes error_text, "This edition is invalid"
+      assert_includes error_text, "Contact ID"
+      assert_includes error_text, "doesn't exist"
+    end
+  end
+
+  view_test "sidebar notices keeps generic association errors when no specific contact errors exist" do
+    edition = create(:draft_news_article, title: "Valid title", body: "Valid body")
+    stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+
+    get :show, params: { id: edition }
+
+    assert_response :success
+  end
+end

--- a/test/functional/admin/generic_editions_controller_test.rb
+++ b/test/functional/admin/generic_editions_controller_test.rb
@@ -113,20 +113,4 @@ class Admin::GenericEditionsControllerTest < ActionController::TestCase
     assert_select ".govuk-link", text: "Preview on website (opens in new tab)", href: draft_edition.public_url(draft: true), count: 0
     assert_select ".govuk-inset-text", text: "To see the changes and share a document preview link, add a change note or mark the change type to minor."
   end
-
-  view_test "visiting an invalid edition should show the validation errors" do
-    bad_id = "9999999999999"
-    edition = create(:draft_edition, body: "[Contact:#{bad_id}]")
-    edition.save!(validate: false)
-    stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
-
-    get :show, params: { id: edition }
-
-    assert_select ".app-view-summary__sidebar .app-c-inset-prompt--error" do |elements|
-      expected_message = "This edition is invalid"
-      assert elements.text.include?(expected_message), "Could not find \"#{expected_message}\" in #{elements.text}"
-      expected_message = "Contact ID #{bad_id} doesn't exist"
-      assert elements.text.include?(expected_message), "Could not find \"#{expected_message}\" in #{elements.text}"
-    end
-  end
 end

--- a/test/unit/app/helpers/application_helper_test.rb
+++ b/test/unit/app/helpers/application_helper_test.rb
@@ -99,36 +99,6 @@ class ApplicationHelperTest < ActionView::TestCase
     end
   end
 
-  test "filtered_validation_errors filters out generic association errors when contact errors exist" do
-    edition = build(:draft_news_article)
-
-    edition.errors.add(:base, "Body contains invalid contact reference: Contact ID 999 doesn't exist")
-    edition.errors.add(:base, "HTML Attachment 'Title' contains invalid contact reference: Contact ID 888 doesn't exist")
-    edition.errors.add(:html_attachments, "is invalid")
-    edition.errors.add(:attachments, "is invalid")
-
-    filtered_errors = filtered_validation_errors(edition)
-
-    assert_includes filtered_errors, "Body contains invalid contact reference: Contact ID 999 doesn't exist"
-    assert_includes filtered_errors, "HTML Attachment 'Title' contains invalid contact reference: Contact ID 888 doesn't exist"
-    assert_not_includes filtered_errors, "Html attachments is invalid"
-    assert_not_includes filtered_errors, "Attachments is invalid"
-  end
-
-  test "filtered_validation_errors keeps generic association errors when no contact errors exist" do
-    edition = build(:draft_news_article)
-
-    edition.errors.add(:title, "is too long")
-    edition.errors.add(:html_attachments, "is invalid")
-    edition.errors.add(:attachments, "is invalid")
-
-    filtered_errors = filtered_validation_errors(edition)
-
-    assert_includes filtered_errors, "Title is too long"
-    assert_includes filtered_errors, "Html attachments is invalid"
-    assert_includes filtered_errors, "Attachments is invalid"
-  end
-
 private
 
   def appoint_minister(attributes = {})

--- a/test/unit/app/helpers/application_helper_test.rb
+++ b/test/unit/app/helpers/application_helper_test.rb
@@ -99,6 +99,36 @@ class ApplicationHelperTest < ActionView::TestCase
     end
   end
 
+  test "filtered_validation_errors filters out generic association errors when contact errors exist" do
+    edition = build(:draft_news_article)
+
+    edition.errors.add(:base, "Body contains invalid contact reference: Contact ID 999 doesn't exist")
+    edition.errors.add(:base, "HTML Attachment 'Title' contains invalid contact reference: Contact ID 888 doesn't exist")
+    edition.errors.add(:html_attachments, "is invalid")
+    edition.errors.add(:attachments, "is invalid")
+
+    filtered_errors = filtered_validation_errors(edition)
+
+    assert_includes filtered_errors, "Body contains invalid contact reference: Contact ID 999 doesn't exist"
+    assert_includes filtered_errors, "HTML Attachment 'Title' contains invalid contact reference: Contact ID 888 doesn't exist"
+    assert_not_includes filtered_errors, "Html attachments is invalid"
+    assert_not_includes filtered_errors, "Attachments is invalid"
+  end
+
+  test "filtered_validation_errors keeps generic association errors when no contact errors exist" do
+    edition = build(:draft_news_article)
+
+    edition.errors.add(:title, "is too long")
+    edition.errors.add(:html_attachments, "is invalid")
+    edition.errors.add(:attachments, "is invalid")
+
+    filtered_errors = filtered_validation_errors(edition)
+
+    assert_includes filtered_errors, "Title is too long"
+    assert_includes filtered_errors, "Html attachments is invalid"
+    assert_includes filtered_errors, "Attachments is invalid"
+  end
+
 private
 
   def appoint_minister(attributes = {})

--- a/test/unit/app/models/edition_test.rb
+++ b/test/unit/app/models/edition_test.rb
@@ -948,68 +948,6 @@ class EditionTest < ActiveSupport::TestCase
     assert_nil edition.published_at
   end
 
-  test "should pass validation on creation of edition with HTML attachment with missing contact" do
-    contact = create(:contact)
-    bad_id = "9999999999999"
-    edition = create(:submitted_case_study, body: "[Contact:#{contact.id}]")
-    edition.html_attachments = [create(:html_attachment, body: "[Contact:#{bad_id}]")]
-
-    assert edition.valid?
-  end
-
-  test "should fail validation on publish of edition with HTML attachment with missing contact" do
-    contact = create(:contact)
-    bad_id = "9999999999999"
-    edition = create(:submitted_case_study, body: "[Contact:#{contact.id}]")
-    edition.html_attachments = [create(:html_attachment, body: "[Contact:#{bad_id}]")]
-
-    edition.publish
-
-    assert_not edition.valid?
-  end
-
-  test "should update cached 'revalidated_at' value on each `valid?(:publish)` call" do
-    edition = create(:edition)
-    edition.valid?(:publish)
-    assert edition.revalidated_at
-
-    # Simulate it becoming invalid in publish contexts - i.e. embed a non-existent
-    # contact - but don't trigger revalidation yet (i.e. use `update_columns` to
-    # avoid callbacks)
-    edition.translations.first.update_columns(body: "[Contact:9999999]")
-
-    # Should still reflect the cached state from earlier call to `valid?(:publish)`
-    assert edition.revalidated_at
-    assert edition.reload.revalidated_at
-
-    # Now force a full validation
-    assert_not edition.valid?(:publish)
-    # It should reset `revalidated_at` to nil
-    assert_nil edition.revalidated_at
-    # ...and ensure the updated value is persisted to the DB
-    assert_nil edition.reload.revalidated_at
-  end
-
-  test "should NOT update cached 'revalidated_at' value on each general `valid?` call" do
-    edition = create(:edition)
-    edition.valid?(:publish)
-    assert edition.revalidated_at
-
-    # Simulate it becoming invalid in publish contexts - i.e. embed a non-existent
-    # contact - but don't trigger revalidation yet (i.e. use `update_columns` to
-    # avoid callbacks)
-    edition.translations.first.update_columns(body: "[Contact:9999999]")
-
-    # Should still reflect the cached state from earlier call to `valid?(:publish)`
-    assert edition.revalidated_at
-    assert edition.reload.revalidated_at
-
-    # Now force a validation but outside of the publish context
-    # ...it shouldn't change anything, since we only care about the publish context
-    assert edition.valid?
-    assert edition.reload.revalidated_at
-  end
-
   def decoded_token_payload(token)
     payload, _header = JWT.decode(
       token,

--- a/test/unit/app/models/html_attachment_contact_validation_test.rb
+++ b/test/unit/app/models/html_attachment_contact_validation_test.rb
@@ -62,5 +62,7 @@ class HtmlAttachmentContactValidationTest < ActiveSupport::TestCase
     error_message = edition.errors[:base].first
     assert_includes error_message, "HTML Attachment 'Invalid Doc' contains invalid contact reference"
     assert_includes error_message, "Contact #{@invalid_contact_id} doesn't exist"
+
+    assert_not(edition.errors.full_messages.any? { |msg| msg == "Html attachments is invalid" })
   end
 end

--- a/test/unit/app/models/html_attachment_contact_validation_test.rb
+++ b/test/unit/app/models/html_attachment_contact_validation_test.rb
@@ -1,0 +1,66 @@
+require "test_helper"
+
+class HtmlAttachmentContactValidationTest < ActiveSupport::TestCase
+  def setup
+    @valid_contact = create(:contact)
+    @invalid_contact_id = "99999"
+  end
+
+  test "validates HTML attachment with valid contact" do
+    attachment = build(:html_attachment, body: "[Contact:#{@valid_contact.id}]")
+    assert attachment.valid?
+  end
+
+  test "validates HTML attachment with invalid contact shows contextual error" do
+    attachment = build(:html_attachment, body: "[Contact:#{@invalid_contact_id}]", title: "Test Document")
+
+    assert_not attachment.valid?
+
+    assert attachment.errors.details[:base].present?
+    error_details = attachment.errors.details[:base].first
+    assert_equal :invalid_contact, error_details[:error]
+    assert_equal @invalid_contact_id, error_details[:contact_id]
+  end
+
+  test "skips validation for attachments created during draft process" do
+    published_edition = create(:published_publication)
+    attachment = build(:html_attachment, body: "[Contact:#{@invalid_contact_id}]", attachable: published_edition)
+    attachment.instance_variable_set(:@created_during_draft, true)
+
+    assert attachment.valid?
+  end
+
+  test "skips validation for new attachments on drafts of previously published documents" do
+    published_edition = create(:published_publication)
+    draft_edition = published_edition.create_draft(create(:user))
+    attachment = build(:html_attachment, body: "[Contact:#{@invalid_contact_id}]", attachable: draft_edition)
+
+    assert attachment.valid?
+  end
+
+  test "validates new attachments on first-time drafts" do
+    draft_edition = create(:draft_publication)
+    attachment = build(:html_attachment, body: "[Contact:#{@invalid_contact_id}]", attachable: draft_edition)
+
+    assert_not attachment.valid?
+
+    assert attachment.errors.details[:base].present?
+    error_details = attachment.errors.details[:base].first
+    assert_equal :invalid_contact, error_details[:error]
+  end
+
+  test "edition bubbles up HTML attachment contact errors on publish validation" do
+    edition = create(:draft_publication)
+    attachment = build(:html_attachment, body: "[Contact:#{@invalid_contact_id}]", title: "Invalid Doc", attachable: edition)
+    attachment.save!(validate: false)
+
+    assert_not edition.valid?(:publish)
+
+    assert edition.errors.present?
+    assert edition.errors[:base].present?
+
+    error_message = edition.errors[:base].first
+    assert_includes error_message, "HTML Attachment 'Invalid Doc' contains invalid contact reference"
+    assert_includes error_message, "Contact #{@invalid_contact_id} doesn't exist"
+  end
+end

--- a/test/unit/app/validators/govspeak_contact_embed_validator_test.rb
+++ b/test/unit/app/validators/govspeak_contact_embed_validator_test.rb
@@ -31,29 +31,4 @@ class GovspeakContactEmbedValidatorTest < ActiveSupport::TestCase
       "Contact ID #{bad_id} doesn't exist",
     ], test_model.errors.map(&:type)
   end
-
-  test "should be valid if the HTML attachment contains a Contact that exists" do
-    contact = create(:contact)
-    edition = create(:case_study, body: "[Contact:#{contact.id}]")
-
-    edition.html_attachments = [create(:html_attachment, body: "[Contact:#{contact.id}]")]
-
-    GovspeakContactEmbedValidator.new.validate(edition)
-
-    assert_equal 0, edition.errors.size
-    assert_equal 0, edition.html_attachments.first.errors.size
-  end
-
-  test "should be invalid if the HTML attachment contains a Contact that doesn't exist" do
-    contact = create(:contact)
-    bad_id = "9999999999999"
-    edition = create(:case_study, body: "[Contact:#{contact.id}]")
-
-    edition.html_attachments = [create(:html_attachment, body: "[Contact:#{bad_id}]")]
-
-    GovspeakContactEmbedValidator.new.validate(edition)
-
-    assert_equal 0, edition.errors.size
-    assert_equal 1, edition.html_attachments.first.errors.size
-  end
 end


### PR DESCRIPTION
[Jira](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-1517)

### Why

This refactoring improves the user experience of Whitehall's publishing workflow—specifically in how embedded contact IDs in Govspeak content are validated within both Editions and HTML attachments.

Previously, Whitehall allowed users to create and publish content containing HTML attachments that may have become invalid over time. This could happen due to:

- Validation rules being introduced or tightened after initial publication
- Contacts being deleted or changed, rendering existing embeds invalid

As a result, users might only discover issues at publish time(usually when making a new edition)—despite having made no changes to the attachment.

### What
This PR introduces a context-aware validation system for embedded contacts in Govspeak content that:

- Surfaces clear, specific errors in the UI when validation fails
- Skips certain validations during draft creation to unblock editors from fixing invalid editions

**BEFORE**
<img width="826" height="458" alt="1 - validation error on html attachment" src="https://github.com/user-attachments/assets/ceb5d6d4-0031-4041-9806-dedfbbb4e42b" />

**AFTER**
<img width="1149" height="605" alt="Screenshot 2025-08-15 at 09 48 23" src="https://github.com/user-attachments/assets/2ad768f5-0f59-4629-ac69-03bbe1da6c76" />


**BEFORE**
<img width="1226" height="816" alt="the problem" src="https://github.com/user-attachments/assets/26638b25-dbf2-4b13-826f-7f67a2e77d50" />

**AFTER**
<img width="1214" height="719" alt="Screenshot 2025-08-15 at 09 47 38" src="https://github.com/user-attachments/assets/2e3302ab-da2d-4b4c-8e89-e95f0c7e03ac" />
