### PR TITLE
Add confirmation step to send_review_reminders.rake [WHIT-1515]

### DIFF
--- a/lib/tasks/confirm_rake_task.rb
+++ b/lib/tasks/confirm_rake_task.rb
@@ -1,0 +1,7 @@
+require "thor"
+
+module Confirm
+  def self.ask(message)
+    Thor::Shell::Basic.new.yes?(message)
+  end
+end

--- a/lib/tasks/send_review_reminders.rake
+++ b/lib/tasks/send_review_reminders.rake
@@ -1,6 +1,17 @@
+require_relative "confirm_rake_task"
+
 desc "Send review reminder emails for when the review_at date has passed"
 task send_review_reminders: :environment do
-  ReviewReminder.reminder_due.pluck(:id).each do |id|
+  ids = ReviewReminder.reminder_due.pluck(:id)
+  puts "Review reminders would be sent for the following IDs:"
+  puts ids.inspect
+
+  unless Confirm.ask("Proceed to send review reminders? (yes/no)")
+    puts "Sending aborted"
+    exit 1
+  end
+
+  ids.each do |id|
     ReviewReminderNotifierWorker.perform_async(id)
   end
 end

--- a/test/unit/lib/tasks/send_review_reminders_test.rb
+++ b/test/unit/lib/tasks/send_review_reminders_test.rb
@@ -22,6 +22,8 @@ class SendReviewRemindersTest < ActiveSupport::TestCase
     ReviewReminderNotifierWorker.expects(:perform_async).with(already_sent.id).never
     ReviewReminderNotifierWorker.expects(:perform_async).with(not_due_yet.id).never
 
-    Rake.application.invoke_task "send_review_reminders"
+    Confirm.stub(:ask, true) do
+      Rake.application.invoke_task "send_review_reminders"
+    end
   end
 end


### PR DESCRIPTION
Spike: Add confirmation step to review reminder rake task as part of an exploration into improving safety for rake tasks after the recent audit.

Adding a simple confirmation step with Thor (e.g `Are you sure want to run this rake task? y/n`) is very straight forward to implement. I showed an example of this in dev catchup last Thursday. The tricky part would be allowing the rake task to figure out the exact number of changes it would be making and then print a message with something like: `you're about to delete x number of documents, are you sure you want to run this rake task? y/n`. That would mean:

- Altering the rake task so that it executes up to a certain point
- Takes in what it's going to do i.e. alter/delete documents/contacts etc
- It "stops"
- Prints you're about to delete x number of documents, are you sure you want to run this rake task? y/n
- Abort or continue the rake task based on the input from the user.

Following on from a conversation with Chris who suggested: 

1. Find a ‘dry run vs wet run’ rake task and spike:
2. Combining them into one Thor based rake task
3. Doing the ‘dry run’ bit above the confirmation prompt
4. Doing the ‘wet run’ bit below the confirmation prompt

This rake task didn't have a 'dry run', nor does it delete/alter anything. It finds all `ReviewReminder` records that are due for a reminder. So I've essentially broken the logic in the rake task down to"
- Add a user confirmation prompt.
- Display the IDs to be processed before sending review reminder emails.
- If the user confirms the rake task will run. 


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
