### PR TITLE
WIP: remove organisation_image option [WHIT-2801]

### DIFF
--- a/app/components/admin/edition_images/lead_image_card_component.html.erb
+++ b/app/components/admin/edition_images/lead_image_card_component.html.erb
@@ -13,7 +13,7 @@
       key: "Image",
       value: thumbnail,
     },
-    image_usage.caption_enabled? ? {
+    image.present? && image_usage.caption_enabled? ? {
       key: "Caption",
       value: caption,
     } : nil,

--- a/app/components/admin/edition_images/lead_image_card_component.rb
+++ b/app/components/admin/edition_images/lead_image_card_component.rb
@@ -63,6 +63,6 @@ private
   end
 
   def show_fallback_image?
-    edition.image_display_option.nil? || edition.image_display_option == "organisation_image"
+    edition.image_display_option.nil?
   end
 end

--- a/app/components/admin/edition_images/lead_image_card_component.rb
+++ b/app/components/admin/edition_images/lead_image_card_component.rb
@@ -19,7 +19,7 @@ private
           destructive: true,
         },
       ]
-    else
+    elsif show_fallback_image?
       [
         {
           label: "Replace",
@@ -31,11 +31,22 @@ private
           destructive: true,
         },
       ]
+    else
+      [
+        {
+          label: "Add image",
+          href: new_admin_edition_image_path(edition_id: edition.id, usage: image_usage.key),
+        },
+        {
+          label: "Use default image",
+          href: confirm_toggle_default_lead_image_behaviour_admin_edition_images_path(edition),
+        },
+      ]
     end
   end
 
   def thumbnail
-    if image.blank?
+    if image.blank? && show_fallback_image?
       if edition.default_lead_image&.all_asset_variants_uploaded?
         return sanitize("<img style=\"width: 100%;\" src=\"#{edition.default_lead_image.url(:s300)}\" alt=\"\" class=\"app-view-edition-resource__preview\">")
       else
@@ -49,5 +60,9 @@ private
   def lead_image_guidance
     tag.p("The lead image appears at the top of the document. The same image should not be used in the body text.", class: "govuk-body") +
       tag.p("Uploading your own lead image is optional. If a custom lead image is not uploaded then the default image for your organisation will be used. If neither is available, a placeholder will appear.", class: "govuk-body")
+  end
+
+  def show_fallback_image?
+    edition.image_display_option.nil? || edition.image_display_option == "organisation_image"
   end
 end

--- a/app/components/admin/edition_images/lead_image_card_component.rb
+++ b/app/components/admin/edition_images/lead_image_card_component.rb
@@ -25,6 +25,11 @@ private
           label: "Replace",
           href: new_admin_edition_image_path(edition_id: edition.id, usage: image_usage.key),
         },
+        {
+          label: "Delete",
+          href: confirm_toggle_default_lead_image_behaviour_admin_edition_images_path(edition),
+          destructive: true,
+        },
       ]
     end
   end

--- a/app/components/admin/edition_images/lead_image_card_component.rb
+++ b/app/components/admin/edition_images/lead_image_card_component.rb
@@ -22,7 +22,7 @@ private
     else
       [
         {
-          label: "Add",
+          label: "Replace",
           href: new_admin_edition_image_path(edition_id: edition.id, usage: image_usage.key),
         },
       ]

--- a/app/components/admin/edition_images/lead_image_card_component.rb
+++ b/app/components/admin/edition_images/lead_image_card_component.rb
@@ -58,8 +58,8 @@ private
   end
 
   def lead_image_guidance
-    tag.p("The lead image appears at the top of the document. The same image should not be used in the body text.", class: "govuk-body") +
-      tag.p("Uploading your own lead image is optional. If a custom lead image is not uploaded then the default image for your organisation will be used. If neither is available, a placeholder will appear.", class: "govuk-body")
+    tag.p("Using a lead image is optional. To use a lead image either select the default image for your organisation or upload an image and select it as the lead image.", class: "govuk-body") +
+      tag.p("The lead image appears at the top of the document. The same image cannot be used in the body text.", class: "govuk-body")
   end
 
   def show_fallback_image?

