### PR TITLE
Validate social media link fields individually [WHIT-3156]

### DIFF
--- a/app/models/configurable_content_blocks/default_array.rb
+++ b/app/models/configurable_content_blocks/default_array.rb
@@ -29,6 +29,20 @@ module ConfigurableContentBlocks
       end
     end
 
+    def each_leaf(&block)
+      return enum_for(:each_leaf) unless block_given?
+
+      items.each_with_index do |_item, index|
+        field_blocks(index).each do |field_block|
+          if field_block.respond_to? :each_leaf
+            field_block.each_leaf(&block)
+          else
+            block.call(field_block)
+          end
+        end
+      end
+    end
+
   private
 
     def template_name

--- a/app/models/configurable_document_types/topical_event.json
+++ b/app/models/configurable_document_types/topical_event.json
@@ -131,6 +131,14 @@
           "url": {
             "type": "string"
           }
+        },
+        "validations": {
+          "presence": {
+            "attributes": ["social_media_service_name"]
+          },
+          "uri": {
+            "attributes": ["url"]
+          }
         }
       }
     },

--- a/app/models/standard_edition.rb
+++ b/app/models/standard_edition.rb
@@ -146,23 +146,26 @@ class StandardEdition < Edition
 
   def error_labels
     {}.tap do |labels|
-      ConfigurableContentBlocks::DefaultObject.root_block_for(self, "documents").each do |block|
-        # we only want labels for leaf fields, so do nothing if this field isn't one
-        next if block.respond_to? :field_blocks
-
+      all_leaf_blocks.each do |block|
         labels[block.path.validation_error_attribute] = block.title
       end
     end
   end
 
   def error_field_order
-    %w[title summary] + ConfigurableContentBlocks::DefaultObject
-                          .root_block_for(self, "documents")
-                          .each_leaf
-                          .map { |block| block.path.validation_error_attribute }
+    %w[title summary] + all_leaf_blocks.map { |block| block.path.validation_error_attribute }
   end
 
 private
+
+  def all_leaf_blocks
+    type_instance.dynamic_tabs
+      .map { |tab| tab["id"] }
+      .prepend("documents")
+      .flat_map do |tab_key|
+        ConfigurableContentBlocks::DefaultObject.root_block_for(self, tab_key).each_leaf.to_a
+      end
+  end
 
   def field_paths(&block)
     [].tap do |paths|

--- a/app/models/standard_edition/block_content.rb
+++ b/app/models/standard_edition/block_content.rb
@@ -50,9 +50,7 @@ class StandardEdition::BlockContent
 private
 
   def run_schema_validations
-    return unless @schema.key?("validations")
-
-    @schema["validations"].each do |key, options|
+    @schema["validations"]&.each do |key, options|
       validator_class = VALIDATORS[key] or raise ArgumentError, "undefined validator type #{key}"
       opts = options.symbolize_keys
 
@@ -60,6 +58,20 @@ private
       next if on && validation_context&.to_sym != on.to_sym
 
       validator_class.new(opts).validate(self)
+    end
+
+    @schema["attributes"]&.each do |attr_name, attr_schema|
+      next unless attr_schema["attributes"]
+
+      item_class = attributes_class_for(attr_schema["attributes"], attr_schema["validations"])
+      (send(attr_name.to_sym) || []).each_with_index do |item, index|
+        item_instance = item_class.new(item)
+        next if item_instance.valid?
+
+        item_instance.errors.each do |error|
+          errors.import(error, attribute: "#{attr_name}.#{index}.#{error.attribute}".to_sym)
+        end
+      end
     end
   end
 
@@ -75,7 +87,7 @@ private
     attributes.class.instance_methods.include?(method_name) || super
   end
 
-  def attributes_class_for(attribute_config)
+  def attributes_class_for(attribute_config, validations_config = nil)
     attributes_class = Class.new do
       include ActiveModel::API
       include ActiveModel::Attributes
@@ -98,6 +110,12 @@ private
         attributes
       end
     end
+
+    validations_config&.each do |validator_key, options|
+      attrs = Array(options["attributes"]).map(&:to_sym)
+      attributes_class.validates(*attrs, validator_key.to_sym => true)
+    end
+
     attributes_class.set_temporary_name("Block content attributes")
     attributes_class
   end

