### PR TITLE
Make AssetManagerAttachmentRedirectUrlUpdateWorker idempotent (WHIT-2371)

### DIFF
--- a/app/sidekiq/asset_manager_attachment_redirect_url_update_worker.rb
+++ b/app/sidekiq/asset_manager_attachment_redirect_url_update_worker.rb
@@ -3,7 +3,7 @@ class AssetManagerAttachmentRedirectUrlUpdateWorker < WorkerBase
 
   def perform(attachment_data_id)
     attachment_data = AttachmentData.find_by(id: attachment_data_id)
-    return if attachment_data.blank? || attachment_data.deleted?
+    return if attachment_data.blank?
 
     attachment_data.assets.each do |asset|
       AssetManager::AssetUpdater.call(asset.asset_manager_id, { "redirect_url" => attachment_data.redirect_url })

--- a/test/unit/app/sidekiq/asset_manager_attachment_redirect_url_update_worker_test.rb
+++ b/test/unit/app/sidekiq/asset_manager_attachment_redirect_url_update_worker_test.rb
@@ -15,4 +15,21 @@ class AssetManagerAttachmentRedirectUrlUpdateWorkerTest < ActiveSupport::TestCas
 
     AssetManagerAttachmentRedirectUrlUpdateWorker.new.perform(attachment.attachment_data.id)
   end
+
+  test "it updates redirect url even when attachment_data is marked deleted" do
+    edition = create(:unpublished_edition)
+    attachment = create(:file_attachment, attachable: edition)
+
+    AttachmentData.any_instance.stubs(:deleted?).returns(true)
+
+    expected_attribute_hash = {
+      "redirect_url" => edition.unpublishing.document_url,
+    }
+
+    attachment.attachment_data.assets.each do |asset|
+      AssetManager::AssetUpdater.expects(:call).with(asset.asset_manager_id, expected_attribute_hash)
+    end
+
+    AssetManagerAttachmentRedirectUrlUpdateWorker.new.perform(attachment.attachment_data.id)
+  end
 end


### PR DESCRIPTION
Problem
-------
We can mark an AttachmentData as `deleted` before Asset Manager has been told
to set a `redirect_url`. That race condition leaves the file still live in Asset Manager,
while Whitehall believes it has been deleted-with-redirect.

Real-world example that surfaced the bug
----------------------------------------
From a live case (edition `1343548`):

```ruby
Edition.find(1343548).attachments.first.attachment_data.deleted?
=> true

Edition.find(1343548).attachments.first.attachment_data.attachments.map { |a|
  [a.id, a.created_at, a.deleted, (a.attachable || Attachable::Null.new).publicly_visible?]
}
=>
[
  [6747851, 2022-06-29 21:03:01.000000000 BST +01:00, false, false],
  [8497733, 2025-03-05 19:19:20.000000000 GMT +00:00, true, false]
]
```

There are no “publicly visible” attachments, so AttachmentData#deleted? resolves
via the significant attachment to the latest attachment (which is deleted: true).
The worker was exiting early on that check, so the redirect update to Asset Manager
was never sent and the asset remained live.

Zendesk reference: 6181171

Change
------
Remove the `attachment_data.deleted?` short-circuit so the worker always
attempts to update Asset Manager. This ensures we don’t skip redirect updates
for assets that still need them.

Why this is safe
----------------
- The worker is only enqueued by AttachmentRedirectUrlUpdater during edition
  lifecycle events (unpublish; publish/unwithdraw) via
  config/initializers/edition_services.rb. So we’re not introducing frequent
  extra traffic.
- AssetManager::AssetUpdater already does a conditional update: it fetches the
  current attributes and only issues a PUT when they differ. That means we at
  most add a few extra GETs, not unnecessary PUTs.

Impact
------
- Closes the window where an asset can remain publicly accessible because the
  redirect was never sent.
- Keeps the operation idempotent and tolerant of already-updated or missing
  assets.

Manual testing
----

1. Temporarily change the redirect URL of an existing unpublished asset:

```
AssetManager::AssetUpdater.call("62bcb0628fa8f535b5ff0b14", { "redirect_url" => "https://www.gov.uk/foo" })
```

2. See the asset now redirect to /foo

3. Trigger the worker:

```
ServiceListeners::AttachmentRedirectUrlUpdater.call(attachable: Edition.find(1707372))
```

4. See it redirect to the correct place as per the Unpublished edition.
   See PUT logs in Asset Manager.

5. Trigger the worker again

6. No failures, no change, redirect continues to work, and no PUT
   requests to Asset Manager.

Also tested by:

```
# Asset Manager
Asset.find("62bcb0628fa8f535b5ff0b14").update(redirect_url: nil)
=> true

# Seeing that the asset loads

# Whitehall
ServiceListeners::AttachmentRedirectUrlUpdater.call(attachable: Edition.find(1707375))
=> nil

# Seeing that the asset now redirects
```

Refs
----
- edition_services callbacks:
  https://github.com/alphagov/whitehall/blob/0172090e2e522c8662d94bedcf4c4036bece03a1/config/initializers/edition_services.rb#L18
  https://github.com/alphagov/whitehall/blob/0172090e2e522c8662d94bedcf4c4036bece03a1/config/initializers/edition_services.rb#L40
- Conditional update logic:
  https://github.com/alphagov/whitehall/blob/74b05441f567a0323a15ed3390d32c9395eb14cc/app/services/asset_manager/asset_updater.rb#L26-L27

JIRA: https://gov-uk.atlassian.net/browse/WHIT-2371

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
