### PR TITLE
[WHIT-3323] Store accurate slug value

### DIFF
--- a/app/models/concerns/edition/identifiable.rb
+++ b/app/models/concerns/edition/identifiable.rb
@@ -6,7 +6,8 @@ module Edition::Identifiable
     validates :document, presence: true
     before_validation :ensure_presence_of_document, on: :create
     before_validation :propagate_type_to_document
-    before_save :set_slug, if: :title_changed?
+    before_save :set_slug_from_title, if: -> { title_changed? }
+    before_save :set_slug, if: -> { slug_from_title_changed? || slug_override_changed? }
 
     scope :latest_edition, -> { joins(:document).where("editions.id = documents.latest_edition_id") }
     scope :live_edition, -> { joins(:document).where("documents.live_edition_id = editions.id") }
@@ -21,15 +22,7 @@ module Edition::Identifiable
 
   delegate :change_history, :content_id, to: :document, allow_nil: true
 
-  def slug
-    slug_override.presence || super
-  end
-
-  def slug_from_title
-    self[:slug]
-  end
-
-  def set_slug
+  def set_slug_from_title
     # Translations return nil from `string_to_slug`, in which case we return early as we should not set the slug based on a translation title
     # Corporate information pages also return nil from `string_to_slug`, because their slugs are set based on document type.
     return if string_for_slug.nil?
@@ -42,7 +35,6 @@ module Edition::Identifiable
     # For languages the babosa gem does not support, its `normalize` method will return an empty string
     # when the to_ascii option is used. In this case we fall back to the document ID as the slug
     if default_slug.blank?
-      self[:slug] = document_id
       self[:slug_from_title] = document_id
       return
     end
@@ -63,10 +55,13 @@ module Edition::Identifiable
         attempt += 1
       else
         candidate_slug_is_a_duplicate = false
-        self[:slug] = candidate_slug
         self[:slug_from_title] = candidate_slug
       end
     end
+  end
+
+  def set_slug
+    self[:slug] = slug_override.presence || slug_from_title
   end
 
   def linkable?

--- a/app/models/concerns/edition/scopes/searchable_by_title.rb
+++ b/app/models/concerns/edition/scopes/searchable_by_title.rb
@@ -6,7 +6,7 @@ module Edition::Scopes::SearchableByTitle
       like_clause = "%#{sanitize_sql_like(keywords)}%"
 
       if keywords.match?(/\A[a-z0-9]+(-[a-z0-9]+)+\z/)
-        where(slug: keywords).or(where(slug_override: keywords))
+        where(slug: keywords)
       else
         in_default_locale
           .includes(:document)

--- a/app/models/plan_for_change_landing_page.rb
+++ b/app/models/plan_for_change_landing_page.rb
@@ -3,8 +3,9 @@ class PlanForChangeLandingPage < Edition
   include Edition::Organisations
   include Edition::Images
 
-  validates :base_path, presence: true, format: { with: /\A\/.*\z/, message: "must start with a slash (/)" }
-  validate :base_path_must_not_be_taken
+  validates :slug_override, presence: true
+  validates :slug_override, format: { with: /\A\/.*\z/, message: "must start with a slash (/)" }, if: -> { slug_override.present? }
+  validate :slug_override_must_not_be_taken
   validate do
     if landing_page_body.invalid?
       errors.add(:body, "contained errors")
@@ -55,7 +56,7 @@ class PlanForChangeLandingPage < Edition
 
 private
 
-  def base_path_must_not_be_taken
-    errors.add(:base_path, " is already taken") if PlanForChangeLandingPage.where(slug_override:).where.not(document_id: document_id).exists?
+  def slug_override_must_not_be_taken
+    errors.add(:slug_override, "is already taken") if PlanForChangeLandingPage.where(slug_override:).where.not(document_id: document_id).exists?
   end
 end

--- a/app/views/admin/republishing/confirm_document.html.erb
+++ b/app/views/admin/republishing/confirm_document.html.erb
@@ -33,7 +33,7 @@
     } %>
     <%= render partial: "shared/republishing_form", locals: {
       republishing_event: @republishing_event,
-      republishing_path: admin_republishing_document_republish_path(@document.live_edition.slug_from_title),
+      republishing_path: admin_republishing_document_republish_path(@document.live_edition.slug),
     } %>
   </section>
 </div>

