### PR TITLE
CM-285 implement Govspeak-enabled textarea component for nested objects

### DIFF
--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/bsl_guidance_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/bsl_guidance_component.html.erb
@@ -1,11 +1,14 @@
 <div class="app-c-content-block-manager-bsl-guidance-component">
   <% value_input = capture do %>
-    <%= render "govuk_publishing_components/components/textarea", {
-      label: { text: label_for("value") },
-      name: name_for_field(value_field) ,
-      id: id_for_field(value_field),
-      value: value_for_field(value_field) || value_field.default_value,
-    } %>
+    <%= render(
+      ContentBlockManager::ContentBlockEdition::Details::Fields::GovspeakEnabledTextareaComponent.new(
+        content_block_edition: content_block_edition,
+        value: value,
+        nested_object_key: field.name,
+        field: value_field,
+        subschema: subschema,
+      ),
+    ) %>
   <% end %>
 
   <input type="hidden" name="<%= name_for_field(show_field) %>" value="false">

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/govspeak_enabled_textarea_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/govspeak_enabled_textarea_component.html.erb
@@ -1,9 +1,10 @@
 <div class="app-c-content-block-manager-govspeak-enabled-textarea-component">
   <%= render("govuk_publishing_components/components/textarea", {
-              label: { text: label },
+              label: { text: label, hint_text: hint_text, hint_id: aria_described_by },
               name: name_attribute,
               id: id_attribute,
               value: value_or_default,
               error_items: error_items,
+              describedby: aria_described_by,
   }) %>
 </div>

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/govspeak_enabled_textarea_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/govspeak_enabled_textarea_component.html.erb
@@ -1,0 +1,9 @@
+<div class="app-c-content-block-manager-govspeak-enabled-textarea-component">
+  <%= render("govuk_publishing_components/components/textarea", {
+              label: { text: label },
+              name: name_attribute,
+              id: id_attribute,
+              value: value_or_default,
+              error_items: error_items,
+  }) %>
+</div>

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/govspeak_enabled_textarea_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/govspeak_enabled_textarea_component.rb
@@ -1,0 +1,49 @@
+class ContentBlockManager::ContentBlockEdition::Details::Fields::GovspeakEnabledTextareaComponent < ContentBlockManager::ContentBlockEdition::Details::Fields::BaseComponent
+  def initialize(content_block_edition:, value:, nested_object_key:, field:, subschema:)
+    @nested_object_key = nested_object_key
+    @field = field
+    @value = value
+    @content_block_edition = content_block_edition
+
+    super(
+      subschema: subschema,
+      content_block_edition: content_block_edition,
+      field: field,
+      value: value,
+    )
+  end
+
+  attr_reader :content_block_edition, :nested_object_key, :field, :subschema, :errors
+
+  def id_attribute
+    "#{PARENT_CLASS}_details_#{subschema_block_type}_#{nested_object_key}_#{field.name}"
+  end
+
+  def label
+    helpers.humanized_label(
+      relative_key: field.name,
+      root_object: "#{subschema_block_type}.#{nested_object_key}",
+    )
+  end
+
+  def name_attribute
+    "content_block/edition[details][#{subschema_block_type}][#{nested_object_key}][#{field.name}]"
+  end
+
+  def value_or_default
+    value_for_field(field) || field.default_value
+  end
+
+  def error_items
+    errors_for(
+      content_block_edition.errors,
+      "details_#{subschema_block_type}_#{nested_object_key}_#{field.name}".to_sym,
+    )
+  end
+
+private
+
+  def value_for_field(field)
+    value&.fetch(field.name, nil)
+  end
+end

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/govspeak_enabled_textarea_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/govspeak_enabled_textarea_component.rb
@@ -15,8 +15,22 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::GovspeakEnabled
 
   attr_reader :content_block_edition, :nested_object_key, :field, :subschema, :errors
 
+  def govspeak_enabled?
+    subschema.govspeak_enabled?(nested_object_key: nested_object_key, field_name: field.name)
+  end
+
   def id_attribute
     "#{PARENT_CLASS}_details_#{subschema_block_type}_#{nested_object_key}_#{field.name}"
+  end
+
+  def aria_described_by
+    "#{id_attribute}-hint"
+  end
+
+  def hint_text
+    return nil unless govspeak_enabled?
+
+    "Govspeak supported"
   end
 
   def label

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/video_relay_service_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/video_relay_service_component.html.erb
@@ -1,13 +1,15 @@
 <div class="app-c-content-block-manager-video-relay-service-component">
 
   <% video_relay_service_inputs = capture do %>
