### PR TITLE
Add a way to restrict usage of a flexible page type to users of specific organisations [WHIT-2377]

### DIFF
--- a/app/controllers/admin/flexible_pages_controller.rb
+++ b/app/controllers/admin/flexible_pages_controller.rb
@@ -2,7 +2,9 @@
 class Admin::FlexiblePagesController < Admin::EditionsController
   before_action :prevent_access_when_disabled
   before_action :create_content_block_context
-  def choose_type; end
+  def choose_type
+    @permitted_flexible_page_types = FlexiblePageType.all.select { |type| can?(current_user, type) }
+  end
 
 private
 

--- a/app/models/flexible_page_types/history_page.json
+++ b/app/models/flexible_page_types/history_page.json
@@ -45,6 +45,7 @@
     "publishing_api_schema_name": "history",
     "publishing_api_document_type": "history",
     "rendering_app": "government-frontend",
-    "images_enabled": true
+    "images_enabled": true,
+    "organisations": ["af07d5a5-df63-4ddc-9383-6a666845ebe9"]
   }
 }

--- a/app/views/admin/flexible_pages/choose_type.html.erb
+++ b/app/views/admin/flexible_pages/choose_type.html.erb
@@ -8,7 +8,7 @@
         heading_level: 1,
         name: "flexible_page_type",
         id: "flexible_page_type",
-        items: FlexiblePageType.all.map { |type| { text: type.label, value: type.key }},
+        items: @permitted_flexible_page_types.map { |type| { text: type.label, value: type.key }},
       } %>
       <div class="govuk-button-group">
         <%= render "govuk_publishing_components/components/button", { text: "Next" } %>

--- a/docs/flexible_pages.md
+++ b/docs/flexible_pages.md
@@ -10,17 +10,18 @@ The JSON for each type has these top level keys:
 
 - 'key': The unique identifier for the flexible page type. This is what will be stored in the edition's `flexible_page_type` column.
 - 'schema': The schema for the flexible page type, defined as [JSON schema](https://json-schema.org/docs). Each schema must have a root schema of the type "object".
-- 'settings': The settings for the flexible page type. All settings are required.
+- 'settings': The settings for the flexible page type.
 
-These are the settings available for flexible page types:
+These are the settings available for flexible page types. All settings are required.
 
-| Key                          | Description                                                                                                                                            |
-|------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
-| base_path_prefix             | The prefix for the base path at which the flexible page will be published. E.g. /government/history for the page /government/history/10-downing-street | 
-| publishing_api_schema_name   | The Publishing API schema name for flexible pages of this type                                                                                         |
-| publishing_api_document_type | The Publishing API document type for flexible pages of this type                                                                                       |
-| rendering_app                | The rendering app for the flexible page type                                                                                                           |
-| images_enabled               | Whether or not users should be able to upload images for this flexible page type using the images tab on the edition form                              |
+| Key                      | Description                                                                                                                                                                          |
+|--------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| base_path_prefix         | The prefix for the base path at which the flexible page will be published. E.g. /government/history for the page /government/history/10-downing-street                               |
+| publishing_api_schema_name | The Publishing API schema name for flexible pages of this type                                                                                                                       |
+| publishing_api_document_type | The Publishing API document type for flexible pages of this type                                                                                                                     |
+| rendering_app            | The redering app for the flexible page type                                                                                                                                         |
+| images_enabled           | Whether or not users should be able to upload images for this flexible page type using the images tab on the edition form                                                            |
+| organisations            | An array of organisation content IDs. Only users from one of the listed organisations will be able to use the flexible page type. Use "null" to allow all users to use the page type |
 
 The types are loaded from the JSON files on the first call to the `types` method on the [flexible page type model](../app/models/flexible_page_type.rb) and cached in memory. The model provides an ergonomic way to read values from a configuration file.
 

--- a/features/fixtures/test_flexible_page_type.json
+++ b/features/fixtures/test_flexible_page_type.json
@@ -44,6 +44,7 @@
     "base_path_prefix": "/government/test-type",
     "publishing_api_schema_name": "test_type",
     "publishing_api_document_type": "test_type",
-    "rendering_app": "government-frontend"
+    "rendering_app": "government-frontend",
+    "organisations": null
   }
 }

