### PR TITLE
First publishing date [WHIT-3076]

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -74,6 +74,7 @@ class Edition < ApplicationRecord
   validates :image_display_option, inclusion: { in: ["no_image", "organisation_image", "custom_image", nil] }
 
   validate :first_published_preceeds_change_notes, if: :draft?
+  validate :first_published_within_current_govt, if: :draft?
 
   UNMODIFIABLE_STATES = %w[scheduled published superseded deleted unpublished].freeze
   FROZEN_STATES = %w[superseded deleted].freeze
@@ -459,6 +460,16 @@ class Edition < ApplicationRecord
 
     if first_published_at > change_note_dates.first
       errors.add(:first_published_at, :after_change_notes, latest: change_note_dates.first.strftime("%d/%m/%Y %H:%M"))
+    end
+  end
+
+  def first_published_within_current_govt
+    return if first_published_at.blank?
+    return if Government.current.blank?
+    return if political? || historic?
+
+    if first_published_at.to_date < Government.current.start_date
+      errors.add(:first_published_at, :before_current_govt, earliest: Government.current.start_date.strftime("%d/%m/%Y"))
     end
   end
 

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -238,6 +238,8 @@ class Edition < ApplicationRecord
   end
 
   def other_editions
+    return [] if document.nil?
+
     if persisted?
       document.editions.where(self.class.arel_table[:id].not_eq(id))
     else

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -68,7 +68,7 @@ class Edition < ApplicationRecord
   validates :summary, presence: true, if: :summary_required?, length: { maximum: 65_535 }
   validates :previously_published, inclusion: { in: [true, false], message: "You must specify whether the document has been published before" }
   validates :first_published_at, presence: true, if: -> { previously_published || published_major_version }
-  validates :first_published_at, inclusion: { in: proc { Date.parse("1900-01-01")..Time.zone.now } }, if: :draft?, allow_blank: true
+  validates :first_published_at, inclusion: { in: proc { Date.parse("1900-01-01")..Time.zone.now } }, if: -> { draft? && other_editions.empty? }, allow_blank: true
   validates :scheduled_publication, inclusion: { in: proc { Time.zone.now.. }, message: "must be in the future" }, if: :draft?, allow_blank: true
   validates :political, inclusion: { in: [true, false] }
   validates :image_display_option, inclusion: { in: ["no_image", "organisation_image", "custom_image", nil] }

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -73,6 +73,8 @@ class Edition < ApplicationRecord
   validates :political, inclusion: { in: [true, false] }
   validates :image_display_option, inclusion: { in: ["no_image", "organisation_image", "custom_image", nil] }
 
+  validate :first_published_preceeds_change_notes, if: :draft?
+
   UNMODIFIABLE_STATES = %w[scheduled published superseded deleted unpublished].freeze
   FROZEN_STATES = %w[superseded deleted].freeze
   PRE_PUBLICATION_STATES = %w[draft submitted rejected scheduled].freeze
@@ -443,6 +445,19 @@ class Edition < ApplicationRecord
 
   def error_labels
     {}
+  end
+
+  def first_published_preceeds_change_notes
+    return if first_published_at.blank?
+    return if other_editions.empty?
+
+    change_note_dates = other_editions.pluck(:major_change_published_at).compact.sort
+
+    return if change_note_dates.empty?
+
+    if first_published_at > change_note_dates.first
+      errors.add(:first_published_at, :after_change_notes, latest: change_note_dates.first.strftime("%d/%m/%Y %H:%M"))
+    end
   end
 
 private

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -24,6 +24,7 @@ en:
               blank: Enter a first published date
               inclusion: First published date must be between 1/1/1900 and the present
               after_change_notes: "First published date must be before the first change note (%{latest})"
+              before_current_govt: "First published date must be after the start of the current government (%{earliest})"
             html_attachments:
               missing_contact_reference: "- \"%{html_attachment_title}\" - embedded Contact (ID %{contact_id}) doesn't exist"
             unpublishing:

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -23,6 +23,7 @@ en:
               invalid_date: First published date is not in the correct format
               blank: Enter a first published date
               inclusion: First published date must be between 1/1/1900 and the present
