### PR TITLE
[WHIT-2257] Display clearer embedded-contact errors on Editions & HTML attachments; relax validation on draft creation

### DIFF
--- a/app/models/concerns/attachable.rb
+++ b/app/models/concerns/attachable.rb
@@ -15,11 +15,13 @@ module Attachable
     has_many :attachments,
              -> { not_deleted.order("attachments.ordering, attachments.id") },
              as: :attachable,
-             inverse_of: :attachable
+             inverse_of: :attachable,
+             validate: false
 
     has_many :html_attachments,
              -> { not_deleted.order("attachments.ordering, attachments.id") },
-             as: :attachable
+             as: :attachable,
+             validate: false
 
     has_many :deleted_html_attachments,
              -> { deleted },
@@ -37,7 +39,7 @@ module Attachable
           @edition.attachments.each do |attachment|
             draft_attachment = attachment.deep_clone
             edition.attachments << draft_attachment
-            raise "Your edition failed to create successfully. Please contact GOV.UK support." unless draft_attachment.save!
+            raise "Your edition failed to create successfully. Please contact GOV.UK support." unless draft_attachment.save!(validate: false)
           end
         end
       end

--- a/app/models/html_attachment.rb
+++ b/app/models/html_attachment.rb
@@ -10,6 +10,7 @@ class HtmlAttachment < Attachment
   before_save :ensure_slug_is_valid
 
   validates :govspeak_content, presence: true
+  validates_with GovspeakContactEmbedValidator
 
   accepts_nested_attributes_for :govspeak_content
   delegate :body,

--- a/app/validators/govspeak_contact_embed_validator.rb
+++ b/app/validators/govspeak_contact_embed_validator.rb
@@ -2,14 +2,15 @@ class GovspeakContactEmbedValidator < ActiveModel::Validator
   def validate(record)
     Govspeak::ContactsExtractor.new(record.body).extracted_contact_ids.each do |contact_id|
       contact = Contact.find_by(id: contact_id)
-      record.errors.add(:base, "Contact ID #{contact_id} doesn't exist") unless contact
+      record.errors.add(:body, "Contact ID #{contact_id} doesn't exist") unless contact
     end
 
     if record.respond_to?(:html_attachments)
       record.html_attachments.each do |html_attachment|
         Govspeak::ContactsExtractor.new(html_attachment.body).extracted_contact_ids.each do |contact_id|
           contact = Contact.find_by(id: contact_id)
-          html_attachment.errors.add(:base, "Contact ID #{contact_id} doesn't exist") unless contact
+          error_message = I18n.t("activerecord.errors.models.edition.attributes.html_attachments.missing_contact_reference", html_attachment_title: html_attachment.title, contact_id: contact_id)
+          record.errors.add(:html_attachments, error_message) unless contact
         end
       end
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -18,6 +18,7 @@ en:
       corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
         file: The attached file
       edition:
+        html_attachments: HTML attachments
         nation_inapplicabilities: Excluded nations
       policy_group/policy_group_attachments/attachment/attachment_data:
         file: The attached file

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -19,6 +19,8 @@ en:
               invalid_date: First published date is not in the correct format
               blank: Enter a first published date
               inclusion: First published date must be between 1/1/1900 and the present
+            html_attachments:
+              missing_contact_reference: "- \"%{html_attachment_title}\" - embedded Contact (ID %{contact_id}) doesn't exist"
         nation_inapplicability:
           attributes:
             alternative_url:

--- a/test/unit/app/models/attachable_test.rb
+++ b/test/unit/app/models/attachable_test.rb
@@ -215,16 +215,15 @@ class AttachableTest < ActiveSupport::TestCase
   end
 
   test "re-editioned editions persists invalid attachments" do
-    file_attachment = build(:file_attachment, command_paper_number: "invalid")
-    file_attachment.save!(validate: false)
+    file_attachment = build(:file_attachment, isbn: "invalid")
     publication = create(
       :published_publication,
       :with_alternative_format_provider,
       attachments: [file_attachment],
     )
+    file_attachment.save!(validate: false)
 
     draft = publication.create_draft(create(:writer))
-
     assert_equal 1, draft.reload.attachments.size
     assert draft.attachments[0].persisted?
   end

--- a/test/unit/app/models/edition_test.rb
+++ b/test/unit/app/models/edition_test.rb
@@ -948,24 +948,22 @@ class EditionTest < ActiveSupport::TestCase
     assert_nil edition.published_at
   end
 
-  test "should pass validation on creation of edition with HTML attachment with missing contact" do
+  test "should pass validation on saving of edition with HTML attachment with deleted contact" do
     contact = create(:contact)
-    bad_id = "9999999999999"
-    edition = create(:submitted_case_study, body: "[Contact:#{contact.id}]")
-    edition.html_attachments = [create(:html_attachment, body: "[Contact:#{bad_id}]")]
+    attachment = create(:html_attachment, body: "[Contact:#{contact.id}]")
+    edition = create(:submitted_case_study, html_attachments: [attachment])
+    contact.destroy!
 
     assert edition.valid?
   end
 
-  test "should fail validation on publish of edition with HTML attachment with missing contact" do
+  test "should fail validation on publish of edition with HTML attachment with deleted contact" do
     contact = create(:contact)
