### PR TITLE
Update search scope for slug and add slug_override index

### DIFF
--- a/app/models/concerns/edition/scopes/searchable_by_title.rb
+++ b/app/models/concerns/edition/scopes/searchable_by_title.rb
@@ -6,7 +6,7 @@ module Edition::Scopes::SearchableByTitle
       like_clause = "%#{sanitize_sql_like(keywords)}%"
 
       if keywords.match?(/\A[a-z0-9]+(-[a-z0-9]+)+\z/)
-        where(slug: keywords)
+        where(slug: keywords).or(where(slug_override: keywords))
       else
         in_default_locale
           .includes(:document)

--- a/db/migrate/20260424093745_add_index_to_editions_slug_override.rb
+++ b/db/migrate/20260424093745_add_index_to_editions_slug_override.rb
@@ -1,0 +1,5 @@
+class AddIndexToEditionsSlugOverride < ActiveRecord::Migration[8.1]
+  def change
+    add_index :editions, :slug_override
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_14_101848) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_24_093745) do
   create_table "assets", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.bigint "assetable_id"
@@ -414,6 +414,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_14_101848) do
     t.index ["publication_type_id"], name: "index_editions_on_publication_type_id"
     t.index ["role_appointment_id"], name: "index_editions_on_role_appointment_id"
     t.index ["slug"], name: "index_editions_on_slug"
+    t.index ["slug_override"], name: "index_editions_on_slug_override"
     t.index ["speech_type_id"], name: "index_editions_on_speech_type_id"
     t.index ["state", "type"], name: "index_editions_on_state_and_type"
     t.index ["state"], name: "index_editions_on_state"

--- a/test/unit/app/models/edition_test.rb
+++ b/test/unit/app/models/edition_test.rb
@@ -512,6 +512,12 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal [edition_with_first_keyword], Edition.with_title_containing("klingons-rule")
   end
 
+  test "should find editions with slug_override containing keyword" do
+    edition_with_slug_override = create(:edition, title: "klingons rule", slug_override: "another-slug")
+    _edition_without_match = create(:edition, title: "this document is about muppets")
+    assert_equal [edition_with_slug_override], Edition.with_title_containing("another-slug")
+  end
+
   test "should find editions with title containing regular expression characters" do
     edition_with_nasty_characters = create(:edition, title: "title with [stuff in brackets]")
     assert_equal [edition_with_nasty_characters], Edition.with_title_containing("[stuff")


### PR DESCRIPTION
Since the introduction of `slug_override`, editions using an overridden slug were not found when searching by that slug value. I've extended the slug search condition to also check `slug_override`, and add a database index on the column to keep lookup performance on par with the existing slug index.

Related PR: https://github.com/alphagov/whitehall/pull/11387

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