+              after_change_notes: "First published date must be before the first change note (%{latest})"
             html_attachments:
               missing_contact_reference: "- \"%{html_attachment_title}\" - embedded Contact (ID %{contact_id}) doesn't exist"
             unpublishing:

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -115,7 +115,7 @@ module DocumentHelper
     fill_in "Logo formatted name", with: "Logo\r\nformatted\r\nname\r\n"
   end
 
-  def fill_in_publication_fields(first_published: "2010-01-01", publication_type: "Research and analysis")
+  def fill_in_publication_fields(first_published: Time.zone.now, publication_type: "Research and analysis")
     checkbox_label = "This document has previously been published on another website"
     check checkbox_label
     within_conditional_reveal checkbox_label do

--- a/test/unit/app/models/call_for_evidence_test.rb
+++ b/test/unit/app/models/call_for_evidence_test.rb
@@ -328,7 +328,7 @@ class CallForEvidenceTest < ActiveSupport::TestCase
   test "#government returns the government active on the first_public_at date" do
     create(:current_government)
     previous_government = create(:previous_government)
-    call_for_evidence = create(:call_for_evidence, first_published_at: 4.years.ago)
+    call_for_evidence = build(:call_for_evidence, first_published_at: 4.years.ago)
 
     assert_equal previous_government, call_for_evidence.government
   end

--- a/test/unit/app/models/consultation_test.rb
+++ b/test/unit/app/models/consultation_test.rb
@@ -368,7 +368,7 @@ class ConsultationTest < ActiveSupport::TestCase
   test "#government returns the government active on the first_public_at date" do
     create(:current_government)
     previous_government = create(:previous_government)
-    consultation = create(:consultation, first_published_at: 4.years.ago)
+    consultation = build(:consultation, first_published_at: 4.years.ago)
 
     assert_equal previous_government, consultation.government
   end

--- a/test/unit/app/models/edition_test.rb
+++ b/test/unit/app/models/edition_test.rb
@@ -684,6 +684,14 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal "First published date must be between 1/1/1900 and the present", edition.errors.full_messages.first
   end
 
+  test "first_published_at cannot be after the date of the first change note" do
+    edition_with_change_note = create(:edition_with_document, :published, change_note: "changed", major_change_published_at: 2.days.ago)
+    edition = build(:edition, document: edition_with_change_note.document, first_published_at: 1.day.ago)
+
+    assert edition.invalid?
+    assert_equal "First published date must be before the first change note (09/11/2011 11:11)", edition.errors.full_messages.first
+  end
+
   test "#government returns the associated government when the edition has a specific government_id" do
     create(:current_government)
     previous_government = create(:previous_government)

--- a/test/unit/app/models/edition_test.rb
+++ b/test/unit/app/models/edition_test.rb
@@ -996,6 +996,12 @@ class EditionTest < ActiveSupport::TestCase
     assert_not edition.valid?
   end
 
