### PR TITLE
[SPIKE] Prototype targeted approach for config-driven tabs [WHIT-3351]

### DIFF
--- a/app/helpers/admin/tabbed_nav_helper.rb
+++ b/app/helpers/admin/tabbed_nav_helper.rb
@@ -51,6 +51,7 @@ module Admin::TabbedNavHelper
           current: on_dynamic_tab && current_tab == tab["id"],
         }
       end
+      nav_items.concat(linked_tabs_nav_items(edition, current_path))
     end
   end
 
@@ -215,5 +216,21 @@ module Admin::TabbedNavHelper
         current: current_path == admin_worldwide_organisation_page_attachments_path(page),
       },
     ]
+  end
+
+  def linked_tabs_nav_items(edition, current_path)
+    edition.type_instance.linked_tabs.map do |tab|
+      href = href_for_linked_tab(tab, edition)
+      { label: tab["label"], href:, current: current_path == href }
+    end
+  end
+
+  def href_for_linked_tab(tab, edition)
+    builders = {
+      "edition_attachments" => -> { admin_edition_attachments_path(edition) },
+      "edition_images" => -> { admin_edition_images_path(edition) },
+      "edition_features" => -> { features_admin_standard_edition_path(edition, locale: edition.primary_locale) },
+    }
+    builders[tab["linked_to"]]&.call
   end
 end

--- a/app/models/configurable_document_type.rb
+++ b/app/models/configurable_document_type.rb
@@ -113,6 +113,16 @@ class ConfigurableDocumentType
     end
   end
 
+  def linked_tabs
+    @linked_tabs ||= @forms.filter_map do |id, form|
+      { "id" => id, "label" => form["label"], "linked_to" => form["linked_to"] } if form["linked_to"]
+    end
+  end
+
+  def has_linked_tab?(tab_key)
+    linked_tabs.any? { |tab| tab["linked_to"] == tab_key }
+  end
+
   def schema_for_fields(field_keys)
     field_keys = field_keys.map(&:to_s)
 

--- a/app/models/configurable_document_types/news_story.json
+++ b/app/models/configurable_document_types/news_story.json
@@ -58,6 +58,10 @@
           "translatable": false
         }
       }
+    },
+    "attachments": {
+      "label": "Attachments",
+      "linked_to": "edition_attachments"
     }
   },
   "schema": {
@@ -122,7 +126,6 @@
       }
     },
     "send_change_history": true,
-    "file_attachments_enabled": true,
     "organisations": null,
     "backdating_enabled": true,
     "history_mode_enabled": true,

--- a/app/presenters/publishing_api/standard_edition_presenter.rb
+++ b/app/presenters/publishing_api/standard_edition_presenter.rb
@@ -43,7 +43,7 @@ module PublishingApi
       details = PayloadBuilder::BlockContent.for(item)
       details.merge!(PayloadBuilder::ChangeHistory.for(item)) if type.settings["send_change_history"] == true
       details.merge!(PayloadBuilder::PoliticalDetails.for(item)) if type.settings["history_mode_enabled"] == true
-      details.merge!(PayloadBuilder::Attachments.for(item)) if type.settings["file_attachments_enabled"] == true
+      details.merge!(PayloadBuilder::Attachments.for(item)) if type.settings["file_attachments_enabled"] == true || type.has_linked_tab?("edition_attachments")
       details.merge!(PayloadBuilder::EmphasisedOrganisations.for(item)) if item.organisation_association_enabled?
       details.merge!(PayloadBuilder::StandardEditionImages.for(item)) if type.settings.dig("images", "enabled")
       details.merge!(PayloadBuilder::Features.for(item)) if type.settings["features_enabled"] == true

--- a/app/validators/schema_validator.rb
+++ b/app/validators/schema_validator.rb
@@ -94,7 +94,11 @@ private
   end
 
   def form_fields