--- a/app/validators/social_media_links_validator.rb
+++ b/app/validators/social_media_links_validator.rb
@@ -1,7 +1,7 @@
 class SocialMediaLinksValidator < ActiveModel::Validator
   def initialize(opts = {})
     @attributes = opts[:attributes]
-    @service_field = opts[:fields]["service_field"]
+    @channel_field = opts[:fields]["service_field"]
     @url_field = opts[:fields]["url_field"]
     super
   end
@@ -10,7 +10,7 @@ class SocialMediaLinksValidator < ActiveModel::Validator
     @attributes.each do |attribute_name|
       arr = record.send(attribute_name.to_sym) || []
       arr.each_with_index do |social_media_service, index|
-        service_name = social_media_service[@service_field]
+        service_name = social_media_service[@channel_field]
         if validate_social_media_service(service_name, record, attribute_name, index)
           validate_social_media_link(social_media_service[@url_field], service_name, record, attribute_name)
         end

--- a/app/validators/social_media_links_validator.rb
+++ b/app/validators/social_media_links_validator.rb
@@ -9,68 +9,25 @@ class SocialMediaLinksValidator < ActiveModel::Validator
   def validate(record)
     @attributes.each do |attribute_name|
       arr = record.send(attribute_name.to_sym) || []
-      arr.each_with_index do |social_media_service, index|
-        service_name = social_media_service[@channel_field]
-        if validate_social_media_service(service_name, record, attribute_name, index)
-          validate_social_media_link(social_media_service[@url_field], service_name, record, attribute_name)
-        end
+
+      duplicate_values(arr, @channel_field, exclude: "Other").each do |channel|
+        record.errors.add(attribute_name.to_sym, :taken, message: "already has an account with a channel of \"#{channel}\"")
+      end
+
+      duplicate_values(arr, @url_field).each do |url|
+        record.errors.add(attribute_name.to_sym, :taken, message: "already has an account with a URL of \"#{url}\"")
       end
     end
   end
 
 private
 
-  def validate_social_media_service(service_name, record, attribute_name, index)
-    @services ||= []
-
-    if service_name.blank?
-      record.errors.add(
-        attribute_name.to_sym,
-        :invalid_social_media_link,
-        message: "contains an account (\"Social media account #{index + 1}\") without a service selected.",
-      )
-      return false
-    end
-
-    if service_name != "Other" && @services.include?(service_name)
-      record.errors.add(
-        attribute_name.to_sym,
-        :invalid_social_media_link,
-        message: "contains another account with a service of \"#{service_name}\".",
-      )
-      return false
-    end
-    @services << service_name
-  end
-
-  def validate_social_media_link(url, service_name, record, attribute_name)
-    if url.blank?
-      record.errors.add(
-        attribute_name.to_sym,
-        :invalid_social_media_link,
-        message: "contains a \"#{service_name}\" account without a URL.",
-      )
-    elsif !valid_url?(url)
-      record.errors.add(
-        attribute_name.to_sym,
-        :invalid_social_media_link,
-        message: "contains a \"#{service_name}\" account with an invalid URL - use the full URL, including https://",
-      )
-    elsif record.social_media_links.pluck("url").count(url) > 1
-      unless record.errors.messages[attribute_name.to_sym].include?("already has an account with a URL of \"#{url}\".")
-        record.errors.add(
-          attribute_name.to_sym,
-          :invalid_social_media_link,
-          message: "already has an account with a URL of \"#{url}\".",
-        )
-      end
-    end
-  end
-
-  def valid_url?(url)
-    uri = URI.parse(url)
-    uri.is_a?(URI::HTTP) && uri.host.present?
-  rescue URI::InvalidURIError
-    false
+  def duplicate_values(arr, field, exclude: nil)
+    arr.map { |item| item[field] }
+       .select(&:present?)
+       .reject { |v| v == exclude }
+       .group_by { |v| v }
+       .select { |_, occurrences| occurrences.size > 1 }
+       .keys
   end
 end

--- a/app/views/admin/configurable_content_blocks/default_select.html.erb
+++ b/app/views/admin/configurable_content_blocks/default_select.html.erb
@@ -4,5 +4,5 @@
   name: block.path.form_control_name,
   options: block.select_options,
   hint: block.hint_text,
-  error_items: errors_for(block.edition.errors, block.path.validation_error_attribute.to_sym),
+  error_items: errors_for(block.edition.errors, block.path.validation_error_attribute.to_sym, block.title),
 } %>

