### PR TITLE
Fix "What's New" page govspeak styling

### DIFF
--- a/app/views/admin/whats_new/index.html.erb
+++ b/app/views/admin/whats_new/index.html.erb
@@ -32,7 +32,7 @@
       } %>
     </div>
 
-    <section class="app-view-whats-new__section" id="<%= t("admin.whats_new.introduction.heading").parameterize(separator: "-") %>">
+    <section class="app-view-whats-new__section govspeak" id="<%= t("admin.whats_new.introduction.heading").parameterize(separator: "-") %>">
       <%= render "govuk_publishing_components/components/heading", {
         text: t("admin.whats_new.introduction.heading"),
         font_size: "m",
@@ -44,7 +44,7 @@
     </section>
 
     <% if upcoming_changes[:updates].present? %>
-      <section class="app-view-whats-new__section" id="<%= t("admin.whats_new.upcoming_changes.heading").parameterize(separator: "-") %>">
+      <section class="app-view-whats-new__section govspeak" id="<%= t("admin.whats_new.upcoming_changes.heading").parameterize(separator: "-") %>">
         <%= render "govuk_publishing_components/components/heading", {
           text: upcoming_changes[:heading],
           font_size: "m",
@@ -56,7 +56,7 @@
       </section>
     <% end %>
 
-    <section class="app-view-whats-new__section" id="<%= t("admin.whats_new.recent_changes.heading").parameterize(separator: "-") %>">
+    <section class="app-view-whats-new__section govspeak" id="<%= t("admin.whats_new.recent_changes.heading").parameterize(separator: "-") %>">
       <%= render "govuk_publishing_components/components/heading", {
         text: t("admin.whats_new.recent_changes.heading"),
         font_size: "m",
@@ -67,7 +67,7 @@
       <%= render partial: "admin/whats_new/back_to_top" %>
     </section>
 
-    <section class="app-view-whats-new__section" id="<%= t("admin.whats_new.guidance.heading").parameterize(separator: "-") %>">
+    <section class="app-view-whats-new__section govspeak" id="<%= t("admin.whats_new.guidance.heading").parameterize(separator: "-") %>">
       <%= render "govuk_publishing_components/components/heading", {
         text: t("admin.whats_new.guidance.heading"),
         font_size: "m",


### PR DESCRIPTION
Since 4efa7cd89646be58c3a6b6f1a35a3d15b20d62ef, we now need all pages that dynamically render govspeak to wrap their contents in a `govspeak` class.

|Before | After |
|-------|-------|
|![](https://github.com/user-attachments/assets/9497304a-0a98-4497-9a99-fc0338fa5c35)|![](https://github.com/user-attachments/assets/9626e98e-4bf6-4173-a5f9-871a9d5e31ff)|

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
