### PR TITLE
[TO BE CONFIRMED] Add data migration to recognise palestine

### DIFF
--- a/db/data_migration/20250919172300_recognise_palestine.rb
+++ b/db/data_migration/20250919172300_recognise_palestine.rb
@@ -1,0 +1,5 @@
+palestine = WorldLocation.find_by(slug: "the-occupied-palestinian-territories")
+raise "Could not find WorldLocation with slug the-occupied-palestinian-territories" if palestine.nil?
+
+palestine.update!(slug: "palestine")
+palestine.translation.update!(name: "Palestine")


### PR DESCRIPTION
This is preparation for a _likely_ change in the status of Palestine. Officially this hasn't been confirmed yet, so the existence of this PR shouldn't be taken as an official confirmation of the change in status or of the new country name / slug. The PR will move out of draft if and when a formal announcement is made.

I'm raising the PR early in the day so I can prepare the on-call team for later as much as possible.