### PR TITLE
News story configurable document type [WHIT-2381]

### DIFF
--- a/app/components/admin/editions/first_published_at_component.html.erb
+++ b/app/components/admin/editions/first_published_at_component.html.erb
@@ -1,26 +1,27 @@
 <div class="govuk-!-margin-bottom-4">
   <% if document_has_never_been_published? %>
     <%= hidden_field_tag "edition[previously_published]", false %>
-
-    <%= render "govuk_publishing_components/components/checkboxes", {
-      name: "edition[previously_published]",
-      id: "edition_previously_published",
-      heading: "First published date",
-      heading_size: "l",
-      hint_text: "If this document has been published on another webpage, you must provide the date it was first published online." +
-        " This only applies to online content. Do not use this for file attachments.",
-      items: [
-        {
-          label: "This document has previously been published on another website",
-          value: true,
-          checked: previously_published,
-          conditional: capture do
-            first_published_at_fields
-          end,
-        },
-      ],
-    } %>
-  <% else %>
+    <% if edition.can_set_previously_published? %>
+      <%= render "govuk_publishing_components/components/checkboxes", {
+        name: "edition[previously_published]",
+        id: "edition_previously_published",
+        heading: "First published date",
+        heading_size: "l",
+        hint_text: "If this document has been published on another webpage, you must provide the date it was first published online." +
+          " This only applies to online content. Do not use this for file attachments.",
+        items: [
+          {
+            label: "This document has previously been published on another website",
+            value: true,
+            checked: previously_published,
+            conditional: capture do
+              first_published_at_fields
+            end,
+          },
+        ],
+      } %>
+    <% end %>
+  <% elsif edition.can_set_previously_published? %>
     <%= render "govuk_publishing_components/components/fieldset", {
       legend_text: "First published",
       heading_size: "l",

--- a/app/components/admin/editions/first_published_at_component.rb
+++ b/app/components/admin/editions/first_published_at_component.rb
@@ -11,10 +11,6 @@ class Admin::Editions::FirstPublishedAtComponent < ViewComponent::Base
     @year = year
   end
 
-  def render?
-    edition.can_set_previously_published?
-  end
-
 private
 
   attr_reader :edition, :previously_published, :day, :month, :year

--- a/app/models/configurable_document_types/history_page.json
+++ b/app/models/configurable_document_types/history_page.json
@@ -29,6 +29,7 @@
     "rendering_app": "government-frontend",
     "images_enabled": true,
     "organisations": ["af07d5a5-df63-4ddc-9383-6a666845ebe9"],
-    "backdating_enabled": false
+    "backdating_enabled": false,
+    "history_mode_enabled": false
   }
 }

--- a/app/models/configurable_document_types/history_page.json
+++ b/app/models/configurable_document_types/history_page.json
@@ -28,6 +28,7 @@
     "publishing_api_document_type": "history",
     "rendering_app": "government-frontend",
     "images_enabled": true,
-    "organisations": ["af07d5a5-df63-4ddc-9383-6a666845ebe9"]
+    "organisations": ["af07d5a5-df63-4ddc-9383-6a666845ebe9"],
+    "backdating_enabled": false
   }
 }

--- a/app/models/configurable_document_types/news_story.json
+++ b/app/models/configurable_document_types/news_story.json
@@ -27,6 +27,7 @@
     "rendering_app": "frontend",
     "images_enabled": true,
     "organisations": null,
-    "backdating_enabled": true
+    "backdating_enabled": true,
+    "history_mode_enabled": true
   }
 }

--- a/app/models/configurable_document_types/news_story.json
+++ b/app/models/configurable_document_types/news_story.json
@@ -1,0 +1,32 @@
+{
+  "key": "news_story",
+  "schema": {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://www.gov.uk/schemas/news_story/v1",
+    "title": "News Story",
+    "description": "News written exclusively for GOV.UK which users need, can act on and can’t get from other sources. Avoid duplicating press releases.",
+    "type": "object",
+    "properties": {
+      "body": {
+        "title": "Body (required)",
+        "type": "string",
+        "format": "govspeak"
+      },
+      "image": {
+        "title": "Lead image",
+        "description": "Select a lead image, if required",
+        "type": "string",
+        "format": "image_select"
+      }
+    }
+  },
+  "settings": {
+    "base_path_prefix": "/government/news",
+    "publishing_api_schema_name": "news_article",
+    "publishing_api_document_type": "news_story",
+    "rendering_app": "frontend",
+    "images_enabled": true,
+    "organisations": null,
+    "backdating_enabled": true
+  }
+}

