### PR TITLE
Make 'protect from forgery' check explicit and strong

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
   include GDS::SSO::ControllerMethods
   helper ComponentGuideHelper
-  protect_from_forgery
+  protect_from_forgery with: :exception, prepend: true
 
   before_action :set_current_user
   before_action :set_authenticated_user_header


### PR DESCRIPTION
- `with: :exception` is the recommended setting for session-based HTML apps (raises on bad/missing CSRF token instead of silently creating a null session).
- `prepend: true` ensures verification runs before other callbacks.

This fixes the following code scan issue:
https://github.com/alphagov/whitehall/security/code-scanning/77

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
