### PR TITLE
Add `data-ga4-form-use-select-count` [WHIT-2394]

### DIFF
--- a/app/assets/javascripts/admin/analytics-modules/ga4-form-setup.js
+++ b/app/assets/javascripts/admin/analytics-modules/ga4-form-setup.js
@@ -69,6 +69,7 @@ window.GOVUK.analyticsGa4.analyticsModules =
 
           form.setAttribute('data-ga4-form-include-text', '')
           form.setAttribute('data-ga4-form-use-text-count', '')
+          form.setAttribute('data-ga4-form-use-select-count', '')
           new window.GOVUK.Modules.Ga4FormTracker(form).init()
 
           form.addEventListener('submit', this.onSubmit)

--- a/spec/javascripts/admin/analytics-modules/ga4-form-setup.spec.js
+++ b/spec/javascripts/admin/analytics-modules/ga4-form-setup.spec.js
@@ -44,6 +44,7 @@ describe('GOVUK.analyticsGa4.analyticsModules.Ga4FormSetup', function () {
         ga4FormRecordJson,
         ga4FormIncludeText,
         ga4FormUseTextCount,
+        ga4FormUseSelectCount,
         ga4FormSplitResponseText
       } = form.dataset
 
@@ -51,6 +52,7 @@ describe('GOVUK.analyticsGa4.analyticsModules.Ga4FormSetup', function () {
       expect(ga4FormIncludeText).toBeDefined()
       expect(ga4FormUseTextCount).toBeDefined()
       expect(ga4FormUseTextCount).toBeDefined()
+      expect(ga4FormUseSelectCount).toBeDefined()
       expect(ga4FormSplitResponseText).toBeDefined()
 
       expect(JSON.parse(ga4Form)).toEqual(expectedDefaults)


### PR DESCRIPTION
## What

- Add `data-ga4-form-use-select-count` to forms in within `GA4FormSetup` 

## Why

Request from Publishing PA team to change how `select[multiple]` are reported in `text` within a tracked form response. Currently the user can usually select unlimited options in `select[multiple]` elements and those options can have very long names. This leads to the reported `text` being too long to record correctly. Moving to reporting the count of selected options means that this is less likely to happen.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