--- a/app/models/standard_edition.rb
+++ b/app/models/standard_edition.rb
@@ -32,6 +32,10 @@ class StandardEdition < Edition
     type_instance.settings["images_enabled"]
   end
 
+  def can_be_marked_political?
+    type_instance.settings["history_mode_enabled"]
+  end
+
   def base_path
     "#{type_instance.settings['base_path_prefix']}/#{slug}"
   end

--- a/app/models/standard_edition.rb
+++ b/app/models/standard_edition.rb
@@ -25,11 +25,7 @@ class StandardEdition < Edition
   end
 
   def can_set_previously_published?
-    false
-  end
-
-  def previously_published
-    false
+    type_instance.settings["backdating_enabled"]
   end
 
   def allows_image_attachments?

--- a/app/views/admin/standard_editions/_form.html.erb
+++ b/app/views/admin/standard_editions/_form.html.erb
@@ -69,6 +69,15 @@
       path: ConfigurableContentBlocks::Path.new,
       root: true,
     }) %>
+
+    <%= render Admin::Editions::FirstPublishedAtComponent.new(
+      edition:,
+      previously_published: params.dig("edition", "previously_published") == "true" || edition.previously_published == true,
+      year: @edition_params.try(:dig, "first_published_at(1i)") || edition.first_published_at&.year,
+      month: @edition_params.try(:dig, "first_published_at(2i)") || edition.first_published_at&.month,
+      day: @edition_params.try(:dig, "first_published_at(3i)") || edition.first_published_at&.day,
+    ) %>
+
     <%= render("settings_fields", form:, edition:) %>
     <%= standard_edition_publishing_controls(form, edition) %>
   </div>

--- a/app/views/admin/standard_editions/_form.html.erb
+++ b/app/views/admin/standard_editions/_form.html.erb
@@ -78,6 +78,8 @@
       day: @edition_params.try(:dig, "first_published_at(3i)") || edition.first_published_at&.day,
     ) %>
 
+    <%= render Admin::Editions::HistoryModeFormControls.new(@edition, current_user) %>
+
     <%= render("settings_fields", form:, edition:) %>
     <%= standard_edition_publishing_controls(form, edition) %>
   </div>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -27,9 +27,12 @@ if Organisation.where(name: "HM Revenue & Customs").blank?
 end
 
 if Organisation.where(name: "Test Organisation").blank?
+  Organisation.skip_callback(:commit, :after, :publish_to_publishing_api)
+  Organisation.skip_callback(:save, :after, :republish_how_government_works_page_to_publishing_api)
   Organisation.create!(
     name: "Test Organisation",
     slug: "government-digital-service",
+    content_id: "af07d5a5-df63-4ddc-9383-6a666845ebe9",
     acronym: "TO",
     organisation_type_key: :other,
     logo_formatted_name: "Test",

--- a/features/fixtures/test_configurable_document_type.json
+++ b/features/fixtures/test_configurable_document_type.json
@@ -26,6 +26,7 @@
     "publishing_api_schema_name": "test_type",
     "publishing_api_document_type": "test_type",
     "rendering_app": "government-frontend",
-    "organisations": null
+    "organisations": null,
+    "backdating_enabled": false
   }
 }

--- a/features/step_definitions/standard_edition_steps.rb
+++ b/features/step_definitions/standard_edition_steps.rb
@@ -35,6 +35,7 @@ When(/^I publish a submitted draft of a test configurable document titled "([^"]
     standard_edition.summary = "A brief summary of the document."
     standard_edition.images = [image]
     standard_edition.state = "submitted"
