### PR TITLE
Report anonymous_user_id to analytics data layer

### DIFF
--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -7,7 +7,7 @@
     <meta name="govuk:user-organisation-name" content="<%= current_user&.organisation_name %>">
     <meta name="govuk:user-role" content="<%= current_user&.role %>">
     <meta name="govuk:format" content="<%= "#{action_name}-#{controller_name}" %>">
-    <meta name="govuk:user-id" content="">
+    <meta name="govuk:user-id" content="<%= current_user&.anonymous_user_id %>">
     <% if get_content_id(@edition) %>
       <meta name="govuk:content-id" content="<%= get_content_id(@edition) %>">
     <% end %>


### PR DESCRIPTION
Now that we've updated gds-sso to 22.1.1 and we have the ANONYMOUS_USER_ID_SECRET environment variable set, we can make use of the anonymous_user_id method to report the govuk:user-id to the data layer.

