### PR TITLE
Fix brakeman warning for YouTube regex

### DIFF
--- a/app/models/promotional_feature_item.rb
+++ b/app/models/promotional_feature_item.rb
@@ -1,5 +1,5 @@
 class PromotionalFeatureItem < ApplicationRecord
-  VALID_YOUTUBE_URL_FORMAT = /\A(?:https:\/\/youtu\.be\/|https:\/\/www\.youtube\.com\/watch\?v=)([0-9A-Za-z_-]*)(?:$|(?:\?|&).*$)/
+  VALID_YOUTUBE_URL_FORMAT = /\A(?:https:\/\/youtu\.be\/|https:\/\/www\.youtube\.com\/watch\?v=)([0-9A-Za-z_-]*)(?:\z|(?:\?|&).*\z)/
 
   include ImageKind
 


### PR DESCRIPTION
Fixes brakeman warning:
> Insufficient validation for youtube_video_url using /\A(?:https:\/\/youtu\.be\/|https:\/\/www\.youtube\.com\/watch\?v=)([0-9A-Za-z_-]*)(?:$|(?:\?|&).*$)/. Use \A and \z as anchors.

https://github.com/alphagov/whitehall/security/code-scanning/309

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
