### PR TITLE
Improve error message for social media [WHIT-3156]

### DIFF
--- a/app/components/admin/error_summary_component.rb
+++ b/app/components/admin/error_summary_component.rb
@@ -24,11 +24,13 @@ private
 
   def error_items
     sorted_errors.map do |error|
-      message = error.full_message
-
-      if object.respond_to?(:error_labels) && object.error_labels.key?(error.attribute.to_s)
-        message = "#{object.error_labels[error.attribute.to_s]} #{error.message}"
-      end
+      message = if dotted_array_attribute?(error)
+                  format_dotted_attribute_message(error)
+                elsif object.respond_to?(:error_labels) && object.error_labels.key?(error.attribute.to_s)
+                  "#{object.error_labels[error.attribute.to_s]} #{error.message}"
+                else
+                  error.full_message
+                end
 
       error_item = {
         text: message,
@@ -74,5 +76,16 @@ private
     return object.class.name.humanize if [ActiveModel::Errors, Array].include?(object.class)
 
     "#{object.try(:new_record?) ? 'New' : 'Editing'} #{object.model_name.human.downcase.titleize}"
+  end
+
+  def dotted_array_attribute?(error)
+    error.attribute.to_s.split(".").any? { |part| part.match?(/\A\d+\z/) }
+  end
+
+  def format_dotted_attribute_message(error)
+    attribute_label = error.attribute.to_s.split(".").map { |part|
+      part.match?(/\A\d+\z/) ? (part.to_i + 1).to_s : part.humanize.downcase
+    }.join(" ").capitalize
+    "#{attribute_label} #{error.message}"
   end
 end

--- a/app/models/configurable_document_type.rb
+++ b/app/models/configurable_document_type.rb
@@ -113,6 +113,11 @@ class ConfigurableDocumentType
     end
   end
 
+  def title_for_attribute(attribute)
+    segments = attribute.split(".").reject { |s| s.match?(/\A\d+\z/) }
+    find_field_title(form, segments)
+  end
+
   def schema_for_fields(field_keys)
     field_keys = field_keys.map(&:to_s)
 
@@ -126,6 +131,21 @@ class ConfigurableDocumentType
   end
 
 private
+
+  def find_field_title(config, segments)
+    return config["title"] if segments.empty?
+    return nil unless config["fields"]
+
+    config["fields"].each_value do |field|
+      path = Array(field["attribute_path"]) - %w[block_content]
+      next if path.empty? || segments.first(path.length) != path
+
+      result = find_field_title(field, segments.drop(path.length))
+      return result if result
+    end
+
+    nil
+  end
 
   def validations_for_fields(field_keys)
     (@schema["validations"] || {}).each_with_object({}) do |(validation_name, options), result|

--- a/app/models/configurable_document_type.rb
+++ b/app/models/configurable_document_type.rb
@@ -113,6 +113,11 @@ class ConfigurableDocumentType
     end
   end
 
+  def title_for_attribute(attribute)
+    segments = attribute.split(".").reject { |s| s.match?(/\A\d+\z/) }
+    find_field_title(form, segments)
+  end
+
   def schema_for_fields(field_keys)
     field_keys = field_keys.map(&:to_s)
 
@@ -126,6 +131,19 @@ class ConfigurableDocumentType
   end
 
 private
+
+  def find_field_title(config, segments)
+    return config["title"] if segments.empty?
+    return nil unless config["fields"]
+
+    config["fields"].each_value do |field|
+      path = Array(field["attribute_path"]) - %w[block_content]
+      next if path.empty? || segments.first(path.length) != path
+
+      result = find_field_title(field, segments.drop(path.length))
+      return result if result
+    end
+  end
 
   def validations_for_fields(field_keys)
     (@schema["validations"] || {}).each_with_object({}) do |(validation_name, options), result|

--- a/app/models/standard_edition.rb
+++ b/app/models/standard_edition.rb
@@ -167,6 +167,10 @@ class StandardEdition < Edition
                           .map { |block| block.path.validation_error_attribute }
   end
 
+  def self.human_attribute_name(attribute, options = {})
+    options[:base]&.type_instance&.title_for_attribute(attribute.to_s) || super
+  end
+
 private
 
   def field_paths(&block)

--- a/app/models/standard_edition.rb
+++ b/app/models/standard_edition.rb
@@ -162,6 +162,10 @@ class StandardEdition < Edition
                           .map { |block| block.path.validation_error_attribute }
   end
 
+  def self.human_attribute_name(attribute, options = {})
+    options[:base]&.type_instance&.title_for_attribute(attribute.to_s) || super
+  end
+
 private
 
   def field_paths(&block)

--- a/app/models/standard_edition/block_content.rb
+++ b/app/models/standard_edition/block_content.rb
@@ -64,7 +64,13 @@ private
   end
 
   def method_missing(symbol, *args)
-    if attributes.class.instance_methods.include?(symbol)
+    # Errors on array item fields use dotted attribute names like
+    # :"social_media_links.0.url" so they can be targeted inline per
+    # field. Rails calls these as methods during error processing;
+    # returning nil here prevents a NoMethodError.
+    if symbol.to_s.include?(".")
+      nil
+    elsif attributes.class.instance_methods.include?(symbol)
       attributes.public_send(symbol, *args)
     else
       super
@@ -72,7 +78,7 @@ private
   end
 
   def respond_to_missing?(method_name, _include_all)
-    attributes.class.instance_methods.include?(method_name) || super
+    method_name.to_s.include?(".") || attributes.class.instance_methods.include?(method_name) || super
   end
 
   def attributes_class_for(attribute_config)

--- a/app/validators/social_media_links_validator.rb
+++ b/app/validators/social_media_links_validator.rb
@@ -1,7 +1,7 @@
 class SocialMediaLinksValidator < ActiveModel::Validator
   def initialize(opts = {})
     @attributes = opts[:attributes]
-    @service_field = opts[:fields]["service_field"]
+    @channel_field = opts[:fields]["service_field"]
     @url_field = opts[:fields]["url_field"]
     super
   end
@@ -9,61 +9,60 @@ class SocialMediaLinksValidator < ActiveModel::Validator
   def validate(record)
     @attributes.each do |attribute_name|
       arr = record.send(attribute_name.to_sym) || []
-      arr.each_with_index do |social_media_service, index|
-        service_name = social_media_service[@service_field]
-        if validate_social_media_service(service_name, record, attribute_name, index)
-          validate_social_media_link(social_media_service[@url_field], service_name, record, attribute_name)
-        end
+      @channels_seen = []
+      @urls_seen = []
+
+      arr.each_with_index do |social_media_account, index|
+        channel_name = social_media_account[@channel_field]
+        url = social_media_account[@url_field]
+
+        validate_social_media_channel(channel_name, index, record, attribute_name)
+        validate_social_media_url(url, index, record, attribute_name)
       end
     end
   end
 
 private
 
-  def validate_social_media_service(service_name, record, attribute_name, index)
-    @services ||= []
-
-    if service_name.blank?
+  def validate_social_media_channel(channel_name, index, record, attribute_name)
+    if channel_name.blank?
       record.errors.add(
-        attribute_name.to_sym,
-        :invalid_social_media_link,
-        message: "contains an account (\"Social media account #{index + 1}\") without a service selected.",
+        :"#{attribute_name}.#{index}.#{@channel_field}",
+        :blank,
+        message: "cannot be blank",
       )
-      return false
-    end
-
-    if service_name != "Other" && @services.include?(service_name)
+    elsif channel_name != "Other" && @channels_seen.include?(channel_name)
       record.errors.add(
-        attribute_name.to_sym,
-        :invalid_social_media_link,
-        message: "contains another account with a service of \"#{service_name}\".",
+        :"#{attribute_name}.#{index}.#{@channel_field}",
+        :taken,
+        message: "must be unique",
       )
-      return false
+    else
+      @channels_seen << channel_name
     end
-    @services << service_name
   end
 
-  def validate_social_media_link(url, service_name, record, attribute_name)
+  def validate_social_media_url(url, index, record, attribute_name)
     if url.blank?
       record.errors.add(
-        attribute_name.to_sym,
-        :invalid_social_media_link,
-        message: "contains a \"#{service_name}\" account without a URL.",
+        :"#{attribute_name}.#{index}.#{@url_field}",
+        :blank,
+        message: "cannot be blank",
       )
     elsif !valid_url?(url)
       record.errors.add(
-        attribute_name.to_sym,
-        :invalid_social_media_link,
-        message: "contains a \"#{service_name}\" account with an invalid URL - use the full URL, including https://",
+        :"#{attribute_name}.#{index}.#{@url_field}",
+        :invalid,
+        message: "is invalid - use the full URL, including https://",
       )
-    elsif record.social_media_links.pluck("url").count(url) > 1
-      unless record.errors.messages[attribute_name.to_sym].include?("already has an account with a URL of \"#{url}\".")
-        record.errors.add(
-          attribute_name.to_sym,
-          :invalid_social_media_link,
-          message: "already has an account with a URL of \"#{url}\".",
-        )
-      end
+    elsif @urls_seen.include?(url)
+      record.errors.add(
+        :"#{attribute_name}.#{index}.#{@url_field}",
+        :taken,
+        message: "must be unique",
+      )
+    else
+      @urls_seen << url
     end
   end
 

--- a/app/validators/social_media_links_validator.rb
+++ b/app/validators/social_media_links_validator.rb
@@ -1,7 +1,7 @@
 class SocialMediaLinksValidator < ActiveModel::Validator
   def initialize(opts = {})
     @attributes = opts[:attributes]
-    @service_field = opts[:fields]["service_field"]
+    @channel_field = opts[:fields]["service_field"]
     @url_field = opts[:fields]["url_field"]
     super
   end
@@ -9,10 +9,10 @@ class SocialMediaLinksValidator < ActiveModel::Validator
   def validate(record)
     @attributes.each do |attribute_name|
       arr = record.send(attribute_name.to_sym) || []
-      arr.each_with_index do |social_media_service, index|
-        service_name = social_media_service[@service_field]
-        if validate_social_media_service(service_name, record, attribute_name, index)
-          validate_social_media_link(social_media_service[@url_field], service_name, record, attribute_name)
+      arr.each_with_index do |social_media_account, index|
+        channel_name = social_media_account[@channel_field]
+        if validate_social_media_channel(channel_name, record, attribute_name, index)
+          validate_social_media_link(social_media_account[@url_field], channel_name, record, attribute_name)
         end
       end
     end
@@ -20,10 +20,10 @@ class SocialMediaLinksValidator < ActiveModel::Validator
 
 private
 
-  def validate_social_media_service(service_name, record, attribute_name, index)
-    @services ||= []
+  def validate_social_media_channel(channel_name, record, attribute_name, index)
+    @channels ||= []
 
-    if service_name.blank?
+    if channel_name.blank?
       record.errors.add(
         attribute_name.to_sym,
         :invalid_social_media_link,
@@ -32,29 +32,29 @@ private
       return false
     end
 
-    if service_name != "Other" && @services.include?(service_name)
+    if channel_name != "Other" && @channels.include?(channel_name)
       record.errors.add(
         attribute_name.to_sym,
         :invalid_social_media_link,
-        message: "contains another account with a service of \"#{service_name}\".",
+        message: "contains another account with a service of \"#{channel_name}\".",
       )
       return false
     end
-    @services << service_name
+    @channels << channel_name
   end
 
-  def validate_social_media_link(url, service_name, record, attribute_name)
+  def validate_social_media_link(url, channel_name, record, attribute_name)
     if url.blank?
       record.errors.add(
         attribute_name.to_sym,
         :invalid_social_media_link,
-        message: "contains a \"#{service_name}\" account without a URL.",
+        message: "contains a \"#{channel_name}\" account without a URL.",
       )
     elsif !valid_url?(url)
       record.errors.add(
         attribute_name.to_sym,
         :invalid_social_media_link,
-        message: "contains a \"#{service_name}\" account with an invalid URL - use the full URL, including https://",
+        message: "contains a \"#{channel_name}\" account with an invalid URL - use the full URL, including https://",
       )
     elsif record.social_media_links.pluck("url").count(url) > 1
       unless record.errors.messages[attribute_name.to_sym].include?("already has an account with a URL of \"#{url}\".")

--- a/app/validators/social_media_links_validator.rb
+++ b/app/validators/social_media_links_validator.rb
@@ -9,61 +9,60 @@ class SocialMediaLinksValidator < ActiveModel::Validator
   def validate(record)
     @attributes.each do |attribute_name|
       arr = record.send(attribute_name.to_sym) || []
+      channels_seen = []
+      urls_seen = []
+
       arr.each_with_index do |social_media_account, index|
         channel_name = social_media_account[@channel_field]
-        if validate_social_media_channel(channel_name, record, attribute_name, index)
-          validate_social_media_link(social_media_account[@url_field], channel_name, record, attribute_name)
-        end
+        url = social_media_account[@url_field]
+
+        validate_social_media_channel(channel_name, channels_seen, index, record, attribute_name)
+        validate_social_media_url(url, urls_seen, index, record, attribute_name)
       end
     end
   end
 
 private
 
-  def validate_social_media_channel(channel_name, record, attribute_name, index)
-    @channels ||= []
-
+  def validate_social_media_channel(channel_name, channels_seen, index, record, attribute_name)
     if channel_name.blank?
       record.errors.add(
-        attribute_name.to_sym,
-        :invalid_social_media_link,
-        message: "contains an account (\"Social media account #{index + 1}\") without a service selected.",
+        :"#{attribute_name}.#{index}.#{@channel_field}",
+        :blank,
+        message: "cannot be blank",
       )
-      return false
-    end
-
-    if channel_name != "Other" && @channels.include?(channel_name)
+    elsif channel_name != "Other" && channels_seen.include?(channel_name)
       record.errors.add(
-        attribute_name.to_sym,
-        :invalid_social_media_link,
-        message: "contains another account with a service of \"#{channel_name}\".",
+        :"#{attribute_name}.#{index}.#{@channel_field}",
+        :taken,
+        message: "must be unique",
       )
-      return false
+    else
+      channels_seen << channel_name
     end
-    @channels << channel_name
   end
 
-  def validate_social_media_link(url, channel_name, record, attribute_name)
+  def validate_social_media_url(url, urls_seen, index, record, attribute_name)
     if url.blank?
       record.errors.add(
-        attribute_name.to_sym,
-        :invalid_social_media_link,
-        message: "contains a \"#{channel_name}\" account without a URL.",
+        :"#{attribute_name}.#{index}.#{@url_field}",
+        :blank,
+        message: "cannot be blank",
       )
     elsif !valid_url?(url)
       record.errors.add(
-        attribute_name.to_sym,
-        :invalid_social_media_link,
-        message: "contains a \"#{channel_name}\" account with an invalid URL - use the full URL, including https://",
+        :"#{attribute_name}.#{index}.#{@url_field}",
+        :invalid,
+        message: "is invalid - use the full URL, including https://",
       )
-    elsif record.social_media_links.pluck("url").count(url) > 1
-      unless record.errors.messages[attribute_name.to_sym].include?("already has an account with a URL of \"#{url}\".")
-        record.errors.add(
-          attribute_name.to_sym,
-          :invalid_social_media_link,
-          message: "already has an account with a URL of \"#{url}\".",
-        )
-      end
+    elsif urls_seen.include?(url)
+      record.errors.add(
+        :"#{attribute_name}.#{index}.#{@url_field}",
+        :taken,
+        message: "must be unique",
+      )
+    else
+      urls_seen << url
     end
   end
 

--- a/test/components/admin/error_summary_component_test.rb
+++ b/test/components/admin/error_summary_component_test.rb
@@ -153,6 +153,16 @@ class Admin::ErrorSummaryComponentTest < ViewComponent::TestCase
     assert_equal third_link.text, "Date label is invalid"
     assert_equal third_link[:href], "#labelled_error_summary_test_object_date"
   end
+
+  test "renders full_message for dotted attributes" do
+    object = DottedAttributeErrorSummaryTestObject.new("title", Time.zone.today)
+    object.errors.add("social_media_links.0.url".to_sym, :blank, message: "cannot be blank")
+    render_inline(Admin::ErrorSummaryComponent.new(object:))
+
+    link = page.find(".gem-c-error-summary__list-item a")
+    assert_equal "Social media links 1 url cannot be blank", link.text
+    assert_equal "#dotted_attribute_error_summary_test_object_social_media_links_0_url", link[:href]
+  end
 end
 
 class ErrorSummaryTestObject
@@ -179,4 +189,8 @@ class LabelledErrorSummaryTestObject < ErrorSummaryTestObject
       "date" => "Date label",
     }
   end
+end
+
+class DottedAttributeErrorSummaryTestObject < ErrorSummaryTestObject
+  include WithNestedAttributeErrors
 end

--- a/test/components/admin/error_summary_component_test.rb
+++ b/test/components/admin/error_summary_component_test.rb
@@ -153,6 +153,16 @@ class Admin::ErrorSummaryComponentTest < ViewComponent::TestCase
     assert_equal third_link.text, "Date label is invalid"
     assert_equal third_link[:href], "#labelled_error_summary_test_object_date"
   end
+
+  test "renders full_message for dotted attributes" do
+    object = DottedAttributeErrorSummaryTestObject.new("title", Time.zone.today)
+    object.errors.add(:"social_media_links.0.url", :blank, message: "cannot be blank")
+    render_inline(Admin::ErrorSummaryComponent.new(object:))
+
+    link = page.find(".gem-c-error-summary__list-item a")
+    assert_equal "Social media links 0 url cannot be blank", link.text
+    assert_equal "#dotted_attribute_error_summary_test_object_social_media_links_0_url", link[:href]
+  end
 end
 
 class ErrorSummaryTestObject
@@ -178,5 +188,15 @@ class LabelledErrorSummaryTestObject < ErrorSummaryTestObject
       "title" => "Title label",
       "date" => "Date label",
     }