-    <%= render("govuk_publishing_components/components/textarea", {
-            label: { text: label_for("prefix") },
-            name: name_for_field(prefix) ,
-            id: id_for_field(prefix),
-            value: value_for_field(prefix) || prefix.default_value,
-            error_items: errors_for_field(prefix),
-    }) %>
+    <%= render(
+      ContentBlockManager::ContentBlockEdition::Details::Fields::GovspeakEnabledTextareaComponent.new(
+        content_block_edition: content_block_edition,
+        value: value,
+        nested_object_key: field.name,
+        field: prefix,
+        subschema: subschema,
+      ),
+    ) %>
 
     <%= render("govuk_publishing_components/components/input", {
               label: { text: label_for("telephone_number") },

--- a/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/bsl_guidance_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/bsl_guidance_component_test.rb
@@ -4,28 +4,43 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::BSLGuidanceComp
   extend Minitest::Spec::DSL
 
   let(:content_block_edition) { build(:content_block_edition, :contact) }
-  let(:schema) { build(:content_block_schema) }
+
+  let(:properties) do
+    {
+      "bsl_guidance" => {
+        "type" => "object",
+        "properties" => {
+          "value" => { "type" => "string", "default" => "DEFAULT VALUE" },
+          "show" => { "type" => "boolean", "default" => false },
+        },
+      },
+    }
+  end
 
   let(:body) do
     {
       "type" => "object",
-      "properties" =>
-        { "bsl_guidance" =>
-            { "type" => "object",
-              "properties" =>
-                { "value" => { "type" => "string", "default" => "DEFAULT VALUE" },
-                  "show" => { "type" => "boolean", "default" => false } } } },
+      "patternProperties" => {
+        "*" => {
+          "type" => "object",
+          "properties" => properties,
+        },
+      },
     }
   end
 
-  before do
-    schema.stubs(:body).returns(body)
+  let(:subschema) do
+    ContentBlockManager::ContentBlock::Schema::EmbeddedSchema.new(
+      "telephones",
+      body,
+      "parent_schema_id",
+    )
   end
 
   let(:field) do
     ContentBlockManager::ContentBlock::Schema::Field.new(
       "bsl_guidance",
-      schema,
+      subschema,
     )
   end
 
@@ -39,6 +54,7 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::BSLGuidanceComp
       content_block_edition:,
       field: field,
       value: field_value,
+      subschema: subschema,
     )
   end
 
@@ -96,7 +112,7 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::BSLGuidanceComp
           assert_selector(".app-c-content-block-manager-bsl-guidance-component") do |component|
             component.assert_selector(
               "textarea" \
-              "[name='content_block/edition[details][bsl_guidance][value]']",
+              "[name='content_block/edition[details][telephones][bsl_guidance][value]']",
               text: "CUSTOM VALUE",
             )
           end
@@ -115,7 +131,7 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::BSLGuidanceComp
           assert_selector(".app-c-content-block-manager-bsl-guidance-component") do |component|
             component.assert_selector(
               "textarea" \
-              "[name='content_block/edition[details][bsl_guidance][value]']",
+              "[name='content_block/edition[details][telephones][bsl_guidance][value]']",
               text: "DEFAULT VALUE",
             )
           end

--- a/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/govspeak_enabled_textarea_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/govspeak_enabled_textarea_component_test.rb
@@ -155,6 +155,72 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::GovspeakEnabled
         end
       end
     end
+
+    describe "'Govspeak supported' indicator" do
+      context "when the field IS declared 'govspeak-enabled' in the subschema" do
+        let(:properties) do
+          {
+            "video_relay_service" => {
+              "x-govspeak_enabled" => %w[prefix],
+            },
+          }
+        end
+
+        it "displays a 'Govspeak supported' hint" do
+          render_inline component
+
+          assert_selector(COMPONENT_CLASS) do |component|
+            displays_indication_that_govspeak_is_supported(component)
+          end
+        end
+
+        describe "hint ID mapping to textarea 'aria-describedby'" do
+          let(:expected_hint_id_to_aria_mapping) do
+            "content_block_manager_content_block_edition_details_" \
+              "telephones_video_relay_service_prefix-" \
+              "hint"
+          end
+
+          it "includes an 'aria-describedby' attribute on the textarea, to match the label hint's ID" do
+            render_inline component
+
+            assert_selector(COMPONENT_CLASS) do |component|
+              component.assert_selector(
+                "textarea[aria-describedby='#{expected_hint_id_to_aria_mapping}']",
+              )
+            end
+          end
+
+          it "includes an ID on the label hint div, matching the 'aria-describedby' on the textarea" do
+            render_inline component
+
+            assert_selector(COMPONENT_CLASS) do |component|
+              component.assert_selector(
+                "div.govuk-hint[id='#{expected_hint_id_to_aria_mapping}']",
+              )
+            end
+          end
+        end
+      end
+
+      context "when the field is NOT declared 'govspeak-enabled in the subschema" do
+        let(:properties) do
+          {
+            "video_relay_service" => {
+              "x-govspeak_enabled" => [],
+            },
+          }
+        end
+
+        it "does NOT display the 'Govspeak supported' hint" do
+          render_inline component
+
+          assert_selector(COMPONENT_CLASS) do |component|
+            displays_no_indication_that_govspeak_is_supported(component)
+          end
+        end
+      end
+    end
   end
 
   def wraps_whole_textarea_in_element_with_id_describing_path_to_field(component)
@@ -193,6 +259,20 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::GovspeakEnabled
     component.assert_selector(
       "textarea",
       text: value,
+    )
+  end
+
+  def displays_indication_that_govspeak_is_supported(component)
+    component.assert_selector(
+      ".govuk-hint",
+      text: "Govspeak supported",
+    )
+  end
+
+  def displays_no_indication_that_govspeak_is_supported(component)
+    component.assert_no_selector(
+      ".govuk-hint",
+      text: "Govspeak supported",
     )
   end
 end

--- a/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/govspeak_enabled_textarea_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/govspeak_enabled_textarea_component_test.rb
@@ -1,0 +1,198 @@
+require "test_helper"
+
+class ContentBlockManager::ContentBlockEdition::Details::Fields::GovspeakEnabledTextareaComponentTest < ViewComponent::TestCase
+  extend Minitest::Spec::DSL
+
+  COMPONENT_CLASS = ".app-c-content-block-manager-govspeak-enabled-textarea-component".freeze
+
+  let(:content_block_edition) { build(:content_block_edition, :contact) }
+
+  let(:properties) do
+    {
+      "video_relay_service" => {
+        "x-govspeak_enabled" => %w[prefix],
+      },
+    }
+  end
+
+  let(:body) do
+    {
+      "type" => "object",
+      "patternProperties" => {
+        "*" => {
+          "type" => "object",
+          "properties" => properties,
+        },
+      },
+    }
+  end
+
+  let(:subschema) do
+    ContentBlockManager::ContentBlock::Schema::EmbeddedSchema.new(
+      "telephones",
+      body,
+      "parent_schema_id",
+    )
+  end
+
+  let(:field) do
+    ContentBlockManager::ContentBlock::Schema::Field::NestedField.new(
+      name: "prefix",
+      format: "string",
+      enum_values: nil,
+      default_value: "**Default** prefix: 18000 then",
+    )
+  end
+
+  let(:field_value) do
+    {
+      "prefix" => nil,
+    }
+  end
+
+  let(:component) do
+    ContentBlockManager::ContentBlockEdition::Details::Fields::GovspeakEnabledTextareaComponent.new(
+      content_block_edition: content_block_edition,
+      field: field,
+      value: field_value,
+      nested_object_key: "video_relay_service",
+      subschema: subschema,
+    )
+  end
+
+  before do
+    I18n.expects(:t).with(
+      "content_block_edition.details.labels.telephones.video_relay_service.prefix",
+      default: "Prefix",
+    ).returns("Translated label")
+  end
+
+  describe "GovspeakEnabledTextareaComponent" do
+    it "wraps component in an element with an ID describing path to field" do
+      render_inline component
+
+      assert_selector(COMPONENT_CLASS) do |component|
+        wraps_whole_textarea_in_element_with_id_describing_path_to_field(component)
+      end
+    end
+
+    it "includes a translated _label_" do
+      render_inline component
+
+      assert_selector(COMPONENT_CLASS) do |component|
+        displays_label_using_translation_system(component)
+      end
+    end
+
+    it "includes a _name_ attribute representing nested field location" do
+      render_inline component
+
+      assert_selector(COMPONENT_CLASS) do |component|
+        sets_name_attribute_on_textarea_describing_nested_path_to_field(component)
+      end
+    end
+
+    describe "default value" do
+      context "when there is NO value set for the textarea" do
+        let(:field_value) do
+          { "prefix" => nil }
+        end
+
+        it "supplies the default value defined in the schema" do
+          render_inline component
+
+          assert_selector(COMPONENT_CLASS) do |component|
+            shows_default_value_in_textarea(component)
+          end
+        end
+      end
+
+      context "when there IS a value set for the textarea" do
+        let(:field_value) do
+          { "prefix" => "Field value *set*" }
+        end
+
+        it "displays that value" do
+          render_inline component
+
+          assert_selector(COMPONENT_CLASS) do |component|
+            shows_set_value_in_textarea(component, "Field value *set*")
+          end
+        end
+      end
+
+      context "when there is an error on the field" do
+        before do
+          content_block_edition.errors.add(
+            :details_telephones_video_relay_service_prefix,
+            "blank",
+          )
+
+          I18n.expects(:t).with(
+            "activerecord.errors.models.content_block_manager/content_block/edition" \
+              ".attributes.details_telephones_video_relay_service_prefix.format".to_sym,
+            has_entry(message: "blank"),
+          ).returns("Prefix must be present")
+        end
+
+        it "adds an error class to the form group to highlight the area needing attention" do
+          render_inline component
+
+          assert_selector(COMPONENT_CLASS) do |component|
+            component.assert_selector(".govuk-form-group.govuk-form-group--error")
+          end
+        end
+
+        it "adds an error message to clarify the error and remedial action required" do
+          render_inline component
+
+          assert_selector(COMPONENT_CLASS) do |component|
+            component.assert_selector(
+              ".govuk-error-message",
+              text: "Prefix must be present",
+            )
+          end
+        end
+      end
+    end
+  end
+
+  def wraps_whole_textarea_in_element_with_id_describing_path_to_field(component)
+    expected_component_id =
+      "content_block_manager_content_block_edition_details_telephones_video_relay_service_prefix"
+
+    component.assert_selector(
+      "div[id='#{expected_component_id}']",
+    )
+  end
+
+  def displays_label_using_translation_system(component)
+    component.assert_selector(
+      "label",
+      text: "Translated label",
+    )
+  end
+
+  def sets_name_attribute_on_textarea_describing_nested_path_to_field(component)
+    expected_name_attribute =
+      "content_block/edition[details][telephones][video_relay_service][prefix]"
+
+    component.assert_selector(
+      "textarea[name='#{expected_name_attribute}']",
+    )
+  end
+
+  def shows_default_value_in_textarea(component)
+    component.assert_selector(
+      "textarea",
+      text: "**Default** prefix: 18000 then",
+    )
+  end
+
+  def shows_set_value_in_textarea(component, value)
+    component.assert_selector(
+      "textarea",
+      text: value,
+    )
+  end
+end

--- a/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/video_relay_service_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/video_relay_service_component_test.rb
@@ -4,32 +4,50 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::VideoRelayServi
   extend Minitest::Spec::DSL
 
   let(:content_block_edition) { build(:content_block_edition, :contact) }
-  let(:schema) { build(:content_block_schema) }
+
+  let(:properties) do
+    {
+      "video_relay_service" => {
+        "type" => "object",
+        "properties" => {
+          "show" => {
+            "type" => "boolean", "default" => false
+          },
+          "prefix" => {
+            "type" => "string", "default" => "**Default** prefix: 18000 then"
+          },
+          "telephone_number" => {
+            "type" => "string", "default" => "0800 123 4567"
+          },
+        },
+      },
+    }
+  end
 
   let(:body) do
     {
       "type" => "object",
-      "properties" =>
-        { "video_relay_service" =>
-          { "type" => "object",
-            "properties" =>
-          { "show" =>
-              { "type" => "boolean", "default" => false },
-            "prefix" =>
-              { "type" => "string", "default" => "**Default** prefix: 18000 then" },
-            "telephone_number" =>
-              { "type" => "string", "default" => "0800 123 4567" } } } },
+      "patternProperties" => {
+        "*" => {
+          "type" => "object",
+          "properties" => properties,
+        },
+      },
     }
   end
 
-  before do
-    schema.stubs(:body).returns(body)
+  let(:subschema) do
+    ContentBlockManager::ContentBlock::Schema::EmbeddedSchema.new(
+      "telephones",
+      body,
+      "parent_schema_id",
+    )
   end
 
   let(:field) do
     ContentBlockManager::ContentBlock::Schema::Field.new(
       "video_relay_service",
-      schema,
+      subschema,
     )
   end
 
@@ -46,6 +64,7 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::VideoRelayServi
       content_block_edition:,
       field: field,
       value: field_value,
+      subschema: subschema,
     )
   end
 
