### PR TITLE
[WHIT-2490] Fix html headers with leading symbols/numbers

### DIFF
--- a/app/helpers/govspeak_helper.rb
+++ b/app/helpers/govspeak_helper.rb
@@ -151,10 +151,11 @@ private
         num = "#{h2}.#{h3}"
       end
 
-      # We have to manually derive and append a slug otherwise when Govspeak
-      # generates the HTML, it includes the <span> and number in the ID. Hence
-      # the `heading_text.parameterize`
-      "#{hashes} <span class=\"number\">#{num} </span>#{heading_text} {##{heading_text.parameterize}}"
+      custom_id_match = heading_text.match(/\{#([^}]+)\}/)
+      clean_heading_text = custom_id_match ? heading_text.gsub(/\s*\{#[^}]+\}/, "") : heading_text
+      id = (custom_id_match&.[](1) || clean_heading_text).gsub(/^[^a-zA-Z]+/, "").parameterize
+
+      "#{hashes} <span class=\"number\">#{num} </span>#{clean_heading_text} {##{id}}"
     end
   end
 


### PR DESCRIPTION
[Jira](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-2490)

**What**

When using auto-numbering for Govspeak headings, certain headings would produce "rogue code" in the HTML output. Specifically:

Currency symbol headings like `## £75,000 fixed payment impact` would generate invalid HTML IDs starting with numbers (e.g., `{#75-000-fixed-payment-impact}`)

This PR seeks to fix that. 


**BEFORE**
<img width="1091" height="458" alt="Screenshot 2025-09-08 at 14 48 30" src="https://github.com/user-attachments/assets/4c1dc8a8-4d6c-442e-b610-8d7a787fdcf5" />

**AFTER**
<img width="1038" height="795" alt="Screenshot 2025-09-08 at 16 24 44" src="https://github.com/user-attachments/assets/1dc30c2c-c45e-41db-9574-1ee23f6c2384" />

