### PR TITLE
[WHIT-2386] Fix indexing of lead organisations for StandardEdition form

### DIFF
--- a/app/models/configurable_associations/organisations.rb
+++ b/app/models/configurable_associations/organisations.rb
@@ -20,8 +20,9 @@ module ConfigurableAssociations
     end
 
     def selected_lead_organisation_id_at(lead_organisation_index)
-      @association.select { |edition_org| lead_organisation_selector(lead_organisation_index, edition_org) }
-                  .first.try(:organisation_id)
+      @association.select(&:lead?)
+                  .sort_by(&:lead_ordering)[lead_organisation_index]
+        &.organisation_id
     end
 
     def selected_supporting_organisation_ids
@@ -34,12 +35,6 @@ module ConfigurableAssociations
 
     def to_partial_path
       "admin/configurable_associations/organisations"
-    end
-
-  private
-
-    def lead_organisation_selector(lead_organisation_index, edition_org)
-      edition_org.lead? && edition_org.lead_ordering == lead_organisation_index
     end
   end
 end

--- a/test/unit/app/models/configurable_associations/organisations_test.rb
+++ b/test/unit/app/models/configurable_associations/organisations_test.rb
@@ -77,13 +77,24 @@ class OrganisationsRenderingTest < ActionView::TestCase
   test "it renders the lead organisation form control with pre-selected options" do
     organisations = create_list(:organisation, 3)
     edition = build(:draft_standard_edition)
-    edition.edition_organisations.build([{ organisation: organisations.first, lead: true, lead_ordering: 0 }, { organisation: organisations.last, lead: true, lead_ordering: 1 }])
+    edition.edition_organisations.build([{ organisation: organisations.first, lead: true, lead_ordering: 3 }, { organisation: organisations.last, lead: true, lead_ordering: 1 }])
 
     organisations_association = ConfigurableAssociations::Organisations.new(edition.edition_organisations, edition.errors)
     render organisations_association
-    assert_dom "option[selected]", text: organisations.first.name
+    assert_dom "#edition_lead_organisation_ids_1 option[selected]", text: organisations.last.name
     assert_not_dom "option[selected]", text: organisations.second.name
-    assert_dom "option[selected]", text: organisations.last.name
+    assert_dom "#edition_lead_organisation_ids_2 option[selected]", text: organisations.first.name
+  end
+
+  test "it renders the lead organisation form control with the default lead organisation" do
+    organisations = create_list(:organisation, 2)
+    edition = build(:draft_standard_edition)
+    edition.edition_organisations.build([{ organisation: organisations.first, lead: true, lead_ordering: 0 }])
+
+    organisations_association = ConfigurableAssociations::Organisations.new(edition.edition_organisations, edition.errors)
+    render organisations_association
+    assert_dom "#edition_lead_organisation_ids_1 option[selected]", text: organisations.first.name
+    assert_not_dom "option[selected]", text: organisations.second.name
   end
 
   test "it renders the supporting organisation form control with pre-selected options" do


### PR DESCRIPTION
## What 
Changed the method used to determine what lead organisations are selected to be displayed on the page to use array index rather than lead organisation order

## Why
Lead ordering is not always zero based. Retrieving in this way ensures we can display pre selected options in from the first position in regardless of the starting lead ordering number.
