### PR TITLE
Revert "feat: adjust lead_paragraph on history pages to allow govspeak"

### DIFF
--- a/app/models/configurable_document_types/history_page.json
+++ b/app/models/configurable_document_types/history_page.json
@@ -23,7 +23,7 @@
         "title": "Lead paragraph",
         "description": "Optional text that appears above the main content",
         "type": "string",
-        "format": "govspeak"
+        "format": "default"
       }
     },
     "required": ["body"]


### PR DESCRIPTION
Reverts alphagov/whitehall#10605 - lead_paragraph components don't allow govspeak, so the pragmatic solution seems to be to just revert this, and remove the links from the header of the history pages (if the links need to be added again, we can add them in the body).