### PR TITLE
Add more properties to StandardEdition's details hash (WHIT-2498)

### DIFF
--- a/app/models/configurable_document_types/history_page.json
+++ b/app/models/configurable_document_types/history_page.json
@@ -35,6 +35,7 @@
     "rendering_app": "frontend",
     "images_enabled": true,
     "send_headings": true,
+    "send_change_history": false,
     "organisations": ["af07d5a5-df63-4ddc-9383-6a666845ebe9"],
     "backdating_enabled": false,
     "history_mode_enabled": false,

--- a/app/models/configurable_document_types/news_story.json
+++ b/app/models/configurable_document_types/news_story.json
@@ -27,6 +27,7 @@
     "rendering_app": "frontend",
     "images_enabled": true,
     "send_headings": false,
+    "send_change_history": true,
     "file_attachments_enabled": true,
     "organisations": null,
     "backdating_enabled": true,

--- a/app/presenters/publishing_api/standard_edition_presenter.rb
+++ b/app/presenters/publishing_api/standard_edition_presenter.rb
@@ -45,6 +45,7 @@ module PublishingApi
       }
       details.merge!(PayloadBuilder::ChangeHistory.for(item)) if type.settings["send_change_history"] == true
       details.merge!(PayloadBuilder::PoliticalDetails.for(item)) if type.settings["history_mode_enabled"] == true
+      details.merge!(PayloadBuilder::Attachments.for(item)) if type.settings["file_attachments_enabled"] == true
       details
     end
 

--- a/app/presenters/publishing_api/standard_edition_presenter.rb
+++ b/app/presenters/publishing_api/standard_edition_presenter.rb
@@ -40,9 +40,11 @@ module PublishingApi
 
     def details
       root_block = ConfigurableContentBlocks::Factory.new(item).build("object")
