### PR TITLE
Remove unnecessary validation rule around 'internal' links (WHIT-2350)

### DIFF
--- a/app/validators/govspeak_link_validator.rb
+++ b/app/validators/govspeak_link_validator.rb
@@ -5,13 +5,9 @@ class GovspeakLinkValidator < ActiveModel::Validator
     matches(record.body, /\[.*?\]\((\S*?)(?:\s+"[^"]+")?\)/) do |match|
       link = match[1]
 
-      fix = if link.first == "/"
-              unless self.class.is_internal_admin_link?(link)
-                "If you are linking to a document created within Whitehall publisher, please use the internal admin path, e.g. /government/admin/publications/3373. If you are linking to other GOV.UK links, please use full URLs."
-              end
-            elsif self.class.is_internal_admin_link?("/#{link}")
+      fix = if self.class.is_internal_admin_link?("/#{link}")
               "This is an invalid admin link.  Did you mean /#{link} instead of #{link}?"
-            elsif !%r{^(?:https?://|mailto:|#)}.match?(link)
+            elsif !self.class.is_internal_admin_link?(link) && !%r{^(?:https?://|mailto:|#)}.match?(link)
               "Non-document or external links should start with http://, https://, mailto:, or # (for linking to sections on the same page, eg #actions on a policy)"
             elsif link.match?(/whitehall-admin/)
               "This links to the whitehall-admin domain. Please use paths, eg /government/admin/publications/3373, for documents created in publisher (see guidance on creating links) or full URLs for other GOV.UK links."

--- a/lib/tasks/reporting.rake
+++ b/lib/tasks/reporting.rake
@@ -91,9 +91,6 @@ def classify_error(error)
   when /Contact ID \d+ doesn't exist/
     # There is one error per Contact ID - so we need to group under the following string
     "Invalid Contact ID"
-  when %r{Issue with link `[^`]+`: If you are linking to a document created within Whitehall publisher}
-    # There is one error per bad internal link - so we need to group under the following string
-    "Invalid internal GOV.UK link format"
   when /Issue with link `.*`: Non-document or external links should start with http:\/\/, https:\/\/, mailto:, or #/
     # There is one error per bad external link - so we need to group under the following string
     "Invalid external link structure"

--- a/test/unit/app/validators/govspeak_link_validator_test.rb
+++ b/test/unit/app/validators/govspeak_link_validator_test.rb
@@ -64,13 +64,6 @@ class GovspeakLinkValidatorTest < ActiveSupport::TestCase
     assert_equal ["Issue with link `government/admin/policies/12345`: This is an invalid admin link.  Did you mean /government/admin/policies/12345 instead of government/admin/policies/12345?"], test_model.errors.map(&:type)
   end
 
-  test "should be invalid if it contains a non-admin absolute path" do
-    test_model = Edition.new(body: "[example text](/government/policies)")
-    GovspeakLinkValidator.new.validate(test_model)
-    assert_equal 1, test_model.errors.size
-    assert_equal ["Issue with link `/government/policies`: If you are linking to a document created within Whitehall publisher, please use the internal admin path, e.g. /government/admin/publications/3373. If you are linking to other GOV.UK links, please use full URLs."], test_model.errors.map(&:type)
-  end
-
   test "should identify internal admin links" do
     assert GovspeakLinkValidator.is_internal_admin_link?([Whitehall.router_prefix, "admin", "test"].join("/"))
     assert_not GovspeakLinkValidator.is_internal_admin_link?("http://www.google.com/")


### PR DESCRIPTION
If publishers choose to link to the user-facing slug (`/government/foo/bar`) instead of the Whitehall admin slug for that page (e.g. `/government/admin/foo/123`), we've traditionally flagged that as a validation error and prevented them from doing so.

[Asking around the content community](https://gds.slack.com/archives/CACV3TACU/p1752572986431479), there is general consensus that, whilst linking to the 'admin' path can have its uses, it shouldn't be enforced at the validation level. Softening this rule should reduce friction for our publishers and also reduce the number of editions considered 'invalid' in our system health reporting.

The only benefit to using the 'admin' links is to batch up publishing of several related drafts. Testing on integration:

- Draft Edition A, internal-admin-linking to Draft Edition B
- Draft Edition B, internal-admin-linking to Draft Edition A
- No links visible on preview (known bug), but…
- …set them both to schedule-publish at the same time, and when they published, they both had correct links to the published editions.

But there's no reason to force publishers to link to the 'admin' version of a thing if that thing is already published! It only adds complexity for both the publisher and the underlying code.

JIRA: https://gov-uk.atlassian.net/browse/WHIT-2350

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
