### PR TITLE
CM-286: Provide preview on govpress enabled textarea component

### DIFF
--- a/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/govspeak_enabled_textarea_component.html.erb
+++ b/lib/engines/content_block_manager/app/components/content_block_manager/content_block_edition/details/fields/govspeak_enabled_textarea_component.html.erb
@@ -1,10 +1,21 @@
 <div class="app-c-content-block-manager-govspeak-enabled-textarea-component">
-  <%= render("govuk_publishing_components/components/textarea", {
-              label: { text: label, hint_text: hint_text, hint_id: aria_described_by },
-              name: name_attribute,
-              id: id_attribute,
-              value:,
-              error_items: error_items,
-              describedby: aria_described_by,
-  }) %>
+  <% if govspeak_enabled? %>
+    <%= render "components/govspeak_editor", {
+                name: name_attribute,
+                id: id_attribute,
+                label: { text: label, hint_text: hint_text, hint_id: aria_described_by },
+                value:,
+                error_items: error_items,
+                hint_id: aria_described_by,
+                rows: 5,
+    } %>
+  <% else %>
+    <%= render "govuk_publishing_components/components/textarea", {
+                label: { text: label },
+                name: name_attribute,
+                id: id_attribute,
+                value:,
+                error_items: error_items,
+    } %>
+  <% end %>
 </div>

--- a/lib/engines/content_block_manager/features/create_contact_object.feature
+++ b/lib/engines/content_block_manager/features/create_contact_object.feature
@@ -96,7 +96,8 @@ Feature: Create a contact object
               "type": "string",
               "default": "0800 123 4567"
             }
-          }
+          },
+          "x-govspeak_enabled": ["prefix"]
         },
         "call_charges": {
           "type": "object",

--- a/lib/engines/content_block_manager/features/step_definitions/video_relay_service_steps.rb
+++ b/lib/engines/content_block_manager/features/step_definitions/video_relay_service_steps.rb
@@ -5,6 +5,7 @@ end
 Given("I provide custom video relay service info where available") do
   within(".app-c-content-block-manager-video-relay-service-component") do
     fill_in(label_for("prefix"), with: "**Custom** prefix: 12345 then")
+    should_be_able_to_preview_the_govspeak_enabled_field
     fill_in(label_for("telephone_number"), with: "01777 123 1234")
   end
 end
@@ -25,4 +26,14 @@ end
 
 def label_for(field_name)
   I18n.t("content_block_edition.details.labels.telephones.video_relay_service.#{field_name}")
+end
+
+def should_be_able_to_preview_the_govspeak_enabled_field
+  click_button("Preview")
+  preliminary_preview_text = page.find(".app-c-govspeak-editor__preview p").text
+
+  assert_equal(
+    "Generating preview, please wait.",
+    preliminary_preview_text,
+  )
 end

--- a/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/govspeak_enabled_textarea_component_test.rb
+++ b/lib/engines/content_block_manager/test/components/content_block/edition/details/fields/govspeak_enabled_textarea_component_test.rb
@@ -64,11 +64,11 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::GovspeakEnabled
   end
 
   describe "GovspeakEnabledTextareaComponent" do
-    it "wraps component in an element with an ID describing path to field" do
+    it "gives the textarea an ID describing path to field" do
       render_inline component
 
       assert_selector(COMPONENT_CLASS) do |component|
-        wraps_whole_textarea_in_element_with_id_describing_path_to_field(component)
+        gives_textarea_id_describing_path_to_field(component)
       end
     end
 
@@ -192,6 +192,39 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::GovspeakEnabled
               )
             end
           end
+
+          it "includes a 'Preview' button" do
+            render_inline component
+
+            assert_selector(COMPONENT_CLASS) do |component|
+              component.assert_selector(
+                "button.js-app-c-govspeak-editor__preview-button",
+                text: "Preview",
+              )
+            end
+          end
+
+          it "includes a 'Back to edit' button" do
+            render_inline component
+
+            assert_selector(COMPONENT_CLASS) do |component|
+              component.assert_selector(
+                "button.js-app-c-govspeak-editor__back-button",
+                text: "Back to edit",
+              )
+            end
+          end
+
+          it "includes a preview element to be replaced by the Govspeak which JS will render into HTML" do
+            render_inline component
+
+            assert_selector(COMPONENT_CLASS) do |component|
+              component.assert_selector(
+                ".app-c-govspeak-editor__preview.js-locale-switcher-custom p",
+                text: "Generating preview, please wait.",
+              )
+            end
+          end
         end
       end
 
@@ -211,16 +244,49 @@ class ContentBlockManager::ContentBlockEdition::Details::Fields::GovspeakEnabled
             displays_no_indication_that_govspeak_is_supported(component)
           end
         end
+
+        it "does NOT  include a 'Preview' button" do
+          render_inline component
+
+          assert_selector(COMPONENT_CLASS) do |component|
+            component.assert_no_selector(
+              "button.js-app-c-govspeak-editor__preview-button",
+              text: "Preview",
+            )
+          end
+        end
+
+        it "does NOT include 'Back to edit' button" do
+          render_inline component
+
+          assert_selector(COMPONENT_CLASS) do |component|
+            component.assert_no_selector(
+              "button.js-app-c-govspeak-editor__back-button",
+              text: "Back to edit",
+            )
+          end
+        end
+
+        it "does NOT include a preview element to be replaced by the rendered Govspeak" do
+          render_inline component
+
+          assert_selector(COMPONENT_CLASS) do |component|
+            component.assert_no_selector(
+              ".app-c-govspeak-editor__preview.js-locale-switcher-custom p",
+              text: "Generating preview, please wait.",
+            )
+          end
+        end
       end
     end
   end
 
-  def wraps_whole_textarea_in_element_with_id_describing_path_to_field(component)
-    expected_component_id =
+  def gives_textarea_id_describing_path_to_field(component)
+    expected_id =
       "content_block_manager_content_block_edition_details_telephones_video_relay_service_prefix"
 
     component.assert_selector(
-      "div[id='#{expected_component_id}']",
+      "textarea[id='#{expected_id}']",
     )
   end
 


### PR DESCRIPTION
See Jira [CM-286](https://gov-uk.atlassian.net/browse/CM-286)

## Use the govspeak-editor to provide HTML previews on govspeak enabled textareas

In the case of fields which are `govspeak-enabled` we use
the existing `component/govspeak-editor` which has all the
functionality we require for toggling between Govspeak
markup and a 'Preview' rendered into HTML.

In the case of textareas which aren't govspeak-enabled, we
use our regular textarea component:

`govuk_publishing_components/components/textarea`



<img width="1108" height="897" alt="toggle_preview_govspeak" src="https://github.com/user-attachments/assets/6eea5b69-cc5a-4ad7-a0cd-203462456fd0" />


[CM-286]: https://gov-uk.atlassian.net/browse/CM-286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