### PR TITLE
Remove org restriction on new topical events [WHIT-3372]

### DIFF
--- a/app/models/configurable_document_types/topical_event.json
+++ b/app/models/configurable_document_types/topical_event.json
@@ -197,7 +197,7 @@
     "send_change_history": false,
     "file_attachments_enabled": false,
     "features_enabled": true,
-    "organisations": ["ae9ef2e1-9de0-4ff8-b560-e6ac28a6205c", "af07d5a5-df63-4ddc-9383-6a666845ebe9"],
+    "organisations": null,
     "backdating_enabled": false,
     "history_mode_enabled": false,
     "translations_enabled": false


### PR DESCRIPTION
As things stand only GDS and DCMS users can create New Topical events
/government/admin/standard-editions/new?configurable_document_type=topical_event
We are making the feature more widely accessible for new Topical events (without “about pages”)
The plan is to send out a basecamp post and update the guidance accordingly.
Before doing that we should remove the gds/dcms restriction.
Publishers will still need to have a conversation with GDS before being granted the option to create an TE.

AC:
As a user who is not in GDS or DCMS
I want to access Topical Event pages
So that I can create a new topical event
