### PR TITLE
[WHIT-3405] Allow document searching by path and URL

### DIFF
--- a/app/models/concerns/edition/scopes/searchable_by_title.rb
+++ b/app/models/concerns/edition/scopes/searchable_by_title.rb
@@ -4,9 +4,10 @@ module Edition::Scopes::SearchableByTitle
   included do
     scope :with_title_containing, lambda { |keywords|
       like_clause = "%#{sanitize_sql_like(keywords)}%"
+      slug_keyword_candidate = keywords.to_s.sub(%r{[?#].*\z}, "").split("/").last
 
-      if keywords.match?(/\A[a-z0-9]+(-[a-z0-9]+)+\z/)
-        where(slug: keywords)
+      if slug_keyword_candidate.match?(/\A[a-z0-9]+(-[a-z0-9]+)+\z/)
+        where(slug: slug_keyword_candidate)
       else
         in_default_locale
           .includes(:document)

--- a/test/unit/app/models/edition_test.rb
+++ b/test/unit/app/models/edition_test.rb
@@ -506,10 +506,36 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal [edition_with_first_keyword], Edition.with_title_containing("klingons")
   end
 
-  test "should find editions with slug containing keyword" do
-    edition_with_first_keyword = create(:edition, title: "klingons rule")
-    _edition_without_first_keyword = create(:edition, title: "this document is about muppets")
-    assert_equal [edition_with_first_keyword], Edition.with_title_containing("klingons-rule")
+  test "should find editions by slug, when given the exact slug" do
+    edition_with_slug = create(:edition, title: "New title", slug_override: "klingons-rule")
+    _edition_without_match = create(:edition, title: "this document is about muppets")
+
+    assert_equal "klingons-rule", edition_with_slug.slug
+    assert_equal [edition_with_slug], Edition.with_title_containing("klingons-rule")
+  end
+
+  test "should find editions by slug, when given a full path ending in a slug" do
+    edition_with_slug = create(:edition, title: "New title", slug_override: "klingons-rule")
+    _edition_without_match = create(:edition, title: "this document is about muppets")
+
+    assert_equal "klingons-rule", edition_with_slug.slug
+    assert_equal [edition_with_slug], Edition.with_title_containing("/government/news/klingons-rule")
+  end
+
+  test "should find editions by slug, when given a full URL ending in a slug" do
+    edition_with_slug = create(:edition, title: "New title", slug_override: "klingons-rule")
+    _edition_without_match = create(:edition, title: "this document is about muppets")
+
+    assert_equal "klingons-rule", edition_with_slug.slug
+    assert_equal [edition_with_slug], Edition.with_title_containing("https://www.gov.uk/government/news/klingons-rule")
+  end
+
+  test "should find editions by slug, when given a full URL, including query string and fragment" do
+    edition_with_slug = create(:edition, title: "New title", slug_override: "klingons-rule")
+    _edition_without_match = create(:edition, title: "this document is about muppets")
+
+    assert_equal "klingons-rule", edition_with_slug.slug
+    assert_equal [edition_with_slug], Edition.with_title_containing("https://www.gov.uk/government/news/klingons-rule?foo=bar#details")
   end
 
   test "should find editions with title containing regular expression characters" do


### PR DESCRIPTION
# What & why

**User story** 

As a user of Whitehall search
I want to cut and paste a whole url (or complete path) from a published Whitehall page into the title field
So that I can quickly find the content in Whitehall without isolating the slug from the whole url


We know from data that a proportion of users cut-and-paste whole urls or paths from a published Whitehall page into the title search field. Previously, these searches would not have matched the slug search rules, and would have returned nothing from the title search. Example searches previously returning no results:
- https://www.gov.uk/government/publications/the-civil-society-resilience-infrastructure-fund
- /government/publications/the-civil-society-resilience-infrastructure-fund
- /the-civil-society-resilience-infrastructure-fund

This commit ensures that:
- Search for full path triggers the slug search (not the title search), using just the slug element of the input
- Search for full URL triggers the slug search (not the title search), using just the slug element of the input

The search keywords above should now return the correct whitehall edition of slug "the-civil-society-resilience-infrastructure-fund".

Changes in `search_by_title`:
- Convert input to a string
- Remove any trailing query string
- Split the string on "/" and take the final segment

So the net effect is: turn either a full URL or a path-like string into the last path segment, then treat that segment as a slug.

[Jira](https://gov-uk.atlassian.net/browse/WHIT-3405)
