### PR TITLE
[WHIT-1882] Remove unused base permission methods

### DIFF
--- a/app/models/concerns/edition/base_permission_methods.rb
+++ b/app/models/concerns/edition/base_permission_methods.rb
@@ -9,15 +9,10 @@ module Edition::BasePermissionMethods
     can_be_associated_with_role_appointments?
     can_be_associated_with_worldwide_organisations?
     can_be_fact_checked?
-    can_be_related_to_mainstream_content?
     can_be_related_to_organisations?
     can_apply_to_subset_of_nations?
     can_be_grouped_in_collections?
-    has_operational_field?
-    national_statistic?
-    has_consultation_participation?
     is_associated_with_a_minister?
-    statistics?
     can_be_tagged_to_worldwide_taxonomy?
   ].each do |method|
     define_method(method) { false }


### PR DESCRIPTION
### **What**

This PR removes unused edition feature methods from Edition::BasePermissionMethods that always returned false and were never overridden or called anywhere in the Whitehall codebase.

These methods were investigated as part of the review into whether the base permission methods list could be pruned.

**Background**

Whitehall defines a set of “base permission methods” in Edition::BasePermissionMethods.
Each edition type may override these methods via concerns (e.g. Edition::FactCheckable, Edition::Organisations), enabling features such as associations with organisations, fact-checking, topical events, etc.

By default, all editions return false for unsupported methods to provide a uniform interface. However, some methods are never overridden or used in the application.

Method | Overridden in | Supported by (Edition Types)
-- | -- | --
can_be_associated_with_social_media_accounts? | Edition::SocialMediaAccounts | WorldwideOrganisation
can_be_associated_with_topical_events? | Edition::TopicalEvents | Speech, FatalityNotice, Consultation, DocumentCollection, DetailedGuide, Publication, NewsArticle, CallForEvidence
can_be_associated_with_roles? | Edition::Roles | WorldwideOrganisation
can_be_associated_with_role_appointments? | Edition::RoleAppointments | FatalityNotice, Consultation, NewsArticle, Publication, CallForEvidence
can_be_associated_with_worldwide_organisations? | Edition::WorldwideOrganisations | CaseStudy, NewsArticle
can_be_fact_checked? | Edition::FactCheckable | FatalityNotice, Consultation, CallForEvidence, CaseStudy, DetailedGuide, NewsArticle, Publication
can_be_related_to_mainstream_content? | (None – base only) | (Always returns false)
can_be_related_to_organisations? | Edition::Organisations | Speech, FatalityNotice, LandingPage, Consultation, StatisticalDataSet, WorldwideOrganisation, DocumentCollection, CallForEvidence, CaseStudy, DetailedGuide, NewsArticle, Publication
can_apply_to_subset_of_nations? | Edition::NationalApplicability | CallForEvidence, DetailedGuide, Publication, Consultation
can_be_grouped_in_collections? | Edition::HasDocumentCollections | Speech, Consultation, CallForEvidence, StatisticalDataSet, NewsArticle, Publication, DetailedGuide, CaseStudy
has_operational_field? | (None – base only) | (Always returns false)
national_statistic? | (None – base only) | (Always returns false)
has_consultation_participation? | (None – base only) | (Always returns false)
is_associated_with_a_minister? | Edition::RoleAppointments, Edition::Appointment | Speech (via Appointment), FatalityNotice, Consultation, NewsArticle, Publication, CallForEvidence (via RoleAppointments)
statistics? | (None – base only) | (Always returns false)
can_be_tagged_to_worldwide_taxonomy? | Edition::TaggableOrganisations | Speech, FatalityNotice, Consultation, StatisticalDataSet, DocumentCollection, CallForEvidence, CaseStudy, DetailedGuide, Publication, NewsArticle


