### PR TITLE
(CM-293) Set default values globally

### DIFF
--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/base_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/base_component.rb
@@ -7,7 +7,7 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::BaseComponent <
   def initialize(content_block_edition:, field:, value: nil, subschema: nil, **_args)
     @content_block_edition = content_block_edition
     @field = field
-    @value = value
+    @value = value || field.default_value
     @subschema = subschema
   end
 

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/bsl_guidance_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/bsl_guidance_component.html.erb
@@ -3,7 +3,7 @@
     <%= render(
       ContentBlockManager::ContentBlockEdition::Details::Fields::GovspeakEnabledTextareaComponent.new(
         content_block_edition: content_block_edition,
-        value: value,
+        value: value_for_field(value_field),
         nested_object_key: field.name,
         field: value_field,
         subschema: subschema,

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/govspeak_enabled_textarea_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/govspeak_enabled_textarea_component.html.erb
@@ -3,7 +3,7 @@
               label: { text: label, hint_text: hint_text, hint_id: aria_described_by },
               name: name_attribute,
               id: id_attribute,
-              value: value_or_default,
+              value:,
               error_items: error_items,
               describedby: aria_described_by,
   }) %>

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/govspeak_enabled_textarea_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/govspeak_enabled_textarea_component.rb
@@ -44,20 +44,10 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::GovspeakEnabled
     "content_block/edition[details][#{subschema_block_type}][#{nested_object_key}][#{field.name}]"
   end
 
-  def value_or_default
-    value_for_field(field) || field.default_value
-  end
-
   def error_items
     errors_for(
       content_block_edition.errors,
       "details_#{subschema_block_type}_#{nested_object_key}_#{field.name}".to_sym,
     )
-  end
-
-private
-
-  def value_for_field(field)
-    value&.fetch(field.name, nil)
   end
 end

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/object_component.rb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/object_component.rb
@@ -14,6 +14,6 @@ private
   end
 
   def value_for_field(field)
-    value&.fetch(field.name, nil)
+    value&.fetch(field.name, nil) || field.default_value
   end
 end

