### PR TITLE
[WHIT-2270] Fix images for configurable documents

### DIFF
--- a/app/helpers/govspeak_helper.rb
+++ b/app/helpers/govspeak_helper.rb
@@ -22,6 +22,13 @@ module GovspeakHelper
     wrapped_in_govspeak_div(bare_govspeak_to_html(body, [], attachments))
   end
 
+  def govspeak_to_html_with_images_and_attachments(govspeak, images = [], attachments = [], alternative_format_contact_email = nil)
+    mapped_images = prepare_images(images)
+    mapped_attachments = prepare_attachments(attachments, alternative_format_contact_email)
+
+    wrapped_in_govspeak_div(bare_govspeak_to_html(govspeak, mapped_images, mapped_attachments))
+  end
+
   def bare_govspeak_edition_to_html(edition)
     images = prepare_images(edition.try(:images) || [])
 

--- a/app/models/configurable_content_blocks/govspeak.rb
+++ b/app/models/configurable_content_blocks/govspeak.rb
@@ -22,7 +22,7 @@ module ConfigurableContentBlocks
 
     def publishing_api_payload(content)
       {
-        html: Whitehall::GovspeakRenderer.new.govspeak_to_html(content, images: @images),
+        html: Whitehall::GovspeakRenderer.new.govspeak_to_html_with_images_and_attachments(content, @images),
         **extract_headings(content),
       }
     end

--- a/app/models/configurable_content_blocks/govspeak.rb
+++ b/app/models/configurable_content_blocks/govspeak.rb
@@ -2,6 +2,8 @@ module ConfigurableContentBlocks
   class Govspeak
     include Presenters::PublishingApi::PayloadHeadingsHelper
 
+    attr_reader :images
+
     def initialize(images = [])
       @images = images
     end

--- a/app/views/admin/configurable_content_blocks/_govspeak.html.erb
+++ b/app/views/admin/configurable_content_blocks/_govspeak.html.erb
@@ -1,11 +1,14 @@
 <% required = required || false %>
-<%= render "govuk_publishing_components/components/textarea", {
+<%= render "components/govspeak_editor", {
   label: {
     text: schema["title"] + (required ? " (required)" : ""),
     heading_size: "m",
   },
+  id: path.form_control_id,
   name: path.form_control_name,
   value: content,
-  hint: schema["description"],
-  textarea_id: path.form_control_id,
+  rows: 20,
+  data_attributes: {
+    image_ids: govspeak.images.map { |img| img[:id] }.to_json,
+  },
 } %>

--- a/lib/whitehall/govspeak_renderer.rb
+++ b/lib/whitehall/govspeak_renderer.rb
@@ -5,6 +5,7 @@ module Whitehall
              :govspeak_to_html,
              :govspeak_with_attachments_to_html,
              :govspeak_html_attachment_to_html,
+             :govspeak_to_html_with_images_and_attachments,
              :block_attachments,
              to: :helpers
 


### PR DESCRIPTION
Images were not included in the govspeak correctly. 

Also added the preview function to the govspeak block.

[Jira](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-2270)
