### PR TITLE
Avoid sending `details.headers` for unsupported content types (WHIT-2440)

### DIFF
--- a/app/models/configurable_document_types/history_page.json
+++ b/app/models/configurable_document_types/history_page.json
@@ -34,6 +34,7 @@
     "publishing_api_document_type": "history",
     "rendering_app": "frontend",
     "images_enabled": true,
+    "send_headings": true,
     "organisations": ["af07d5a5-df63-4ddc-9383-6a666845ebe9"],
     "backdating_enabled": false,
     "history_mode_enabled": false,

--- a/app/models/configurable_document_types/news_story.json
+++ b/app/models/configurable_document_types/news_story.json
@@ -26,6 +26,7 @@
     "publishing_api_document_type": "news_story",
     "rendering_app": "frontend",
     "images_enabled": true,
+    "send_headings": false,
     "file_attachments_enabled": true,
     "organisations": null,
     "backdating_enabled": true,

--- a/app/presenters/publishing_api/standard_edition_presenter.rb
+++ b/app/presenters/publishing_api/standard_edition_presenter.rb
@@ -59,7 +59,7 @@ module PublishingApi
         headers << headers_for_content_block if headers_for_content_block.present?
       end
 
-      content[:headers] = headers.any? ? headers.flatten : nil
+      content[:headers] = type.settings["send_headings"] == true && headers.any? ? headers.flatten : nil
       content.compact
     end
 

--- a/test/unit/app/presenters/publishing_api/standard_edition_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/standard_edition_presenter_test.rb
@@ -80,6 +80,9 @@ class PublishingApi::StandardEditionPresenterTest < ActiveSupport::TestCase
   test "it includes headers once, in the details, from all govspeak blocks, based on the order they are listed in the schema" do
     type_key = "test_type_key"
     ConfigurableDocumentType.setup_test_types(build_configurable_document_type(type_key, {
+      "settings" => {
+        "send_headings" => true,
+      },
       "schema" => {
         "properties" => {
           "chunk_of_content_one" => {
@@ -136,6 +139,9 @@ class PublishingApi::StandardEditionPresenterTest < ActiveSupport::TestCase
   test "it includes headers once, one layer up, if there is a govspeak block with a 'body' key" do
     type_key = "test_type_key"
     ConfigurableDocumentType.setup_test_types(build_configurable_document_type(type_key, {
+      "settings" => {
+        "send_headings" => true,
+      },
       "schema" => {
         "properties" => {
           "body" => {
@@ -194,6 +200,42 @@ class PublishingApi::StandardEditionPresenterTest < ActiveSupport::TestCase
                                       block_content: {
                                         "chunk_of_content_one" => "Some content",
                                         "chunk_of_content_two" => "Some more content",
+                                      } })
+    page.document = Document.new
+    page.document.slug = "page-title"
+    presenter = PublishingApi::StandardEditionPresenter.new(page)
+    content = presenter.content
+
+    assert_nil content[:details][:headers]
+  end
+
+  test "it does not include a headers key in the details if the document type is not configured to send headings" do
+    type_key = "test_type_key"
+    ConfigurableDocumentType.setup_test_types(build_configurable_document_type(type_key, {
+      "settings" => {
+        "send_headings" => false,
+      },
+      "schema" => {
+        "properties" => {
+          "chunk_of_content_one" => {
+            "title" => "A govspeak block",
+            "description" => "Some bit of content",
+            "type" => "string",
+            "format" => "govspeak",
+          },
+          "chunk_of_content_two" => {
+            "title" => "Another govspeak block",
+            "description" => "Another bit of content",
+            "type" => "string",
+            "format" => "govspeak",
+          },
+        },
+      },
+    }))
+    page = build(:standard_edition, { configurable_document_type: type_key,
+                                      block_content: {
+                                        "chunk_of_content_one" => "## Header for chunk one\nSome content",
+                                        "chunk_of_content_two" => "## Header for chunk two\nSome more content",
                                       } })
     page.document = Document.new
     page.document.slug = "page-title"


### PR DESCRIPTION
The top level `details.headers` property is required for History Pages:
https://github.com/alphagov/publishing-api/blob/4005b72ce5996ade8b83eda568c38afcbe63fd79/content_schemas/formats/history.jsonnet#L19-L20

It is not allowed by the schema for News Articles, nor do we see much purpose in allowing it:
https://gds.slack.com/archives/C02L13S214K/p1757428495759379

It is therefore a configurable property in our JSON. We can always revisit this later (e.g. split out into separate presenter for History pages, or adding support for headers to the News Article jsonnet, etc).

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
