### PR TITLE
Sort translation languages by English name and switch labels to - "English (Native)" format [WHIT-3354]

### DIFF
--- a/features/people.feature
+++ b/features/people.feature
@@ -19,10 +19,10 @@ Feature: Managing a person
 
   Scenario: Adding a new translation
     Given a person called "Amanda Appleford" exists with the biography "She was born. She lived. She died."
-    When I add a new "Français" translation to the person "Amanda Appleford" setting biography to "Ca va"
-    Then I should see the translation "Français" and body text "Ca va"
+    When I add a new "French (Français)" translation to the person "Amanda Appleford" setting biography to "Ca va"
+    Then I should see the translation "French (Français)" and body text "Ca va"
 
   Scenario: Editing an existing translation
-    Given a person called "Amanda Appleford" exists with a translation for the locale "Français"
-    When I edit the "Français" translation for the person "Amanda Appleford" updating the biography to "Ca va bien"
-    Then I should see the translation "Français" and body text "Ca va bien"
+    Given a person called "Amanda Appleford" exists with a translation for the locale "French (Français)"
+    When I edit the "French (Français)" translation for the person "Amanda Appleford" updating the biography to "Ca va bien"
+    Then I should see the translation "French (Français)" and body text "Ca va bien"

--- a/features/step_definitions/organisation_steps.rb
+++ b/features/step_definitions/organisation_steps.rb
@@ -47,7 +47,7 @@ When(/^I add a translation for an organisation called "([^"]*)"$/) do |organisat
 
   click_link "Translations"
 
-  select "Cymraeg (Welsh)", from: "Language"
+  select "Welsh (Cymraeg)", from: "Language"
   click_button "Create new translation"
 
   fill_in "Name", with: "Organisation Name in another language"

