### PR TITLE
fix: update model rendering app for case_study

### DIFF
--- a/app/models/case_study.rb
+++ b/app/models/case_study.rb
@@ -11,7 +11,7 @@ class CaseStudy < Edition
   include Edition::LeadImage
 
   def rendering_app
-    Whitehall::RenderingApp::GOVERNMENT_FRONTEND
+    Whitehall::RenderingApp::FRONTEND
   end
 
   def display_type_key


### PR DESCRIPTION
- This is an odd case where rendering_app exists in the model and presenter. Republishing seems to have worked through the presenter, but items have been published since that time with the wrong rendering app (possibly getting the information from the model without using the presenter? Is that possible?) Anyway, make them identical.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
