### PR TITLE
Add deputy high commissions to the embassy office types

### DIFF
--- a/app/models/worldwide_office_type.rb
+++ b/app/models/worldwide_office_type.rb
@@ -50,5 +50,6 @@ class WorldwideOfficeType
     Consulate,
     Embassy,
     HighCommission,
+    DeputyHighCommission,
   ].freeze
 end


### PR DESCRIPTION
This will allow deputy high commissions to appear on the main UK embassies page

This change originates from [this Zendesk ticket](https://govuk.zendesk.com/agent/tickets/6226542) 
