### PR TITLE
Remove call to `@image_usage.label`

### DIFF
--- a/app/controllers/admin/edition_images_controller.rb
+++ b/app/controllers/admin/edition_images_controller.rb
@@ -134,7 +134,7 @@ private
 
   def redirect_if_single_usage_image_exists
     if @image_usage && !@image_usage.multiple? && @edition.images.usable_as(@image_usage).any?
-      redirect_to admin_edition_images_path(@edition), alert: "#{@image_usage.label.titleize} already uploaded. Delete the currently uploaded #{@image_usage.label} to upload a new #{@image_usage.label}."
+      redirect_to admin_edition_images_path(@edition), alert: "#{@image_usage.title.upcase_first} already uploaded. Delete the currently uploaded #{@image_usage.title} to upload a new #{@image_usage.title}."
 
       true
     else

--- a/test/functional/admin/edition_images_controller_test.rb
+++ b/test/functional/admin/edition_images_controller_test.rb
@@ -550,6 +550,32 @@ class Admin::EditionImagesControllerTest < ActionController::TestCase
     assert_select ".govuk-error-summary li", "Image \"hero_image_mobile_2x.png\" is not unique. All your file names must be different. Do not use special characters to create another version of the same file name."
   end
 
+  view_test "POST :create shows a validation error if 'mulitple' of image usage is `false` and another image of same image usage is uploaded" do
+    login_authorised_user
+    ConfigurableDocumentType.setup_test_types(build_configurable_document_type("test_type", {
+      "settings" => {
+        "images" => {
+          "enabled" => "true",
+          "usages" => {
+            "hero" => {
+              "label" => "hero",
+              "kinds" => %w[hero_mobile],
+              "multiple" => false,
+            },
+          },
+        },
+      },
+    }))
+    edition = create(:draft_standard_edition)
+    file = upload_fixture("hero_image_mobile_2x.png")
+    create(:image, usage: "hero", edition:, image_data: build(:image_data, file:))
+
+    post :create, params: { edition_id: edition.id, usage: "hero", image_kind: "hero_mobile", images: [{ image_data_attributes: { file: } }] }
+
+    assert_redirected_to admin_edition_images_path(edition)
+    assert_equal "Hero already uploaded. Delete the currently uploaded hero to upload a new hero.", flash[:alert]
+  end
+
   view_test "POST :create with multiple invalid files shows each filename in error summary" do
     login_authorised_user
     edition = create(:draft_case_study)


### PR DESCRIPTION
## What

Replace `@image_usage.label` to `@image_usage.title`.

## Why

Was not replaced in https://github.com/alphagov/whitehall/pull/11358 which reworked how image usage label is used in the interface to refer to images.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
