### PR TITLE
First publishing date validation [WHIT-3076]

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -238,6 +238,8 @@ class Edition < ApplicationRecord
   end
 
   def other_editions
+    return [] if document.nil?
+
     if persisted?
       document.editions.where(self.class.arel_table[:id].not_eq(id))
     else

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -68,7 +68,7 @@ class Edition < ApplicationRecord
   validates :summary, presence: true, if: :summary_required?, length: { maximum: 65_535 }
   validates :previously_published, inclusion: { in: [true, false], message: "You must specify whether the document has been published before" }
   validates :first_published_at, presence: true, if: -> { previously_published || published_major_version }
-  validates :first_published_at, inclusion: { in: proc { Date.parse("1900-01-01")..Time.zone.now } }, if: :draft?, allow_blank: true
+  validates :first_published_at, inclusion: { in: proc { Date.parse("1900-01-01")..Time.zone.now } }, if: -> { draft? && other_editions.empty? }, allow_blank: true
   validates :scheduled_publication, inclusion: { in: proc { Time.zone.now.. }, message: "must be in the future" }, if: :draft?, allow_blank: true
   validates :political, inclusion: { in: [true, false] }
   validates :image_display_option, inclusion: { in: ["no_image", "organisation_image", "custom_image", nil] }

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -73,6 +73,8 @@ class Edition < ApplicationRecord
   validates :political, inclusion: { in: [true, false] }
   validates :image_display_option, inclusion: { in: ["no_image", "organisation_image", "custom_image", nil] }
 
+  validate :first_published_preceeds_change_notes, if: :draft?
+
   UNMODIFIABLE_STATES = %w[scheduled published superseded deleted unpublished].freeze
   FROZEN_STATES = %w[superseded deleted].freeze
   PRE_PUBLICATION_STATES = %w[draft submitted rejected scheduled].freeze
@@ -443,6 +445,19 @@ class Edition < ApplicationRecord
 
   def error_labels
     {}
+  end
+
+  def first_published_preceeds_change_notes
+    return if first_published_at.blank?
+    return if other_editions.empty?
+
+    change_note_dates = other_editions.pluck(:major_change_published_at).compact.sort
+
+    return if change_note_dates.empty?
+
+    if first_published_at > change_note_dates.first
+      errors.add(:first_published_at, :after_change_notes, latest: change_note_dates.first.strftime("%d/%m/%Y %H:%M"))
+    end
   end
 
 private

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -23,6 +23,7 @@ en:
               invalid_date: First published date is not in the correct format
               blank: Enter a first published date
               inclusion: First published date must be between 1/1/1900 and the present
+              after_change_notes: "First published date must be before the first change note (%{latest})"
             html_attachments:
               missing_contact_reference: "- \"%{html_attachment_title}\" - embedded Contact (ID %{contact_id}) doesn't exist"
             unpublishing:

--- a/test/unit/app/models/edition_test.rb
+++ b/test/unit/app/models/edition_test.rb
@@ -684,6 +684,14 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal "First published date must be between 1/1/1900 and the present", edition.errors.full_messages.first
   end
 
+  test "first_published_at cannot be after the date of the first change note" do
+    edition_with_change_note = create(:edition_with_document, :published, change_note: "changed", major_change_published_at: 2.days.ago)
+    edition = build(:edition, document: edition_with_change_note.document, first_published_at: 1.day.ago)
+
+    assert edition.invalid?
+    assert_equal "First published date must be before the first change note (09/11/2011 11:11)", edition.errors.full_messages.first
+  end
+
   test "#government returns the associated government when the edition has a specific government_id" do
     create(:current_government)
     previous_government = create(:previous_government)

--- a/test/unit/app/models/edition_test.rb
+++ b/test/unit/app/models/edition_test.rb
@@ -996,6 +996,12 @@ class EditionTest < ActiveSupport::TestCase
     assert_not edition.valid?
   end
 
+  test "#other_editions returns an empty array if there is no associated document" do
+    edition = build(:edition)
+
+    assert_equal edition.other_editions, []
+  end
+
   def decoded_token_payload(token)
     payload, _header = JWT.decode(
       token,

--- a/test/unit/app/models/edition_test.rb
+++ b/test/unit/app/models/edition_test.rb
@@ -692,6 +692,15 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal "First published date must be before the first change note (09/11/2011 11:11)", edition.errors.full_messages.first
   end
 
+  test "after_change_notes' error message takes priority if multiple validation errors on first_published_at" do
+    edition_with_change_note = create(:edition_with_document, :published, change_note: "changed", major_change_published_at: 2.days.ago)
+    edition = build(:edition, document: edition_with_change_note.document, first_published_at: 10.years.from_now)
+    edition.validate
+
+    assert_equal 1, edition.errors.size
+    assert_equal "First published date must be before the first change note (09/11/2011 11:11)", edition.errors.full_messages.first
+  end
+
   test "#government returns the associated government when the edition has a specific government_id" do
     create(:current_government)
     previous_government = create(:previous_government)


### PR DESCRIPTION
## What

This PR:

- adds validation to the `Edition` model to prevent users changing the `first_published_at` date to a date after the first change note was created
- stops two contradictory errors messages being shown to the user when `first_published_at` is set to a future date on an edition with changes notes in associated editions

## Why

Allowing users to change `first_published_at` to a date after the earliest change note causes undesirable behaviour including items appearing in the wrong order in the 'See all updates' section of a rendered page.

The `first_published_preceeds_change_notes` validation caused two contradictory error messages when the `first_published_at` date was set to the future on editions with `change_notes`, ie:

- "First published date must be between 01/01/1900 and the present"
- "First published must be before the first change note (<change note date>)"

This change fixes this by only running the `first_published_at, inclusion` validation if there are no `other_editions` present for the draft edition in question.

https://gov-uk.atlassian.net/browse/WHIT-3076

### before

<img width="656" height="315" alt="image" src="https://github.com/user-attachments/assets/573be60b-3063-42db-a48c-fea6fe04ab12" />

<img width="1538" height="412" alt="image" src="https://github.com/user-attachments/assets/d5dcdd7b-1ffe-48bc-9fca-14a93dbcc736" />


### After

<img width="1542" height="364" alt="image" src="https://github.com/user-attachments/assets/82f3a4d1-f407-4a0e-a705-750d8d3a30a0" />



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
