### PR TITLE
Add details of unpublishing to document summary page (WHIT-2474)

### DIFF
--- a/app/helpers/admin/editions_helper.rb
+++ b/app/helpers/admin/editions_helper.rb
@@ -185,12 +185,14 @@ module Admin::EditionsHelper
 
       if edition.state == "unpublished"
         reason = consolidated ? "being consolidated into another page" : "being published in error"
-        details = if consolidated || edition.unpublishing.redirect
-                    "User is redirected from<br><a href='#{Whitehall.public_root}#{edition.base_path}'>#{Whitehall.public_root}#{edition.base_path}</a><br>to<br><a href='#{edition.unpublishing.alternative_url}'>#{edition.unpublishing.alternative_url}</a>"
-                  else
-                    "User-facing reason: '#{edition.unpublishing.explanation}'. Alternative URL displayed to user:<br><a href='#{edition.unpublishing.alternative_url}'>#{edition.unpublishing.alternative_url}</a>"
-                  end
-        summary = "#{summary} due to #{reason}. #{details}"
+        details = ""
+        if consolidated || edition.unpublishing.redirect
+          details = " User is redirected from<br><a href='#{Whitehall.public_root}#{edition.base_path}'>#{Whitehall.public_root}#{edition.base_path}</a><br>to<br><a href='#{edition.unpublishing.alternative_url}'>#{edition.unpublishing.alternative_url}</a>"
+        else
+          details << " User-facing reason: '#{edition.unpublishing.explanation}'." if edition.unpublishing.explanation.present?
+          details << " Alternative URL displayed to user:<br><a href='#{edition.unpublishing.alternative_url}'>#{edition.unpublishing.alternative_url}</a>" if edition.unpublishing.alternative_url.present?
+        end
+        summary = "#{summary} due to #{reason}.#{details}"
       end
 
       summary

--- a/app/helpers/admin/editions_helper.rb
+++ b/app/helpers/admin/editions_helper.rb
@@ -186,9 +186,9 @@ module Admin::EditionsHelper
       if edition.state == "unpublished"
         reason = consolidated ? "being consolidated into another page" : "being published in error"
         details = if consolidated || edition.unpublishing.redirect
-                    "User is redirected from <a href='#{Whitehall.public_root}#{edition.base_path}'>#{Whitehall.public_root}#{edition.base_path}</a> to <a href='#{edition.unpublishing.alternative_url}'>#{edition.unpublishing.alternative_url}</a>"
+                    "User is redirected from<br><a href='#{Whitehall.public_root}#{edition.base_path}'>#{Whitehall.public_root}#{edition.base_path}</a><br>to<br><a href='#{edition.unpublishing.alternative_url}'>#{edition.unpublishing.alternative_url}</a>"
                   else
-                    "User-facing reason: '#{edition.unpublishing.explanation}'. Alternative URL displayed to user: <a href='#{edition.unpublishing.alternative_url}'>#{edition.unpublishing.alternative_url}</a>"
+                    "User-facing reason: '#{edition.unpublishing.explanation}'. Alternative URL displayed to user:<br><a href='#{edition.unpublishing.alternative_url}'>#{edition.unpublishing.alternative_url}</a>"
                   end
         summary = "#{summary} due to #{reason}. #{details}"
       end

--- a/app/helpers/admin/editions_helper.rb
+++ b/app/helpers/admin/editions_helper.rb
@@ -180,7 +180,20 @@ module Admin::EditionsHelper
 
   def status_text(edition)
     if edition.unpublishing.present?
-      "#{edition.state.capitalize} (unpublished #{time_ago_in_words(edition.unpublishing.created_at)} ago)"
+      summary = "#{edition.state.capitalize} (#{time_ago_in_words(edition.unpublishing.created_at)} ago)"
+      consolidated = edition.unpublishing.unpublishing_reason_id == UnpublishingReason::CONSOLIDATED_ID
+
+      if edition.state == "unpublished"
+        reason = consolidated ? "being consolidated into another page" : "being published in error"
+        details = if consolidated || edition.unpublishing.redirect
+                    "User is redirected from <a href='#{Whitehall.public_root}#{edition.base_path}'>#{Whitehall.public_root}#{edition.base_path}</a> to <a href='#{edition.unpublishing.alternative_url}'>#{edition.unpublishing.alternative_url}</a>"
+                  else
+                    "User-facing reason: '#{edition.unpublishing.explanation}'. Alternative URL displayed to user: <a href='#{edition.unpublishing.alternative_url}'>#{edition.unpublishing.alternative_url}</a>"
+                  end
+        summary = "#{summary} due to #{reason}. #{details}"
+      end
+
+      summary
     else
       edition.state.capitalize
     end