--- a/lib/whitehall/authority/enforcer.rb
+++ b/lib/whitehall/authority/enforcer.rb
@@ -43,6 +43,8 @@ module Whitehall::Authority
     "Edition" => Rules::EditionRules,
     "FatalityNotice" => Rules::FatalityNoticeRules,
     "LandingPage" => Rules::LandingPageRules,
+    "FlexiblePage" => Rules::FlexiblePageRules,
+    "FlexiblePageType" => Rules::FlexiblePageTypeRules,
     "MinisterialRole" => Rules::MinisterialRoleRules,
     "Person" => Rules::PersonRules,
     "PolicyGroup" => Rules::PolicyGroupRules,

--- a/lib/whitehall/authority/rules/flexible_page_rules.rb
+++ b/lib/whitehall/authority/rules/flexible_page_rules.rb
@@ -1,0 +1,10 @@
+module Whitehall::Authority::Rules
+  class FlexiblePageRules < Whitehall::Authority::Rules::EditionRules
+  protected
+
+    def can_with_an_instance?(action)
+      permitted_organisations = subject.type_instance.settings["organisations"]
+      super && (permitted_organisations.nil? || permitted_organisations.include?(actor.organisation.content_id))
+    end
+  end
+end

--- a/lib/whitehall/authority/rules/flexible_page_type_rules.rb
+++ b/lib/whitehall/authority/rules/flexible_page_type_rules.rb
@@ -1,0 +1,17 @@
+module Whitehall::Authority::Rules
+  class FlexiblePageTypeRules
+    def initialize(actor, subject)
+      @actor = actor
+      @subject = subject
+    end
+
+    def can?(_action)
+      permitted_organisations = subject.settings["organisations"]
+      permitted_organisations.nil? || permitted_organisations.include?(actor.organisation.content_id)
+    end
+
+  private
+
+    attr_reader :actor, :subject
+  end
+end

--- a/test/unit/lib/whitehall/authority/flexible_page_rules_test.rb
+++ b/test/unit/lib/whitehall/authority/flexible_page_rules_test.rb
@@ -1,0 +1,82 @@
+require "test_helper"
+
+class FlexiblePageRulesTest < ActiveSupport::TestCase
+  setup do
+    @organisation = create(:organisation)
+    @type_key = "test_type"
+    @no_organisations_type_key = "test_type_without_orgs"
+    test_types = {
+      "test_type" => {
+        "key" => @type_key,
+        "schema" => {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "$id": "https://www.gov.uk/schemas/test_type/v1",
+          "title": "Test type",
+          "type": "object",
+          "properties" => {
+            "test_attribute" => {
+              "title" => "Test attribute",
+              "type" => "string",
+            },
+          },
+        },
+        "settings" => {
+          "organisations" => [@organisation.content_id],
+        },
+      },
+      "test_type_without_orgs" => {
+        "key" => @no_organisations_type_key,
+        "schema" => {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "$id": "https://www.gov.uk/schemas/test_type/v1",
+          "title": "Test type without orgs",
+          "type": "object",
+          "properties" => {
+            "test_attribute" => {
+              "title" => "Test attribute",
+              "type" => "string",
+            },
+          },
+        },
+        "settings" => {
+          "organisations" => nil,
+        },
+      },
+    }
+    FlexiblePageType.setup_test_types(test_types)
+  end
+
+  test "user can see a flexible page if the flexible page type is managed by their organisation" do
+    user = User.new(organisation: @organisation)
+    page = FlexiblePage.new(flexible_page_type: @type_key)
+    assert Whitehall::Authority::Enforcer.new(user, page).can?(:see)
+  end
+
+  test "user can not see a flexible page if the flexible page type is not managed by their organisation" do
+    user = User.new(organisation: create(:organisation))
+    page = FlexiblePage.new(flexible_page_type: @type_key)
+    assert_not Whitehall::Authority::Enforcer.new(user, page).can?(:see)
+  end
+
+  test "normal edition rules are applied for actions requiring higher privileges" do
+    user = User.new(organisation: @organisation)
+    page = FlexiblePage.new(flexible_page_type: @type_key)
+    assert_not Whitehall::Authority::Enforcer.new(user, page).can?(:force_publish)
+  end
+
+  test "normal edition rules are applied when the flexible page type is not limited to specific organisations" do
+    user = User.new(organisation: create(:organisation))
+    page = FlexiblePage.new(flexible_page_type: @no_organisations_type_key)
+    assert Whitehall::Authority::Enforcer.new(user, page).can?(:see)
+  end
+
+  test "cannot do anything to a flexible page if they do not belong to a permitted organisation" do
+    user = User.new(organisation: create(:organisation))
+    page = FlexiblePage.new(flexible_page_type: @type_key)
+    enforcer = Whitehall::Authority::Enforcer.new(user, page)
+
+    Whitehall::Authority::Rules::EditionRules.actions.each do |action|
+      assert_not enforcer.can?(action)
+    end
+  end
+end

