### PR TITLE
[WHIT-2270] Additional fixes for configurable documents images

### DIFF
--- a/app/models/configurable_content_blocks/image_select.rb
+++ b/app/models/configurable_content_blocks/image_select.rb
@@ -25,7 +25,7 @@ module ConfigurableContentBlocks
     def publishing_api_payload(content)
       return nil if content.blank?
 
-      if (selected_image = images.find { |image| image.id == content.to_i })
+      if (selected_image = images.find { |image| image.image_data.id == content.to_i })
         {
           url: selected_image.url,
           caption: selected_image.caption,

--- a/app/models/configurable_document_types/history_page.json
+++ b/app/models/configurable_document_types/history_page.json
@@ -19,7 +19,8 @@
         "type": "string",
         "format": "image_select"
       }
-    }
+    },
+    "required": ["body"]
   },
   "settings": {
     "base_path_prefix": "/government/history",

--- a/app/models/standard_edition.rb
+++ b/app/models/standard_edition.rb
@@ -8,6 +8,14 @@ class StandardEdition < Edition
     "choose_type_admin_standard_editions_path"
   end
 
+  def format_name
+    type_instance.label.downcase
+  end
+
+  def display_type
+    type_instance.label
+  end
+
   def publishing_api_presenter
     PublishingApi::StandardEditionPresenter
   end

--- a/app/models/standard_edition.rb
+++ b/app/models/standard_edition.rb
@@ -20,10 +20,6 @@ class StandardEdition < Edition
     PublishingApi::StandardEditionPresenter
   end
 
-  def summary_required?
-    false
-  end
-
   def body_required?
     false
   end

--- a/app/presenters/publishing_api/standard_edition_presenter.rb
+++ b/app/presenters/publishing_api/standard_edition_presenter.rb
@@ -14,6 +14,7 @@ module PublishingApi
     def content
       content = BaseItemPresenter.new(item, update_type:).base_attributes
       content.merge!(
+        description: item.summary,
         details:,
         document_type: type.settings["publishing_api_document_type"],
         public_updated_at: item.public_timestamp || item.updated_at,

--- a/app/views/admin/configurable_content_blocks/_image_select.html.erb
+++ b/app/views/admin/configurable_content_blocks/_image_select.html.erb
@@ -7,8 +7,8 @@
    ] + image_select.images.map do |image|
   {
     text: image.filename,
-    value: image.id,
-    selected: image.id == content.to_i,
+    value: image.image_data.id,
+    selected: image.image_data.id == content.to_i,
   }
 end %>
 

--- a/app/views/admin/standard_editions/_form.html.erb
+++ b/app/views/admin/standard_editions/_form.html.erb
@@ -21,6 +21,25 @@
       } %>
     </div>
 
+    <div class="govuk-!-margin-bottom-6 js-locale-switcher-field">
+      <%= render "govuk_publishing_components/components/character_count", {
+        textarea: {
+          label: {
+            text: "Summary (required)",
+            heading_size: "m",
+          },
+          name: "edition[summary]",
+          value: edition.summary,
+          error_items: errors_for(edition.errors, :summary),
+          right_to_left: form.object.translation_rtl?,
+          right_to_left_help: false,
+          rows: 1,
+        },
+        id: "edition_summary",
+        maxlength: MaxLengths::SUMMARY,
+      } %>
+    </div>
+
     <% if edition.document&.slug.present? %>
       <div class="app-view-edit-edition__page-address govuk-!-margin-bottom-6">
         <%= render "govuk_publishing_components/components/heading", {

--- a/features/fixtures/test_configurable_document_type.json
+++ b/features/fixtures/test_configurable_document_type.json
@@ -7,24 +7,6 @@
     "description": "A test configurable document on GOV.UK",
     "type": "object",
     "properties": {
-      "page_title": {
-        "title": "Page title",
-        "description": "The title of the page",
-        "type": "object",
-        "properties": {
-          "heading_text": {
-            "title": "Heading text",
-            "description": "The main heading text for the page title",
-            "type": "string"
-          },
-          "context": {
-            "title": "Context",
-            "description": "Some additional context for the page title",
-            "type": "string"
-          }
-        },
-        "required": ["heading_text"]
-      },
       "body": {
         "title": "Body",
         "description": "The main content of the page",
@@ -37,8 +19,7 @@
         "type": "string",
         "format": "image_select"
       }
-    },
-    "required": ["page_title"]
+    }
   },
   "settings": {
     "base_path_prefix": "/government/test-type",

--- a/features/standard-edition.feature
+++ b/features/standard-edition.feature
@@ -13,3 +13,4 @@ Feature: Standard Editions
     And the test configurable document type is defined
     When I publish a submitted draft of a test configurable document titled "The history of GOV.UK"
     Then I can see that the draft edition of "The history of GOV.UK" was published successfully
+    And a new draft of "The history of GOV.UK" is created with the correct field values

--- a/features/step_definitions/standard_edition_steps.rb
+++ b/features/step_definitions/standard_edition_steps.rb
@@ -16,6 +16,7 @@ When(/^I draft a new "([^"]*)" configurable document titled "([^"]*)"$/) do |con
   click_button("Next")
   page.choose(configurable_document_type)
   click_button("Next")
+  expect(page).to have_content("New test")
   within "form" do
     fill_in "edition_title", with: title
     fill_in "edition_block_content_page_title_heading_text", with: title
@@ -54,6 +55,7 @@ end
 Then(/^I am on the summary page of the draft titled "([^"]*)"$/) do |title|
   expect(page.find("h1")).to have_content(title)
   expect(page).to have_content("Your document has been saved.")
