### PR TITLE
Consolidate 'dry run' and 'real run' variants of `redirect_html_attachments` [WHIT-1876]

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -38,13 +38,13 @@ namespace :publishing_api do
   end
 
   namespace :redirect_html_attachments do
-    desc "Redirect HTML Attachments to a given URL (dry run)"
-    task :by_content_id_dry_run, %i[content_id destination] => :environment do |_, args|
-      DataHygiene::PublishingApiHtmlAttachmentRedirector.call(args[:content_id], args[:destination], dry_run: true)
-    end
-
-    desc "Redirect HTML Attachments to a given URL (for reals)"
+    desc "Redirect HTML Attachments to a given URL"
     task :by_content_id, %i[content_id destination] => :environment do |_, args|
+      DataHygiene::PublishingApiHtmlAttachmentRedirector.call(args[:content_id], args[:destination], dry_run: true)
+      unless Thor::Shell::Basic.new.yes?("Proceed with redirecting these HTML attachments? (yes/no)")
+        puts "Aborted"
+        next
+      end
       DataHygiene::PublishingApiHtmlAttachmentRedirector.call(args[:content_id], args[:destination], dry_run: false)
     end
   end


### PR DESCRIPTION
I've added a confirmation step, using the Thor gem, to have the user explicitly opt in to running the 'real' task, once they have been presented with details of what will be redirected and to where. I have also deleted the 'dry run' rake task.

I've also added a 'dry run' expectation in the `publishing_api_test` file, to verify that the redirector is correctly being invoked in the 'dry run' part of the rake task before asking for confirmation.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
