### PR TITLE
Add `Archived` as `UnpublishingReason` [WHIT-3283]

### DIFF
--- a/app/assets/javascripts/admin/views/unpublish-display-conditions.js
+++ b/app/assets/javascripts/admin/views/unpublish-display-conditions.js
@@ -11,7 +11,8 @@ window.GOVUK.Modules = window.GOVUK.Modules || {}
     this.unpublishReasonIds = {
       PublishedInError: 1,
       Consolidated: 4,
-      Withdrawn: 5
+      Withdrawn: 5,
+      Archived: 6
     }
   }
 
@@ -68,7 +69,12 @@ window.GOVUK.Modules = window.GOVUK.Modules || {}
     unpublishingReasonId
   ) {
     const showSection = function (selectedSectionId) {
-      const sections = ['withdrawal', 'published-in-error', 'consolidated']
+      const sections = [
+        'withdrawal',
+        'published-in-error',
+        'consolidated',
+        'archived'
+      ]
 
       sections.forEach(
         function (sectionId) {
@@ -91,6 +97,10 @@ window.GOVUK.Modules = window.GOVUK.Modules || {}
         break
       case this.unpublishReasonIds.Consolidated:
         showSection('consolidated')
+
+        break
+      case this.unpublishReasonIds.Archived:
+        showSection('archived')
 
         break
     }

--- a/app/helpers/admin/editions_helper.rb
+++ b/app/helpers/admin/editions_helper.rb
@@ -169,9 +169,16 @@ module Admin::EditionsHelper
     if edition.unpublishing.present?
       summary = "#{edition.state.capitalize} (#{time_ago_in_words(edition.unpublishing.created_at)} ago)"
       consolidated = edition.unpublishing.unpublishing_reason_id == UnpublishingReason::CONSOLIDATED_ID
+      archived = edition.unpublishing.unpublishing_reason_id == UnpublishingReason::ARCHIVED_ID
 
       if edition.state == "unpublished"
-        reason = consolidated ? "being consolidated into another page" : "being published in error"
+        reason = if consolidated
+                   "being consolidated into another page"
+                 elsif archived
+                   "being archived via the National Archives"
+                 else
+                   "being published in error"
+                 end
         details = ""
         if consolidated || edition.unpublishing.redirect
           details = " User is redirected from<br><a href='#{Whitehall.public_root}#{edition.base_path}'>#{Whitehall.public_root}#{edition.base_path}</a><br>to<br><a href='#{edition.unpublishing.alternative_url}'>#{edition.unpublishing.alternative_url}</a>"

--- a/app/models/unpublishing.rb
+++ b/app/models/unpublishing.rb
@@ -9,6 +9,7 @@ class Unpublishing < ApplicationRecord
   validates :alternative_url, uri: true, allow_blank: true
   validates :alternative_url, gov_uk_url_format: true, allow_blank: true
   validate :redirect_not_circular
+  validate :live_archived_url, if: :archived?
 
   after_initialize :ensure_presence_of_content_id
 
@@ -32,6 +33,10 @@ class Unpublishing < ApplicationRecord
     unpublishing_reason == UnpublishingReason::Withdrawn
   end
 
+  def archived?
+    unpublishing_reason == UnpublishingReason::Archived
+  end
+
   def unpublishing_reason
     UnpublishingReason.find_by_id unpublishing_reason_id
   end
@@ -52,6 +57,8 @@ class Unpublishing < ApplicationRecord
       "consolidated"
     when UnpublishingReason::Withdrawn
       "withdrawn"
+    when UnpublishingReason::Archived
+      "archived"
     end
   end
 
@@ -67,6 +74,12 @@ class Unpublishing < ApplicationRecord
     edition.public_url.gsub(edition.slug, slug)
   end
 
+  def archived_url
+    full_address = "https://www.gov.uk#{edition.base_path}"
+
+    "https://webarchive.nationalarchives.gov.uk/ukgwa/3000/#{full_address}"
+  end
+
   # Because the edition may have been deleted, we need to find it unscoped to
   # get around the default scope.
   def edition
@@ -76,6 +89,8 @@ class Unpublishing < ApplicationRecord
   delegate :translated_locales, to: :edition
 
   def alternative_path
+    return archived_url if archived?
+
     return if alternative_uri.nil?
 
     return alternative_uri.to_s unless GovUkUrlFormatValidator.can_be_converted_to_relative_path?(alternative_uri)
@@ -95,6 +110,15 @@ private
     rescue URI::InvalidURIError, Addressable::URI::InvalidURIError
       nil
     end
+  end
+
+  def live_archived_url
+    url = URI.parse(archived_url)
+    req = Net::HTTP.new(url.host, url.port)
+    req.use_ssl = true
+    res = req.request_head(url.path)
+
+    errors.add(:unpublishing_reason, "cannot be \"Archived\" if page has not been archived by the National Archives (\"https://www.webarchive.nationalarchives.gov.uk\")") unless res.code == "200"
   end
 
   def redirect_not_circular

--- a/app/models/unpublishing_reason.rb
+++ b/app/models/unpublishing_reason.rb
@@ -6,8 +6,10 @@ class UnpublishingReason
   PUBLISHED_IN_ERROR_ID = 1
   CONSOLIDATED_ID = 4
   WITHDRAWN_ID = 5
+  ARCHIVED_ID = 6
 
   PublishedInError  = create!(id: 1, name: "Published in error", as_sentence: "it was published in error")
   Consolidated      = create!(id: 4, name: "Consolidated into another GOV.UK page", as_sentence: "it has been consolidated into another GOV.UK page")
   Withdrawn         = create!(id: 5, name: "No longer current government policy/activity", as_sentence: "it is no longer current government policy/activity")
+  Archived          = create!(id: 6, name: "Archived via National Archives", as_sentence: "it has been archived via National Archives")
 end

--- a/app/sidekiq/publishing_api_unpublishing_job.rb
+++ b/app/sidekiq/publishing_api_unpublishing_job.rb
@@ -41,6 +41,14 @@ class PublishingApiUnpublishingJob < JobBase
           allow_draft,
           unpublishing.unpublished_at.to_s,
         )
+      when UnpublishingReason::ARCHIVED_ID
+        PublishingApiGoneJob.new.perform(
+          content_id,
+          unpublishing.alternative_path,
+          unpublishing.explanation,
+          locale.to_s,
+          allow_draft,
+        )
       end
     end
   end

--- a/app/views/admin/edition_workflow/confirm_unpublish.html.erb
+++ b/app/views/admin/edition_workflow/confirm_unpublish.html.erb
@@ -20,6 +20,11 @@
       value: UnpublishingReason::Consolidated,
       label: "Unpublish: consolidated into another GOV.UK page",
     },
+    archived: {
+      id: UnpublishingReason::Archived.id,
+      value: UnpublishingReason::Archived,
+      label: "Unpublish: archived via the National Archives",
+    },
   }
 
   withdrawal_public_explanation_field = render("components/govspeak_editor", {
@@ -57,11 +62,16 @@
           text: unpublish_reasons[:consolidated][:label],
           checked: @unpublishing.unpublishing_reason == unpublish_reasons[:consolidated][:value],
         },
-        :or,
         {
           value: unpublish_reasons[:withdrawn][:id],
           text: unpublish_reasons[:withdrawn][:label],
           checked: @unpublishing.unpublishing_reason == unpublish_reasons[:withdrawn][:value],
+        },
+        :or,
+        {
+          value: unpublish_reasons[:archived][:id],
+          text: unpublish_reasons[:archived][:label],
+          checked: @unpublishing.unpublishing_reason == unpublish_reasons[:archived][:value],
         },
       ],
     } %>
