### PR TITLE
Automatically fix up associations when converting news article subtypes [WHIT-2883]

### DIFF
--- a/app/models/standard_edition.rb
+++ b/app/models/standard_edition.rb
@@ -37,7 +37,11 @@ class StandardEdition < Edition
       ConfigurableDocumentType.convertible_from(configurable_document_type).none? { |type| type.key == new_type_key }
 
     self.configurable_document_type = new_type_key
-    save!(validate: false)
+    if save(validate: false)
+      StandardEdition::HygieneEnforcer.new(self).cleanup!
+      return true
+    end
+    false
   end
 
   def body_required?

--- a/app/services/standard_edition/hygiene_enforcer.rb
+++ b/app/services/standard_edition/hygiene_enforcer.rb
@@ -51,14 +51,30 @@ class StandardEdition::HygieneEnforcer
   end
 
   def cleanup!
-    if (edition.configurable_document_type == "world_news_story") && edition.organisations.any?
+    if dirty_world_news_story?(edition)
       edition.organisations.delete_all
-      # Temporarily pretend this is still a news story, so that we send the correct
-      # associations (empty 'organisations' array) as links to Publishing API.
-      # The change below isn't persisted. The patch_links method acts on the instance,
-      # so the change is only in-memory and only for the duration of this method call.
-      edition.configurable_document_type = "news_story"
-      Whitehall::PublishingApi.patch_links(edition)
+      patch_links_as_document_type(edition, "news_story")
+    elsif dirty_other_news_article_subtype?(edition)
+      edition.worldwide_organisation_documents.delete_all
+      patch_links_as_document_type(edition, "world_news_story")
     end
+  end
+
+private
+
+  def dirty_world_news_story?(edition)
+    edition.configurable_document_type == "world_news_story" && edition.organisations.any?
+  end
+
+  def dirty_other_news_article_subtype?(edition)
+    edition.configurable_document_type.in?(%w[news_story press_release government_response]) && edition.worldwide_organisations.any?
+  end
+
+  def patch_links_as_document_type(edition, document_type)
+    # Temporarily pretend this document if of document type 'document_type', so that we send the correct
+    # associations (e.g. empty 'worldwide_organisations' and 'world_locations' arrays for a doc that has
+    # been converted from a "world_news_story") as links to Publishing API.
+    edition.configurable_document_type = document_type
+    Whitehall::PublishingApi.patch_links(edition)
   end
 end

--- a/app/services/standard_edition/hygiene_enforcer.rb
+++ b/app/services/standard_edition/hygiene_enforcer.rb
@@ -1,0 +1,64 @@
+# This class is considered technical debt. We hope to remove it one day if we implement
+# https://gov-uk.atlassian.net/browse/WHIT-2883?focusedCommentId=185941
+#
+# ==== WHAT THIS CODE DOES ====
+#
+# We allow converting from one configurable document type to another (within reason),
+#  such as converting a world news story to a news story. Most conversions work fine
+# because their associations are identical (e.g. news_story -> government_response)
+# but world_news_story has different associations to the other subtypes. When
+# converting to or from world_news_story, we want to clean up the redundant associations
+# as otherwise that can present as a bug on the frontend (e.g. a world news story
+# having its 'organisations' being surfaced as the organisations on the page, instead of
+# the selected 'worldwide_organisations'. And given we hide the organisations field on
+# the world news story form, it's not possible for publishers to fix it up themselves.)
+#
+# We therefore need to:
+#   1. Remove the redundant associations in Whitehall's database, and
+#   2. Patch the links in the Publishing API to remove the redundant associations from there too.
+#
+# But that's complicated by the fact that we dynamically determine which subset of associations
+# to send to Publishing API (see `PublishingApi::PayloadBuilder::ConfigurableDocumentLinks`)
+# so we can't just call `patch_links` and call it a day. We instead need to 'spoof' the
+# configurable document type to pretend to be of the _previous_ content type, so that we can
+# patch links to send an empty array (to remove the values in Publishing API).
+#
+# ==== WHY THIS CODE EXISTS ====
+# The ideal solution outlined in Jira is deemed overly complex for our needs right now, because:
+#
+#   1. This is ONLY about 'news story subtype' → world news story conversion (and the reverse) -
+#      no other content type conversions. All other news story subtype conversions are fine.
+#   2. The document type conversion feature is not blocked - publishers are still free to convert
+#      news article subtypes.
+#   4. There's no expectation we'll roll out document type conversion more widely (e.g. topical
+#      events → history pages).
+#   5. It should only ever be used in response to human error, i.e. if FCDO have chosen the wrong
+#      content type to begin with, despite the guidance.
+#
+# We did have a rake task to run to patch up things manually, in response to support tickets, but
+# that required publishers remembering to raise tickets, and was a cause of toil for us. We also
+# considered running said rake task on a cron, which would avoid the need for most support work,
+# but publishers could still be caught in a window where their doc is a bit broken for up to 24
+# hours. So we agreed we should just run the logic - self-contained in a nicely signposted
+# hacky file - after every document conversion, to automatically clean up data at the point of
+# conversion.
+
+class StandardEdition::HygieneEnforcer
+  attr_reader :edition
+
+  def initialize(edition)
+    @edition = edition
+  end
+
+  def cleanup!
+    if (edition.configurable_document_type == "world_news_story") && edition.organisations.any?
+      edition.organisations.delete_all
+      # Temporarily pretend this is still a news story, so that we send the correct
+      # associations (empty 'organisations' array) as links to Publishing API.
+      # The change below isn't persisted. The patch_links method acts on the instance,
+      # so the change is only in-memory and only for the duration of this method call.
+      edition.configurable_document_type = "news_story"
+      Whitehall::PublishingApi.patch_links(edition)
+    end
+  end
+end

