### PR TITLE
(CM-434) Link to new content block manager

### DIFF
--- a/app/components/admin/editions/host_content_update_event_component.html.erb
+++ b/app/components/admin/editions/host_content_update_event_component.html.erb
@@ -6,7 +6,7 @@
   </p>
 
   <p class="govuk-body app-view-editions-host-content-update-event-entry__link">
-    <%= link_to link_text, helpers.content_block_manager.content_block_manager_content_block_content_id_path(content_id: event.content_id), class: "govuk-link" %>
+    <%= link_to link_text, block_url, class: "govuk-link" %>
   </p>
 
   <p class="govuk-body-s app-view-editions-host-content-update-event-entry__datetime">

--- a/app/components/admin/editions/host_content_update_event_component.rb
+++ b/app/components/admin/editions/host_content_update_event_component.rb
@@ -28,4 +28,12 @@ private
   def actor
     event.author ? linked_author(event.author, class: "govuk-link") : "User (removed)"
   end
+
+  def block_url
+    [
+      Plek.find("content-block-manager"),
+      "content-id",
+      event.content_id,
+    ].join("/")
+  end
 end

--- a/app/views/admin/editions/_content_block_guidance.html.erb
+++ b/app/views/admin/editions/_content_block_guidance.html.erb
@@ -2,5 +2,5 @@
 
 <p class="govuk-body">
   To create, edit and use standardised content, go to the
-  <%= link_to "Content Block Manager (opens in new tab)", content_block_manager.content_block_manager_root_path, class: "govuk-link", target: "_blank", rel: "noopener" %>.
+  <%= link_to "Content Block Manager (opens in new tab)", Plek.find("content-block-manager"), class: "govuk-link", target: "_blank", rel: "noopener" %>.
 </p>

--- a/test/components/admin/editions/host_content_update_event_component_test.rb
+++ b/test/components/admin/editions/host_content_update_event_component_test.rb
@@ -19,7 +19,7 @@ class Admin::Editions::HostContentUpdateEventComponentTest < ViewComponent::Test
     assert_equal page.find("h4").text, "Content block updated"
     assert_equal page.all("p")[0].text.strip, "#{document_type}: #{content_title}"
     assert_equal page.all("a")[0].native.inner_html, "[View<span class=\"govuk-visually-hidden\"> #{content_title}</span> in Content Block Manager]"
-    assert_equal page.all("a")[0].native["href"], content_block_manager_content_block_content_id_path(content_id: host_content_update_event.content_id)
+    assert_equal page.all("a")[0].native["href"], "#{Plek.find('content-block-manager')}/content-id/#{host_content_update_event.content_id}"
 
     assert_equal page.all("p")[2].text.strip, "1 January 2020 11:11am by #{user.name}"
   end


### PR DESCRIPTION
We’re in the process of moving Content Block Manager to its own app, so let’s switch the URL out to link to the new app.

I'll leave this in draft until we've done the move. Once everything is stable, we'll open another PR to delete the engine from the Whitehall repo, but will leave it a couple of weeks while we wait to see everything is stable.