--- a/app/components/admin/edition_images/lead_image_component.rb
+++ b/app/components/admin/edition_images/lead_image_component.rb
@@ -40,12 +40,12 @@ private
 
   def show_default_lead_image?
     if case_study?
-      edition.emphasised_organisation_default_image_available? && [nil, "organisation_image"].include?(edition.image_display_option)
+      edition.emphasised_organisation_default_image_available? && edition.image_display_option.nil?
     end
   end
 
   def new_image_display_option
-    @new_image_display_option ||= image_display_option_is_no_image? ? "organisation_image" : "no_image"
+    @new_image_display_option ||= image_display_option_is_no_image? ? nil : "no_image"
   end
 
   def image_display_option_is_no_image?

--- a/app/controllers/admin/edition_images_controller.rb
+++ b/app/controllers/admin/edition_images_controller.rb
@@ -10,6 +10,17 @@ class Admin::EditionImagesController < Admin::BaseController
 
   def confirm_destroy; end
 
+  def confirm_toggle_default_lead_image_behaviour; end
+
+  def toggle_default_lead_image_behaviour
+    if @edition.update(image_display_option: params[:image_display_option])
+      redirect_to admin_edition_images_path(@edition)
+    else
+      flash.now[:alert] = "Failed to update the lead image behaviour"
+      render :confirm_toggle_default_lead_image_behaviour
+    end
+  end
+
   def destroy
     filename = image.image_data.carrierwave_image
     image.destroy!
@@ -160,7 +171,7 @@ private
     case action_name
     when "index"
       enforce_permission!(:see, @edition)
-    when "edit", "update", "destroy", "confirm_destroy", "create", "new"
+    when "edit", "update", "destroy", "confirm_destroy", "create", "new", "confirm_toggle_default_lead_image_behaviour", "toggle_default_lead_image_behaviour"
       enforce_permission!(:update, @edition)
     else
       raise Whitehall::Authority::Errors::InvalidAction, action_name

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -71,6 +71,7 @@ class Edition < ApplicationRecord
   validates :first_published_at, inclusion: { in: proc { Date.parse("1900-01-01")..Time.zone.now } }, if: :draft?, allow_blank: true
   validates :scheduled_publication, inclusion: { in: proc { Time.zone.now.. }, message: "must be in the future" }, if: :draft?, allow_blank: true
   validates :political, inclusion: { in: [true, false] }
+  validates :image_display_option, inclusion: { in: ["no_image", "organisation_image", nil] }
 
   UNMODIFIABLE_STATES = %w[scheduled published superseded deleted unpublished].freeze
   FROZEN_STATES = %w[superseded deleted].freeze

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -71,7 +71,7 @@ class Edition < ApplicationRecord
   validates :first_published_at, inclusion: { in: proc { Date.parse("1900-01-01")..Time.zone.now } }, if: :draft?, allow_blank: true
   validates :scheduled_publication, inclusion: { in: proc { Time.zone.now.. }, message: "must be in the future" }, if: :draft?, allow_blank: true
   validates :political, inclusion: { in: [true, false] }
-  validates :image_display_option, inclusion: { in: ["no_image", "organisation_image", nil] }
+  validates :image_display_option, inclusion: { in: ["no_image", nil] }
 
   UNMODIFIABLE_STATES = %w[scheduled published superseded deleted unpublished].freeze
   FROZEN_STATES = %w[superseded deleted].freeze

--- a/app/views/admin/edition_images/confirm_toggle_default_lead_image_behaviour.html.erb
+++ b/app/views/admin/edition_images/confirm_toggle_default_lead_image_behaviour.html.erb
@@ -1,6 +1,6 @@
 <%
   # This is the behaviour we're changing to, rather than current behaviour.
