### PR TITLE
[WHIT-3323] Update slug generation code to skip callbacks

### DIFF
--- a/app/models/concerns/edition/identifiable.rb
+++ b/app/models/concerns/edition/identifiable.rb
@@ -31,6 +31,7 @@ module Edition::Identifiable
 
   def set_slug
     # Translations return nil from `string_to_slug`, in which case we return early as we should not set the slug based on a translation title
+    # Corporate information pages also return nil from `string_to_slug`, because their slugs are set based on document type.
     return if string_for_slug.nil?
 
     # Generate a default slug using the babosa gem's to_slug and normalize methods

--- a/db/data_migration/20260414111505_generate_slug_from_title.rb
+++ b/db/data_migration/20260414111505_generate_slug_from_title.rb
@@ -1,9 +1,12 @@
 total_processed = 0
 
-Edition.skip_callback(:update, :after, :republish_topical_event_to_publishing_api)
 Edition.in_pre_publication_state.find_each(batch_size: 1000) do |edition|
   edition.set_slug
-  total_processed += 1 if edition.save(validate: false)
+  total_processed += 1 if edition.update_columns(
+    slug: edition.slug,
+    slug_from_title: edition.slug_from_title,
+    touch: false,
+  )
 
   puts "Processed #{total_processed} editions" if (total_processed % 5000).zero?
 end


### PR DESCRIPTION
We got a stale object error in production. We're not entirely sure what caused it, but this should eliminate some of the likely responsible behaviours.

The original data migration has not run in production, so it's safe to update the file.

[Jira](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-3323)
