### PR TITLE
[WHIT-3323] Keep page URL by default when re-editing a published document

### DIFF
--- a/app/assets/javascripts/admin/views/edition-form.js
+++ b/app/assets/javascripts/admin/views/edition-form.js
@@ -160,25 +160,25 @@
   EditionForm.prototype.setupTitleInputEventListener = function () {
     const form = this.module
     const titleInput = form.querySelector('#edition_title')
-    const checkboxContainer = form.querySelector('.js-keep-slug-form-group')
+    const keepSlugControls = form.querySelector('.js-keep-slug-form-group')
 
-    if (!titleInput || !checkboxContainer) {
+    if (!titleInput || !keepSlugControls) {
       return
     }
 
     const originalTitle = titleInput.value
 
-    const setCheckboxVisibility = () => {
+    const setKeepSlugControlsVisibility = () => {
       const titleHasChanged = originalTitle !== titleInput.value
       if (titleHasChanged) {
-        checkboxContainer.removeAttribute('hidden')
+        keepSlugControls.removeAttribute('hidden')
       } else {
-        checkboxContainer.setAttribute('hidden', 'hidden')
+        keepSlugControls.setAttribute('hidden', 'hidden')
       }
     }
 
-    titleInput.addEventListener('input', () => setCheckboxVisibility())
-    setCheckboxVisibility()
+    titleInput.addEventListener('input', () => setKeepSlugControlsVisibility())
+    setKeepSlugControlsVisibility()
   }
 
   Modules.EditionForm = EditionForm

--- a/app/models/concerns/edition/identifiable.rb
+++ b/app/models/concerns/edition/identifiable.rb
@@ -6,6 +6,8 @@ module Edition::Identifiable
     validates :document, presence: true
     before_validation :ensure_presence_of_document, on: :create
     before_validation :propagate_type_to_document
+    before_save :default_slug_override_to_live_edition_slug,
+                if: -> { new_record? && document&.live_edition_id.present? && slug_override.blank? }
     before_save :set_slug_from_title, if: -> { title_changed? }
     before_save :set_slug, if: -> { slug_from_title_changed? || slug_override_changed? }
 
@@ -62,6 +64,10 @@ module Edition::Identifiable
 
   def set_slug
     self[:slug] = slug_override.presence || slug_from_title
+  end
+
+  def default_slug_override_to_live_edition_slug
+    self.slug_override = document.live_edition.slug
   end
 
   def linkable?

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -192,7 +192,7 @@ class Edition < ApplicationRecord
                                     force_published
                                     scheduled_publication]
       draft_attributes = attributes.except(*ignorable_attribute_keys)
-        .merge("state" => "draft", "creator" => user, "previously_published" => previously_published)
+        .merge("state" => "draft", "creator" => user, "previously_published" => previously_published, "slug_override" => slug)
 
       self.class.new(draft_attributes).tap do |draft|
         traits.each { |t| t.process_associations_before_save(draft) }

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -192,7 +192,7 @@ class Edition < ApplicationRecord
                                     force_published
                                     scheduled_publication]
       draft_attributes = attributes.except(*ignorable_attribute_keys)
-        .merge("state" => "draft", "creator" => user, "previously_published" => previously_published, "slug_override" => slug)
+        .merge("state" => "draft", "creator" => user, "previously_published" => previously_published)
 
       self.class.new(draft_attributes).tap do |draft|
         traits.each { |t| t.process_associations_before_save(draft) }

--- a/app/views/admin/editions/_page_address_controls.html.erb
+++ b/app/views/admin/editions/_page_address_controls.html.erb
@@ -13,17 +13,20 @@
   </div>
 
   <div class="<%= (edition.document.live_edition.slug == edition.slug_from_title) && "js-keep-slug-form-group" %> govuk-!-margin-bottom-6">