--- a/db/migrate/20260503161913_set_slug_to_slug_override_when_slug_override_present.rb
+++ b/db/migrate/20260503161913_set_slug_to_slug_override_when_slug_override_present.rb
@@ -1,0 +1,27 @@
+class SetSlugToSlugOverrideWhenSlugOverridePresent < ActiveRecord::Migration[8.1]
+  def change
+    find_slug_overrides_sql = <<-SQL
+      SELECT e.id
+      FROM editions e
+      WHERE e.slug_override IS NOT NULL
+      AND e.slug_override != ''
+      AND e.slug != e.slug_override
+      AND e.state NOT IN ('deleted', 'superseded');
+    SQL
+
+    edition_ids = ActiveRecord::Base.connection.select_values(find_slug_overrides_sql)
+    Rails.logger.info "Found #{edition_ids.size} editions where the slug does not match the slug_override."
+
+    update_sql = <<-SQL
+      UPDATE editions e
+      SET e.slug = e.slug_override
+      WHERE e.slug_override IS NOT NULL
+      AND e.slug_override != ''
+      AND e.slug != e.slug_override
+      AND e.state NOT IN ('deleted', 'superseded');
+    SQL
+
+    updated_editions = ActiveRecord::Base.connection.update(update_sql)
+    Rails.logger.info "\nMigration complete. Slug set to the value of the slug_override for #{updated_editions} editions."
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_24_093745) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_03_161913) do
   create_table "assets", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.bigint "assetable_id"