+  end
+end
+
+class DottedAttributeErrorSummaryTestObject < ErrorSummaryTestObject
+  def method_missing(method_name, *args)
+    method_name.to_s.include?(".") ? nil : super
+  end
+
+  def respond_to_missing?(method_name, include_private = false)
+    method_name.to_s.include?(".") || super
   end
 end

--- a/test/support/with_nested_attribute_errors.rb
+++ b/test/support/with_nested_attribute_errors.rb
@@ -1,0 +1,13 @@
+module WithNestedAttributeErrors
+  # Errors on array item fields use dotted attribute names like
+  # :"social_media_links.0.url" so they can be targeted inline per field.
+  # Rails tries to call these as methods during error processing; returning
+  # nil here prevents a NoMethodError.
+  def method_missing(method_name, *args)
+    method_name.to_s.include?(".") ? nil : super
+  end
+
+  def respond_to_missing?(method_name, include_private = false)
+    method_name.to_s.include?(".") || super
+  end
+end

--- a/test/unit/app/models/configurable_document_type_test.rb
+++ b/test/unit/app/models/configurable_document_type_test.rb
@@ -1,6 +1,96 @@
 require "test_helper"
 
 class ConfigurableDocumentTypeTest < ActiveSupport::TestCase
+  test "#title_for_attribute strips numeric index segments and returns the field title" do
+    type_config = build_configurable_document_type("test_type", {
+      "forms" => {
+        "documents" => {
+          "fields" => {
+            "field_attribute" => {
+              "title" => "Test Attribute",
+              "attribute_path" => %w[field_attribute],
+            },
+          },
+        },
+      },
+    })
+    ConfigurableDocumentType.setup_test_types(type_config)
+    document_type = ConfigurableDocumentType.find("test_type")
+
+    assert_equal "Test Attribute", document_type.title_for_attribute("field_attribute.0")
+  end
+
+  test "#find_field_title returns the field title when segments is empty" do
+    type_config = build_configurable_document_type("test_type", {
+      "forms" => {
+        "documents" => {
+          "fields" => {
+            "field_attribute" => {
+              "title" => "Test Attribute",
+              "attribute_path" => %w[field_attribute],
+            },
+          },
+        },
+      },
+    })
+    ConfigurableDocumentType.setup_test_types(type_config)
+    document_type = ConfigurableDocumentType.find("test_type")
+
+    assert_equal "Test Attribute", document_type.title_for_attribute("field_attribute")
+    assert_equal document_type.title_for_attribute("field_attribute"), document_type.title_for_attribute("field_attribute.0")
+  end
+
+  test "#title_for_attribute returns the title for a nested field" do
+    type_config = build_configurable_document_type("test_type", {
+      "forms" => {
+        "documents" => {
+          "fields" => {
+            "outer_field" => {
+              "title" => "Outer Field",
+              "attribute_path" => %w[outer_field],
+              "fields" => {
+                "inner_field" => {
+                  "title" => "Inner Field Title",
+                  "attribute_path" => %w[inner_field],
+                },
+              },
+            },
+          },
+        },
+      },
+    })
+    ConfigurableDocumentType.setup_test_types(type_config)
+    document_type = ConfigurableDocumentType.find("test_type")
+
+    assert_equal "Inner Field Title", document_type.title_for_attribute("outer_field.0.inner_field")
+  end
+
+  test "#title_for_attribute returns the configured title for a field whose attribute_path includes 'block_content', so error messages use the exact label from the document type config rather than Rails' default humanisation" do
+    type_config = build_configurable_document_type("test_type", {
+      "forms" => {
+        "documents" => {
+          "fields" => {
+            "social_media_links" => {
+              "title" => "Social Media Links",
+              "attribute_path" => %w[block_content social_media_links],
+            },
+          },
+        },
+      },
+    })
+    ConfigurableDocumentType.setup_test_types(type_config)
+    document_type = ConfigurableDocumentType.find("test_type")
+
+    assert_equal "Social Media Links", document_type.title_for_attribute("social_media_links")
+  end
+
+  test "#title_for_attribute returns nil for an unrecognised attribute" do
+    ConfigurableDocumentType.setup_test_types(build_configurable_document_type("test_type"))
+    document_type = ConfigurableDocumentType.find("test_type")
+
+    assert_nil document_type.title_for_attribute("nonexistent_attribute")
+  end
+
   test ".find raises an error if the type is not specified" do
     error = assert_raises(ConfigurableDocumentType::NotFoundError) { ConfigurableDocumentType.find(nil) }
     assert_equal "No document type specified", error.message