-    <%= render "govuk_publishing_components/components/hint", {
-      text: "The title of this document has changed since the page URL was generated. Check the box below to keep the existing URL, or leave it unchecked to update the URL for this page to match the new title when you publish this edition.",
-    } %>
-    <%= hidden_field(:edition, :slug_override, value: "") %>
-    <%= render "govuk_publishing_components/components/checkboxes", {
+    <%= render "govuk_publishing_components/components/radio", {
+      heading: "Page URL",
+      hint: "The title of this document has changed since the page URL was generated. Choose whether to keep the existing URL, or update it to match the new title when you publish this edition.",
       name: "edition[slug_override]",
       items: [
         {
-          label: "Keep the current page URL",
           value: edition.document.live_edition.slug,
+          text: "Keep the current page URL (#{edition.document.live_edition.public_url})",
           checked: edition.slug_override.present?,
+        },
+        {
+          value: "",
+          text: "Update the page URL to match the new title",
+          checked: edition.slug_override.blank?,
         },
       ],
     } %>

--- a/app/views/admin/editions/_page_address_controls.html.erb
+++ b/app/views/admin/editions/_page_address_controls.html.erb
@@ -1,15 +1,16 @@
 <% if edition.document&.live_edition.present? %>
   <div class="app-view-edit-edition__page-address govuk-!-margin-bottom-4">
     <%= render "govuk_publishing_components/components/heading", {
-      text: "Live page address",
+      text: "URL",
       heading_level: 3,
       font_size: "m",
       margin_bottom: 2,
     } %>
 
-    <%= render "govuk_publishing_components/components/hint", {
-      text: edition.document&.live_edition.public_url,
-    } %>
+    <p class="govuk-body">
+      Current GOV.UK URL:<br>
+      <%= link_to edition.document.live_edition.public_url, edition.document.live_edition.public_url, class: "govuk-link" %>
+    </p>
   </div>
 
   <div class="<%= (edition.document.live_edition.slug == edition.slug_from_title) && "js-keep-slug-form-group" %> govuk-!-margin-bottom-6">

--- a/app/views/admin/editions/_page_address_controls.html.erb
+++ b/app/views/admin/editions/_page_address_controls.html.erb
@@ -14,19 +14,21 @@
   </div>
 
   <div class="<%= (edition.document.live_edition.slug == edition.slug_from_title) && "js-keep-slug-form-group" %> govuk-!-margin-bottom-6">
+    <p class="govuk-body">
+      The title has changed since this URL was created. Choose whether to keep the current URL or update it to match the title.
+    </p>
+
     <%= render "govuk_publishing_components/components/radio", {
-      heading: "Page URL",
-      hint: "The title of this document has changed since the page URL was generated. Choose whether to keep the existing URL, or update it to match the new title when you publish this edition.",
       name: "edition[slug_override]",
       items: [
         {
           value: edition.document.live_edition.slug,
-          text: "Keep the current page URL (#{edition.document.live_edition.public_url})",
+          text: "Keep current URL",
           checked: edition.slug_override.present?,
         },
         {
           value: "",
-          text: "Update the page URL to match the new title",
+          text: "Update URL to match title",
           checked: edition.slug_override.blank?,
         },
       ],

--- a/features/edition-update-slug.feature
+++ b/features/edition-update-slug.feature
@@ -1,132 +1,51 @@
 Feature: Edition update slug
 
-  Scenario: A fresh draft does not show the keep-slug option
-    Given I am a writer
-    When I begin drafting a new publication "Brand new doc"
-    Then I cannot see the option to keep the current page URL
-    When I save the edition and go to the document summary
-    And I reopen the draft of the publication "Brand new doc"
-    And I change the title to "Edited new doc"
-    Then I cannot see the option to keep the current page URL
+  Rule: The URL control only appears when the URL can be changed
 
-  Scenario: The keep-slug option shows the live URL
-    Given I am a writer
-    And a published publication "You will never guess" exists
-    When I edit the publication "You will never guess"
-    And I change the title to "Ten facts that will shock you"
-    Then the keep-slug option shows the live URL
+    @javascript
+    Scenario: The URL control is revealed when the title changes
+      Given I am a writer
+      And a published publication "You will never guess" exists
+      And I edit the publication "You will never guess"
+      And I cannot see the option to keep the current page URL
+      When I change the title to "Ten facts that will shock you"
+      Then I can see the option to keep the current page URL
 
-  @javascript
-  Scenario: The keep-slug option is revealed when the title changes
-    Given I am a writer
-    And a published publication "You will never guess" exists
-    When I edit the publication "You will never guess"
-    Then I cannot see the option to keep the current page URL
-    When I change the title to "Ten facts that will shock you"
-    Then I can see the option to keep the current page URL
+  Rule: Renaming a draft keeps the live URL unless an editor opts out
 
-  Scenario: Writer updates the title of a document and keeps the live slug
-    Given I am a writer
-    And a published publication "You will never guess" exists
-    When I edit the publication "You will never guess"
-    And I change the title to "Ten facts that will shock you"
-    And I save my changes to the publication
-    Then the option to keep the current page URL is selected
-    When I save the edition and go to the document summary
-    Then I can see the preview URL of the publication "Ten facts that will shock you" contains "you-will-never-guess"
-    When I reopen the draft of the publication "Ten facts that will shock you"
-    Then the option to keep the current page URL is selected
+    Scenario: Renaming a draft keeps the live URL by default
+      Given I am a writer
+      And a published publication "You will never guess" exists
+      When I edit the publication "You will never guess"
+      And I change the title to "Ten facts that will shock you"
+      And I save the edition and go to the document summary
+      Then I can see the preview URL of the publication "Ten facts that will shock you" contains "you-will-never-guess"
+      And the saved URL choice is reflected on re-entering the edit page
 
-  Scenario: Writer updates the title of a document and opts in to the slug update
-    Given I am a writer
-    And a published publication "You will never guess" exists
-    When I edit the publication "You will never guess"
-    And I change the title to "Ten facts that will shock you"
-    And I opt out of keeping the live slug
-    And I save my changes to the publication
-    Then the option to update the page URL is selected
-    When I save the edition and go to the document summary
-    Then I can see the preview URL of the publication "Ten facts that will shock you" contains "ten-facts-that-will-shock-you"
-    When I reopen the draft of the publication "Ten facts that will shock you"
-    Then the option to update the page URL is selected
+    Scenario: Opting to use the title based slug updates the URL to match the title
+      Given I am a writer
+      And a published publication "You will never guess" exists
+      When I edit the publication "You will never guess"
+      And I change the title to "Ten facts that will shock you"
+      And I opt out of keeping the live slug
+      And I save the edition and go to the document summary
+      Then I can see the preview URL of the publication "Ten facts that will shock you" contains "ten-facts-that-will-shock-you"
+      And the saved URL choice is reflected on re-entering the edit page
 
-  Scenario: Editor saves a published document (saved live slug, previously changed title)
-    Given I am an editor
-    And a published publication "You will never guess" exists
-    When I edit the publication "You will never guess"
-    And I change the title to "Ten facts that will shock you"
-    And I save the edition and go to the document summary
-    And I can see the preview URL of the publication "Ten facts that will shock you" contains "you-will-never-guess"
-    And I force publish the publication "Ten facts that will shock you"
-    And I edit the publication "Ten facts that will shock you"
-    And I save the edition and go to the document summary
-    Then I can see the preview URL of the publication "Ten facts that will shock you" contains "you-will-never-guess"
+    Scenario: A force-published edition with the original URL still keeps it on the next rename
+      Given I am an editor
+      And the publication "You will never guess" has been renamed to "Ten facts that will shock you" with the original URL kept
+      When I edit the publication "Ten facts that will shock you"
+      And I change the title to "Remember this person from the 90's"
+      And I save the edition and go to the document summary
+      Then I can see the preview URL of the publication "Remember this person from the 90's" contains "you-will-never-guess"
+      And the saved URL choice is reflected on re-entering the edit page
 
-  Scenario: Editor updates the title of a published document (saved live slug, previously changed title) and keeps the live slug
-    Given I am an editor
-    And a published publication "You will never guess" exists
-    When I edit the publication "You will never guess"
-    And I change the title to "Ten facts that will shock you"
-    And I save the edition and go to the document summary
-    And I can see the preview URL of the publication "Ten facts that will shock you" contains "you-will-never-guess"
-    And I force publish the publication "Ten facts that will shock you"
-    And I edit the publication "Ten facts that will shock you"
-    And I change the title to "Remember this person from the 90's"
-    And I save the edition and go to the document summary
-    Then I can see the preview URL of the publication "Remember this person from the 90's" contains "you-will-never-guess"
-
-  Scenario: Editor updates the title of a published document (saved live slug, previously changed title) and opts out of keeping the live slug
-    Given I am an editor
-    And a published publication "You will never guess" exists
-    When I edit the publication "You will never guess"
-    And I change the title to "Ten facts that will shock you"
-    And I save the edition and go to the document summary
-    And I can see the preview URL of the publication "Ten facts that will shock you" contains "you-will-never-guess"
-    And I force publish the publication "Ten facts that will shock you"
-    And I edit the publication "Ten facts that will shock you"
-    And I change the title to "Remember this person from the 90's"
-    And I opt out of keeping the live slug
-    And I save the edition and go to the document summary
-    Then I can see the preview URL of the publication "Remember this person from the 90's" contains "remember-this-person-from-the-90s"
-
-  Scenario: Editor saves a published document (title based slug, previously changed title)
-    Given I am an editor
-    And a published publication "You will never guess" exists
-    When I edit the publication "You will never guess"
-    And I change the title to "Ten facts that will shock you"
-    And I opt out of keeping the live slug
-    And I save the edition and go to the document summary
-    And I can see the preview URL of the publication "Ten facts that will shock you" contains "ten-facts-that-will-shock-you"
-    And I force publish the publication "Ten facts that will shock you"
-    And I edit the publication "Ten facts that will shock you"
-    And I save the edition and go to the document summary
-    Then I can see the preview URL of the publication "Ten facts that will shock you" contains "ten-facts-that-will-shock-you"
-
-  Scenario: Editor updates the title of a published document (title based slug, previously changed title) and keeps the live slug
-    Given I am an editor
-    And a published publication "You will never guess" exists
-    When I edit the publication "You will never guess"
-    And I change the title to "Ten facts that will shock you"
-    And I opt out of keeping the live slug
-    And I save the edition and go to the document summary
-    And I can see the preview URL of the publication "Ten facts that will shock you" contains "ten-facts-that-will-shock-you"
-    And I force publish the publication "Ten facts that will shock you"
-    And I edit the publication "Ten facts that will shock you"
-    And I change the title to "Remember this person from the 90's"
-    And I save the edition and go to the document summary
-    Then I can see the preview URL of the publication "Remember this person from the 90's" contains "ten-facts-that-will-shock-you"
-
-  Scenario: Editor updates the title of a published document (title based slug, previously changed title) and opts out of keeping the live slug
-    Given I am an editor
-    And a published publication "You will never guess" exists
-    When I edit the publication "You will never guess"
-    And I change the title to "Ten facts that will shock you"
-    And I opt out of keeping the live slug
-    And I save the edition and go to the document summary
-    And I can see the preview URL of the publication "Ten facts that will shock you" contains "ten-facts-that-will-shock-you"
-    And I force publish the publication "Ten facts that will shock you"
-    And I edit the publication "Ten facts that will shock you"
-    And I change the title to "Remember this person from the 90's"
-    And I opt out of keeping the live slug
-    And I save the edition and go to the document summary
-    Then I can see the preview URL of the publication "Remember this person from the 90's" contains "remember-this-person-from-the-90s"
+    Scenario: A force-published edition with a title-based URL still keeps it on the next rename
+      Given I am an editor
+      And the publication "You will never guess" has been renamed to "Ten facts that will shock you" with the URL updated to match the new title
+      When I edit the publication "Ten facts that will shock you"
+      And I change the title to "Remember this person from the 90's"
+      And I save the edition and go to the document summary
+      Then I can see the preview URL of the publication "Remember this person from the 90's" contains "ten-facts-that-will-shock-you"
+      And the saved URL choice is reflected on re-entering the edit page

--- a/features/edition-update-slug.feature
+++ b/features/edition-update-slug.feature
@@ -16,3 +16,84 @@ Feature: Edition update slug
     And I opt out of keeping the live slug
     And I save the edition and go to the document summary
     Then I can see the preview URL of the publication "Ten facts that will shock you" contains "ten-facts-that-will-shock-you"
+
+  Scenario: Editor saves a published document (saved live slug, previously changed title)
+    Given I am an editor
+    And a published publication "You will never guess" exists
+    When I edit the publication "You will never guess"
+    And I change the title to "Ten facts that will shock you"
+    And I save the edition and go to the document summary
+    And I can see the preview URL of the publication "Ten facts that will shock you" contains "you-will-never-guess"
+    And I force publish the publication "Ten facts that will shock you"
+    And I edit the publication "Ten facts that will shock you"
+    And I save the edition and go to the document summary
+    Then I can see the preview URL of the publication "Ten facts that will shock you" contains "you-will-never-guess"
+
+  Scenario: Editor updates the title of a published document (saved live slug, previously changed title) and keeps the live slug
+    Given I am an editor
+    And a published publication "You will never guess" exists
+    When I edit the publication "You will never guess"
+    And I change the title to "Ten facts that will shock you"
+    And I save the edition and go to the document summary
+    And I can see the preview URL of the publication "Ten facts that will shock you" contains "you-will-never-guess"
+    And I force publish the publication "Ten facts that will shock you"
+    And I edit the publication "Ten facts that will shock you"
+    And I change the title to "Remember this person from the 90's"
+    And I save the edition and go to the document summary
+    Then I can see the preview URL of the publication "Remember this person from the 90's" contains "you-will-never-guess"
+
+  Scenario: Editor updates the title of a published document (saved live slug, previously changed title) and opts out of keeping the live slug
+    Given I am an editor
+    And a published publication "You will never guess" exists
+    When I edit the publication "You will never guess"
+    And I change the title to "Ten facts that will shock you"
+    And I save the edition and go to the document summary
+    And I can see the preview URL of the publication "Ten facts that will shock you" contains "you-will-never-guess"
+    And I force publish the publication "Ten facts that will shock you"
+    And I edit the publication "Ten facts that will shock you"
+    And I change the title to "Remember this person from the 90's"
+    And I opt out of keeping the live slug
+    And I save the edition and go to the document summary
+    Then I can see the preview URL of the publication "Remember this person from the 90's" contains "remember-this-person-from-the-90s"
+
+  Scenario: Editor saves a published document (title based slug, previously changed title)
+    Given I am an editor
+    And a published publication "You will never guess" exists
+    When I edit the publication "You will never guess"
+    And I change the title to "Ten facts that will shock you"
+    And I opt out of keeping the live slug
+    And I save the edition and go to the document summary
+    And I can see the preview URL of the publication "Ten facts that will shock you" contains "ten-facts-that-will-shock-you"
+    And I force publish the publication "Ten facts that will shock you"
+    And I edit the publication "Ten facts that will shock you"
+    And I save the edition and go to the document summary
+    Then I can see the preview URL of the publication "Ten facts that will shock you" contains "ten-facts-that-will-shock-you"
+
+  Scenario: Editor updates the title of a published document (title based slug, previously changed title) and keeps the live slug
+    Given I am an editor
+    And a published publication "You will never guess" exists
+    When I edit the publication "You will never guess"
+    And I change the title to "Ten facts that will shock you"
+    And I opt out of keeping the live slug
+    And I save the edition and go to the document summary
+    And I can see the preview URL of the publication "Ten facts that will shock you" contains "ten-facts-that-will-shock-you"
+    And I force publish the publication "Ten facts that will shock you"
+    And I edit the publication "Ten facts that will shock you"
+    And I change the title to "Remember this person from the 90's"
+    And I save the edition and go to the document summary
+    Then I can see the preview URL of the publication "Remember this person from the 90's" contains "ten-facts-that-will-shock-you"
+
+  Scenario: Editor updates the title of a published document (title based slug, previously changed title) and opts out of keeping the live slug
+    Given I am an editor
+    And a published publication "You will never guess" exists
+    When I edit the publication "You will never guess"
+    And I change the title to "Ten facts that will shock you"
+    And I opt out of keeping the live slug
+    And I save the edition and go to the document summary
+    And I can see the preview URL of the publication "Ten facts that will shock you" contains "ten-facts-that-will-shock-you"
+    And I force publish the publication "Ten facts that will shock you"
+    And I edit the publication "Ten facts that will shock you"
+    And I change the title to "Remember this person from the 90's"
+    And I opt out of keeping the live slug
+    And I save the edition and go to the document summary
+    Then I can see the preview URL of the publication "Remember this person from the 90's" contains "remember-this-person-from-the-90s"

--- a/features/edition-update-slug.feature
+++ b/features/edition-update-slug.feature
@@ -1,18 +1,18 @@
 Feature: Edition update slug
-  Scenario: Writer updates the title of a document
-    Given I am a writer
-    And a published publication "You will never guess" exists
-    When I edit the publication "You will never guess"
-    And I change the title to "Ten facts that will shock you"
-    And I save the edition and go to the document summary
-    Then I can see the preview URL of the publication "Ten facts that will shock you" contains "ten-facts-that-will-shock-you"
 
-  @javascript
-  Scenario: Writer updates the title of a document and opts out of slug update
+  Scenario: Writer updates the title of a document and keeps the live slug
     Given I am a writer
     And a published publication "You will never guess" exists
     When I edit the publication "You will never guess"
     And I change the title to "Ten facts that will shock you"
-    And I opt out of updating the slug
     And I save the edition and go to the document summary
     Then I can see the preview URL of the publication "Ten facts that will shock you" contains "you-will-never-guess"
+
+  Scenario: Writer updates the title of a document and opts in to the slug update
+    Given I am a writer
+    And a published publication "You will never guess" exists
+    When I edit the publication "You will never guess"
+    And I change the title to "Ten facts that will shock you"
+    And I opt out of keeping the live slug
+    And I save the edition and go to the document summary
+    Then I can see the preview URL of the publication "Ten facts that will shock you" contains "ten-facts-that-will-shock-you"

--- a/features/edition-update-slug.feature
+++ b/features/edition-update-slug.feature
@@ -1,12 +1,41 @@
 Feature: Edition update slug
 
+  Scenario: A fresh draft does not show the keep-slug option
+    Given I am a writer
+    When I begin drafting a new publication "Brand new doc"
+    Then I cannot see the option to keep the current page URL
+    When I save the edition and go to the document summary
+    And I reopen the draft of the publication "Brand new doc"
+    And I change the title to "Edited new doc"
+    Then I cannot see the option to keep the current page URL
+
+  Scenario: The keep-slug option shows the live URL
+    Given I am a writer
+    And a published publication "You will never guess" exists
+    When I edit the publication "You will never guess"
+    And I change the title to "Ten facts that will shock you"
+    Then the keep-slug option shows the live URL
+
+  @javascript
+  Scenario: The keep-slug option is revealed when the title changes
+    Given I am a writer
+    And a published publication "You will never guess" exists
+    When I edit the publication "You will never guess"
+    Then I cannot see the option to keep the current page URL
+    When I change the title to "Ten facts that will shock you"
+    Then I can see the option to keep the current page URL
+
   Scenario: Writer updates the title of a document and keeps the live slug
     Given I am a writer
     And a published publication "You will never guess" exists
     When I edit the publication "You will never guess"
     And I change the title to "Ten facts that will shock you"
-    And I save the edition and go to the document summary
+    And I save my changes to the publication
+    Then the option to keep the current page URL is selected
+    When I save the edition and go to the document summary
     Then I can see the preview URL of the publication "Ten facts that will shock you" contains "you-will-never-guess"
+    When I reopen the draft of the publication "Ten facts that will shock you"
+    Then the option to keep the current page URL is selected
 
   Scenario: Writer updates the title of a document and opts in to the slug update
     Given I am a writer
@@ -14,8 +43,12 @@ Feature: Edition update slug
     When I edit the publication "You will never guess"
     And I change the title to "Ten facts that will shock you"
     And I opt out of keeping the live slug
-    And I save the edition and go to the document summary
+    And I save my changes to the publication
+    Then the option to update the page URL is selected
+    When I save the edition and go to the document summary
     Then I can see the preview URL of the publication "Ten facts that will shock you" contains "ten-facts-that-will-shock-you"
+    When I reopen the draft of the publication "Ten facts that will shock you"
+    Then the option to update the page URL is selected
 
   Scenario: Editor saves a published document (saved live slug, previously changed title)
     Given I am an editor

--- a/features/step_definitions/edition_update_slug_steps.rb
+++ b/features/step_definitions/edition_update_slug_steps.rb
@@ -1,26 +1,6 @@
-And(/^I visit the edit slug page for "([^"]*)"$/) do |edition_title|
-  @edition = Edition.find_by!(title: edition_title)
-  visit edit_slug_admin_edition_path(@edition)
-end
-
-And(/^I update the slug to "([^"]*)"$/) do |new_slug|
-  fill_in "Slug", with: new_slug
-  click_button "Update"
-end
-
-Then(/^I can see the edition's public URL contains "([^"]*)"$/) do |new_slug|
-  visit admin_edition_path(@edition)
-  click_button "Create new edition"
-  expect(page.find(".app-view-edit-edition__page-address .govuk-hint")).to have_content new_slug
-end
-
 Then(/^I can see the preview URL of the publication "([^"]*)" contains "([^"]*)"$/) do |title, new_slug|
   visit admin_edition_path(Publication.latest_edition.find_by!(title:))
   expect(page).to have_link "Preview on website (opens in new tab)", href: "https://draft-origin.test.gov.uk/government/publications/#{new_slug}"
-end
-
-Then(/^I am told I do not have permissions to access this page/) do
-  expect(page).to have_content "You do not have permission to access this page."
 end
 
 When(/^I reopen the draft of the publication "([^"]*)"$/) do |title|

