### PR TITLE
Added world location news links to world location items [WHIT-2471]

### DIFF
--- a/app/presenters/publishing_api/world_location_presenter.rb
+++ b/app/presenters/publishing_api/world_location_presenter.rb
@@ -32,7 +32,9 @@ module PublishingApi
     end
 
     def links
-      {}
+      {
+        world_location_news: [item.world_location_news.content_id],
+      }
     end
   end
 end

--- a/test/unit/app/presenters/publishing_api/world_location_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/world_location_presenter_test.rb
@@ -23,7 +23,9 @@ class PublishingApi::WorldLocationPresenterTest < ActiveSupport::TestCase
       base_path: nil,
       rendering_app: nil,
     }
-    expected_links = {}
+    expected_links = {
+      world_location_news: [world_location.world_location_news.content_id],
+    }
 
     presented_item = present(world_location)
 


### PR DESCRIPTION
This will allow GOV.UK to link from non-English editions tagged with a world location to the world location's news page, which isn't currently possible.

[JIRA](https://gov-uk.atlassian.net/browse/WHIT-2471)