--- a/test/unit/app/models/configurable_document_type_test.rb
+++ b/test/unit/app/models/configurable_document_type_test.rb
@@ -91,6 +91,30 @@ class ConfigurableDocumentTypeTest < ActiveSupport::TestCase
     assert_nil document_type.title_for_attribute("nonexistent_attribute")
   end
 
+  test "#title_for_attribute only returns the title for the field whose attribute_path matches the given attribute, not the first field it encounters" do
+    type_config = build_configurable_document_type("test_type", {
+      "forms" => {
+        "documents" => {
+          "fields" => {
+            "social_media_links" => {
+              "title" => "Social Media Links",
+              "attribute_path" => %w[social_media_links],
+            },
+            "body" => {
+              "title" => "Body",
+              "attribute_path" => %w[body],
+            },
+          },
+        },
+      },
+    })
+    ConfigurableDocumentType.setup_test_types(type_config)
+    document_type = ConfigurableDocumentType.find("test_type")
+
+    assert_equal "Body", document_type.title_for_attribute("body")
+    assert_equal "Social Media Links", document_type.title_for_attribute("social_media_links")
+  end
+
   test ".find raises an error if the type is not specified" do
     error = assert_raises(ConfigurableDocumentType::NotFoundError) { ConfigurableDocumentType.find(nil) }
     assert_equal "No document type specified", error.message