-    (@document["forms"] || [])&.keys&.flat_map { |key| obj_dig(@document, "fields", ["forms", key]) }
+    (@document["forms"] || [])&.keys&.flat_map do |key|
+      next [] if @document.dig("forms", key, "linked_to") # linked tabs have no block content fields, so skip it
+
+      obj_dig(@document, "fields", ["forms", key])
+    end
   end
 
   def obj_dig(obj, attr, keys, &visitor)

--- a/public/configurable-document-type.schema.json
+++ b/public/configurable-document-type.schema.json
@@ -243,7 +243,6 @@
       },
       "additionalProperties": {
         "type": "object",
-        "required": ["fields"],
         "description": "Definition of a group of form fields to group.",
         "properties": {
           "dynamic": {
@@ -262,8 +261,21 @@
                 "$ref": "#/$defs/form_field"
               }
             }
+          },
+          "linked_to": {
+            "type": "string",
+            "description": "Named route this tab links to. Mutually exclusive with fields. Used for tabs whose UI is owned by an existing controller (attachments, features, images).",
+            "enum": [
+              "edition_attachments",
+              "edition_features",
+              "edition_images"
+            ]
           }
-        }
+        },
+        "oneOf": [
+          { "required": ["fields"] },
+          { "required": ["linked_to"] }
+        ]
       }
     },
     "presenters": {
@@ -471,7 +483,6 @@
         "organisations",
         "backdating_enabled",
         "history_mode_enabled",
-        "file_attachments_enabled",
         "translations_enabled"
       ]
     }


### PR DESCRIPTION
Tabs like Attachments, Images, and Featured are currently in legacy hardwired form and they're toggled by boolean flags in `settings`; then added to the nav by some `if edition.allows_attachments?` checks in the helper. The goal of this spike was to understand whether we could instead declare them in `forms` (alongside dynamic tabs like Social Media Accounts), making the JSON config the single source of truth for all tabs on a StandardEdition.

As part of [WHIT-3351](https://gov-uk.atlassian.net/browse/WHIT-3351), I've made a quick prototype on how we can make these legacy tabs (Featured, Images, Attachements) expressed in the config-driven way; maintaining a minimal approach to support existing code.

In this approach, I have introduced `"linked_to": "foo"` in the `forms` object to declare a tab that routes to a separate controller rather than rendering inline.

I struggled with the naming here. Had to decide between `linked_tabs` and `external_tabs`. I thought `linked_tabs` will communicate the idea more effectively.

**Key things I learned:**

- The targeted approach works well with the dynamic tab (Understood as in-line tabs) pipeline with minimal changes and no new abstractions
- Linked tabs don't need `valid_tab_key?` changes, since they never submit via `?current_tab=`, so scoped validation is not a concern for them. **Or not?**
- We can safely (I guess) get rid of `settings.file_attachments_enabled`  in a configurable document type.

**Note:** The `type.settings["..."] == true` fallback on the Attachments line is intentional for transition purposes. Once all document type configs have been updated to declare their tabs via linked_to, the settings flags (file_attachments_enabled, features_enabled, etc) and the `||` fallbacks can be removed from the presenter and StandardEdition model methods.


To add other tabs, follow the approach in `news_story.json`. For example, to add features tab to News Story:

``` json

  "forms": {
    "documents": {
      "fields": { ... }
    },
    "attachments": {
      "label": "Attachments",
      "linked_to": "edition_attachments"
    },
    "features": {
      "label": "Features",
      "linked_to": "edition_features"
    },
  }
```
 
Then update the presenter: `app/presenters/publishing_api/standard_edition_presenter.rb`:

**Existing code:** 
`details.merge!(PayloadBuilder::Features.for(item)) if type.settings["features_enabled"] == true`

**Updated code:**
`details.merge!(PayloadBuilder::Features.for(item)) if type.settings["features_enabled"] == true || type.has_linked_tab?("edition_features")` 





**TODO:**
- [x]  Run test suites to catch edge cases
- [ ] Thorough testing on the UI

[JIRA](https://gov-uk.atlassian.net/browse/WHIT-3351)


--- 
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.


[WHIT-3351]: https://gov-uk.atlassian.net/browse/WHIT-3351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