### PR TITLE
Loosen 'all_asset_variants_uploaded?' check to just required sizes (WHIT-2440)

### DIFF
--- a/app/models/image_data.rb
+++ b/app/models/image_data.rb
@@ -1,6 +1,7 @@
 require "mini_magick"
 
 class ImageData < ApplicationRecord
+  has_one :image
   attr_accessor :validate_on_image
 
   include ImageKind
@@ -38,8 +39,10 @@ class ImageData < ApplicationRecord
 
   def all_asset_variants_uploaded?
     asset_variants = assets.map(&:variant).map(&:to_sym)
-    required_variants = file.active_version_names + [:original]
-
+    # TODO: figure out the required variants based on `image.edition.type`
+    # or do something funky like define an `all_asset_variants_uploaded?` method on each content type
+    required_variants = [:original]
+    required_variants += image_kind_config.required_version_names.map(&:to_sym) unless svg?
     (required_variants - asset_variants).empty?
   end
 

--- a/config/image_kinds.yml
+++ b/config/image_kinds.yml
@@ -5,6 +5,10 @@ default:
   valid_height: 640
   permitted_uses:
     - govspeak_embed
+  required_versions: # TODO: make this dynamic per model, as discussed in
+    # https://github.com/alphagov/content-publisher/pull/3311#discussion_r2329354424
+    - s960
+    - s300
   versions:
     - name: s960
       width: 960

--- a/lib/whitehall/image_kinds.rb
+++ b/lib/whitehall/image_kinds.rb
@@ -19,7 +19,7 @@ module Whitehall
   end
 
   class ImageKind
-    attr_reader :name, :display_name, :valid_width, :valid_height, :permitted_uses, :versions
+    attr_reader :name, :display_name, :valid_width, :valid_height, :permitted_uses, :versions, :required_version_names
 
     def initialize(name, config)
       @name = name
@@ -28,6 +28,7 @@ module Whitehall
       @valid_height = config.fetch("valid_height")
       @permitted_uses = config.fetch("permitted_uses")
       @versions = config.fetch("versions").map { |version_config| ImageVersion.new(version_config) }.freeze
+      @required_version_names = Array(config["required_versions"]).presence || @versions.map(&:name).freeze
     end
 
     def deconstruct_keys(_keys)


### PR DESCRIPTION
When we import news articles from Content Publisher, we'll only be importing the original ('high_resolution') size and two variants: s960 (960) and s300 (300). Content Publisher only produced those two variants in the first place because that's all that is used by News Articles.

Whitehall, however, imposes other variants on top of that: s712, s630, s465 and s216. These sizes are not used anywhere in the news articles end-to-end journey (and perhaps not on our other content types either?).

Nevertheless, `all_asset_variants_uploaded?` checks that ALL DEFINED variants exist and have been uploaded - so would always return `false` for our Content-Publisher-imported images. Whilst we could hack some means of downloading and reuploading said images (to force images through Whitehall's Carrierwave pipeline and generate all defined variants of images), this is a lot of extra work for zero benefit given those other variants aren't used.

NB the `unless svg?` conditional is because we handle SVGs differently. SVGs can't have variants as vector graphics are, by their nature, scalable, so we only ever have the `:original` variant there. We therefore don't want to enforce a `s960` and `s300` variant when the uploaded image is not a bitmap.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
