### PR TITLE
Implement polling for `Image Processing` check [WHIT-3389]

### DIFF
--- a/app/assets/javascripts/admin/modules/image-processing-checker.js
+++ b/app/assets/javascripts/admin/modules/image-processing-checker.js
@@ -1,0 +1,113 @@
+'use strict'
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {}
+;(function (Modules) {
+  class ImageProcessingChecker {
+    static TIMEOUT_DURATION = 1000
+    static MAX_ATTEMPTS = 5
+
+    constructor($root) {
+      this.$root = $root
+      this.imageLink = this.$root.dataset.imageLink
+
+      this.timeoutDuration =
+        parseInt(this.$root.dataset.timeoutDuration, 10) ||
+        ImageProcessingChecker.TIMEOUT_DURATION
+      this.maxAttempts =
+        parseInt(this.$root.dataset.maxAttempts) ||
+        ImageProcessingChecker.MAX_ATTEMPTS
+
+      const imagePreview = this.$root.querySelector('.js-image-preview')
+      const imagePreviewFailure = this.$root.querySelector(
+        '.js-image-preview-failure'
+      )
+
+      if (imagePreview) {
+        this.imagePreview = document.importNode(
+          imagePreview.content,
+          true
+        ).firstElementChild
+      }
+
+      if (imagePreviewFailure) {
+        this.imagePreviewFailure = document.importNode(
+          imagePreviewFailure.content,
+          true
+        ).firstElementChild
+      }
+
+      this.imageStatus = this.$root.querySelector('.js-image-processing-status')
+
+      // the image was not already loaded on page load
+      if (this.imageStatus && !this.imageStatus.querySelector('img')) {
+        this.checkImageStatus()
+      }
+    }
+
+    checkImageStatus(attempts = 0) {
+      if (attempts !== this.maxAttempts) {
+        fetch(this.imageLink)
+          .then((response) => {
+            if (response.ok) {
+              return response.clone().json()
+            } else {
+              throw new Error(
+                `Supplied URL ${this.imageLink} returned ${response.status}`
+              )
+            }
+          })
+          // eslint-disable-next-line camelcase
+          .then(({ image_data: { all_assets_uploaded, assets } }) =>
+            // eslint-disable-next-line camelcase
+            !all_assets_uploaded
+              ? setTimeout(
+                  () => this.checkImageStatus(attempts + 1),
+                  this.timeoutDuration * Math.pow(2, attempts + 1)
+                )
+              : this.handleSuccess(assets)
+          )
+          .catch((error) => this.handleFailure(error.message))
+      } else {
+        this.handleFailure(`Image at ${this.imageLink} was not ready in time`)
+      }
+    }
+
+    updateImageStatus(replacementEl) {
+      if (replacementEl) {
+        this.$root.replaceChild(replacementEl, this.imageStatus)
+      } else {
+        this.imageStatus.remove()
+      }
+    }
+
+    handleFailure(error) {
+      console.error(error)
+      this.updateImageStatus(this.imagePreviewFailure)
+    }
+
+    handleSuccess(assets) {
+      if (!this.imagePreview) {
+        this.updateImageStatus()
+      } else {
+        const imgElement =
+          this.imagePreview.querySelector('img') ||
+          (this.imagePreview.tagName === 'IMG' && this.imagePreview)
+
+        if (imgElement) {
+          const previewAsset = assets.find(
+            ({ variant }) => variant !== 'original'
+          )
+
+          // images with multiple assets can have
+          // transformed variants so we should not use
+          // the `original` asset if this is the case
+          imgElement.src = previewAsset ? previewAsset.url : assets[0].url
+        }
+
+        this.updateImageStatus(this.imagePreview)
+      }
+    }
+  }
+
+  Modules.ImageProcessingChecker = ImageProcessingChecker
+})(window.GOVUK.Modules)

