### PR TITLE
[WHIT-2518] Send Government links to Publishing API for configurable documents

### DIFF
--- a/app/presenters/publishing_api/payload_builder/configurable_document_links.rb
+++ b/app/presenters/publishing_api/payload_builder/configurable_document_links.rb
@@ -1,0 +1,18 @@
+module PublishingApi::PayloadBuilder
+  class ConfigurableDocumentLinks
+    def self.for(item)
+      association_links(item).merge(government_links(item))
+    end
+
+    def self.association_links(item)
+      factory = ConfigurableAssociations::Factory.new(item)
+      factory.configurable_associations.map(&:links).reduce({}, :merge)
+    end
+
+    def self.government_links(item)
+      return {} unless item.type_instance.settings["history_mode_enabled"]
+
+      { government: [item.government&.content_id] }.compact
+    end
+  end
+end

--- a/app/presenters/publishing_api/standard_edition_presenter.rb
+++ b/app/presenters/publishing_api/standard_edition_presenter.rb
@@ -29,16 +29,7 @@ module PublishingApi
     end
 
     def links
-      factory = ConfigurableAssociations::Factory.new(item)
-      links = factory.configurable_associations.reduce({}) do |links_hash, association|
-        links_hash.merge(association.links)
-      end
-      if type.settings["history_mode_enabled"] == true
-        links.merge!(
-          PayloadBuilder::Links.for(item).extract(%i[government]),
-        )
-      end
-      links
+      PayloadBuilder::ConfigurableDocumentLinks.for(item)
     end
 
     def document_type

--- a/test/unit/app/presenters/publishing_api/payload_builder/configurable_document_links_test.rb
+++ b/test/unit/app/presenters/publishing_api/payload_builder/configurable_document_links_test.rb
@@ -1,0 +1,76 @@
+require "test_helper"
+
+class PublishingApi::PayloadBuilder::ConfigurableDocumentLinksTest < ActiveSupport::TestCase
+  test "includes the selected content IDs for each configured association" do
+    ConfigurableDocumentType.setup_test_types(
+      build_configurable_document_type("test_type", {
+        "associations" => [
+          {
+            "key" => "ministerial_role_appointments",
+          },
+          {
+            "key" => "topical_events",
+          },
+          {
+            "key" => "world_locations",
+          },
+          {
+            "key" => "organisations",
+          },
+        ],
+      }),
+    )
+    ministerial_role_appointments = create_list(:ministerial_role_appointment, 2)
+    topical_events = create_list(:topical_event, 2)
+    world_locations = create_list(:world_location, 2, active: true)
+    organisations = create_list(:organisation, 2)
+    edition = build(:standard_edition,
+                    role_appointments: ministerial_role_appointments,
+                    topical_events:,
+                    world_locations:)
+    edition.edition_organisations.build([{ organisation: organisations.first, lead: true, lead_ordering: 0 }, { organisation: organisations.last, lead: false }])
+    links = PublishingApi::PayloadBuilder::ConfigurableDocumentLinks.for(edition)
+    expected_people, expected_roles = ministerial_role_appointments
+                                        .map { |appointment| [appointment.person.content_id, appointment.role.content_id] }
+                                        .transpose
+    assert_equal expected_people, links[:people]
+    assert_equal expected_roles, links[:roles]
+    expected_topical_events = topical_events.map(&:content_id)
+    assert_equal expected_topical_events, links[:topical_events]
+    expected_world_locations = world_locations.map(&:content_id)
+    assert_equal expected_world_locations, links[:world_locations]
+    expected_organisations = organisations.map(&:content_id)
+    assert_equal expected_organisations, links[:organisations]
+    expected_primary_publishing_organisation = [organisations.first.content_id]
+    assert_equal expected_primary_publishing_organisation, links[:primary_publishing_organisation]
+  end
+
+  test "includes government link if the document type has it configured" do
+    ConfigurableDocumentType.setup_test_types(
+      build_configurable_document_type("test_type", {
+        "settings" => {
+          "history_mode_enabled" => true,
+        },
+      }),
+    )
+    government = create(:government)
+    edition = build(:standard_edition, government_id: government.id)
+    links = PublishingApi::PayloadBuilder::ConfigurableDocumentLinks.for(edition)
+    expected_government = [edition.government.content_id]
+    assert_equal expected_government, links[:government]
+  end
+
+  test "does not include government link if the document type does not have it configured" do
+    ConfigurableDocumentType.setup_test_types(
+      build_configurable_document_type("test_type", {
+        "settings" => {
+          "history_mode_enabled" => false,
+        },
+      }),
+    )
+    government = create(:government)
+    edition = build(:standard_edition, government_id: government.id)
+    links = PublishingApi::PayloadBuilder::ConfigurableDocumentLinks.for(edition)
+    assert_nil links[:government]
+  end
+end

--- a/test/unit/app/presenters/publishing_api/standard_edition_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/standard_edition_presenter_test.rb
@@ -345,21 +345,12 @@ class PublishingApi::StandardEditionPresenterTest < ActiveSupport::TestCase
     assert_not content[:details].key?(:attachments)
   end
 
-  test "#links includes the selected content IDs for each configured association" do
+  test "#links includes the required content IDs" do
     ConfigurableDocumentType.setup_test_types(
       build_configurable_document_type("test_type", {
         "associations" => [
           {
-            "key" => "ministerial_role_appointments",
-          },
-          {
-            "key" => "topical_events",
-          },
-          {
             "key" => "world_locations",
-          },
-          {
-            "key" => "organisations",
           },
         ],
         "settings" => {
@@ -367,31 +358,16 @@ class PublishingApi::StandardEditionPresenterTest < ActiveSupport::TestCase
         },
       }),
     )
-    ministerial_role_appointments = create_list(:ministerial_role_appointment, 2)
-    topical_events = create_list(:topical_event, 2)
     world_locations = create_list(:world_location, 2, active: true)
-    organisations = create_list(:organisation, 2)
     government = create(:government)
     edition = build(:standard_edition,
-                    role_appointments: ministerial_role_appointments,
-                    topical_events:,
                     world_locations:,
                     government_id: government.id)
-    edition.edition_organisations.build([{ organisation: organisations.first, lead: true, lead_ordering: 0 }, { organisation: organisations.last, lead: false }])
     presenter = PublishingApi::StandardEditionPresenter.new(edition)
     links = presenter.links
-    expected_people, expected_roles = ministerial_role_appointments
-                                        .map { |appointment| [appointment.person.content_id, appointment.role.content_id] }
-                                        .transpose
-    assert_equal expected_people, links[:people]
-    assert_equal expected_roles, links[:roles]
-    expected_topical_events = topical_events.map(&:content_id)
-    assert_equal expected_topical_events, links[:topical_events]
     expected_world_locations = world_locations.map(&:content_id)
     assert_equal expected_world_locations, links[:world_locations]
-    expected_organisations = organisations.map(&:content_id)
-    assert_equal expected_organisations, links[:organisations]
-    expected_government = edition.government.content_id
-    assert_equal [expected_government], links[:government]
+    expected_government = [edition.government.content_id]
+    assert_equal expected_government, links[:government]
   end
 end


### PR DESCRIPTION
## What
* Use `history_mode_enabled` in a configurable document to determine if Government links should be sent to Publishing API
* Move logic to build links into its own Payload Builder for configurable document types

## Why
News stories need to send Government links but this was not yet supported by the `StandardEditionPresenter`

[JIRA](https://gov-uk.atlassian.net/browse/WHIT-2518)