### PR TITLE
Fix content block edition factory after factory_bot 6.5.5 upgrade

### DIFF
--- a/lib/engines/content_block_manager/test/factories/content_block_edition.rb
+++ b/lib/engines/content_block_manager/test/factories/content_block_edition.rb
@@ -24,7 +24,11 @@ FactoryBot.define do
 
     ContentBlockManager::ContentBlock::Schema.valid_schemas.each do |type|
       trait type.to_sym do
-        document { build(:content_block_document, block_type: type) }
+        after(:build) do |edition, _evaluator|
+          unless edition.document_id || edition.document
+            edition.document = build(:content_block_document, block_type: type)
+          end
+        end
       end
     end
 


### PR DESCRIPTION
After [upgrading factory_bot from 6.5.4 to 6.5.5](https://github.com/alphagov/whitehall/pull/10570), tests in documents_test.rb started failing. The tests were expecting multiple editions to belong to the same document, but the factory was creating separate documents for each edition.

The factory_bot 6.5.5 upgrade included a change that ensures callbacks only run once per instance, which exposed a logical flaw in our `content_block_edition` factory. 

Previously we always created a new document, completely ignoring any explicitly passed `document_id` parameter. When tests tried to create multiple editions for the same document by passing `document_id: document.id`, the factory would still create a new document, resulting in multiple documents instead of multiple editions for one document.

### Solution
Changed the trait implementation to use an `after(:build)` callback that only creates a new document when neither `document_id` nor `document` is already provided:

```ruby
ContentBlockManager::ContentBlock::Schema.valid_schemas.each do |type|
  trait type.to_sym do
    after(:build) do |edition, _evaluator|
      unless edition.document_id || edition.document
        edition.document = build(:content_block_document, block_type: type)
      end
    end
  end
end
```