### PR TITLE
Standard Edition Migrator can support non-edition types [WHIT-3268]

### DIFF
--- a/app/services/standard_edition_migrator.rb
+++ b/app/services/standard_edition_migrator.rb
@@ -4,21 +4,38 @@ class StandardEditionMigrator
   end
 
   def preview
-    total_editions = @scope.sum { |doc| Edition.unscoped.where(document: doc).count }
-
-    {
-      unique_documents: @scope.count,
-      total_editions: total_editions,
-    }
-  end
-
-  def migrate!(republish: false, compare_payloads: true)
-    @scope.each do |document|
-      StandardEditionMigratorJob.perform_async(document.id, { "republish" => republish, "compare_payloads" => compare_payloads })
+    if document_scope?
+      total_editions = @scope.sum { |doc| Edition.unscoped.where(document: doc).count }
+      { unique_documents: @scope.count, total_editions: total_editions }
+    else
+      { unique_records: @scope.count }
     end
   end
 
-  def self.recipe_for(edition)
-    raise "No migration recipe defined for Edition type #{edition.type}"
+  def migrate!(republish: false, compare_payloads: true)
+    @scope.each do |record|
+      StandardEditionMigratorJob.perform_async(
+        record.id,
+        { "republish" => republish, "compare_payloads" => compare_payloads, "model_class" => model_class_name },
+      )
+    end
+  end
+
+  def self.recipe_for(model)
+    if model.is_a?(Edition)
+      raise "No migration recipe defined for Edition type #{model.type}"
+    end
+
+    raise "No migration recipe defined for #{model.class.name}"
+  end
+
+private
+
+  def model_class_name
+    @scope.model.name
+  end
+
+  def document_scope?
+    model_class_name == "Document"
   end
 end

--- a/app/sidekiq/standard_edition_migrator_job.rb
+++ b/app/sidekiq/standard_edition_migrator_job.rb
@@ -7,10 +7,21 @@ class StandardEditionMigratorJob < JobBase
   # and any failure is unlikely to resolve itself on a retry.
   sidekiq_options queue: "standard_edition_migration", retry: 0
 
-  def perform(document_id, args)
+  def perform(record_id, args)
     republish = args["republish"]
     compare_payloads = args["compare_payloads"]
+    model_class_name = args["model_class"]
 
+    if model_class_name != "Document"
+      perform_for_non_editionable(record_id, model_class_name, republish:, compare_payloads:)
+    else
+      perform_for_document(record_id, republish:, compare_payloads:)
+    end
+  end
+
+private
+
+  def perform_for_document(document_id, republish:, compare_payloads:)
     ActiveRecord::Base.transaction do
       document = Document.find(document_id)
       migrate_editions!(document, compare_payloads)
@@ -19,7 +30,16 @@ class StandardEditionMigratorJob < JobBase
     PublishingApiDocumentRepublishingJob.new.perform(document_id, true) if republish
   end
 
-private
+  def perform_for_non_editionable(record_id, model_class_name, republish:, compare_payloads:)
+    record = model_class_name.constantize.find(record_id)
+    recipe = StandardEditionMigrator.recipe_for(record)
+
+    new_document_id = ActiveRecord::Base.transaction do
+      migrate_non_editionable!(record, recipe, compare_payloads)
+    end
+
+    PublishingApiDocumentRepublishingJob.new.perform(new_document_id, true) if republish
+  end
 
   def migrate_editions!(document, compare_payloads)
     editions_to_migrate = Edition.unscoped.where(document: document)
@@ -34,6 +54,36 @@ private
         migrate_edition!(edition, recipe)
       end
     end