--- a/app/assets/javascripts/admin/modules/image-processing-checker.js
+++ b/app/assets/javascripts/admin/modules/image-processing-checker.js
@@ -1,0 +1,88 @@
+'use strict'
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {}
+;(function (Modules) {
+  class ImageProcessingChecker {
+    static TIMEOUT_DURATION = 500
+    static MAX_ATTEMPTS = 5
+
+    constructor($root) {
+      this.$root = $root
+      this.imageLink = this.$root.dataset.imageLink
+
+      this.timeoutDuration =
+        this.$root.dataset.timeoutDuration ||
+        ImageProcessingChecker.TIMEOUT_DURATION
+      this.maxAttempts =
+        this.$root.dataset.maxAttempts || ImageProcessingChecker.MAX_ATTEMPTS
+
+      this.imagePreview = this.$root.querySelector('.js-image-preview')
+      this.imagePreviewFailure = this.$root.querySelector(
+        '.js-image-preview-failure'
+      )
+      this.imageStatus = this.$root.querySelector('.js-image-processing-status')
+
+      // the image was not already loaded on page load
+      if (this.imageStatus && !this.imageStatus.querySelector('img')) {
+        this.checkImageStatus(this.maxAttempts)()
+      }
+    }
+
+    checkImageStatus(attempts) {
+      return () => {
+        if (attempts > 0) {
+          fetch(this.imageLink)
+            .then((response) => response.json())
+            // eslint-disable-next-line camelcase
+            .then(({ image_data: { all_assets_uploaded, assets } }) => {
+              // eslint-disable-next-line camelcase
+              if (!all_assets_uploaded) {
+                setTimeout(
+                  this.checkImageStatus(attempts - 1),
+                  this.timeoutDuration
+                )
+              } else {
+                this.updateImageStatus(assets)
+              }
+            })
+        } else {
+          this.updateImageStatus()
+        }
+      }
+    }
+
+    updateImageStatus(assets) {
+      this.imageStatus.innerHTML = ''
+
+      let imagePreviewElement
+
+      if (!assets) {
+        // failed to acquire asset
+        imagePreviewElement = document.importNode(
+          this.imagePreviewFailure.content,
+          true
+        ).firstElementChild
+      } else {
+        imagePreviewElement = document.importNode(
+          this.imagePreview.content,
+          true
+        ).firstElementChild
+
+        const notOriginalAsset = assets.find(
+          ({ variant }) => variant !== 'original'
+        )
+
+        // images with multiple assets can have
+        // transformed variants so we should not use
+        // the `original` asset if this is the case
+        imagePreviewElement.src = notOriginalAsset
+          ? notOriginalAsset.url
+          : assets[0].url
+      }
+
+      this.imageStatus.appendChild(imagePreviewElement)
+    }
+  }
+
+  Modules.ImageProcessingChecker = ImageProcessingChecker
+})(window.GOVUK.Modules)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -31,6 +31,7 @@
 //= require admin/modules/navbar-toggle
 //= require admin/modules/paste-html-to-govspeak
 //= require admin/modules/prevent-multiple-form-submissions
+//= require admin/modules/image-processing-checker
 
 //= require admin/views/broken-links-report
 //= require admin/views/edition-form

