### PR TITLE
Explicitly mark "Caption and credit" as an optional field

### DIFF
--- a/app/views/admin/edition_images/edit.html.erb
+++ b/app/views/admin/edition_images/edit.html.erb
@@ -42,7 +42,7 @@
         <% if @image_usage.caption_enabled? %>
           <%= render "govuk_publishing_components/components/textarea", {
             label: {
-              text: "Caption and credit",
+              text: "Caption and credit (optional)",
               heading_size: "l",
             },
             name: "image[caption]",


### PR DESCRIPTION
It's not entirely clear it's optional for the image upload workflow for the new topical event header image. We'd like to reassess more widely the distinction between "required" and "optional" fields throughout Whitehall, but given this is causing confusion already, it doesn't seem a bad idea to mark this out as optional pending a wider consistency check.

Agreed with content that this change is OK:
https://gds.slack.com/archives/C08B3CJGD3N/p1776958770490279?thread_ts=1776956609.017429&cid=C08B3CJGD3N

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