--- a/lib/tasks/data_hygiene.rake
+++ b/lib/tasks/data_hygiene.rake
@@ -110,20 +110,4 @@ namespace :data_hygiene do
 
     shell.say "Speeches reassigned to #{new_role_appointment.role_name}"
   end
-
-  desc "Remove organisation links from converted world news stories"
-  task remove_org_links_from_world_news: :environment do
-    world_news_with_orgs = StandardEdition.where(configurable_document_type: "world_news_story").joins(:organisations)
-
-    world_news_with_orgs.each do |edition|
-      if edition.worldwide_organisations.empty?
-        shell.say "Skipping #{edition.public_url} as no worldwide orgs have been assigned"
-      else
-        edition.organisations.delete_all
-        edition.configurable_document_type = "news_story"
-        Whitehall::PublishingApi.patch_links(edition)
-        shell.say "Removed organisation links from #{edition.public_url}"
-      end
-    end
-  end
 end

--- a/test/unit/app/models/standard_edition_test.rb
+++ b/test/unit/app/models/standard_edition_test.rb
@@ -778,6 +778,17 @@ class StandardEditionTest < ActiveSupport::TestCase
       }, page.block_content.to_h)
     end
 
+    test "calls StandardEdition::HygieneEnforcer to drop invalid associations after changing document type" do
+      initial_type = build_configurable_document_type("initial_type", "settings" => { "configurable_document_group" => "test_group" })
+      new_type = build_configurable_document_type("new_type", "settings" => { "configurable_document_group" => "test_group" })
+      ConfigurableDocumentType.setup_test_types(initial_type.merge(new_type))
+      edition = create(:draft_standard_edition, configurable_document_type: "initial_type")
+
+      StandardEdition::HygieneEnforcer.expects(:new).with(edition).returns(stub(cleanup!: true))
+
+      edition.update_configurable_document_type("new_type")
+    end
+
     test "#error_labels returns a mapping of dot-separated attribute paths to field titles" do
       test_type = build_configurable_document_type(
         "test_type", {

--- a/test/unit/app/services/standard_edition/hygiene_enforcer_test.rb
+++ b/test/unit/app/services/standard_edition/hygiene_enforcer_test.rb
@@ -1,0 +1,41 @@
+require "test_helper"
+
+class StandardEdition::HygieneEnforcerTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
+  setup do
+    # Load the live schemas for these content types
+    world_news_story_definition = JSON.parse(File.read(Rails.root.join("app/models/configurable_document_types/world_news_story.json")))
+    news_story_definition = JSON.parse(File.read(Rails.root.join("app/models/configurable_document_types/news_story.json")))
+    ConfigurableDocumentType.setup_test_types({
+      "world_news_story" => world_news_story_definition,
+      "news_story" => news_story_definition,
+    })
+  end
+
+  describe "#cleanup" do
+    context "cleaning up a document that has been converted into a world news story" do
+      test "removes organisation associations and patches links with explicit empty array" do
+        # Create a world news story that is mocked up to have been converted from a
+        # news story (because it has organisations)
+        edition = create(
+          :standard_edition,
+          configurable_document_type: "world_news_story",
+          worldwide_organisations: [create(:worldwide_organisation)],
+          world_locations: [create(:world_location)], # required for world news stories
+          block_content: { body: "foo" },
+          lead_organisations: [create(:organisation)], # this isn't usually set on World News Stories
+        )
+
+        # Assert that calling the hygiene enforcer removes the orgs and presents that downstream
+        Services.publishing_api.expects(:patch_links).with(
+          edition.document.content_id,
+          links: has_entry(:organisations, []),
+          bulk_publishing: false,
+        )
+        StandardEdition::HygieneEnforcer.new(edition).cleanup!
+        assert edition.organisations.empty?
+      end
+    end
+  end
+end

--- a/test/unit/app/services/standard_edition/hygiene_enforcer_test.rb
+++ b/test/unit/app/services/standard_edition/hygiene_enforcer_test.rb
@@ -37,5 +37,28 @@ class StandardEdition::HygieneEnforcerTest < ActiveSupport::TestCase
         assert edition.organisations.empty?
       end
     end
+
+    context "cleaning up a document that has been converted from a world news story into another news article subtype" do
+      test "removes worldwide organisation associations and patches links with explicit empty arrays" do
+        edition = create(
+          :standard_edition,
+          configurable_document_type: "news_story",
+          lead_organisations: [create(:organisation)],
+          block_content: { body: "foo" },
+          # these aren't usually set on anything other than World News Stories
+          worldwide_organisations: [create(:worldwide_organisation)],
+        )
+
+        Services.publishing_api.expects(:patch_links).with(
+          edition.document.content_id,
+          links: has_entries(
+            worldwide_organisations: [],
+          ),
+          bulk_publishing: false,
+        )
+        StandardEdition::HygieneEnforcer.new(edition).cleanup!
+        assert edition.worldwide_organisations.empty?
+      end
+    end
   end
 end


### PR DESCRIPTION
## What

Adds a new `StandardEdition::HygieneEnforcer` class that contains all the hard-coded rules around which associations to drop when converting from one configurable document type to another. The class is invoked via a callback on the `update_configurable_document_type` method call.

This is the least worst solution we have for now, as it's relatively lightweight, scalable, and follows the Open-Closed principle. The alternatives are:

1. Continue as we are, patching up news articles manually in response to support tickets.
2. Running the remediation rake task on a cron, so that we don't have to run it manually (but still may get support tickets for newly converted documents).
3. Build fully fledged 'association management' [as outlined here](https://gov-uk.atlassian.net/browse/WHIT-2883?focusedCommentId=185941) - quite a heavyweight solution for what is pretty niche behaviour.

### 'Links' behaviour when changing type

The original rake task had a [guardrail](https://github.com/alphagov/whitehall/pull/10952/changes#diff-ae83cbb49dd3aa3f1e0567300c835676c0d70a3f0ae5fb84b0fb2e2445f1291fR119-R121) in it that only did the association removal if there was a new 'equivalent' value specified. E.g. a news_story, converted to a world_news_story, would only have its 'organisations' dropped if there were at least one worldwide organisation set.

We couldn't carry this over as-is because we're now calling this cleanup code immediately after changing the document type. At that point, the user hasn't had a chance to set a value for worldwide organisations yet - meaning that association would always be empty, and thus the HygieneEnforcer wouldn't do anything.

Instead of calling the HygieneEnforcer class on changing document type, I considered calling it after every single save, so that we drop the old association as soon as we have a new equivalent. But that felt surprising, very unclean and potentially could lead to poor performance.

Therefore what I've done instead is drop the guardrail. We drop the obsolete associations (e.g. organisations) **as soon as the document type is changed**, without checking if there is an equivalent set (e.g. worldwide organisations).

This does cause some interesting behaviour. Consider the following:

1. A news story is created, with organisations set (as [edition links](https://github.com/alphagov/whitehall/blob/1fd2d4701c9f92beb025168cae30fc850b98aa27/app/presenters/publishing_api/standard_edition_presenter.rb#L24) _and_ as [link set links](https://github.com/alphagov/whitehall/blob/1fd2d4701c9f92beb025168cae30fc850b98aa27/app/presenters/publishing_api/standard_edition_presenter.rb#L32)), and is published. This is (live) `Edition 1`.

Here's how it might look (note the organisation link):

> <img width="722" height="632" alt="Screenshot 2026-04-27 at 13 20 17" src="https://github.com/user-attachments/assets/64c02623-6165-44df-a9a1-79c08d6a0fea" />

2. A new draft of it is created and it is converted to a world news story, which **removes 'organisations' from the link set links via the `patch_links` call in `HygieneEnforcer`**. It's edited to have a worldwide organisation added (again, as edition links and link set links). This is (draft) `Edition 2`.

Now when we render the live page again (edition 2), we see **both organisations (via edition links) and worldwide organisations (via link set links)**.

> <img width="1103" height="817" alt="Screenshot 2026-04-27 at 12 59 26" src="https://github.com/user-attachments/assets/0f14328f-7546-484e-a35c-c19bb7436a37" />

When we render the _draft_ page (edition 2): we see only worldwide organisations (via edition links). We don't see any organisations because they're not on the edition as edition_links, and their link set link has been removed.

> <img width="1164" height="972" alt="Screenshot 2026-04-27 at 12 59 30" src="https://github.com/user-attachments/assets/66dba1ee-8ef2-4656-ad25-734dac883af9" />

Explanation: we send all links as both Edition Links and Link Set Links, and in link expansion, [edition links take priority](https://docs.publishing.service.gov.uk/repos/publishing-api/link-expansion.html#put-content-edition-links). Organisations were sent as link set links and edition links *on the original publish* (of `Edition 1`), but they've been dropped from link set links in the HygieneEnforcer `patch_links` call when we changed the document type. They still exist as _edition_ links, so are visible on live, but on draft they don't exist as either link type, so they're not visible.

After clicking 'Publish', the draft edition goes live, and thus only its edition links (and any remaining link set links) are rendered, and thus the organisations are dropped from the page, leaving only the worldwide organisations:

> <img width="1054" height="784" alt="Screenshot 2026-04-27 at 13 23 50" src="https://github.com/user-attachments/assets/9be13594-1f8d-41cb-ba0e-baf2445bec0a" />

### So why merge this PR?

Without this PR, we already have this bug, but it's not user-remediable. Prior to this PR, if a publisher converts a news story to a world news story, the 'organisations' will not be carried over as edition links but they _do_ persist as link set links, meaning even when the publisher publishes their new (world news story) draft, the 'organisations' remain on the page. It's then a support ticket for us to step in and manually purge the link set links. So document conversion is already likely to lead to user-visible weirdness on org/worldwide-org links.

This PR, however, means that the bug is eradicated the moment the new draft is published. And as a bonus, the draft _preview_ for the publisher is always accurate.

## Why

When converting from one news article subtype to another, namely to or from world news stories, we carry over associations that are no longer relevant. In the case of 'news story' to 'world news story', the edition's `organisations` are carried over, even though only `worldwide_organisations` are supported on world news stories.

The impact of this is that the wrong organisations may be surfaced to users on the frontend, as the edition now has both organisations _and_ worldwide organisations set, and Frontend defaults to the former. There is no way for the publisher to manually remove the organisations from the edition, as the 'world news story' configurable document type doesn't have organisations listed as a field and thus no form is rendered through which they could remove existing organisations.

We therefore need to purge the old associations when changing content type, and also ensure Publishing API has the corresponding links purged too, since sending a `patch_links` call which _omits_ the old association doesn't remove them - we have to explicitly send an empty array value for the old association.

Jira: https://gov-uk.atlassian.net/browse/WHIT-2883

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
