### PR TITLE
Prevent H4s being converted to H3s inadvertently during govspeak header numbering [WHIT-2473]

### DIFF
--- a/app/helpers/govspeak_helper.rb
+++ b/app/helpers/govspeak_helper.rb
@@ -134,9 +134,12 @@ private
     h2 = 0
     h3 = 0
 
-    govspeak.gsub(/^(###|##)\s*(.+)$/) do
+    govspeak.gsub(/^(##+)\s*(.+)$/) do
       hashes = Regexp.last_match(1)
       heading_text = Regexp.last_match(2).strip
+
+      # Heading numbers aren't applied for H4s and below, so skip replacement.
+      next "#{hashes} #{heading_text}" if hashes.length > 3
 
       if hashes == "##"
         h2 += 1

--- a/test/unit/app/helpers/govspeak_helper_test.rb
+++ b/test/unit/app/helpers/govspeak_helper_test.rb
@@ -317,6 +317,12 @@ class GovspeakHelperTest < ActionView::TestCase
     assert actual_output.include?("café</h1>")
   end
 
+  it "should not turn h4 headings into h3s" do
+    input = "#### Level 4 Heading"
+    actual_output = govspeak_to_html(input, heading_numbering: :auto)
+    assert_equal "<div class=\"govspeak\"><h4 id=\"level-4-heading\">Level 4 Heading</h4>\n</div>", actual_output
+  end
+
   it "converts [Contact:<id>] into a rendering of contacts/_contact for the Contact with id = <id>" do
     contact = build(:contact)
     Contact.stubs(:find_by).with(id: "1").returns(contact)


### PR DESCRIPTION
In [this commit](https://github.com/alphagov/whitehall/pull/10589/commits/e026691e77a49add1672dd6a114387eafa2183f5) we moved header numbering into a pre govspeak processing rather than a post govspeak processing step. Unfortunately the regex we used to capture the H2 and H3 headings also captured lower level headings and converted them into H3s, leaving the extra hashes in the heading text. This commit prevents heading numbers from being applied for headings lower than H3.