-      {
+      details = {
         **flatten_headers(root_block.publishing_api_payload(type.schema, item.block_content)),
       }
+      details.merge!(PayloadBuilder::PoliticalDetails.for(item)) if type.settings["history_mode_enabled"] == true
+      details
     end
 
     def flatten_headers(content)

--- a/app/presenters/publishing_api/standard_edition_presenter.rb
+++ b/app/presenters/publishing_api/standard_edition_presenter.rb
@@ -43,6 +43,7 @@ module PublishingApi
       details = {
         **flatten_headers(root_block.publishing_api_payload(type.schema, item.block_content)),
       }
+      details.merge!(PayloadBuilder::ChangeHistory.for(item)) if type.settings["send_change_history"] == true
       details.merge!(PayloadBuilder::PoliticalDetails.for(item)) if type.settings["history_mode_enabled"] == true
       details
     end

--- a/test/unit/app/presenters/publishing_api/standard_edition_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/standard_edition_presenter_test.rb
@@ -244,4 +244,39 @@ class PublishingApi::StandardEditionPresenterTest < ActiveSupport::TestCase
 
     assert_nil content[:details][:headers]
   end
+
+  test "it includes a political key in the details if history mode enabled" do
+    type_key = "test_type_key"
+    ConfigurableDocumentType.setup_test_types(build_configurable_document_type(type_key, {
+      "settings" => {
+        "history_mode_enabled" => true,
+      },
+    }))
+    page = build(:standard_edition, { configurable_document_type: type_key,
+                                      political: true })
+    page.document = Document.new
+    page.document.slug = "page-title"
+    page.expects(:political?).returns(true)
+    presenter = PublishingApi::StandardEditionPresenter.new(page)
+    content = presenter.content
+
+    assert_equal true, content[:details][:political]
+  end
+
+  test "it does not include a political key in the details if history mode not enabled" do
+    type_key = "test_type_key"
+    ConfigurableDocumentType.setup_test_types(build_configurable_document_type(type_key, {
+      "settings" => {
+        "history_mode_enabled" => false,
+      },
+    }))
+    page = build(:standard_edition, { configurable_document_type: type_key,
+                                      political: true })
+    page.document = Document.new
+    page.document.slug = "page-title"
+    presenter = PublishingApi::StandardEditionPresenter.new(page)
+    content = presenter.content
+
+    assert_not content[:details].key?(:political)
+  end
 end

--- a/test/unit/app/presenters/publishing_api/standard_edition_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/standard_edition_presenter_test.rb
@@ -279,4 +279,32 @@ class PublishingApi::StandardEditionPresenterTest < ActiveSupport::TestCase
 
     assert_not content[:details].key?(:political)
   end
+
+  test "it includes change history in the details if sending change history is enabled" do
+    type_key = "test_type_key"
+    ConfigurableDocumentType.setup_test_types(build_configurable_document_type(type_key, {
+      "settings" => {
+        "send_change_history" => true,
+      },
+    }))
+    page = create(:published_standard_edition, { configurable_document_type: type_key })
+    presenter = PublishingApi::StandardEditionPresenter.new(page)
+    content = presenter.content
+
+    assert_equal [{ "public_timestamp" => "2011-11-09T11:11:11.000+00:00", "note" => "change-note" }], content[:details][:change_history]
+  end
+
+  test "it does not include change history in the details if sending change history is not enabled" do
+    type_key = "test_type_key"
+    ConfigurableDocumentType.setup_test_types(build_configurable_document_type(type_key, {
+      "settings" => {
+        "send_change_history" => false,
+      },
+    }))
+    page = create(:published_standard_edition, { configurable_document_type: type_key })
+    presenter = PublishingApi::StandardEditionPresenter.new(page)
+    content = presenter.content
+
+    assert_not content[:details].key?(:change_history)
+  end
 end


### PR DESCRIPTION
We want to replicate the News Articles payload as closely as possible, in migrating them to the new 'StandardEdition' format. The [relevant NewsArticlePresenter code](https://github.com/alphagov/whitehall/blob/d8f5013d0ab3eefbb78c007e860942aa43e970a5/app/presenters/publishing_api/news_article_presenter.rb#L72-L80) is:

```
 details
      base_details
        .merge(ChangeHistory.for(news_article))
        .merge(Image.for(news_article))
        .merge(PayloadBuilder::FirstPublicAt.for(news_article))
        .merge(PayloadBuilder::PoliticalDetails.for(news_article))
        .merge(PayloadBuilder::TagDetails.for(news_article))
        .merge(PayloadBuilder::Attachments.for(news_article))
    end
```

This PR carries over the relevant properties from the above, into the StandardEditionPresenter, with the following exceptions:

1. No `first_public_at` property, which is just a [duplication](https://github.com/alphagov/whitehall/blob/aa9cdc7d53e68f1bf75443e60d7d3186534208de/app/presenters/publishing_api/payload_builder/first_public_at.rb#L9) of the existing `first_published_at` property. It isn't included on the live news articles originating from Content Publisher ([example](https://www.gov.uk/api/content/government/news/covid-19-vaccine-surveillance-report-published)) and is [considered deprecated](https://github.com/alphagov/content-publisher/blob/7a999c738bb982db267a23577af80db66a66312d/docs/adr/0016-publishing-times-and-change-history.md?plain=1#L40). government-frontend [falls back to first_published_at](https://github.com/alphagov/government-frontend/blob/f38f22922249a57e9df5ec9fe9a520ad91e8b0dd/app/presenters/content_item/updatable.rb#L18), as does Frontend ([for detailed guides](https://github.com/alphagov/frontend/blob/10bd509470017853ec103c075cb9bfcc54d067ca/app/views/detailed_guide/show.html.erb#L41) - but [not for case studies](https://github.com/alphagov/frontend/blob/10bd509470017853ec103c075cb9bfcc54d067ca/app/views/case_study/show.html.erb#L65)) - one can imagine how any rendering app references to `first_public_at` can be swapped out for `first_published_at`.
2. No `tags` (`{ browse_pages: [] }`) property, which has been [recognised as legacy and unused](https://github.com/alphagov/email-alert-api/pull/2136#discussion_r1594207581).
3. No `image` property (yet) while we're figuring out how to represent lead images (WHIT-2384](https://gov-uk.atlassian.net/browse/WHIT-2384).

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
