### PR TITLE
[WHIT-2374] feat: adjust lead_paragraph on history pages to allow govspeak

### DIFF
--- a/app/models/configurable_document_types/history_page.json
+++ b/app/models/configurable_document_types/history_page.json
@@ -23,7 +23,7 @@
         "title": "Lead paragraph",
         "description": "Optional text that appears above the main content",
         "type": "string",
-        "format": "default"
+        "format": "govspeak"
       }
     },
     "required": ["body"]


### PR DESCRIPTION
Updates lead_paragraph on history pages to allow govspeak. (in the hub history page we're replacing, the lead_paragraph contains links, so to match it exactly we need to allow them too).

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
