### PR TITLE
Add support for translation [WHIT-2385]

### DIFF
--- a/app/controllers/admin/edition_translations_controller.rb
+++ b/app/controllers/admin/edition_translations_controller.rb
@@ -6,7 +6,15 @@ class Admin::EditionTranslationsController < Admin::BaseController
   def new; end
 
   def edit
-    load_document_history
+    if @edition.is_a?(StandardEdition)
+      redirect_to edit_admin_standard_edition_translation_path(
+        standard_edition_id: @edition.id,
+        id: translation_locale.code,
+      )
+    else
+      load_document_history
+      render :edit
+    end
   end
 
   def update

--- a/app/controllers/admin/standard_edition_translations_controller.rb
+++ b/app/controllers/admin/standard_edition_translations_controller.rb
@@ -1,0 +1,2 @@
+class Admin::StandardEditionTranslationsController < Admin::BaseController
+end

--- a/app/controllers/admin/standard_edition_translations_controller.rb
+++ b/app/controllers/admin/standard_edition_translations_controller.rb
@@ -1,2 +1,25 @@
 class Admin::StandardEditionTranslationsController < Admin::BaseController
+  before_action :load_translatable_item
+  before_action :load_translated_models, except: %i[index new]
+  helper_method :translation_locale
+
+  before_action :prevent_modification_of_unmodifiable_edition
+
+  def edit; end
+
+private
+
+  def load_translatable_item
+    @edition ||= Edition.find(params[:standard_edition_id])
+    enforce_permission!(:update, @edition)
+    limit_edition_access!
+  end
+
+  def load_translated_models
+    @translated_edition = LocalisedModel.new(@edition, translation_locale.code)
+  end
+
+  def translation_locale
+    @translation_locale ||= Locale.new(params[:translation_locale] || params[:id])
+  end
 end

--- a/app/controllers/admin/standard_edition_translations_controller.rb
+++ b/app/controllers/admin/standard_edition_translations_controller.rb
@@ -12,7 +12,7 @@ class Admin::StandardEditionTranslationsController < Admin::BaseController
   def update
     @translated_edition.change_note = "Added translation" if @translated_edition.change_note.blank?
     if @translated_edition.update(translation_params)
-      save_draft_translation # TODO: revise - removed send_downstream?
+      save_draft_translation
       redirect_to admin_standard_edition_path(@edition), notice: notice_message("saved")
     else
       load_document_history

--- a/app/controllers/admin/standard_edition_translations_controller.rb
+++ b/app/controllers/admin/standard_edition_translations_controller.rb
@@ -5,7 +5,9 @@ class Admin::StandardEditionTranslationsController < Admin::BaseController
 
   before_action :prevent_modification_of_unmodifiable_edition
 
-  def edit; end
+  def edit
+    load_document_history
+  end
 
 private
 
@@ -21,5 +23,9 @@ private
 
   def translation_locale
     @translation_locale ||= Locale.new(params[:translation_locale] || params[:id])
+  end
+
+  def load_document_history
+    @document_history = Document::PaginatedTimeline.new(document: @edition.document, page: params[:page] || 1, only: params[:only])
   end
 end

--- a/app/models/concerns/edition/organisations.rb
+++ b/app/models/concerns/edition/organisations.rb
@@ -67,10 +67,6 @@ module Edition::Organisations
     true
   end
 
-  def limits_access_via_organisations?
-    true
-  end
-
 private
 
   def at_least_one_lead_organisation

--- a/app/models/configurable_document_types/history_page.json
+++ b/app/models/configurable_document_types/history_page.json
@@ -40,6 +40,7 @@
     "organisations": ["af07d5a5-df63-4ddc-9383-6a666845ebe9"],
     "backdating_enabled": false,
     "history_mode_enabled": false,
-    "file_attachments_enabled": false
+    "file_attachments_enabled": false,
+    "translations_enabled": false
   }
 }

--- a/app/models/configurable_document_types/news_story.json
+++ b/app/models/configurable_document_types/news_story.json
@@ -45,6 +45,7 @@
     "file_attachments_enabled": true,
     "organisations": null,
     "backdating_enabled": true,
-    "history_mode_enabled": true
+    "history_mode_enabled": true,
+    "translations_enabled": true
   }
 }

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -448,10 +448,6 @@ class Edition < ApplicationRecord
     []
   end
 
-  def limits_access_via_organisations?
-    false
-  end
-
 private
 
   def date_for_government

--- a/app/models/standard_edition.rb
+++ b/app/models/standard_edition.rb
@@ -35,6 +35,10 @@ class StandardEdition < Edition
     type_instance.settings["backdating_enabled"]
   end
 
+  def translatable?
+    type_instance.settings["translations_enabled"]
+  end
+
   def allows_image_attachments?
     type_instance.settings["images_enabled"]
   end

--- a/app/services/draft_edition_updater.rb
+++ b/app/services/draft_edition_updater.rb
@@ -28,6 +28,6 @@ private
   end
 
   def access_limit_excludes_current_user?
