### PR TITLE
Bump `content_block_tools` from `1.1.2` to `1.2.0`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,7 +137,7 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
-    content_block_tools (1.1.2)
+    content_block_tools (1.2.0)
       actionview (>= 6)
       govspeak (= 10.6.1)
       rails


### PR DESCRIPTION
Having to do this manually, as there are too many Dependabot PRs open