### PR TITLE
[PNP-5604] Add headers to html_publication content items

### DIFF
--- a/app/presenters/publishing_api/html_attachment_presenter.rb
+++ b/app/presenters/publishing_api/html_attachment_presenter.rb
@@ -60,7 +60,9 @@ module PublishingApi
         public_timestamp:,
         first_published_version: first_published_version?,
         political: political?,
-      }
+      }.tap do |details_hash|
+        details_hash.merge!(PayloadBuilder::BodyHeadings.for(item))
+      end
 
       maybe_add_national_applicability(details_hash)
     end

--- a/test/unit/app/presenters/publishing_api/html_attachment_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/html_attachment_presenter_test.rb
@@ -61,6 +61,38 @@ class PublishingApi::HtmlAttachmentPresenterTest < ActiveSupport::TestCase
     %i[organisations parent primary_publishing_organisation government].each { |k| assert_includes(expected_content[:links].keys, k) }
   end
 
+  test "it includes headers when headers are present in body" do
+    html_attachment = create(
+      :html_attachment,
+      title: "Some html attachment",
+      body: "##Some header\n\nSome content",
+    )
+
+    presented_html_attachment = PublishingApi::HtmlAttachmentPresenter.new(html_attachment)
+
+    expected_headers = [
+      {
+        text: "Some header",
+        level: 2,
+        id: "some-header",
+      },
+    ]
+
+    assert_equal expected_headers, presented_html_attachment.content[:details][:headers]
+  end
+
+  test "it does not include headers when headers are not present in body" do
+    html_attachment = create(
+      :html_attachment,
+      title: "Some html attachment",
+      body: "Some content",
+    )
+
+    presented_html_attachment = PublishingApi::HtmlAttachmentPresenter.new(html_attachment)
+
+    assert_nil presented_html_attachment.content[:details][:headers]
+  end
+
   test "HtmlAttachment presentation includes the correct locale" do
     create(:publication, :with_html_attachment, :published)
 


### PR DESCRIPTION
Adds parsed header elements (if headers are present in the govspeak body) to html_publications - similar to https://github.com/alphagov/whitehall/pull/10360). Needed for consolidating the rendering of these documents into Frontend.


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
