### PR TITLE
Add `title` to `ImageUsage` [WHIT-3298]

### DIFF
--- a/app/components/admin/edition_images/image_card_component.html.erb
+++ b/app/components/admin/edition_images/image_card_component.html.erb
@@ -1,7 +1,7 @@
 <%= render "govuk_publishing_components/components/summary_card", {
   id: "uploaded_#{image_usage.key}_image_card",
-  title: image_usage.label&.titleize || image_usage.key.titleize,
   summary_card_actions: summary_card_actions,
+  title: image_usage.title.upcase_first,
   rows: [
     {
       key: "Image",

--- a/app/components/admin/edition_images/image_upload_component.html.erb
+++ b/app/components/admin/edition_images/image_upload_component.html.erb
@@ -1,9 +1,10 @@
 <%
   image_kind = image_usage.kinds.first
+  image_usage_title = image_usage.title.downcase
 
-  hint_text = ["A #{image_kind.display_name} image must be at least <strong>#{image_kind.valid_width}x#{image_kind.valid_height}</strong>."]
+  hint_text = ["#{image_usage_title.articleize.upcase_first} must be at least <strong>#{image_kind.valid_width}x#{image_kind.valid_height}</strong>."]
   unless image_usage.multiple
-    hint_text << " If you are uploading more than one image, <a class=\"govuk-link\" href=\"https://www.gov.uk/guidance/how-to-publish-on-gov-uk/images-and-videos\">read the image guidance</a> on using unique file names."
+    hint_text << " If you are uploading more than one #{image_usage_title}, <a class=\"govuk-link\" href=\"https://www.gov.uk/guidance/how-to-publish-on-gov-uk/images-and-videos\">read the image guidance</a> on using unique file names."
   end
 %>
 

--- a/app/components/admin/edition_images/lead_image_card_component.html.erb
+++ b/app/components/admin/edition_images/lead_image_card_component.html.erb
@@ -6,7 +6,7 @@
 
 <%= render "govuk_publishing_components/components/summary_card", {
   id: "uploaded_#{image_usage.key}_image_card",
-  title: image_usage.label&.titleize || image_usage.key.titleize,
+  title: image_usage.title.upcase_first,
   summary_card_actions: summary_card_actions,
   rows: [
     {

--- a/app/models/configurable_document_types/case_study.json
+++ b/app/models/configurable_document_types/case_study.json
@@ -99,7 +99,6 @@
           "caption_enabled": true
         },        
         "lead": {
-          "label": "lead",
           "kinds": ["default"],
           "multiple": false,
           "caption_enabled": true

--- a/app/models/configurable_document_types/government_response.json
+++ b/app/models/configurable_document_types/government_response.json
@@ -115,7 +115,6 @@
           "caption_enabled": true
         },
         "lead": {
-          "label": "lead",
           "kinds": ["default"],
           "multiple": false,
           "caption_enabled": true

--- a/app/models/configurable_document_types/news_story.json
+++ b/app/models/configurable_document_types/news_story.json
@@ -115,7 +115,6 @@
           "caption_enabled": true
         },
         "lead": {
-          "label": "lead",
           "kinds": ["default"],
           "multiple": false,
           "caption_enabled": true

--- a/app/models/configurable_document_types/press_release.json
+++ b/app/models/configurable_document_types/press_release.json
@@ -115,7 +115,6 @@
           "caption_enabled": true
         },
         "lead": {
-          "label": "lead",
           "kinds": ["default"],
           "multiple": false,
           "caption_enabled": true

--- a/app/models/configurable_document_types/topical_event.json
+++ b/app/models/configurable_document_types/topical_event.json
@@ -181,7 +181,6 @@
       "enabled": true,
       "usages": {
         "header": {
-          "label": "header image",
           "kinds": ["topical_event_header"],
           "multiple": false,
           "caption_enabled": true

--- a/app/models/configurable_document_types/world_news_story.json
+++ b/app/models/configurable_document_types/world_news_story.json
@@ -100,7 +100,6 @@
           "caption_enabled": true
         },
         "lead": {
-          "label": "lead",
           "kinds": ["default"],
           "multiple": false,
           "caption_enabled": true

--- a/app/models/image_usage.rb
+++ b/app/models/image_usage.rb
@@ -21,4 +21,10 @@ class ImageUsage
   def lead?
     key == "lead"
   end
+
+  def title
+    return "image" if embeddable?
+
+    label || "#{key} image"
+  end
 end

--- a/app/views/admin/edition_images/new.html.erb
+++ b/app/views/admin/edition_images/new.html.erb
@@ -1,6 +1,6 @@
 <% content_for :context, "#{@edition.title}" %>
-<% content_for :page_title, "New #{@image_usage.label} image for #{@edition.format_name}" %>
-<% content_for :title, "New #{@image_usage.label} image for #{@edition.format_name}" %>
+<% content_for :page_title, "New #{@image_usage.title} for #{@edition.format_name}" %>
+<% content_for :title, "New #{@image_usage.title} for #{@edition.format_name}" %>
 <% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @images.flat_map { |image| image&.errors&.errors }, parent_class: "edition_images")) if @images.present? %>
 
 <div class="govuk-grid-row">

--- a/lib/patches/string.rb
+++ b/lib/patches/string.rb
@@ -11,4 +11,8 @@ class String
       "#{self}’s"
     end
   end
+
+  def articleize
+    %w[a e i o u].include?(self[0].downcase) ? "an #{self}" : "a #{self}"
+  end
 end

--- a/test/unit/app/models/image_usage_test.rb
+++ b/test/unit/app/models/image_usage_test.rb
@@ -15,4 +15,19 @@ class ImageUsageTest < ActiveSupport::TestCase
     usage = ImageUsage.new(key: "header", kinds: [], multiple: false, caption_enabled: true)
     assert usage.caption_enabled?
   end
+
+  test "default title is \"`key` image\"" do
+    usage = ImageUsage.new(key: "header", kinds: [], multiple: false, caption_enabled: true)
+    assert_equal "header image", usage.title
+  end
+
+  test "title uses label as override if provided" do
+    usage = ImageUsage.new(key: "logo", label: "header logo", kinds: [], multiple: false, caption_enabled: true)
+    assert_equal "header logo", usage.title
+  end
+
+  test "title is `image` if embeddable (default) image usage" do
+    usage = ImageUsage.new(key: "govspeak_embed", kinds: [], multiple: false, caption_enabled: true)
+    assert_equal "image", usage.title
+  end
 end

--- a/test/unit/lib/patches/string.rb
+++ b/test/unit/lib/patches/string.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class StringTest < ActiveSupport::TestCase
+  test "`articleize` uses correct `article` for a given word" do
+    assert_equal "an apple", "apple".articleize
+    assert_equal "a banana", "banana".articleize
+  end
+end


### PR DESCRIPTION
## What

- Add `title` to `ImageUsage` which returns either the `label` (if defined), `KEY image` or `image` (if an embeddable or default image).
- Add `articleize` function to use `a` or `an` correctly depending on label name
- Update `ImageUpload`, `ImageCard` and `LeadImageCard` to use `image_usage.title`
- Update `edition_images#new` to use `image_usage.title`

### Visual Differences
<img width="638" height="325" alt="Screenshot 2026-04-20 at 11 24 38" src="https://github.com/user-attachments/assets/c526fe36-b96e-4114-a5c9-20d451353d06" />

<img width="629" height="479" alt="Screenshot 2026-04-20 at 10 44 55" src="https://github.com/user-attachments/assets/c68baaa2-9da1-4515-b36c-2c5e2fa7d831" />

<img width="654" height="449" alt="Screenshot 2026-04-14 at 10 45 14" src="https://github.com/user-attachments/assets/6dcfcfec-85ad-43a7-b911-628cd9217afa" />

<img width="663" height="448" alt="Screenshot 2026-04-14 at 10 45 09" src="https://github.com/user-attachments/assets/aab3c2a0-78a2-459d-96de-6b47406d2b84" />

<img width="642" height="315" alt="Screenshot 2026-04-14 at 10 44 56" src="https://github.com/user-attachments/assets/83492222-e38a-4c5b-bd3c-9c950dbf30d8" />

## Why

Ensure consistency when referring to an image in the UI. Means that `label` does not have to be filled in each time an image is defined in the configuration of a document (unless `title` needs to be overridden). 

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