--- a/test/unit/lib/whitehall/authority/flexible_page_type_rules_test.rb
+++ b/test/unit/lib/whitehall/authority/flexible_page_type_rules_test.rb
@@ -1,0 +1,61 @@
+require "test_helper"
+
+class FlexiblePageTypeRulesTest < ActiveSupport::TestCase
+  setup do
+    @organisation = create(:organisation)
+    @type_key = "test_type"
+    @no_organisations_type_key = "test_type_without_orgs"
+    test_types = {
+      "test_type" => {
+        "key" => @type_key,
+        "schema" => {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "$id": "https://www.gov.uk/schemas/test_type/v1",
+          "title": "Test type",
+          "type": "object",
+          "properties" => {
+            "test_attribute" => {
+              "title" => "Test attribute",
+              "type" => "string",
+            },
+          },
+        },
+        "settings" => {
+          "organisations" => [@organisation.content_id],
+        },
+      },
+      "test_type_without_orgs" => {
+        "key" => @no_organisations_type_key,
+        "schema" => {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "$id": "https://www.gov.uk/schemas/test_type/v1",
+          "title": "Test type without orgs",
+          "type": "object",
+          "properties" => {
+            "test_attribute" => {
+              "title" => "Test attribute",
+              "type" => "string",
+            },
+          },
+        },
+        "settings" => {
+          "organisations" => nil,
+        },
+      },
+    }
+    FlexiblePageType.setup_test_types(test_types)
+  end
+
+  test "user can create a flexible page if the flexible page type is managed by their organisation" do
+    user = User.new(organisation_slug: @organisation.slug)
+    type = FlexiblePageType.find(@type_key)
+    assert Whitehall::Authority::Enforcer.new(user, type).can?(:create)
+  end
+
+  test "user can not create a flexible page if the flexible page type is not managed by their organisation" do
+    other_organisation = create(:organisation)
+    user = User.new(organisation_slug: other_organisation.slug)
+    type = FlexiblePageType.find(@type_key)
+    assert_not Whitehall::Authority::Enforcer.new(user, type).can?(:create)
+  end
+end


### PR DESCRIPTION
We use the content ID to identify the organisation, on the basis that Whitehall organisation IDs are not well known, and the organisation slug is more likely to change than the content ID.

The organisations setting is optional. If the setting is omitted from the type config, it is assumed that all users can use the page type. This seemed more intuitive than making the settings required and using an empty array to indicate that the page type is not restricted by organisation.
