### PR TITLE
Run Dependabot at 7am

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,19 @@ updates:
     directory: /
     schedule:
       interval: daily
+      time: "07:00"
 
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: daily
+      time: "07:00"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule: 
+      interval: daily
+      time: "07:00"
 
   # Ruby needs to be upgraded manually in multiple places, so cannot
   # be upgraded by Dependabot. That effectively makes the below
@@ -21,7 +29,3 @@ updates:
     directory: /
     schedule:
       interval: weekly
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule: 
-      interval: daily


### PR DESCRIPTION
Dependabot often raises PRs _after_ govuk-dependabot-merger has been triggered (at [08:30 UTC](https://github.com/alphagov/govuk-dependabot-merger/blob/335d186988c7e36688e16b25872a0a1bef180233/.github/workflows/merge-dependabot-prs.yml#L6)) meaning we then get [alerted](https://gds.slack.com/archives/C02L13S214K/p1756372592120269) about outstanding Dependabot PRs. We then either have to manually merge these, or wait until the next day for them to be auto-merged.

By specifying the time at which Whitehall should have Dependabot PRs raised for it, we should ensure that any qualifying PRs will be auto-merged before we're notified of the outstanding PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