-  @image_display_option = @edition.image_display_option == "no_image" ? "organisation_image" : "no_image"
+  @image_display_option = @edition.image_display_option == "no_image" ? nil : "no_image"
 %>
 <% content_for :context, @edition.title %>
 <% content_for :page_title, "Update lead image default" %>

--- a/app/views/admin/edition_images/confirm_toggle_default_lead_image_behaviour.html.erb
+++ b/app/views/admin/edition_images/confirm_toggle_default_lead_image_behaviour.html.erb
@@ -1,0 +1,53 @@
+<%
+  # This is the behaviour we're changing to, rather than current behaviour.
+  @image_display_option = @edition.image_display_option == "no_image" ? "organisation_image" : "no_image"
+%>
+<% content_for :context, @edition.title %>
+<% content_for :page_title, "Update lead image default" %>
+<% content_for :title, "Update lead image default" %>
+<% content_for :title_margin_bottom, 6 %>
+
+<div class="govuk-grid-row">
+  <section class="govuk-grid-column-two-thirds">
+    <%
+      if @image_display_option == "no_image"
+        action_label = "Remove lead image"
+    %>
+      <p class="govuk-body govuk-!-margin-bottom-7">Are you sure you want to remove the default lead image?</p>
+    <%
+      else
+        action_label = "Use organisation default"
+    %>
+      <p class="govuk-body govuk-!-margin-bottom-7">Are you sure you want to use the organisation default lead image?</p>
+
+      <%
+        # TODO: pull this out into a helper (or Payload builder?) to be used here and in the lead image card component
+        def thumbnail
+          if @edition.default_lead_image&.all_asset_variants_uploaded?
+            return sanitize("<img width=\"300\" src=\"#{@edition.default_lead_image.url(:s300)}\" alt=\"\"")
+          else
+            return "<img src=\"#{@edition.placeholder_image_url}\" alt=\"\">".html_safe
+          end
+        end
+      %>
+      <div class="govuk-!-margin-bottom-7">
+        <%= thumbnail %>
+      </div>
+    <%
+      end
+    %>
+
+    <%= form_with(url: toggle_default_lead_image_behaviour_admin_edition_images_path(@edition), method: :patch, data: { ga4_form_no_answer_undefined: action_label }) do |form| %>
+      <%= hidden_field_tag "image_display_option", @image_display_option %>
+
+      <div class="govuk-button-group govuk-!-margin-bottom-6">
+        <%= render "govuk_publishing_components/components/button", {
+          text: action_label,
+          secondary_solid: true,
+        } %>
+
+        <%= link_to("Cancel", admin_edition_images_path(@edition), class: "govuk-link govuk-link--no-visited-state") %>
+      </div>
+    <% end %>
+  </section>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -258,6 +258,8 @@ Whitehall::Application.routes.draw do
         resources :fact_check_requests, only: %i[show create edit update], shallow: true
         resources :images, controller: "edition_images", only: %i[create new destroy edit update index] do
           get :confirm_destroy, on: :member
+          get :confirm_toggle_default_lead_image_behaviour, on: :collection
+          patch :toggle_default_lead_image_behaviour, on: :collection
         end
         resources :lead_images, controller: "edition_lead_images", only: %i[update] # Legacy - delete when CaseStudy migrated to StandardEdition
         resources :social_media_accounts, only: %i[create destroy edit index new update], controller: "editionable_social_media_accounts" do

--- a/features/step_definitions/standard_edition_steps.rb
+++ b/features/step_definitions/standard_edition_steps.rb
@@ -98,7 +98,7 @@ When("I upload single and multiple usage images") do
   expect(page).to have_css("img[src='#{edition.placeholder_image_url}']") # Lead image shows a placeholder when there is no selection
 
   within "#uploaded_lead_image_card" do
-    click_link "Add"
+    click_link "Replace"
   end
 
   lead_image_file = Rails.root.join("test/fixtures/big-cheese.960x640.jpg")