--- a/test/unit/app/models/standard_edition/block_content_test.rb
+++ b/test/unit/app/models/standard_edition/block_content_test.rb
@@ -177,6 +177,26 @@ class BlockContentTest < ActiveSupport::TestCase
 
     page.attributes = { "test_array_attribute" => [{ "social_media_service_id" => "1", "url" => "broken url" }] }
     assert_not page.valid?
-    assert_not page.errors.where("test_array_attribute", :invalid_social_media_link).empty?
+    assert_not page.errors.where("test_array_attribute.0.url".to_sym, :invalid).empty?
+  end
+
+  test "social_media_links validation adds per-field errors when channel and URL are blank" do
+    schema = @schema.merge({
+      "validations" => {
+        "social_media_links" => {
+          "attributes" => %w[test_array_attribute],
+          "fields" => {
+            "service_field" => "social_media_service_id",
+            "url_field" => "url",
+          },
+        },
+      },
+    })
+    page = StandardEdition::BlockContent.new(schema)
+
+    page.attributes = { "test_array_attribute" => [{ "social_media_service_id" => "", "url" => "" }] }
+    assert_not page.valid?
+    assert page.errors[:"test_array_attribute.0.social_media_service_id"].any?
+    assert page.errors[:"test_array_attribute.0.url"].any?
   end
 end