--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/video_relay_service_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/video_relay_service_component.html.erb
@@ -4,7 +4,7 @@
     <%= render(
       ContentBlockManager::ContentBlockEdition::Details::Fields::GovspeakEnabledTextareaComponent.new(
         content_block_edition: content_block_edition,
-        value: value,
+        value: value_for_field(prefix) ,
         nested_object_key: field.name,
         field: prefix,
         subschema: subschema,

--- a/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/array_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/array_component_test.rb
@@ -4,7 +4,8 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::ArrayComponentT
   extend Minitest::Spec::DSL
 
   let(:content_block_edition) { build(:content_block_edition, :pension) }
-  let(:field) { stub("field", name: "items", array_items:, is_required?: true) }
+  let(:default_value) { nil }
+  let(:field) { stub("field", name: "items", array_items:, is_required?: true, default_value:) }
   let(:array_items) { { "type" => "string" } }
   let(:field_value) { nil }
   let(:object_title) { nil }
@@ -70,6 +71,31 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::ArrayComponentT
 
       assert_selector ".js-add-another__fieldset", text: /Item 2/ do |fieldset|
         fieldset.assert_selector "input[type='checkbox'][name='content_block/edition[details][items][][_destroy]']"
+      end
+    end
+  end
+
+  describe "when a default value is present" do
+    let(:default_value) { %w[foo bar] }
+
+    it "renders a fieldset for each item and a template" do
+      render_inline component
+
+      assert_selector ".gem-c-add-another" do |component|
+        component.assert_selector ".js-add-another__fieldset", count: 2
+        component.assert_selector ".js-add-another__empty", count: 1
+
+        component.assert_selector ".js-add-another__fieldset", text: /Item 1/ do |fieldset|
+          expect_form_fields(fieldset, 0, "foo", 2)
+        end
+
+        component.assert_selector ".js-add-another__fieldset", text: /Item 2/ do |fieldset|
+          expect_form_fields(fieldset, 1, "bar", 2)
+        end
+
+        component.assert_selector ".js-add-another__empty", text: /Item 3/ do |fieldset|
+          expect_form_fields(fieldset, 2)
+        end
       end
     end
   end

--- a/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/boolean_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/boolean_component_test.rb
@@ -4,41 +4,49 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::BooleanComponen
   extend Minitest::Spec::DSL
 
   let(:content_block_edition) { build(:content_block_edition, :pension) }
-  let(:field) { stub("field", name: "email_address", is_required?: true) }
+  let(:default_value) { nil }
+  let(:field) { stub("field", name: "email_address", is_required?: true, default_value:) }
 
-  it "should not check the checkbox if no value given" do
+  before do
     render_inline(
       ContentBlockManager::ContentBlockEdition::Details::Fields::BooleanComponent.new(
         content_block_edition:,
         field:,
+        value: field_value,
       ),
     )
-
-    assert_selector "input[type=\"checkbox\"][value=\"true\"]"
-    assert_no_selector "input[type=\"checkbox\"][value=\"true\"][checked=\"checked\"]"
   end
 
-  it "should check checkbox if value given is 'true'" do
-    render_inline(
-      ContentBlockManager::ContentBlockEdition::Details::Fields::BooleanComponent.new(
-        content_block_edition:,
-        field:,
-        value: "true",
-      ),
-    )
+  describe "when no value is given" do
+    let(:field_value) { nil }
 
-    assert_selector "input[type=\"checkbox\"][value=\"true\"][checked=\"checked\"]"
+    it "should not check the checkbox" do
+      assert_selector "input[type=\"checkbox\"][value=\"true\"]"
+      assert_no_selector "input[type=\"checkbox\"][value=\"true\"][checked=\"checked\"]"
+    end
+
+    describe "when the default value is true" do
+      let(:default_value) { "true" }
+
+      it "should check the checkbox" do
+        assert_selector "input[type=\"checkbox\"][value=\"true\"][checked=\"checked\"]"
+      end
+    end
   end
 
-  it "should not check the checkbox if value given is 'false'" do
-    render_inline(
-      ContentBlockManager::ContentBlockEdition::Details::Fields::BooleanComponent.new(
-        content_block_edition:,
-        field:,
-        value: "false",
-      ),
-    )
+  describe "when the value given is 'true'" do
+    let(:field_value) { "true" }
 
-    assert_no_selector "input[type=\"checkbox\"][value=\"true\"][checked=\"checked\"]"
+    it "should check the checkbox" do
+      assert_selector "input[type=\"checkbox\"][value=\"true\"][checked=\"checked\"]"
+    end
+  end
+
+  describe "when the value given is 'false'" do
+    let(:field_value) { "false" }
+
+    it "should check the checkbox" do
+      assert_no_selector "input[type=\"checkbox\"][value=\"true\"][checked=\"checked\"]"
+    end
   end
 end

--- a/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/bsl_guidance_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/bsl_guidance_component_test.rb
@@ -97,6 +97,21 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::BSLGuidanceComp
           end
         end
       end
+
+      context "when the 'show' value is nil" do
+        let(:field_value) do
+          { "value" => nil,
+            "show" => nil }
+        end
+
+        it "sets the checkbox to _unchecked_" do
+          render_inline(component)
+
+          assert_selector(".app-c-content-block-manager-bsl-guidance-component") do |component|
+            component.assert_no_selector("input[checked='checked']")
+          end
+        end
+      end
     end
 
     describe "'value' nested field" do

--- a/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/country_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/country_component_test.rb
@@ -4,7 +4,7 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::CountryComponen
   extend Minitest::Spec::DSL
 
   let(:content_block_edition) { build(:content_block_edition, :pension) }
-  let(:field) { stub("field", name: "country", is_required?: true) }
+  let(:field) { stub("field", name: "country", is_required?: true, default_value: nil) }
 
   let(:world_locations) { 5.times.map { |i| build(:world_location, name: "World location #{i}") } }
   let(:uk) { build(:world_location, name: "United Kingdom") }

--- a/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/enum_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/enum_component_test.rb
@@ -4,7 +4,7 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::EnumComponentTe
   extend Minitest::Spec::DSL
 
   let(:content_block_edition) { build(:content_block_edition, :pension) }
-  let(:field) { stub("field", name: "something", is_required?: true) }
+  let(:field) { stub("field", name: "something", is_required?: true, default_value: nil) }
 
   describe "when there is no default value" do
     it "should render a select field with given parameters" do

--- a/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/govspeak_enabled_textarea_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/govspeak_enabled_textarea_component_test.rb
@@ -44,11 +44,7 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::GovspeakEnabled
     )
   end
 
-  let(:field_value) do
-    {
-      "prefix" => nil,
-    }
-  end
+  let(:field_value) { nil }
 
   let(:component) do
     ContentBlockManager::ContentBlockEdition::Details::Fields::GovspeakEnabledTextareaComponent.new(
@@ -94,9 +90,7 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::GovspeakEnabled
 
     describe "default value" do
       context "when there is NO value set for the textarea" do
-        let(:field_value) do
-          { "prefix" => nil }
-        end
+        let(:field_value) { nil }
 
         it "supplies the default value defined in the schema" do
           render_inline component
@@ -108,9 +102,7 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::GovspeakEnabled
       end
 
       context "when there IS a value set for the textarea" do
-        let(:field_value) do
-          { "prefix" => "Field value *set*" }
-        end
+        let(:field_value) {  "Field value *set*" }
 
         it "displays that value" do
           render_inline component

--- a/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/object_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/object_component_test.rb
@@ -6,13 +6,13 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::ObjectComponent
   let(:content_block_edition) { build(:content_block_edition, :pension) }
   let(:nested_fields) do
     [
-      stub("field", name: "label", enum_values: nil),
-      stub("field", name: "type", enum_values: %w[enum_1 enum_2 enum_3]),
-      stub("field", name: "email_address", enum_values: nil),
+      stub("field", name: "label", enum_values: nil, default_value: nil),
+      stub("field", name: "type", enum_values: %w[enum_1 enum_2 enum_3], default_value: nil),
+      stub("field", name: "email_address", enum_values: nil, default_value: nil),
     ]
   end
   let(:schema) { stub("schema", id: "root") }
-  let(:field) { stub("field", name: "nested", nested_fields:, schema:, is_required?: true) }
+  let(:field) { stub("field", name: "nested", nested_fields:, schema:, is_required?: true, default_value: nil) }
 
   let(:label_stub) { stub("string_component") }
   let(:type_stub) { stub("enum_component") }
@@ -60,6 +60,24 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::ObjectComponent
       render_inline(component)
 
       assert_selector "input[name=\"content_block/edition[details][nested][label]\"][value=\"something\"]"
+    end
+  end
+
+  describe "when default values are present for the object" do
+    let(:nested_fields) do
+      [
+        stub("field", name: "label", enum_values: nil, default_value: "LABEL DEFAULT"),
+        stub("field", name: "type", enum_values: %w[enum_1 enum_2 enum_3], default_value: "TYPE DEFAULT"),
+        stub("field", name: "email_address", enum_values: nil, default_value: "EMAIL DEFAULT"),
+      ]
+    end
+
+    it "renders the field with the default values" do
+      render_inline(component)
+
+      assert_selector "input[name=\"content_block/edition[details][nested][label]\"][value=\"LABEL DEFAULT\"]"
+      assert_selector "input[name=\"content_block/edition[details][nested][type]\"][value=\"TYPE DEFAULT\"]"
+      assert_selector "input[name=\"content_block/edition[details][nested][email_address]\"][value=\"EMAIL DEFAULT\"]"
     end
   end
 

--- a/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/string_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/string_component_test.rb
@@ -4,7 +4,7 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::StringComponent
   extend Minitest::Spec::DSL
 
   let(:content_block_edition) { build(:content_block_edition, :pension) }
-  let(:field) { stub("field", name: "email_address", is_required?: true) }
+  let(:field) { stub("field", name: "email_address", is_required?: true, default_value: nil) }
 
   it "should render an input field with default parameters" do
     render_inline(
@@ -22,7 +22,7 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::StringComponent
   end
 
   it "should show optional label when field is optional" do
-    optional_field = stub("field", name: "email_address", is_required?: false)
+    optional_field = stub("field", name: "email_address", is_required?: false, default_value: nil)
 
     render_inline(
       ContentBlockManager::ContentBlockEdition::Details::Fields::StringComponent.new(


### PR DESCRIPTION
This simplifies the way we handle default values, so the way they are handled when set in the schema is more predictable.