@@ -112,7 +131,7 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::VideoRelayServi
           assert_selector(".app-c-content-block-manager-video-relay-service-component") do |component|
             component.assert_selector(
               "textarea" \
-              "[name='content_block/edition[details][video_relay_service][prefix]']",
+              "[name='content_block/edition[details][telephones][video_relay_service][prefix]']",
               text: "**Custom** prefix: 19222 then",
             )
           end
@@ -134,7 +153,7 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::VideoRelayServi
           assert_selector(".app-c-content-block-manager-video-relay-service-component") do |component|
             component.assert_selector(
               "textarea" \
-              "[name='content_block/edition[details][video_relay_service][prefix]']",
+              "[name='content_block/edition[details][telephones][video_relay_service][prefix]']",
               text: "**Default** prefix: 18000 then",
             )
           end
@@ -158,7 +177,7 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::VideoRelayServi
           assert_selector(".app-c-content-block-manager-video-relay-service-component") do |component|
             component.assert_selector(
               "input" \
-              "[name='content_block/edition[details][video_relay_service][telephone_number]']" \
+              "[name='content_block/edition[details][telephones][video_relay_service][telephone_number]']" \
               "[value='1234 987 6543']",
             )
           end
@@ -180,7 +199,7 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::VideoRelayServi
           assert_selector(".app-c-content-block-manager-video-relay-service-component") do |component|
             component.assert_selector(
               "input" \
-              "[name='content_block/edition[details][video_relay_service][telephone_number]']" \
+              "[name='content_block/edition[details][telephones][video_relay_service][telephone_number]']" \
               "[value='0800 123 4567']",
             )
           end
