### PR TITLE
[WHIT-2532] Remove Palestine from British Consulate General Jerusalem

### DIFF
--- a/db/data_migration/20250923152852_remove_palestine_from_jerusalem_consulate.rb
+++ b/db/data_migration/20250923152852_remove_palestine_from_jerusalem_consulate.rb
@@ -1,0 +1,4 @@
+jerusalem_worldwide_org = WorldwideOrganisation.where(title: "British Consulate General Jerusalem", state: "published").last
+jerusalem_worldwide_org.world_locations = []
+jerusalem_worldwide_org.save!(validate: false)
+Whitehall::PublishingApi.publish(jerusalem_worldwide_org)


### PR DESCRIPTION
Removing world location from the [consulate](https://www.gov.uk/world/organisations/british-consulate-general-jerusalem) page. This is using the published edition and republishing. 

We expect that changes to the body of the edition, including references to OPT and office addresses, will be made on the [existing draft](https://whitehall-admin.publishing.service.gov.uk/government/admin/worldwide-organisations/1718995), and published as such. Then this PR can be merged.

[Jira](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-2532)