-    edition.limits_access_via_organisations? && edition.edition_organisations.map(&:organisation_id).exclude?(@options[:current_user].organisation.id)
+    edition.organisation_association_enabled? && edition.edition_organisations.map(&:organisation_id).exclude?(@options[:current_user].organisation.id)
   end
 end

--- a/app/views/admin/configurable_content_blocks/_default_object.html.erb
+++ b/app/views/admin/configurable_content_blocks/_default_object.html.erb
@@ -1,6 +1,8 @@
 <% required = required || false %>
 <% content = content || {} %>
+<% translated_content = translated_content || {} %>
 <% root = root || false %>
+<% right_to_left = right_to_left || false %>
 <% unless root %>
   <%= render "govuk_publishing_components/components/fieldset", {
     legend_text: schema["title"] + (required ? " (required)" : ""),
@@ -12,8 +14,10 @@
       <%= render block, {
         schema: property_schema,
         content: content[property_key],
+        translated_content: translated_content.key?(property_key) ? translated_content[property_key] : nil,
         path: path.push(property_key),
         required: schema["required"].present? ? schema["required"].include?(property_key) : false,
+        right_to_left:,
       } %>
     <% end %>
   <% end %>
@@ -23,8 +27,10 @@
     <%= render block, {
       schema: property_schema,
       content: content[property_key],
+      translated_content: translated_content.key?(property_key) ? translated_content[property_key] : nil,
       path: path.push(property_key),
       required: schema["required"].present? ? schema["required"].include?(property_key) : false,
+      right_to_left:,
     } %>
   <% end %>
 <% end %>

--- a/app/views/admin/configurable_content_blocks/_default_string.html.erb
+++ b/app/views/admin/configurable_content_blocks/_default_string.html.erb
@@ -1,8 +1,18 @@
 <% required = required || false %>
+<% right_to_left = right_to_left || false %>
+<% translated_content = translated_content || nil %>
 <%= render "govuk_publishing_components/components/input", {
   id: path.form_control_id,
   label: { text: schema["title"] + (required ? " (required)" : "") },
   name: path.form_control_name,
-  value: content,
+  value: translated_content ? translated_content : content,
   hint: schema["description"],
+  right_to_left:,
 } %>
+<% if translated_content.present? %>
+  <%= render "govuk_publishing_components/components/details", {
+    title: "Primary locale content for #{schema["title"]}",
+  } do %>
+    <%= content %>
+  <% end %>
+<% end %>

--- a/app/views/admin/configurable_content_blocks/_govspeak.html.erb
+++ b/app/views/admin/configurable_content_blocks/_govspeak.html.erb
@@ -1,4 +1,6 @@
 <% required = required || false %>
+<% right_to_left = right_to_left || false %>
+<% translated_content = translated_content || nil %>
 <%= render "components/govspeak_editor", {
   label: {
     text: schema["title"] + (required ? " (required)" : ""),
@@ -6,10 +8,18 @@
   },
   id: path.form_control_id,
   name: path.form_control_name,
-  value: content,
+  value: (translated_content.presence || content),
   rows: 20,
   data_attributes: {
     attachment_ids: govspeak.attachments.map(&:id),
     image_ids: govspeak.images.map { |img| img[:id] }.to_json,
   },
+  right_to_left:,
 } %>
+<% if translated_content.present? %>
+  <%= render "govuk_publishing_components/components/details", {
+    title: "Primary locale content for #{schema["title"]}",
+  } do %>
+    <%= content %>
+  <% end %>
+<% end %>

--- a/app/views/admin/configurable_content_blocks/_image_select.html.erb
+++ b/app/views/admin/configurable_content_blocks/_image_select.html.erb
@@ -1,4 +1,5 @@
 <% required = required || false %>
+<% translated_content = translated_content || nil %>
 <% select_options = [
      {
        text: "No image selected",
@@ -8,7 +9,7 @@
   {
     text: image.filename,
     value: image.image_data.id,
-    selected: image.image_data.id == content.to_i,
+    selected: image.image_data.id == (translated_content || content).to_i,
   }
 end %>
 

--- a/app/views/admin/editions/_settings_fields.html.erb
+++ b/app/views/admin/editions/_settings_fields.html.erb
@@ -6,7 +6,7 @@
     } %>
 
     <%= render "accessible_attachment_field", form: form, edition: edition %>
-    <%= render "access_limiting_fields", form: form, edition: edition %>
+    <%= render "access_limiting_fields", form: form, edition: edition if edition.organisation_association_enabled? %>
     <%= render "scheduled_publication_fields", form: form, edition: edition %>
     <%= render "review_reminder_fields", form: form, review_reminder: edition.document.review_reminder %>
 </div>

--- a/app/views/admin/standard_edition_translations/edit.html.erb
+++ b/app/views/admin/standard_edition_translations/edit.html.erb
@@ -64,8 +64,32 @@
       </div>
     <% end %>
   </section>
-
-  <section class="govuk-grid-column-one-third">
-    <!-- TODO: render sidebar-->
-  </section>
+  <div class="govuk-grid-column-one-third">
+    <%= render "govuk_publishing_components/components/tabs", {
+      disable_ga4: true,
+      tabs: [
+        {
+          id: "govspeak_tab",
+          label: "Help",
+          content: simple_formatting_sidebar(
+            hide_inline_attachments_help: !@edition.allows_inline_attachments?,
+            show_attachments_tab_help: true,
+            link_check_report: LinkCheckerApiService.has_links?(@edition, convert_admin_links: false) ? @edition.link_check_report : nil,
+            ),
+        },
+        {
+          id: "history_tab",
+          label: "History",
+          content: tag.div(
+            render(Admin::Editions::DocumentHistoryTabComponent.new(
+              edition: @edition,
+              document_history: @document_history,
+              editing: true,
+              )),
+            data: { module: "document-history-paginator" },
+            ),
+        },
+      ],
+    } %>
+  </div>
 </div>

--- a/app/views/admin/standard_edition_translations/edit.html.erb
+++ b/app/views/admin/standard_edition_translations/edit.html.erb
@@ -7,8 +7,6 @@
   <section class="govuk-grid-column-two-thirds">
     <%= form_for @translated_edition, as: :edition, url: admin_standard_edition_translation_path(@translated_edition, translation_locale), method: :put do |form| %>
 
-      <%= form.hidden_field :lock_version %>
-
       <%= render "components/translated_input", {
         input: {
           label: {

--- a/app/views/admin/standard_edition_translations/edit.html.erb
+++ b/app/views/admin/standard_edition_translations/edit.html.erb
@@ -1,0 +1,65 @@
+<% content_for :context, @edition.title %>
+<% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @edition, parent_class: "edition")) %>
+<% content_for :page_title, "Edit translation for: #{@edition.title}" %>
+<% content_for :title, "#{@translation_locale.native_language_name} (#{@translation_locale.english_language_name}) translation" %>
+
+<div class="govuk-grid-row">
+  <section class="govuk-grid-column-two-thirds">
+    <%= form_for @translated_edition, as: :edition, url: admin_standard_edition_translation_path(@translated_edition, translation_locale), method: :put do |form| %>
+      <div class="<%= "right-to-left" if @edition.rtl? %>">
+        <%= form.hidden_field :lock_version %>
+
+        <%= render "components/translated_input", {
+          input: {
+            label: {
+              text: "Translated title (required)",
+            },
+            name: "edition[title]",
+            id: "edition_title",
+            heading_level: 2,
+            heading_size: "l",
+            value: @translated_edition.title,
+            error_items: errors_for(form.object.errors, :title),
+            right_to_left: form.object.translation_rtl?,
+            right_to_left_help: false,
+          },
+          details: {
+            text: @edition.title,
+          },
+        } %>
+
+        <%= render "components/translated_textarea", {
+          textarea: {
+            label: {
+              heading_size: "l",
+              text: "Translated summary#{' (required)' unless @edition.is_a?(CorporateInformationPage)}",
+            },
+            name: "edition[summary]",
+            textarea_id: "edition_summary",
+            value: @translated_edition.summary,
+            rows: 2,
+            error_items: errors_for(form.object.errors, :summary),
+            right_to_left: form.object.translation_rtl?,
+            right_to_left_help: false,
+          },
+          details: {
+            text: @edition.summary,
+          },
+        } %>
+
+        <!-- TODO: render content blocks -->
+
+        <div class="govuk-button-group">
+          <%= render "govuk_publishing_components/components/button", {
+            text: "Save",
+          } %>
+          <%= link_to("Cancel", admin_edition_path(@edition), class: "govuk-link govuk-link--no-visited-state") %>
+        </div>
+      </div>
+    <% end %>
+  </section>
+
+  <section class="govuk-grid-column-one-third">
+    <!-- TODO: render sidebar-->
+  </section>
+</div>

--- a/app/views/admin/standard_edition_translations/edit.html.erb
+++ b/app/views/admin/standard_edition_translations/edit.html.erb
@@ -47,7 +47,13 @@
           },
         } %>
 
-        <!-- TODO: render content blocks -->
+        <% root_block = ConfigurableContentBlocks::Factory.new(@translated_edition).build("object") %>
+        <%= render(root_block, {
+          schema: ConfigurableDocumentType.find(@translated_edition.configurable_document_type).schema,
+          content: @translated_edition.block_content,
+          path: ConfigurableContentBlocks::Path.new,
+          root: true,
+        }) %>
 
         <div class="govuk-button-group">
           <%= render "govuk_publishing_components/components/button", {

--- a/app/views/admin/standard_edition_translations/edit.html.erb
+++ b/app/views/admin/standard_edition_translations/edit.html.erb
@@ -6,61 +6,62 @@
 <div class="govuk-grid-row">
   <section class="govuk-grid-column-two-thirds">
     <%= form_for @translated_edition, as: :edition, url: admin_standard_edition_translation_path(@translated_edition, translation_locale), method: :put do |form| %>
-      <div class="<%= "right-to-left" if @edition.rtl? %>">
-        <%= form.hidden_field :lock_version %>
 
-        <%= render "components/translated_input", {
-          input: {
-            label: {
-              text: "Translated title (required)",
-            },
-            name: "edition[title]",
-            id: "edition_title",
-            heading_level: 2,
+      <%= form.hidden_field :lock_version %>
+
+      <%= render "components/translated_input", {
+        input: {
+          label: {
+            text: "Translated title (required)",
+          },
+          name: "edition[title]",
+          id: "edition_title",
+          heading_level: 2,
+          heading_size: "l",
+          value: @translated_edition.title,
+          error_items: errors_for(form.object.errors, :title),
+          right_to_left: form.object.translation_rtl?,
+          right_to_left_help: false,
+        },
+        details: {
+          text: @edition.title,
+        },
+      } %>
+
+      <%= render "components/translated_textarea", {
+        textarea: {
+          label: {
             heading_size: "l",
-            value: @translated_edition.title,
-            error_items: errors_for(form.object.errors, :title),
-            right_to_left: form.object.translation_rtl?,
-            right_to_left_help: false,
+            text: "Translated summary#{' (required)' unless @edition.is_a?(CorporateInformationPage)}",
           },
-          details: {
-            text: @edition.title,
-          },
+          name: "edition[summary]",
+          textarea_id: "edition_summary",
+          value: @translated_edition.summary,
+          rows: 2,
+          error_items: errors_for(form.object.errors, :summary),
+          right_to_left: form.object.translation_rtl?,
+          right_to_left_help: false,
+        },
+        details: {
+          text: @edition.summary,
+        },
+      } %>
+
+      <% root_block = ConfigurableContentBlocks::Factory.new(@translated_edition).build("object") %>
+      <%= render(root_block, {
+        schema: ConfigurableDocumentType.find(@translated_edition.configurable_document_type).schema,
+        content: @edition.block_content,
+        translated_content: @translated_edition.block_content,
+        path: ConfigurableContentBlocks::Path.new,
+        right_to_left: form.object.translation_rtl?,
+        root: true,
+      }) %>
+
+      <div class="govuk-button-group">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Save",
         } %>
-
-        <%= render "components/translated_textarea", {
-          textarea: {
-            label: {
-              heading_size: "l",
-              text: "Translated summary#{' (required)' unless @edition.is_a?(CorporateInformationPage)}",
-            },
-            name: "edition[summary]",
-            textarea_id: "edition_summary",
-            value: @translated_edition.summary,
-            rows: 2,
-            error_items: errors_for(form.object.errors, :summary),
-            right_to_left: form.object.translation_rtl?,
-            right_to_left_help: false,
-          },
-          details: {
-            text: @edition.summary,
-          },
-        } %>
-
-        <% root_block = ConfigurableContentBlocks::Factory.new(@translated_edition).build("object") %>
-        <%= render(root_block, {
-          schema: ConfigurableDocumentType.find(@translated_edition.configurable_document_type).schema,
-          content: @translated_edition.block_content,
-          path: ConfigurableContentBlocks::Path.new,
-          root: true,
-        }) %>
-
-        <div class="govuk-button-group">
-          <%= render "govuk_publishing_components/components/button", {
-            text: "Save",
-          } %>
-          <%= link_to("Cancel", admin_edition_path(@edition), class: "govuk-link govuk-link--no-visited-state") %>
-        </div>
+        <%= link_to("Cancel", admin_edition_path(@edition), class: "govuk-link govuk-link--no-visited-state") %>
       </div>
     <% end %>
   </section>

--- a/app/views/admin/standard_editions/_form.html.erb
+++ b/app/views/admin/standard_editions/_form.html.erb
@@ -67,6 +67,7 @@
       schema: ConfigurableDocumentType.find(@edition.configurable_document_type).schema,
       content: @edition.block_content,
       path: ConfigurableContentBlocks::Path.new,
+      right_to_left: @edition.rtl?,
       root: true,
     }) %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -298,6 +298,10 @@ Whitehall::Application.routes.draw do
 
       resources :standard_editions, path: "standard-editions", except: [:index] do
         get :choose_type, on: :collection, as: :choose_type
+
+        resources :translations, controller: "standard_edition_translations", except: %i[index show create] do
+          get :confirm_destroy, on: :member
+        end
       end
       resources :landing_pages, path: "landing-pages", except: [:index]
 

--- a/docs/configurable_document_types.md
+++ b/docs/configurable_document_types.md
@@ -39,10 +39,12 @@ Each content block implements the following methods:
 - `to_partial_path`: Returns the path to the view that renders the form control for the property. 
 
 Block views use the following [partial-local](https://guides.rubyonrails.org/action_view_overview.html#passing-data-to-partials-with-locals-option) variables: 
-- The property `schema` and `content` (default `{}`) are provided for the specific part of the tree being rendered by the content block. 
+- The property `schema` and `content` (default `{}`) are provided for the specific part of the tree being rendered by the content block. The content is for the edition's primary locale.
 - The location in the tree is specified by the immutable [`path` object](../app/models/configurable_content_blocks/path.rb), which provides convenience methods for doing things such as building the correct name attribute for the form control. If you are rendering child properties for an "object" block, ensure that you push a new segment onto the path (see the [default object implementation](../app/models/configurable_content_blocks/default_object.rb) for an example). 
 - The `root` (default `false`) attribute, which is only set to `true` for the rendering of the original `DefaultObject` block that wraps all the other blocks in the schema. 
 - The `required` attribute. The required properties are defined at the parent level in [JSON schema](https://json-schema.org/docs), so the `required` attribute is extracted in the parent view, and passed on to any required child property, which then gets rendered with a "(required)" specification in its label.
+- The `right_to_left` (default `false`) attribute. This is set to true if the locale for the edition translation is set to a language which is read from right to left.
+- The `translated_content` (default `nil`) attribute. If the edition is a translation, then this will be populated with the translated content. Blocks must populate their values with the translated content if it is provided, and may wish to show the content for the primary locale as an aid to the user.
 
 Content blocks are instantiated via the [content block factory](../app/models/configurable_content_blocks/factory.rb). To add a new block type, add a new block class implementing the methods above to the `app/models/configurable_content_blocks` directory, and add the block type to the private blocks method in the factory class. The `blocks` method returns a hash that maps each block type and format to a constructor lambda. The constructor lambda receives the configurable document edition object as its only argument. Any values from the edition object needed by the block can be passed to the block's initialize method, e.g. the Image Select block is passed the edition's images.
 

--- a/features/fixtures/test_configurable_document_type.json
+++ b/features/fixtures/test_configurable_document_type.json
@@ -28,6 +28,7 @@
     "publishing_api_document_type": "test_type",
     "rendering_app": "government-frontend",
     "organisations": null,
-    "backdating_enabled": false
+    "backdating_enabled": false,
+    "translations_enabled": true
   }
 }

--- a/features/standard-edition.feature
+++ b/features/standard-edition.feature
@@ -14,3 +14,24 @@ Feature: Standard Editions
     When I publish a submitted draft of a test configurable document titled "The history of GOV.UK"
     Then I can see that the draft edition of "The history of GOV.UK" was published successfully
     And a new draft of "The history of GOV.UK" is created with the correct field values
+
+  Scenario: Adding translations with all content block types
+    Given I am a GDS admin
+    And the configurable document types feature flag is enabled
+    And the test configurable document type is defined with translations enabled
+    And I have drafted an English configurable document titled "Digital transformation report"
+    When I add a Welsh translation "Adroddiad trawsnewid digidol"
+    Then configured content blocks should appear on the translation page
+    And the Welsh translation fields should be pre-populated with primary locale content
+    And the image selections should be preserved from the primary locale
+    And I should see the original English content in "original text" sections
+
+  Scenario: Creating a non-English primary locale configurable document
+    Given I am a GDS admin
+    And the configurable document types feature flag is enabled
+    And the test configurable document type is defined with translations enabled
+    When I create a new configurable document with Welsh as the primary locale titled "Strategaeth Ddigidol Cymru"
+    Then the document should be saved with Welsh as the primary locale
+    And English should not appear as a translation option
+
+

--- a/test/factories/standard_editions.rb
+++ b/test/factories/standard_editions.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     previously_published { false }
     configurable_document_type { "test_type" }
     block_content { {} }
+    body { nil }
 
     factory :draft_standard_edition, parent: :standard_edition, traits: [:draft]
     factory :submitted_standard_edition, parent: :standard_edition, traits: [:submitted]

--- a/test/functional/admin/edition_translations_controller_test.rb
+++ b/test/functional/admin/edition_translations_controller_test.rb
@@ -37,6 +37,15 @@ class Admin::EditionTranslationsControllerTest < ActionController::TestCase
     assert_redirected_to @controller.edit_admin_edition_translation_path(edition, id: "fr")
   end
 
+  test "edit redirects to edit for a standard edition, with the chosen language" do
+    ConfigurableDocumentType.setup_test_types(build_configurable_document_type("test_type", {}))
+    edition = create(:standard_edition, { configurable_document_type: "test_type", title: "english-title" })
+
+    get :edit, params: { edition_id: edition, id: "fr" }
+
+    assert_redirected_to edit_admin_standard_edition_translation_path(edition, id: "fr")
+  end
+
   view_test "edit indicates which language we are adding a translation for" do
     edition = create(:edition, title: "english-title")
 

--- a/test/functional/admin/standard_edition_translations_controller_test.rb
+++ b/test/functional/admin/standard_edition_translations_controller_test.rb
@@ -55,4 +55,15 @@ class Admin::StandardEditionTranslationsControllerTest < ActionController::TestC
     assert_select ".app-c-translated-textarea__english-translation .govuk-details__text", text: edition.summary
     assert_select ".app-c-translated-textarea__english-translation .govuk-details__text", text: edition.block_content["body"]
   end
+
+  view_test "renders the govspeak help and history tab" do
+    # TODO: confirm that fact checking is not included at the minute
+    edition = create(:standard_edition, { configurable_document_type: "test_type", title: "english-title" })
+    create(:editorial_remark, edition:)
+
+    get :edit, params: { standard_edition_id: edition, id: "cy" }
+
+    assert_select ".govuk-tabs__tab", text: "Help"
+    assert_select ".govuk-tabs__tab", text: "History"
+  end
 end

--- a/test/functional/admin/standard_edition_translations_controller_test.rb
+++ b/test/functional/admin/standard_edition_translations_controller_test.rb
@@ -45,19 +45,21 @@ class Admin::StandardEditionTranslationsControllerTest < ActionController::TestC
     end
   end
 
-  view_test "edit shows the english values underneath the associated form fields" do
-    # TODO: - this test should probably be rephrased as the "primary locale" values
-    edition = create(:standard_edition, { configurable_document_type: "test_type", title: "english-title" })
+  view_test "edit shows the primary locale value underneath the associated form fields" do
+    edition = create(:standard_edition, { configurable_document_type: "test_type",
+                                          title: "english-title",
+                                          summary: "english-summary",
+                                          block_content: {
+                                            body: "test body",
+                                          } })
 
     get :edit, params: { standard_edition_id: edition, id: "fr" }
 
-    assert_select ".app-c-translated-input__english-translation .govuk-details__text", text: edition.title
-    assert_select ".app-c-translated-textarea__english-translation .govuk-details__text", text: edition.summary
-    assert_select ".app-c-translated-textarea__english-translation .govuk-details__text", text: edition.block_content["body"]
+    assert_select ".app-c-translated-input__english-translation .govuk-details__text", text: "english-title"
+    assert_select ".app-c-translated-textarea__english-translation .govuk-details__text", text: "english-summary"
   end
 
   view_test "renders the govspeak help and history tab" do
-    # TODO: confirm that fact checking is not included at the minute
     edition = create(:standard_edition, { configurable_document_type: "test_type", title: "english-title" })
     create(:editorial_remark, edition:)
 

--- a/test/functional/admin/standard_edition_translations_controller_test.rb
+++ b/test/functional/admin/standard_edition_translations_controller_test.rb
@@ -1,0 +1,47 @@
+require "test_helper"
+
+class Admin::StandardEditionTranslationsControllerTest < ActionController::TestCase
+  setup do
+    @writer = login_as(:writer)
+    ConfigurableDocumentType.setup_test_types(build_configurable_document_type("test_type", {}))
+  end
+
+  should_be_an_admin_controller
+
+  view_test "edit indicates which language we are adding a translation for" do
+    edition = create(:standard_edition, { configurable_document_type: "test_type", title: "english-title" })
+
+    get :edit, params: { standard_edition_id: edition, id: "fr" }
+
+    assert_select "h1", text: "Français (French) translation"
+    assert_select ".govuk-caption-xl", text: "english-title"
+  end
+
+  view_test "edit presents a form to update an existing translation" do
+    edition = create(:standard_edition, { configurable_document_type: "test_type", title: "english-title" })
+    with_locale(:fr) { edition.update!(title: "french-title", summary: "french-summary") }
+
+    get :edit, params: { standard_edition_id: edition, id: "fr" }
+
+    assert_select "form[action='#{@controller.admin_standard_edition_translation_path(edition, 'fr')}']" do
+      assert_select "h2", text: "Translated title (required)", count: 1
+      assert_select "input[type=text][name='edition[title]'][value='french-title']"
+      assert_select "label", text: "Translated summary (required)"
+      assert_select "textarea[name='edition[summary]']", text: "french-summary"
+      # assert_select "textarea[name='edition[body]']", "french-body"
+
+      assert_select "button[type=submit]"
+      assert_select "a[href=?]", @controller.admin_edition_path(edition), text: "Cancel"
+    end
+  end
+
+  view_test "edit shows the english values underneath the associated form fields" do
+    edition = create(:standard_edition, { configurable_document_type: "test_type", title: "english-title" })
+
+    get :edit, params: { standard_edition_id: edition, id: "fr" }
+
+    assert_select ".app-c-translated-input__english-translation .govuk-details__text", text: edition.title
+    assert_select ".app-c-translated-textarea__english-translation .govuk-details__text", text: edition.summary
+    # assert_select ".app-c-translated-textarea__english-translation .govuk-details__text", text: edition.body
+  end
+end

--- a/test/unit/app/models/configurable_content_blocks/default_object_test.rb
+++ b/test/unit/app/models/configurable_content_blocks/default_object_test.rb
@@ -137,6 +137,25 @@ class ConfigurableContentBlocks::DefaultObjectRenderingTest < ActionView::TestCa
     assert_dom "label", text: "#{schema['properties']['test_attribute']['title']} (required)"
   end
 
+  test "it passes the right_to_left attribute on to child blocks" do
+    schema = {
+      "title" => "Test object",
+      "type" => "object",
+      "properties" => {
+        "test_attribute" => {
+          "title" => "Test attribute",
+          "type" => "string",
+        },
+      },
+      "required" => %w[test_attribute],
+    }
+    factory = ConfigurableContentBlocks::Factory.new(StandardEdition.new)
+    block = ConfigurableContentBlocks::DefaultObject.new(factory)
+    render block, { schema:, content: {}, path: Path.new, right_to_left: true }
+    assert_dom "label", text: "#{schema['properties']['test_attribute']['title']} (required)"
+    assert_dom "input[dir=\"rtl\"]"
+  end
+
   test "it renders not-nested child attribute content" do
     schema = {
       "title" => "Test object",

--- a/test/unit/app/models/configurable_content_blocks/default_string_test.rb
+++ b/test/unit/app/models/configurable_content_blocks/default_string_test.rb
@@ -70,4 +70,36 @@ class ConfigurableContentBlocks::DefaultStringRenderingTest < ActionView::TestCa
     }
     assert_dom ".govuk-hint", text: @schema["properties"]["test_attribute"]["description"]
   end
+
+  test "it sets the direction on the input to right to left when the rtl option returns true" do
+    render @block, {
+      schema: @schema["properties"]["test_attribute"],
+      content: @page.block_content["test_attribute"],
+      path: Path.new.push("test_attribute"),
+      right_to_left: true,
+    }
+    assert_dom "input[dir=\"rtl\"]"
+  end
+
+  test "it renders the primary locale content under the input when the translated content is provided" do
+    render @block, {
+      schema: @schema["properties"]["test_attribute"],
+      content: @page.block_content["test_attribute"],
+      path: Path.new.push("test_attribute"),
+      translated_content: "bar",
+    }
+
+    assert_dom ".govuk-details__text", text: @page.block_content["test_attribute"]
+  end
+
+  test "it sets the value of the textarea to the translated content when the translated content is provided" do
+    render @block, {
+      schema: @schema["properties"]["test_attribute"],
+      content: @page.block_content["test_attribute"],
+      path: Path.new.push("test_attribute"),
+      translated_content: "bar",
+    }
+
+    assert_dom "input[value=?]", "bar"
+  end
 end

--- a/test/unit/app/models/configurable_content_blocks/govspeak_test.rb
+++ b/test/unit/app/models/configurable_content_blocks/govspeak_test.rb
@@ -74,10 +74,6 @@ class ConfigurableContentBlocks::GovspeakRenderingTest < ActionView::TestCase
           "format" => "govspeak",
         },
       },