--- a/test/components/admin/edition_images/lead_image_card_component_test.rb
+++ b/test/components/admin/edition_images/lead_image_card_component_test.rb
@@ -29,6 +29,17 @@ class Admin::EditionImages::LeadImageCardComponentTest < ViewComponent::TestCase
     assert_selector ".govuk-link[href='#{confirm_toggle_default_lead_image_behaviour_admin_edition_images_path(edition)}']", text: "Delete"
   end
 
+  test "summary card actions contains 'Add image' and 'Use default image' options if no custom or default image is present" do
+    ConfigurableDocumentType.setup_test_types(build_configurable_document_type("test_type", lead_image_usage_test_type))
+    edition = build_stubbed(:standard_edition, image_display_option: "no_image")
+    lead_usage = edition.permitted_image_usages.find { |usage| usage.key == "lead" }
+
+    render_inline(Admin::EditionImages::LeadImageCardComponent.new(edition:, image: nil, image_usage: lead_usage))
+
+    assert_selector ".govuk-link[href='#{new_admin_edition_image_path(edition_id: edition.id, usage: lead_usage.key)}']", text: "Add image"
+    assert_selector ".govuk-link[href='#{confirm_toggle_default_lead_image_behaviour_admin_edition_images_path(edition)}']", text: "Use default image"
+  end
+
   test "there are no summary card actions if the edition isn't editable" do
     ConfigurableDocumentType.setup_test_types(build_configurable_document_type("test_type", lead_image_usage_test_type))
     edition = build_stubbed(:published_standard_edition)

--- a/test/components/admin/edition_images/lead_image_card_component_test.rb
+++ b/test/components/admin/edition_images/lead_image_card_component_test.rb
@@ -124,6 +124,36 @@ class Admin::EditionImages::LeadImageCardComponentTest < ViewComponent::TestCase
     assert_selector "img[src='#{placeholder_image_url}']"
   end
 
