### PR TITLE
WHIT-2483 Support bulk-republishing of config-driven Standard Editions

### DIFF
--- a/app/services/bulk_republisher.rb
+++ b/app/services/bulk_republisher.rb
@@ -51,20 +51,19 @@ class BulkRepublisher
 
   def republish_all_non_editionable_content
     non_editionable_content_types.each do |type|
-      republish_all_by_non_editionable_type(type.constantize)
+      republish_all_by_non_editionable_type(type)
     end
   end
 
   def republish_all_by_type(content_type)
-    begin
-      content_type_klass = content_type.constantize
-      raise NameError unless republishable_content_types.include?(content_type)
-    rescue NameError
-      raise "Unknown content type #{content_type}\nCheck the GOV.UK developer documentation for a list of acceptable document types: https://docs.publishing.service.gov.uk/manual/republishing-content.html#whitehall"
-    end
+    error_message = "Unknown content type #{content_type}\n" \
+                    "Check the GOV.UK developer documentation for a list of acceptable document types: " \
+                    "https://docs.publishing.service.gov.uk/manual/republishing-content.html#whitehall"
+
+    raise NameError, error_message unless republishable_content_types.include?(content_type)
 
     if non_editionable_content_types.include?(content_type)
-      republish_all_by_non_editionable_type(content_type_klass)
+      republish_all_by_non_editionable_type(content_type)
     else
       republish_all_by_editionable_type(content_type)
     end
@@ -89,7 +88,8 @@ class BulkRepublisher
 
 private
 
-  def republish_all_by_non_editionable_type(content_type_klass)
+  def republish_all_by_non_editionable_type(content_type)
+    content_type_klass = content_type.constantize
     content_type_klass.find_each(&:bulk_republish_to_publishing_api_async)
   end
 

--- a/app/services/bulk_republisher.rb
+++ b/app/services/bulk_republisher.rb
@@ -18,27 +18,27 @@ class BulkRepublisher
 
   def republish_all_documents_with_pre_publication_editions_with_html_attachments
     document_ids = Edition
-      .in_pre_publication_state
-      .where(id: HtmlAttachment.where(attachable_type: "Edition").select(:attachable_id))
-      .pluck(:document_id)
+                     .in_pre_publication_state
+                     .where(id: HtmlAttachment.where(attachable_type: "Edition").select(:attachable_id))
+                     .pluck(:document_id)
 
     republish_all_documents_by_ids(document_ids)
   end
 
   def republish_all_documents_with_publicly_visible_editions_with_attachments
     document_ids = Edition
-      .publicly_visible
-      .where(id: Attachment.where(attachable_type: "Edition").select(:attachable_id))
-      .pluck(:document_id)
+                     .publicly_visible
+                     .where(id: Attachment.where(attachable_type: "Edition").select(:attachable_id))
+                     .pluck(:document_id)
 
     republish_all_documents_by_ids(document_ids)
   end
 
   def republish_all_documents_with_publicly_visible_editions_with_html_attachments
     document_ids = Edition
-      .publicly_visible
-      .where(id: HtmlAttachment.where(attachable_type: "Edition").select(:attachable_id))
-      .pluck(:document_id)
+                     .publicly_visible
+                     .where(id: HtmlAttachment.where(attachable_type: "Edition").select(:attachable_id))
+                     .pluck(:document_id)
 
     republish_all_documents_by_ids(document_ids)
   end
@@ -66,8 +66,7 @@ class BulkRepublisher
     if non_editionable_content_types.include?(content_type)
       republish_all_by_non_editionable_type(content_type_klass)
     else
-      republishable_document_ids = content_type_klass.joins("INNER JOIN documents ON documents.latest_edition_id = editions.id").pluck(:document_id)
-      republish_all_documents_by_ids(republishable_document_ids)
+      republish_all_by_editionable_type(content_type)
     end
   end
 
@@ -75,9 +74,9 @@ class BulkRepublisher
     raise "Argument must be an organisation" unless organisation.is_a?(Organisation)
 
     document_ids = Edition
-      .latest_edition
-      .in_organisation(organisation)
-      .pluck(:document_id)
+                     .latest_edition
+                     .in_organisation(organisation)
+                     .pluck(:document_id)
 
     republish_all_documents_by_ids(document_ids)
   end
@@ -92,5 +91,33 @@ private
 
   def republish_all_by_non_editionable_type(content_type_klass)
     content_type_klass.find_each(&:bulk_republish_to_publishing_api_async)