-      "settings" => {
-        "file_attachments_enabled" => true,
-        "images_enabled" => true,
-      },
     }
 
     govspeak_content = "## foo\n[Attachment: #{file_attachment.filename}]"
@@ -90,5 +86,74 @@ class ConfigurableContentBlocks::GovspeakRenderingTest < ActionView::TestCase
     }
 
     assert_dom ".app-c-govspeak-editor[data-attachment-ids=\"[#{file_attachment.id}]\"][data-image-ids=\"[#{image.id}]\"]"
+  end
+
+  test "it sets the direction on the textarea to right to left when the rtl option returns true" do
+    schema = {
+      "type" => "object",
+      "properties" => {
+        "test_attribute" => {
+          "type" => "string",
+          "title" => "Test attribute",
+          "description" => "A test attribute",
+          "format" => "govspeak",
+        },
+      },
+    }
+    govspeak_content = "## foo"
+    block = ConfigurableContentBlocks::Govspeak.new([], [])
+    render block, {
+      schema: schema["properties"]["test_attribute"],
+      content: govspeak_content,
+      path: Path.new.push("test_attribute"),
+      right_to_left: true,
+    }
+    assert_dom ".app-c-govspeak-editor textarea[dir=\"rtl\"]"
+  end
+
+  test "it renders the primary locale content under the textarea when the translated content is provided" do
+    schema = {
+      "type" => "object",
+      "properties" => {
+        "test_attribute" => {
+          "type" => "string",
+          "title" => "Test attribute",
+          "description" => "A test attribute",
+          "format" => "govspeak",
+        },
+      },
+    }
+    govspeak_content = "## foo"
+    block = ConfigurableContentBlocks::Govspeak.new([], [])
+    render block, {
+      schema: schema["properties"]["test_attribute"],
+      content: govspeak_content,
+      path: Path.new.push("test_attribute"),
+      translated_content: "## bar",
+    }
+    assert_dom ".govuk-details__text", text: govspeak_content
+  end
+
+  test "it sets the value of the textarea to the translated content when the translated content is provided" do
+    schema = {
+      "type" => "object",
+      "properties" => {
+        "test_attribute" => {
+          "type" => "string",
+          "title" => "Test attribute",
+          "description" => "A test attribute",
+          "format" => "govspeak",
+        },
+      },
+    }
+    translated_content = "## foo"
+    block = ConfigurableContentBlocks::Govspeak.new([], [])
+    render block, {
+      schema: schema["properties"]["test_attribute"],
+      content: "## bar",
+      path: Path.new.push("test_attribute"),
+      translated_content:,
+    }
+    assert_dom "textarea", text: translated_content
   end
 end