--- a/features/step_definitions/standard_edition_steps.rb
+++ b/features/step_definitions/standard_edition_steps.rb
@@ -216,7 +216,7 @@ When(/^I create a new "([^"]*)" with Welsh as the primary locale titled "([^"]*)
     fill_in "edition[block_content][date_field][3]", with: "01"
     fill_in "edition[block_content][date_field][2]", with: "11"
     fill_in "edition[block_content][date_field][1]", with: "2011"
-    select "Cymraeg (Welsh)", from: "Language"
+    select "Welsh (Cymraeg)", from: "Language"
   end
   click_button "Save and go to document summary"
 end
@@ -311,7 +311,7 @@ When(/^I create a new draft and visit the Welsh translation$/) do
 end
 
 And(/^the language of the document should be Welsh$/) do
-  expect(page).to have_content("Primary language Cymraeg (Welsh)")
+  expect(page).to have_content("Primary language Welsh (Cymraeg)")
 end
 
 Given("the test configurable document type group is defined") do

--- a/features/step_definitions/translated_content_steps.rb
+++ b/features/step_definitions/translated_content_steps.rb
@@ -25,9 +25,9 @@ Then(/^English should not appear on the list of language choices$/) do
 end
 
 When(/^I create a foreign language only document$/) do
-  begin_drafting_document type: "document_collection", locale: "Cymraeg (Welsh)", title: "Foreign Language Only"
+  begin_drafting_document type: "document_collection", locale: "Welsh (Cymraeg)", title: "Foreign Language Only"
   click_button "Save and go to document summary"
-  expect(page).to have_content("Primary language Cymraeg (Welsh)")
+  expect(page).to have_content("Primary language Welsh (Cymraeg)")
 end
 
 And(/^I return to the edit screen$/) do

--- a/features/step_definitions/worldwide_organisation_steps.rb
+++ b/features/step_definitions/worldwide_organisation_steps.rb
@@ -184,7 +184,7 @@ end
 And(/^I add a Welsh translation of the worldwide organisation "([^"]*)" named "([^"]*)"$/) do |title, translated_title|
   visit_edition_admin(title)
   click_link "Add translation"
-  select "Cymraeg (Welsh)", from: "Choose language"
+  select "Welsh (Cymraeg)", from: "Choose language"
   click_button "Next"
   fill_in "Translated title (required)", with: translated_title
   click_button "Save"

--- a/lib/locale.rb
+++ b/lib/locale.rb
@@ -36,7 +36,7 @@ Locale = Struct.new(:code) do
   end
 
   def self.non_english
-    all.reject(&:english?)
+    all.reject(&:english?).sort_by(&:english_language_name)
   end
 
   def self.right_to_left
@@ -78,7 +78,7 @@ Locale = Struct.new(:code) do
     if english?
       native_language_name
     else
-      "#{native_language_name} (#{english_language_name})"
+      "#{english_language_name} (#{native_language_name})"
     end
   end
 

--- a/lib/translatable_model.rb
+++ b/lib/translatable_model.rb
@@ -33,7 +33,7 @@ module TranslatableModel
   end
 
   def non_english_translated_locales
-    non_english_translated_locale_codes.map { |l| Locale.new(l) }
+    non_english_translated_locale_codes.map { |l| Locale.new(l) }.sort_by(&:english_language_name)
   end
 
   def missing_translations

--- a/test/components/admin/editions/show/preview_component_test.rb
+++ b/test/components/admin/editions/show/preview_component_test.rb
@@ -40,8 +40,8 @@ class Admin::Editions::Show::PreviewComponentTest < ViewComponent::TestCase
 
     render_inline(Admin::Editions::Show::PreviewComponent.new(edition:))
     assert_selector "a[href='#{edition.public_url(draft: true)}']", text: "Preview on website - English (opens in new tab)"
-    assert_selector "a[href='#{edition.public_url(locale: 'fr', draft: true)}']", visible: false, text: "Preview on website - Français (French) (opens in new tab)"
-    assert_selector "a[href='#{edition.public_url(locale: 'es', draft: true)}']", visible: false, text: "Preview on website - Español (Spanish) (opens in new tab)"
+    assert_selector "a[href='#{edition.public_url(locale: 'fr', draft: true)}']", visible: false, text: "Preview on website - French (Français) (opens in new tab)"
+    assert_selector "a[href='#{edition.public_url(locale: 'es', draft: true)}']", visible: false, text: "Preview on website - Spanish (Español) (opens in new tab)"
   end
 
   test "renders sharable preview functionality when edition is a pre-publication state" do

--- a/test/components/admin/editions/show/translations_test.rb
+++ b/test/components/admin/editions/show/translations_test.rb
@@ -29,8 +29,8 @@ class Admin::Editions::Show::TranslationsTest < ViewComponent::TestCase
     edition.translations.build(locale: "es")
     render_inline(Admin::Editions::Show::Translations.new(edition))
 
-    assert page.has_content? "Deutsch (German)"
-    assert page.has_content? "Español (Spanish)"
-    assert_not page.has_content? "Français (French)"
+    assert page.has_content? "German (Deutsch)"
+    assert page.has_content? "Spanish (Español)"
+    assert_not page.has_content? "French (Français)"
   end
 end

--- a/test/components/admin/social_media_accounts/index/summary_card_component_test.rb
+++ b/test/components/admin/social_media_accounts/index/summary_card_component_test.rb
@@ -61,14 +61,14 @@ class Admin::SocialMediaAccounts::Index::SummaryCardComponentTest < ViewComponen
     assert_selector ".govuk-summary-list__row:nth-child(1) .govuk-summary-list__value", text: english_social_media_account.url
     assert_selector ".govuk-summary-list__row:nth-child(1) .govuk-summary-list__actions a[href='#{english_social_media_account.url}']", text: "View English"
     assert_selector ".govuk-summary-list__row:nth-child(1) .govuk-summary-list__actions a[href='#{edit_polymorphic_path([:admin, socialable, english_social_media_account], locale: :en)}']", text: "Edit English account"
-    assert_selector ".govuk-summary-list__row:nth-child(2) .govuk-summary-list__key", text: "Spanish"
-    assert_selector ".govuk-summary-list__row:nth-child(2) .govuk-summary-list__value", text: english_social_media_account.url
-    assert_selector ".govuk-summary-list__row:nth-child(2) .govuk-summary-list__actions a[href='#{english_social_media_account.url}']", text: "View Spanish"
-    assert_selector ".govuk-summary-list__row:nth-child(2) .govuk-summary-list__actions a[href='#{edit_polymorphic_path([:admin, socialable, english_social_media_account], locale: :es)}']", text: "Edit Spanish account"
-    assert_selector ".govuk-summary-list__row:nth-child(3) .govuk-summary-list__key", text: "French"
-    assert_selector ".govuk-summary-list__row:nth-child(3) .govuk-summary-list__value", text: french_social_media_account_translation.title
-    assert_selector ".govuk-summary-list__row:nth-child(3) .govuk-summary-list__actions a[href='#{french_social_media_account_translation.url}']", text: "View French"
-    assert_selector ".govuk-summary-list__row:nth-child(3) .govuk-summary-list__actions a[href='#{edit_polymorphic_path([:admin, socialable, english_social_media_account], locale: :fr)}']", text: "Edit French account"
+    assert_selector ".govuk-summary-list__row:nth-child(2) .govuk-summary-list__key", text: "French"
+    assert_selector ".govuk-summary-list__row:nth-child(2) .govuk-summary-list__value", text: french_social_media_account_translation.title
+    assert_selector ".govuk-summary-list__row:nth-child(2) .govuk-summary-list__actions a[href='#{french_social_media_account_translation.url}']", text: "View French"
+    assert_selector ".govuk-summary-list__row:nth-child(2) .govuk-summary-list__actions a[href='#{edit_polymorphic_path([:admin, socialable, english_social_media_account], locale: :fr)}']", text: "Edit French account"
+    assert_selector ".govuk-summary-list__row:nth-child(3) .govuk-summary-list__key", text: "Spanish"
+    assert_selector ".govuk-summary-list__row:nth-child(3) .govuk-summary-list__value", text: english_social_media_account.url
+    assert_selector ".govuk-summary-list__row:nth-child(3) .govuk-summary-list__actions a[href='#{english_social_media_account.url}']", text: "View Spanish"
+    assert_selector ".govuk-summary-list__row:nth-child(3) .govuk-summary-list__actions a[href='#{edit_polymorphic_path([:admin, socialable, english_social_media_account], locale: :es)}']", text: "Edit Spanish account"
   end
 
   test "omits the edit link if the user does not have permission to edit the social media account" do

--- a/test/components/admin/worldwide_organisation_pages/index/summary_card_component_test.rb
+++ b/test/components/admin/worldwide_organisation_pages/index/summary_card_component_test.rb
@@ -37,7 +37,7 @@ class Admin::WorldwideOrganisationPages::Index::SummaryCardComponentTest < ViewC
 
     render_inline(Admin::WorldwideOrganisationPages::Index::SummaryCardComponent.new(page: french_translation, worldwide_organisation: page.edition))
 
-    assert_selector ".govuk-summary-card__title", text: "Publication scheme - Français (French)"
+    assert_selector ".govuk-summary-card__title", text: "Publication scheme - French (Français)"
     assert_selector ".govuk-summary-card__actions .govuk-summary-card__action:nth-child(1) a[href='#{edit_admin_worldwide_organisation_page_translation_path(page.edition, page, french_translation.translation_locale)}']"
     assert_selector ".govuk-summary-card__actions .govuk-summary-card__action:nth-child(2) a[href='#{confirm_destroy_admin_worldwide_organisation_page_translation_path(page.edition, page, french_translation.translation_locale)}']"
 

--- a/test/functional/admin/generic_editions_controller_tests/translation_test.rb
+++ b/test/functional/admin/generic_editions_controller_tests/translation_test.rb
@@ -63,7 +63,7 @@ class Admin::GenericEditionsController::TranslationTest < ActionController::Test
 
     get :show, params: { id: edition }
 
-    assert_select ".govuk-table__cell", text: "Français (French)"
+    assert_select ".govuk-table__cell", text: "French (Français)"
   end
 
   view_test "show omits the link to edit an existing translation unless the edition is editable" do

--- a/test/functional/admin/organisation_translations_controller_test.rb
+++ b/test/functional/admin/organisation_translations_controller_test.rb
@@ -18,8 +18,8 @@ class Admin::OrganisationTranslationsControllerTest < ActionController::TestCase
     translations_path = admin_organisation_translations_path(@organisation)
     assert_select "form[action=?]", translations_path do
       assert_select "select[name=translation_locale]" do
-        assert_select "option[value=fr]", text: "Français (French)"
-        assert_select "option[value=es]", text: "Español (Spanish)"
+        assert_select "option[value=fr]", text: "French (Français)"
+        assert_select "option[value=es]", text: "Spanish (Español)"
       end
 
       assert_select "button[type=submit]"
@@ -46,9 +46,9 @@ class Admin::OrganisationTranslationsControllerTest < ActionController::TestCase
     edit_translation_path = edit_admin_organisation_translation_path(organisation, "fr")
     view_organisation_url = organisation.public_url(draft: true, locale: "fr")
     confirm_destroy_url = confirm_destroy_admin_organisation_translation_path(organisation, :fr)
-    assert_select "a[href=?]", edit_translation_path, text: "Edit Français (French)"
-    assert_select "a[href=?]", view_organisation_url, text: "View Français (French)"
-    assert_select "a[href=?]", confirm_destroy_url, text: "Delete Français (French)"
+    assert_select "a[href=?]", edit_translation_path, text: "Edit French (Français)"
+    assert_select "a[href=?]", view_organisation_url, text: "View French (Français)"
+    assert_select "a[href=?]", confirm_destroy_url, text: "Delete French (Français)"
   end
 
   view_test "index does not list the english translation" do

--- a/test/functional/admin/person_translations_controller_test.rb
+++ b/test/functional/admin/person_translations_controller_test.rb
@@ -16,8 +16,8 @@ class Admin::PersonTranslationsControllerTest < ActionController::TestCase
     translations_path = admin_person_translations_path(@person)
     assert_select "form[action=?]", translations_path do
       assert_select "select[name=translation_locale]" do
-        assert_select "option[value=fr]", text: "Français (French)"
-        assert_select "option[value=es]", text: "Español (Spanish)"
+        assert_select "option[value=fr]", text: "French (Français)"
+        assert_select "option[value=es]", text: "Spanish (Español)"
       end
 
       assert_select "button[type=submit]"
@@ -77,9 +77,9 @@ class Admin::PersonTranslationsControllerTest < ActionController::TestCase
     edit_translation_path = edit_admin_person_translation_path(person, "fr")
     view_person_path = person.public_url(locale: :fr)
     confirm_destroy_url = confirm_destroy_admin_person_translation_path(person, :fr)
-    assert_select "a[href=?]", edit_translation_path, text: "Edit Français (French)"
-    assert_select "a[href=?]", view_person_path, text: "View Français (French)"
-    assert_select "a[href=?]", confirm_destroy_url, text: "Delete Français (French)"
+    assert_select "a[href=?]", edit_translation_path, text: "Edit French (Français)"
+    assert_select "a[href=?]", view_person_path, text: "View French (Français)"
+    assert_select "a[href=?]", confirm_destroy_url, text: "Delete French (Français)"
   end
 
   view_test "index does not list the english translation" do

--- a/test/functional/admin/role_translations_controller_test.rb
+++ b/test/functional/admin/role_translations_controller_test.rb
@@ -16,8 +16,8 @@ class Admin::RoleTranslationsControllerTest < ActionController::TestCase
     translations_path = admin_role_translations_path(@role)
     assert_select "form[action=?]", translations_path do
       assert_select "select[name=translation_locale]" do
-        assert_select "option[value=fr]", text: "Français (French)"
-        assert_select "option[value=es]", text: "Español (Spanish)"
+        assert_select "option[value=fr]", text: "French (Français)"
+        assert_select "option[value=es]", text: "Spanish (Español)"
       end
 
       assert_select "button[type=submit]"
@@ -50,8 +50,8 @@ class Admin::RoleTranslationsControllerTest < ActionController::TestCase
     edit_translation_path = edit_admin_role_translation_path(role, "fr")
     confirm_destroy_url = confirm_destroy_admin_role_translation_path(role, "fr")
 
-    assert_select "a[href=?]", edit_translation_path, text: "Edit Français (French)"
-    assert_select "a[href=?]", confirm_destroy_url, text: "Delete Français (French)"
+    assert_select "a[href=?]", edit_translation_path, text: "Edit French (Français)"
+    assert_select "a[href=?]", confirm_destroy_url, text: "Delete French (Français)"
   end
 
   view_test "index does not list the english translation" do

--- a/test/functional/admin/world_location_news_translations_controller_test.rb
+++ b/test/functional/admin/world_location_news_translations_controller_test.rb
@@ -18,8 +18,8 @@ class Admin::WorldLocationNewsTranslationsControllerTest < ActionController::Tes
     translations_path = admin_world_location_news_translations_path(@world_location)
     assert_select "form[action=?]", translations_path do
       assert_select "select[name=translation_locale]" do
-        assert_select "option[value=fr]", text: "Français (French)"
-        assert_select "option[value=es]", text: "Español (Spanish)"
+        assert_select "option[value=fr]", text: "French (Français)"
+        assert_select "option[value=es]", text: "Spanish (Español)"
       end
 
       assert_select "button[type=submit]"

--- a/test/functional/admin/worldwide_office_translations_controller_test.rb
+++ b/test/functional/admin/worldwide_office_translations_controller_test.rb
@@ -17,8 +17,8 @@ class Admin::WorldwideOfficeTranslationsControllerTest < ActionController::TestC
     assert_select "form[action=?]", translations_path do
       assert_select "select[name=translation_locale]" do
         assert_select "option", count: 2
-        assert_select "option[value=fr]", text: "Français (French)"
-        assert_select "option[value=es]", text: "Español (Spanish)"
+        assert_select "option[value=fr]", text: "French (Français)"
+        assert_select "option[value=es]", text: "Spanish (Español)"
       end
 
       assert_select ".govuk-button-group .govuk-button", text: "Next"

--- a/test/functional/admin/worldwide_organisation_page_translations_controller_test.rb
+++ b/test/functional/admin/worldwide_organisation_page_translations_controller_test.rb
@@ -17,8 +17,8 @@ class Admin::WorldwideOrganisationPageTranslationsControllerTest < ActionControl
     assert_select "form[action=?]", translations_path do
       assert_select "select[name=translation_locale]" do
         assert_select "option", count: 2
-        assert_select "option[value=fr]", text: "Français (French)"
-        assert_select "option[value=es]", text: "Español (Spanish)"
+        assert_select "option[value=fr]", text: "French (Français)"
+        assert_select "option[value=es]", text: "Spanish (Español)"
       end
 
       assert_select ".govuk-button-group .govuk-button", text: "Next"

--- a/test/unit/app/models/contact_test.rb
+++ b/test/unit/app/models/contact_test.rb
@@ -115,7 +115,7 @@ class ContactTest < ActiveSupport::TestCase
     organisation = create(:organisation, translated_into: %i[de es fr])
     contact = create(:contact, contactable: organisation, translated_into: [:es])
 
-    expected_locales = %i[de fr].map { |l| Locale.new(l) }
+    expected_locales = %i[fr de].map { |l| Locale.new(l) }
     assert_equal expected_locales, contact.missing_translations
   end
 
@@ -232,6 +232,6 @@ class ContactTest < ActiveSupport::TestCase
     contact = create(:contact, contactable: office, translated_into: %i[cy es-419])
 
     assert_not contact.valid?
-    assert contact.errors[:base].include?("Translations 'cy, es-419' do not exist for this worldwide organisation")
+    assert contact.errors[:base].include?("Translations 'es-419, cy' do not exist for this worldwide organisation")
   end
 end

--- a/test/unit/app/models/worldwide_organisation_page_test.rb
+++ b/test/unit/app/models/worldwide_organisation_page_test.rb
@@ -85,7 +85,7 @@ class WorldwideOrganisationPageTest < ActiveSupport::TestCase
     worldwide_organisation = create(:worldwide_organisation, translated_into: %i[de es fr])
     page = create(:worldwide_organisation_page, edition: worldwide_organisation, translated_into: [:es])
 
-    expected_locales = %i[de fr].map { |l| Locale.new(l) }
+    expected_locales = %i[fr de].map { |l| Locale.new(l) }
     assert_equal expected_locales, page.missing_translations
   end
 
@@ -101,6 +101,6 @@ class WorldwideOrganisationPageTest < ActiveSupport::TestCase
     page = create(:worldwide_organisation_page, edition: worldwide_organisation, translated_into: %i[cy es-419])
 
     assert_not page.valid?
-    assert page.errors[:base].include?("Translations 'cy, es-419' do not exist for this worldwide organisation")
+    assert page.errors[:base].include?("Translations 'es-419, cy' do not exist for this worldwide organisation")
   end
 end

--- a/test/unit/lib/locale_test.rb
+++ b/test/unit/lib/locale_test.rb
@@ -52,7 +52,7 @@ class LocaleTest < ActiveSupport::TestCase
 
   test "returns both native and english name for locale, unless locale is english" do
     assert_equal "English", Locale.new(:en).native_and_english_language_name
-    assert_equal "Español (Spanish)", Locale.new(:es).native_and_english_language_name
+    assert_equal "Spanish (Español)", Locale.new(:es).native_and_english_language_name
   end
 
   test "returns locale code for parameter form" do


### PR DESCRIPTION
Publishers have requested to have the language dropdown (and implicitly table displays) show as "English (Native)" instead of the current "Native (English)" format we have across whitehall. This PR implements that and also ensures the list is sorted alphabetically using the new format.

Original request: 

> Right now it looks like it's ordered alphabetically by the target language e.g. 'Cymraeg (Welsh)' is near the top of the list as it starts with 'C'.
As an English user I always scroll to the bottom of the list to find 'Welsh', but it's actually near the top.
I've checked with the other content designers on the HMRC GOV.UK Guidance team and we think it would make the language easier to find if the list was ordered by the English name of the language e.g Welsh (Cymraeg)




| OLD | NEW |
|------|------|
| <img width="1622" height="1068" alt="Screenshot 2026-04-21 at 16 42 59" src="https://github.com/user-attachments/assets/8ce24c85-b9ae-4605-bb6b-04a0b593f0a5" /> |  <img width="1682" height="1046" alt="Screenshot 2026-04-21 at 16 45 30" src="https://github.com/user-attachments/assets/3228262d-c0f5-4f94-814e-9f555b5765b0" /> |

<br>

[JIRA](https://gov-uk.atlassian.net/browse/WHIT-3354)

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
