### PR TITLE
Allow publishing of conflicting topical events to one base_path - attempt two

### DIFF
--- a/lib/whitehall/publishing_api.rb
+++ b/lib/whitehall/publishing_api.rb
@@ -182,6 +182,8 @@ module Whitehall
     end
 
     def self.ensure_base_path_is_associated_with_this_content_id!(base_path, content_id)
+      return if base_path.nil?
+
       existing_content_id = Services.publishing_api.lookup_content_id(base_path:)
       return if existing_content_id.nil? || existing_content_id == content_id
 

--- a/lib/whitehall/publishing_api.rb
+++ b/lib/whitehall/publishing_api.rb
@@ -182,7 +182,9 @@ module Whitehall
     end
 
     def self.ensure_base_path_is_associated_with_this_content_id!(base_path, content_id)
-      return if base_path.nil?
+      # Temporary hack to allow both legacy and config-driven topical events to co-exist,
+      # to aid in the migration. This early return should be removed once the migration is finished.
+      return if base_path.nil? || base_path.match?(%r{^/government/topical-events/})
 
       existing_content_id = Services.publishing_api.lookup_content_id(base_path:)
       return if existing_content_id.nil? || existing_content_id == content_id

--- a/test/unit/lib/whitehall/publishing_api_test.rb
+++ b/test/unit/lib/whitehall/publishing_api_test.rb
@@ -314,6 +314,14 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     )
   end
 
+  test "#ensure_base_path_is_associated_with_this_content_id! skips Publishing API lookup if no base_path provided" do
+    Whitehall::PublishingApi.unstub(:ensure_base_path_is_associated_with_this_content_id!)
+
+    Services.publishing_api.expects(:lookup_content_id).with(base_path: nil).never
+
+    Whitehall::PublishingApi.ensure_base_path_is_associated_with_this_content_id!(nil, "any-content-id")
+  end
+
   test ".publish_redirect_async publishes a redirect to the Publishing API" do
     document = create(:document)
     destination = "/government/people/milli-vanilli"

--- a/test/unit/lib/whitehall/publishing_api_test.rb
+++ b/test/unit/lib/whitehall/publishing_api_test.rb
@@ -314,6 +314,15 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     )
   end
 
+  test ".save_draft does not raise exception if there is a live content item with the same base path but different content ID, if the base path indicates it is a topical event. This is a temporary loophole to allow both legacy and config-driven topical events to co-exist, which will de-risk the migration, as we will be able to trivially publish either version as needed." do
+    ConfigurableDocumentType.setup_test_types(build_configurable_document_type("topical_event", { "settings" => { "base_path_prefix" => "/government/topical-events" } }))
+    edition = create(:draft_standard_edition, configurable_document_type: "topical_event", slug: "slug-for-topical-event")
+    Whitehall::PublishingApi.unstub(:ensure_base_path_is_associated_with_this_content_id!)
+    Services.publishing_api.expects(:lookup_content_id).with(base_path: edition.public_path).never
+
+    Whitehall::PublishingApi.save_draft(edition)
+  end
+
   test "#ensure_base_path_is_associated_with_this_content_id! skips Publishing API lookup if no base_path provided" do
     Whitehall::PublishingApi.unstub(:ensure_base_path_is_associated_with_this_content_id!)
 


### PR DESCRIPTION
This is a second attempt of #11198, which had to be reverted because role appointments don't have a `base_path` sent to Publishing API, which caused Whitehall to crash on the introduced line. See [Sentry error](https://govuk.sentry.io/issues/7312203252/?alert_rule_id=9401721&alert_type=issue&environment=production&notification_uuid=d0d266c2-afbd-4eaa-86b0-7715c16eda1d&project=202259&referrer=slack).

That got reverted, and this PR is a second attempt at the change but accounting for the possibility of the `base_path` not being present.

Original PR description below.

---

Currently, Whitehall has a safeguard that raises an exception if you try to publish a Whitehall-owned piece of content under the same public_path as another Whitehall-owned piece of content.

In the short term, however, we'd like to allow the publish (effectively an overwrite) in the case of topical events. This is to aid in the migration of topical events.

Proposed migration workflow:

1. A legacy topical event exists
2. We write a migration script that creates a StandardEdition _copy_ of the legacy topical event
3. We can save and publish the StandardEdition version and see how that looks on the frontend
4. We can also interchangably swap back to the legacy version if for whatever reason the config-driven version is problematic. We would simply edit and 'save' the legacy version, which automatically publishes to Publishing API.

Once all legacy topical events have been migrated, we will revert this change.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