--- a/app/views/admin/editions/show/_main.html.erb
+++ b/app/views/admin/editions/show/_main.html.erb
@@ -8,7 +8,7 @@
       <%= render "govuk_publishing_components/components/summary_list", {
         items: [
           { field: "Type of document", value: edition_type(@edition) },
-          { field: "Status", value: status_text(@edition) },
+          { field: "Status", value: status_text(@edition).html_safe },
           { field: "Change type", value: @edition.minor_change? ? "Minor" : "Major" },
           *([{ field: "Organisations", value: joined_list(@edition.organisations.map { |o| o.name }) }] if @edition.respond_to?(:organisations)),
           {

--- a/test/unit/app/helpers/admin/editions_helper_test.rb
+++ b/test/unit/app/helpers/admin/editions_helper_test.rb
@@ -101,4 +101,19 @@ class Admin::EditionsHelperTest < ActionView::TestCase
 
     assert_equal "It's my title!", edition_title_link_or_edition_title(edition)
   end
+
+  test "#status_text returns the state if it is anything other than unpublished" do
+    edition = build(:published_edition)
+
+    assert_equal "Published", status_text(edition)
+  end
+
+  test "#status_text returns information about when the document was unpublished" do
+    edition = create(:unpublished_edition)
+
+    assert_equal "Unpublished (unpublished less than a minute ago)", status_text(edition)
+
+    edition.unpublishing.created_at = 1.year.ago
+    assert_equal "Unpublished (unpublished about 1 year ago)", status_text(edition)
+  end
 end

--- a/test/unit/app/helpers/admin/editions_helper_test.rb
+++ b/test/unit/app/helpers/admin/editions_helper_test.rb
@@ -121,7 +121,7 @@ class Admin::EditionsHelperTest < ActionView::TestCase
     edition.unpublishing.alternative_url = alternative_url
     edition.unpublishing.unpublishing_reason_id = UnpublishingReason::CONSOLIDATED_ID
     edition.unpublishing.save!
-    assert_equal "Unpublished (less than a minute ago) due to being consolidated into another page. User is redirected from <a href='https://www.test.gov.uk#{edition.base_path}'>https://www.test.gov.uk#{edition.base_path}</a> to <a href='#{alternative_url}'>#{alternative_url}</a>", status_text(edition)
+    assert_equal "Unpublished (less than a minute ago) due to being consolidated into another page. User is redirected from<br><a href='https://www.test.gov.uk#{edition.base_path}'>https://www.test.gov.uk#{edition.base_path}</a><br>to<br><a href='#{alternative_url}'>#{alternative_url}</a>", status_text(edition)
 
     edition.unpublishing.unpublishing_reason_id = UnpublishingReason::PUBLISHED_IN_ERROR_ID
     edition.unpublishing.redirect = false
@@ -129,11 +129,11 @@ class Admin::EditionsHelperTest < ActionView::TestCase
     edition.unpublishing.explanation = "the doc was published in error"
     edition.unpublishing.save!
 
-    assert_equal "Unpublished (less than a minute ago) due to being published in error. User-facing reason: 'the doc was published in error'. Alternative URL displayed to user: <a href='#{alternative_url}'>#{alternative_url}</a>", status_text(edition)
+    assert_equal "Unpublished (less than a minute ago) due to being published in error. User-facing reason: 'the doc was published in error'. Alternative URL displayed to user:<br><a href='#{alternative_url}'>#{alternative_url}</a>", status_text(edition)
 
     edition.unpublishing.created_at = 1.year.ago
     edition.unpublishing.redirect = true
     edition.unpublishing.save!
-    assert_equal "Unpublished (about 1 year ago) due to being published in error. User is redirected from <a href='https://www.test.gov.uk#{edition.base_path}'>https://www.test.gov.uk#{edition.base_path}</a> to <a href='#{alternative_url}'>#{alternative_url}</a>", status_text(edition)
+    assert_equal "Unpublished (about 1 year ago) due to being published in error. User is redirected from<br><a href='https://www.test.gov.uk#{edition.base_path}'>https://www.test.gov.uk#{edition.base_path}</a><br>to<br><a href='#{alternative_url}'>#{alternative_url}</a>", status_text(edition)
   end
 end


### PR DESCRIPTION
## What

This PR adds contextual information about the 'unpublishing' of an edition, to the document summary screen.

## Why

This information was difficult or impossible to derive otherwise.

## Screenshots

First, the "before" (basically the same for all scenarios):

> ![](https://github.com/user-attachments/assets/d79b2371-f7ba-438e-9b75-1f1a609be476)

After:

### Unpublished (consolidated) with redirect)

<https://whitehall-admin.integration.publishing.service.gov.uk/government/admin/collections/1661556>

> ![](https://github.com/user-attachments/assets/83f8dfbd-4111-46c4-a4fc-24e6eb05a984)

### Unpublished (in error) with redirect

<https://whitehall-admin.integration.publishing.service.gov.uk/government/admin/detailed-guides/1677115>.

> ![](https://github.com/user-attachments/assets/0794f92a-2b3a-4040-adf7-5ed0ece5585a)

### Unpublished (in error) - no redirect, no explanation (i.e. 'gone')

<https://whitehall-admin.integration.publishing.service.gov.uk/government/admin/publications/1690033> (user facing page at <https://www.gov.uk/government/publications/sellafield-ltd-key-targets-202526>).

> ![](https://github.com/user-attachments/assets/713c09eb-cbe9-47ca-a750-e948dacdacf5)

### Unpublished (in error) - explanation provided, no alternative URL

<https://whitehall-admin.integration.publishing.service.gov.uk/government/admin/publications/1683678> (user facing page at <https://www.gov.uk/government/publications/nio-spending-over-25000-february-2025>).

> ![](https://github.com/user-attachments/assets/b69614ee-f690-4770-b3d7-c9d957818fbd)

### Unpublished (in error) - no explanation, but alternative URL provided

<https://whitehall-admin.integration.publishing.service.gov.uk/government/admin/collections/1660363> (user facing page at <https://www.gov.uk/government/collections/ad-hoc-statistical-analyses-2026>).

> ![](https://github.com/user-attachments/assets/4dd7cac8-1cb2-49b2-a5f7-998533933d5b)

### Unpublished (in error) - explanation and alternative URL provided

<https://whitehall-admin.integration.publishing.service.gov.uk/government/admin/detailed-guides/435815> (user facing page at <https://www.gov.uk/guidance/notarial-and-documentary-services-guide-for-yemen>).

> ![](https://github.com/user-attachments/assets/4cbcd076-852e-47b0-97f2-abe83af01a99)

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
