### PR TITLE
Improve wording of the bulk-republish by content ID screens

### DIFF
--- a/app/views/admin/bulk_republishing/confirm_documents_by_content_ids.html.erb
+++ b/app/views/admin/bulk_republishing/confirm_documents_by_content_ids.html.erb
@@ -6,7 +6,7 @@
 <div class="govuk-grid-row">
   <section class="govuk-grid-column-two-thirds">
     <p class="govuk-body govuk-!-margin-bottom-7">
-      This will queue the following editions to be republished.
+      This queues the following editions for republishing, but retaining their current state. For example, an "Unpublished" document will remain unpublished, but it will be re-presented to Publishing API.
     </p>
     <%= render "govuk_publishing_components/components/table", {
       head: [

--- a/app/views/admin/bulk_republishing/new_documents_by_content_ids.html.erb
+++ b/app/views/admin/bulk_republishing/new_documents_by_content_ids.html.erb
@@ -9,7 +9,7 @@
         label: {
           text: "Enter the content IDs for the documents",
         },
-        hint: "Use commas and/or new lines to separate each content ID.",
+        hint: "Use commas to separate each content ID.",
         name: "content_ids",
       } %>
       <%= render "govuk_publishing_components/components/button", {


### PR DESCRIPTION
- Remove misleading hint that commas or newlines can be used to separate content IDs. In practice, only commas are supported.
- Add clarification that the document's existing state will be retained when republishing, since the language of "republish" could certainly lead some to believe that the content itself will become published, and that's not the case. Really what we're doing is "presenting" the same content to Publishing API again.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
