### PR TITLE
Ensure our fixture file test data is validated [WHIT-3341]

### DIFF
--- a/features/fixtures/test_configurable_document_type_group.json
+++ b/features/fixtures/test_configurable_document_type_group.json
@@ -1,6 +1,6 @@
 [
   {
-    "key": "test_type_1",
+    "key": "test_type_one",
     "title": "Test configurable document type one",
     "description": "A test configurable document on GOV.UK",
     "forms": {
@@ -33,9 +33,9 @@
     },
     "settings": {
       "base_path_prefix": "/government/test-type",
-      "publishing_api_schema_name": "test_type",
-      "publishing_api_document_type": "test_type_1",
-      "configurable_document_group": "test_group",
+      "publishing_api_schema_name": "news_article",
+      "publishing_api_document_type": "news_story",
+      "configurable_document_group": "news_article",
       "rendering_app": "frontend",
       "organisations": null,
       "backdating_enabled": false,
@@ -45,14 +45,18 @@
         "usages": {
           "govspeak_embed": {
             "kinds": ["default"],
-            "multiple": true
+            "multiple": true,
+            "caption_enabled": true
           }
         }
-      }
+      },
+      "send_change_history": true,
+      "file_attachments_enabled": true,
+      "history_mode_enabled": true
     }
   },
   {
-    "key": "test_type_2",
+    "key": "test_type_two",
     "title": "Test configurable document type two",
     "description": "A test configurable document on GOV.UK",
     "forms": {
@@ -77,15 +81,17 @@
     },
     "presenters": {
       "publishing_api": {
-        "body": "govspeak"
+        "details": {
+          "body": "govspeak"
+        },
+        "links": []
       }
     },
-    "associations": [],
     "settings": {
       "base_path_prefix": "/government/test-type",
-      "publishing_api_schema_name": "test_type",
-      "publishing_api_document_type": "test_type_2",
-      "configurable_document_group": "test_group",
+      "publishing_api_schema_name": "news_article",
+      "publishing_api_document_type": "press_release",
+      "configurable_document_group": "news_article",
       "rendering_app": "frontend",
       "organisations": null,
       "backdating_enabled": false,
@@ -95,10 +101,14 @@
         "usages": {
           "govspeak_embed": {
             "kinds": ["default"],
-            "multiple": true
+            "multiple": true,
+            "caption_enabled": true
           }
         }
-      }
+      },
+      "send_change_history": true,
+      "file_attachments_enabled": true,
+      "history_mode_enabled": true
     }
   }
 ]

--- a/features/standard-edition.feature
+++ b/features/standard-edition.feature
@@ -45,7 +45,7 @@ Feature: Standard Editions
     Given I am a GDS admin
     And the configurable document types feature flag is enabled
     And the test configurable document type group is defined
-    And I have created a new "test_type_1" draft
+    And I have created a new "test_type_one" draft
     Then I should see a 'Change' link in the 'Type of document' row
     And clicking it should take me to a form listing the document types I can switch to
     And choosing a document type should take me to a preview page summarising the changes

--- a/features/step_definitions/standard_edition_steps.rb
+++ b/features/step_definitions/standard_edition_steps.rb
@@ -319,7 +319,7 @@ Given("the test configurable document type group is defined") do
   types = {}
   type_definitions.each do |type_definition|
     types[type_definition["key"]] = type_definition
-    ConfigurableDocumentType.stubs(:find).returns(ConfigurableDocumentType.new(type_definition))
+    ConfigurableDocumentType.stubs(:find).with(type_definition["key"]).returns(ConfigurableDocumentType.new(type_definition))
   end
   ConfigurableDocumentType.setup_test_types(types)
 end

--- a/test/unit/app/models/configurable_document_types/validate_configurable_document_schemas_test.rb
+++ b/test/unit/app/models/configurable_document_types/validate_configurable_document_schemas_test.rb
@@ -22,6 +22,15 @@ class ValidateConfigurableDocumentSchemasTest < ActiveSupport::TestCase
       end
     end
 
+    it "validates that the test_configurable_document_type_group.json fixtures are valid" do
+      document_types = JSON.parse(File.read("features/fixtures/test_configurable_document_type_group.json"))
+      document_types.each do |document_type|
+        errors = SchemaValidator.for(document_type)
+
+        assert errors.empty?, "Schema validation errors for #{document_type['key']}:\n#{errors.join("\n")}"
+      end
+    end
+
     context "root level mandatory fields" do
       %w[title description].each do |key|
         it "will cause a validation error if not defined" do


### PR DESCRIPTION
We should have confidence that any fixtures we run tests against are in sync with reality.

Loosely related to https://gov-uk.atlassian.net/browse/WHIT-3341

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
