### PR TITLE
Stop swallowing 422 responses from Publishing API (WHIT-2401)

### DIFF
--- a/app/sidekiq/publishing_api_gone_worker.rb
+++ b/app/sidekiq/publishing_api_gone_worker.rb
@@ -1,4 +1,7 @@
 class PublishingApiGoneWorker < PublishingApiWorker
+  # Retrying is unlikely to fix the problem - so disable retries.
+  sidekiq_options retry: 0
+
   def perform(content_id, alternative_path, explanation, locale, allow_draft = false)
     if explanation.present?
       rendered_explanation = Whitehall::GovspeakRenderer
@@ -19,8 +22,5 @@ class PublishingApiGoneWorker < PublishingApiWorker
   rescue GdsApi::HTTPNotFound
     # nothing to do here as we can't unpublish something that doesn't exist
     nil
-  rescue GdsApi::HTTPUnprocessableEntity => e
-    # retrying is unlikely to fix the problem, we can send the error straight to Sentry
-    GovukError.notify(e)
   end
 end

--- a/app/sidekiq/publishing_api_redirect_worker.rb
+++ b/app/sidekiq/publishing_api_redirect_worker.rb
@@ -1,4 +1,7 @@
 class PublishingApiRedirectWorker < PublishingApiWorker
+  # Retrying is unlikely to fix the problem - so disable retries.
+  sidekiq_options retry: 0
+
   def perform(content_id, destination, locale, allow_draft = false)
     Services.publishing_api.unpublish(
       content_id,
@@ -11,8 +14,5 @@ class PublishingApiRedirectWorker < PublishingApiWorker
   rescue GdsApi::HTTPNotFound
     # nothing to do here as we can't unpublish something that doesn't exist
     nil
-  rescue GdsApi::HTTPUnprocessableEntity => e
-    # retrying is unlikely to fix the problem, we can send the error straight to Sentry
-    GovukError.notify(e)
   end
 end

--- a/test/unit/app/sidekiq/publishing_api_redirect_worker_test.rb
+++ b/test/unit/app/sidekiq/publishing_api_redirect_worker_test.rb
@@ -61,19 +61,15 @@ class PublishingApiRedirectWorkerTest < ActiveSupport::TestCase
     assert_requested request
   end
 
-  test "sends an error to sentry if there is a problem with the request" do
-    govukerror_notify = Minitest::Mock.new
-    govukerror_notify.expect :call, nil, [GdsApi::HTTPUnprocessableEntity]
-
+  test "avoids swallowing the error if there is a problem with the request" do
     publishing_api = Minitest::Mock.new
     def publishing_api.unpublish(_content_id, _options)
       raise GdsApi::HTTPUnprocessableEntity, "test"
     end
 
     Services.stub :publishing_api, publishing_api do
-      GovukError.stub :notify, govukerror_notify do
+      assert_raises(GdsApi::HTTPUnprocessableEntity) do
         PublishingApiRedirectWorker.new.perform(@uuid, @destination, "fr", true)
-        assert_mock govukerror_notify
       end
     end
   end


### PR DESCRIPTION
When attempting to unpublish a document, if Whitehall's validation rules don't align with Publishing API's validation rules, we can get into a state whereby Whitehall thinks the document has been successfully unpublished but Publishing API rejects the change, and the document continues to remain live.

Instead of just swallowing the error and manually sending details of it to Sentry, we want to bubble the error up and essentially cause Whitehall to crash ("Server error") rather than have the document states become out of sync.

Whilst it would be good to go the extra mile and handle the exception properly - displaying details of the validation issue to the user - in practice, we're only seeing this in non production environments, due to an issue that we hope to resolve separately in #10549. So showing the "Server error" message and forcing users to get in touch with support seems a reasonable improvement for now.

JIRA: https://gov-uk.atlassian.net/browse/WHIT-2401

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
