### PR TITLE
Add `republish_worldwide_organisations` [WHIT-2570]

### DIFF
--- a/app/models/world_location.rb
+++ b/app/models/world_location.rb
@@ -32,6 +32,7 @@ class WorldLocation < ApplicationRecord
   delegate :title, to: :world_location_news
 
   after_commit :republish_index_pages_to_publishing_api
+  after_commit :republish_worldwide_organisations
 
   enum :world_location_type, { world_location: 1, international_delegation: 3 }
 
@@ -96,6 +97,12 @@ class WorldLocation < ApplicationRecord
 
   extend FriendlyId
   friendly_id
+
+  def republish_worldwide_organisations
+    worldwide_organisations.pluck(:document_id).each do |document_id|
+      PublishingApiDocumentRepublishingWorker.perform_async(document_id)
+    end
+  end
 
   def republish_index_pages_to_publishing_api
     PresentPageToPublishingApiWorker.perform_async("PublishingApi::EmbassiesIndexPresenter")

--- a/test/unit/app/models/world_location_test.rb
+++ b/test/unit/app/models/world_location_test.rb
@@ -127,6 +127,19 @@ class WorldLocationTest < ActiveSupport::TestCase
     end
   end
 
+  test "republishes associated Worldwide Organisation pages on update of world location" do
+    world_location = create(:world_location, :with_worldwide_organisations)
+    world_location.worldwide_organisations.each do |worldwide_organisation|
+      PublishingApiDocumentRepublishingWorker
+        .expects(:perform_async)
+        .with(worldwide_organisation.document_id)
+    end
+
+    Sidekiq::Testing.inline! do
+      world_location.update!(name: "new-name")
+    end
+  end
+
   test "republishes embassies and world index pages on update of world location" do
     location = create(:world_location)
 


### PR DESCRIPTION
## What

Add `republish_worldwide_organisations` callback to `WorldLocation` on `commit`.

## Why

Missing callback meant that changes to a World location were not reflected on associated worldwide organisation pages.



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