--- a/test/unit/app/models/edition/identifiable_test.rb
+++ b/test/unit/app/models/edition/identifiable_test.rb
@@ -64,6 +64,8 @@ class Edition::IdentifiableTest < ActiveSupport::TestCase
 end
 
 class Edition::SluggingTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
   class SluggableEdition < Edition
     def self.create!(attributes)
       super({
@@ -90,97 +92,171 @@ class Edition::SluggingTest < ActiveSupport::TestCase
     end
   end
 
-  test "it does not update the slug if the `string_for_slug` method returns nil" do
-    slug = "test-title"
-    edition = SluggableEdition.create!(title: "Test Title", slug: slug)
-    edition.stubs(:string_for_slug).returns(nil)
-    edition.save!
-    assert_equal slug, edition.slug
+  # Edition state is not listed in UNMODIFIABLE_STATES; edition can be generally edited, including title changes.
+  describe "modifiable edition slug behaviour" do
+    test "it does not update the slug if the `string_for_slug` method returns nil" do
+      slug = "test-title"
+      edition = SluggableEdition.create!(title: "Test Title", slug: slug)
+      edition.stubs(:string_for_slug).returns(nil)
+      edition.save!
+      assert_equal slug, edition.slug
+    end
+
+    test "it updates the slug and slug_from_title when the title changes and override is nil" do
+      edition = SluggableEdition.create!(title: "Original Title", slug_override: nil)
+      original_slug = edition.slug
+      edition.title = "New Title"
+      edition.save!
+      assert_not_equal original_slug, edition.slug
+      assert_equal "new-title", edition.slug
+      assert_equal "new-title", edition.slug_from_title
+    end
+
+    test "it updates the slug and slug_from_title when the title changes and override is blank" do
+      edition = SluggableEdition.create!(title: "Original Title", slug_override: "")
+      original_slug = edition.slug
+      edition.title = "New Title"
+      edition.save!
+      assert_not_equal original_slug, edition.slug
+      assert_equal "new-title", edition.slug
+      assert_equal "new-title", edition.slug_from_title
+    end
+
+    test "it applies the slug override to a draft, if override present" do
+      draft_edition = SluggableEdition.create!(title: "Original Title")
+      draft_edition.slug_override = "original-title-override"
+      draft_edition.save!
+      assert_equal "original-title-override", draft_edition.slug
+    end
+
+    test "it generates a unique slug when a duplicate exists of the same edition type" do
+      first_edition = SluggableEdition.create!(title: "Same Title", slug: nil)
+      second_edition = SluggableEdition.create!(title: "Same Title", slug: nil)
+
+      assert_equal "same-title", first_edition.slug
+      assert_equal "same-title--2", second_edition.slug
+    end
+
+    test "it generates a unique slug when two duplicates exist of the same edition type" do
+      SluggableEdition.create!(title: "Same Title", slug: nil)
+      SluggableEdition.create!(title: "Same Title", slug: nil)
+      third_edition = SluggableEdition.create!(title: "Same Title", slug: nil)
+
+      assert_equal "same-title--3", third_edition.slug
+    end
+
+    test "it reuses a slug if it becomes available" do
+      clashing_draft = SluggableEdition.create!(title: "Original Title")
+      draft_edition = SluggableEdition.create!(title: "Original Title")
+      assert_equal "original-title", clashing_draft.slug
+      assert_equal "original-title--2", draft_edition.slug
+
+      clashing_draft.destroy!
+      another_draft_edition = SluggableEdition.create!(title: "Original Title")
+
+      assert_equal "original-title", another_draft_edition.slug
+    end
+
+    test "it generates a unique slug when a duplicate exists of a configurable document type with the same base path prefix" do
+      ConfigurableDocumentType.setup_test_types(build_configurable_document_type("type_one")
+                                                  .merge(build_configurable_document_type("type_two")))
+
+      first_edition = StandardEdition.create!(title: "Shared Title", type: "StandardEdition", configurable_document_type: "type_one", document: Document.new, creator: User.new, previously_published: Time.zone.now, summary: "test", body: "test", block_content: {})
+
+      second_edition = StandardEdition.create!(title: "Shared Title", type: "StandardEdition", configurable_document_type: "type_two", document: Document.new, creator: User.new, previously_published: Time.zone.now, summary: "test", body: "test", block_content: {})
+
+      assert_equal "shared-title", first_edition.slug
+      assert_equal "shared-title--2", second_edition.slug
+    end
+
+    test "it normalizes special characters in slugs" do
+      edition = SluggableEdition.create!(title: "Title with Special! Characters & Stuff", slug: nil)
+      assert_match(/^[a-z0-9-]+$/, edition.slug)
+    end
+
+    test "it sets the slug to the document ID if the title language cannot be normalised" do
+      document = create(:document)
+      edition = SluggableEdition.create!(title: "英国驻华大使馆", slug: nil, document:)
+      assert_equal(document.id.to_s, edition.slug)
+    end
+
+    test "it truncates slugs to 150 characters" do
+      long_title = "a" * 200
+      edition = SluggableEdition.create!(title: long_title, slug: nil)
+      assert edition.slug.length <= 150
+    end
+
+    test "it allows same slug for different edition types" do
+      Edition.create!(title: "Shared Title", type: "Edition", document: Document.new, creator: User.new, previously_published: Time.zone.now, summary: "test", body: "test")
+
+      first_edition = SluggableEdition.create!(title: "Shared Title", slug: nil)
+
+      assert_equal "shared-title", first_edition.slug
+    end
+
+    test "it allows same slug for configurable document edition types with different base path prefixes" do
+      ConfigurableDocumentType.setup_test_types(build_configurable_document_type("type_one")
+                                                  .merge(build_configurable_document_type("type_two", {
+                                                    "settings" => {
+                                                      "base_path_prefix" => "/government/type_two",
+                                                    },
+                                                  })))
+
+      StandardEdition.create!(title: "Shared Title", type: "StandardEdition", configurable_document_type: "type_one", document: Document.new, creator: User.new, previously_published: Time.zone.now, summary: "test", body: "test", block_content: {})
+
+      first_edition = StandardEdition.create!(title: "Shared Title", type: "StandardEdition", configurable_document_type: "type_two", document: Document.new, creator: User.new, previously_published: Time.zone.now, summary: "test", body: "test", block_content: {})
+
+      assert_equal "shared-title", first_edition.slug
+    end
   end
 
-  test "it applies the slug override if one is present" do
-    first_edition = SluggableEdition.create_published!(title: "Original Title", slug: "original-title")
-    second_edition = SluggableEdition.create!(title: "Draft Title", slug: "draft-title", slug_override: "original-title", document: first_edition.document)
+  # Edition state is listed in UNMODIFIABLE_STATES. Changing the title or the override requires skipping validations.
+  describe "unmodifiable edition slug behaviour" do
+    test "updates slug for published editions when saved with validate: false, if slug_from_title changes" do
+      published_edition = SluggableEdition.create_published!(title: "Original Title")
+      assert_equal "original-title", published_edition.slug
+      assert_equal "original-title", published_edition.slug_from_title
 
-    assert_equal first_edition.slug, second_edition.slug
-    assert_equal "original-title", second_edition.slug
-  end
+      published_edition.title = "New title"
+      published_edition.save!(validate: false)
 
-  test "it updates the slug and slug_from_title when the title changes" do
-    edition = SluggableEdition.create!(title: "Original Title", slug: nil)
-    original_slug = edition.slug
-    edition.title = "New Title"
-    edition.save!
-    assert_not_equal original_slug, edition.slug
-    assert_equal "new-title", edition.slug
-    assert_equal "new-title", edition.slug_from_title
-  end
+      published_edition.reload
+      assert_equal "new-title", published_edition.slug
+      assert_equal "new-title", published_edition.slug_from_title
+    end
 
-  test "it generates a unique slug when a duplicate exists of the same edition type" do
-    first_edition = SluggableEdition.create!(title: "Same Title", slug: nil)
-    second_edition = SluggableEdition.create!(title: "Same Title", slug: nil)
+    test "updates slug for published editions when saved with validate: false, if override changes" do
+      published_edition = SluggableEdition.create_published!(title: "Original Title")
+      assert_equal "original-title", published_edition.slug
+      assert_equal "original-title", published_edition.slug_from_title
 
-    assert_equal "same-title", first_edition.slug
-    assert_equal "same-title--2", second_edition.slug
-  end
+      published_edition.slug_override = "slug-override"
+      published_edition.save!(validate: false)
 
-  test "it generates a unique slug when two duplicates exist of the same edition type" do
-    SluggableEdition.create!(title: "Same Title", slug: nil)
-    SluggableEdition.create!(title: "Same Title", slug: nil)
-    third_edition = SluggableEdition.create!(title: "Same Title", slug: nil)
+      published_edition.reload
+      assert_equal "slug-override", published_edition.slug
+      assert_equal "slug-override", published_edition.slug_override
+    end
 
-    assert_equal "same-title--3", third_edition.slug
-  end
+    test "it preservers the slug state from the published edition when redrafting" do
+      published_edition = SluggableEdition.create_published!(title: "Original Title", slug_override: "original-title-override")
+      assert_equal "original-title-override", published_edition.slug
 
-  test "it generates a unique slug when a duplicate exists of a configurable document type with the same base path prefix" do
-    ConfigurableDocumentType.setup_test_types(build_configurable_document_type("type_one")
-                                                .merge(build_configurable_document_type("type_two")))
+      draft_edition_with_slug_override = published_edition.create_draft(create(:writer))
 
-    first_edition = StandardEdition.create!(title: "Shared Title", type: "StandardEdition", configurable_document_type: "type_one", document: Document.new, creator: User.new, previously_published: Time.zone.now, summary: "test", body: "test", block_content: {})
+      assert_equal "original-title-override", draft_edition_with_slug_override.slug
+      assert_equal "original-title-override", draft_edition_with_slug_override.slug_override
+    end
 
-    second_edition = StandardEdition.create!(title: "Shared Title", type: "StandardEdition", configurable_document_type: "type_two", document: Document.new, creator: User.new, previously_published: Time.zone.now, summary: "test", body: "test", block_content: {})
+    test "it applies the slug override to a draft from published, if override present" do
+      published_edition = SluggableEdition.create_published!(title: "Original Title")
+      draft_edition_with_slug_override = published_edition.create_draft(create(:writer))
+      draft_edition_with_slug_override.slug_override = "original-title-override"
+      draft_edition_with_slug_override.save!(validate: false) # skip change note validation
 
-    assert_equal "shared-title", first_edition.slug
-    assert_equal "shared-title--2", second_edition.slug
-  end
-
-  test "it normalizes special characters in slugs" do
-    edition = SluggableEdition.create!(title: "Title with Special! Characters & Stuff", slug: nil)
-    assert_match(/^[a-z0-9-]+$/, edition.slug)
-  end
-
-  test "it sets the slug to the document ID if the title language cannot be normalised" do
-    document = create(:document)
-    edition = SluggableEdition.create!(title: "英国驻华大使馆", slug: nil, document:)
-    assert_equal(document.id.to_s, edition.slug)
-  end
-
-  test "it truncates slugs to 150 characters" do
-    long_title = "a" * 200
-    edition = SluggableEdition.create!(title: long_title, slug: nil)
-    assert edition.slug.length <= 150
-  end
-
-  test "it allows same slug for different edition types" do
-    Edition.create!(title: "Shared Title", type: "Edition", document: Document.new, creator: User.new, previously_published: Time.zone.now, summary: "test", body: "test")
-
-    first_edition = SluggableEdition.create!(title: "Shared Title", slug: nil)
-
-    assert_equal "shared-title", first_edition.slug
-  end
-
-  test "it allows same slug for configurable document edition types with different base path prefixes" do
-    ConfigurableDocumentType.setup_test_types(build_configurable_document_type("type_one")
-                                                .merge(build_configurable_document_type("type_two", {
-                                                  "settings" => {
-                                                    "base_path_prefix" => "/government/type_two",
-                                                  },
-                                                })))
-
-    StandardEdition.create!(title: "Shared Title", type: "StandardEdition", configurable_document_type: "type_one", document: Document.new, creator: User.new, previously_published: Time.zone.now, summary: "test", body: "test", block_content: {})
-
-    first_edition = StandardEdition.create!(title: "Shared Title", type: "StandardEdition", configurable_document_type: "type_two", document: Document.new, creator: User.new, previously_published: Time.zone.now, summary: "test", body: "test", block_content: {})
-
-    assert_equal "shared-title", first_edition.slug
+      assert_equal "original-title", published_edition.slug
+      assert_equal "original-title-override", draft_edition_with_slug_override.slug
+      assert_equal "original-title-override", draft_edition_with_slug_override.slug_override
+    end
   end
 end

--- a/test/unit/app/models/edition_test.rb
+++ b/test/unit/app/models/edition_test.rb
@@ -512,12 +512,6 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal [edition_with_first_keyword], Edition.with_title_containing("klingons-rule")
   end
 
-  test "should find editions with slug_override containing keyword" do
-    edition_with_slug_override = create(:edition, title: "klingons rule", slug_override: "another-slug")
-    _edition_without_match = create(:edition, title: "this document is about muppets")
-    assert_equal [edition_with_slug_override], Edition.with_title_containing("another-slug")
-  end
-
   test "should find editions with title containing regular expression characters" do
     edition_with_nasty_characters = create(:edition, title: "title with [stuff in brackets]")
     assert_equal [edition_with_nasty_characters], Edition.with_title_containing("[stuff")

--- a/test/unit/app/models/plan_for_change_landing_page_test.rb
+++ b/test/unit/app/models/plan_for_change_landing_page_test.rb
@@ -6,21 +6,35 @@ class PlanForChangeLandingPageTest < ActiveSupport::TestCase
   should_protect_against_xss_and_content_attacks_on :plan_for_change_landing_page, :body
 
   test "landing-page base_path is not overwritten from title" do
-    plan_for_change_landing_page = build(:plan_for_change_landing_page, slug_override: "/landing-page/test")
+    plan_for_change_landing_page = create(:plan_for_change_landing_page, title: "New title", slug_override: "/landing-page/test")
+
+    assert_equal plan_for_change_landing_page.slug, "/landing-page/test"
     assert_equal plan_for_change_landing_page.base_path, "/landing-page/test"
   end
 
-  test "landing-page is not valid if base_path is already in use" do
-    create(:plan_for_change_landing_page, slug_override: "/landing-page/test")
+  test "landing-page slug gets set to the value of the slug_override" do
+    plan_for_change_landing_page = create(:plan_for_change_landing_page, slug_override: "/landing-page/test")
 
-    plan_for_change_landing_page = build(:plan_for_change_landing_page, slug_override: "/landing-page/test")
-    assert_not plan_for_change_landing_page.valid?
-    assert_equal :base_path, plan_for_change_landing_page.errors.first.attribute
+    assert_equal plan_for_change_landing_page.slug, "/landing-page/test"
   end
 
-  test "landing-page is not valid if base_path does not start with a slash" do
-    plan_for_change_landing_page = build(:plan_for_change_landing_page, body: "blocks: []", slug_override: "/landing-page/test")
+  test "landing-page is not valid if slug_override is nil" do
+    plan_for_change_landing_page = build(:plan_for_change_landing_page, slug_override: nil)
     assert_not plan_for_change_landing_page.valid?
+    assert_equal "cannot be blank", plan_for_change_landing_page.errors[:slug_override].first
+  end
+
+  test "landing-page is not valid if slug_override is already in use" do
+    create(:plan_for_change_landing_page, slug_override: "/landing-page/test")
+    plan_for_change_landing_page = build(:plan_for_change_landing_page, slug_override: "/landing-page/test")
+    assert_not plan_for_change_landing_page.valid?
+    assert_equal "is already taken", plan_for_change_landing_page.errors[:slug_override].first
+  end
+
+  test "landing-page is not valid if slug_override does not start with a slash" do
+    plan_for_change_landing_page = build(:plan_for_change_landing_page, slug_override: "landing-page/test")
+    assert_not plan_for_change_landing_page.valid?
+    assert_equal "must start with a slash (/)", plan_for_change_landing_page.errors[:slug_override].first
   end
 
   test "landing-page is valid if body is YAML with at least one block" do


### PR DESCRIPTION
## What & why

We have recently introduced a third column for storing slug-related data, `slug_from_title`, and set its value to the value of the title-based `slug`. This PR's migration and adjacent changes will allow us to make use of this new column - the `slug_from_title` column will only hold the title-based slug, whilst the `slug` will store the "accurate" slug value.

We have previously backfilled `slug_from_title` values for pre-publication editions in https://github.com/alphagov/whitehall/pull/11359. For live editions, we have run [a distinct data migration](https://github.com/alphagov/whitehall/pull/11424) to set the `slug_from_title` to the historical value of the `slug`, where the slug wasn't already set to the value of the override. This ensures we keep a record of the slug column, before repurposing it to store the "accurate" slug value with this commit's migration.

This PR includes the following changes:
1. Add migration to set `slug` to `slug_override`, if override is present
- This migration prepares the data. It sets the value of the `slug` column to the value of the `slug_override`, if the latter is present, for all edition states (bar superseded and deleted). We will be running this as a regular migration to ensure that no mismatched data gets created between the migration run and the code merge.

2. Update callbacks for slug generation:
- set `slug_from_title` on title updates
- set `slug` to either `slug_override` or `slug_from_title`

3. Correct remaining usages of `slug`, `slug_override` and `slug_from_title`
This wraps up the changes whereby we now have distinct usages for our three slug-related columns:
- `slug_from_title` holds the title-based slug
- `slug_override` holds a custom slug, different from the title-based
- `slug` holds the accurate value between the other two fields, `slug_override` if override is present, otherwise `slug_from_title`.
The only place where we use the `slug_from_title` is now the override checkbox in the `_page_address_controls.html.erb` view.

## Test plan

Types coverage:
1. ✅ Publication (as a regular edition, no support for non-en primary)
2. ✅ News story (as a regular standard edition, english primary locale)
3. ✅ World news story (non-en primary support, plus legacy data for supported locales)
4. ✅ Collection (non-en edition)
5. ✅ CIPs
6. ✅ LPs

Data combinations that we need to look into:
- ✅ published with no SO
- ✅ published with SO
- ✅ published with no SO and slug is not title based e.g. suffix
- ✅ draft with SO
- ✅ draft with no SO
- ✅ withdrawn with SO
- ✅ withdrawn without SO
- ✅ withdrawn no SO and slug not title-based
- ✅ unpublished with SO
- ✅ unpublished without SO
- ✅ unpublished with a deleted prefix
- ✅ scheduled (already scheduled and newly scheduled, with/without SO)
- ✅ blank SO
- ✅ translations
- ✅ New draft for regular edition 
- ✅ New draft for config driven edition 
- ✅ New draft for editions of non-en primary with a babosa supported locale
- ✅ New draft for editions of non-en primary with a babosa non-supported locale

Test sequence: 
Live states:
- Republish
- Make new draft from live
- Does checkbox look correct?
- Save with "keep live slug" checked; preview
- Save with "keep new slug" checked; preview
- Revert to previous checkbox option and save; preview
- Publish; preview
- Unpublish/Withdraw; preview

Existing Draft From Published (created before migration):
- Change title, save, preview
- Does checkbox look correct?
- Save with "keep live slug" checked; preview 
- Save with "keep new slug" checked; preview
- Revert to previous checkbox option and save; preview
- Publish

Create new document:
- Change title, save, preview
- Does checkbox look correct?
- Publish
- Redraft
- Does checkbox look correct?
- Save with "keep live slug" checked; preview
- Save with "keep new slug" checked; preview
- Revert to previous checkbox option and save; preview
- Publish


[Jira](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-3323)