### PR TITLE
Rename existing LandingPage documents/editions [WHIT-3282]

### DIFF
--- a/db/data_migration/20260428113433_rename_landing_pages_to_plan_for_change_landing_pages.rb
+++ b/db/data_migration/20260428113433_rename_landing_pages_to_plan_for_change_landing_pages.rb
@@ -1,0 +1,15 @@
+conn = ActiveRecord::Base.connection
+
+conn.execute(<<~SQL)
+  UPDATE documents
+  SET document_type = 'PlanForChangeLandingPage'
+  WHERE document_type = 'LandingPage';
+SQL
+
+conn.execute(<<~SQL)
+  UPDATE editions
+  SET type = 'PlanForChangeLandingPage'
+  WHERE document_id IN (
+    SELECT id FROM documents WHERE document_type = 'PlanForChangeLandingPage'
+  );
+SQL


### PR DESCRIPTION
These should now be called PlanForChangeLandingPage. Without this data migration, some Edition lookups raise STI exceptions, and the Whitehall search UI doesn't surface any existing landing page documents.

Follows on from #11408.

Jira: https://gov-uk.atlassian.net/browse/WHIT-3282

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