--- a/app/views/admin/configurable_content_blocks/default_string.html.erb
+++ b/app/views/admin/configurable_content_blocks/default_string.html.erb
@@ -5,7 +5,7 @@
   value: block.value,
   hint: block.hint_text,
   right_to_left: block.edition.translation_locale.rtl?,
-  error_items: errors_for(block.edition.errors, block.path.validation_error_attribute.to_sym),
+  error_items: errors_for(block.edition.errors, block.path.validation_error_attribute.to_sym, block.title),
 } %>
 <% if block.primary_locale_value.present? %>
   <%= render "govuk_publishing_components/components/details", {

--- a/public/configurable-document-type.schema.json
+++ b/public/configurable-document-type.schema.json
@@ -33,6 +33,7 @@
           "presence",
           "safe_html",
           "valid_internal_path_links",
+          "uri",
           "social_media_links"
         ]
       }
@@ -158,6 +159,10 @@
         "attributes": {
           "description": "For array types, defines the schema of each array item using the same minimal attribute format.",
           "$ref": "#/$defs/block_attributes"
+        },
+        "validations": {
+          "description": "For array types, defines validations to run against each item in the array.",
+          "$ref": "#/$defs/validations"
         }
       },
       "required": ["type"],

--- a/test/unit/app/models/standard_edition/block_content_test.rb
+++ b/test/unit/app/models/standard_edition/block_content_test.rb
@@ -175,8 +175,32 @@ class BlockContentTest < ActiveSupport::TestCase
     })
     page = StandardEdition::BlockContent.new(schema)
 
-    page.attributes = { "test_array_attribute" => [{ "social_media_service_id" => "1", "url" => "broken url" }] }
+    page.attributes = { "test_array_attribute" => [{ "social_media_service_id" => "Facebook", "url" => "http://facebook.com" }, { "social_media_service_id" => "Facebook", "url" => "http://facebook.com/other" }] }
     assert_not page.valid?
-    assert_not page.errors.where("test_array_attribute", :invalid_social_media_link).empty?
+    assert_not page.errors.where(:test_array_attribute, :taken).empty?
+  end
+
+  test "runs per-item validations for array attributes with sub-field validations" do
+    schema = @schema.deep_merge({
+      "attributes" => {
+        "test_array_attribute" => {
+          "type" => "array",
+          "attributes" => {
+            "social_media_service_id" => { "type" => "string" },
+            "url" => { "type" => "string" },
+          },
+          "validations" => {
+            "presence" => { "attributes" => %w[social_media_service_id] },
+            "uri" => { "attributes" => %w[url] },
+          },
+        },
+      },
+    })
+    page = StandardEdition::BlockContent.new(schema)
+
+    page.attributes = { "test_array_attribute" => [{ "social_media_service_id" => "", "url" => "not-a-url" }] }
+    assert_not page.valid?
+    assert page.errors[:"test_array_attribute.0.social_media_service_id"].any?
+    assert page.errors[:"test_array_attribute.0.url"].any?
   end
 end

--- a/test/unit/app/models/standard_edition_test.rb
+++ b/test/unit/app/models/standard_edition_test.rb
@@ -840,6 +840,58 @@ class StandardEditionTest < ActiveSupport::TestCase
 
       assert_equal %w[title summary field_attribute object_attribute.nested_attribute], page.error_field_order
     end
