### PR TITLE
[WHIT-3323] Fix base_path setting on new landing pages

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -299,7 +299,6 @@ private
         fatality_notice_casualties_attributes: %i[id personal_details _destroy],
         document_attributes: [
           :id,
-          :slug,
           {
             review_reminder_attributes: %i[
               id

--- a/app/views/admin/plan_for_change_landing_pages/_additional_significant_fields.html.erb
+++ b/app/views/admin/plan_for_change_landing_pages/_additional_significant_fields.html.erb
@@ -3,10 +3,10 @@
     label: {
       text: "Base Path",
     },
-    name: "edition[document_attributes][slug]",
-    id: "edition_document_slug",
+    name: "edition[slug_override]",
+    id: "edition_slug_override",
     heading_size: "m",
-    value: edition.slug,
-    error_items: errors_for(edition.document.errors, :slug),
+    value: edition.slug_override,
+    error_items: errors_for(edition.errors, :slug_override),
   } %>
 <% end %>


### PR DESCRIPTION
Previously the custom slug for landing pages was set via the document slug. Now we need to set it via the `slug_override`. The field is validated for presence. The `slug` will get set to the value of the `slug_override` in the `set_slug` callback in the `identifiable` concern.

[Jira](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-3323)