+    standard_edition.previously_published = false
     standard_edition.document = Document.new
     standard_edition.document.slug = title.parameterize
     standard_edition.block_content = {

--- a/test/components/admin/editions/first_published_at_component_test.rb
+++ b/test/components/admin/editions/first_published_at_component_test.rb
@@ -3,12 +3,23 @@
 require "test_helper"
 
 class Admin::Editions::FirstPublishedAtComponentTest < ViewComponent::TestCase
-  test "doesn't render when the edition can't set previously published" do
+  test "renders a hidden checkbox with the value set to false when the document can't set previously published and has never been published before" do
     edition = build(:consultation)
+
+    render_inline(Admin::Editions::FirstPublishedAtComponent.new(edition:, previously_published: false))
+
+    assert_selector "input[type='hidden'][name='edition[previously_published]'][value='false']", visible: :hidden
+    assert_selector ".govuk-checkboxes", count: 0
+  end
+
+  test "renders nothing when the document can't set previously published and has been published before" do
+    edition = build(:published_consultation)
 
     render_inline(Admin::Editions::FirstPublishedAtComponent.new(edition:, previously_published: true))
 
-    assert page.text.blank?
+    assert_selector "input[type='hidden'][name='edition[previously_published]'][value='false']", visible: :hidden, count: 0
+    assert_selector ".govuk-checkboxes", count: 0
+    assert_selector ".govuk-fieldset", text: "First published", count: 0
   end
 
   test "when the document has never been published it renders with the correct fields" do

--- a/test/factories/standard_editions.rb
+++ b/test/factories/standard_editions.rb
@@ -1,0 +1,25 @@
+FactoryBot.define do
+  factory :standard_edition, class: StandardEdition, parent: :edition do
+    sequence(:title) { |index| "standard-edition-title-#{index}" }
+    summary { "standard-edition-summary" }
+
+    factory :draft_standard_edition, parent: :standard_edition, traits: [:draft]
+    factory :submitted_standard_edition, parent: :standard_edition, traits: [:submitted]
+    factory :rejected_standard_edition, parent: :standard_edition, traits: [:rejected]
+    factory :published_standard_edition, parent: :standard_edition, traits: [:published]
+    factory :deleted_standard_edition, parent: :standard_edition, traits: [:deleted]
+    factory :superseded_standard_edition, parent: :standard_edition, traits: [:superseded]
+    factory :scheduled_standard_edition, parent: :standard_edition, traits: [:scheduled]
+    factory :unpublished_standard_edition, parent: :standard_edition, traits: [:unpublished]
+    factory :unpublished_standard_edition_in_error_no_redirect,
+            parent: :standard_edition,
+            traits: %i[published_in_error_no_redirect]
+    factory :unpublished_standard_edition_in_error_redirect,
+            parent: :standard_edition,
+            traits: %i[published_in_error_redirect]
+    factory :unpublished_standard_edition_consolidated,
+            parent: :standard_edition,
+            traits: %i[consolidated_redirect]
+    factory :withdrawn_standard_edition, parent: :standard_edition, traits: [:withdrawn]
+  end
+end

--- a/test/functional/admin/standard_editions_controller_test.rb
+++ b/test/functional/admin/standard_editions_controller_test.rb
@@ -67,6 +67,40 @@ class Admin::StandardEditionsControllerTest < ActionController::TestCase
     refute_dom "label", "Test Type Two"
   end
 
+  view_test "GET edit renders previously published form controls if backdating is enabled" do
+    configurable_document_types = {
+      "test_type" => {
+        "key" => "test_type_one",
+        "schema" => {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "$id": "https://www.gov.uk/schemas/test_type/v1",
+          "title" => "Test Type One",
+          "type" => "object",
+          "properties" => {
+            "test_attribute" => {
+              "title" => "Test Attribute",
+              "type" => "string",
+            },
+          },
+        },
+        "settings" => {
+          "backdating_enabled" => true,
+        },
+      },
+    }
+    ConfigurableDocumentType.setup_test_types(configurable_document_types)
+
+    edition = build(:standard_edition)
+    edition.configurable_document_type = "test_type"
+    edition.block_content = { "test_attribute" => "test" }
+    edition.save!
+
+    get :edit, params: { id: edition }
+
+    assert_response :ok
+    assert_select "legend", text: "First published date"
+  end
+
   view_test "GET edit renders the history mode form controls when history mode is enabled" do
     configurable_document_types = {
       "test_type" => {

--- a/test/unit/app/models/standard_edition_test.rb
+++ b/test/unit/app/models/standard_edition_test.rb
@@ -102,6 +102,54 @@ class StandardEditionTest < ActiveSupport::TestCase
     assert_not page_without_backdating.can_set_previously_published?
   end
 
+  test "it allows marking content as political if the history mode configurable document type setting permits it" do
+    test_types = {
+      "test_type_with_history_mode" => {
+        "key" => "test_type_with_history_mode",
+        "schema" => {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "$id": "https://www.gov.uk/schemas/test_type/v1",
+          "title": "Test type",
+          "type": "object",
+          "properties" => {
+            "test_attribute" => {
+              "title": "Test attribute",
+              "type": "string",
+            },
+          },
+          "required" => %w[test_attribute],
+        },
+        "settings" => {
+          "history_mode_enabled" => true,
+        },
+      },
+      "test_type_without_history_mode" => {
+        "key" => "test_type_without_history_mode",
+        "schema" => {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "$id": "https://www.gov.uk/schemas/test_type/v1",
+          "title": "Test type",
+          "type": "object",
+          "properties" => {
+            "test_attribute" => {
+              "title": "Test attribute",
+              "type": "string",
+            },
+          },
+          "required" => %w[test_attribute],
+        },
+        "settings" => {
+          "history_mode_enabled" => false,
+        },
+      },
+    }
+    ConfigurableDocumentType.setup_test_types(test_types)
+    page_with_history_mode = StandardEdition.new(configurable_document_type: "test_type_with_history_mode")
+    page_without_history_mode = StandardEdition.new(configurable_document_type: "test_type_without_history_mode")
+    assert page_with_history_mode.can_be_marked_political?
+    assert_not page_without_history_mode.can_be_marked_political?
+  end
+
   test "it is invalid if the block content does not conform to the configurable document type schema" do
     test_types = {
       "test_type" => {

--- a/test/unit/app/models/standard_edition_test.rb
+++ b/test/unit/app/models/standard_edition_test.rb
@@ -4,8 +4,6 @@ class StandardEditionTest < ActiveSupport::TestCase
   test "does not require some of the standard edition fields" do
     page = StandardEdition.new
     assert_not page.body_required?
-    assert_not page.can_set_previously_published?
-    assert_not page.previously_published
   end
 
   test "it allows images if the configurable document type settings permit them" do
@@ -54,6 +52,54 @@ class StandardEditionTest < ActiveSupport::TestCase
     page_without_images = StandardEdition.new(configurable_document_type: "test_type_without_images")
     assert page_with_images.allows_image_attachments?
     assert_not page_without_images.allows_image_attachments?
+  end
+
+  test "it allows backdating if the configurable document type settings permit them" do
+    test_types = {
+      "test_type_with_backdating" => {
+        "key" => "test_type_with_backdating",
+        "schema" => {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "$id": "https://www.gov.uk/schemas/test_type/v1",
+          "title": "Test type",
+          "type": "object",
+          "properties" => {
+            "test_attribute" => {
+              "title" => "Test attribute",
+              "type" => "string",
+            },
+          },
+          "required" => %w[test_attribute],
+        },
+        "settings" => {
+          "backdating_enabled" => true,
+        },
+      },
+      "test_type_without_backdating" => {
+        "key" => "test_type_without_backdating",
+        "schema" => {
+          "$schema": "https://json-schema.org/draft/2020-12/schema",
+          "$id": "https://www.gov.uk/schemas/test_type/v1",
+          "title": "Test type",
+          "type": "object",
+          "properties" => {
+            "test_attribute" => {
+              "title" => "Test attribute",
+              "type" => "string",
+            },
+          },
+          "required" => %w[test_attribute],
+        },
+        "settings" => {
+          "backdating_enabled" => false,
+        },
+      },
+    }
+    ConfigurableDocumentType.setup_test_types(test_types)
+    page_with_backdating = StandardEdition.new(configurable_document_type: "test_type_with_backdating")
+    page_without_backdating = StandardEdition.new(configurable_document_type: "test_type_without_backdating")
+    assert page_with_backdating.can_set_previously_published?
+    assert_not page_without_backdating.can_set_previously_published?
   end
 
   test "it is invalid if the block content does not conform to the configurable document type schema" do


### PR DESCRIPTION
This includes a new news story configurable document type.

In order to achieve parity with base Whitehall editions, we needed to:

- Add the summary field to standard editions
- Add the first publishing backdating behaviour
- Add history mode

These can all be disabled in the settings.

We also made the test organisation seed use the real GDS content ID, which helped when testing the behaviour of history pages.
