### PR TITLE
[WHIT-3323] Add migration to backfill `slug_from_title` with the value of `slug`

### DIFF
--- a/db/data_migration/20260505152712_backfill_slug_from_title_on_post_publication_editions.rb
+++ b/db/data_migration/20260505152712_backfill_slug_from_title_on_post_publication_editions.rb
@@ -1,0 +1,13 @@
+update_sql = <<~SQL
+  UPDATE editions
+  SET slug_from_title = slug
+  WHERE state IN ('published', 'withdrawn', 'unpublished')
+    AND (
+      (slug_override IS NULL OR slug_override = '')
+      OR
+      (slug_override IS NOT NULL AND slug_override != '' AND slug != slug_override)
+    )
+SQL
+updated_editions = ActiveRecord::Base.connection.update(update_sql)
+
+puts "Updated slug_from_title for #{updated_editions} editions"


### PR DESCRIPTION
# What & why

This continues the work done in `20260414111505_generate_slug_from_title.rb`, by setting the `slug_from_title` value for post-publication editions. The `generate` migration set the `slug_from_title` for all drafts; code changes released since also ensured that new drafts always have a `slug_from_title` set. The `slug_from_title` has not been set for post-publication editions (published, unpublished, withdrawn). The intention is to backfill it before we repurpose the slug column. This migration is mostly for data integrity, and as a safety measure.

We investigated what `slug_for_title` re-generation would look like for live data and found that there would be a lot of suffix discrepancies. Simply put, the value of the `slug_from_title` at publish time (if that code had existed) would not match something generated today, so the safest backfill is to fetch the value of the `slug` (with some caveats, depending on `slug_override` presence, see below).

# Background

The latest changes have introduced the `slug_from_title` column with the purpose of replacing the behaviour of the current `slug` column, which stores a title-based slug. The issue with the current slug column is that, while it holds the title-based slug, there is a `slug` reader returning the "accurate" slug value (the `slug_override`, when present) - which can be confusing to reason about.

When redrafting a published edition (or other post-publication state), the draft will get its own `slug_from_title` because the `set_slug` (in the identifiable concern) runs on new model instantiation. Equally, for live data the slug setting callback is protected by the `title_changed?` check, so routine console tasks (e.g. running `touch`) should not affect live data, unless intentionally changing the title. So, while live data does not necessarily require the backfill, we will be repurposing the slug column to store the "accurate" slug value, and drop the reader, in future work. With that in mind, it is a good precaution to store the existing slug value in the `slug_from_title` before writing over the `slug` value.

Data combination cases breakdown (SO = slug_override; S = slug; SFT = slug_from_title), all post-publication states:
- SO not present (null or blank) -> slug the only source of truth, set SFT to S.
- SO present (not null and not blank), and S=SO -> only possible if the edition has been touched by the `generate` migration, meaning SFT is also set.
- SO present and S!=SO -> live data not touched by migration; slug still holds title-based value, must set SFT=S before writing S to SO in future work.

[Jira](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-3323)

Related PR: https://github.com/alphagov/whitehall/pull/11428
