### PR TITLE
Wait 3 days before raising a dependabot update PR [WHIT-3214]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
       interval: daily
       time: "07:00"
     open-pull-requests-limit: 25
+    cooldown:
+      default-days: 3
 
   - package-ecosystem: npm
     directory: /
@@ -13,6 +15,8 @@ updates:
       interval: daily
       time: "07:00"
     open-pull-requests-limit: 25
+    cooldown:
+      default-days: 3
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -20,6 +24,8 @@ updates:
       interval: daily
       time: "07:00"
     open-pull-requests-limit: 25
+    cooldown:
+      default-days: 3
 
   # Ruby needs to be upgraded manually in multiple places, so cannot
   # be upgraded by Dependabot. That effectively makes the below
@@ -33,3 +39,5 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 25
+    cooldown:
+      default-days: 3


### PR DESCRIPTION
govuk-dependabot-auto-merger will soon require the dependabot config to include a cooldown period for it to merge external dependendcies.  This commit adds a 3 day cooldown to all package ecosystems.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
