### PR TITLE
Improve Whitehall's search performance

### DIFF
--- a/app/models/concerns/edition/scopes/searchable_by_title.rb
+++ b/app/models/concerns/edition/scopes/searchable_by_title.rb
@@ -2,15 +2,17 @@ module Edition::Scopes::SearchableByTitle
   extend ActiveSupport::Concern
 
   included do
-    scope :with_title_containing,
-          lambda { |keywords|
-            escaped_like_expression = keywords.gsub(/([%_])/, "%" => '\\%', "_" => '\\_')
-            like_clause = "%#{escaped_like_expression}%"
+    scope :with_title_containing, lambda { |keywords|
+      escaped_like_expression = keywords.gsub(/([%_])/, "%" => '\\%', "_" => '\\_')
+      like_clause = "%#{escaped_like_expression}%"
 
-            scope = in_default_locale.includes(:document)
-            scope
-              .where("edition_translations.title LIKE :like_clause", like_clause:)
-              .or(scope.where(slug: keywords))
-          }
+      if keywords.match?(/\A[a-z0-9]+(-[a-z0-9]+)+\z/)
+        where(slug: keywords)
+      else
+        in_default_locale
+          .includes(:document)
+          .where("edition_translations.title LIKE ?", like_clause)
+      end
+    }
   end
 end

--- a/app/models/concerns/edition/scopes/searchable_by_title.rb
+++ b/app/models/concerns/edition/scopes/searchable_by_title.rb
@@ -3,8 +3,7 @@ module Edition::Scopes::SearchableByTitle
 
   included do
     scope :with_title_containing, lambda { |keywords|
-      escaped_like_expression = keywords.gsub(/([%_])/, "%" => '\\%', "_" => '\\_')
-      like_clause = "%#{escaped_like_expression}%"
+      like_clause = "%#{sanitize_sql_like(keywords)}%"
 
       if keywords.match?(/\A[a-z0-9]+(-[a-z0-9]+)+\z/)
         where(slug: keywords)

--- a/script/benchmark_edition_search.rb
+++ b/script/benchmark_edition_search.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+# DEPENDENT ON having a full production database replicated locally.
+# Run with:
+#   govuk-docker-run bin/rails runner script/benchmark_edition_search.rb
+
+require "benchmark"
+$stdout.sync = true
+
+module EditionFilterBench
+module_function
+
+  CASES = [
+    { name: "no title filter", term: nil },
+    { name: "exact slug", term: "windrush-scheme-application-form-uk" },
+    { name: "fuzzy title", term: "Windrush Scheme application form (UK)" },
+    { name: "many matches", term: "NHS" },
+  ].freeze
+
+  WARMUPS = 3
+  RUNS = 10
+
+  def run!
+    user = benchmark_user
+    edition_count = Edition.count
+
+    CASES.each do |kase|
+      term = kase[:term]
+
+      puts
+      if term.present?
+        puts %(Searching #{edition_count} editions for "#{term}"...)
+      else
+        puts "Searching #{edition_count} editions with no title filter..."
+      end
+
+      baseline_ms = timed_ms { Edition.limit(1).count }
+
+      warmup_times_ms = []
+      run_times_ms = []
+      result_count = nil
+
+      total_elapsed_s = Benchmark.realtime do
+        WARMUPS.times do
+          elapsed_ms = timed_ms { result_count = run_count(user:, term:) }
+          warmup_times_ms << elapsed_ms
+        end
+
+        RUNS.times do
+          elapsed_ms = timed_ms { result_count = run_count(user:, term:) }
+          run_times_ms << elapsed_ms
+        end
+      end
+
+      first_search_ms = warmup_times_ms.first
+      warm_avg_ms = average(warmup_times_ms.drop(1) + run_times_ms)
+
+      puts "count: #{result_count}"
+      puts sprintf(
+        "baseline query (simple query to show DB connection / cache / memory warm state): %.1f ms",
+        baseline_ms,
+      )
+      puts sprintf(
+        "first search (cold run of this specific filter/query shape): %.1f ms",
+        first_search_ms,
+      )
+      puts sprintf(
+        "warm avg (average after initial caches/plans are warm): %.1f ms",
+        warm_avg_ms,
+      )
+      puts sprintf(
+        "total duration (all warmups + measured runs): %.1fs",
+        total_elapsed_s,
+      )
+    end
+  end
+
+  def timed_ms(&block)
+    Benchmark.realtime(&block) * 1000.0
+  end
+
+  def run_count(user:, term:)
+    build_filter(user:, term:).send(:unpaginated_editions).count
+  end
+
+  def build_filter(user:, term:)
+    options = {
+      state: "published",
+      include_unpublishing: true,
+      include_link_check_report: true,
+      include_last_author: true,
+      per_page: Admin::EditionFilter::GOVUK_DESIGN_SYSTEM_PER_PAGE,
+    }
+
+    options[:title] = term if term.present?
+
+    Admin::EditionFilter.new(Edition, user, options)
+  end
+
+  def average(values)
+    return 0.0 if values.empty?
+
+    values.sum / values.size
+  end
+
+  def benchmark_user
+    User.where(disabled: false).first || User.first || raise("No users found")
+  end
+end
+
+EditionFilterBench.run!


### PR DESCRIPTION
## What

This PR:

- Adds a benchmarking script we can use to track search performance before-and-after edits
- Makes a low hanging fruit improvement in terms of detecting if the input is likely a slug (by checking that the search term contains at least one hyphen), and if so, doing a wildcard search on `slug`, otherwise making that search on `title`. This makes slug searches 99% faster (! 🎉  !) and general title search about 40% faster (as we're only searching against one field now, not two.

There is an edge case where a title could be 'slug-like', e.g. "Covid-19", and in that case no results would be returned if the slug itself is different. But most of the time the slug should match, since it is derived from the title. So it should be _extremely_ rare for that to be an issue.

## Why

We've known for a long time that Whitehall search (by title) is _sloooooow_. We've also had some recent reports of related 5xx errors. This is a first iteration attempt at speeding up the search performance.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