+  end
+
+  def republish_all_by_editionable_type(content_type)
+    republishable_document_ids = Edition
+                                   .joins("INNER JOIN documents ON documents.latest_edition_id = editions.id")
+                                   .where(republishable_editions_predicate(content_type)
+                                            .or(republishable_standard_editions_predicate(content_type)))
+                                   .pluck("documents.id")
+
+    republish_all_documents_by_ids(republishable_document_ids)
+  end
+
+  def republishable_editions_predicate(content_type)
+    table = Edition.arel_table
+    table[:type].eq(content_type)
+  end
+
+  def republishable_standard_editions_predicate(content_type)
+    table = Edition.arel_table
+    configurable_document_types_for_schema = ConfigurableDocumentType.all
+                                                                     .select { |configurable_type| configurable_type.settings["publishing_api_schema_name"] == content_type.underscore }
+                                                                     .map(&:key)
+
+    if configurable_document_types_for_schema
+      table[:type].eq("StandardEdition").and(table[:configurable_document_type].in(configurable_document_types_for_schema))
+    else
+      Arel.sql("FALSE")
+    end
   end
 end

--- a/test/unit/app/services/bulk_republisher_test.rb
+++ b/test/unit/app/services/bulk_republisher_test.rb
@@ -330,7 +330,7 @@ class BulkRepublisherTest < ActiveSupport::TestCase
   describe "#republish_all_by_type" do
     setup do
       BulkRepublisher.any_instance.stubs(:non_editionable_content_types).returns(%w[Contact])
-      BulkRepublisher.any_instance.stubs(:republishable_content_types).returns(%w[Contact CaseStudy NewsArticle])
+      BulkRepublisher.any_instance.stubs(:republishable_content_types).returns(%w[Contact CaseStudy NewsArticle History])
     end
 
     context "for editionable content types, like CaseStudy" do
@@ -373,6 +373,18 @@ class BulkRepublisherTest < ActiveSupport::TestCase
       end
     end
 
+    context "for content types that only belong to standard editions, like History" do
+      test "republishes content for the specified type via the PublishingApiDocumentRepublishingWorker" do
+        history = create(:published_standard_edition, { configurable_document_type: "history_page", block_content: { body: "some history" } })
+        PublishingApiDocumentRepublishingWorker.expects(:perform_async_in_queue).with(
+          "bulk_republishing",
+          history.document_id,
+          true,
+        )
+        BulkRepublisher.new.republish_all_by_type("History")
+      end
+    end
+
     context "for non-editionable content types, like Contact, when publishable to Publishing API" do
       test "republishes all content of the specified type via the Whitehall::Publishing API" do
         2.times do
@@ -399,14 +411,6 @@ class BulkRepublisherTest < ActiveSupport::TestCase
       test "it raises an error" do
         assert_raises(StandardError, match: "Unknown content type User") do
           BulkRepublisher.new.republish_all_by_type("User")
-        end
-      end
-    end
-
-    context "for non-existent content types" do
-      test "it raises an error" do
-        assert_raises(StandardError, match: "Unknown content type SomeDocumentTypeThatDoesntExist") do
-          BulkRepublisher.new.republish_all_by_type("SomeDocumentTypeThatDoesntExist")
         end
       end
     end

--- a/test/unit/app/services/bulk_republisher_test.rb
+++ b/test/unit/app/services/bulk_republisher_test.rb
@@ -330,7 +330,7 @@ class BulkRepublisherTest < ActiveSupport::TestCase
   describe "#republish_all_by_type" do
     setup do
       BulkRepublisher.any_instance.stubs(:non_editionable_content_types).returns(%w[Contact])
-      BulkRepublisher.any_instance.stubs(:republishable_content_types).returns(%w[Contact CaseStudy])
+      BulkRepublisher.any_instance.stubs(:republishable_content_types).returns(%w[Contact CaseStudy NewsArticle])
     end
 
     context "for editionable content types, like CaseStudy" do
@@ -355,6 +355,21 @@ class BulkRepublisherTest < ActiveSupport::TestCase
           true,
         )
         BulkRepublisher.new.republish_all_by_type("CaseStudy")
+      end
+    end
+
+    context "for editionable content types that also have configurable document types, like NewsArticle" do
+      test "republishes content for the specified type and configurable types via the PublishingApiDocumentRepublishingWorker" do
+        news_article_type = create(:published_news_article)
+        standard_edition_news_article_type = create(:published_standard_edition, :with_organisations, { configurable_document_type: "news_story" })
+        [news_article_type, standard_edition_news_article_type].each do |article|
+          PublishingApiDocumentRepublishingWorker.expects(:perform_async_in_queue).with(
+            "bulk_republishing",
+            article.document_id,
+            true,
+          )
+        end
+        BulkRepublisher.new.republish_all_by_type("NewsArticle")
       end
     end
 


### PR DESCRIPTION
## What

- Enable bulk republishing of configurable document editions under legacy schema types e.g. NewsArticle for bulk republishing
- Add support for bulk republishing of configurable documents with no legacy schema type e.g. History pages

[JIRA](https://gov-uk.atlassian.net/browse/WHIT-2483)

## TODO

- Add bulk republishing select option on bulk republishing page for History document types.