--- a/test/unit/app/models/configurable_content_blocks/image_select_test.rb
+++ b/test/unit/app/models/configurable_content_blocks/image_select_test.rb
@@ -61,4 +61,33 @@ class ConfigurableContentBlocks::ImageSelectRenderingTest < ActionView::TestCase
       assert_dom "option", text: image.filename
     end
   end
+
+  test "it uses the translated content value when provided" do
+    @schema = {
+      "type" => "object",
+      "properties" => {
+        "test_attribute" => {
+          "type" => "string",
+          "title" => "Test attribute",
+          "description" => "A test attribute",
+          "format" => "image_select",
+        },
+      },
+    }
+
+    @page = StandardEdition.new
+    @page.images = create_list(:image, 3)
+    @page.block_content = { "test_attribute" => @page.images.last.image_data.id.to_s }
+    @block = ConfigurableContentBlocks::ImageSelect.new(@page.images)
+
+    render @block, {
+      schema: @schema["properties"]["test_attribute"],
+      content: @page.block_content["test_attribute"],
+      translated_content: @page.images.first.image_data.id.to_s,
+      path: Path.new.push("test_attribute"),
+    }
+
+    assert_dom "select[name=?]", "edition[block_content][test_attribute]"
+    assert_dom "option[selected][value=?]", @page.images.first.image_data.id.to_s
+  end
 end