--- a/test/unit/app/models/standard_edition/block_content_test.rb
+++ b/test/unit/app/models/standard_edition/block_content_test.rb
@@ -177,6 +177,26 @@ class BlockContentTest < ActiveSupport::TestCase
 
     page.attributes = { "test_array_attribute" => [{ "social_media_service_id" => "1", "url" => "broken url" }] }
     assert_not page.valid?
-    assert_not page.errors.where("test_array_attribute", :invalid_social_media_link).empty?
+    assert_not page.errors.where(:"test_array_attribute.0.url", :invalid).empty?
+  end
+
+  test "social_media_links validation adds per-field errors when channel and URL are blank" do
+    schema = @schema.merge({
+      "validations" => {
+        "social_media_links" => {
+          "attributes" => %w[test_array_attribute],
+          "fields" => {
+            "service_field" => "social_media_service_id",
+            "url_field" => "url",
+          },
+        },
+      },
+    })
+    page = StandardEdition::BlockContent.new(schema)
+
+    page.attributes = { "test_array_attribute" => [{ "social_media_service_id" => "", "url" => "" }] }
+    assert_not page.valid?
+    assert page.errors[:"test_array_attribute.0.social_media_service_id"].any?
+    assert page.errors[:"test_array_attribute.0.url"].any?
   end
 end

--- a/test/unit/app/models/standard_edition_test.rb
+++ b/test/unit/app/models/standard_edition_test.rb
@@ -893,4 +893,27 @@ class StandardEditionTest < ActiveSupport::TestCase
 
     assert_not edition.change_note_required?
   end
+
+  test ".human_attribute_name returns a field title when the base edition has a matching document type attribute" do
+    type_config = build_configurable_document_type("test_type", {
+      "forms" => {
+        "documents" => {
+          "fields" => {
+            "my_field" => {
+              "title" => "My Field Title",
+              "attribute_path" => %w[my_field],
+            },
+          },
+        },
+      },
+    })
+    ConfigurableDocumentType.setup_test_types(type_config)
+    edition = build(:standard_edition, configurable_document_type: "test_type")
+
+    assert_equal "My Field Title", StandardEdition.human_attribute_name("my_field", base: edition)
+  end
+
+  test ".human_attribute_name falls back to the Rails default when no base edition is provided" do
+    assert_equal "Title", StandardEdition.human_attribute_name("title")
+  end
 end

--- a/test/unit/app/validators/social_media_links_validator_test.rb
+++ b/test/unit/app/validators/social_media_links_validator_test.rb
@@ -2,8 +2,6 @@ require "test_helper"
 
 class SocialMediaLinksValidatorTest < ActiveSupport::TestCase
   setup do
