### PR TITLE
Move `invalid_edition` filter test to features [WHIT-2458]

### DIFF
--- a/features/admin-filtering-documents.feature
+++ b/features/admin-filtering-documents.feature
@@ -41,3 +41,17 @@ Feature: Filtering documents by author in admin
     When I filter by review overdue
     Then I should see the publication "I moustache you a question"
     And I should not see the publication "Standard Beard Lengths"
+
+  Scenario: Viewing only invalid documents
+    Given I am a writer
+    And a world location "United Kingdom" exists
+    When I draft a new worldwide organisation "Test Worldwide Organisation" assigned to world location "United Kingdom"
+
+    And I draft a new invalid publication "Invalid Publication"
+    And I visit the list of documents
+    Then I should see the publication "Invalid Publication"
+    And I should see the worldwide organisation "Test Worldwide Organisation"
+
+    When I filter by only invalid editions
+    Then I should see the publication "Invalid Publication"
+    And I should not see the worldwide organisation "Test Worldwide Organisation"

--- a/features/step_definitions/document_steps.rb
+++ b/features/step_definitions/document_steps.rb
@@ -61,6 +61,10 @@ When(/^I view the (publication|news article|consultation|speech|document) "([^"]
   click_link title
 end
 
+When(/^I visit the list of documents$/) do
+  visit admin_editions_path
+end
+
 When(/^I visit the list of draft documents$/) do
   visit admin_editions_path(state: :draft)
 end
@@ -79,6 +83,13 @@ end
 
 When(/^I filter by organisation "([^"]*)"$/) do |organisation_name|
   filter_editions_by :organisation, organisation_name
+end
+
+When(/^I filter by only invalid editions/) do
+  within ".app-view-filter" do
+    check "Only invalid editions"
+    click_on "Search"
+  end
 end
 
 When("I submit {edition}") do |edition|

--- a/features/step_definitions/publication_steps.rb
+++ b/features/step_definitions/publication_steps.rb
@@ -19,6 +19,15 @@ When(/^I draft a new publication "([^"]*)"$/) do |title|
   add_external_attachment
 end
 
+When(/^I draft a new invalid publication "([^"]*)"$/) do |title|
+  bad_id = 9_999_999_999_999
+  begin_drafting_publication(title)
+  within "form" do
+    fill_in "edition_body", with: "[Contact:#{bad_id}]"
+  end
+  click_button "Save and go to document summary"
+end
+
 Given(/^"([^"]*)" drafts a new publication "([^"]*)"$/) do |user_name, title|
   user = User.find_by(name: user_name)
   as_user(user) do

--- a/test/functional/admin/editions_controller_test.rb
+++ b/test/functional/admin/editions_controller_test.rb
@@ -158,13 +158,6 @@ class Admin::EditionsControllerTest < ActionController::TestCase
     assert_equal "test", session[:document_filters]["title"]
   end
 
-  view_test "should have an 'only invalid editions' checkbox that sets the 'only_invalid_editions' filter" do
-    visit "/government/admin/editions"
-    check "Only invalid editions"
-    click_button "Search"
-    assert_includes current_url, "only_invalid_editions=1"
-  end
-
   test "should remember 'only invalid editions' option" do
     get :index, params: { only_invalid_editions: "1" }
     assert_equal "1", session[:document_filters]["only_invalid_editions"]


### PR DESCRIPTION
## What

Move the `only_invalid_edition` test to `features/admin-filtering-documents.feature`

### Implementation note

All (apart from one type) of the documents derived from `GenericEdition` instances created by `FactoryBot` are invalid, as none of them are tagged (will return `false` for `has_been_tagged?`) since we don't stub `Services.publishing_api.get_expanded_links`. To get around this for the filter test (we need at least one invalid edition and one valid edition), we can use `WorldwideOrganisation` which does not require tags to be a valid. I suspect this difficulty in getting examples of valid and invalid editions is why this test was moved to the controller test suite.

## Why

The previous test for this functionality kept randomly failing. Reading the test, it seemed to be an anomaly within the controller test suite. There are no other examples of controller tests that interact with the rendered page (apart from checking to see what has been rendered). So therefore it made sense to move this test to a feature test suite.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