+  expect(page).to have_content("Standard edition: Test")
 end
 
 Then(/^I can see that the draft edition of "([^"]*)" was published successfully$/) do |title|

--- a/features/step_definitions/standard_edition_steps.rb
+++ b/features/step_definitions/standard_edition_steps.rb
@@ -20,7 +20,6 @@ When(/^I draft a new "([^"]*)" configurable document titled "([^"]*)"$/) do |con
   within "form" do
     fill_in "edition_title", with: title
     fill_in "edition_summary", with: "A brief summary of the document."
-    fill_in "edition_block_content_page_title_heading_text", with: title
     fill_in "edition_block_content_body", with: "## Some govspeak\n\nThis is the body content"
   end
   click_button "Save and go to document summary"
@@ -39,10 +38,6 @@ When(/^I publish a submitted draft of a test configurable document titled "([^"]
     standard_edition.document = Document.new
     standard_edition.document.slug = title.parameterize
     standard_edition.block_content = {
-      "page_title" => {
-        "heading_text" => title,
-        "context" => "Additional context",
-      },
       "image" => image.image_data.id.to_s,
       "body" => "Some text",
     }

--- a/features/step_definitions/standard_edition_steps.rb
+++ b/features/step_definitions/standard_edition_steps.rb
@@ -19,6 +19,7 @@ When(/^I draft a new "([^"]*)" configurable document titled "([^"]*)"$/) do |con
   expect(page).to have_content("New test")
   within "form" do
     fill_in "edition_title", with: title
+    fill_in "edition_summary", with: "A brief summary of the document."
     fill_in "edition_block_content_page_title_heading_text", with: title
     fill_in "edition_block_content_body", with: "## Some govspeak\n\nThis is the body content"
   end
@@ -31,6 +32,7 @@ When(/^I publish a submitted draft of a test configurable document titled "([^"]
   as_user(submitter) do
     standard_edition.configurable_document_type = "test"
     standard_edition.title = title
+    standard_edition.summary = "A brief summary of the document."
     standard_edition.state = "submitted"
     standard_edition.document = Document.new
     standard_edition.document.slug = title.parameterize

--- a/features/step_definitions/standard_edition_steps.rb
+++ b/features/step_definitions/standard_edition_steps.rb
@@ -28,11 +28,13 @@ end
 
 When(/^I publish a submitted draft of a test configurable document titled "([^"]*)"$/) do |title|
   submitter = create(:user)
+  image = create(:image)
   standard_edition = StandardEdition.new
   as_user(submitter) do
     standard_edition.configurable_document_type = "test"
     standard_edition.title = title
     standard_edition.summary = "A brief summary of the document."
+    standard_edition.images = [image]
     standard_edition.state = "submitted"
     standard_edition.document = Document.new
     standard_edition.document.slug = title.parameterize
@@ -41,6 +43,7 @@ When(/^I publish a submitted draft of a test configurable document titled "([^"]
         "heading_text" => title,
         "context" => "Additional context",
       },
