### PR TITLE
Stop 'invalid' organisations from blocking edits to publications (WHIT-2396)

### DIFF
--- a/app/models/concerns/edition/organisations.rb
+++ b/app/models/concerns/edition/organisations.rb
@@ -90,6 +90,25 @@ module Edition::Organisations
     true
   end
 
+  # Rails automatically defines methods called
+  # `validate_associated_records_for_<association>` for any association that is
+  # autosaved or validated. These methods run validations on each associated
+  # EditionOrganisation and Organisation, which causes an otherwise-valid edition
+  # to become invalid if any linked organisation is invalid (for example, because
+  # of an overlong custom_jobs_url). We don’t want an invalid organisation to
+  # block publication of an edition, so we override these methods to no-op.
+  #
+  # Presence and uniqueness of associated organisations are already enforced
+  # by our own custom validators, so skipping these auto-generated validations
+  # has no negative side-effects.
+  def validate_associated_records_for_edition_organisations
+    # no-op: prevent associated EditionOrganisation validations from running
+  end
+
+  def validate_associated_records_for_organisations
+    # no-op: prevent associated Organisation validations from running
+  end
+
 private
 
   def at_least_one_lead_organisation


### PR DESCRIPTION
If an organisation is invalid (e.g. has a custom_jobs_url that is longer than 255 characters, which is one of our current restrictions) then `organisation.valid?` is `false`. This is good and expected.

If a publisher tries to edit a document where one of its associated organisations is the 'bad' organisation, the sidebar will have the contents "Edition is invalid" => "Organisations is invalid". Edits of the edition are possible, but publishing is blocked.

This is an overstep of the organisation validation. The organisation is already live and the edition's relation to it is, frankly, minimal. Publishers should not be prevented from editing their documents just because the object at the end of a bit of metadata isn't quite perfect.

We therefore need to stop the organisation validation logic from being called when evaluating `edition.valid?(:publish)`. A very puzzling thing is that, calling `Edition.find(<id>).valid?(:publish)` of a known problematic edition in the rails console would return `true` rather than `false`. Digging into the issue further locally, we were able to determine that that same edition returns `false` on `.valid?(:publish)` after the following bit of code is evaluated in `admin/editions/show/_main.html.erb`:

```
@edition.organisations.map { |o| o.name }) }
```

That map { |o| o.name } forces ActiveRecord to load each Organisation and call the name accessors. Because Organisation uses globalize translations (translates :name, :logo_formatted_name, :acronym), a missing translation will be lazily built on the fly when name is read. The freshly built translation is unsaved, so the associated Organisation becomes "dirty".

The fundamental issue is that Rails automatically defines methods named `validate_associated_records_for_<association>` whenever an association is set to autosave or validate its children. For Edition this happens for both the edition_organisations and organisations associations. Those methods run validations on each associated record, so as soon as you read a translated attribute on an Organisation (which builds an unsaved translation), Rails will attempt to validate the organisation when you later call `edition.valid?(:publish)`. If any organisation is invalid, the entire edition becomes invalid.

The simplest way to stop an invalid organisation from blocking publication is to override those auto-generated validation methods to no-ops. This prevents Rails from running validations on the associated organisations or edition_organisations when validating the edition.

JIRA: https://gov-uk.atlassian.net/browse/WHIT-2396

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
