### PR TITLE
Revert "First publishing date validation [WHIT-3076]"

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -68,12 +68,10 @@ class Edition < ApplicationRecord
   validates :summary, presence: true, if: :summary_required?, length: { maximum: 65_535 }
   validates :previously_published, inclusion: { in: [true, false], message: "You must specify whether the document has been published before" }
   validates :first_published_at, presence: true, if: -> { previously_published || published_major_version }
-  validates :first_published_at, inclusion: { in: proc { Date.parse("1900-01-01")..Time.zone.now } }, if: -> { draft? && other_editions.empty? }, allow_blank: true
+  validates :first_published_at, inclusion: { in: proc { Date.parse("1900-01-01")..Time.zone.now } }, if: :draft?, allow_blank: true
   validates :scheduled_publication, inclusion: { in: proc { Time.zone.now.. }, message: "must be in the future" }, if: :draft?, allow_blank: true
   validates :political, inclusion: { in: [true, false] }
   validates :image_display_option, inclusion: { in: ["no_image", "organisation_image", "custom_image", nil] }
-
-  validate :first_published_preceeds_change_notes, if: :draft?
 
   UNMODIFIABLE_STATES = %w[scheduled published superseded deleted unpublished].freeze
   FROZEN_STATES = %w[superseded deleted].freeze
@@ -238,8 +236,6 @@ class Edition < ApplicationRecord
   end
 
   def other_editions
-    return [] if document.nil?
-
     if persisted?
       document.editions.where(self.class.arel_table[:id].not_eq(id))
     else
@@ -447,19 +443,6 @@ class Edition < ApplicationRecord
 
   def error_labels
     {}
-  end
-
-  def first_published_preceeds_change_notes
-    return if first_published_at.blank?
-    return if other_editions.empty?
-
-    change_note_dates = other_editions.pluck(:major_change_published_at).compact.sort
-
-    return if change_note_dates.empty?
-
-    if first_published_at > change_note_dates.first
-      errors.add(:first_published_at, :after_change_notes, latest: change_note_dates.first.strftime("%d/%m/%Y %H:%M"))
-    end
   end
 
 private

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -23,7 +23,6 @@ en:
               invalid_date: First published date is not in the correct format
               blank: Enter a first published date
               inclusion: First published date must be between 1/1/1900 and the present
-              after_change_notes: "First published date must be before the first change note (%{latest})"
             html_attachments:
               missing_contact_reference: "- \"%{html_attachment_title}\" - embedded Contact (ID %{contact_id}) doesn't exist"
             unpublishing:

--- a/test/unit/app/models/edition_test.rb
+++ b/test/unit/app/models/edition_test.rb
@@ -684,23 +684,6 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal "First published date must be between 1/1/1900 and the present", edition.errors.full_messages.first
   end
 
-  test "first_published_at cannot be after the date of the first change note" do
-    edition_with_change_note = create(:edition_with_document, :published, change_note: "changed", major_change_published_at: 2.days.ago)
-    edition = build(:edition, document: edition_with_change_note.document, first_published_at: 1.day.ago)
-
-    assert edition.invalid?
-    assert_equal "First published date must be before the first change note (09/11/2011 11:11)", edition.errors.full_messages.first
-  end
-
-  test "after_change_notes' error message takes priority if multiple validation errors on first_published_at" do
-    edition_with_change_note = create(:edition_with_document, :published, change_note: "changed", major_change_published_at: 2.days.ago)
-    edition = build(:edition, document: edition_with_change_note.document, first_published_at: 10.years.from_now)
-    edition.validate
-
-    assert_equal 1, edition.errors.size
-    assert_equal "First published date must be before the first change note (09/11/2011 11:11)", edition.errors.full_messages.first
-  end
-
   test "#government returns the associated government when the edition has a specific government_id" do
     create(:current_government)
     previous_government = create(:previous_government)
@@ -1003,12 +986,6 @@ class EditionTest < ActiveSupport::TestCase
 
     edition.image_display_option = "invalid_option"
     assert_not edition.valid?
-  end
-
-  test "#other_editions returns an empty array if there is no associated document" do
-    edition = build(:edition)
-
-    assert_equal edition.other_editions, []
   end
 
   def decoded_token_payload(token)


### PR DESCRIPTION
Reverts alphagov/whitehall#11393

This change appears to have introduced a validation issue affecting edition workflows for published  pages, resulting in drafts becoming locked as historic editions with restricted deletion permissions.

**Usual Flow**

1. User starts with an existing published page
2. Creates a new draft (edition) to update the page
3. Updates the title, PDF, and adds an HTML version
4. Sets the first published date to the new strategy publication date
5. System validates successfully or allows publish in previous behaviour

**New Issue Introduced by Validation Change**

1. Setting the first published date to a newer date triggers the error:
2. “first published date cannot be after first amended date”
3. User attempts to resolve by setting the first published date earlier than the amended date
4. This causes the page to be reassigned to a previous government
5. User attempts to delete the draft to restart the process
6. Deletion fails with a permission error

**Impact**

1. The draft is converted into a historic edition state
2. Historic editions restrict deletion to users with:

- GDS Editor permissions
- GDS Admin permissions

As a result, standard users are unable to delete or recover the draft
Users are left stuck in an unrecoverable state without elevated permissions