-    @social_media_service_1 = create(:social_media_service, name: "Facebook")
-    @social_media_service_2 = create(:social_media_service, name: "LinkedIn")
     @validator = SocialMediaLinksValidator.new({
       attributes: %w[social_media_links],
       fields: {
@@ -15,6 +13,7 @@ class SocialMediaLinksValidatorTest < ActiveSupport::TestCase
 
   class SocialMediaLinksValidatorTestClass
     include ActiveModel::API
+    include WithNestedAttributeErrors
     attr_accessor :social_media_links
   end
 
@@ -25,48 +24,61 @@ class SocialMediaLinksValidatorTest < ActiveSupport::TestCase
     assert block_content.errors.empty?
   end
 
-  test "social media links are invalid when none of social media service and URL are provided" do
+  test "social media links are invalid when both channel and URL are blank" do
     block_content = SocialMediaLinksValidatorTestClass.new
     block_content.social_media_links = [
       { "social_media_service_name" => "", "url" => "" },
     ]
     @validator.validate(block_content)
 
-    assert_equal ["Social media links contains an account (\"Social media account 1\") without a service selected."], block_content.errors.full_messages
+    assert_includes block_content.errors["social_media_links.0.social_media_service_name".to_sym], "cannot be blank"
+    assert_includes block_content.errors["social_media_links.0.url".to_sym], "cannot be blank"
   end
 
-  test "social media links are invalid when no social media service is chosen and a URL is provided" do
+  test "social media links are invalid when no channel is chosen and a URL is provided" do
     block_content = SocialMediaLinksValidatorTestClass.new
     block_content.social_media_links = [
       { "social_media_service_name" => "", "url" => "https://facebook.com" },
     ]
     @validator.validate(block_content)
 
-    assert_equal ["Social media links contains an account (\"Social media account 1\") without a service selected."], block_content.errors.full_messages
+    assert_includes block_content.errors["social_media_links.0.social_media_service_name".to_sym], "cannot be blank"
+    assert_empty block_content.errors["social_media_links.0.url".to_sym]
   end
 
-  test "social media links are invalid when a social media service is chosen but no URL is provided" do
+  test "social media links are invalid when a channel is chosen but no URL is provided" do
     block_content = SocialMediaLinksValidatorTestClass.new
     block_content.social_media_links = [
       { "social_media_service_name" => "Facebook", "url" => "" },
     ]
     @validator.validate(block_content)
 
-    assert_equal ["Social media links contains a \"Facebook\" account without a URL."], block_content.errors.full_messages
+    assert_empty block_content.errors["social_media_links.0.social_media_service_name".to_sym]
+    assert_includes block_content.errors["social_media_links.0.url".to_sym], "cannot be blank"
   end
 
-  test "social media links are invalid when a social media service is chosen and a malformed URL is provided" do
+  test "social media links are invalid when a channel is chosen and a malformed URL is provided" do
     block_content = SocialMediaLinksValidatorTestClass.new
     block_content.social_media_links = [
       { "social_media_service_name" => "Facebook", "url" => "not-a-url" },
-      { "social_media_service_name" => "Twitter", "url" => "http://linkedin.com" },
     ]
     @validator.validate(block_content)
 
-    assert_equal ["Social media links contains a \"Facebook\" account with an invalid URL - use the full URL, including https://"], block_content.errors.full_messages
+    assert_includes block_content.errors["social_media_links.0.url".to_sym], "is invalid - use the full URL, including https://"
   end
 
-  test "social media links are invalid if two of the same social media service are provided" do
+  test "social media links are invalid when no channel is chosen and a malformed URL is provided" do
+    block_content = SocialMediaLinksValidatorTestClass.new
+    block_content.social_media_links = [
+      { "social_media_service_name" => "", "url" => "not-a-url" },
+    ]
+    @validator.validate(block_content)
+
+    assert_includes block_content.errors["social_media_links.0.social_media_service_name".to_sym], "cannot be blank"
+    assert_includes block_content.errors["social_media_links.0.url".to_sym], "is invalid - use the full URL, including https://"
+  end
+
+  test "social media links are invalid if two of the same channel are provided" do
     block_content = SocialMediaLinksValidatorTestClass.new
     block_content.social_media_links = [
       { "social_media_service_name" => "Facebook", "url" => "http://facebook.com/govuk" },
@@ -74,21 +86,23 @@ class SocialMediaLinksValidatorTest < ActiveSupport::TestCase
     ]
     @validator.validate(block_content)
 
-    assert_equal ["Social media links contains another account with a service of \"Facebook\"."], block_content.errors.full_messages
+    assert_empty block_content.errors["social_media_links.0.social_media_service_name".to_sym]
+    assert_includes block_content.errors["social_media_links.1.social_media_service_name".to_sym], "must be unique"
   end
 
-  test "social media links are invalid if two services have the same URL" do
+  test "social media links are invalid if two channels have the same URL" do
     block_content = SocialMediaLinksValidatorTestClass.new
     block_content.social_media_links = [
-      { "social_media_service_name" => "Twiter", "url" => "http://facebook.com/govuk" },
+      { "social_media_service_name" => "Twitter", "url" => "http://facebook.com/govuk" },
       { "social_media_service_name" => "Facebook", "url" => "http://facebook.com/govuk" },
     ]
     @validator.validate(block_content)
 
-    assert_equal ["Social media links already has an account with a URL of \"http://facebook.com/govuk\"."], block_content.errors.full_messages
+    assert_empty block_content.errors["social_media_links.0.url".to_sym]
+    assert_includes block_content.errors["social_media_links.1.url".to_sym], "must be unique"
   end
 
-  test "social media links are valid when multiple 'Other' services are provided with different URLs" do
+  test "social media links are valid when multiple 'Other' channels are provided with different URLs" do
     block_content = SocialMediaLinksValidatorTestClass.new
     block_content.social_media_links = [
       { "social_media_service_name" => "Other", "url" => "http://example.com/one" },
@@ -99,7 +113,7 @@ class SocialMediaLinksValidatorTest < ActiveSupport::TestCase
     assert block_content.errors.empty?
   end
 
-  test "social media links are valid when a social media service is chosen and a well-formed URL is provided" do
+  test "social media links are valid when a channel is chosen and a well-formed URL is provided" do
     block_content = SocialMediaLinksValidatorTestClass.new
     block_content.social_media_links = [
       { "social_media_service_name" => "Facebook", "url" => "http://facebook.com/govuk" },

--- a/test/unit/app/validators/social_media_links_validator_test.rb
+++ b/test/unit/app/validators/social_media_links_validator_test.rb
@@ -2,8 +2,6 @@ require "test_helper"
 
 class SocialMediaLinksValidatorTest < ActiveSupport::TestCase
   setup do
-    @social_media_service_1 = create(:social_media_service, name: "Facebook")
-    @social_media_service_2 = create(:social_media_service, name: "LinkedIn")
     @validator = SocialMediaLinksValidator.new({
       attributes: %w[social_media_links],
       fields: {
@@ -25,7 +23,7 @@ class SocialMediaLinksValidatorTest < ActiveSupport::TestCase
     assert block_content.errors.empty?
   end
 
-  test "social media links are invalid when none of social media service and URL are provided" do
+  test "social media links are invalid when both channel and URL are blank" do
     block_content = SocialMediaLinksValidatorTestClass.new
     block_content.social_media_links = [
       { "social_media_service_name" => "", "url" => "" },
@@ -35,7 +33,7 @@ class SocialMediaLinksValidatorTest < ActiveSupport::TestCase
     assert_equal ["Social media links contains an account (\"Social media account 1\") without a service selected."], block_content.errors.full_messages
   end
 
-  test "social media links are invalid when no social media service is chosen and a URL is provided" do
+  test "social media links are invalid when no channel is chosen and a URL is provided" do
     block_content = SocialMediaLinksValidatorTestClass.new
     block_content.social_media_links = [
       { "social_media_service_name" => "", "url" => "https://facebook.com" },
@@ -45,7 +43,7 @@ class SocialMediaLinksValidatorTest < ActiveSupport::TestCase
     assert_equal ["Social media links contains an account (\"Social media account 1\") without a service selected."], block_content.errors.full_messages
   end
 
-  test "social media links are invalid when a social media service is chosen but no URL is provided" do
+  test "social media links are invalid when a channel is chosen but no URL is provided" do
     block_content = SocialMediaLinksValidatorTestClass.new
     block_content.social_media_links = [
       { "social_media_service_name" => "Facebook", "url" => "" },
@@ -55,7 +53,7 @@ class SocialMediaLinksValidatorTest < ActiveSupport::TestCase
     assert_equal ["Social media links contains a \"Facebook\" account without a URL."], block_content.errors.full_messages
   end
 
-  test "social media links are invalid when a social media service is chosen and a malformed URL is provided" do
+  test "social media links are invalid when a channel is chosen and a malformed URL is provided" do
     block_content = SocialMediaLinksValidatorTestClass.new
     block_content.social_media_links = [
       { "social_media_service_name" => "Facebook", "url" => "not-a-url" },
@@ -66,7 +64,7 @@ class SocialMediaLinksValidatorTest < ActiveSupport::TestCase
     assert_equal ["Social media links contains a \"Facebook\" account with an invalid URL - use the full URL, including https://"], block_content.errors.full_messages
   end
 
-  test "social media links are invalid if two of the same social media service are provided" do
+  test "social media links are invalid if two of the same channel are provided" do
     block_content = SocialMediaLinksValidatorTestClass.new
     block_content.social_media_links = [
       { "social_media_service_name" => "Facebook", "url" => "http://facebook.com/govuk" },
@@ -77,7 +75,7 @@ class SocialMediaLinksValidatorTest < ActiveSupport::TestCase
     assert_equal ["Social media links contains another account with a service of \"Facebook\"."], block_content.errors.full_messages
   end
 
-  test "social media links are invalid if two services have the same URL" do
+  test "social media links are invalid if two channels have the same URL" do
     block_content = SocialMediaLinksValidatorTestClass.new
     block_content.social_media_links = [
       { "social_media_service_name" => "Twiter", "url" => "http://facebook.com/govuk" },
@@ -88,7 +86,7 @@ class SocialMediaLinksValidatorTest < ActiveSupport::TestCase
     assert_equal ["Social media links already has an account with a URL of \"http://facebook.com/govuk\"."], block_content.errors.full_messages
   end
 
-  test "social media links are valid when multiple 'Other' services are provided with different URLs" do
+  test "social media links are valid when multiple 'Other' channels are provided with different URLs" do
     block_content = SocialMediaLinksValidatorTestClass.new
     block_content.social_media_links = [
       { "social_media_service_name" => "Other", "url" => "http://example.com/one" },
@@ -99,7 +97,7 @@ class SocialMediaLinksValidatorTest < ActiveSupport::TestCase
     assert block_content.errors.empty?
   end
 
-  test "social media links are valid when a social media service is chosen and a well-formed URL is provided" do
+  test "social media links are valid when a channel is chosen and a well-formed URL is provided" do
     block_content = SocialMediaLinksValidatorTestClass.new
     block_content.social_media_links = [
       { "social_media_service_name" => "Facebook", "url" => "http://facebook.com/govuk" },

--- a/test/unit/app/validators/social_media_links_validator_test.rb
+++ b/test/unit/app/validators/social_media_links_validator_test.rb
@@ -14,6 +14,18 @@ class SocialMediaLinksValidatorTest < ActiveSupport::TestCase
   class SocialMediaLinksValidatorTestClass
     include ActiveModel::API
     attr_accessor :social_media_links
+
+    # Errors are added with dotted attribute names e.g. :"social_media_links.0.url".
+    # Rails tries to call these as methods, which would raise NoMethodError since dots
+    # aren't valid in Ruby method names. BlockContent handles this in production; we
+    # replicate it here.
+    def method_missing(method_name, *args)
+      method_name.to_s.include?(".") ? nil : super
+    end
+
+    def respond_to_missing?(method_name, include_private = false)
+      method_name.to_s.include?(".") || super
+    end
   end
 
   test "empty social media links are valid" do
@@ -30,7 +42,8 @@ class SocialMediaLinksValidatorTest < ActiveSupport::TestCase
     ]
     @validator.validate(block_content)
 
-    assert_equal ["Social media links contains an account (\"Social media account 1\") without a service selected."], block_content.errors.full_messages
+    assert_includes block_content.errors[:"social_media_links.0.social_media_service_name"], "cannot be blank"
+    assert_includes block_content.errors[:"social_media_links.0.url"], "cannot be blank"
   end
 
   test "social media links are invalid when no channel is chosen and a URL is provided" do
@@ -40,7 +53,8 @@ class SocialMediaLinksValidatorTest < ActiveSupport::TestCase
     ]
     @validator.validate(block_content)
 
-    assert_equal ["Social media links contains an account (\"Social media account 1\") without a service selected."], block_content.errors.full_messages
+    assert_includes block_content.errors[:"social_media_links.0.social_media_service_name"], "cannot be blank"
+    assert_empty block_content.errors[:"social_media_links.0.url"]
   end
 
   test "social media links are invalid when a channel is chosen but no URL is provided" do
@@ -50,18 +64,29 @@ class SocialMediaLinksValidatorTest < ActiveSupport::TestCase
     ]
     @validator.validate(block_content)
 
-    assert_equal ["Social media links contains a \"Facebook\" account without a URL."], block_content.errors.full_messages
+    assert_empty block_content.errors[:"social_media_links.0.social_media_service_name"]
+    assert_includes block_content.errors[:"social_media_links.0.url"], "cannot be blank"
   end
 
   test "social media links are invalid when a channel is chosen and a malformed URL is provided" do
     block_content = SocialMediaLinksValidatorTestClass.new
     block_content.social_media_links = [
       { "social_media_service_name" => "Facebook", "url" => "not-a-url" },
-      { "social_media_service_name" => "Twitter", "url" => "http://linkedin.com" },
     ]
     @validator.validate(block_content)
 
-    assert_equal ["Social media links contains a \"Facebook\" account with an invalid URL - use the full URL, including https://"], block_content.errors.full_messages
+    assert_includes block_content.errors[:"social_media_links.0.url"], "is invalid - use the full URL, including https://"
+  end
+
+  test "social media links are invalid when no channel is chosen and a malformed URL is provided" do
+    block_content = SocialMediaLinksValidatorTestClass.new
+    block_content.social_media_links = [
+      { "social_media_service_name" => "", "url" => "not-a-url" },
+    ]
+    @validator.validate(block_content)
+
+    assert_includes block_content.errors[:"social_media_links.0.social_media_service_name"], "cannot be blank"
+    assert_includes block_content.errors[:"social_media_links.0.url"], "is invalid - use the full URL, including https://"
   end
 
   test "social media links are invalid if two of the same channel are provided" do
@@ -72,18 +97,20 @@ class SocialMediaLinksValidatorTest < ActiveSupport::TestCase
     ]
     @validator.validate(block_content)
 
-    assert_equal ["Social media links contains another account with a service of \"Facebook\"."], block_content.errors.full_messages
+    assert_empty block_content.errors[:"social_media_links.0.social_media_service_name"]
+    assert_includes block_content.errors[:"social_media_links.1.social_media_service_name"], "must be unique"
   end
 
   test "social media links are invalid if two channels have the same URL" do
     block_content = SocialMediaLinksValidatorTestClass.new
     block_content.social_media_links = [
-      { "social_media_service_name" => "Twiter", "url" => "http://facebook.com/govuk" },
+      { "social_media_service_name" => "Twitter", "url" => "http://facebook.com/govuk" },
       { "social_media_service_name" => "Facebook", "url" => "http://facebook.com/govuk" },
     ]
     @validator.validate(block_content)
 
-    assert_equal ["Social media links already has an account with a URL of \"http://facebook.com/govuk\"."], block_content.errors.full_messages
+    assert_empty block_content.errors[:"social_media_links.0.url"]
+    assert_includes block_content.errors[:"social_media_links.1.url"], "must be unique"
   end
 
   test "social media links are valid when multiple 'Other' channels are provided with different URLs" do

--- a/test/unit/support/with_nested_attribute_errors_test.rb
+++ b/test/unit/support/with_nested_attribute_errors_test.rb
@@ -1,0 +1,32 @@
+require "test_helper"
+
+class WithNestedAttributeErrorsTest < ActiveSupport::TestCase
+  class TestClass
+    include ActiveModel::API
+    include WithNestedAttributeErrors
+    attr_accessor :name
+  end
+
+  setup do
+    @obj = TestClass.new
+  end
+
+  test "prevents NoMethodError when Rails processes dotted attribute errors" do
+    @obj.errors.add(:"social_media_links.0.url", "cannot be blank")
+    assert_nothing_raised { @obj.errors.full_messages }
+  end
+
+  test "returns nil for dotted attribute names and responds to them" do
+    assert_nil @obj.public_send(:"social_media_links.0.url")
+    assert @obj.respond_to?(:"social_media_links.0.url")
+  end
+
+  test "raises NoMethodError for non-dotted unknown methods and does not respond to them" do
+    assert_raises(NoMethodError) { @obj.public_send(:nonexistent_method) }
+    assert_not @obj.respond_to?(:nonexistent_method)
+  end
+
+  test "does not affect respond_to? for known methods" do
+    assert @obj.respond_to?(:name)
+  end
+end


### PR DESCRIPTION
## Overview
This update improves the clarity, consistency, and usability of validation errors when publishers add social media accounts.

## Why
Previously, validation feedback for social media accounts was unclear and inconsistent:
- Errors only appeared in the summary, not inline  
- It wasn’t obvious which field (Channel or URL) needed fixing  
- Terminology used “service” instead of “channel”  
- Only one error appeared even when multiple fields were invalid  

## What Changed
Validation behaviour and messaging have been enhanced:
- Terminology updated from **service → channel** to match the UI  
- Errors are now attached to **individual fields (Channel, URL)** instead of a shared attribute  
- Errors display **both inline and in the summary**  
- Validation runs **independently per field**  
- Multiple errors are shown when applicable (e.g. both fields blank)  
- Invalid fields are highlighted with a **red border**  

## ACs

Meets the ACs as described in the [Jira ticket](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?assignee=5caf4d888c2c1a75f3e46ef6&selectedIssue=WHIT-3156)

---

## UI Error Examples

### 1. Both fields blank

<img width="857" height="824" alt="Screenshot 2026-04-14 at 11 33 54" src="https://github.com/user-attachments/assets/a1bcc138-c10e-423b-9000-392585af585b" />

---

### 2. Channel selected, URL missing

<img width="836" height="849" alt="Screenshot 2026-04-14 at 11 34 13" src="https://github.com/user-attachments/assets/b31f2a69-23ce-44de-80db-c7fd79290aac" />

---

### 3. URL entered, channel missing

<img width="857" height="855" alt="Screenshot 2026-04-14 at 11 34 25" src="https://github.com/user-attachments/assets/cc15eb95-9140-4be5-a82f-6a4ed22a4b5b" />

---

### 4. Multiple accounts, mixed errors

<img width="816" height="987" alt="Screenshot 2026-04-14 at 11 35 34" src="https://github.com/user-attachments/assets/a20ad5f7-96be-41d8-a814-980610037ce8" />

---