### PR TITLE
Merge all headers from all govspeak  blocks in the publishing api payload

### DIFF
--- a/app/presenters/publishing_api/standard_edition_presenter.rb
+++ b/app/presenters/publishing_api/standard_edition_presenter.rb
@@ -46,13 +46,20 @@ module PublishingApi
     end
 
     def flatten_headers(content)
-      if content[:body]
-        html = content.dig(:body, :html)
-        headers = content.dig(:body, :headers)
-        content[:body] = html
-        content[:headers] = headers
+      headers = []
+
+      content.keys.each do |key|
+        content_for_key = content[key]
+
+        next unless content_for_key.is_a?(Hash)
+
+        html_for_content_block = content_for_key[:html]
+        headers_for_content_block = content_for_key[:headers]
+        content[key] = html_for_content_block if html_for_content_block.present?
+        headers << headers_for_content_block if headers_for_content_block.present?
       end
 
+      content[:headers] = headers.any? ? headers.flatten : nil
       content.compact
     end
 


### PR DESCRIPTION
Rather than only doing this for a block with the "body" key, merge all headers from all blocks.

The assumption is that in reality, or at least for our immediate use cases (history pages), only the "body"-key block will actually have any headers.

[Jira](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-2374)
