### PR TITLE
Revert "First publishing date [WHIT-3076]"

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -68,13 +68,10 @@ class Edition < ApplicationRecord
   validates :summary, presence: true, if: :summary_required?, length: { maximum: 65_535 }
   validates :previously_published, inclusion: { in: [true, false], message: "You must specify whether the document has been published before" }
   validates :first_published_at, presence: true, if: -> { previously_published || published_major_version }
-  validates :first_published_at, inclusion: { in: proc { Date.parse("1900-01-01")..Time.zone.now } }, if: -> { draft? && other_editions.empty? }, allow_blank: true
+  validates :first_published_at, inclusion: { in: proc { Date.parse("1900-01-01")..Time.zone.now } }, if: :draft?, allow_blank: true
   validates :scheduled_publication, inclusion: { in: proc { Time.zone.now.. }, message: "must be in the future" }, if: :draft?, allow_blank: true
   validates :political, inclusion: { in: [true, false] }
   validates :image_display_option, inclusion: { in: ["no_image", "organisation_image", "custom_image", nil] }
-
-  validate :first_published_preceeds_change_notes, if: :draft?
-  validate :first_published_within_current_govt, if: :draft?
 
   UNMODIFIABLE_STATES = %w[scheduled published superseded deleted unpublished].freeze
   FROZEN_STATES = %w[superseded deleted].freeze
@@ -239,8 +236,6 @@ class Edition < ApplicationRecord
   end
 
   def other_editions
-    return [] if document.nil?
-
     if persisted?
       document.editions.where(self.class.arel_table[:id].not_eq(id))
     else
@@ -448,29 +443,6 @@ class Edition < ApplicationRecord
 
   def error_labels
     {}
-  end
-
-  def first_published_preceeds_change_notes
-    return if first_published_at.blank?
-    return if other_editions.empty?
-
-    change_note_dates = other_editions.pluck(:major_change_published_at).compact.sort
-
-    return if change_note_dates.empty?
-
-    if first_published_at > change_note_dates.first
-      errors.add(:first_published_at, :after_change_notes, latest: change_note_dates.first.strftime("%d/%m/%Y %H:%M"))
-    end
-  end
-
-  def first_published_within_current_govt
-    return if first_published_at.blank?
-    return if Government.current.blank?
-    return if political? || historic?
-
-    if first_published_at.to_date < Government.current.start_date
-      errors.add(:first_published_at, :before_current_govt, earliest: Government.current.start_date.strftime("%d/%m/%Y"))
-    end
   end
 
 private

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -23,8 +23,6 @@ en:
               invalid_date: First published date is not in the correct format
               blank: Enter a first published date
               inclusion: First published date must be between 1/1/1900 and the present
-              after_change_notes: "First published date must be before the first change note (%{latest})"
-              before_current_govt: "First published date must be after the start of the current government (%{earliest})"
             html_attachments:
               missing_contact_reference: "- \"%{html_attachment_title}\" - embedded Contact (ID %{contact_id}) doesn't exist"
             unpublishing:

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -115,7 +115,7 @@ module DocumentHelper
     fill_in "Logo formatted name", with: "Logo\r\nformatted\r\nname\r\n"
   end
 
-  def fill_in_publication_fields(first_published: Time.zone.now, publication_type: "Research and analysis")
+  def fill_in_publication_fields(first_published: "2010-01-01", publication_type: "Research and analysis")
     checkbox_label = "This document has previously been published on another website"
     check checkbox_label
     within_conditional_reveal checkbox_label do

--- a/test/unit/app/models/call_for_evidence_test.rb
+++ b/test/unit/app/models/call_for_evidence_test.rb
@@ -328,7 +328,7 @@ class CallForEvidenceTest < ActiveSupport::TestCase
   test "#government returns the government active on the first_public_at date" do
     create(:current_government)
     previous_government = create(:previous_government)
-    call_for_evidence = build(:call_for_evidence, first_published_at: 4.years.ago)
+    call_for_evidence = create(:call_for_evidence, first_published_at: 4.years.ago)
 
     assert_equal previous_government, call_for_evidence.government
   end

--- a/test/unit/app/models/consultation_test.rb
+++ b/test/unit/app/models/consultation_test.rb
@@ -368,7 +368,7 @@ class ConsultationTest < ActiveSupport::TestCase
   test "#government returns the government active on the first_public_at date" do
     create(:current_government)
     previous_government = create(:previous_government)