@@ -188,6 +198,25 @@
           error_items: errors_for(@unpublishing.errors, :alternative_url),
         } %>
         <%= render "alternative_url_constraints" %>
+
+        <div class="govuk-button-group govuk-!-margin-bottom-6">
+          <%= render "govuk_publishing_components/components/button", {
+            text: "Unpublish",
+            destructive: true,
+          } %>
+
+          <%= link_to("Cancel", [:admin, @edition], class: "govuk-link govuk-link--no-visited-state") %>
+        </div>
+      <% end %>
+    </div>
+
+    <div class="app-view-unpublish-withdrawal__form-wrapper js-app-view-unpublish-withdraw-form__archived">
+      <%= form_for @unpublishing, url: unpublish_admin_edition_path(@edition, lock_version: @edition.lock_version) do |form| %>
+        <%= hidden_field_tag "unpublishing[unpublishing_reason_id]", unpublish_reasons[:archived][:id] %>
+
+        <p class="govuk-body">
+          This document <a class="govuk-link" href="https://https://www.webarchive.nationalarchives.gov.uk/<%= @unpublishing.archived_url %>">must be live on the National Archives website</a> to select this reason. The URL to the National Archives website will be determined automatically based on the URL of the document.
+        </p>
 
         <div class="govuk-button-group govuk-!-margin-bottom-6">
           <%= render "govuk_publishing_components/components/button", {

--- a/spec/javascripts/admin/modules/unpublish-display-conditions.spec.js
+++ b/spec/javascripts/admin/modules/unpublish-display-conditions.spec.js
@@ -18,10 +18,14 @@ describe('GOVUK.Modules.UnpublishDisplayConditions', function () {
                 <input type="radio" name="unpublishing_reason" id="radio-published-consolidated" value="4" class="govuk-radios__input">
                 <label for="radio-published-consolidated" class="gem-c-label govuk-label govuk-radios__label">Unpublish: consolidated into another GOV.UK page</label>
               </div>
-              <div class="govuk-radios__divider">or</div>
               <div class="gem-c-radio govuk-radios__item">
                 <input type="radio" name="unpublishing_reason" id="radio-withdraw" value="5" class="govuk-radios__input">
                 <label for="radio-withdraw" class="gem-c-label govuk-label govuk-radios__label">Withdraw: no longer current government policy/activity</label>
+              </div>      
+              <div class="govuk-radios__divider">or</div>
+              <div class="gem-c-radio govuk-radios__item">
+                <input type="radio" name="unpublishing_reason" id="radio-archived" value="6" class="govuk-radios__input">
+                <label for="radio-archived" class="gem-c-label govuk-label govuk-radios__label">Archived: via the National Archives</label>
               </div>
             </div>
           </fieldset>
@@ -44,6 +48,9 @@ describe('GOVUK.Modules.UnpublishDisplayConditions', function () {
         <div class="app-view-unpublish-withdrawal__form-wrapper js-app-view-unpublish-withdraw-form__consolidated">
           this is the consolidated section
         </div>
+        <div class="app-view-unpublish-withdrawal__form-wrapper js-app-view-unpublish-withdraw-form__archived">
+          this is the archived section
+        </div>      
       </div>
     `
     const checkbox = body.querySelector(
@@ -69,6 +76,10 @@ describe('GOVUK.Modules.UnpublishDisplayConditions', function () {
       body.querySelector('.js-app-view-unpublish-withdraw-form__withdrawal')
         .style.display
     ).not.toEqual('block')
+    expect(
+      body.querySelector('.js-app-view-unpublish-withdraw-form__archived').style
+        .display
+    ).not.toEqual('block')
   })
 
   it('should only show publish in error section when selecting unpublish: published in error', function () {
@@ -88,6 +99,10 @@ describe('GOVUK.Modules.UnpublishDisplayConditions', function () {
     expect(
       body.querySelector('.js-app-view-unpublish-withdraw-form__withdrawal')
         .style.display
+    ).not.toEqual('block')
+    expect(
+      body.querySelector('.js-app-view-unpublish-withdraw-form__archived').style
+        .display
     ).not.toEqual('block')
   })
 
@@ -109,6 +124,10 @@ describe('GOVUK.Modules.UnpublishDisplayConditions', function () {
       body.querySelector('.js-app-view-unpublish-withdraw-form__withdrawal')
         .style.display
     ).not.toEqual('block')
+    expect(
+      body.querySelector('.js-app-view-unpublish-withdraw-form__archived').style
+        .display
+    ).not.toEqual('block')
   })
 
   it('should only show withdrawal section when selecting withdrawal', function () {
@@ -129,6 +148,10 @@ describe('GOVUK.Modules.UnpublishDisplayConditions', function () {
       body.querySelector('.js-app-view-unpublish-withdraw-form__withdrawal')
         .style.display
     ).toEqual('block')
+    expect(
+      body.querySelector('.js-app-view-unpublish-withdraw-form__archived').style
+        .display
+    ).not.toEqual('block')
   })
 
   it('should show last chosen option if user changes their selected option', function () {
@@ -149,6 +172,10 @@ describe('GOVUK.Modules.UnpublishDisplayConditions', function () {
       body.querySelector('.js-app-view-unpublish-withdraw-form__withdrawal')
         .style.display
     ).toEqual('block')
+    expect(
+      body.querySelector('.js-app-view-unpublish-withdraw-form__archived').style
+        .display
+    ).not.toEqual('block')
 
     const radio2 = body.querySelector('#radio-published-consolidated')
     radio2.checked = true
@@ -166,6 +193,10 @@ describe('GOVUK.Modules.UnpublishDisplayConditions', function () {
     expect(
       body.querySelector('.js-app-view-unpublish-withdraw-form__withdrawal')
         .style.display
+    ).not.toEqual('block')
+    expect(
+      body.querySelector('.js-app-view-unpublish-withdraw-form__archived').style
+        .display
     ).not.toEqual('block')
   })
 

--- a/test/unit/app/helpers/admin/editions_helper_test.rb
+++ b/test/unit/app/helpers/admin/editions_helper_test.rb
@@ -139,6 +139,17 @@ class Admin::EditionsHelperTest < ActionView::TestCase
     assert_equal "Unpublished (less than a minute ago) due to being consolidated into another page. User is redirected from<br><a href='https://www.test.gov.uk#{edition.base_path}'>https://www.test.gov.uk#{edition.base_path}</a><br>to<br><a href='#{alternative_url}'>#{alternative_url}</a>", status_text(edition)
   end
 
+  test "#status_text has special handling for unpublished (due to being archived)" do
+    edition = create(:edition, :unpublished)
+
+    stub_request(:head, edition.unpublishing.archived_url)
+      .to_return(status: 200, body: "", headers: {})
+
+    edition.unpublishing.unpublishing_reason_id = UnpublishingReason::ARCHIVED_ID
+    edition.unpublishing.save!
+    assert_equal "Unpublished (less than a minute ago) due to being archived via the National Archives.", status_text(edition)
+  end
+
   test "#status_text has special handling for unpublished (due to publish in error) - redirect to alternative URL" do
     alternative_url = "https://gov.uk/foo"
     edition = create(:edition, :unpublished)

--- a/test/unit/app/models/unpublishing_test.rb
+++ b/test/unit/app/models/unpublishing_test.rb
@@ -172,6 +172,25 @@ class UnpublishingTest < ActiveSupport::TestCase
     assert_equal ["must be provided to redirect the document"], unpublishing.errors[:alternative_url]
   end
 
+  test "unpublishing_reason is invalid if the reason is Archived and document has not been archived by the National Archives" do
+    unpublishing = build(:unpublishing, unpublishing_reason: UnpublishingReason::Archived)
+
+    stub_request(:head, unpublishing.archived_url)
+      .to_return(status: 404, body: "", headers: {})
+
+    assert_not unpublishing.valid?
+    assert_equal ["cannot be \"Archived\" if page has not been archived by the National Archives (\"https://www.webarchive.nationalarchives.gov.uk\")"], unpublishing.errors[:unpublishing_reason]
+  end
+
+  test "unpublishing_reason is valid if the reason is Archived and document has been archived by the National Archives" do
+    unpublishing = build(:unpublishing, unpublishing_reason: UnpublishingReason::Archived)
+
+    stub_request(:head, unpublishing.archived_url)
+      .to_return(status: 200, body: "", headers: {})
+
+    assert unpublishing.valid?
+  end
+
   test "always redirects if the reason is Consolidated" do
     unpublishing = Unpublishing.new(unpublishing_reason: UnpublishingReason::Consolidated)
     assert unpublishing.redirect?


### PR DESCRIPTION
## What

Add `Archived` as a `UnpublishingReason`.

### Technical Details

- Add `Archived` to list of unpublishing reasons
- Add new section for Unpublishing Display Reasons component
- Add validator to check if document has been archived by National Archives
- Add clause to `PublishingApiUnpublishingJob` when reason is `Archived`

#### Visual Differences

<img width="616" height="578" alt="Screenshot 2026-04-23 at 13 34 32" src="https://github.com/user-attachments/assets/719b8240-7c59-4041-9fd6-4571171bdfd4" />

<img width="626" height="313" alt="Screenshot 2026-04-23 at 13 45 46" src="https://github.com/user-attachments/assets/a6f890ab-4eba-418f-afb6-c97089fbc762" />

<img width="602" height="376" alt="Screenshot 2026-04-23 at 16 03 12" src="https://github.com/user-attachments/assets/5491ccf2-99a1-4388-a8ad-b39fe49f3bc7" />

## Why

Required for upcoming work to archive documents in Whitehall.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