+  end
+
+  def migrate_non_editionable!(record, recipe, compare_payloads)
+    document = Document.create!(document_type: "StandardEdition", content_id: record.content_id)
+    edition = StandardEdition.new(
+      document:,
+      configurable_document_type: recipe.configurable_document_type,
+      state: "published",
+    )
+    edition.save!(validate: false)
+
+    record.translations.each do |record_translation|
+      edition.translations.find_or_create_by!(locale: record_translation.locale).update_columns(
+        title: recipe.title(record_translation),
+        summary: recipe.summary(record_translation),
+        block_content: recipe.map_legacy_fields_to_block_content(record, record_translation),
+      )
+    end
+
+    if compare_payloads
+      old_presenter = recipe.presenter.new(record)
+      new_presenter = PublishingApi::StandardEditionPresenter.new(edition)
+      compare_presenter_payloads(
+        old_presenter.content, new_presenter.content,
+        old_presenter.links, new_presenter.links,
+        recipe, subject: "#{record.class.name} ID #{record.id}"
+      )
+    end
+
+    document.id
   end
 
   def migrate_edition!(edition, recipe)
@@ -62,12 +112,19 @@ private
     new_content = new_presenter.content
     new_links = new_presenter.links
 
+    compare_presenter_payloads(
+      old_content, new_content, old_links, new_links,
+      recipe, subject: "Edition ID #{edition.id}"
+    )
+  end
+
+  def compare_presenter_payloads(old_content, new_content, old_links, new_links, recipe, subject:)
     diff = diff_values(
       recipe.ignore_legacy_content_fields(old_content),
       recipe.ignore_new_content_fields(new_content),
     )
     unless diff.to_s.empty?
-      raise "Presenter content mismatch after migration for Edition ID #{edition.id}: #{diff}"
+      raise "Presenter content mismatch after migration for #{subject}: #{diff}"
     end
 
     diff = diff_values(
@@ -75,7 +132,7 @@ private
       recipe.ignore_new_links(new_links),
     )
     unless diff.to_s.empty?
-      raise "Presenter links mismatch after migration for Edition ID #{edition.id}: #{diff}"
+      raise "Presenter links mismatch after migration for #{subject}: #{diff}"
     end
   end
 

--- a/docs/migrating_to_standard_edition.md
+++ b/docs/migrating_to_standard_edition.md
@@ -89,4 +89,32 @@ With that in mind, the steps for migrating a legacy content type to being config
 
 ### The legacy content type does not use the Edition model
 
