### PR TITLE
Fix CodeQL parsing errors

### DIFF
--- a/app/views/admin/attachments/_form.html.erb
+++ b/app/views/admin/attachments/_form.html.erb
@@ -2,7 +2,7 @@
 
   <%= render "form_fields", form:, attachment:, attachable:, heading_size:, subheading_size: %>
 
-  <%= hidden_field_tag :type, params[:type] %>
+  <%= hidden_field_tag(:type, params[:type]) %>
 
   <div class="govuk-button-group">
     <%= render "govuk_publishing_components/components/button", { text: "Save" } %>

--- a/app/views/admin/shared/_featurable_editions.html.erb
+++ b/app/views/admin/shared/_featurable_editions.html.erb
@@ -9,7 +9,7 @@
   </div>
   <div class="govuk-grid-column-two-thirds">
     <div class="app-view-features-search-results__table" aria-label="Search results">
-      <%= render "admin/featurable_editions/search_results", featurable_editions:, paginator:, anchor:, feature_path: %>
+      <%= render("admin/featurable_editions/search_results", featurable_editions:, paginator:, anchor:, feature_path:) %>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Looking at https://github.com/alphagov/whitehall/actions/runs/17075395186/job/48415312255

- Expand 'Perform CodeQL Analysis'
- Expand 'Extracting ruby'
- See the following in the output:

```
  [2025-08-19 16:12:30] [build-stdout] [2025-08-19 16:12:30] [build-stdout]  WARN /home/runner/work/whitehall/whitehall/app/views/admin/shared/_featurable_editions.html.erb:12: A parse error occurred. Check the syntax of the file. If the file is invalid, correct the error or exclude the file from analysis.
  [2025-08-19 16:12:31] [build-stdout] [2025-08-19 16:12:31] [build-stdout]  WARN /home/runner/work/whitehall/whitehall/app/views/admin/attachments/_form.html.erb:5: A parse error occurred. Check the syntax of the file. If the file is invalid, correct the error or exclude the file from analysis.
```

This is currently a limitation of CodeQL. Using explicit parentheses works around the issue in the meantime.

See https://github.com/github/codeql/issues/16006

Screenshots
---

Before:
> <img width="1536" height="352" alt="Screenshot 2025-08-21 at 13 49 38" src="https://github.com/user-attachments/assets/563a61ba-128d-4b47-8fc7-99dcaea44f0f" />

After:
> <img width="1304" height="269" alt="Screenshot 2025-08-21 at 13 49 11" src="https://github.com/user-attachments/assets/cd4d5d4e-d865-40bc-b562-c39eb9e42862" />

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
