### PR TITLE
Refactor edition organisations association trait module

### DIFF
--- a/app/controllers/admin/edition_access_limited_controller.rb
+++ b/app/controllers/admin/edition_access_limited_controller.rb
@@ -67,9 +67,7 @@ private
 
   def changed?
     if @edition.can_be_related_to_organisations?
-      @edition.changed? ||
-        @edition.lead_organisation_ids.map(&:to_s) != edition_params[:lead_organisation_ids] ||
-        @edition.supporting_organisations.map(&:id).map(&:to_s) != edition_params[:supporting_organisation_ids]
+      @edition.changed? || @edition.edition_organisations != Edition.find(params[:id]).edition_organisations
     else
       @edition.changed?
     end

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -548,8 +548,10 @@ module AdminEditionControllerTestHelpers
         organisation2 = create(:organisation)
         organisation3 = create(:organisation)
 
-        edition = create(edition_type, organisations: [organisation1, organisation2])
-        edition.organisations << organisation3
+        edition = build(edition_type)
+        edition.lead_organisations = [organisation1, organisation2]
+        edition.supporting_organisations = [organisation3]
+        edition.save!
 
         put :update,
             params: {

--- a/test/unit/app/models/edition/organisations_test.rb
+++ b/test/unit/app/models/edition/organisations_test.rb
@@ -76,13 +76,4 @@ class Edition::OrganisationsTest < ActiveSupport::TestCase
 
     assert_equal [organisation2, organisation3, organisation1], edition.sorted_organisations
   end
-
-  test "#importance_ordered_organisations" do
-    first_lead_org = create(:organisation)
-    second_lead_org = create(:organisation)
-    supporting_org = create(:organisation)
-    edition = create(:publication, lead_organisations: [first_lead_org, second_lead_org], supporting_organisations: [supporting_org])
-
-    assert_equal [first_lead_org, second_lead_org, supporting_org], edition.importance_ordered_organisations
-  end
 end

--- a/test/unit/app/models/edition/validation_test.rb
+++ b/test/unit/app/models/edition/validation_test.rb
@@ -74,7 +74,7 @@ class Edition::ValidationTest < ActiveSupport::TestCase
 
   test "should be invalid when it duplicates lead organisations on save" do
     organisation1 = create(:organisation)
-    edition = create(
+    edition = build(
       :publication,
       create_default_organisation: false,
       lead_organisations: [organisation1],
@@ -143,7 +143,7 @@ class Edition::ValidationTest < ActiveSupport::TestCase
   test "should be invalid when it duplicates support organisations on save" do
     organisation1 = create(:organisation)
     organisation2 = create(:organisation)
-    edition = create(
+    edition = build(
       :publication,
       create_default_organisation: false,
       lead_organisations: [organisation1],

--- a/test/unit/app/models/topical_event_test.rb
+++ b/test/unit/app/models/topical_event_test.rb
@@ -108,17 +108,6 @@ class TopicalEventTest < ActiveSupport::TestCase
     assert topical_event.featured_editions.include?(new_version)
   end
 
-  test "#importance_ordered_organisations" do
-    topical_event = create(:topical_event)
-    supporting_org = create(:organisation)
-    supporting_org.topical_event_organisations.create!(topical_event_id: topical_event.id, lead: false)
-    second_lead_org = create(:organisation)
-    second_lead_org.topical_event_organisations.create!(topical_event_id: topical_event.id, lead: true, lead_ordering: 2)
-    first_lead_org = create(:organisation)
-    first_lead_org.topical_event_organisations.create!(topical_event_id: topical_event.id, lead: true, lead_ordering: 1)
-    assert_equal topical_event.importance_ordered_organisations, [first_lead_org, second_lead_org, supporting_org]
-  end
-
   test "#next_ordering gives a value of 0 when there are no existing features" do
     topical_event = create(:topical_event)
 

--- a/test/unit/lib/data_hygiene/bulk_organisation_updater_test.rb
+++ b/test/unit/lib/data_hygiene/bulk_organisation_updater_test.rb
@@ -183,7 +183,7 @@ class DataHygiene::BulkOrganisationUpdaterTest < ActiveSupport::TestCase
 
     process(csv_file)
 
-    assert_equal [organisation], edition.lead_organisations
+    assert_equal [organisation], edition.reload.lead_organisations
     assert_equal 1, PublishingApiDocumentRepublishingWorker.jobs.size
     assert_equal document.id, PublishingApiDocumentRepublishingWorker.jobs.first["args"].first
   end
@@ -191,17 +191,18 @@ class DataHygiene::BulkOrganisationUpdaterTest < ActiveSupport::TestCase
   test "it changes the supporting organisations" do
     csv_file = <<~CSV
       URL,New lead organisations,New supporting organisations
-      https://www.gov.uk/government/publications/some-slug,,"supporting-organisation-1,supporting-organisation-2"
+      https://www.gov.uk/government/publications/some-slug,"lead-organisation-1","supporting-organisation-1,supporting-organisation-2"
     CSV
 
     document = create(:document, slug: "some-slug")
     edition = create(:published_publication, document:)
+    create(:organisation, slug: "lead-organisation-1")
     organisation1 = create(:organisation, slug: "supporting-organisation-1")
     organisation2 = create(:organisation, slug: "supporting-organisation-2")
 
     process(csv_file)
 
-    assert_equal [organisation1, organisation2], edition.supporting_organisations
+    assert_equal [organisation1, organisation2], edition.reload.supporting_organisations
     assert_equal 1, PublishingApiDocumentRepublishingWorker.jobs.size
     assert_equal document.id, PublishingApiDocumentRepublishingWorker.jobs.first["args"].first
   end
@@ -228,7 +229,7 @@ class DataHygiene::BulkOrganisationUpdaterTest < ActiveSupport::TestCase
 
     process(csv_file)
 
-    assert_equal [organisation], draft_edition.lead_organisations
+    assert_equal [organisation], draft_edition.reload.lead_organisations
     assert_equal 0, PublishingApiDocumentRepublishingWorker.jobs.size
   end
 


### PR DESCRIPTION
This is a pure readability improvement. The previous implementation of this module was hard to follow and to reason about.

It's worth noting why we don't use normal associations for lead and supporting organisations. Rails persists association changes to has_many associations as soon as they're assigned, meaning that validation never runs. This meant when using real associations, users experienced a server error instead of a validation error. We get around this by implementing faux associations. The new implementation isn't really any different from the old, but it's more concise and avoids keeping state in instance variables.

We also delete a few unused methods.

I started this thinking it would make [WHIT-2386](https://gov-uk.atlassian.net/browse/WHIT-2386). I'm not sure it really does, on reflection, but at least there aren't any occurrences of the word "mange" in Whitehall code now, so I think that it has been worth it 🤞 

[WHIT-2386]: https://gov-uk.atlassian.net/browse/WHIT-2386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