+  test "#other_editions returns an empty array if there is no associated document" do
+    edition = build(:edition)
+
+    assert_equal edition.other_editions, []
+  end
+
   def decoded_token_payload(token)
     payload, _header = JWT.decode(
       token,

--- a/test/unit/app/models/edition_test.rb
+++ b/test/unit/app/models/edition_test.rb
@@ -744,7 +744,7 @@ class EditionTest < ActiveSupport::TestCase
   test "#government returns the historic government for a previously published edition" do
     previous_government = create(:previous_government)
     create(:current_government)
-    edition = create(:edition, first_published_at: 4.years.ago)
+    edition = build(:edition, first_published_at: 4.years.ago)
     assert_equal previous_government, edition.government
   end
 
@@ -766,7 +766,7 @@ class EditionTest < ActiveSupport::TestCase
 
     previous_government = create(:previous_government)
 
-    edition = create(:edition, political: false, first_published_at: previous_government.start_date)
+    edition = build(:edition, political: false, first_published_at: previous_government.start_date)
     assert_not edition.historic?
 
     edition = create(:edition, political: false, first_published_at: current_government.start_date)

--- a/test/unit/app/models/edition_test.rb
+++ b/test/unit/app/models/edition_test.rb
@@ -692,6 +692,21 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal "First published date must be before the first change note (09/11/2011 11:11)", edition.errors.full_messages.first
   end
 
+  test "first_published_at cannot be before the start of the current government" do
+    create(:current_government)
+    edition = build(:edition, first_published_at: 10.years.ago)
+
+    assert edition.invalid?
+    assert_equal "First published date must be after the start of the current government (11/11/2009)", edition.errors.full_messages.first
+  end
+
+  test "polictial editions can have their first_published_at date set before the current government " do
+    create(:current_government)
+    political_edition = create(:edition, political: true, first_published_at: 10.years.ago)
+
+    assert political_edition.valid?
+  end
+
   test "after_change_notes' error message takes priority if multiple validation errors on first_published_at" do
     edition_with_change_note = create(:edition_with_document, :published, change_note: "changed", major_change_published_at: 2.days.ago)
     edition = build(:edition, document: edition_with_change_note.document, first_published_at: 10.years.from_now)

--- a/test/unit/app/models/edition_test.rb
+++ b/test/unit/app/models/edition_test.rb
@@ -692,6 +692,15 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal "First published date must be before the first change note (09/11/2011 11:11)", edition.errors.full_messages.first
   end
 
+  test "after_change_notes' error message takes priority if multiple validation errors on first_published_at" do
+    edition_with_change_note = create(:edition_with_document, :published, change_note: "changed", major_change_published_at: 2.days.ago)
+    edition = build(:edition, document: edition_with_change_note.document, first_published_at: 10.years.from_now)
+    edition.validate
+
+    assert_equal 1, edition.errors.size
+    assert_equal "First published date must be before the first change note (09/11/2011 11:11)", edition.errors.full_messages.first
+  end
+
   test "#government returns the associated government when the edition has a specific government_id" do
     create(:current_government)
     previous_government = create(:previous_government)

--- a/test/unit/app/presenters/publishing_api/document_collection_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/document_collection_presenter_test.rb
@@ -403,7 +403,7 @@ class PublishingApi::DocumentCollectionPresenterPreviousGovernmentTest < ActiveS
       slug: "a-previous-government",
     )
     @presented_document_collection = PublishingApi::DocumentCollectionPresenter.new(
-      create(
+      build(
         :document_collection,
         first_published_at: @previous_government.start_date + 1.day,
       ),

--- a/test/unit/app/presenters/publishing_api/statistical_data_set_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/statistical_data_set_presenter_test.rb
@@ -268,7 +268,7 @@ class PublishingApi::StatisticalDataSetPresenterPreviousGovernmentTest < ActiveS
       slug: "a-previous-government",
     )
     @presented_statistical_data_set = PublishingApi::StatisticalDataSetPresenter.new(
-      create(
+      build(
         :statistical_data_set,
         first_published_at: @previous_government.start_date + 1.day,
       ),


### PR DESCRIPTION
## What

This PR:
- re-implements the previously merged `first_published_at` validation in #11393  
- adds validation to prevent users from backdating the `first_published_at` date before the start of the current government
- updates some of the test code to just build the test edition models rather than validate and persist them
- updates the default `first_published_at` date in the behavioural tests so it is in line with how the current government is created in those tests

## Why

#11393  was merged but reverted because of problematic interaction with history mode (see https://govuk.zendesk.com/agent/tickets/6565061), where:
- a user followed the new validation instructions 
- backdated an edition into a previous government
- the edition entered history mode
- the user could not edit or delete the edition because they didn't have sufficient privileges

This PR fixes that by adding the validation described above.

Some unit tests use FactoryBot's `#create` build strategy, which meant they failed the new validation.  Changing to `#build` allows the tests to assert on the same behaviour without requiring the models to be valid - this makes sense since the changed tests relate to behaviour of models in previous governments rather than specific details of persistence / associations that come with using `#create`(**AFAICT - it would be great if someone could check this** - it's in commit ~99c5882902921476245c192d4f11c7aaf9a86eba~ 69d30438a3574e8564d59bb899266fcc7d48f0c2 🙏🏻 )

---
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
