### PR TITLE
[WHIT-1819] Prevent deletion of assets associated with unpublished documents

### DIFF
--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -100,6 +100,10 @@ class AttachmentData < ApplicationRecord
     attachments.size == 1 && attachments.first.attachable.publicly_visible?
   end
 
+  def needs_discarding?
+    attachments.size == 1
+  end
+
   delegate :accessible_to?, to: :significant_attachable
 
   delegate :access_limited?, to: :last_attachable

--- a/app/services/service_listeners/draft_attachment_asset_discarder.rb
+++ b/app/services/service_listeners/draft_attachment_asset_discarder.rb
@@ -1,12 +1,10 @@
 module ServiceListeners
-  class AttachmentAssetDeleter
+  class DraftAttachmentAssetDiscarder
     def self.call(attachable)
       Attachment.includes(:attachment_data).where(attachable: attachable.attachables).find_each do |attachment|
         attachment_data = attachment.attachment_data
 
-        next unless attachment_data&.deleted?
-
-        DeleteAttachmentAssetJob.perform_async(attachment_data.id)
+        DeleteAttachmentAssetJob.perform_async(attachment_data.id) if attachment_data&.needs_discarding?
       end
     end
   end

--- a/config/initializers/edition_services.rb
+++ b/config/initializers/edition_services.rb
@@ -4,7 +4,7 @@ Whitehall::Application.config.to_prepare do
       if %w[publish force_publish].include?(event)
         ServiceListeners::AttachmentAssetPublisher.call(edition)
       elsif event == "delete"
-        ServiceListeners::AttachmentAssetDeleter.call(edition)
+        ServiceListeners::DraftAttachmentAssetDiscarder.call(edition)
       else
         ServiceListeners::AttachmentUpdater.call(attachable: edition)
       end


### PR DESCRIPTION
Previously, when discarding a new edition of an unpublished document, any assets would get deleted. That meant that if a new edition of that document was subsequently published, the assets would return a 404 response in Asset Manager.

These changes ensure that we only delete the assets if they have never been associated with a published edition.

[Jira](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-1819)
