### PR TITLE
[WHIT-2374] Add lead paragraph property to history page schema

### DIFF
--- a/app/models/configurable_document_types/history_page.json
+++ b/app/models/configurable_document_types/history_page.json
@@ -18,6 +18,12 @@
         "description": "Enter the markdown code for the sidebar image",
         "type": "string",
         "format": "image_select"
+      },
+      "lead_paragraph": {
+        "title": "Lead paragraph",
+        "description": "Optional text that appears above the main content",
+        "type": "string",
+        "format": "default"
       }
     },
     "required": ["body"]


### PR DESCRIPTION
[Jira](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-2374)

Add a new lead paragraph property to history page, so that we can use it to render https://www.gov.uk/government/history.

Identified some issues with the rendering, but that can be fixed separately. We should probably display the default blocks with a bigger header as well, otherwise it looks as if they're subfields of the previous object type block:
<img width="1100" height="543" alt="Screenshot 2025-08-27 at 16 42 31" src="https://github.com/user-attachments/assets/f8e0f4de-cda6-4fcb-9c44-fd18d99667aa" />