### PR TITLE
[WHIT-3323] Introduce `slug_from_title` column

### DIFF
--- a/app/models/concerns/edition/identifiable.rb
+++ b/app/models/concerns/edition/identifiable.rb
@@ -42,6 +42,7 @@ module Edition::Identifiable
     # when the to_ascii option is used. In this case we fall back to the document ID as the slug
     if default_slug.blank?
       self[:slug] = document_id
+      self[:slug_from_title] = document_id
       return
     end
 
@@ -62,6 +63,7 @@ module Edition::Identifiable
       else
         candidate_slug_is_a_duplicate = false
         self[:slug] = candidate_slug
+        self[:slug_from_title] = candidate_slug
       end
     end
   end

--- a/db/data_migration/20260414111505_generate_slug_from_title.rb
+++ b/db/data_migration/20260414111505_generate_slug_from_title.rb
@@ -1,0 +1,11 @@
+total_processed = 0
+
+Edition.skip_callback(:update, :after, :republish_topical_event_to_publishing_api)
+Edition.in_pre_publication_state.find_each(batch_size: 1000) do |edition|
+  edition.set_slug
+  total_processed += 1 if edition.save(validate: false)
+
+  puts "Processed #{total_processed} editions" if (total_processed % 5000).zero?
+end
+
+puts "Total editions processed: #{total_processed}"

--- a/db/migrate/20260414101848_add_slug_from_title_to_editions.rb
+++ b/db/migrate/20260414101848_add_slug_from_title_to_editions.rb
@@ -1,0 +1,5 @@
+class AddSlugFromTitleToEditions < ActiveRecord::Migration[8.1]
+  def change
+    add_column :editions, :slug_from_title, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_13_155934) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_14_101848) do
   create_table "assets", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.bigint "assetable_id"
@@ -392,6 +392,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_13_155934) do
     t.text "roll_call_introduction", size: :medium
     t.datetime "scheduled_publication", precision: nil
     t.string "slug"
+    t.string "slug_from_title"
     t.string "slug_override"
     t.integer "speech_type_id"
     t.string "state", default: "draft", null: false

--- a/test/unit/app/models/edition/identifiable_test.rb
+++ b/test/unit/app/models/edition/identifiable_test.rb
@@ -106,13 +106,14 @@ class Edition::SluggingTest < ActiveSupport::TestCase
     assert_equal "original-title", second_edition.slug
   end
 
-  test "it updates the slug when the title changes" do
+  test "it updates the slug and slug_from_title when the title changes" do
     edition = SluggableEdition.create!(title: "Original Title", slug: nil)
     original_slug = edition.slug
     edition.title = "New Title"
     edition.save!
     assert_not_equal original_slug, edition.slug
     assert_equal "new-title", edition.slug
+    assert_equal "new-title", edition.slug_from_title
   end
 
   test "it generates a unique slug when a duplicate exists of the same edition type" do


### PR DESCRIPTION
We are introducing this as a column so that we can, in the future, store an accurate value for the slug. The `slug_from_title` column will store the title-based slug, while the `slug` column will store the `slug_override` if present, otherwise the `slug_from_title`.

[Jira](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-3323)
