### PR TITLE
Notify Slack if CI fails on the 'main' branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,3 +62,11 @@ jobs:
   test-features:
     name: Test features
     uses: ./.github/workflows/cucumber.yml
+
+  notify-slack-if-failure-on-main:
+    if: ${{ failure() }}
+    uses: alphagov/govuk-infrastructure/.github/actions/report-run-failure/action.yml@main
+    with:
+      slack_webhook_url: ${{ secrets.GOVUK_SLACK_WEBHOOK_URL }}
+      channel: govuk-whitehall-experience-tech
+      message: "Whitehall CI failed on 'main' and blocked the deployment. Investigate!"


### PR DESCRIPTION
We sometimes have cases where CI passed on the build of the branch in the PR, but subsequently fails when the PR has been merged (e.g. due to a flaky test). In such cases, the deployment is blocked and so it is easy to assume that your merged code has been deployed when in fact it hasn't! This [happened to us recently](https://gds.slack.com/archives/C013F737737/p1755507962456949).

Luckily for us, Platform Engineering have already built a workflow to notify us of this very situation. They've documented how to use the workflow, here:
https://github.com/alphagov/govuk-infrastructure/blob/main/.github/actions/report-run-failure/README.md

This commit follows those instructions, with the small tweak of specifying the name of the `action.yml` file, which was being enforced as good practice directly in my VS Code editor.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
