### PR TITLE
Expand the 'matches_gov_uk' checks (WHIT-2401)

### DIFF
--- a/app/validators/gov_uk_url_format_validator.rb
+++ b/app/validators/gov_uk_url_format_validator.rb
@@ -19,7 +19,26 @@ class GovUkUrlFormatValidator < ActiveModel::EachValidator
   end
 
   def self.matches_gov_uk?(value)
-    %r{\A#{Whitehall.public_protocol}://#{Whitehall.public_host}/}.match?(value)
+    uri = URI.parse(value)
+    return false unless uri.is_a?(URI::HTTP) || uri.is_a?(URI::HTTPS)
+
+    host = uri.host&.downcase
+    return false if host.blank?
+
+    %w[
+      gov.uk
+      www.gov.uk
+      staging.publishing.service.gov.uk
+      www.staging.publishing.service.gov.uk
+      integration.publishing.service.gov.uk
+      www.integration.publishing.service.gov.uk
+      test.gov.uk
+      www.test.gov.uk
+      dev.gov.uk
+      www.dev.gov.uk
+    ].include?(host)
+  rescue URI::InvalidURIError
+    false
   end
 
 private

--- a/test/unit/app/validators/gov_uk_url_format_validator_test.rb
+++ b/test/unit/app/validators/gov_uk_url_format_validator_test.rb
@@ -1,0 +1,30 @@
+require "test_helper"
+
+class GovUkUrlFormatValidatorTest < ActiveSupport::TestCase
+  test "matches GOV.UK URLs" do
+    # Production
+    assert GovUkUrlFormatValidator.matches_gov_uk?("https://gov.uk")
+    assert GovUkUrlFormatValidator.matches_gov_uk?("http://gov.uk")
+    assert GovUkUrlFormatValidator.matches_gov_uk?("https://www.gov.uk")
+    assert GovUkUrlFormatValidator.matches_gov_uk?("http://www.gov.uk")
+    # Test environments
+    assert GovUkUrlFormatValidator.matches_gov_uk?("https://www.integration.publishing.service.gov.uk")
+    assert GovUkUrlFormatValidator.matches_gov_uk?("https://www.staging.publishing.service.gov.uk")
+    assert GovUkUrlFormatValidator.matches_gov_uk?("http://www.integration.publishing.service.gov.uk")
+    assert GovUkUrlFormatValidator.matches_gov_uk?("http://www.staging.publishing.service.gov.uk")
+    assert GovUkUrlFormatValidator.matches_gov_uk?("https://integration.publishing.service.gov.uk")
+    assert GovUkUrlFormatValidator.matches_gov_uk?("https://staging.publishing.service.gov.uk")
+    assert GovUkUrlFormatValidator.matches_gov_uk?("http://integration.publishing.service.gov.uk")
+    assert GovUkUrlFormatValidator.matches_gov_uk?("http://staging.publishing.service.gov.uk")
+    # Local environments
+    assert GovUkUrlFormatValidator.matches_gov_uk?("http://www.test.gov.uk")
+    assert GovUkUrlFormatValidator.matches_gov_uk?("http://www.dev.gov.uk")
+    assert GovUkUrlFormatValidator.matches_gov_uk?("http://test.gov.uk")
+    assert GovUkUrlFormatValidator.matches_gov_uk?("http://dev.gov.uk")
+  end
+
+  test "doesn't match other gov.uk subdomains" do
+    assert_not GovUkUrlFormatValidator.matches_gov_uk?("https://foo.gov.uk")
+    assert_not GovUkUrlFormatValidator.matches_gov_uk?("http://foo.gov.uk")
+  end
+end


### PR DESCRIPTION
We had a confusing issue when trying to reproduce a bug reported in WHIT-2371: unpublishing (with redirect) a document on Integration would appear to succeed in Whitehall, but would be rejected by Publishing API (422 error). The corresponding [Sentry error](https://govuk.sentry.io/issues/6340746667/events/50a708c091dc4c3ca5173610fed3ee19/?project=202259) stated:

> `{"error":{"code":422,"message":"Validation failed: Redirects internal redirect should not be specified with full url (https://www.gov.uk/government/collections/statistical-digest-of-rural-england)","fields":{}}}`

On closer inspection, this is what was happening:

- I was working on integration and trying to unpublish with redirect to a URL on `https://www.gov.uk`.
- This caused the [matches_gov_uk? method](https://github.com/alphagov/whitehall/blob/c1d093552a824feab9a0047750584245cd004b28/app/validators/gov_uk_url_format_validator.rb#L21-L23)   to return false, because it checks the inputted value (`www.gov.uk`) against the `Whitehall.public_host` (in this case, `www.integration.publishing.service.gov.uk`).
- Therefore at the point of sending the Unpublishing to Publishing API, [we were sending the full URL rather than just the path](https://github.com/alphagov/whitehall/blob/fc53422fd5e21e5e4a3a86c3f36b30fc832e52f5/app/models/unpublishing.rb#L77), and Publishing API then rejected the update as internal URLs should send paths only.
- I've now patched Whitehall to not 'silently fail' in such scenarios, in https://github.com/alphagov/whitehall/pull/10550.

I did consider changing the `Whitehall.public_host` call to just be a hardcoded `www.gov.uk`/`gov.uk` check, which would be a reasonable solution as it's less surprising for us to put in a `www.integration.publishing.service.gov.uk` redirect and have that fail, than it is for us to put a `www.gov.uk` redirect in and have that fail. But there may be times we want to test redirect flows on integration/staging, so probably best to just account for all environments (including the local dev/test ones).

JIRA: https://gov-uk.atlassian.net/browse/WHIT-2401

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
