### PR TITLE
Allow embedding of inline images in Govspeak blocks

### DIFF
--- a/app/models/flexible_page_content_blocks/govspeak.rb
+++ b/app/models/flexible_page_content_blocks/govspeak.rb
@@ -17,7 +17,7 @@ module FlexiblePageContentBlocks
 
     def publishing_api_payload(content)
       {
-        html: Whitehall::GovspeakRenderer.new.govspeak_to_html(content),
+        html: Whitehall::GovspeakRenderer.new.govspeak_to_html(content, images: Context.page.images),
         **extract_headings(content),
       }
     end

--- a/test/unit/app/models/flexible_page_content_blocks/default_object_test.rb
+++ b/test/unit/app/models/flexible_page_content_blocks/default_object_test.rb
@@ -24,6 +24,8 @@ class FlexiblePageContentBlocks::DefaultObjectTest < ActiveSupport::TestCase
         "test_string" => "bar",
       },
     }
+    page = FlexiblePage.new
+    FlexiblePageContentBlocks::Context.create_for_page(page)
     payload = FlexiblePageContentBlocks::DefaultObject.new.publishing_api_payload(schema, content)
     assert_equal(Whitehall::GovspeakRenderer.new.govspeak_to_html(content["test_attribute"]), payload[:test_attribute][:html])
     assert_equal(content["test_object_attribute"]["test_string"], payload[:test_object_attribute][:test_string])

--- a/test/unit/app/models/flexible_page_content_blocks/govspeak_test.rb
+++ b/test/unit/app/models/flexible_page_content_blocks/govspeak_test.rb
@@ -17,11 +17,13 @@ class FlexiblePageContentBlocks::GovspeakTest < ActiveSupport::TestCase
       "test_attribute" => govspeak,
     }
     page = FlexiblePage.new
+    page.images = [create(:image)]
     page.flexible_page_content = content
+    FlexiblePageContentBlocks::Context.create_for_page(page)
     govspeak_renderer = mock("Whitehall::GovspeakRenderer")
     govspeak_renderer
       .expects(:govspeak_to_html)
-      .with(govspeak)
+      .with(govspeak, images: page.images)
       .returns(html)
     Whitehall::GovspeakRenderer.stub :new, govspeak_renderer do
       payload = FlexiblePageContentBlocks::Govspeak.new.publishing_api_payload(govspeak)
@@ -37,10 +39,11 @@ class FlexiblePageContentBlocks::GovspeakTest < ActiveSupport::TestCase
     }
     page = FlexiblePage.new
     page.flexible_page_content = content
+    FlexiblePageContentBlocks::Context.create_for_page(page)
     govspeak_renderer = mock("Whitehall::GovspeakRenderer")
     govspeak_renderer
       .expects(:govspeak_to_html)
-      .with(govspeak)
+      .with(govspeak, images: [])
       .returns(html)
     expected_headers = [
       {
@@ -64,10 +67,11 @@ class FlexiblePageContentBlocks::GovspeakTest < ActiveSupport::TestCase
     }
     page = FlexiblePage.new
     page.flexible_page_content = content
+    FlexiblePageContentBlocks::Context.create_for_page(page)
     govspeak_renderer = mock("Whitehall::GovspeakRenderer")
     govspeak_renderer
       .expects(:govspeak_to_html)
-      .with(govspeak)
+      .with(govspeak, images: [])
       .returns(html)
     Whitehall::GovspeakRenderer.stub :new, govspeak_renderer do
       payload = FlexiblePageContentBlocks::Govspeak.new.publishing_api_payload(govspeak)


### PR DESCRIPTION
History pages need to support images embedded in the body of the content. To make this possible, we need to pass the images to the govspeak renderer so that any inline image shortcodes can be converted to `<img>` tags. Luckily we have the page available in the flexible block context.
