### PR TITLE
Remove 'rubyzip' dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,6 @@ gem "record_tag_helper", require: false
 gem "redis"
 gem "responders"
 gem "rinku", require: "rails_rinku"
-gem "rubyzip"
 gem "sentry-sidekiq"
 gem "sidekiq-scheduler"
 gem "sprockets-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1139,7 +1139,6 @@ DEPENDENCIES
   responders
   rinku
   rubocop-govuk
-  rubyzip
   sentry-sidekiq
   sidekiq-scheduler
   simplecov


### PR DESCRIPTION
This doesn't appear to be used anywhere now. Nowhere in our codebase does the term `Zip::` appear.

It was first added in #4678 and the case it was added for there no longer exists.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
