### PR TITLE
Include StandardEdition document types in Whitehall search (WHIT-2482)

### DIFF
--- a/app/controllers/admin/statistics_announcement_publications_controller.rb
+++ b/app/controllers/admin/statistics_announcement_publications_controller.rb
@@ -42,8 +42,7 @@ private
     params_filters_with_default_state
                        .symbolize_keys
                        .merge(
-                         type: "publication",
-                         subtypes: @statistics_announcement.publication_type,
+                         type: @statistics_announcement.publication_type.key,
                          per_page: Admin::EditionFilter::GOVUK_DESIGN_SYSTEM_PER_PAGE,
                        )
   end

--- a/app/helpers/admin/edition_actions_helper.rb
+++ b/app/helpers/admin/edition_actions_helper.rb
@@ -24,33 +24,30 @@ module Admin::EditionActionsHelper
       [
         "Publication sub-types",
         PublicationType.ordered_by_prevalence.map do |sub_type|
-          value = "publication_#{sub_type.id}"
           {
             text: sub_type.plural_name,
-            value:,
-            selected: selected == value,
+            value: sub_type.key,
+            selected: selected == sub_type.key,
           }
         end,
       ],
       [
         "News article sub-types",
         NewsArticleType.all.map do |sub_type|
-          value = "news_article_#{sub_type.id}"
           {
             text: sub_type.plural_name,
-            value:,
-            selected: selected == value,
+            value: sub_type.key,
+            selected: selected == sub_type.key,
           }
         end,
       ],
       [
         "Speech sub-types",
         SpeechType.all.map do |sub_type|
-          value = "speech_#{sub_type.id}"
           {
             text: sub_type.plural_name,
-            value:,
-            selected: selected == value,
+            value: sub_type.key,
+            selected: selected == sub_type.key,
           }
         end,
       ],

--- a/app/models/concerns/edition/scopes/filterable_by_type.rb
+++ b/app/models/concerns/edition/scopes/filterable_by_type.rb
@@ -2,21 +2,9 @@ module Edition::Scopes::FilterableByType
   extend ActiveSupport::Concern
 
   included do
-    scope :by_type, lambda { |type|
-      where(type: type.to_s)
-    }
-
-    scope :by_subtype, lambda { |type, subtype|
-      merge(type.by_subtype(subtype))
-    }
-
-    scope :by_subtypes, lambda { |type, subtype_ids|
-      merge(type.by_subtypes(subtype_ids))
-    }
-
-    scope :consultations, -> { by_type("Consultation") }
-    scope :call_for_evidence, -> { by_type("CallForEvidence") }
-    scope :detailed_guides, -> { by_type("DetailedGuide") }
-    scope :corporate_information_pages, -> { by_type("CorporateInformationPage") }
+    scope :consultations, -> { where(type: "Consultation") }
+    scope :call_for_evidence, -> { where(type: "CallForEvidence") }
+    scope :detailed_guides, -> { where(type: "DetailedGuide") }
+    scope :corporate_information_pages, -> { where(type: "CorporateInformationPage") }
   end
 end

--- a/app/models/news_article.rb
+++ b/app/models/news_article.rb
@@ -19,16 +19,8 @@ class NewsArticle < Edition
   validate :non_english_primary_locale_only_for_world_news_story
   validate :organisations_are_not_associated, if: :world_news_story?
 
-  def self.subtypes
-    NewsArticleType.all
-  end
-
   def self.by_subtype(subtype)
     where(news_article_type_id: subtype.id)
-  end
-
-  def self.by_subtypes(subtype_ids)
-    where(news_article_type_id: subtype_ids)
   end
 
   def news_article_type

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -51,16 +51,8 @@ class Publication < Edition
     end
   end
 
-  def self.subtypes
-    PublicationType.all
-  end
-
   def self.by_subtype(subtype)
     where(publication_type_id: subtype.id)
-  end
-
-  def self.by_subtypes(subtype_ids)
-    where(publication_type_id: subtype_ids)
   end
 
   def self.not_statistics

--- a/app/models/speech.rb
+++ b/app/models/speech.rb
@@ -13,16 +13,8 @@ class Speech < Edition
 
   delegate :display_type_key, :explanation, to: :speech_type
 
-  def self.subtypes
-    SpeechType.all
-  end
-
   def self.by_subtype(subtype)
     where(speech_type_id: subtype.id)
-  end
-
-  def self.by_subtypes(subtype_ids)
-    where(speech_type_id: subtype_ids)
   end
 
   def speech_type

--- a/test/functional/admin/statistics_announcement_publications_controller_test.rb
+++ b/test/functional/admin/statistics_announcement_publications_controller_test.rb
@@ -8,8 +8,7 @@ class Admin::StatisticsAnnouncementPublicationsControllerTest < ActionController
     @title = "publication-title"
     @default_filter_params = {
       state: "active",
-      type: "publication",
-      subtypes: @official_statistics_announcement.publication_type,
+      type: @official_statistics_announcement.publication_type.key,
       per_page: 15,
     }
   end

--- a/test/unit/app/models/edition_test.rb
+++ b/test/unit/app/models/edition_test.rb
@@ -418,18 +418,6 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal "something-going-on", edition.document.slug
   end
 
-  test "is filterable by edition type" do
-    publication = create(:publication)
-    news = create(:news_article)
-    speech = create(:speech)
-    consultation = create(:consultation)
-
-    assert_equal [publication], Edition.by_type("Publication")
-    assert_equal [news], Edition.by_type("NewsArticle")
-    assert_equal [speech], Edition.by_type("Speech")
-    assert_equal [consultation], Edition.by_type("Consultation")
-  end
-
   test "#destroy should also remove the relationship to any authors" do
     edition = create(:draft_edition, creator: create(:writer))
     relation = edition.edition_authors.first


### PR DESCRIPTION
This PR changes the behaviour of Whitehall search to include new config-driven types in the search results, alongside the 'legacy' document types that they are slowly replacing.

Details:

- Changes the behaviour of the search options from a 'type=<parent type>_<child ID>' (`news_article_2`) format to a 'type=<subtype>' format (`press_release`).
- `type` continues to look for top level types by default (e.g. `type="news_article"` -> `type: "NewsArticle"`)
- if there is no matching top level type, it looks for BOTH `StandardEdition` where the `configurable_document_type` is the same as `type`, AND any subtypes of 'inflexible' parent types (NewsArticle, Publication, Speech) whose subtype key is the same as `type`.
- ...in other words, a search for `type=press_release` will surface both `StandardEdition.where(configurable_document_type: "press_release")` _and_ `NewsArticle.where(news_article_type_id: 2)`. 

The PR also tidies up some legacy scopes etc that are no longer needed.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