+  test "renders the caption if provided" do
+    image_data = create(:image_data, image_kind: "default")
+    image = build_stubbed(:image, usage: "lead", image_data:, caption: "Caption Value")
+    ConfigurableDocumentType.setup_test_types(build_configurable_document_type("test_type", lead_image_usage_test_type))
+    edition = build_stubbed(:standard_edition, images: [image])
+    lead_usage = edition.permitted_image_usages.find { |usage| usage.key == "lead" }
+
+    render_inline(Admin::EditionImages::LeadImageCardComponent.new(edition:, image:, image_usage: lead_usage))
+
+    assert_selector ".govuk-summary-list__row .govuk-summary-list__key", text: "Caption"
+    assert_selector ".govuk-summary-list__row .govuk-summary-list__value", text: "Caption Value"
+  end
+
+  test "does not render caption when caption_enabled is false for custom image" do
+    image = create(:image, image_data: build(:image_data), caption: "caption")
+    edition = build_stubbed(:draft_publication, images: [image])
+    render_inline(Admin::EditionImages::LeadImageCardComponent.new(edition:, image:, image_usage: ImageUsage.new(key: "lead", caption_enabled: false)))
+
+    assert_no_selector ".govuk-summary-list__row .govuk-summary-list__key", text: "Caption"
+  end
+
+  test "renders placeholder text for caption when none has been provided for custom image" do
+    image = build_stubbed(:image, caption: nil)
+    edition = build_stubbed(:draft_publication, images: [image])
+    render_inline(Admin::EditionImages::LeadImageCardComponent.new(edition:, image:, image_usage: ImageUsage.new(key: "lead", caption_enabled: true)))
+
+    assert_selector ".govuk-summary-list__row .govuk-summary-list__key", text: "Caption"
+    assert_selector ".govuk-summary-list__row .govuk-summary-list__value", text: "Not set"
+  end
+
   def lead_image_usage_test_type
     {
       "settings" => {

--- a/test/components/admin/edition_images/lead_image_card_component_test.rb
+++ b/test/components/admin/edition_images/lead_image_card_component_test.rb
@@ -137,6 +137,17 @@ class Admin::EditionImages::LeadImageCardComponentTest < ViewComponent::TestCase
     assert_selector ".govuk-summary-list__row .govuk-summary-list__value", text: "Caption Value"
   end
 
+  test "does not render caption when placeholder image is used" do
+    default_lead_image = build(:featured_image_data)
+    ConfigurableDocumentType.setup_test_types(build_configurable_document_type("test_type", lead_image_usage_test_type))
+    edition = create(:standard_edition, images: [], organisations: [create(:organisation, default_news_image: default_lead_image)])
+    lead_usage = edition.permitted_image_usages.find { |usage| usage.key == "lead" }
+
+    render_inline(Admin::EditionImages::LeadImageCardComponent.new(edition:, image: nil, image_usage: lead_usage))
+
+    assert_no_selector ".govuk-summary-list__row .govuk-summary-list__key", text: "Caption"
+  end
+
   test "does not render caption when caption_enabled is false for custom image" do
     image = create(:image, image_data: build(:image_data), caption: "caption")
     edition = build_stubbed(:draft_publication, images: [image])

--- a/test/components/admin/edition_images/lead_image_card_component_test.rb
+++ b/test/components/admin/edition_images/lead_image_card_component_test.rb
@@ -18,14 +18,14 @@ class Admin::EditionImages::LeadImageCardComponentTest < ViewComponent::TestCase
     assert_selector ".govuk-link[href='#{confirm_destroy_admin_edition_image_path(edition, image)}']", text: "Delete"
   end
 
-  test "summary card actions contains Add option if image not present" do
+  test "summary card actions contains Replace option if image not present" do
     ConfigurableDocumentType.setup_test_types(build_configurable_document_type("test_type", lead_image_usage_test_type))
     edition = build_stubbed(:draft_standard_edition)
     lead_usage = edition.permitted_image_usages.find { |usage| usage.key == "lead" }
 
     render_inline(Admin::EditionImages::LeadImageCardComponent.new(edition:, image: nil, image_usage: lead_usage))
 
-    assert_selector ".govuk-link[href='#{new_admin_edition_image_path(edition_id: edition.id, usage: lead_usage.key)}']", text: "Add"
+    assert_selector ".govuk-link[href='#{new_admin_edition_image_path(edition_id: edition.id, usage: lead_usage.key)}']", text: "Replace"
   end
 
   test "there are no summary card actions if the edition isn't editable" do

--- a/test/components/admin/edition_images/lead_image_card_component_test.rb
+++ b/test/components/admin/edition_images/lead_image_card_component_test.rb
@@ -18,7 +18,7 @@ class Admin::EditionImages::LeadImageCardComponentTest < ViewComponent::TestCase
     assert_selector ".govuk-link[href='#{confirm_destroy_admin_edition_image_path(edition, image)}']", text: "Delete"
   end
 
-  test "summary card actions contains Replace option if image not present" do
+  test "summary card actions contains Replace and Delete options if image and fallback not present" do
     ConfigurableDocumentType.setup_test_types(build_configurable_document_type("test_type", lead_image_usage_test_type))
     edition = build_stubbed(:draft_standard_edition)
     lead_usage = edition.permitted_image_usages.find { |usage| usage.key == "lead" }
@@ -26,6 +26,7 @@ class Admin::EditionImages::LeadImageCardComponentTest < ViewComponent::TestCase
     render_inline(Admin::EditionImages::LeadImageCardComponent.new(edition:, image: nil, image_usage: lead_usage))
 
     assert_selector ".govuk-link[href='#{new_admin_edition_image_path(edition_id: edition.id, usage: lead_usage.key)}']", text: "Replace"
+    assert_selector ".govuk-link[href='#{confirm_toggle_default_lead_image_behaviour_admin_edition_images_path(edition)}']", text: "Delete"
   end
 
   test "there are no summary card actions if the edition isn't editable" do

--- a/test/functional/admin/edition_images_controller_test.rb
+++ b/test/functional/admin/edition_images_controller_test.rb
@@ -726,6 +726,68 @@ class Admin::EditionImagesControllerTest < ActionController::TestCase
     assert_response :forbidden
   end
 
+  view_test "GET :confirm_toggle_default_lead_image_behaviour asks for confirmation before removing default lead image when default lead image has not yet been opted out of" do
+    login_authorised_user
+    edition = create(:draft_standard_edition, image_display_option: nil)
+
+    get :confirm_toggle_default_lead_image_behaviour, params: { edition_id: edition.id }
+
+    assert_select "h1", text: "Update lead image default"
+    assert_select "p", text: "Are you sure you want to remove the default lead image?"
+  end
+
+  view_test "GET :confirm_toggle_default_lead_image_behaviour asks for confirmation before removing default lead image when default lead image has been explicitly opted into" do
+    login_authorised_user
+    edition = create(:draft_standard_edition, image_display_option: "organisation_image")
+
+    get :confirm_toggle_default_lead_image_behaviour, params: { edition_id: edition.id }
+
+    assert_select "h1", text: "Update lead image default"
+    assert_select "p", text: "Are you sure you want to remove the default lead image?"
+  end
+
+  view_test "GET :confirm_toggle_default_lead_image_behaviour asks for confirmation before adding default lead image when default lead image has been explicitly opted out of" do
+    login_authorised_user
+    edition = create(:draft_standard_edition, image_display_option: "no_image")
+
+    get :confirm_toggle_default_lead_image_behaviour, params: { edition_id: edition.id }
+
+    assert_select "h1", text: "Update lead image default"
+    assert_select "p", text: "Are you sure you want to use the organisation default lead image?"
+  end
+
+  # TODO: add unit test for checking preview thumbnail is rendered
+
+  view_test "PATCH :toggle_default_lead_image_behaviour toggles from explicitly using default lead image to not using it" do
+    login_authorised_user
+    edition = create(:draft_standard_edition, image_display_option: "organisation_image")
+
+    patch :toggle_default_lead_image_behaviour, params: { edition_id: edition.id, image_display_option: "no_image" }
+
+    assert_equal "no_image", edition.reload.image_display_option
+    assert_redirected_to admin_edition_images_path(edition)
+  end
+
+  view_test "PATCH :toggle_default_lead_image_behaviour toggles from implicitly using default lead image to not using it" do
+    login_authorised_user
+    edition = create(:draft_standard_edition, image_display_option: nil)
+
+    patch :toggle_default_lead_image_behaviour, params: { edition_id: edition.id, image_display_option: "no_image" }
+
+    assert_equal "no_image", edition.reload.image_display_option
+    assert_redirected_to admin_edition_images_path(edition)
+  end
+
+  view_test "PATCH :toggle_default_lead_image_behaviour toggles from not using default lead image to using it" do
+    login_authorised_user
+    edition = create(:draft_standard_edition, image_display_option: "no_image")
+
+    patch :toggle_default_lead_image_behaviour, params: { edition_id: edition.id, image_display_option: "organisation_image" }
+
+    assert_equal "organisation_image", edition.reload.image_display_option
+    assert_redirected_to admin_edition_images_path(edition)
+  end
+
   def login_authorised_user
     user = create(:gds_editor)
     login_as user

--- a/test/functional/admin/edition_images_controller_test.rb
+++ b/test/functional/admin/edition_images_controller_test.rb
@@ -726,19 +726,9 @@ class Admin::EditionImagesControllerTest < ActionController::TestCase
     assert_response :forbidden
   end
 
-  view_test "GET :confirm_toggle_default_lead_image_behaviour asks for confirmation before removing default lead image when default lead image has not yet been opted out of" do
+  view_test "GET :confirm_toggle_default_lead_image_behaviour asks for confirmation before removing default lead image when default lead image has not been opted out of" do
     login_authorised_user
     edition = create(:draft_standard_edition, image_display_option: nil)
-
-    get :confirm_toggle_default_lead_image_behaviour, params: { edition_id: edition.id }
-
-    assert_select "h1", text: "Update lead image default"
-    assert_select "p", text: "Are you sure you want to remove the default lead image?"
-  end
-
-  view_test "GET :confirm_toggle_default_lead_image_behaviour asks for confirmation before removing default lead image when default lead image has been explicitly opted into" do
-    login_authorised_user
-    edition = create(:draft_standard_edition, image_display_option: "organisation_image")
 
     get :confirm_toggle_default_lead_image_behaviour, params: { edition_id: edition.id }
 
@@ -758,17 +748,7 @@ class Admin::EditionImagesControllerTest < ActionController::TestCase
 
   # TODO: add unit test for checking preview thumbnail is rendered
 
-  view_test "PATCH :toggle_default_lead_image_behaviour toggles from explicitly using default lead image to not using it" do
-    login_authorised_user
-    edition = create(:draft_standard_edition, image_display_option: "organisation_image")
-
-    patch :toggle_default_lead_image_behaviour, params: { edition_id: edition.id, image_display_option: "no_image" }
-
-    assert_equal "no_image", edition.reload.image_display_option
-    assert_redirected_to admin_edition_images_path(edition)
-  end
-
-  view_test "PATCH :toggle_default_lead_image_behaviour toggles from implicitly using default lead image to not using it" do
+  view_test "PATCH :toggle_default_lead_image_behaviour toggles from using default lead image to not using it" do
     login_authorised_user
     edition = create(:draft_standard_edition, image_display_option: nil)
 
@@ -782,9 +762,9 @@ class Admin::EditionImagesControllerTest < ActionController::TestCase
     login_authorised_user
     edition = create(:draft_standard_edition, image_display_option: "no_image")
 
-    patch :toggle_default_lead_image_behaviour, params: { edition_id: edition.id, image_display_option: "organisation_image" }
+    patch :toggle_default_lead_image_behaviour, params: { edition_id: edition.id, image_display_option: nil }
 
-    assert_equal "organisation_image", edition.reload.image_display_option
+    assert_equal nil, edition.reload.image_display_option
     assert_redirected_to admin_edition_images_path(edition)
   end
 

--- a/test/unit/app/models/edition_test.rb
+++ b/test/unit/app/models/edition_test.rb
@@ -1016,6 +1016,20 @@ class EditionTest < ActiveSupport::TestCase
     assert edition.reload.revalidated_at
   end
 
+  test "validates `image_display_option` value" do
+    edition = build(:edition, image_display_option: "organisation_image")
+    assert edition.valid?
+
+    edition.image_display_option = "no_image"
+    assert edition.valid?
+
+    edition.image_display_option = nil
+    assert edition.valid?
+
+    edition.image_display_option = "invalid_option"
+    assert_not edition.valid?
+  end
+
   def decoded_token_payload(token)
     payload, _header = JWT.decode(
       token,

--- a/test/unit/app/models/edition_test.rb
+++ b/test/unit/app/models/edition_test.rb
@@ -1017,10 +1017,7 @@ class EditionTest < ActiveSupport::TestCase
   end
 
   test "validates `image_display_option` value" do
-    edition = build(:edition, image_display_option: "organisation_image")
-    assert edition.valid?
-
-    edition.image_display_option = "no_image"
+    edition = build(:edition, image_display_option: "no_image")
     assert edition.valid?
 
     edition.image_display_option = nil


### PR DESCRIPTION
The behaviour designated by this option is the same behaviour designated by a `nil` value.

The reason we've had to support both `nil` and `organisation_image` in the past is because of the legacy CaseStudy behaviour in which, when deleting an image, the next applicable image would become the new lead image. If the publisher had not yet chosen a lead image and was using the organisation fallback image, then this would have led to a bug where they suddenly have a lead image set when they didn't expect to. Thus the check for 'organisation_image' (no lead image set) vs 'nil' (we should auto-select a lead image when an image is deleted).

This workflow doesn't make sense in the new world where lead images have their own dedicated workflow - they are no longer selected from a 'pool' of images all uploaded to the edition.

We can't merge this commit as-is until we write a data migration to make all "organisation_image" image_display_options now 'nil'.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