--- a/features/step_definitions/edition_update_slug_steps.rb
+++ b/features/step_definitions/edition_update_slug_steps.rb
@@ -4,7 +4,7 @@ Then(/^I can see the preview URL of the publication "([^"]*)" contains "([^"]*)"
 end
 
 Then(/^I cannot see the option to keep the current page URL$/) do
-  expect(page).not_to have_field("Keep the current page URL")
+  expect(page).not_to have_field("Keep current URL")
 end
 
 Then(/^I can see the option to keep the current page URL$/) do
@@ -14,7 +14,7 @@ end
 Then(/^the saved URL choice is reflected on re-entering the edit page$/) do
   draft = Publication.where(state: "draft").last
   visit edit_admin_edition_path(draft)
-  expected_choice = draft.slug_override.present? ? "Keep the current page URL" : "Update the page URL to match the new title"
+  expected_choice = draft.slug_override.present? ? "Keep current URL" : "Update URL to match title"
   expect(page).to have_checked_field(expected_choice)
 end
 

--- a/features/step_definitions/edition_update_slug_steps.rb
+++ b/features/step_definitions/edition_update_slug_steps.rb
@@ -15,7 +15,7 @@ Then(/^I can see the edition's public URL contains "([^"]*)"$/) do |new_slug|
 end
 
 Then(/^I can see the preview URL of the publication "([^"]*)" contains "([^"]*)"$/) do |title, new_slug|
-  visit admin_edition_path(Publication.find_by(title:))
+  visit admin_edition_path(Publication.latest_edition.find_by!(title:))
   expect(page).to have_link "Preview on website (opens in new tab)", href: "https://draft-origin.test.gov.uk/government/publications/#{new_slug}"
 end
 

--- a/features/step_definitions/edition_update_slug_steps.rb
+++ b/features/step_definitions/edition_update_slug_steps.rb
@@ -3,10 +3,6 @@ Then(/^I can see the preview URL of the publication "([^"]*)" contains "([^"]*)"
   expect(page).to have_link "Preview on website (opens in new tab)", href: "https://draft-origin.test.gov.uk/government/publications/#{new_slug}"
 end
 
-When(/^I reopen the draft of the publication "([^"]*)"$/) do |title|
-  begin_editing_document(title)
-end
-
 Then(/^I cannot see the option to keep the current page URL$/) do
   expect(page).not_to have_field("Keep the current page URL")
 end
@@ -15,15 +11,26 @@ Then(/^I can see the option to keep the current page URL$/) do
   expect(page).to have_css(".js-keep-slug-form-group:not([hidden])")
 end
 
-Then(/^the option to keep the current page URL is selected$/) do
-  expect(page).to have_checked_field("Keep the current page URL")
+Then(/^the saved URL choice is reflected on re-entering the edit page$/) do
+  draft = Publication.where(state: "draft").last
+  visit edit_admin_edition_path(draft)
+  expected_choice = draft.slug_override.present? ? "Keep the current page URL" : "Update the page URL to match the new title"
+  expect(page).to have_checked_field(expected_choice)
 end
 
-Then(/^the option to update the page URL is selected$/) do
-  expect(page).to have_checked_field("Update the page URL to match the new title")
+Given(/^the publication "([^"]*)" has been renamed to "([^"]*)" with the original URL kept$/) do |original_title, new_title|
+  step %(a published publication "#{original_title}" exists)
+  step %(I edit the publication "#{original_title}")
+  step %(I change the title to "#{new_title}")
+  step %(I save the edition and go to the document summary)
+  step %(I force publish the publication "#{new_title}")
 end
 
-Then(/^the keep-slug option shows the live URL$/) do
-  live_edition = Publication.live_edition.first
-  expect(page).to have_field("Keep the current page URL (#{live_edition.public_url})")
+Given(/^the publication "([^"]*)" has been renamed to "([^"]*)" with the URL updated to match the new title$/) do |original_title, new_title|
+  step %(a published publication "#{original_title}" exists)
+  step %(I edit the publication "#{original_title}")
+  step %(I change the title to "#{new_title}")
+  step %(I opt out of keeping the live slug)
+  step %(I save the edition and go to the document summary)
+  step %(I force publish the publication "#{new_title}")
 end

--- a/features/step_definitions/edition_update_slug_steps.rb
+++ b/features/step_definitions/edition_update_slug_steps.rb
@@ -22,3 +22,28 @@ end
 Then(/^I am told I do not have permissions to access this page/) do
   expect(page).to have_content "You do not have permission to access this page."
 end
+
+When(/^I reopen the draft of the publication "([^"]*)"$/) do |title|
+  begin_editing_document(title)
+end
+
+Then(/^I cannot see the option to keep the current page URL$/) do
+  expect(page).not_to have_field("Keep the current page URL")
+end
+
+Then(/^I can see the option to keep the current page URL$/) do
+  expect(page).to have_css(".js-keep-slug-form-group:not([hidden])")
+end
+
+Then(/^the option to keep the current page URL is selected$/) do
+  expect(page).to have_checked_field("Keep the current page URL")
+end
+
+Then(/^the option to update the page URL is selected$/) do
+  expect(page).to have_checked_field("Update the page URL to match the new title")
+end
+
+Then(/^the keep-slug option shows the live URL$/) do
+  live_edition = Publication.live_edition.first
+  expect(page).to have_field("Keep the current page URL (#{live_edition.public_url})")
+end

--- a/features/step_definitions/publication_steps.rb
+++ b/features/step_definitions/publication_steps.rb
@@ -52,12 +52,8 @@ When(/^I change the title to "([^"]*)"$/) do |new_title|
   fill_in "Title", with: new_title
 end
 
-When("I opt out of updating the slug") do
-  check "Keep the current page URL"
-end
-
-Then("I cannot opt out of updating the slug") do
-  expect(page).not_to have_selector("label", text: "Keep the current page URL")
+When("I opt out of keeping the live slug") do
+  choose "Update the page URL to match the new title"
 end
 
 When("I save the edition and go to the document summary") do

--- a/features/step_definitions/publication_steps.rb
+++ b/features/step_definitions/publication_steps.rb
@@ -61,7 +61,7 @@ When(/^I change the title to "([^"]*)"$/) do |new_title|
 end
 
 When("I opt out of keeping the live slug") do
