### PR TITLE
feat: Add lead_paragraph property to history page configuration

### DIFF
--- a/app/models/configurable_document_types/history_page.json
+++ b/app/models/configurable_document_types/history_page.json
@@ -7,6 +7,12 @@
     "description": "A history page on GOV.UK",
     "type": "object",
     "properties": {
+      "lead_paragraph": {
+        "title": "Lead Paragraph",
+        "description": "Optional text that appears above the main content",
+        "type": "string",
+        "format": "govspeak"
+      },
       "body": {
         "title": "Body",
         "description": "The main content for the page",


### PR DESCRIPTION
- This property allows us to define the lead_paragraph used on /government/history, or can be ignored if empty.
- lead_property added to history schema in https://github.com/alphagov/publishing-api/pull/3550

https://trello.com/c/pMEJlBME/796-build-history-pages-from-content-item

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
