### PR TITLE
Move validation for `attachable` supporting`type` of attachment to `Attachment`

### DIFF
--- a/app/controllers/admin/attachments_controller.rb
+++ b/app/controllers/admin/attachments_controller.rb
@@ -1,6 +1,5 @@
 class Admin::AttachmentsController < Admin::BaseController
   before_action :limit_attachable_access, if: :attachable_is_an_edition?
-  before_action :check_attachable_allows_attachment_type, only: %i[create new update edit]
   before_action :update_attachment_params, only: :update
 
   rescue_from Mysql2::Error, with: :handle_duplicate_key_errors_caused_by_double_create_requests
@@ -80,10 +79,6 @@ private
     attachment.readable_type.downcase
   end
   helper_method :type
-
-  def check_attachable_allows_attachment_type
-    redirect_to attachable_attachments_path(attachable) unless attachable.allows_attachment_type?(type)
-  end
 
   def attachable_param
     params.keys.find { |k| k =~ /_id$/ }

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -16,6 +16,7 @@ class Attachment < ApplicationRecord
 
   validates_with AttachmentValidator, on: :user_input
   validates :attachable, presence: true
+  validate :is_supported_attachable?
   validates :title, presence: true, length: { maximum: 255 }
   validates :isbn, isbn_format: true, allow_blank: true
   validates :unique_reference, length: { maximum: 255 }, allow_blank: true
@@ -147,6 +148,14 @@ class Attachment < ApplicationRecord
   end
 
 private
+
+  def is_supported_attachable?
+    prevent_saving_of_abstract_base_class
+
+    unless attachable && attachable.allows_attachment_type?(readable_type.downcase)
+      errors.add(:base, "Attachable does not allow attachment type of #{readable_type.downcase}")
+    end
+  end
 
   def set_ordering
     self.ordering = attachable.next_ordering

--- a/test/functional/admin/attachments_controller_test.rb
+++ b/test/functional/admin/attachments_controller_test.rb
@@ -6,6 +6,7 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
   setup do
     login_as :gds_editor
     @edition = create(:consultation)
+    @publication = create(:publication)
   end
 
   def self.supported_attachable_types
@@ -39,12 +40,12 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
   end
 
   view_test "GET :index renders the uploading banner when an attachment hasn't been uploaded to asset manager" do
-    create(:html_attachment, title: "An HTML attachment", attachable: @edition)
-    create(:file_attachment, title: "An uploaded file attachment", attachable: @edition)
-    create(:file_attachment_with_no_assets, title: "An uploading file attachment", attachable: @edition, file: upload_fixture("two-pages.pdf"))
-    create(:external_attachment, title: "An external attachment", attachable: @edition)
+    create(:html_attachment, title: "An HTML attachment", attachable: @publication)
+    create(:file_attachment, title: "An uploaded file attachment", attachable: @publication)
+    create(:file_attachment_with_no_assets, title: "An uploading file attachment", attachable: @publication, file: upload_fixture("two-pages.pdf"))
+    create(:external_attachment, title: "An external attachment", attachable: @publication)
 
-    get :index, params: { edition_id: @edition }
+    get :index, params: { edition_id: @publication }
 
     assert_response :success
     assert_select "p.govuk-body", text: "Title: An HTML attachment"
@@ -54,9 +55,9 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
   end
 
   view_test "GET :index shows external attachments" do
-    create(:external_attachment, title: "An external attachment", attachable: @edition)
+    create(:external_attachment, title: "An external attachment", attachable: @publication)
 
-    get :index, params: { edition_id: @edition }
+    get :index, params: { edition_id: @publication }
 
     assert_response :success
     assert_select "p.govuk-body", text: "Title: An external attachment"

--- a/test/functional/admin/external_attachments_controller_test.rb
+++ b/test/functional/admin/external_attachments_controller_test.rb
@@ -26,11 +26,10 @@ class Admin::ExternalAttachmentsControllerTest < ActionController::TestCase
   end
 
   test "POST :create ignores external attachments when attachable does not allow them" do
-    attachable = create(:statistical_data_set, access_limited: false)
+    attachable = create(:statistical_data_set, attachments: [])
 
     post :create, params: { edition_id: attachable, attachment: valid_external_attachment_params }
 
-    assert_response :redirect
     assert_equal 0, attachable.reload.attachments.size
   end
 

--- a/test/functional/admin/html_attachments_controller_test.rb
+++ b/test/functional/admin/html_attachments_controller_test.rb
@@ -53,12 +53,11 @@ class Admin::HtmlAttachmentsControllerTest < ActionController::TestCase
     post :create, params: { edition_id: @edition.id, attachment: }
   end
 