-  choose "Update the page URL to match the new title"
+  choose "Update URL to match title"
 end
 
 When("I save the edition and go to the document summary") do

--- a/features/step_definitions/publication_steps.rb
+++ b/features/step_definitions/publication_steps.rb
@@ -13,6 +13,10 @@ When(/^I start drafting a new publication "([^"]*)"$/) do |title|
   click_button "Save and go to document summary"
 end
 
+When(/^I begin drafting a new publication "([^"]*)"$/) do |title|
+  begin_drafting_publication(title)
+end
+
 When(/^I draft a new publication "([^"]*)"$/) do |title|
   begin_drafting_publication(title)
   click_button "Save and go to document summary"

--- a/features/step_definitions/publication_steps.rb
+++ b/features/step_definitions/publication_steps.rb
@@ -17,6 +17,10 @@ When(/^I begin drafting a new publication "([^"]*)"$/) do |title|
   begin_drafting_publication(title)
 end
 
+When(/^I begin drafting a new publication "([^"]*)" and save it$/) do |title|
+  step %(I start drafting a new publication "#{title}")
+end
+
 When(/^I draft a new publication "([^"]*)"$/) do |title|
   begin_drafting_publication(title)
   click_button "Save and go to document summary"

--- a/spec/javascripts/admin/modules/edition-form.spec.js
+++ b/spec/javascripts/admin/modules/edition-form.spec.js
@@ -333,11 +333,11 @@ describe('GOVUK.Modules.EditionForm', function () {
                 <div class="govuk-radios">
                   <div class="gem-c-radio govuk-radios__item">
                     <input type="radio" name="edition[slug_override]" id="radio-ab8fa8f0-0" value="${liveEditionTitle}" class="govuk-radios__input" checked>
-                    <label for="radio-ab8fa8f0-0" class="govuk-label govuk-radios__label">Keep the current page URL</label>
+                    <label for="radio-ab8fa8f0-0" class="govuk-label govuk-radios__label">Keep current URL</label>
                   </div>
                   <div class="gem-c-radio govuk-radios__item">
                     <input type="radio" name="edition[slug_override]" id="radio-ab8fa8f0-1" value="" class="govuk-radios__input">
-                    <label for="radio-ab8fa8f0-1" class="govuk-label govuk-radios__label">Update the page URL to match the new title</label>
+                    <label for="radio-ab8fa8f0-1" class="govuk-label govuk-radios__label">Update URL to match title</label>
                   </div>
                 </div>
               </fieldset>

--- a/spec/javascripts/admin/modules/edition-form.spec.js
+++ b/spec/javascripts/admin/modules/edition-form.spec.js
@@ -189,25 +189,25 @@ describe('GOVUK.Modules.EditionForm', function () {
       editionForm.init()
     })
 
-    it('hides the checkbox on page load', function () {
-      const checkboxContainer = form.querySelector('.js-keep-slug-form-group')
+    it('hides the keep-slug controls on page load', function () {
+      const keepSlugControls = form.querySelector('.js-keep-slug-form-group')
 
-      expect(checkboxContainer.hidden).toEqual(true)
+      expect(keepSlugControls.hidden).toEqual(true)
     })
 
-    it('shows the checkbox when the title is edited, and hides it if the title is reset', function () {
+    it('shows the keep-slug controls when the title is edited, and hides them if the title is reset', function () {
       const titleInput = form.querySelector('#edition_title')
-      const checkboxContainer = form.querySelector('.js-keep-slug-form-group')
+      const keepSlugControls = form.querySelector('.js-keep-slug-form-group')
 
       titleInput.value = 'Some new title'
       titleInput.dispatchEvent(new Event('input'))
 
-      expect(checkboxContainer.hidden).toEqual(false)
+      expect(keepSlugControls.hidden).toEqual(false)
 
       titleInput.value = newEditionTitle
       titleInput.dispatchEvent(new Event('input'))
 
-      expect(checkboxContainer.hidden).toEqual(true)
+      expect(keepSlugControls.hidden).toEqual(true)
     })
   })
 
@@ -328,11 +328,19 @@ describe('GOVUK.Modules.EditionForm', function () {
               </div>
             </div>
             <div id="hint-f0e80744" class="gem-c-hint govuk-hint">http://www.dev.gov.uk/guidance/test-document</div>
-            <input type="hidden" value="" />
-            <div id="checkboxes-ab8fa8f0" data-module="gem-checkboxes govuk-checkboxes" class="gem-c-checkboxes govuk-form-group js-keep-slug-form-group">
-              <div class="govuk-checkboxes__item">
-                <input type="checkbox" name="slug_override" id="checkboxes-ab8fa8f0-0" value="${liveEditionTitle}" class="govuk-checkboxes__input"><label for="checkboxes-ab8fa8f0-0" class="govuk-label govuk-checkboxes__label">Keep current page URL</label>
-              </div>
+            <div class="gem-c-radio govuk-form-group js-keep-slug-form-group">
+              <fieldset class="govuk-fieldset">
+                <div class="govuk-radios">
+                  <div class="gem-c-radio govuk-radios__item">
+                    <input type="radio" name="edition[slug_override]" id="radio-ab8fa8f0-0" value="${liveEditionTitle}" class="govuk-radios__input" checked>
+                    <label for="radio-ab8fa8f0-0" class="govuk-label govuk-radios__label">Keep the current page URL</label>
+                  </div>
+                  <div class="gem-c-radio govuk-radios__item">
+                    <input type="radio" name="edition[slug_override]" id="radio-ab8fa8f0-1" value="" class="govuk-radios__input">
+                    <label for="radio-ab8fa8f0-1" class="govuk-label govuk-radios__label">Update the page URL to match the new title</label>
+                  </div>
+                </div>
+              </fieldset>
             </div>`
   }
 })

--- a/test/functional/admin/document_collections_controller_test.rb
+++ b/test/functional/admin/document_collections_controller_test.rb
@@ -72,7 +72,6 @@ class Admin::DocumentCollectionsControllerTest < ActionController::TestCase
     get :edit, params: { id: document_collection }
 
     assert_select "form[action=?]", admin_document_collection_path(document_collection) do
-      assert_select ".app-view-edit-edition__page-address .govuk-hint", document_collection.public_url
       assert_select "textarea[name='edition[title]']", document_collection.title
       assert_select "textarea[name='edition[summary]']", text: document_collection.summary
       assert_select "textarea[name='edition[body]']", text: document_collection.body

--- a/test/functional/admin/standard_editions_controller_test.rb
+++ b/test/functional/admin/standard_editions_controller_test.rb
@@ -186,6 +186,23 @@ class Admin::StandardEditionsControllerTest < ActionController::TestCase
     assert_select "legend", text: "Review date"
   end
 
+  view_test "GET edit shows the current GOV.UK URL as a link when the edition has a live edition" do
+    configurable_document_type = build_configurable_document_type("test_type")
+    ConfigurableDocumentType.setup_test_types(configurable_document_type)
+
+    published_edition = create(:published_standard_edition, :with_organisations, configurable_document_type: "test_type")
+    edition = create(:draft_standard_edition, :with_organisations, configurable_document_type: "test_type", document: published_edition.document)
+
+    get :edit, params: { id: edition }
+
+    assert_response :ok
+    assert_select ".app-view-edit-edition__page-address" do
+      assert_select "h3", "URL"
+      assert_select "p", text: /Current GOV\.UK URL:/
+      assert_select "a.govuk-link[href=?]", published_edition.public_url, text: published_edition.public_url
+    end
+  end
+
   view_test "GET new does not show the keep current URL option" do
     configurable_document_type = build_configurable_document_type("test_type")
     ConfigurableDocumentType.setup_test_types(configurable_document_type)

--- a/test/functional/admin/standard_editions_controller_test.rb
+++ b/test/functional/admin/standard_editions_controller_test.rb
@@ -210,7 +210,7 @@ class Admin::StandardEditionsControllerTest < ActionController::TestCase
     get :new, params: { configurable_document_type: "test_type" }
 
     assert_response :ok
-    refute_select "label", text: /Keep the current page URL/
+    refute_select "label", text: /Keep current URL/
   end
 
   view_test "GET edit does not show the keep current URL option for a draft with no live edition" do
@@ -222,7 +222,7 @@ class Admin::StandardEditionsControllerTest < ActionController::TestCase
     get :edit, params: { id: edition }
 
     assert_response :ok
-    refute_select "label", text: /Keep the current page URL/
+    refute_select "label", text: /Keep current URL/
   end
 
   view_test "GET edit pre-selects the keep current URL option when slug_override is set" do
@@ -255,7 +255,7 @@ class Admin::StandardEditionsControllerTest < ActionController::TestCase
     refute_select "input[type=radio][name=?][value=?][checked]", "edition[slug_override]", published_edition.slug
   end
 
-  view_test "GET edit appends the keep current URL option with the live URL" do
+  view_test "GET edit shows the URL change explanation and option labels" do
     configurable_document_type = build_configurable_document_type("test_type")
     ConfigurableDocumentType.setup_test_types(configurable_document_type)
 
@@ -265,7 +265,9 @@ class Admin::StandardEditionsControllerTest < ActionController::TestCase
     get :edit, params: { id: edition }
 
     assert_response :ok
-    assert_select "label", text: "Keep the current page URL (#{published_edition.public_url})"
+    assert_select "p", text: "The title has changed since this URL was created. Choose whether to keep the current URL or update it to match the title."
+    assert_select "label", text: "Keep current URL"
+    assert_select "label", text: "Update URL to match title"
   end
 
   view_test "GET edit renders only the fields for the selected tab" do

--- a/test/functional/admin/standard_editions_controller_test.rb
+++ b/test/functional/admin/standard_editions_controller_test.rb
@@ -245,7 +245,8 @@ class Admin::StandardEditionsControllerTest < ActionController::TestCase
     ConfigurableDocumentType.setup_test_types(configurable_document_type)
 
     published_edition = create(:published_standard_edition, :with_organisations, configurable_document_type: "test_type")
-    edition = create(:draft_standard_edition, :with_organisations, configurable_document_type: "test_type", document: published_edition.document, slug_override: nil)
+    edition = create(:draft_standard_edition, :with_organisations, configurable_document_type: "test_type", document: published_edition.document)
+    edition.update!(slug_override: "")
 
     get :edit, params: { id: edition }
 

--- a/test/functional/admin/standard_editions_controller_test.rb
+++ b/test/functional/admin/standard_editions_controller_test.rb
@@ -186,6 +186,71 @@ class Admin::StandardEditionsControllerTest < ActionController::TestCase
     assert_select "legend", text: "Review date"
   end
 
+  view_test "GET new does not show the keep current URL option" do
+    configurable_document_type = build_configurable_document_type("test_type")
+    ConfigurableDocumentType.setup_test_types(configurable_document_type)
+
+    get :new, params: { configurable_document_type: "test_type" }
+
+    assert_response :ok
+    refute_select "label", text: /Keep the current page URL/
+  end
+
+  view_test "GET edit does not show the keep current URL option for a draft with no live edition" do
+    configurable_document_type = build_configurable_document_type("test_type")
+    ConfigurableDocumentType.setup_test_types(configurable_document_type)
+
+    edition = create(:draft_standard_edition, :with_organisations, configurable_document_type: "test_type")
+
+    get :edit, params: { id: edition }
+
+    assert_response :ok
+    refute_select "label", text: /Keep the current page URL/
+  end
+
+  view_test "GET edit pre-selects the keep current URL option when slug_override is set" do
+    configurable_document_type = build_configurable_document_type("test_type")
+    ConfigurableDocumentType.setup_test_types(configurable_document_type)
+
+    published_edition = create(:published_standard_edition, :with_organisations, configurable_document_type: "test_type")
+    edition = create(:draft_standard_edition, :with_organisations, configurable_document_type: "test_type", document: published_edition.document, slug_override: published_edition.slug)
+
+    get :edit, params: { id: edition }
+
+    assert_response :ok
+    assert_select "input[type=radio][name=?]", "edition[slug_override]", count: 2
+    assert_select "input[type=radio][name=?][value=?][checked]", "edition[slug_override]", published_edition.slug
+    refute_select "input[type=radio][name=?][value=''][checked]", "edition[slug_override]"
+  end
+
+  view_test "GET edit pre-selects the update URL option when slug_override is blank" do
+    configurable_document_type = build_configurable_document_type("test_type")
+    ConfigurableDocumentType.setup_test_types(configurable_document_type)
+
+    published_edition = create(:published_standard_edition, :with_organisations, configurable_document_type: "test_type")
+    edition = create(:draft_standard_edition, :with_organisations, configurable_document_type: "test_type", document: published_edition.document, slug_override: nil)
+
+    get :edit, params: { id: edition }
+
+    assert_response :ok
+    assert_select "input[type=radio][name=?]", "edition[slug_override]", count: 2
+    assert_select "input[type=radio][name=?][value=''][checked]", "edition[slug_override]"
+    refute_select "input[type=radio][name=?][value=?][checked]", "edition[slug_override]", published_edition.slug
+  end
+
+  view_test "GET edit appends the keep current URL option with the live URL" do
+    configurable_document_type = build_configurable_document_type("test_type")
+    ConfigurableDocumentType.setup_test_types(configurable_document_type)
+
+    published_edition = create(:published_standard_edition, :with_organisations, configurable_document_type: "test_type")
+    edition = create(:draft_standard_edition, :with_organisations, configurable_document_type: "test_type", document: published_edition.document)
+
+    get :edit, params: { id: edition }
+
+    assert_response :ok
+    assert_select "label", text: "Keep the current page URL (#{published_edition.public_url})"
+  end
+
   view_test "GET edit renders only the fields for the selected tab" do
     configurable_document_type = build_configurable_document_type("test_type", {
       "forms" => {

--- a/test/unit/app/models/edition_test.rb
+++ b/test/unit/app/models/edition_test.rb
@@ -538,6 +538,23 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal [edition_with_slug], Edition.with_title_containing("https://www.gov.uk/government/news/klingons-rule?foo=bar#details")
   end
 
+  test "#create_draft populates slug_override with the parent's slug when the parent has none" do
+    published_edition = create(:published_edition, title: "Klingons rule")
+    assert published_edition[:slug_override].blank?
+
+    draft = published_edition.create_draft(create(:writer))
+
+    assert_equal published_edition.slug, draft.slug_override
+  end
+
+  test "#create_draft preserves an existing slug_override on the parent" do
+    published_edition = create(:published_edition, title: "Klingons rule", slug_override: "kept-url")
+
+    draft = published_edition.create_draft(create(:writer))
+
+    assert_equal "kept-url", draft.slug_override
+  end
+
   test "should find editions with title containing regular expression characters" do
     edition_with_nasty_characters = create(:edition, title: "title with [stuff in brackets]")
     assert_equal [edition_with_nasty_characters], Edition.with_title_containing("[stuff")

--- a/test/unit/app/models/edition_test.rb
+++ b/test/unit/app/models/edition_test.rb
@@ -538,21 +538,20 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal [edition_with_slug], Edition.with_title_containing("https://www.gov.uk/government/news/klingons-rule?foo=bar#details")
   end
 
-  test "#create_draft populates slug_override with the parent's slug when the parent has none" do
+  test "a new edition on a document with a live edition defaults slug_override to the live edition's slug" do
     published_edition = create(:published_edition, title: "Klingons rule")
-    assert published_edition[:slug_override].blank?
-
-    draft = published_edition.create_draft(create(:writer))
+    draft = create(:draft_edition, document: published_edition.document, title: "Klingons returneth")
 
     assert_equal published_edition.slug, draft.slug_override
+    assert_equal published_edition.slug, draft.slug
   end
 
-  test "#create_draft preserves an existing slug_override on the parent" do
-    published_edition = create(:published_edition, title: "Klingons rule", slug_override: "kept-url")
+  test "a new edition does not overwrite an explicitly set slug_override" do
+    published_edition = create(:published_edition, title: "Klingons rule")
+    draft = create(:draft_edition, document: published_edition.document, slug_override: "chosen-slug", title: "Klingons returneth")
 
-    draft = published_edition.create_draft(create(:writer))
-
-    assert_equal "kept-url", draft.slug_override
+    assert_equal "chosen-slug", draft.slug_override
+    assert_equal "chosen-slug", draft.slug
   end
 
   test "should find editions with title containing regular expression characters" do


### PR DESCRIPTION
## Summary

- Populate `slug_override` on new drafts so the page URL is preserved by default when a writer re-edits a published document.
- "Keep the current page URL" checkbox now renders ticked on title change; writers explicitly untick to opt the URL into the rename.

[Jira](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-3323)