### PR TITLE
Fix server error when submitting invalid URL in external websites form [WHIT-3329]

### DIFF
--- a/app/models/offsite_link.rb
+++ b/app/models/offsite_link.rb
@@ -88,10 +88,10 @@ class OffsiteLink < ApplicationRecord
     end
 
     unless government_or_permitted_url?(host)
-      errors.add(:base, "Please enter a valid alternative URL, such as https://www.nhs.uk/")
+      errors.add(:url, "must be a valid URL, such as https://www.nhs.uk/")
     end
-  rescue URI::InvalidURIError
-    errors.add(:base, "Please enter a valid alternative URL, such as https://www.nhs.uk/")
+  rescue URI::InvalidURIError, Addressable::URI::InvalidURIError
+    errors.add(:url, "must be a valid URL, such as https://www.nhs.uk/")
   end
 
   def humanized_link_type

--- a/test/functional/admin/offsite_links_controller_test.rb
+++ b/test/functional/admin/offsite_links_controller_test.rb
@@ -33,7 +33,7 @@ class Admin::OffsiteLinksControllerTest < ActionController::TestCase
       },
     }
 
-    assert_select ".govuk-error-summary__body", text: "Please enter a valid alternative URL, such as https://www.nhs.uk/"
+    assert_select ".govuk-error-summary__body", text: "Url must be a valid URL, such as https://www.nhs.uk/"
   end
 
   view_test "GET :edit should render existing offside links form" do
@@ -104,7 +104,23 @@ class Admin::OffsiteLinksControllerTest < ActionController::TestCase
     }
 
     assert_response :success
-    assert_select ".govuk-error-summary__body", text: "Please enter a valid alternative URL, such as https://www.nhs.uk/"
+    assert_select ".govuk-error-summary__body", text: "Url must be a valid URL, such as https://www.nhs.uk/"
+  end
+
+  view_test "POST :create with an invalid url should render form with errors" do
+    edition = create(:standard_edition, :published)
+    post :create, params: {
+      standard_edition_id: edition,
+      offsite_link: {
+        title: "foo",
+        summary: "barb",
+        link_type: "blog_post",
+        url: "http://[",
+      },
+    }
+
+    assert_response :success
+    assert_select ".govuk-error-summary__body", text: "Url must be a valid URL, such as https://www.nhs.uk/"
   end
 
   view_test "GET :new renders form for standard edition parent" do

--- a/test/unit/app/models/offsite_link_test.rb
+++ b/test/unit/app/models/offsite_link_test.rb
@@ -25,6 +25,12 @@ class OffsiteLinkTest < ActiveSupport::TestCase
     assert_not offsite_link.valid?
   end
 
+  test "should be invalid with an invalid url" do
+    offsite_link = build(:offsite_link, url: "http://[")
+    assert_not offsite_link.valid?
+    assert_includes offsite_link.errors[:url], "must be a valid URL, such as https://www.nhs.uk/"
+  end
+
   test "should be valid with a gov.uk url" do
     offsite_link = build(:offsite_link, url: "http://gov.uk/greatpage")
     assert offsite_link.valid?


### PR DESCRIPTION
Addressable::URI::InvalidURIError (raised by Addressable 2.8+) does not inherit from URI::InvalidURIError, so certain malformed URLs were not caught by the rescue clause in OffsiteLink#check_url_is_allowed, causing a 500 instead of a validation error.

[JIRA](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?assignee=5caf4d888c2c1a75f3e46ef6&selectedIssue=WHIT-3229)

**BEFORE**


https://github.com/user-attachments/assets/640701ec-2ff7-4e3a-9892-bca43cb542ad

**AFTER**


https://github.com/user-attachments/assets/d97f2d06-d70f-4c16-aff6-4078b713eb1b

