### PR TITLE
Data migration to delete orphaned HMRC customs guidance assets [WHIT-2509]

### DIFF
--- a/db/data_migration/20250915164800_fix_up_orphaned_assets.rb
+++ b/db/data_migration/20250915164800_fix_up_orphaned_assets.rb
@@ -1,0 +1,13 @@
+orphaned_assets_for_deletion = %w[
+  5bdc102ce5274a6e0e61f420
+  5bdc10f2ed915d150754eb67
+  5bdc1115e5274a6e0bc6cfdc
+  5c9a0858ed915d07a97369f8
+  5c9a10cee5274a3ca310bb2f
+]
+
+orphaned_assets_for_deletion.each do |asset_manager_id|
+  AssetManager::AssetDeleter.call(asset_manager_id)
+rescue AssetManager::ServiceHelper::AssetNotFound
+  logger.info("Asset #{asset_manager_id} has already been deleted from Asset Manager")
+end


### PR DESCRIPTION
The state of these assets was modified directly in Asset Manager, so we need to reapply the Whitehall state to synchronise the two systems. The assets became orphaned when a redirect was created for them in Asset Manager, but Whitehall's "AssetManagerAttachmentRedirectUrlUpdateWorker" was retrying still and subsequently removed the redirect because there is no redirect configured for the attachment that owns these assets in Whitehall.

[JIRA](https://gov-uk.atlassian.net/browse/WHIT-2509)
