### PR TITLE
[WHIT-2374] Render history pages on frontend rather than government-frontend

### DIFF
--- a/app/models/configurable_document_types/history_page.json
+++ b/app/models/configurable_document_types/history_page.json
@@ -32,7 +32,7 @@
     "base_path_prefix": "/government/history",
     "publishing_api_schema_name": "history",
     "publishing_api_document_type": "history",
-    "rendering_app": "government-frontend",
+    "rendering_app": "frontend",
     "images_enabled": true,
     "organisations": ["af07d5a5-df63-4ddc-9383-6a666845ebe9"],
     "backdating_enabled": false,


### PR DESCRIPTION
This will allow us to render the pages in the new "flexible" format.

[Jira](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-2374)
