### PR TITLE
[WHIT-2374] Include Standard Edition in recognize embedded content patterns

### DIFF
--- a/lib/whitehall.rb
+++ b/lib/whitehall.rb
@@ -103,7 +103,7 @@ module Whitehall
   end
 
   def self.edition_route_path_segments
-    %w[news speeches policies publications consultations priority detailed-guides case-studies statistical-data-sets fatalities collections supporting-pages calls-for-evidence worldwide-organisations landing-pages]
+    %w[news speeches policies publications consultations priority detailed-guides case-studies statistical-data-sets fatalities collections supporting-pages calls-for-evidence worldwide-organisations landing-pages standard-editions]
   end
 
   def self.analytics_format(format)


### PR DESCRIPTION
This will ensure the correct handling of admin links embedded in govspeak.

[Jira](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-2374)