-    consultation = build(:consultation, first_published_at: 4.years.ago)
+    consultation = create(:consultation, first_published_at: 4.years.ago)
 
     assert_equal previous_government, consultation.government
   end

--- a/test/unit/app/models/edition_test.rb
+++ b/test/unit/app/models/edition_test.rb
@@ -678,38 +678,6 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal "First published date must be between 1/1/1900 and the present", edition.errors.full_messages.first
   end
 
-  test "first_published_at cannot be after the date of the first change note" do
-    edition_with_change_note = create(:edition_with_document, :published, change_note: "changed", major_change_published_at: 2.days.ago)
-    edition = build(:edition, document: edition_with_change_note.document, first_published_at: 1.day.ago)
-
-    assert edition.invalid?
-    assert_equal "First published date must be before the first change note (09/11/2011 11:11)", edition.errors.full_messages.first
-  end
-
-  test "first_published_at cannot be before the start of the current government" do
-    create(:current_government)
-    edition = build(:edition, first_published_at: 10.years.ago)
-
-    assert edition.invalid?
-    assert_equal "First published date must be after the start of the current government (11/11/2009)", edition.errors.full_messages.first
-  end
-
-  test "polictial editions can have their first_published_at date set before the current government " do
-    create(:current_government)
-    political_edition = create(:edition, political: true, first_published_at: 10.years.ago)
-
-    assert political_edition.valid?
-  end
-
-  test "after_change_notes' error message takes priority if multiple validation errors on first_published_at" do
-    edition_with_change_note = create(:edition_with_document, :published, change_note: "changed", major_change_published_at: 2.days.ago)
-    edition = build(:edition, document: edition_with_change_note.document, first_published_at: 10.years.from_now)
-    edition.validate
-
-    assert_equal 1, edition.errors.size
-    assert_equal "First published date must be before the first change note (09/11/2011 11:11)", edition.errors.full_messages.first
-  end
-
   test "#government returns the associated government when the edition has a specific government_id" do
     create(:current_government)
     previous_government = create(:previous_government)
@@ -738,7 +706,7 @@ class EditionTest < ActiveSupport::TestCase
   test "#government returns the historic government for a previously published edition" do
     previous_government = create(:previous_government)
     create(:current_government)
-    edition = build(:edition, first_published_at: 4.years.ago)
+    edition = create(:edition, first_published_at: 4.years.ago)
     assert_equal previous_government, edition.government
   end
 
@@ -760,7 +728,7 @@ class EditionTest < ActiveSupport::TestCase
 
     previous_government = create(:previous_government)
 
-    edition = build(:edition, political: false, first_published_at: previous_government.start_date)
+    edition = create(:edition, political: false, first_published_at: previous_government.start_date)
     assert_not edition.historic?
 
     edition = create(:edition, political: false, first_published_at: current_government.start_date)
@@ -1012,12 +980,6 @@ class EditionTest < ActiveSupport::TestCase
 
     edition.image_display_option = "invalid_option"
     assert_not edition.valid?
-  end
-
-  test "#other_editions returns an empty array if there is no associated document" do
-    edition = build(:edition)
-
-    assert_equal edition.other_editions, []
   end
 
   def decoded_token_payload(token)

--- a/test/unit/app/presenters/publishing_api/document_collection_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/document_collection_presenter_test.rb
@@ -403,7 +403,7 @@ class PublishingApi::DocumentCollectionPresenterPreviousGovernmentTest < ActiveS
       slug: "a-previous-government",
     )
     @presented_document_collection = PublishingApi::DocumentCollectionPresenter.new(
-      build(
+      create(
         :document_collection,
         first_published_at: @previous_government.start_date + 1.day,
       ),

--- a/test/unit/app/presenters/publishing_api/statistical_data_set_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/statistical_data_set_presenter_test.rb
@@ -268,7 +268,7 @@ class PublishingApi::StatisticalDataSetPresenterPreviousGovernmentTest < ActiveS
       slug: "a-previous-government",
     )
     @presented_statistical_data_set = PublishingApi::StatisticalDataSetPresenter.new(
-      build(
+      create(
         :statistical_data_set,
         first_published_at: @previous_government.start_date + 1.day,
       ),


### PR DESCRIPTION
Reverts alphagov/whitehall#11429

It's causing issues for existing content where the 'first published' date is prior to the start of the current government. (Unable to publish new drafts of said content).