@@ -191,8 +210,8 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::VideoRelayServi
 
   describe "when errors are present" do
     before do
-      content_block_edition.errors.add(:details_video_relay_service_prefix, "Prefix error")
-      content_block_edition.errors.add(:details_video_relay_service_telephone_number, "Telephone error")
+      content_block_edition.errors.add(:details_telephones_video_relay_service_prefix, "Prefix error")
+      content_block_edition.errors.add(:details_telephones_video_relay_service_telephone_number, "Telephone error")
     end
 
     it "should show errors" do


### PR DESCRIPTION
See Jira [CM-285](https://gov-uk.atlassian.net/browse/CM-285)

In this PR we extract 2 `govspeak_enabled` textareas from 2 of the "Contact" content-block's nested `telephones` items to a new `GovspeakEnabledTextAreaComponent`. This component:

- introduces a 'Govspeak supported' indicator. If the field in question is declared to be  `govspeak_enabled`
in the subschema we add a [label hint element][] to the textarea's `label` element.

- will (in a future PR) add the facility to "Preview" govspeak content as rendered HTML

### Screenshot

<img width="1129" height="902" alt="govspeak_supported_textareas_hint" src="https://github.com/user-attachments/assets/dd759d3f-296b-4559-ac83-c3de0ec9d82f" />



### A note on aria-describedby
The GOV.UK Design System requires that a "hint" element has
an `id` whose value matches that of the `aria-describedby`
attribute of the input to which it relates e.g. as per
[their example][]:

```html
<div class="govuk-form-group">
  <h1 class="govuk-label-wrapper">
    <label
      class="govuk-label govuk-label--l"
      for="event-name"
      >
      What is the name of the event?
    </label>
  </h1>
  <div
    id="event-name-hint"
    class="govuk-hint"
    >
    The name you’ll use on promotional material
  </div>
  <input
    class="govuk-input"
    id="event-name"
    name="eventName"
    type="text"
    aria-describedby="event-name-hint"
    >
</div>
```

They write that:

> Hint text must:
>
> - be associated with an input. The `hint_id` must match the
> `aria-describedby` property on the input your label is associated
> with.
>
> If hint text is within a label it will be announced in its
> entirety by screen readers. By putting the hint alongside labels
> and associating hints with inputs using `aria-describedby`,
> then screen readers will read the label, describe the type of
> input (eg radio) and then read additional text. It means users
> of screen readers can scan and skip options as easy as people
> making choices with sight. [A discussion of this approach](https://github.com/alphagov/govuk_elements/issues/574)

[label hint element]:
https://components.publishing.service.gov.uk/component-guide/label#with_hint

[their example]:
https://design-system.service.gov.uk/components/text-input/input-hint-text/


[CM-285]: https://gov-uk.atlassian.net/browse/CM-285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