+
+    test "validation errors on list row fields use the field title, not the internal field path" do
+      ConfigurableDocumentType.setup_test_types(build_configurable_document_type("test_type", {
+        "forms" => {
+          "social_media_accounts" => {
+            "dynamic" => true,
+            "fields" => {
+              "links" => {
+                "title" => "Social media links",
+                "block" => "default_array",
+                "attribute_path" => %w[block_content links],
+                "fields" => {
+                  "channel" => { "title" => "Channel", "block" => "default_string", "attribute_path" => %w[channel] },
+                  "url" => { "title" => "URL", "block" => "default_string", "attribute_path" => %w[url] },
+                },
+              },
+            },
+          },
+        },
+        "schema" => {
+          "attributes" => {
+            "links" => {
+              "type" => "array",
+              "attributes" => {
+                "channel" => { "type" => "string" },
+                "url" => { "type" => "string" },
+              },
+              "validations" => {
+                "presence" => { "attributes" => %w[channel] },
+                "uri" => { "attributes" => %w[url] },
+              },
+            },
+          },
+        },
+      }))
+      page = StandardEdition.new(
+        configurable_document_type: "test_type",
+        block_content: { "links" => [{ "channel" => "", "url" => "not-a-url" }] },
+      )
+      page.valid?
+
+      labels = page.error_labels
+      messages = page.errors.map { |error|
+        next unless labels.key?(error.attribute.to_s)
+
+        "#{labels[error.attribute.to_s]} #{error.message}"
+      }.compact
+
+      assert_includes messages, "Channel cannot be blank"
+      assert_includes messages, "URL is not a valid URI. Make sure it starts with http(s)"
+      assert messages.none? { |m| m.match?(/links \d/i) }, "error messages should not contain internal field paths, got: #{messages}"
+    end
   end
 
   test "permitted_image_usages passes caption_enabled through from config" do

--- a/test/unit/app/validators/social_media_links_validator_test.rb
+++ b/test/unit/app/validators/social_media_links_validator_test.rb
@@ -2,8 +2,6 @@ require "test_helper"
 
 class SocialMediaLinksValidatorTest < ActiveSupport::TestCase
   setup do
