### PR TITLE
[PP-7384] PUT content when republishing unpublished editions

### DIFF
--- a/test/integration/workers/publishing_api_document_republishing_worker_integration_test.rb
+++ b/test/integration/workers/publishing_api_document_republishing_worker_integration_test.rb
@@ -156,15 +156,17 @@ class PublishingApiDocumentRepublishingWorkerIntegrationTest < ActiveSupport::Te
       WebMock.reset!
 
       requests = [
+        stub_publishing_api_put_content(publication_presenter.content_id, publication_presenter.content),
+        stub_publishing_api_put_content(publication_presenter.content_id, with_locale(:es) { publication_presenter.content }),
         stub_publishing_api_unpublish(publication_presenter.content_id, body: {
           type: "gone",
           locale: "en",
-          discard_drafts: true,
+          allow_draft: true,
         }),
         stub_publishing_api_unpublish(publication_presenter.content_id, body: {
           type: "gone",
           locale: "es",
-          discard_drafts: true,
+          allow_draft: true,
         }),
         stub_publishing_api_put_content(html_attachment_presenter.content_id, html_attachment_presenter.content),
         stub_publishing_api_patch_links(html_attachment_presenter.content_id, links: html_attachment_presenter.links),
@@ -198,15 +200,17 @@ class PublishingApiDocumentRepublishingWorkerIntegrationTest < ActiveSupport::Te
       WebMock.reset!
 
       requests = [
+        stub_publishing_api_put_content(publication_presenter.content_id, publication_presenter.content),
+        stub_publishing_api_put_content(publication_presenter.content_id, with_locale(:es) { publication_presenter.content }),
         stub_publishing_api_unpublish(publication_presenter.content_id, body: {
           type: "gone",
           locale: "en",
-          discard_drafts: true,
+          allow_draft: true,
         }),
         stub_publishing_api_unpublish(publication_presenter.content_id, body: {
           type: "gone",
           locale: "es",
-          discard_drafts: true,
+          allow_draft: true,
         }),
         stub_publishing_api_put_content(html_attachment_presenter.content_id, html_attachment_presenter.content),
         stub_publishing_api_patch_links(html_attachment_presenter.content_id, links: html_attachment_presenter.links),
@@ -239,10 +243,11 @@ class PublishingApiDocumentRepublishingWorkerIntegrationTest < ActiveSupport::Te
       WebMock.reset!
 
       requests = [
+        stub_publishing_api_put_content(publication_presenter.content_id, publication_presenter.content),
         stub_publishing_api_unpublish(publication_presenter.content_id, body: {
           type: "gone",
           locale: "en",
-          discard_drafts: true,
+          allow_draft: true,
         }),
         stub_publishing_api_put_content(html_attachment_presenter.content_id, html_attachment_presenter.content),
         stub_publishing_api_patch_links(html_attachment_presenter.content_id, links: html_attachment_presenter.links),


### PR DESCRIPTION
Currently, when republishing unpublished editions we only call the

  ```
  POST /v2/content/:content_id/unpublish
  ```

endpoint. This updates details of the unpublishing, but doesn't touch fields on the edition itself (things like `rendering_app`, which we occasionally care about).

This means that when the presenter is updated and content republished in bulk, any changes in that presenter do not take effect for these unpublished content items.

Therefore adding an additional request to

  ```
  PUT /v2/content/:content_id
  ```

prior to making the POST request.

This will have the effect of creating a draft in Publishing API. By changing `allow_draft` to true in the POST request, we will then use the newly created draft when updating the unpublishing.