+      "image" => image.image_data.id.to_s,
       "body" => "Some text",
     }
     standard_edition.creator = submitter
@@ -62,4 +65,11 @@ end
 
 Then(/^I can see that the draft edition of "([^"]*)" was published successfully$/) do |title|
   expect(page).to have_content("The document #{title} has been published")
+end
+
+And(/^a new draft of "([^"]*)" is created with the correct field values$/) do |title|
+  standard_edition = StandardEdition.find_by(title: title)
+  visit admin_standard_edition_path(standard_edition)
+  click_button "Create new edition"
+  expect(page).to have_select("Image", selected: standard_edition.images.first.filename)
 end

--- a/test/unit/app/models/configurable_content_blocks/image_select_test.rb
+++ b/test/unit/app/models/configurable_content_blocks/image_select_test.rb
@@ -15,7 +15,7 @@ class ConfigurableContentBlocks::ImageSelectTest < ActiveSupport::TestCase
     images = create_list(:image, 3)
     page = StandardEdition.new
     page.images = images
-    payload = ConfigurableContentBlocks::ImageSelect.new(page.images).publishing_api_payload(images[1].id)
+    payload = ConfigurableContentBlocks::ImageSelect.new(page.images).publishing_api_payload(images[1].image_data.id)
 
     assert_equal({
       url: images[1].url,
@@ -46,7 +46,7 @@ class ConfigurableContentBlocks::ImageSelectRenderingTest < ActionView::TestCase
 
     @page = StandardEdition.new
     @page.images = create_list(:image, 3)
-    @page.block_content = { "test_attribute" => @page.images.last.id.to_s }
+    @page.block_content = { "test_attribute" => @page.images.last.image_data.id.to_s }
     @block = ConfigurableContentBlocks::ImageSelect.new(@page.images)
 
     render @block, {

--- a/test/unit/app/models/standard_edition_test.rb
+++ b/test/unit/app/models/standard_edition_test.rb
@@ -3,7 +3,6 @@ require "test_helper"
 class StandardEditionTest < ActiveSupport::TestCase
   test "does not require some of the standard edition fields" do
     page = StandardEdition.new
-    assert_not page.summary_required?
     assert_not page.body_required?
     assert_not page.can_set_previously_published?
     assert_not page.previously_published

--- a/test/unit/app/presenters/publishing_api/standard_edition_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/standard_edition_presenter_test.rb
@@ -75,6 +75,29 @@ class PublishingApi::StandardEditionPresenterTest < ActiveSupport::TestCase
     assert_equal page.block_content["property_two"], content[:details][:property_two]
   end
 
+  test "it includes a title and a description" do
+    type_key = "test_type_key"
+    ConfigurableDocumentType.setup_test_types({
+      type_key => {
+        "key" => type_key,
+        "schema" => {
+          "type" => "object",
+          "title" => "An object",
+          "description" => "A test schema",
+          "properties" => {},
+        },
+        "settings" => {},
+      },
+    })
+    page = StandardEdition.new(title: "Page Title", summary: "Page Summary")
+    page.configurable_document_type = type_key
+    page.document = Document.new(slug: "page-title")
+    presenter = PublishingApi::StandardEditionPresenter.new(page)
+    content = presenter.content
+    assert_equal page.title, content[:title]
+    assert_equal page.summary, content[:description]
+  end
+
   test "it includes headers for each govspeak type block" do
     type_key = "test_type_key"
     ConfigurableDocumentType.setup_test_types({


### PR DESCRIPTION
Few tweaks for Standard Editions & other clean-ups, including:
- Fix bug where the (sidebar) image is not persisted.
- Change rendering of title so we can refer to a "history page" rather than a "standard edition"
- Include a description field in the publishing api payload.

Screenshots
<img width="574" height="360" alt="Screenshot 2025-08-27 at 10 41 20" src="https://github.com/user-attachments/assets/419bdfb7-e15f-4f19-ba9e-ed7c36d29395" />
<img width="574" height="360" alt="Screenshot 2025-08-27 at 10 41 08" src="https://github.com/user-attachments/assets/15ed2ebd-fc18-4a79-8178-4c5c5968b7a8" />



[Jira](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-2270)