### PR TITLE
Fix error when generated notice becomes too large

### DIFF
--- a/app/controllers/admin/bulk_republishing_controller.rb
+++ b/app/controllers/admin/bulk_republishing_controller.rb
@@ -114,7 +114,8 @@ class Admin::BulkRepublishingController < Admin::BaseController
 
     bulk_content_type_key = :all_documents_by_content_ids
     bulk_content_type_metadata_for_content_ids = bulk_content_type_metadata.fetch(bulk_content_type_key)
-    action = "#{bulk_content_type_metadata_for_content_ids[:name].upcase_first} #{content_ids_array_to_string(content_ids)} have been queued for republishing"
+    content_ids_string = content_ids.length > 20 ? "specified" : content_ids_array_to_string(content_ids)
+    action = "#{bulk_content_type_metadata_for_content_ids[:name].upcase_first} #{content_ids_string} have been queued for republishing"
     bulk_content_type_value = RepublishingEvent.bulk_content_types.fetch(bulk_content_type_key)
     @republishing_event = build_republishing_event(action:, bulk_content_type: bulk_content_type_value, content_ids:)
 


### PR DESCRIPTION
## What

If the number of `content_id`s specified for the bulk republisher is over 100, don't include them in the `flash[:notice]`.

## Why

`republish_documents_by_content_ids` can generate a notice that will cause an `ActionDispatch::Cookies::CookieOverflow` error to occur if the list of `content_ids` provided is large enough. This is because the session generated as a result of the notice exceeds the size limit due to the notice including the list of all the `content_ids`.



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
