### PR TITLE
Add confirmation step to election rake tasks [WHIT-1876]

### DIFF
--- a/test/unit/lib/tasks/election_identify_political_content_test.rb
+++ b/test/unit/lib/tasks/election_identify_political_content_test.rb
@@ -4,6 +4,10 @@ require "rake"
 class IdentifyPoliticalContentFor < ActiveSupport::TestCase
   extend Minitest::Spec::DSL
 
+  setup do
+    Thor::Shell::Basic.any_instance.stubs(:yes?).returns(true)
+  end
+
   teardown { task.reenable }
 
   describe "#identify_political_content" do

--- a/test/unit/lib/tasks/election_remove_mp_letters_test.rb
+++ b/test/unit/lib/tasks/election_remove_mp_letters_test.rb
@@ -16,13 +16,21 @@ class RemoveMpLettersRake < ActiveSupport::TestCase
       member_d = create(:person, forename: "D", surname: "Member", letters: "CBE MP MPhil")
       non_member_a = create(:person, forename: "A", surname: "Non-Member", letters: "CBE MPhil VC")
 
+      Thor::Shell::Basic.any_instance.stubs(:yes?).returns(true)
       out, _err = capture_io { task.invoke }
 
-      assert_match(/updated A Member MP to A Member/, out)
-      assert_match(/updated B Member CBE MP to B Member CBE/, out)
-      assert_match(/updated C Member MP MEng to C Member MEng/, out)
-      assert_match(/updated D Member CBE MP MPhil to D Member CBE MPhil/, out)
-      assert_match(/skipped A Non-Member/, out)
+      assert_match(/----------DRY RUN----------/, out)
+      assert_match(/Found A Member MP that matches 'MP'/, out)
+      assert_match(/Found B Member CBE MP that matches 'MP'/, out)
+      assert_match(/Found C Member MP MEng that matches 'MP'/, out)
+      assert_match(/Found D Member CBE MP MPhil that matches 'MP'/, out)
+      assert_match(/Skipped A Non-Member CBE MPhil VC - includes 'MP' \(case insensitive\), but doesn't match exactly/, out)
+
+      assert_match(/----------CHANGES SUMMARY----------/, out)
+      assert_match(/Updated A Member MP to A Member/, out)
+      assert_match(/Updated B Member CBE MP to B Member CBE/, out)
+      assert_match(/Updated C Member MP MEng to C Member MEng/, out)
+      assert_match(/Updated D Member CBE MP MPhil to D Member CBE MPhil/, out)
 
       assert_equal "A Member", member_a.reload.name
       assert_equal "B Member CBE", member_b.reload.name


### PR DESCRIPTION
Tasks include:
- remove_mp_letters
- republish_political_content
- end_ministerial_appointments
- identify_political_content_for

I have added a confirmation step, using the Thor gem, to the above rake tasks. This is to ensure that the person running these tasks explicitly opts in to making these changes. Also corrected description for "identify_political_content_for" and updated test file name.

This is part of an ongoing task to add confirmation steps to our dangerous rake tasks following our rake task audit. 
