### PR TITLE
Use embeddable image version as thumbnail URL [WHIT-3378]

### DIFF
--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -31,6 +31,10 @@ class Image < ApplicationRecord
   def thumbnail
     return image_data.file_url unless bitmap? && !requires_crop?
 
+    if image_data.respond_to?(:image_kind_config) && image_data.image_kind_config.embed_version
+      return url(image_data.image_kind_config.embed_version.to_sym)
+    end
+
     variant = image_data.assets.find { |asset| asset.variant != "original" }&.variant&.to_sym
 
     return if variant.blank?

--- a/test/unit/app/models/image_test.rb
+++ b/test/unit/app/models/image_test.rb
@@ -62,6 +62,18 @@ class ImageTest < ActiveSupport::TestCase
     assert_equal image.embed_url, image.url(version)
   end
 
+  test "#thumbnail returns variant url of embed_version if specified in config" do
+    image = create(:image)
+
+    image_data = image.image_data
+
+    version = image_data.image_kind_config.versions.first.name
+
+    image_data.image_kind_config.stubs(:embed_version).returns(version)
+
+    assert_equal image.thumbnail, image.url(version)
+  end
+
   test "returns original url if embed_version not specified in config" do
     image = create(:image)
 


### PR DESCRIPTION
## What

Render the embeddable version of the image in the Image Component.

## Why

So users can download the images they've uploaded from Whitehall. A temporary measure until we update the UI to allow users to do this.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
