### PR TITLE
[WHIT-2446] Create data migration to fix up orphaned asset for Pubs Code Adjudicator

### DIFF
--- a/db/data_migration/20250820154558_fix_up_orphaned_asset_pca.rb
+++ b/db/data_migration/20250820154558_fix_up_orphaned_asset_pca.rb
@@ -1,0 +1,7 @@
+asset_manager_id = "655b5723046ed400148b9be1"
+redirect_url = AttachmentData.joins(:assets)
+                             .where(assets: { asset_manager_id: asset_manager_id })
+                             .first
+                             .redirect_url
+
+AssetManager::AssetUpdater.call(asset_manager_id, { "redirect_url" => redirect_url })


### PR DESCRIPTION
## What

Migration to update the redirect url for an orphaned pdf for Pubs Code Adjudicator

## Why

An unpublished publication had a new draft created and subsequently deleted which left an orphaned asset. This migration ensures that the asset is redirected to the correct URL.

[Jira](https://gov-uk.atlassian.net/browse/WHIT-2446)

## How

Run the following command in each environment

```
 bundle exec rake db:data:migrate
```
