### PR TITLE
fix: Filter markdown links from collected headers

### DIFF
--- a/app/helpers/presenters/publishing_api/payload_headings_helper.rb
+++ b/app/helpers/presenters/publishing_api/payload_headings_helper.rb
@@ -6,6 +6,7 @@ module Presenters
 
         body_headings = Govspeak::Document.new(govspeak).structured_headers
         headers = remove_empty_headers(body_headings.map(&:to_h))
+        headers = remove_links_in_headers(headers)
 
         headers.empty? ? {} : { headers: headers }
       end
@@ -16,6 +17,13 @@ module Presenters
         body_headings.each do |body_heading|
           body_heading.delete_if { |k, v| k == :headers && v.empty? }
           remove_empty_headers(body_heading[:headers]) if body_heading.key?(:headers)
+        end
+      end
+
+      def remove_links_in_headers(body_headings)
+        body_headings.each do |body_heading|
+          body_heading[:text].gsub!(/\[(.+)\]\((.*)\)/, '\1')
+          remove_links_in_headers(body_heading[:headers]) if body_heading.key?(:headers)
         end
       end
     end

--- a/test/unit/app/presenters/publishing_api/payload_builder/body_headings_test.rb
+++ b/test/unit/app/presenters/publishing_api/payload_builder/body_headings_test.rb
@@ -41,6 +41,27 @@ module PublishingApi
 
         assert_equal BodyHeadings.for(item), {}
       end
+
+      test "filters out govspeak links from the headers text" do
+        item = stub(body: "##Normal Heading\n\nSome stuff\n\n##[Link Heading](https://www.example.com)\n\nSome stuff\n\n")
+
+        expected_headers = {
+          headers: [
+            {
+              text: "Normal Heading",
+              level: 2,
+              id: "normal-heading",
+            },
+            {
+              text: "Link Heading",
+              level: 2,
+              id: "link-heading",
+            },
+          ],
+        }
+
+        assert_equal BodyHeadings.for(item), expected_headers
+      end
     end
   end
 end


### PR DESCRIPTION
- The page https://www.gov.uk/guidance/employment-tribunal-offices-and-venues (before and after links at the bottom), has h2 elements in govspeak that are links. Government Frontend, picking the text out of HTML on the fly to create the contents list, handled this somehow. When we moved it to publish time (picking the links out of govspeak), we introduced a bug where the markdown would be used as the link title in the content list.
- This pattern (of H2s as links) is itself not a good idea and may cause accessibility issues.  We should try to dissuade people from using it. That said, we should at least handle it gracefully. This commit allows us to filter out the markdown link and extract only the link text as our header item.

- before headers collected in Whitehall: https://webarchive.nationalarchives.gov.uk/ukgwa/20250716183242/https://www.gov.uk/guidance/employment-tribunal-offices-and-venues
- after headers collected in Whitehall: https://webarchive.nationalarchives.gov.uk/ukgwa/20250813183618/https://www.gov.uk/guidance/employment-tribunal-offices-and-venues

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
