### PR TITLE
[WHIT-3323] Add check to migration to ensure it cannot run again

### DIFF
--- a/db/data_migration/20260505152712_backfill_slug_from_title_on_post_publication_editions.rb
+++ b/db/data_migration/20260505152712_backfill_slug_from_title_on_post_publication_editions.rb
@@ -7,6 +7,7 @@ update_sql = <<~SQL
       OR
       (slug_override IS NOT NULL AND slug_override != '' AND slug != slug_override)
     )
+    AND slug_from_title IS NULL;
 SQL
 updated_editions = ActiveRecord::Base.connection.update(update_sql)
 


### PR DESCRIPTION
This prevents it from affecting data if the [migration](https://github.com/alphagov/whitehall/pull/11424) runs after other migrations [planned next](https://github.com/alphagov/whitehall/pull/11371) (e.g. backfilling `slug` to match the value of the `slug_override`).

[Jira](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-3323)