--- a/app/assets/javascripts/components/image-cropper.js
+++ b/app/assets/javascripts/components/image-cropper.js
@@ -184,6 +184,34 @@
   }
 
   ImageCropper.prototype.init = function () {
+    if (this.$imageCropper.querySelector('img')) {
+      this.start()
+    } else {
+      this.$imageCropper.ariaLabel = 'The image cropper is loading.'
+      // The image is still processing, start the
+      // cropping tool when the image is ready to be cropped
+      const callback = (mutationList, observer) => {
+        for (const mutation of mutationList) {
+          if (mutation.type === 'childList') {
+            if (!this.$image) {
+              observer.disconnect()
+              this.$imageCropper.ariaLabel = 'The image cropper is now ready.'
+              this.start()
+            }
+          }
+        }
+      }
+
+      const observer = new MutationObserver(callback)
+      observer.observe(this.$imageCropper, { childList: true, subtree: true })
+    }
+  }
+
+  ImageCropper.prototype.start = function () {
+    this.$image = this.$imageCropper.querySelector(
+      '.app-c-image-cropper__image'
+    )
+
     // This only runs if the image isn't cached
     this.$image.addEventListener(
       'load',

--- a/app/assets/javascripts/components/image-cropper.js
+++ b/app/assets/javascripts/components/image-cropper.js
@@ -186,6 +186,32 @@ window.GOVUK.Modules = window.GOVUK.Modules || {}
   }
 
   ImageCropper.prototype.init = function () {
+    if (this.$imageCropper.querySelector('img')) {
+      this.start()
+    } else {
+      // The image is still processing, start the
+      // cropping tool when the image is ready to be cropped
+      const callback = (mutationList, observer) => {
+        for (const mutation of mutationList) {
+          if (mutation.type === 'childList') {
+            if (!this.$image) {
+              observer.disconnect()
+              this.start()
+            }
+          }
+        }
+      }
+
+      const observer = new MutationObserver(callback)
+      observer.observe(this.$imageCropper, { childList: true, subtree: true })
+    }
+  }
+
+  ImageCropper.prototype.start = function () {
+    this.$image = this.$imageCropper.querySelector(
+      '.app-c-image-cropper__image'
+    )
+
     // This only runs if the image isn't cached
     this.$image.addEventListener(
       'load',

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -8,6 +8,7 @@ $govuk-page-width: 1140px;
 @import "./components/image-cropper";
 @import "./components/inset-prompt";
 @import "./components/miller-columns";
+@import "./components/loading-spinner";
 @import "./components/secondary-navigation";
 @import "./components/single-image-upload";
 @import "./components/sub-navigation";

--- a/app/assets/stylesheets/components/_loading-spinner.scss
+++ b/app/assets/stylesheets/components/_loading-spinner.scss
@@ -1,0 +1,43 @@
+// this is from the Home Office Design System
+// https://design.homeoffice.gov.uk/design-system/components?name=Loading%20spinner
+
+.hods-loading-spinner {
+  @include govuk-responsive-padding(4, "top");
+
+  &__spinner {
+    margin-left: auto;
+    margin-right: auto;
+    border: 12px solid #dee0e2;
+    border-radius: 50%;
+    border-top-color: govuk-colour("blue");
+    width: 80px;
+    height: 80px;
+    -webkit-animation: hods-loading-spinner-animation 2s linear infinite;
+    animation: hods-loading-spinner-animation 2s linear infinite;
+  }
+
+  &__content {
+    text-align: center;
+    @include govuk-responsive-padding(4, "top");
+  }
+}
+
+@-webkit-keyframes hods-loading-spinner-animation {
+  0% {
+    -webkit-transform: rotate(0deg);
+  }
+
+  100% {
+    -webkit-transform: rotate(360deg);
+  }
+}
+
+@keyframes hods-loading-spinner-animation {
+  0% {
+    transform: rotate(0deg);
+  }
+
+  100% {
+    transform: rotate(360deg);
+  }
+}

--- a/app/components/admin/edition_images/image_component.html.erb
+++ b/app/components/admin/edition_images/image_component.html.erb
@@ -1,11 +1,19 @@
- <li class="govuk-grid-row">
-  <div class="govuk-grid-column-one-third">
-    <% if image.image_data&.original_uploaded? && image.thumbnail %>
+ <li data-module="image-processing-checker" data-image-link="<%= admin_edition_image_path(edition, image) %>" class="govuk-grid-row">
+  <template class="js-image-preview">
+    <div class="govuk-grid-column-one-third">
+      <img src="" alt="" class="app-view-edition-resource__preview">
+    </div>
+  </template>
+
+  <% if image.image_data&.original_uploaded? && image.thumbnail %>
+    <div class="govuk-grid-column-one-third">
       <img src="<%= image.thumbnail %>" alt="" class="app-view-edition-resource__preview">
-    <% else %>
+    </div>
+  <% else %>
+    <div class="govuk-grid-column-one-third js-image-processing-status">
       <span class="govuk-tag govuk-tag--green">Processing</span>
-    <% end %>
-  </div>
+    </div>
+  <% end %>
 
   <div class="govuk-grid-column-two-thirds">
     <% if image_usage.caption_enabled? %>

--- a/app/components/admin/edition_images/image_component.html.erb
+++ b/app/components/admin/edition_images/image_component.html.erb
@@ -1,5 +1,9 @@
- <li class="govuk-grid-row">
-  <div class="govuk-grid-column-one-third">
+ <li data-module="image-processing-checker" data-image-link="<%= admin_edition_image_path(edition, image) %>" class="govuk-grid-row">
+  <template id="image-preview">
+    <img src="<%= image.thumbnail %>" alt="" class="app-view-edition-resource__preview">
+  </template>
+
+  <div class="govuk-grid-column-one-third js-image-processing-status">
     <% if image.image_data&.original_uploaded? && image.thumbnail %>
       <img src="<%= image.thumbnail %>" alt="" class="app-view-edition-resource__preview">
     <% else %>

--- a/app/controllers/admin/edition_images_controller.rb
+++ b/app/controllers/admin/edition_images_controller.rb
@@ -127,10 +127,6 @@ class Admin::EditionImagesController < Admin::BaseController
     end
   end
 
-  def edit
-    flash.now.notice = "The image is being processed. Try refreshing the page." unless image&.image_data&.original_uploaded?
-  end
-
 private
 
   def usage_not_permitted

--- a/app/controllers/admin/edition_images_controller.rb
+++ b/app/controllers/admin/edition_images_controller.rb
@@ -1,8 +1,16 @@
 class Admin::EditionImagesController < Admin::BaseController
   before_action :find_edition
   before_action :enforce_permissions!
-  before_action :set_image_usage, only: %i[new create confirm_destroy edit update]
+  before_action :set_image_usage, only: %i[new create confirm_destroy edit update end show]
   def index; end
+
+  def show
+    json = image.as_json(include: { image_data: { include: :assets } })
+    json["image_data"]["all_assets_uploaded"] = image.image_data.all_asset_variants_uploaded?
+    json["image_data"]["assets"] = json["image_data"]["assets"].map { |asset| asset.merge({ "url" => asset["variant"] != "original" ? image.image_data.url(asset["variant"]) : image.image_data.url }) }
+
+    render json: json.to_json
+  end
 
   def new
     nil if redirect_if_single_usage_image_exists
@@ -173,7 +181,7 @@ private
     case action_name
     when "index"
       enforce_permission!(:see, @edition)
-    when "edit", "update", "destroy", "confirm_destroy", "create", "new", "confirm_toggle_default_lead_image_behaviour", "toggle_default_lead_image_behaviour"
+    when "edit", "update", "destroy", "confirm_destroy", "create", "new", "confirm_toggle_default_lead_image_behaviour", "toggle_default_lead_image_behaviour", "show"
       enforce_permission!(:update, @edition)
     else
       raise Whitehall::Authority::Errors::InvalidAction, action_name

--- a/app/views/admin/edition_images/_image_information.html.erb
+++ b/app/views/admin/edition_images/_image_information.html.erb
@@ -1,4 +1,11 @@
-<section class="govuk-grid-column-one-third">
+<section data-module="image-processing-checker" data-image-link="<%= admin_edition_image_path(edition, image) %>" class="govuk-grid-column-one-third">
+
+  <template id="image-preview">
+    <% if !image.bitmap? %>
+      <img alt="Image preview" class="app-view-edition-resource__preview govuk-!-margin-bottom-4">
+    <% end %>
+  </template>
+
   <div class="app-c-image-cropper__controls-container" hidden>
     <h2 class="govuk-heading-m">Crop controls</h2>
   </div>
@@ -16,14 +23,11 @@
       </template>
     </ul>
   </div>
+
   <h2 class="govuk-heading-m">Image information</h2>
 
-  <% if image.image_data.original_uploaded? %>
-    <% unless image.can_be_cropped? %>
-      <img src="<%= image.image_data.url %>" alt="Image preview" class="app-view-edition-resource__preview govuk-!-margin-bottom-4">
-    <% end %>
-  <% else %>
-    <div class="govuk-!-margin-bottom-4">
+  <% unless image.image_data&.original_uploaded? %>
+    <div class="govuk-!-margin-bottom-4 js-image-processing-status">
       <span class="govuk-tag govuk-tag--green">Processing</span>
     </div>
   <% end %>

--- a/app/views/admin/edition_images/_image_information.html.erb
+++ b/app/views/admin/edition_images/_image_information.html.erb
@@ -1,4 +1,13 @@
-<section class="govuk-grid-column-one-third">
+<section data-module="image-processing-checker" data-image-link="<%= admin_edition_image_path(edition, image) %>" class="govuk-grid-column-one-third">
+
+  <template id="image-preview">
+    <% if !image.bitmap? %>
+      <img alt="Image preview" class="app-view-edition-resource__preview govuk-!-margin-bottom-4">
+    <% else %>
+      <div></div>
+    <% end %>
+  </template>
+
   <div class="app-c-image-cropper__controls-container" hidden>
     <h2 class="govuk-heading-m">Crop controls</h2>
   </div>
@@ -16,14 +25,11 @@
       </template>
     </ul>
   </div>
+
   <h2 class="govuk-heading-m">Image information</h2>
 
-  <% if image.image_data.original_uploaded? %>
-    <% unless image.can_be_cropped? %>
-      <img src="<%= image.image_data.url %>" alt="Image preview" class="app-view-edition-resource__preview govuk-!-margin-bottom-4">
-    <% end %>
-  <% else %>
-    <div class="govuk-!-margin-bottom-4">
+  <% unless image.image_data&.original_uploaded? %>
+    <div class="govuk-!-margin-bottom-4 js-image-processing-status">
       <span class="govuk-tag govuk-tag--green">Processing</span>
     </div>
   <% end %>

--- a/app/views/admin/edition_images/edit.html.erb
+++ b/app/views/admin/edition_images/edit.html.erb
@@ -14,7 +14,7 @@
         </div>
       <% end %>
 
-      <% if image.can_be_cropped? && image.image_data&.original_uploaded? %>
+      <% if image.bitmap? %>
         <div class="govuk-grid-column-two-thirds">
           <p class="govuk-body-lead">
             To crop the image, select the area you would like to show. Ensure the main focus of the image is in the centre.
@@ -34,6 +34,7 @@
             y: image.image_data.crop_data_y,
             versions: image_kind_config.versions,
             image:,
+            edition: @edition,
           } %>
         </div>
       <% end %>
@@ -66,8 +67,8 @@
         </div>
       </section>
 
-    <% unless image.can_be_cropped? && image.image_data&.original_uploaded? %>
-      <%= render "image_information" %>
+    <% unless image.can_be_cropped? || !image.image_data&.original_uploaded? %>
+      <%= render "image_information", edition: @edition %>
     <% end %>
   <% end %>
 </div>

--- a/app/views/components/_image_cropper.html.erb
+++ b/app/views/components/_image_cropper.html.erb
@@ -7,6 +7,7 @@
   target_width ||= 0
   target_height ||= 0
   image ||= nil
+  edition ||= nil
 %>
 
 <%= tag.div class: "app-c-image-cropper govuk-grid-column-row", tabindex: "0", data: { module: "image-cropper", filename:, type:, width:, height:, x:, y:, versions:, target_width:, target_height: }, "aria-live" => "polite" do %>
@@ -15,10 +16,24 @@
     <input class="js-cropped-image-input" name="<%= name %>[y]" hidden value="<%= y %>">
     <input class="js-cropped-image-input" name="<%= name %>[height]" hidden value="<%= height %>">
     <input class="js-cropped-image-input" name="<%= name %>[width]" hidden value="<%= width %>">
-    <%= tag.img class: "app-c-image-cropper__image", src: image.image_data.url %>
+    <% if image.image_data&.original_uploaded? %>
+      <%= tag.img class: "app-c-image-cropper__image", src: image.image_data.url %>
+    <% else %>
+      <div data-module="image-processing-checker" data-image-link="<%= admin_edition_image_path(edition, image) %>">
+        <template class="js-image-preview">
+          <%= tag.img class: "app-c-image-cropper__image" %>
+        </template>
+        <template class="js-image-preview-failure">
+          <span class="govuk-tag govuk-tag--red">
+            Failed to load image. Please refresh the page.
+          </span>
+        </template>
+        <div class="js-image-processing-status">
+          <%= render "/components/loading_spinner", content: "Loading image for cropping..." %>
+        </div>
+      </div>
+    <% end %>
   <% end %>
 
-  <% if image.present? %>
-    <%= render "admin/edition_images/image_information", image: %>
-  <% end %>
+  <%= render "admin/edition_images/image_information", image:, edition: %>
 <% end %>

--- a/app/views/components/_image_cropper.html.erb
+++ b/app/views/components/_image_cropper.html.erb
@@ -7,6 +7,7 @@
   target_width ||= 0
   target_height ||= 0
   image ||= nil
+  edition ||= nil
 %>
 
 <%= tag.div class: "app-c-image-cropper govuk-grid-column-row", tabindex: "0", data: { module: "image-cropper", filename:, type:, width:, height:, x:, y:, versions:, target_width:, target_height: }, "aria-live" => "polite" do %>
@@ -15,10 +16,19 @@
     <input class="js-cropped-image-input" name="<%= name %>[y]" hidden value="<%= y %>">
     <input class="js-cropped-image-input" name="<%= name %>[height]" hidden value="<%= height %>">
     <input class="js-cropped-image-input" name="<%= name %>[width]" hidden value="<%= width %>">
-    <%= tag.img class: "app-c-image-cropper__image", src: image.image_data.url %>
+    <% if image.image_data&.original_uploaded? %>
+      <%= tag.img class: "app-c-image-cropper__image", src: image.image_data.url %>
+    <% else %>
+      <div data-module="image-processing-checker" data-image-link="<%= admin_edition_image_path(edition, image) %>">
+        <template id="image-preview">
+          <%= tag.img class: "app-c-image-cropper__image" %>
+        </template>
+        <div class="js-image-processing-status">
+          <span class="govuk-tag govuk-tag--green govuk-visually-hidden">Processing</span>
+        </div>
+      </div>
+    <% end %>
   <% end %>
 
-  <% if image.present? %>
-    <%= render "admin/edition_images/image_information", image: %>
-  <% end %>
+  <%= render "admin/edition_images/image_information", image:, edition: %>
 <% end %>

--- a/app/views/components/_loading_spinner.html.erb
+++ b/app/views/components/_loading_spinner.html.erb
@@ -1,0 +1,14 @@
+<!--
+  This is from the Home Office Design System
+  https://design.homeoffice.gov.uk/design-system/components?name=Loading%20spinner
+-->
+<%
+  content ||= "Loading..."
+%>
+
+<div class="hods-loading-spinner" role="status">
+  <div class="hods-loading-spinner__spinner"></div>
+  <div class="hods-loading-spinner__content">
+    <%= tag.h2(content, class: "govuk-heading-m" ) %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -253,7 +253,7 @@ Whitehall::Application.routes.draw do
           get :confirm_destroy, on: :member
         end
         resources :fact_check_requests, only: %i[show create edit update], shallow: true
-        resources :images, controller: "edition_images", only: %i[create new destroy edit update index] do
+        resources :images, controller: "edition_images", only: %i[create new destroy edit update index show] do
           get :confirm_destroy, on: :member
           get :confirm_toggle_default_lead_image_behaviour, on: :collection
           patch :toggle_default_lead_image_behaviour, on: :collection

--- a/features/edition-images-javascript.feature
+++ b/features/edition-images-javascript.feature
@@ -44,3 +44,11 @@ Feature: Images tab on edit edition
     When I update the image details and save
     And I upload a 960x960 image
     Then I should get 1 error message
+
+  @javascript
+  Scenario: User goes to index page before an image has finished processing
+    When a draft document with images exists including an image that is not yet ready
+    When I visit the images tab of the document with images
+    Then I should I see the processing status tag
+    When the image is ready
+    Then I should I see the image thumbnail    

--- a/features/edition-images-javascript.feature
+++ b/features/edition-images-javascript.feature
@@ -27,7 +27,16 @@ Feature: Images tab on edit edition
     Then I should see the image cropper in the following edit screen
     When I update the image details and save
     Then I should see a list with 4 images
-    Then I should not see that the image requires cropping 
+    Then I should not see that the image requires cropping
+
+  @javascript
+  Scenario: User edits image before image has is ready for cropping
+    When a draft document with images exists including an image that is not yet ready
+    When I visit the images tab of the document with images
+    When I click to edit the details of the image that needs to be cropped
+    Then I should see the spinner in the following edit screen
+    When the image is ready
+    Then I should see the image cropper image in the edit screen
 
   Scenario: Image uploaded with no cropping required
     And a draft publication "New Draft Publication" exists
@@ -35,7 +44,7 @@ Feature: Images tab on edit edition
     And I upload an image
     Then I should not see the image cropper in the following edit screen
     When I update the image details and save
-    Then I should see a list with 1 image      
+    Then I should see a list with 1 image
 
   Scenario: Uploading a file with a duplicated filename
     When a draft document with images exists

--- a/features/step_definitions/image_steps.rb
+++ b/features/step_definitions/image_steps.rb
@@ -116,20 +116,24 @@ When("I click to edit the details of the image that needs to be cropped") do
   find_all("a", text: "Edit details").last.click
 end
 
-Then("I should see the image cropper in the following edit screen") do
-  expect(page).to have_selector(".app-c-image-cropper")
-end
-
-Then("I should not see the image cropper in the following edit screen") do
-  expect(page).not_to have_selector(".app-c-image-cropper")
-end
-
 Then("I should I see the processing status tag") do
   expect(page).to have_selector(".govuk-tag--green")
 end
 
 Then("I should I see the image thumbnail") do
   expect(page).to have_selector(".app-view-edition-resource__preview")
+end
+
+Then("I should see the spinner in the following edit screen") do
+  expect(page).to have_selector(".hods-loading-spinner")
+end
+
+Then("I should see the image cropper in the following edit screen") do
+  expect(page).to have_selector(".app-c-image-cropper")
+end
+
+Then("I should not see the image cropper in the following edit screen") do
+  expect(page).not_to have_selector(".app-c-image-cropper")
 end
 
 When("the image is ready") do
@@ -139,6 +143,10 @@ When("the image is ready") do
   image_data = build(:image_data)
   image.image_data.stubs(:assets).returns(image_data.assets)
   Admin::EditionImagesController.any_instance.stubs(:find_image).returns(image)
+end
+
+Then("I should see the image cropper image in the edit screen") do
+  expect(page).to have_selector(".app-c-image-cropper__image")
 end
 
 When("I click to hide the lead image") do

--- a/features/step_definitions/image_steps.rb
+++ b/features/step_definitions/image_steps.rb
@@ -40,6 +40,11 @@ Given("a draft document with images exists") do
   @edition = create(:draft_publication, body: "!!2", images:)
 end
 
+Given("a draft document with images exists including an image that is not yet ready") do
+  @edition = create(:draft_publication, body: "!!2", images: [build(:image_with_no_assets)])
+  @edition.images.first.image_data.assets.destroy_all
+end
+
 Given("a draft case study with images exists") do
   images = [build(:image), build(:image)]
   @edition = create(:draft_case_study, body: "!!2", images:, lead_image: images.first)
@@ -117,6 +122,23 @@ end
 
 Then("I should not see the image cropper in the following edit screen") do
   expect(page).not_to have_selector(".app-c-image-cropper")
+end
+
+Then("I should I see the processing status tag") do
+  expect(page).to have_selector(".govuk-tag--green")
+end
+
+Then("I should I see the image thumbnail") do
+  expect(page).to have_selector(".app-view-edition-resource__preview")
+end
+
+When("the image is ready") do
+  image = @edition.images.reload.last
+  image.image_data.stubs(:all_asset_variants_uploaded?).returns(true)
+  image.image_data.stubs(:original_uploaded?).returns(true)
+  image_data = build(:image_data)
+  image.image_data.stubs(:assets).returns(image_data.assets)
+  Admin::EditionImagesController.any_instance.stubs(:find_image).returns(image)
 end
 
 When("I click to hide the lead image") do

--- a/spec/javascripts/admin/modules/image-processing-checker.spec.js
+++ b/spec/javascripts/admin/modules/image-processing-checker.spec.js
@@ -1,0 +1,134 @@
+describe('GOVUK.Modules.ImageProcessingChecker', function () {
+  let imagePreview
+
+  const imageProcessingTimeout = 1
+  const responseJSON = {
+    image_data: {
+      assets: [
+        {
+          variant: 'original',
+          url: 'http://assets.gov.uk/media/960x640.png'
+        },
+        {
+          variant: 's960',
+          url: 'http://assets.gov.uk/media/s960_960x640.png'
+        }
+      ],
+      all_assets_uploaded: true
+    }
+  }
+  const notReadyJSON = JSON.parse(JSON.stringify(responseJSON))
+  notReadyJSON.image_data.all_assets_uploaded = false
+
+  const okResponse = new Response(JSON.stringify(responseJSON), {
+    status: 200,
+    statusText: 'OK'
+  })
+  const okNotReadyResponse = new Response(JSON.stringify(notReadyJSON), {
+    status: 200,
+    statusText: 'OK'
+  })
+
+  beforeEach(() => {
+    imagePreview = document.createElement('div')
+    imagePreview.dataset.module = 'image-processing-checker'
+    imagePreview.dataset.imageLink = 'https://placeholder.com/image/1'
+    imagePreview.dataset.timeoutDuration = imageProcessingTimeout
+
+    imagePreview.innerHTML = `
+      <template class="js-image-preview">
+        <img src="" />
+      </template>
+      <div class="js-image-processing-status">
+        <span class="js-image-processing-preview-tag">
+          PROCESSING
+        </span>
+      </div>
+      <template class="js-image-preview-failure">
+        <span class="js-image-processing-failure-tag">
+          FAILED
+        </span>
+      </template>
+    `
+    document.body.appendChild(imagePreview)
+  })
+
+  afterEach(() => imagePreview.remove())
+
+  it('should replace the processing status with the image preview', (done) => {
+    spyOn(window, 'fetch').and.resolveTo(okResponse)
+    // eslint-disable-next-line no-new
+    new GOVUK.Modules.ImageProcessingChecker(imagePreview)
+
+    expect(imagePreview.querySelector('img')).toBe(null)
+
+    window.setTimeout(() => {
+      expect(imagePreview.querySelector('img'))
+      done()
+    }, imageProcessingTimeout * 2)
+  })
+
+  it('should replace the processing status with the image preview after multiple attempts', (done) => {
+    let calls = 4
+
+    const responder = () => {
+      if (calls > 0) {
+        calls -= 1
+        return new Promise((resolve) => {
+          resolve(okNotReadyResponse)
+        })
+      } else {
+        return new Promise((resolve) => {
+          resolve(okResponse)
+        })
+      }
+    }
+
+    spyOn(window, 'fetch').and.callFake(responder)
+
+    // eslint-disable-next-line no-new
+    new GOVUK.Modules.ImageProcessingChecker(imagePreview)
+
+    expect(imagePreview.querySelector('img')).toBe(null)
+
+    window.setTimeout(() => {
+      expect(imagePreview.querySelector('img')).toBeTruthy()
+      done()
+    }, 100)
+  })
+
+  it('should render error if URL does not return 200', (done) => {
+    const errorResponse = new Response(JSON.stringify(responseJSON), {
+      status: 404,
+      statusText: 'OK'
+    })
+
+    spyOn(window, 'fetch').and.resolveTo(errorResponse)
+    // eslint-disable-next-line no-new
+    new GOVUK.Modules.ImageProcessingChecker(imagePreview)
+
+    expect(imagePreview.querySelector('img')).toBe(null)
+
+    window.setTimeout(() => {
+      expect(
+        imagePreview.querySelector('.js-image-processing-failure-tag')
+      ).toBeTruthy()
+      done()
+    }, 100)
+  })
+
+  it('should render error if image is not ready in time', (done) => {
+    spyOn(window, 'fetch').and.resolveTo(okNotReadyResponse)
+    // eslint-disable-next-line no-new
+    new GOVUK.Modules.ImageProcessingChecker(imagePreview)
+
+    expect(imagePreview.querySelector('img')).toBe(null)
+
+    window.setTimeout(() => {
+      expect(
+        imagePreview.querySelector('.js-image-processing-failure-tag')
+      ).toBeTruthy()
+      done()
+    }, 100)
+  })
+})

--- a/spec/javascripts/admin/modules/image-processing-checker.spec.js
+++ b/spec/javascripts/admin/modules/image-processing-checker.spec.js
@@ -1,0 +1,75 @@
+describe('GOVUK.Modules.ImageProcessingChecker', function () {
+  let imagePreview
+
+  beforeEach(() => {
+    const okResponse = new Response(
+      JSON.stringify({
+        image_data: {
+          assets: [
+            {
+              variant: 'original',
+              url: 'http://asset-manager.dev.gov.uk/media/69d8ed16af0b323dbb43e3b7/960x640.png'
+            },
+            {
+              variant: 's712',
+              url: 'http://asset-manager.dev.gov.uk/media/69d8ed166315c04d2043e3b7/s712_960x640.png'
+            },
+            {
+              variant: 's300',
+              url: 'http://asset-manager.dev.gov.uk/media/69d8ed186315c04d2043e3b8/s300_960x640.png'
+            },
+            {
+              variant: 's630',
+              url: 'http://asset-manager.dev.gov.uk/media/69d8ed18af0b323dbb43e3b8/s630_960x640.png'
+            },
+            {
+              variant: 's960',
+              url: 'http://asset-manager.dev.gov.uk/media/69d8ed18af0b323dbb43e3b9/s960_960x640.png'
+            },
+            {
+              variant: 's465',
+              url: 'http://asset-manager.dev.gov.uk/media/69d8ed186315c04d2043e3b9/s465_960x640.png'
+            },
+            {
+              variant: 's216',
+              url: 'http://asset-manager.dev.gov.uk/media/69d8ed18af0b323dbb43e3ba/s216_960x640.png'
+            }
+          ],
+          all_assets_uploaded: true
+        }
+      }),
+      { status: 200, statusText: 'OK' }
+    )
+    spyOn(window, 'fetch').and.resolveTo(okResponse)
+
+    imagePreview = document.createElement('div')
+    imagePreview.dataset.module = 'image-processing-checker'
+    imagePreview.dataset.imageLink = 'https://placeholder.com/image/1'
+
+    imagePreview.innerHTML = `
+      <template class="js-image-preview">
+        <img src="" />
+      </template>
+      <div class="js-image-processing-status">
+        <span class="govuk-tag">
+          PROCESSING
+        </span>
+      </div>
+      <span class="js-image-preview-failure">
+        FAILED
+      </span>
+    `
+    document.body.appendChild(imagePreview)
+  })
+
+  it('should replace the processing status with the image preview', () => {
+    // eslint-disable-next-line no-new
+    new GOVUK.Modules.ImageProcessingChecker(imagePreview)
+
+    expect(imagePreview.querySelector('img')).toBe(null)
+
+    window.setTimeout(() => {
+      expect(imagePreview.querySelector('img'))
+    }, 600)
+  })
+})

--- a/spec/javascripts/components/image-cropper-spec.js
+++ b/spec/javascripts/components/image-cropper-spec.js
@@ -26,12 +26,7 @@ describe('GOVUK.Modules.ImageCropper', () => {
     }
   ]
 
-  const initCropperHTML = () => {
-    const canvas = document.createElement('canvas')
-    canvas.setAttribute('width', imageWidth)
-    canvas.setAttribute('height', imageHeight)
-    const src = canvas.toDataURL('image/png')
-
+  const initCropperHTML = (imageOnLoad = true) => {
     component = document.createElement('div')
     component.setAttribute('data-filename', 'icon.png')
     component.setAttribute('data-type', 'image/png')
@@ -48,15 +43,56 @@ describe('GOVUK.Modules.ImageCropper', () => {
       <input class="js-cropped-image-input" name="[y]" hidden>
       <input class="js-cropped-image-input" name="[height]" hidden>
       <input class="js-cropped-image-input" name="[width]" hidden>
-      <div style="position: relative; width: 1920px; height: 1280px;">
-        <img class="app-c-image-cropper__image" src="${src}"/>
-      </div>
+      <div class="js-cropped-image-img-container" style="position: relative; width: 1920px; height: 1280px;"></div>
     `
+
+    if (imageOnLoad) {
+      const canvas = document.createElement('canvas')
+      canvas.setAttribute('width', imageWidth)
+      canvas.setAttribute('height', imageHeight)
+      const src = canvas.toDataURL('image/png')
+
+      component.querySelector('.js-cropped-image-img-container').innerHTML = `
+        <img class="app-c-image-cropper__image" src="${src}"/>
+      `
+    }
 
     form = document.createElement('form')
     form.appendChild(component)
     document.body.append(form)
   }
+
+  describe('without image on initial load', () => {
+    beforeEach(() => {
+      initCropperHTML(false)
+      window.setTimeout(() => {
+        module = new GOVUK.Modules.ImageCropper(component)
+        module.init()
+      }, 1)
+    })
+
+    afterEach(() => form.remove())
+
+    it('should init the cropper when an image is provided', (done) => {
+      const canvas = document.createElement('canvas')
+      canvas.setAttribute('width', imageWidth)
+      canvas.setAttribute('height', imageHeight)
+      const src = canvas.toDataURL('image/png')
+
+      expect(document.querySelector('.app-c-image-cropper__image')).toBe(null)
+
+      component.querySelector('.js-cropped-image-img-container').innerHTML = `
+        <img class="app-c-image-cropper__image" src="${src}"/>
+      `
+      const image = document.querySelector('.app-c-image-cropper__image')
+
+      image.addEventListener('ready', () => {
+        const imageCropper = image.cropper
+        expect(imageCropper.getCropBoxData()).toBeTruthy()
+        done()
+      })
+    })
+  })
 
   describe('without versions', () => {
     beforeEach((done) => {

--- a/test/components/image_cropper_test.rb
+++ b/test/components/image_cropper_test.rb
@@ -18,7 +18,8 @@ class ImagecropperComponentTest < ComponentTestCase
       type: "type",
       width: 960,
       height: 640,
-      image: build(:image),
+      image: create(:image),
+      edition: create(:edition),
     })
 
     assert_select ".app-c-image-cropper"

--- a/test/functional/admin/edition_images_controller_test.rb
+++ b/test/functional/admin/edition_images_controller_test.rb
@@ -277,6 +277,34 @@ class Admin::EditionImagesControllerTest < ActionController::TestCase
     assert_redirected_to admin_edition_images_path(edition)
   end
 
+  test "GET :show returns JSON of edition image when assets are uploaded" do
+    login_authorised_user
+    image = build(:image)
+    edition = create(:draft_publication, images: [image])
+
+    get :show, params: { edition_id: edition.id, id: image.id }
+
+    json_reponse = image.as_json(include: { image_data: { include: :assets } })
+    json_reponse["image_data"]["all_assets_uploaded"] = true
+    json_reponse["image_data"]["assets"] = json_reponse["image_data"]["assets"].map { |asset| asset.merge({ "url" => asset["variant"] != "original" ? image.image_data.url(asset["variant"]) : image.image_data.url }) }
+
+    assert_equal response.body, json_reponse.to_json
+  end
+
+  test "GET :show returns JSON of edition image when assets are not uploaded" do
+    login_authorised_user
+    image = build(:image_with_no_assets)
+    edition = create(:draft_publication, images: [image])
+
+    get :show, params: { edition_id: edition.id, id: image.id }
+
+    json_reponse = image.as_json(include: { image_data: { include: :assets } })
+    json_reponse["image_data"]["all_assets_uploaded"] = false
+    json_reponse["image_data"]["assets"] = []
+
+    assert_equal response.body, json_reponse.to_json
+  end
+
   test "POST :create uploads one valid 'single' usage image, and redirects to 'edit'" do
     login_authorised_user
     ConfigurableDocumentType.setup_test_types(build_configurable_document_type("test_type", {


### PR DESCRIPTION
## What

Implement polling to check if an image is processed, rather than asking the user to refresh the page to see a processed image.

### Technical Details

- Add new JSON route `edition_images#show`
- Create new component `ImageProcessingChecker`
- Add `ImageProcessingChecker` to `ImageComponent`
- Add `ImageProcessingChecker` to `ImageCropper`
  - Move `init` to `start`
  - Add MutationObserver to `init` that runs `start` if there is an image in the `ImageCropper` component

### Visual Differences

<img width="1520" height="1456" alt="Screen Recording 2026-04-24 at 12 11 44" src="https://github.com/user-attachments/assets/d10aec1d-ccd3-4f9c-acc3-bcaabfb6aa27" />

## Why

Provides a more intuitive experience if users do not have to refresh the page to see uploaded images.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
