### PR TITLE
Change Topical Event label and remove create button for legacy TEs

### DIFF
--- a/app/controllers/admin/new_document_controller.rb
+++ b/app/controllers/admin/new_document_controller.rb
@@ -87,7 +87,7 @@ class Admin::NewDocumentController < Admin::BaseController
       types["topical_event"] = {
         "klass" => StandardEdition,
         "hint_text" => ConfigurableDocumentType.find("topical_event").description,
-        "label" => "#{ConfigurableDocumentType.find('topical_event').label} (experimental)",
+        "label" => ConfigurableDocumentType.find("topical_event").label,
         "redirect" => new_admin_standard_edition_path(configurable_document_type: "topical_event"),
       }
     end

--- a/app/helpers/admin/url_helper.rb
+++ b/app/helpers/admin/url_helper.rb
@@ -1,7 +1,7 @@
 module Admin::UrlHelper
   # legacy
   def admin_topical_events_link
-    admin_link "Topical events", admin_topical_events_path
+    admin_link "Topical events (old)", admin_topical_events_path
   end
 
   def admin_organisations_link

--- a/app/views/admin/topical_events/index.html.erb
+++ b/app/views/admin/topical_events/index.html.erb
@@ -2,15 +2,14 @@
 <% content_for :title, "Topical events" %>
 <% content_for :title_margin_bottom, 4 %>
 
-<%= render "govuk_publishing_components/components/warning_text", {
-  text: "Do not create topical events without consulting GDS. New documents will be live immediately on selecting save.",
-} %>
+<div class="format-advice">
+  <p class="govuk-body">You can create a new topical event in the 'New document' tab.</p>
 
-<%= render "govuk_publishing_components/components/button", {
-  text: "Create topical event",
-  href: [:new, :admin, :topical_event],
-  margin_bottom: 8,
+  <%= render "govuk_publishing_components/components/warning_text", {
+  text: "Changes to old topical events will be live immediately when you select ‘Save’.",
 } %>
+</div>
+
 <div class="app-view-topical-events-index__table govuk-table--with-actions app-c-govuk-table--filterable">
   <%= render "govuk_publishing_components/components/table", {
     filterable: true,

--- a/features/step_definitions/topical_event_steps.rb
+++ b/features/step_definitions/topical_event_steps.rb
@@ -7,10 +7,6 @@ Given(/^a topical event called "(.*?)" with summary "([^"]*)" and description "(
   stub_topical_event_in_content_store(name)
 end
 
-When(/^I create a new topical event "([^"]*)" with summary "([^"]*)" and description "([^"]*)"$/) do |name, summary, description|
-  create_topical_event_and_stub_in_content_store(name:, summary:, description:)
-end
-
 Then(/^I should see the topical event "([^"]*)" in the admin interface$/) do |topical_event_name|
   topical_event = TopicalEvent.find_by!(name: topical_event_name)
   visit admin_topical_events_path(topical_event)

--- a/features/support/topical_events_helper.rb
+++ b/features/support/topical_events_helper.rb
@@ -4,26 +4,6 @@ ParameterType(
   transformer: ->(section) { section },
 )
 module TopicalEventsHelper
-  def create_topical_event_and_stub_in_content_store(options = {})
-    visit admin_root_path
-    click_link "More"
-    click_link "Topical events"
-    click_link "Create topical event"
-    fill_in "Name", with: options[:name] || "topic-name"
-    fill_in "Description", with: options[:description] || "topic-description"
-    fill_in "Summary", with: options[:description] || "topic-summary"
-    within "#topical_event_start_date" do
-      fill_in_date_fields(options[:start_date] || 1.day.ago.to_s)
-    end
-    within "#topical_event_end_date" do
-      fill_in_date_fields(options[:end_date] || 1.month.from_now.to_s)
-    end
-
-    click_button "Save"
-
-    stub_topical_event_in_content_store(options[:name])
-  end
-
   def stub_topical_event_in_content_store(name)
     content_item = {
       format: "topical_event",

--- a/features/topical_events.feature
+++ b/features/topical_events.feature
@@ -1,14 +1,9 @@
-Feature: Creating and publishing topical events
+Feature: Editing existing legacy topical events
   As an editor
-  I want to be able to create and publish topical events
-  So that I can communicate about them
+  I want to be able to edit and publish existing legacy topical events
 
   Background:
     Given I am an editor
-
-  Scenario: Adding a new topical event
-    When I create a new topical event "An Event" with summary "A topical event" and description "About this topical event"
-    Then I should see the topical event "An Event" in the admin interface
 
   Scenario: Adding more information about the event
     Given I'm administering a topical event


### PR DESCRIPTION
### Change Topical Event labels and remove create button for legacy Topical events

These changes are as requested on the content review itemised on https://gov-uk.atlassian.net/browse/WHIT-3202

On the New document page "Topical event (experimental)" becomes "Topical event"
On the More page "Topical event" becomes "Topical event (old)"

On the Legacy Topical event page `/government/admin/topical-events` 
The Create topical event button has been removed and the text has changed:

BEFORE
![](https://github.com/user-attachments/assets/3eb71c4c-2b4a-44a0-a841-e924955af322)

AFTER
![](https://github.com/user-attachments/assets/28d0f5ac-e113-4600-b449-3526aa5d1877)

NOTE: The warning format has been retained on purpose as the information about immediately going live is still a warning (this is slightly different to the information on the ticket, but intentional)

The feature tests related to the Create topical event button have been removed, as they were related to a feature we no longer support.
