### PR TITLE
Retire preview_url from attachments

### DIFF
--- a/app/models/file_attachment.rb
+++ b/app/models/file_attachment.rb
@@ -52,7 +52,6 @@ class FileAttachment < Attachment
       file_size:,
       filename:,
       number_of_pages:,
-      preview_url:,
       assets:,
     }
   end
@@ -74,11 +73,5 @@ private
         filename: asset.filename,
       }
     end
-  end
-
-  def preview_url
-    return unless csv? && attachable.is_a?(Edition) && attachment_data.all_asset_variants_uploaded?
-
-    Plek.asset_root + "/media/#{attachment_data.id}/#{filename}/preview"
   end
 end

--- a/test/unit/app/models/file_attachment_test.rb
+++ b/test/unit/app/models/file_attachment_test.rb
@@ -64,11 +64,6 @@ class FileAttachmentTest < ActiveSupport::TestCase
     assert attachment.filename_changed?
   end
 
-  test "return media preview_url if all_asset_variants_uploaded?" do
-    attachment = create(:csv_attachment, attachable: create(:edition))
-    assert_equal Plek.asset_root + "/media/#{attachment.attachment_data.id}/sample.csv/preview", attachment.publishing_api_details_for_format[:preview_url]
-  end
-
   test "#assets returns assets list if all_asset_variants_uploaded?" do
     attachment = create(:csv_attachment, attachable: create(:edition))
 

--- a/test/unit/app/presenters/publishing_api/publication_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/publication_presenter_test.rb
@@ -289,6 +289,6 @@ class PublishingApi::PublicationPresenterTest < ActiveSupport::TestCase
 
     attachments = presented_publication.content[:details][:attachments]
     assert_equal 1, attachments.length
-    assert_not_nil attachments[0][:preview_url]
+    assert_not_nil attachments[0][:assets]
   end
 end


### PR DESCRIPTION
Jira card: https://gov-uk.atlassian.net/browse/NAV-18198
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
