### PR TITLE
Use `plan_for_change_landing_page` [WHIT-3282]

### DIFF
--- a/app/presenters/publishing_api/landing_page_presenter.rb
+++ b/app/presenters/publishing_api/landing_page_presenter.rb
@@ -22,7 +22,7 @@ module PublishingApi
           document_type:,
           public_updated_at: item.public_timestamp || item.updated_at,
           rendering_app: item.rendering_app,
-          schema_name: "landing_page",
+          schema_name: "plan_for_change_landing_page",
           details:,
           links: edition_links,
           auth_bypass_ids: [item.auth_bypass_id],
@@ -41,7 +41,7 @@ module PublishingApi
     end
 
     def document_type
-      "landing_page"
+      "plan_for_change_landing_page"
     end
 
   private

--- a/test/unit/app/presenters/publishing_api/landing_page_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/landing_page_presenter_test.rb
@@ -18,7 +18,7 @@ class PublishingApi::LandingPagePresenterTest < ActiveSupport::TestCase
   end
 
   test "it presents a valid landing_page content item" do
-    assert_valid_against_publisher_schema @presented_content, "landing_page"
+    assert_valid_against_publisher_schema @presented_content, "plan_for_change_landing_page"
     assert_valid_against_links_schema({ links: @presented_links }, "landing_page")
   end
 
@@ -52,12 +52,12 @@ class PublishingApi::LandingPagePresenterTest < ActiveSupport::TestCase
     assert_equal "frontend", @presented_content[:rendering_app]
   end
 
-  test "it presents the schema_name as landing_page" do
-    assert_equal "landing_page", @presented_content[:schema_name]
+  test "it presents the schema_name as plan_for_change_landing_page" do
+    assert_equal "plan_for_change_landing_page", @presented_content[:schema_name]
   end
 
-  test "it presents the document type as landing_page" do
-    assert_equal "landing_page", @presented_content[:document_type]
+  test "it presents the document type as plan_for_change_landing_page" do
+    assert_equal "plan_for_change_landing_page", @presented_content[:document_type]
   end
 
   test "it presents the global process wide locale as the locale of the landing_page" do


### PR DESCRIPTION
## What

Change `document_type` and `schema_name` of Landing Page to `plan_for_change_landing_page`

### Technical Details

We don't need to update the controller or model names of `Landing Page` as the new landing pages will be config driven and so won't have a model or controller that conflicts with these (similar to `Topical Event`).

## Why

We are going to work on a new `Landing Page` document type that is different to the previous implementation of landing pages in Whitehall.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