-    @social_media_service_1 = create(:social_media_service, name: "Facebook")
-    @social_media_service_2 = create(:social_media_service, name: "LinkedIn")
     @validator = SocialMediaLinksValidator.new({
       attributes: %w[social_media_links],
       fields: {
@@ -25,48 +23,18 @@ class SocialMediaLinksValidatorTest < ActiveSupport::TestCase
     assert block_content.errors.empty?
   end
 
-  test "social media links are invalid when none of social media service and URL are provided" do
+  test "social media links with no duplicates are valid" do
     block_content = SocialMediaLinksValidatorTestClass.new
     block_content.social_media_links = [
-      { "social_media_service_name" => "", "url" => "" },
+      { "social_media_service_name" => "Facebook", "url" => "http://facebook.com/govuk" },
+      { "social_media_service_name" => "LinkedIn", "url" => "https://linkedin.com/company/govuk" },
     ]
     @validator.validate(block_content)
 
-    assert_equal ["Social media links contains an account (\"Social media account 1\") without a service selected."], block_content.errors.full_messages
+    assert block_content.errors.empty?
   end
 
-  test "social media links are invalid when no social media service is chosen and a URL is provided" do
-    block_content = SocialMediaLinksValidatorTestClass.new
-    block_content.social_media_links = [
-      { "social_media_service_name" => "", "url" => "https://facebook.com" },
-    ]
-    @validator.validate(block_content)
-
-    assert_equal ["Social media links contains an account (\"Social media account 1\") without a service selected."], block_content.errors.full_messages
-  end
-
-  test "social media links are invalid when a social media service is chosen but no URL is provided" do
-    block_content = SocialMediaLinksValidatorTestClass.new
-    block_content.social_media_links = [
-      { "social_media_service_name" => "Facebook", "url" => "" },
-    ]
-    @validator.validate(block_content)
-
-    assert_equal ["Social media links contains a \"Facebook\" account without a URL."], block_content.errors.full_messages
-  end
-
-  test "social media links are invalid when a social media service is chosen and a malformed URL is provided" do
-    block_content = SocialMediaLinksValidatorTestClass.new
-    block_content.social_media_links = [
-      { "social_media_service_name" => "Facebook", "url" => "not-a-url" },
-      { "social_media_service_name" => "Twitter", "url" => "http://linkedin.com" },
-    ]
-    @validator.validate(block_content)
-
-    assert_equal ["Social media links contains a \"Facebook\" account with an invalid URL - use the full URL, including https://"], block_content.errors.full_messages
-  end
-
-  test "social media links are invalid if two of the same social media service are provided" do
+  test "social media links are invalid if two of the same channel are provided" do
     block_content = SocialMediaLinksValidatorTestClass.new
     block_content.social_media_links = [
       { "social_media_service_name" => "Facebook", "url" => "http://facebook.com/govuk" },
@@ -74,21 +42,21 @@ class SocialMediaLinksValidatorTest < ActiveSupport::TestCase
     ]
     @validator.validate(block_content)
 
-    assert_equal ["Social media links contains another account with a service of \"Facebook\"."], block_content.errors.full_messages
+    assert_includes block_content.errors[:social_media_links], "already has an account with a channel of \"Facebook\""
   end
 
-  test "social media links are invalid if two services have the same URL" do
+  test "social media links are invalid if two channels have the same URL" do
     block_content = SocialMediaLinksValidatorTestClass.new
     block_content.social_media_links = [
-      { "social_media_service_name" => "Twiter", "url" => "http://facebook.com/govuk" },
+      { "social_media_service_name" => "Twitter", "url" => "http://facebook.com/govuk" },
       { "social_media_service_name" => "Facebook", "url" => "http://facebook.com/govuk" },
     ]
     @validator.validate(block_content)
 
-    assert_equal ["Social media links already has an account with a URL of \"http://facebook.com/govuk\"."], block_content.errors.full_messages
+    assert_includes block_content.errors[:social_media_links], "already has an account with a URL of \"http://facebook.com/govuk\""
   end
 
-  test "social media links are valid when multiple 'Other' services are provided with different URLs" do
+  test "social media links are valid when multiple 'Other' channels are provided with different URLs" do
     block_content = SocialMediaLinksValidatorTestClass.new
     block_content.social_media_links = [
       { "social_media_service_name" => "Other", "url" => "http://example.com/one" },
@@ -99,11 +67,11 @@ class SocialMediaLinksValidatorTest < ActiveSupport::TestCase
     assert block_content.errors.empty?
   end
 
-  test "social media links are valid when a social media service is chosen and a well-formed URL is provided" do
+  test "does not flag blank channels or URLs as duplicates" do
     block_content = SocialMediaLinksValidatorTestClass.new
     block_content.social_media_links = [
-      { "social_media_service_name" => "Facebook", "url" => "http://facebook.com/govuk" },
-      { "social_media_service_name" => "LinkedIn", "url" => "https://linkedin.com/company/govuk" },
+      { "social_media_service_name" => "", "url" => "" },
+      { "social_media_service_name" => "", "url" => "" },
     ]
     @validator.validate(block_content)
 


### PR DESCRIPTION
## Overview
This update improves the clarity, consistency, and usability of validation errors when publishers add social media accounts.

## Why
Previously, validation feedback for social media accounts was unclear and inconsistent:
- Errors only appeared in the summary, not inline  
- It wasn’t obvious which field (Channel or URL) needed fixing  
- Terminology used “service” instead of “channel”  
- Only one error appeared even when multiple fields were invalid  

## What Changed
Validation behaviour and messaging have been enhanced:
- Terminology updated from **service → channel** to match the UI  
- Errors are now attached to **individual fields (Channel, URL)** instead of a shared attribute  
- Errors display **both inline and in the summary**  
- Validation runs **independently per field**  
- Multiple errors are shown when applicable (e.g. both fields blank)  
- Invalid fields are highlighted with a **red border**  
- Presence and URL format validation are now declared in the document type schema and run per-item, replacing bespoke logic in SocialMediaLinksValidator which is now scoped to uniqueness checking only.

## ACs

Meets the ACs as described in the [Jira ticket](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?assignee=5caf4d888c2c1a75f3e46ef6&selectedIssue=WHIT-3156)

---

| # | Channel| URL  | Expected Channel Error | Expected URL Error | Summary Box | Red Border |
|---|----------------|------------|------------------------|-------------------|-------------|------------|
| 1 | Blank | Blank | Channel cannot be blank | URL cannot be blank | Both errors | Both fields |
| 2 | Selected | Blank | — | URL cannot be blank | URL error | URL field |
| 3 | Blank | Valid | Channel cannot be blank | — | Channel error | Channel field |
| 4 | Selected | Invalid (e.g. `foo`) | — | Invalid URL - use the full URL, including `https://` | URL error | URL field |
| 5 | Blank | Invalid (e.g. `foo`) | Channel cannot be blank | Invalid URL - use the full URL, including `https://` | Both errors | Both fields |
| 6 | Duplicate (e.g. Facebook already exists) | Valid | Channel must be unique | — | Channel error | Channel field |
| 7 | Different | Duplicate URL (already exists) | — | URL must be unique | URL error | URL field |
| 8 | Selected | Valid | — | — | Happy path (no errors) | None |
| 9 | Both “Other” with different URLs | Both valid | — | — | Happy path (no errors) | None |
