### PR TITLE
Allow destroying of Document that has a link checker api report (WHIT-2440)

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -43,7 +43,7 @@ class Edition < ApplicationRecord
   has_many :edition_authors, dependent: :destroy
   has_many :authors, through: :edition_authors, source: :user
   has_many :topical_event_featurings, inverse_of: :edition
-  has_one :link_check_report, class_name: "LinkCheckerApiReport"
+  has_one :link_check_report, class_name: "LinkCheckerApiReport", dependent: :destroy
 
   has_many :edition_dependencies, dependent: :destroy
   has_many :depended_upon_contacts, through: :edition_dependencies, source: :dependable, source_type: "Contact"


### PR DESCRIPTION
Discovered whilst locally testing imports (which involved a lot of `Document.last.destroy!` while iterating). Attempting to delete a document which acquires a link check report would raise an exception:

```
ActiveRecord::InvalidForeignKey: Mysql2::Error: Cannot delete or update a parent row: a foreign key constraint fails (`whitehall_development`.`link_checker_api_reports`, CONSTRAINT `fk_rails_d657556faa` FOREIGN KEY (`edition_id`) REFERENCES `editions` (`id`)) (ActiveRecord::InvalidForeignKey) from /root/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/mysql2-0.5.6/lib/mysql2/client.rb:151:in `_query' Caused by Mysql2::Error: Cannot delete or update a parent row: a foreign key constraint fails (`whitehall_development`.`link_checker_api_reports`, CONSTRAINT `fk_rails_d657556faa` FOREIGN KEY (`edition_id`) REFERENCES `editions` (`id`)) from /root/.rbenv/versions/3.3.6/lib/ruby/gems/3.3.0/gems/mysql2-0.5.6/lib/mysql2/client.rb:151:in `_query'
```

There's no value in blocking document deletion for this - link checker API reports are throwaway in nature, so let's just destroy them at the same time.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
