### PR TITLE
[WHIT-3127] Remove redundant scheduled jobs that should have been dequeued

### DIFF
--- a/db/data_migration/20260410101603_remove_redundant_scheduled_jobs.rb
+++ b/db/data_migration/20260410101603_remove_redundant_scheduled_jobs.rb
@@ -1,0 +1,53 @@
+deleted_count = 0
+kept_count = 0
+skipped_count = 0
+
+Sidekiq::ScheduledSet.new
+                     .select { |j| j.klass == "ScheduledPublishingJob" }
+                     .group_by { |j| j.args[0] }
+                     .select { |_id, jobs| jobs.size > 1 }
+                     .each do |id, jobs|
+                       edition = Edition.find_by(id: id)
+                       unless edition
+                         puts "ID: #{id} — edition not found, skipping"
+                         skipped_count += 1
+                         next
+                       end
+
+                       scheduled = edition.scheduled_publication&.utc
+                       unless scheduled
+                         puts "ID: #{id} — no scheduled_publication, skipping"
+                         skipped_count += 1
+                         next
+                       end
+
+                       puts "\nID: #{id} (state: #{edition.state}, scheduled_publication: #{scheduled})"
+
+                       matching, non_matching = jobs.partition { |j| j.at == scheduled }
+
+                       # Delete all non-matching jobs (before or after the scheduled date)
+                       non_matching.each do |j|
+                         puts "  Deleting non-matching job at: #{j.at}"
+                         j.delete
+                         deleted_count += 1
+                       end
+
+                       # Keep one matching job, delete the rest
+                       if matching.any?
+                         keeper = matching.shift
+                         puts "  Keeping job at: #{keeper.at}"
+                         kept_count += 1
+                         matching.each do |j|
+                           puts "  Deleting duplicate job at: #{j.at}"
+                           j.delete
+                           deleted_count += 1
+                         end
+                       else
+                         puts "  ⚠️   No matching jobs found — none kept"
+                       end
+end
+
+puts "\n--- Summary ---"
+puts "Kept: #{kept_count}"
+puts "Deleted: #{deleted_count}"
+puts "Skipped: #{skipped_count}"


### PR DESCRIPTION
## What & why

Remove duplicate (same edition ID) jobs from the `ScheduledSet` to prevent unnecessary raising of `ScheduledPublishingFailure` Sentry errors, requiring developer investigation. The underlying issue has been fixed by re-queueing "_Worker"-named jobs as "_Job"-named jobs. No job aliases are present in the codebase anymore, and we only have "_Job"-named jobs in all the Sidekiq sets.

This duplication happened due to a failure to dequeue scheduled jobs when the publisher unscheduled an edition. This was caused by the introduction of aliases for "_Worker" named jobs (in https://github.com/alphagov/whitehall/pull/11171). The dequeue method in `ScheduledPublishingJob` always checks for matching names between the current job running (named "ScheduledPublishingJob") and the job it's trying to dequeue in the `ScheduledSet` (named "_Worker").

The editions affected here would have had their scheduled time changed after the aliases PR was merged. To change the time, publishers must unschedule the edition, which, under normal circumstances, dequeues the original scheduled job. The aliases change caused the unschedule to fail and the early jobs to persist in the `ScheduledSet`. Future reschedule actions would add new jobs to the set.

Having the early jobs in the Set means they will get executed at an "earlier" or "later" scheduled time, potentially risking early publication of editions. Nonetheless, this is not the case as the [`ScheduledEditionPublisher`](https://github.com/alphagov/whitehall/blob/c875f5f969ec0b6aff1d1a84a84e596504900666/app/services/scheduled_edition_publisher.rb#L8) runs a check against the `scheduled_publication` field of the edition, and fails is it's `too_early_to_publish?`, causing the job to raise [`ScheduledPublishingFailure`](https://github.com/alphagov/whitehall/blob/79b1c6c59e1bff368c6bab2957741b1954736d45/app/sidekiq/scheduled_publishing_job.rb#L51). Equally, for "later" runs, the job would raise the same error if the edition is not `scheduled_for_publication?` (which it would not be if earlier, correct, scheduling jobs have run successfully and published the edition).  Nonetheless, this can be an alarming Sentry error, which developers would have to investigate. Since some of these editions are not scheduled to run for quite some time yet, the context of this issue may be lost, causing unnecessary work.

## TL;DR
For context, this is the sequence of events that would cause the sentry error:
- Publishers queue a job such as “_Worker”, which adds a job to the `ScheduledSet`
- We merged the aliases PR
- Publishers unscheduled the “_Worker” -> the `ScheduledPublishingJob` calls the `dequeue` function, the “_Worker” and the “_Job” names don’t match so nothing gets dequeued
- The original “_Worker” scheduled job runs and fails with a “too early” failure reason

For context, here's a breakdown of the re-schedule publisher flow under "working" circumstances:
- Set a scheduled date → edition state: submitted/draft
- Schedule the edition → edition state: scheduled; new job added to `ScheduledSet`
- To change the schedule date you must unschedule (edition is not editable otherwise), which dequeues the original job (removed it from `ScheduledSet`); edition state → always goes back to submitted as per the state machine
- Change schedule date → edition state: submitted
- Re-schedule → new job added to `ScheduledSet`


See dry run output in [Jira](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-3127) ticket.