--- a/test/unit/app/models/standard_edition_test.rb
+++ b/test/unit/app/models/standard_edition_test.rb
@@ -125,4 +125,28 @@ class StandardEditionTest < ActiveSupport::TestCase
     page = build(:standard_edition, { configurable_document_type: test_type, block_content: {} })
     assert page.invalid?
   end
+
+  test "it allows translations if the configurable document type settings permit them" do
+    test_type_with_translation =
+      build_configurable_document_type(
+        "test_type_with_translation", {
+          "settings" => {
+            "translations_enabled" => true,
+          },
+        }
+      )
+    test_type_without_translation =
+      build_configurable_document_type(
+        "test_type_without_translation", {
+          "settings" => {
+            "translations_enabled" => false,
+          },
+        }
+      )
+    ConfigurableDocumentType.setup_test_types(test_type_with_translation.merge(test_type_without_translation))
+    page_with_translation = StandardEdition.new(configurable_document_type: "test_type_with_translation")
+    page_without_translation = StandardEdition.new(configurable_document_type: "test_type_without_translation")
+    assert page_with_translation.translatable?
+    assert_not page_without_translation.translatable?
+  end
 end

--- a/test/unit/app/models/standard_edition_test.rb
+++ b/test/unit/app/models/standard_edition_test.rb
@@ -149,4 +149,19 @@ class StandardEditionTest < ActiveSupport::TestCase
     assert page_with_translation.translatable?
     assert_not page_without_translation.translatable?
   end
+
+  test "non-English documents exclude English as a translation option" do
+    test_type = build_configurable_document_type("test_type", {
+      "settings" => { "translations_enabled" => true },
+    })
+    ConfigurableDocumentType.setup_test_types(test_type)
+
+    welsh_edition = create(:standard_edition,
+                           configurable_document_type: "test_type",
+                           primary_locale: "cy")
+
+    missing_translations = welsh_edition.missing_translations
+
+    assert_not_includes missing_translations, :en
+  end
 end


### PR DESCRIPTION
JIRA: [WHIT-2385](https://gov-uk.atlassian.net/browse/WHIT-2385?atlOrigin=eyJpIjoiMTQ0NGNjY2M2M2Q3NDgzNmE2MWU4ZDZlYTYxMWYwZjciLCJwIjoiaiJ9)

This PR allows standard editions to support translations.

The translated content and RTL support being drilled down through the configurable block templates to the leaf blocks feels a bit clunky. Blocks are starting to receive a lot of arguments, either via their initialiser or via template partial local assigns, so we probably need to look at a refactoring soon to manage that complexity.


[WHIT-2385]: https://gov-uk.atlassian.net/browse/WHIT-2385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