### PR TITLE
[PNP-5618] Change rendering app for Consultation pages from government-frontend …

### DIFF
--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -79,7 +79,7 @@ class Consultation < Edition
   end
 
   def rendering_app
-    Whitehall::RenderingApp::GOVERNMENT_FRONTEND
+    Whitehall::RenderingApp::FRONTEND
   end
 
   def outcome_published?

--- a/app/presenters/publishing_api/consultation_presenter.rb
+++ b/app/presenters/publishing_api/consultation_presenter.rb
@@ -26,7 +26,7 @@ module PublishingApi
           details:,
           document_type:,
           public_updated_at:,
-          rendering_app: Whitehall::RenderingApp::GOVERNMENT_FRONTEND,
+          rendering_app: Whitehall::RenderingApp::FRONTEND,
           schema_name: SCHEMA_NAME,
           links: edition_links,
           auth_bypass_ids: [consultation.auth_bypass_id],

--- a/test/unit/app/models/consultation_test.rb
+++ b/test/unit/app/models/consultation_test.rb
@@ -460,4 +460,8 @@ class ConsultationTest < ActiveSupport::TestCase
     assert_not consultation.valid?
     assert_includes consultation.errors[:consultation_response_form], "must have finished uploading"
   end
+
+  test "is rendered by frontend" do
+    assert Consultation.new.rendering_app == Whitehall::RenderingApp::FRONTEND
+  end
 end

--- a/test/unit/app/presenters/publishing_api/consultation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/consultation_presenter_test.rb
@@ -153,7 +153,7 @@ module PublishingApi::ConsultationPresenterTest
     end
 
     test "rendering app" do
-      assert_attribute :rendering_app, "government-frontend"
+      assert_attribute :rendering_app, "frontend"
     end
 
     test "schema name" do


### PR DESCRIPTION
…to frontend

Do not merge until:

- [ ] [https://github.com/alphagov/frontend/pull/4855 has been merged and deployed](https://github.com/alphagov/frontend/pull/5015)

[Jira Issue](https://gov-uk.atlassian.net/jira/software/c/projects/PNP/boards/1356?selectedIssue=PNP-5618)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