-  test "POST :create ignores html attachments when attachable does not allow them" do
-    attachable = create(:statistical_data_set, access_limited: false)
+  test "POST :create does not create attachment if attachable does not allow html attachments" do
+    attachable = create(:statistical_data_set, access_limited: false, attachments: [])
 
     post :create, params: { edition_id: attachable, attachment: valid_html_attachment_params }
 
-    assert_response :redirect
     assert_equal 0, attachable.reload.attachments.size
   end
 

--- a/test/support/generic_edition.rb
+++ b/test/support/generic_edition.rb
@@ -14,4 +14,12 @@ class GenericEdition < Edition
   def publishing_api_presenter
     GenericEditionPresenter
   end
+
+  def allows_external_attachments?
+    true
+  end
+
+  def allows_html_attachments?
+    true
+  end
 end

--- a/test/unit/app/helpers/attachments_helper_test.rb
+++ b/test/unit/app/helpers/attachments_helper_test.rb
@@ -2,11 +2,13 @@ require "test_helper"
 
 class AttachmentsHelperTest < ActionView::TestCase
   test "block_attachments renders an array of rendered attachments and ignores attachments with missing assets" do
-    file_attachment_with_all_assets = create(:file_attachment)
-    file_attachment_with_missing_assets = create(:file_attachment_with_no_assets)
+    alternative_format_contact_email = "test@example.com"
+    attachable = create(:publication)
+    file_attachment_with_all_assets = create(:csv_attachment, attachable:)
+    file_attachment_with_missing_assets = create(:file_attachment_with_no_assets, attachable:)
     attachments = [
-      create(:html_attachment),
-      create(:external_attachment),
+      create(:html_attachment, attachable:),
+      create(:external_attachment, attachable:),
       file_attachment_with_all_assets,
       file_attachment_with_missing_assets,
     ]
@@ -36,7 +38,7 @@ class AttachmentsHelperTest < ActionView::TestCase
   end
 
   test "component params for External attachment" do
-    attachment = create(:external_attachment)
+    attachment = create(:external_attachment, attachable: create(:publication))
     expect_params = {
       type: "external",
       title: attachment.title,

--- a/test/unit/app/models/attachment_test.rb
+++ b/test/unit/app/models/attachment_test.rb
@@ -131,4 +131,10 @@ class AttachmentTest < ActiveSupport::TestCase
     attachment.destroy!
     assert attachment.deleted?
   end
+
+  test "prevents save on attachable that does not support attachment type" do
+    attachment = build(:external_attachment, attachable: build(:statistical_data_set))
+
+    assert_not attachment.valid?
+  end
 end

--- a/test/unit/app/validators/govspeak_contact_embed_validator_test.rb
+++ b/test/unit/app/validators/govspeak_contact_embed_validator_test.rb
@@ -34,7 +34,7 @@ class GovspeakContactEmbedValidatorTest < ActiveSupport::TestCase
 
   test "should be valid if the HTML attachment contains a Contact that exists" do
     contact = create(:contact)
-    edition = create(:case_study, body: "[Contact:#{contact.id}]")
+    edition = create(:publication, body: "[Contact:#{contact.id}]")
 
     edition.html_attachments = [create(:html_attachment, body: "[Contact:#{contact.id}]")]
 
@@ -46,7 +46,7 @@ class GovspeakContactEmbedValidatorTest < ActiveSupport::TestCase
 
   test "should be invalid if the HTML attachment contains a Contact that has been deleted" do
     contact = create(:contact)
-    edition = create(:case_study, html_attachments: [create(:html_attachment, body: "[Contact:#{contact.id}]")])
+    edition = create(:publication, html_attachments: [create(:html_attachment, body: "[Contact:#{contact.id}]")])
     contact.destroy!
 
     GovspeakContactEmbedValidator.new.validate(edition)


### PR DESCRIPTION
Need https://github.com/alphagov/whitehall/pull/10521 first!

## What

- Move the check to see if an attachable document supports the attachment to `Attachment` model instead of the `AttachmentController`
- Update testing suite for the new validation

## Why

In attachment controllers, `check_attachable_allows_attachment_type` is executed before creation of an attachment. This method acts as a validation, it prevents the user creating the attachment (from the controller) if the attachable does not support that attachment type.

It's unusual to have a validation occur in the controller and not in the model. So therefore I wanted to see if it would be possible to move this check to `Attachment` instead of `AttachmentController`.

The current implementation means that unsupported attachments can be created outside of the controller. This is evident from the testing suite, which has several occurrences of this. If we move this validation to the model, this ensures that this will not happen.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