-You'll need to perform a bespoke migration.
+If the legacy content type doesn't use the Edition model (e.g. `TopicalEvent`), you can still use the `StandardEditionMigrator` — just pass a scope of the legacy records directly rather than a `Document` scope.
+
+For each record in scope, the migrator creates a brand new `Document` and `StandardEdition`, preserving the original record's `content_id` on the new document. Note that for the base path overwrite to work in Publishing API you'll need to do the groundwork described in [#11210](https://github.com/alphagov/whitehall/pull/11210) — this lets you interchangeably publish either the legacy content item or the new `StandardEdition` at the same path for testing purposes. The original record is left untouched, so you can remove it manually afterwards (or leave the two co-existing for a while if that's useful).
+
+The recipe works the same way as for editionable content types, with two differences:
+
+- Use the same `StandardEditionMigrator.recipe_for` method (it accepts any model, not just editions)
+- Add `title(record_translation)` and `summary(record_translation)` methods — these are called once per source record translation, so if the record has multiple locales, each gets its own edition translation. The argument is the Globalize translation object, so you can read locale-specific attributes directly from it (e.g. `record_translation.name`).
+
+`map_legacy_fields_to_block_content` takes `(record, record_translation)` — the first argument is your record (for any non-translated data) and the second is the source translation being processed. Everything else — `presenter`, `configurable_document_type`, and the `ignore_*` methods — works identically to the editionable recipe.
+
+The steps from there are the same as above. To preview:
+
+```ruby
+StandardEditionMigrator.new(scope: TopicalEvent.all).preview
+```
+
+To migrate a handful locally first:
+
+```ruby
+StandardEditionMigrator.new(scope: TopicalEvent.first(5)).migrate!(compare_payloads: true, republish: false)
+```
+
+Or to call the job directly for a single record:
+
+```ruby
+StandardEditionMigratorJob.new.perform(topical_event.id, { "model_class" => "TopicalEvent", "republish" => false, "compare_payloads" => true })
+```
+

--- a/test/unit/app/services/standard_edition_migrator_test.rb
+++ b/test/unit/app/services/standard_edition_migrator_test.rb
@@ -81,6 +81,15 @@ class StandardEditionMigratorTest < ActiveSupport::TestCase
 
       assert_equal summary, migrator.preview
     end
+
+    test "summarises how many non-editionable records will be migrated" do
+      org1 = create(:organisation)
+      org2 = create(:organisation)
+
+      migrator = StandardEditionMigrator.new(scope: Organisation.where(id: [org1.id, org2.id]))
+
+      assert_equal({ unique_records: 2 }, migrator.preview)
+    end
   end
 
   describe "#migrate!" do
@@ -105,8 +114,8 @@ class StandardEditionMigratorTest < ActiveSupport::TestCase
 
       migrator = StandardEditionMigrator.new(scope: Document.all)
 
-      StandardEditionMigratorJob.expects(:perform_async).with(some_doc_1.document.id, { "republish" => false, "compare_payloads" => true }).once
-      StandardEditionMigratorJob.expects(:perform_async).with(some_doc_2.document.id, { "republish" => false, "compare_payloads" => true }).once
+      StandardEditionMigratorJob.expects(:perform_async).with(some_doc_1.document.id, { "republish" => false, "compare_payloads" => true, "model_class" => "Document" }).once
+      StandardEditionMigratorJob.expects(:perform_async).with(some_doc_2.document.id, { "republish" => false, "compare_payloads" => true, "model_class" => "Document" }).once
 
       migrator.migrate!
     end
@@ -116,8 +125,22 @@ class StandardEditionMigratorTest < ActiveSupport::TestCase
 
       migrator = StandardEditionMigrator.new(scope: Document.all)
 
-      StandardEditionMigratorJob.expects(:perform_async).with(some_doc.document.id, { "republish" => true, "compare_payloads" => false }).once
+      StandardEditionMigratorJob.expects(:perform_async).with(some_doc.document.id, { "republish" => true, "compare_payloads" => false, "model_class" => "Document" }).once
       migrator.migrate!(republish: true, compare_payloads: false)
+    end
+
+    test "enqueues a migration job for each non-editionable record, passing the model class" do
+      org1 = create(:organisation)
+      org2 = create(:organisation)
+
+      migrator = StandardEditionMigrator.new(scope: Organisation.where(id: [org1.id, org2.id]))
+
+      StandardEditionMigratorJob.expects(:perform_async)
+        .with(org1.id, { "republish" => false, "compare_payloads" => true, "model_class" => "Organisation" }).once
+      StandardEditionMigratorJob.expects(:perform_async)
+        .with(org2.id, { "republish" => false, "compare_payloads" => true, "model_class" => "Organisation" }).once
+
+      migrator.migrate!
     end
   end
 end

--- a/test/unit/app/sidekiq/standard_edition_migrator_job_test.rb
+++ b/test/unit/app/sidekiq/standard_edition_migrator_job_test.rb
@@ -17,7 +17,7 @@ class StandardEditionMigratorJobTest < ActiveSupport::TestCase
       job = StandardEditionMigratorJob.new
       job.stubs(:migrate_editions!)
       assert_nothing_raised do
-        job.perform(document.id, "republish" => true, "compare_payloads" => true)
+        job.perform(document.id, "republish" => true, "compare_payloads" => true, "model_class" => "Document")
       end
     end
 
@@ -28,7 +28,7 @@ class StandardEditionMigratorJobTest < ActiveSupport::TestCase
       job = StandardEditionMigratorJob.new
 
       assert_raises(ActiveRecord::RecordNotFound) do
-        job.perform(invalid_document_id, "republish" => true, "compare_payloads" => true)
+        job.perform(invalid_document_id, "republish" => true, "compare_payloads" => true, "model_class" => "Document")
       end
     end
 
@@ -83,13 +83,13 @@ class StandardEditionMigratorJobTest < ActiveSupport::TestCase
       test "doesn't change the document history" do
         change_history = Document.find(@document_id).change_history.to_json
 
-        Sidekiq::Testing.inline! { StandardEditionMigratorJob.new.perform(@document_id, "republish" => true, "compare_payloads" => true) }
+        Sidekiq::Testing.inline! { StandardEditionMigratorJob.new.perform(@document_id, "republish" => true, "compare_payloads" => true, "model_class" => "Document") }
 
         assert_equal change_history, Document.find(@document_id).change_history.to_json
       end
 
       test "migrates all editions in the scope to the configurable_document_type variant of StandardEdition" do
-        Sidekiq::Testing.inline! { StandardEditionMigratorJob.new.perform(@document_id, "republish" => true, "compare_payloads" => true) }
+        Sidekiq::Testing.inline! { StandardEditionMigratorJob.new.perform(@document_id, "republish" => true, "compare_payloads" => true, "model_class" => "Document") }
         superseded_edition = Edition.find(@superseded_edition_id)
         published_edition = Edition.find(@published_edition_id)
         draft_edition = Edition.find(@draft_edition_id)
@@ -110,7 +110,7 @@ class StandardEditionMigratorJobTest < ActiveSupport::TestCase
       end
 
       test "migrates all editions in the scope and retains their original states" do
-        Sidekiq::Testing.inline! { StandardEditionMigratorJob.new.perform(@document_id, "republish" => true, "compare_payloads" => true) }
+        Sidekiq::Testing.inline! { StandardEditionMigratorJob.new.perform(@document_id, "republish" => true, "compare_payloads" => true, "model_class" => "Document") }
         superseded_edition = Edition.find(@superseded_edition_id)
         published_edition = Edition.find(@published_edition_id)
         draft_edition = Edition.find(@draft_edition_id)
@@ -123,7 +123,7 @@ class StandardEditionMigratorJobTest < ActiveSupport::TestCase
       end
 
       test "defers to `map_legacy_fields_to_block_content` to set the block_content= field" do
-        Sidekiq::Testing.inline! { StandardEditionMigratorJob.new.perform(@document_id, "republish" => true, "compare_payloads" => true) }
+        Sidekiq::Testing.inline! { StandardEditionMigratorJob.new.perform(@document_id, "republish" => true, "compare_payloads" => true, "model_class" => "Document") }
         superseded_edition = Edition.find(@superseded_edition_id)
         published_edition = Edition.find(@published_edition_id)
         deleted_edition = Edition.unscoped.find(@deleted_edition_id)
@@ -140,7 +140,7 @@ class StandardEditionMigratorJobTest < ActiveSupport::TestCase
       end
 
       test "clears the legacy body field" do
-        Sidekiq::Testing.inline! { StandardEditionMigratorJob.new.perform(@document_id, "republish" => true, "compare_payloads" => true) }
+        Sidekiq::Testing.inline! { StandardEditionMigratorJob.new.perform(@document_id, "republish" => true, "compare_payloads" => true, "model_class" => "Document") }
         superseded_edition = Edition.find(@superseded_edition_id)
         published_edition = Edition.find(@published_edition_id)
         deleted_edition = Edition.unscoped.find(@deleted_edition_id)
@@ -160,7 +160,7 @@ class StandardEditionMigratorJobTest < ActiveSupport::TestCase
         draft_edition.attachments = [attachment]
         draft_edition.save!
 
-        Sidekiq::Testing.inline! { StandardEditionMigratorJob.new.perform(@document_id, "republish" => true, "compare_payloads" => true) }
+        Sidekiq::Testing.inline! { StandardEditionMigratorJob.new.perform(@document_id, "republish" => true, "compare_payloads" => true, "model_class" => "Document") }
 
         draft_edition = Edition.find(@draft_edition_id)
         assert_equal draft_edition.images, [image]
@@ -176,7 +176,7 @@ class StandardEditionMigratorJobTest < ActiveSupport::TestCase
         end
         draft_edition.save!
 
-        Sidekiq::Testing.inline! { StandardEditionMigratorJob.new.perform(@document_id, "republish" => true, "compare_payloads" => true) }
+        Sidekiq::Testing.inline! { StandardEditionMigratorJob.new.perform(@document_id, "republish" => true, "compare_payloads" => true, "model_class" => "Document") }
 
         draft_edition = Edition.find(@draft_edition_id)
         with_locale(:fr) do
@@ -191,7 +191,7 @@ class StandardEditionMigratorJobTest < ActiveSupport::TestCase
         # be a reasonable simulation of a failure part way through the migration.
         Document.any_instance.stubs(:update_column).raises(StandardError.new("Simulated failure"))
         assert_raises(StandardError) do
-          Sidekiq::Testing.inline! { StandardEditionMigratorJob.new.perform(@document_id, "republish" => true, "compare_payloads" => true) }
+          Sidekiq::Testing.inline! { StandardEditionMigratorJob.new.perform(@document_id, "republish" => true, "compare_payloads" => true, "model_class" => "Document") }
         end
         superseded_edition = Edition.find(@superseded_edition_id)
         published_edition = Edition.find(@published_edition_id)
@@ -206,13 +206,13 @@ class StandardEditionMigratorJobTest < ActiveSupport::TestCase
       test "re-presents document to Publishing API (on bulk publishing queue) when `republish => true` is passed" do
         PublishingApiDocumentRepublishingJob.any_instance.expects(:perform).with(Edition.find(@draft_edition_id).document.id, true).once
 
-        Sidekiq::Testing.inline! { StandardEditionMigratorJob.new.perform(@document_id, "republish" => true, "compare_payloads" => true) }
+        Sidekiq::Testing.inline! { StandardEditionMigratorJob.new.perform(@document_id, "republish" => true, "compare_payloads" => true, "model_class" => "Document") }
       end
 
       test "doesn't re-present document to Publishing API if `republish => true` isn't passed" do
         PublishingApiDocumentRepublishingJob.any_instance.expects(:perform).with(Edition.find(@draft_edition_id).document.id, true).never
 
-        Sidekiq::Testing.inline! { StandardEditionMigratorJob.new.perform(@document_id, "republish" => false, "compare_payloads" => true) }
+        Sidekiq::Testing.inline! { StandardEditionMigratorJob.new.perform(@document_id, "republish" => false, "compare_payloads" => true, "model_class" => "Document") }
       end
 
       test "doesn't re-present document to Publishing API if exception encountered during migration" do
@@ -220,7 +220,7 @@ class StandardEditionMigratorJobTest < ActiveSupport::TestCase
 
         Document.any_instance.stubs(:update_column).raises(StandardError.new("Simulated failure"))
         assert_raises(StandardError) do
-          Sidekiq::Testing.inline! { StandardEditionMigratorJob.new.perform(@document_id, "republish" => true, "compare_payloads" => true) }
+          Sidekiq::Testing.inline! { StandardEditionMigratorJob.new.perform(@document_id, "republish" => true, "compare_payloads" => true, "model_class" => "Document") }
         end
       end
 
@@ -232,7 +232,7 @@ class StandardEditionMigratorJobTest < ActiveSupport::TestCase
           true
         end
 
-        Sidekiq::Testing.inline! { StandardEditionMigratorJob.new.perform(@document_id, "republish" => true, "compare_payloads" => true) }
+        Sidekiq::Testing.inline! { StandardEditionMigratorJob.new.perform(@document_id, "republish" => true, "compare_payloads" => true, "model_class" => "Document") }
         assert_equal [@published_edition_id, @draft_edition_id], calls
       end
 
@@ -240,7 +240,7 @@ class StandardEditionMigratorJobTest < ActiveSupport::TestCase
         StandardEditionMigratorJob.any_instance.stubs(:migrate_edition!)
         StandardEditionMigratorJob.any_instance.expects(:ensure_payloads_remain_identical).never
 
-        Sidekiq::Testing.inline! { StandardEditionMigratorJob.new.perform(@document_id, "republish" => true, "compare_payloads" => false) }
+        Sidekiq::Testing.inline! { StandardEditionMigratorJob.new.perform(@document_id, "republish" => true, "compare_payloads" => false, "model_class" => "Document") }
       end
     end
 
@@ -260,7 +260,7 @@ class StandardEditionMigratorJobTest < ActiveSupport::TestCase
         PublishingApi::StandardEditionPresenter.any_instance.stubs(:links).returns({ some: "links" })
 
         assert_nothing_raised do
-          Sidekiq::Testing.inline! { StandardEditionMigratorJob.new.perform(@document_id, "republish" => true, "compare_payloads" => true) }
+          Sidekiq::Testing.inline! { StandardEditionMigratorJob.new.perform(@document_id, "republish" => true, "compare_payloads" => true, "model_class" => "Document") }
         end
       end
 
@@ -301,7 +301,7 @@ class StandardEditionMigratorJobTest < ActiveSupport::TestCase
           calls << edition.id
           true
         end
-        Sidekiq::Testing.inline! { StandardEditionMigratorJob.new.perform(document_id, "republish" => true, "compare_payloads" => true) }
+        Sidekiq::Testing.inline! { StandardEditionMigratorJob.new.perform(document_id, "republish" => true, "compare_payloads" => true, "model_class" => "Document") }
         assert_equal [published_edition_id, draft_edition_id], calls
       end
 
@@ -312,7 +312,7 @@ class StandardEditionMigratorJobTest < ActiveSupport::TestCase
         PublishingApi::StandardEditionPresenter.any_instance.stubs(:links).returns({ some: "links", nested: { baz: "bax", foo: "bar" } })
 
         assert_nothing_raised do
-          Sidekiq::Testing.inline! { StandardEditionMigratorJob.new.perform(@document_id, "republish" => true, "compare_payloads" => true) }
+          Sidekiq::Testing.inline! { StandardEditionMigratorJob.new.perform(@document_id, "republish" => true, "compare_payloads" => true, "model_class" => "Document") }
         end
       end
 
@@ -323,7 +323,7 @@ class StandardEditionMigratorJobTest < ActiveSupport::TestCase
         PublishingApi::StandardEditionPresenter.any_instance.stubs(:links).returns({ some: "links" })
 
         error = assert_raises(RuntimeError) do
-          Sidekiq::Testing.inline! { StandardEditionMigratorJob.new.perform(@document_id, "republish" => true, "compare_payloads" => true) }
+          Sidekiq::Testing.inline! { StandardEditionMigratorJob.new.perform(@document_id, "republish" => true, "compare_payloads" => true, "model_class" => "Document") }
         end
         assert_match(/Presenter content mismatch after migration for Edition ID/, error.message)
       end
@@ -335,7 +335,7 @@ class StandardEditionMigratorJobTest < ActiveSupport::TestCase
         PublishingApi::StandardEditionPresenter.any_instance.stubs(:links).returns({ some: "something else" })
 
         error = assert_raises(RuntimeError) do
-          Sidekiq::Testing.inline! { StandardEditionMigratorJob.new.perform(@document_id, "republish" => true, "compare_payloads" => true) }
+          Sidekiq::Testing.inline! { StandardEditionMigratorJob.new.perform(@document_id, "republish" => true, "compare_payloads" => true, "model_class" => "Document") }
         end
         assert_match(/Presenter links mismatch after migration for Edition ID/, error.message)
       end
@@ -351,7 +351,7 @@ class StandardEditionMigratorJobTest < ActiveSupport::TestCase
         PublishingApi::StandardEditionPresenter.any_instance.stubs(:links).returns({ some: "links" })
 
         assert_nothing_raised do
-          Sidekiq::Testing.inline! { StandardEditionMigratorJob.new.perform(@document_id, "republish" => true, "compare_payloads" => true) }
+          Sidekiq::Testing.inline! { StandardEditionMigratorJob.new.perform(@document_id, "republish" => true, "compare_payloads" => true, "model_class" => "Document") }
         end
       end
 
@@ -367,14 +367,159 @@ class StandardEditionMigratorJobTest < ActiveSupport::TestCase
         PublishingApi::StandardEditionPresenter.any_instance.stubs(:links).returns({ some: "links", ignore_new: "new_value" })
 
         assert_nothing_raised do
-          Sidekiq::Testing.inline! { StandardEditionMigratorJob.new.perform(@document_id, "republish" => true, "compare_payloads" => true) }
+          Sidekiq::Testing.inline! { StandardEditionMigratorJob.new.perform(@document_id, "republish" => true, "compare_payloads" => true, "model_class" => "Document") }
         end
+      end
+    end
+  end
+
+  describe "#perform with non-editionable records" do
+    setup do
+      ConfigurableDocumentType.setup_test_types(build_configurable_document_type("test_type"))
+      StandardEditionMigrator.stubs(:recipe_for).returns(StandardEditionMigratorJobTest::TestNonEditionableRecipe.new)
+
+      TestNonEditionablePresenter.any_instance.stubs(:content).returns({ some: "content" })
+      PublishingApi::StandardEditionPresenter.any_instance.stubs(:content).returns({ some: "content" })
+      TestNonEditionablePresenter.any_instance.stubs(:links).returns({ some: "links" })
+      PublishingApi::StandardEditionPresenter.any_instance.stubs(:links).returns({ some: "links" })
+
+      @test_record = StandardEditionMigratorJobTest::TestNonEditionableRecord.new(
+        id: 1,
+        name: "My Event",
+        summary: "Event summary",
+        description: "Event description",
+        content_id: SecureRandom.uuid,
+      )
+      TestNonEditionableRecord.register(@test_record)
+    end
+
+    teardown do
+      TestNonEditionableRecord.clear
+    end
+
+    test "creates a new Document and StandardEdition, mapping fields from the recipe" do
+      assert_difference("Document.count", 1) do
+        assert_difference("Edition.count", 1) do
+          perform_non_editionable_migration
+        end
+      end
+
+      new_document = Document.last
+      assert_equal "StandardEdition", new_document.document_type
+      assert_equal @test_record.content_id, new_document.content_id
+
+      new_edition = Edition.last
+      assert_equal "published", new_edition.state
+      assert_equal TestNonEditionableRecipe.new.configurable_document_type, new_edition.configurable_document_type
+      assert_equal "My Event", new_edition.title
+      assert_equal "Event summary", new_edition.summary
+      assert_equal({ "description" => "Event description" }, new_edition[:block_content])
+    end
+
+    test "carries over translations from the non-editionable record to the new edition" do
+      bilingual_record = TestNonEditionableRecord.new(
+        id: 2,
+        name: "",
+        summary: "",
+        description: "",
+        content_id: SecureRandom.uuid,
+        translations: [
+          TestNonEditionableRecord::Translation.new(locale: :en, name: "english name", summary: "english summary", description: "english description"),
+          TestNonEditionableRecord::Translation.new(locale: :cy, name: "welsh name", summary: "welsh summary", description: "welsh description"),
+        ],
+      )
+      TestNonEditionableRecord.register(bilingual_record)
+
+      Sidekiq::Testing.inline! do
+        StandardEditionMigratorJob.new.perform(
+          bilingual_record.id,
+          "republish" => false,
+          "compare_payloads" => false,
+          "model_class" => "StandardEditionMigratorJobTest::TestNonEditionableRecord",
+        )
+      end
+
+      new_edition = Edition.last
+      en_translation = new_edition.translations.find_by(locale: "en")
+      assert_not_nil en_translation
+      assert_equal "english name", en_translation.title
+      assert_equal "english summary", en_translation.summary
+
+      cy_translation = new_edition.translations.find_by(locale: "cy")
+      assert_not_nil cy_translation
+      assert_equal "welsh name", cy_translation.title
+      assert_equal "welsh summary", cy_translation.summary
+    end
+
+    test "the original non-editionable record is not deleted" do
+      perform_non_editionable_migration
+
+      assert TestNonEditionableRecord.find(@test_record.id).present?,
+             "Expected original TestNonEditionableRecord to still exist after migration"
+    end
+
+    test "re-presents document to Publishing API when republish => true" do
+      PublishingApiDocumentRepublishingJob.any_instance.expects(:perform).once
+
+      perform_non_editionable_migration(republish: true)
+    end
+
+    test "republishes the newly created document (not some other document) when republish => true" do
+      republished_document_id = nil
+      PublishingApiDocumentRepublishingJob.any_instance.expects(:perform).with do |document_id, _bulk|
+        republished_document_id = document_id
+        true
+      end
+
+      perform_non_editionable_migration(republish: true)
+
+      assert_equal Document.last.id, republished_document_id
+    end
+
+    test "runs payload comparison when compare_payloads => true and raises if content differs" do
+      TestNonEditionablePresenter.any_instance.stubs(:content).returns({ some: "legacy content" })
+      PublishingApi::StandardEditionPresenter.any_instance.stubs(:content).returns({ some: "different content" })
+
+      error = assert_raises(RuntimeError) do
+        perform_non_editionable_migration(compare_payloads: true)
+      end
+
+      assert_match(/Presenter content mismatch after migration for StandardEditionMigratorJobTest::TestNonEditionableRecord ID/, error.message)
+    end
+
+    test "runs payload comparison when compare_payloads => true and raises if links differ" do
+      TestNonEditionablePresenter.any_instance.stubs(:links).returns({ some: "legacy links" })
+      PublishingApi::StandardEditionPresenter.any_instance.stubs(:links).returns({ some: "different links" })
+
+      error = assert_raises(RuntimeError) do
+        perform_non_editionable_migration(compare_payloads: true)
+      end
+
+      assert_match(/Presenter links mismatch after migration for StandardEditionMigratorJobTest::TestNonEditionableRecord ID/, error.message)
+    end
+
+  private
+
+    def perform_non_editionable_migration(republish: false, compare_payloads: false)
+      Sidekiq::Testing.inline! do
+        StandardEditionMigratorJob.new.perform(
+          @test_record.id,
+          "republish" => republish,
+          "compare_payloads" => compare_payloads,
+          "model_class" => "StandardEditionMigratorJobTest::TestNonEditionableRecord",
+        )
       end
     end
   end
 
   class TestPresenter
     def initialize(_edition); end
+    def content; end
+    def links; end
+  end
+
+  class TestNonEditionablePresenter
+    def initialize(_record); end
     def content; end
     def links; end
   end
@@ -430,6 +575,59 @@ class StandardEditionMigratorJobTest < ActiveSupport::TestCase
     def ignore_new_links(links)
       links.delete(:ignore_new)
       links
+    end
+  end
+
+  class TestNonEditionableRecipe < TestRecipe
+    def presenter
+      StandardEditionMigratorJobTest::TestNonEditionablePresenter
+    end
+
+    def title(record_translation)
+      record_translation.name
+    end
+
+    def summary(record_translation)
+      record_translation.summary
+    end
+
+    def map_legacy_fields_to_block_content(_record, record_translation)
+      { "description" => record_translation.description }
+    end
+  end
+
+  class TestNonEditionableRecord
+    Translation = Struct.new(:locale, :name, :summary, :description, keyword_init: true)
+
+    attr_reader :id, :name, :summary, :description, :content_id
+
+    def initialize(id:, name:, summary:, description:, content_id:, translations: nil)
+      @id = id
+      @name = name
+      @summary = summary
+      @description = description
+      @content_id = content_id
+      @translations = translations
+    end
+
+    def translations
+      @translations || [Translation.new(locale: :en, name: @name, summary: @summary, description: @description)]
+    end
+
+    def self.find(id)
+      all_instances.find { |r| r.id == id } || raise(ActiveRecord::RecordNotFound)
+    end
+
+    def self.register(record)
+      all_instances << record
+    end
+
+    def self.clear
+      @all_instances = []
+    end
+
+    def self.all_instances
+      @all_instances ||= []
     end
   end
 end


### PR DESCRIPTION
## Summary

Extends `StandardEditionMigrator` and `StandardEditionMigratorJob` to support migrating legacy content types that do not use the Edition model (e.g. `TopicalEvent`), in addition to the existing editionable migration path.

Previously, passing a non-`Document` scope would fail. Now, any ActiveRecord model scope can be passed, and the migrator routes to the appropriate code path.

---

## Key behavior changes

### Flexible scope handling

- Before: Only `Document` scopes were supported  
- Now: Any ActiveRecord model scope is supported  


### Preview changes

- Editionable: unchanged (edition-based summary)  
- Non-editionable:
  ```ruby
  { unique_records: N }
  

### `StandardEditionMigrator#migrate!`
- Enqueues jobs with an additional `model_class` argument

### `StandardEditionMigratorJob`
- Loads records using `model_class`
- For each record:
  - Creates a new `Document`
  - Creates a new `StandardEdition`
  - Maps fields using the recipe
- Leaves the original record untouched (manual cleanup required)

[JIRA](https://gov-uk.atlassian.net/browse/WHIT-3268)