-    bad_id = "9999999999999"
-    edition = create(:submitted_case_study, body: "[Contact:#{contact.id}]")
-    edition.html_attachments = [create(:html_attachment, body: "[Contact:#{bad_id}]")]
+    attachment = create(:html_attachment, body: "[Contact:#{contact.id}]")
+    edition = create(:submitted_case_study, html_attachments: [attachment])
+    contact.destroy!
 
-    edition.publish
-
-    assert_not edition.valid?
+    assert_not edition.valid?(:publish)
   end
 
   test "should update cached 'revalidated_at' value on each `valid?(:publish)` call" do

--- a/test/unit/app/validators/govspeak_contact_embed_validator_test.rb
+++ b/test/unit/app/validators/govspeak_contact_embed_validator_test.rb
@@ -44,16 +44,25 @@ class GovspeakContactEmbedValidatorTest < ActiveSupport::TestCase
     assert_equal 0, edition.html_attachments.first.errors.size
   end
 
-  test "should be invalid if the HTML attachment contains a Contact that doesn't exist" do
+  test "should be invalid if the HTML attachment contains a Contact that has been deleted" do
     contact = create(:contact)
-    bad_id = "9999999999999"
-    edition = create(:case_study, body: "[Contact:#{contact.id}]")
-
-    edition.html_attachments = [create(:html_attachment, body: "[Contact:#{bad_id}]")]
+    edition = create(:case_study, html_attachments: [create(:html_attachment, body: "[Contact:#{contact.id}]")])
+    contact.destroy!
 
     GovspeakContactEmbedValidator.new.validate(edition)
 
-    assert_equal 0, edition.errors.size
-    assert_equal 1, edition.html_attachments.first.errors.size
+    assert_equal 1, edition.errors.where(:html_attachments).size
+  end
+
+  test "should add a specific error message if the HTML attachment contains a Contact that doesn't exist" do
+    bad_id = "9999999999999"
+    html_attachment = build(:html_attachment, title: "Test Doc", body: "[Contact:#{bad_id}]")
+    edition = build(:case_study, html_attachments: [html_attachment])
+
+    GovspeakContactEmbedValidator.new.validate(edition)
+
+    error_message = edition.errors[:html_attachments].first
+    expected_message = '"Test Doc" - embedded Contact (ID 9999999999999) doesn\'t exist'
+    assert_includes error_message, expected_message
   end
 end


### PR DESCRIPTION
[Jira](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-1517)

### **Why**

Editors were not only confronted with vague error messages (e.g. “attachments is invalid”) but also completely blocked by validation when trying to create new editions or publish content whose HTML attachments had silently become invalid over time. This could happen when:

- Validation rules were introduced or tightened after initial publication, or
- Contacts referenced in Govspeak were deleted/changed.

As a result, users often discovered issues only at publish time—despite making no changes to the attachment—leading to both confusing feedback and an inability to progress with their workflow in Whitehall.

### **What**

We’ve introduced a context-aware validation approach for embedded contact IDs in Govspeak that:

- Surfaces clear, specific errors in the UI for both Editions and HTML attachments (e.g. helpful “missing contact” messages now appear on the edition summary page).
- Improves labelling: adds a more human-friendly label for the HTML attachments edition attribute.
- Improves validator copy: the Govspeak contact-embedding validator now explains what’s wrong and how to fix it.
- Unblocks draft creation: skips certain validations when creating a new draft, allowing editors to get past legacy/externally-introduced invalid states so they can fix issues in the UI.

### **Technical notes**

- Skip validation during new draft creation: Previously it wasn’t possible to create a new draft if an HTML attachment was invalid. We now skip validation in that specific flow, which is a safe choice that lets editors repair content without being blocked.
- Disable association validation in attachable trait: We explicitly turned off association validation for attachments and html_attachments when using custom validation contexts (e.g. :publish). Rails will otherwise validate loaded associations under the custom context—an unexpected behaviour that produced generic, unhelpful errors like “attachments is invalid.” See: https://github.com/rails/rails/issues/45209

Test updates: Fixed tests that were passing erroneously due to the previous behaviour; added/adjusted specs to assert clearer error messaging and the relaxed validation during draft creation.

### **User impact**

- Editors see actionable, field-level errors when embedded contacts are invalid.
- Creating a new draft no longer fails due to historical or external changes—editors can create, then fix.
- Overall: smoother, more predictable publishing flow with better guidance.


**BEFORE**

<img width="866" height="196" alt="Screenshot 2025-08-15 at 09 29 01" src="https://github.com/user-attachments/assets/b90cffe4-dd25-42a1-b1f8-9d63a1e405bc" />

<img width="830" height="554" alt="Screenshot 2025-08-22 at 10 46 10" src="https://github.com/user-attachments/assets/67a7967e-dddf-40b8-afda-b2f1c0f3b1ba" />



**AFTER**

[
<img width="964" height="220" alt="Screenshot 2025-08-22 at 09 53 17" src="https://github.com/user-attachments/assets/fad1257c-019e-4692-8451-650ab8bc4e85" />
<img width="1248" height="518" alt="Screenshot 2025-08-22 at 09 53 39" src="https://github.com/user-attachments/assets/fd6ae9c7-8fa5-442d-80d0-779afedffe68" />
](url)