### PR TITLE
 Validate each document tab form separately [WHIT-3214]

### DIFF
--- a/app/components/admin/editions/show/preview_component.html.erb
+++ b/app/components/admin/editions/show/preview_component.html.erb
@@ -7,6 +7,11 @@
     margin_bottom: 3,
   } %>
 
+  <% if local_edition.is_a?(StandardEdition) && invalid_tab_forms&.any? %>
+    <%= render "govuk_publishing_components/components/inset_text", {
+      text: "This preview may be out of date because the edition is invalid.",
+    } %>
+  <% end %>
   <% if versioning_completed %>
     <p class="govuk-body">
       <%= preview_link(primary_locale_link_text, preview_url) %>

--- a/app/components/admin/editions/show/preview_component.rb
+++ b/app/components/admin/editions/show/preview_component.rb
@@ -3,8 +3,9 @@
 class Admin::Editions::Show::PreviewComponent < ViewComponent::Base
   include Admin::UrlOptionsHelper
 
-  def initialize(edition:)
+  def initialize(edition:, invalid_tab_forms: [])
     @edition = edition
+    @invalid_tab_forms = invalid_tab_forms
   end
 
   def render?
@@ -13,7 +14,7 @@ class Admin::Editions::Show::PreviewComponent < ViewComponent::Base
 
 private
 
-  attr_reader :edition
+  attr_reader :edition, :invalid_tab_forms
 
   def versioning_completed
     @versioning_completed ||= edition.versioning_completed?

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -21,6 +21,8 @@ class Admin::EditionsController < Admin::BaseController
   before_action :redirect_to_controller_for_type, only: [:show]
   before_action :construct_similar_slug_warning_error, only: %i[edit]
 
+  rescue_from ActiveRecord::StaleObjectError, with: :handle_stale_object_error
+
   def enforce_permissions!
     case action_name
     when "index", "topics"
@@ -116,26 +118,13 @@ class Admin::EditionsController < Admin::BaseController
     @edition.assign_attributes(edition_params)
 
     if updater.can_perform? && @edition.save_as(current_user)
-      updater.perform!
 
-      if @edition.link_check_report
-        LinkCheckerApiService.check_links(@edition, admin_link_checker_api_callback_url)
-      end
-
+      after_update_operations
       redirect_to redirect_param(fallback: show_or_edit_path), saved_confirmation_notice
     else
       flash.now[:alert] = updater.failure_reason
-      build_edition_dependencies
-      fetch_version_and_remark_trails
-      construct_similar_slug_warning_error
-      render :edit
+      render_edition_update_failure
     end
-  rescue ActiveRecord::StaleObjectError
-    flash.now[:alert] = "This document has been saved since you opened it"
-    @conflicting_edition = Edition.find(params[:id])
-    @edition.lock_version = @conflicting_edition.lock_version
-    build_edition_dependencies
-    render :edit
   end
 
   def revise
@@ -538,5 +527,25 @@ private
     return url if url && URI.parse(url).host.blank? # only allow same-site paths
 
     fallback
+  end
+
+  def after_update_operations
+    updater.perform!
+    LinkCheckerApiService.check_links(@edition, admin_link_checker_api_callback_url) if @edition.link_check_report
+  end
+
+  def render_edition_update_failure
+    build_edition_dependencies
+    fetch_version_and_remark_trails
+    construct_similar_slug_warning_error
+    render :edit
+  end
+
+  def handle_stale_object_error
+    flash.now[:alert] = "This document has been saved since you opened it"
+    @conflicting_edition = Edition.find(params[:id])
+    @edition.lock_version = @conflicting_edition.lock_version
+    build_edition_dependencies
+    render :edit
   end
 end

--- a/app/controllers/admin/standard_editions_controller.rb
+++ b/app/controllers/admin/standard_editions_controller.rb
@@ -37,9 +37,33 @@ class Admin::StandardEditionsController < Admin::EditionsController
     end
   end
 
-  def update
-    @edition.current_tab_context = @current_tab_context
+  def edit
     super
+    return if @current_tab_context.blank?
+
+    tab_form = StandardEdition::TabForm.new(@edition, @current_tab_context)
+    apply_tab_errors_to_edition(tab_form) unless tab_form.valid?
+  end
+
+  def update
+    @edition.assign_attributes(edition_params)
+
+    if @current_tab_context.present?
+      tab_form = StandardEdition::TabForm.new(@edition, @current_tab_context)
+
+      if tab_form.valid?
+        @edition.save_as(current_user, validate: false)
+        after_update_operations
+        redirect_to redirect_param(fallback: show_or_edit_path), saved_confirmation_notice
+      else
+        apply_tab_errors_to_edition(tab_form)
+        render_edition_update_failure
+      end
+    else
+      # non-tabbed forms in standard edition, or non-tab pages like translations
+      @edition.current_tab_context = nil
+      super
+    end
   end
 
   def features
@@ -65,6 +89,15 @@ class Admin::StandardEditionsController < Admin::EditionsController
     render :features
   end
 
+  def show
+    super
+    type_instance = @edition.type_instance
+    @invalid_tab_forms = type_instance.form_keys.filter_map do |tab_key|
+      tab_form = StandardEdition::TabForm.new(@edition, tab_key)
+      { tab_key:, label: type_instance.form(tab_key)["label"] || tab_key.humanize } unless tab_form.valid?
+    end
+  end
+
 private
 
   def edition_class
@@ -87,6 +120,11 @@ private
     else
       super
     end
+  end
+
+  def apply_tab_errors_to_edition(tab_form)
+    @edition.errors.clear
+    tab_form.errors.each { |e| @edition.errors.add(e.attribute, e.message) }
   end
 
   def render_not_found

--- a/app/controllers/admin/standard_editions_controller.rb
+++ b/app/controllers/admin/standard_editions_controller.rb
@@ -41,7 +41,7 @@ class Admin::StandardEditionsController < Admin::EditionsController
     super
     return if @current_tab_context.blank?
 
-    tab_form = StandardEdition::TabForm.new(@edition, @current_tab_context)
+    tab_form = StandardEdition::TabForm.new(@edition.reload, @current_tab_context)
     apply_tab_errors_to_edition(tab_form) unless tab_form.valid?
   end
 

--- a/app/helpers/admin/tabbed_nav_helper.rb
+++ b/app/helpers/admin/tabbed_nav_helper.rb
@@ -42,8 +42,9 @@ module Admin::TabbedNavHelper
   def config_driven_nav_items(edition, current_path, current_tab)
     base_url = tab_url_for_edition(edition)
     on_dynamic_tab = current_tab.present? || current_path == base_url
+    on_default_tab = current_tab == edition.default_tab || (current_tab.nil? && current_path == base_url)
 
-    [{ label: "Document", href: base_url, current: on_dynamic_tab && current_tab.nil? }].tap do |nav_items|
+    [{ label: "Document", href: base_url, current: on_default_tab }].tap do |nav_items|
       edition.type_instance.dynamic_tabs.each do |tab|
         nav_items << {
           label: tab["label"],

--- a/app/models/concerns/edition/organisations.rb
+++ b/app/models/concerns/edition/organisations.rb
@@ -15,9 +15,9 @@ module Edition::Organisations
 
     has_many :organisations, -> { includes(:translations) }, through: :edition_organisations, validate: false
 
-    validate :at_least_one_lead_organisation, if: -> { organisation_association_enabled? && lead_organisation_association_required? }
-    validate :at_least_one_supporting_organisation, if: -> { organisation_association_enabled? && supporting_organisation_association_required? }
-    validate :no_duplication_of_organisations, if: :organisation_association_enabled?
+    validate :at_least_one_lead_organisation, if: -> { organisation_association_enabled? && lead_organisation_association_required? && current_tab_context_includes_field?("lead_organisation_ids") }
+    validate :at_least_one_supporting_organisation, if: -> { organisation_association_enabled? && supporting_organisation_association_required? && current_tab_context_includes_field?("lead_organisation_ids") }
+    validate :no_duplication_of_organisations, if: -> { organisation_association_enabled? && current_tab_context_includes_field?("lead_organisation_ids") }
 
     add_trait Trait
   end

--- a/app/models/concerns/edition/workflow.rb
+++ b/app/models/concerns/edition/workflow.rb
@@ -100,8 +100,8 @@ module Edition::Workflow
     Edition::PRE_PUBLICATION_STATES.include?(state.to_s)
   end
 
-  def save_as(user)
-    if save
+  def save_as(user, options = {})
+    if save(**options)
       edition_authors.create!(user:)
       recent_edition_openings.where(editor_id: user).delete_all
     end

--- a/app/models/concerns/edition/world_locations.rb
+++ b/app/models/concerns/edition/world_locations.rb
@@ -10,7 +10,7 @@ module Edition::WorldLocations
   end
 
   included do
-    validate :at_least_one_world_location, if: :world_location_association_required?
+    validate :at_least_one_world_location, if: -> { world_location_association_required? && current_tab_context_includes_field?("world_location_ids") }
 
     has_many :edition_world_locations, foreign_key: :edition_id, inverse_of: :edition, dependent: :destroy, autosave: true
     has_many :world_locations, through: :edition_world_locations

--- a/app/models/concerns/edition/worldwide_organisations.rb
+++ b/app/models/concerns/edition/worldwide_organisations.rb
@@ -15,7 +15,7 @@ module Edition::WorldwideOrganisations
 
     add_trait Trait
 
-    validate :at_least_one_worldwide_organisation, if: :worldwide_organisation_association_required?
+    validate :at_least_one_worldwide_organisation, if: -> { worldwide_organisation_association_required? && current_tab_context_includes_field?("worldwide_organisation_document_ids") }
   end
 
   def worldwide_organisations=(worldwide_organisations)

--- a/app/models/concerns/standard_edition/tab_form.rb
+++ b/app/models/concerns/standard_edition/tab_form.rb
@@ -13,6 +13,10 @@ class StandardEdition::TabForm
 
 private
 
+  def default_tab?
+    tab_key == edition.default_tab
+  end
+
   def form_config
     @form_config ||= edition.type_instance.form(tab_key).tap do |config|
       raise ArgumentError, "Unknown tab key '#{tab_key}'" unless config
@@ -62,11 +66,32 @@ private
 
     edition.current_tab_context = tab_key
     edition.valid?(validation_context)
-    edition.current_tab_context = nil
 
+    if default_tab?
+      import_non_block_content_edition_errors
+    else
+      import_scoped_edition_errors
+    end
+    edition.current_tab_context = nil
+  end
+
+  def import_scoped_edition_errors
     edition_attribute_keys.each do |attr|
       edition.errors.where(attr.to_sym).each { |error| errors.import(error, attribute: error.attribute.to_s) }
     end
-    edition.errors.clear # clear unscoped edition errors so only the imported tab-scoped errors reach the controller.
+  end
+
+  def import_non_block_content_edition_errors
+    edition.errors.each do |error|
+      next if block_content_error_attribute?(error.attribute.to_s)
+
+      errors.import(error, attribute: error.attribute.to_s)
+    end
+  end
+
+  def block_content_error_attribute?(attribute)
+    block_content_field_keys.any? do |field_key|
+      attribute == field_key
+    end
   end
 end

--- a/app/models/concerns/standard_edition/tab_form.rb
+++ b/app/models/concerns/standard_edition/tab_form.rb
@@ -1,0 +1,71 @@
+class StandardEdition::TabForm
+  include ActiveModel::Model
+
+  attr_reader :edition, :tab_key
+
+  validate :validate_block_content
+  validate :validate_edition_fields
+
+  def initialize(edition, tab_key)
+    @edition = edition
+    @tab_key = tab_key
+  end
+
+private
+
+  def form_config
+    @form_config ||= edition.type_instance.form(tab_key).tap do |config|
+      raise ArgumentError, "Unknown tab key '#{tab_key}'" unless config
+    end
+  end
+
+  # Fields whose data lives inside block_content (e.g. "body", "social_media_links")
+  def block_content_field_keys
+    (form_config["fields"] || {}).filter_map do |_key, field|
+      attr_path = Array(field["attribute_path"])
+      attr_path.last if attr_path.first == "block_content"
+    end
+  end
+
+  # Fields whose data lives directly on the edition (e.g. "lead_organisation_ids")
+  def edition_attribute_keys
+    keys = (form_config["fields"] || {}).filter_map do |_key, field|
+      attr_path = Array(field["attribute_path"])
+      attr_path.first unless attr_path.first == "block_content"
+    end
+
+    # TODO: Move these fields into document form configuration
+    # so that we don't have to inject them here
+    if tab_key == edition.default_tab
+      keys.concat(%w[title summary])
+    end
+
+    keys
+  end
+
+  def scoped_block_content
+    schema = edition.type_instance.schema_for_fields(block_content_field_keys)
+    StandardEdition::BlockContent.new(schema).tap do |bc|
+      bc.assign_attributes(edition[:block_content] || {})
+    end
+  end
+
+  def validate_block_content
+    block_content = scoped_block_content
+    return if block_content.valid?(validation_context)
+
+    block_content.errors.each { |error| errors.import(error, attribute: error.attribute.to_s) }
+  end
+
+  def validate_edition_fields
+    return unless edition_attribute_keys.any?
+
+    edition.current_tab_context = tab_key
+    edition.valid?(validation_context)
+    edition.current_tab_context = nil
+
+    edition_attribute_keys.each do |attr|
+      edition.errors.where(attr.to_sym).each { |error| errors.import(error, attribute: error.attribute.to_s) }
+    end
+  end
+end

--- a/app/models/concerns/standard_edition/tab_form.rb
+++ b/app/models/concerns/standard_edition/tab_form.rb
@@ -67,5 +67,6 @@ private
     edition_attribute_keys.each do |attr|
       edition.errors.where(attr.to_sym).each { |error| errors.import(error, attribute: error.attribute.to_s) }
     end
+    edition.errors.clear # clear unscoped edition errors so only the imported tab-scoped errors reach the controller.
   end
 end

--- a/app/models/configurable_document_type.rb
+++ b/app/models/configurable_document_type.rb
@@ -104,6 +104,10 @@ class ConfigurableDocumentType
     end
   end
 
+  def form_keys
+    @forms.keys
+  end
+
   def presenter(key)
     @presenters[key]
   end

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -492,4 +492,8 @@ private
 
     first_version_with_state.try(:user)
   end
+
+  def current_tab_context_includes_field?(_attribute_name)
+    true
+  end
 end

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -443,6 +443,10 @@ class Edition < ApplicationRecord
     {}
   end
 
+  def invalid_tab_messages
+    []
+  end
+
 private
 
   def date_for_government

--- a/app/models/standard_edition.rb
+++ b/app/models/standard_edition.rb
@@ -179,6 +179,16 @@ class StandardEdition < Edition
     options[:base]&.type_instance&.title_for_attribute(attribute.to_s) || super
   end
 
+  def invalid_tab_messages
+    type_instance.form_keys.filter_map do |tab_key|
+      tab_form = StandardEdition::TabForm.new(self, tab_key)
+      unless tab_form.valid?(:publish)
+        tab_label = type_instance.form(tab_key)["label"] || tab_key.humanize
+        "#{tab_label} tab is invalid"
+      end
+    end
+  end
+
 private
 
   def field_paths(&block)

--- a/app/models/standard_edition.rb
+++ b/app/models/standard_edition.rb
@@ -199,4 +199,15 @@ private
   def string_for_slug
     title if primary_locale.to_sym == translation.locale
   end
+
+  def current_tab_context_includes_field?(attribute_name)
+    return true if current_tab_context.blank? # assume we are checking against the entire edition
+
+    form = type_instance.form(current_tab_context)
+    return true if form.nil?
+
+    (form["fields"] || {}).any? do |_key, field|
+      Array(field["attribute_path"]).include?(attribute_name)
+    end
+  end
 end

--- a/app/services/edition_publisher.rb
+++ b/app/services/edition_publisher.rb
@@ -10,6 +10,7 @@ class EditionPublisher < EditionService
     reasons << "This edition is invalid: #{edition.errors.full_messages.to_sentence}" unless edition.valid?(:publish)
     reasons << "An edition that is #{edition.current_state} cannot be #{past_participle}" unless can_transition?
     reasons << "Scheduled editions cannot be published. This edition is scheduled for publication on #{edition.scheduled_publication}" if scheduled_for_publication?
+    reasons.concat(edition.invalid_tab_messages)
 
     @failure_reasons = reasons
   end

--- a/app/services/edition_scheduler.rb
+++ b/app/services/edition_scheduler.rb
@@ -24,6 +24,7 @@ class EditionScheduler < EditionService
     elsif scheduled_publication_is_not_within_cache_limit?
       reasons << "Scheduled publication date must be at least #{Whitehall.default_cache_max_age / 60} minutes from now"
     end
+    reasons.concat(edition.invalid_tab_messages)
     @failure_reasons = reasons
   end
 

--- a/app/views/admin/editions/show/_main.html.erb
+++ b/app/views/admin/editions/show/_main.html.erb
@@ -34,8 +34,7 @@
   </section>
 
   <%= render partial: "admin/editions/show/main_notices", locals: { edition: @edition } %>
-
-  <%= render Admin::Editions::Show::PreviewComponent.new(edition: @edition) %>
+  <%= render Admin::Editions::Show::PreviewComponent.new(edition: @edition, invalid_tab_forms: @invalid_tab_forms) %>
 
   <% if @edition.change_note_required? %>
     <section class="app-view-summary__section">

--- a/app/views/admin/editions/show/_sidebar_notices.html.erb
+++ b/app/views/admin/editions/show/_sidebar_notices.html.erb
@@ -7,6 +7,17 @@
 
 <div class="app-view-summary__sidebar-notices">
   <% unless @edition.valid?(:publish) %>
+    <% invalid_items = if @edition.is_a?(StandardEdition) && @invalid_tab_forms&.any?
+      @invalid_tab_forms.map do |tab|
+        link_to(
+          "#{tab[:label]} tab is invalid",
+          edit_admin_standard_edition_path(@edition, current_tab: tab[:tab_key]),
+          class: "govuk-link",
+        )
+      end
+    else
+      @edition.errors.map(&:full_message)
+    end %>
     <%= render "components/inset_prompt", {
       data_attributes: {
         module: "ga4-auto-tracker",
@@ -18,7 +29,7 @@
       title: "This edition is invalid",
       description: render("govuk_publishing_components/components/list", {
         visible_counters: true,
-        items:  @edition.errors.map(&:full_message),
+        items: invalid_items,
       }),
       error: true,
     } %>

--- a/test/components/admin/editions/show/preview_component_test.rb
+++ b/test/components/admin/editions/show/preview_component_test.rb
@@ -108,4 +108,21 @@ class Admin::Editions::Show::PreviewComponentTest < ViewComponent::TestCase
     assert page.has_content? "Preview on website - French (opens in new tab)"
     assert_not page.has_content? "Preview on website - Français (French) (opens in new tab)"
   end
+
+  test "renders a hint text when the edition is a StandardEdition with invalid tab forms" do
+    edition = build_stubbed(:standard_edition, document: @document)
+    invalid_tab_forms = [{ tab_key: "documents", label: "Document" }]
+
+    render_inline(Admin::Editions::Show::PreviewComponent.new(edition:, invalid_tab_forms:))
+
+    assert_selector ".govuk-inset-text", text: "This preview may be out of date because the edition is invalid."
+  end
+
+  test "does not render a hint text when there are no invalid tab forms" do
+    edition = build_stubbed(:standard_edition, document: @document)
+
+    render_inline(Admin::Editions::Show::PreviewComponent.new(edition:, invalid_tab_forms: []))
+
+    assert_selector ".govuk-inset-text", text: "This preview may be out of date because the edition is invalid.", count: 0
+  end
 end

--- a/test/functional/admin/standard_editions_controller_test.rb
+++ b/test/functional/admin/standard_editions_controller_test.rb
@@ -1243,6 +1243,22 @@ class Admin::StandardEditionsControllerTest < ActionController::TestCase
     assert_select ".govuk-error-summary__body", text: "Body cannot be blank"
   end
 
+  test "GET edit runs validation against a fresh copy of an edition from the database, not the in-memory version" do
+    ConfigurableDocumentType.setup_test_types(tabbed_document_type)
+    edition = create(:draft_standard_edition, :with_organisations,
+                     configurable_document_type: "test_type",
+                     block_content: { body: "original" })
+
+    get :edit, params: { id: edition, current_tab: "documents" }
+
+    # Tab validation runs on a fresh DB copy via edition.reload,
+    # so the in-memory placeholder fields built by build_edition_dependencies eg review_reminder
+    # should never be validated if untouched and should send no errors when loading the edit view.
+    reminder = assigns(:edition).document.review_reminder
+    assert reminder.nil? || reminder.errors.empty?,
+           "Expected no review_reminder errors but found: #{reminder&.errors&.full_messages}"
+  end
+
   view_test "POST create surfaces Publishing API validation error if save_draft fails" do
     error_hash = {
       "error" => {

--- a/test/functional/admin/standard_editions_controller_test.rb
+++ b/test/functional/admin/standard_editions_controller_test.rb
@@ -1197,7 +1197,7 @@ class Admin::StandardEditionsControllerTest < ActionController::TestCase
     )
 
     @controller.stubs(:updater).returns(stub(can_perform?: true, perform!: true, failure_reason: nil))
-    StandardEdition.any_instance.stubs(:save_as).with(current_user).returns(true)
+    StandardEdition.any_instance.stubs(:save_as).with(current_user, validate: false).returns(true)
 
     patch :update, params: {
       id: edition.id,
@@ -1239,6 +1239,76 @@ class Admin::StandardEditionsControllerTest < ActionController::TestCase
           "body" => { "type" => "string" },
           "sidebar" => { "type" => "string" },
         },
+        "validations" => {
+          "presence" => { "attributes" => %w[sidebar] },
+        },
+      },
+    })
+    ConfigurableDocumentType.setup_test_types(configurable_document_type)
+
+    edition = create(
+      :draft_standard_edition,
+      :with_organisations,
+      configurable_document_type: "test_type",
+      title: "Title",
+      summary: "Summary",
+      block_content: { "sidebar" => "My sidebar content" },
+    )
+
+    get :edit, params: { id: edition, current_tab: "extra_fields" }
+    assert_select "textarea[name='edition[block_content][sidebar]']", text: "My sidebar content"
+
+    patch :update, params: {
+      id: edition.id,
+      edition: {
+        title: "",
+        summary: edition.summary,
+        configurable_document_type: "test_type",
+        block_content: { sidebar: "" },
+      },
+      current_tab: "extra_fields",
+      save: "save",
+    }
+
+    assert_template :edit
+    assert_select "input[type=hidden][name=current_tab][value=extra_fields]"
+    assert_select "textarea[name='edition[block_content][sidebar]']", text: ""
+  end
+
+  test "PATCH update calls updater.perform! after a successful tab save" do
+    updater = stub(can_perform?: true, failure_reason: nil)
+    updater.expects(:perform!).once
+    @controller.stubs(:updater).returns(updater)
+
+    configurable_document_type = build_configurable_document_type("test_type", {
+      "forms" => {
+        "documents" => {
+          "label" => "Document",
+          "fields" => {
+            "body" => {
+              "title" => "Body",
+              "block" => "govspeak",
+              "attribute_path" => %w[block_content body],
+            },
+          },
+        },
+        "extra_fields" => {
+          "dynamic" => true,
+          "label" => "Extra fields",
+          "fields" => {
+            "sidebar" => {
+              "title" => "Sidebar",
+              "block" => "govspeak",
+              "attribute_path" => %w[block_content sidebar],
+            },
+          },
+        },
+      },
+      "schema" => {
+        "attributes" => {
+          "body" => { "type" => "string" },
+          "sidebar" => { "type" => "string" },
+        },
       },
     })
     ConfigurableDocumentType.setup_test_types(configurable_document_type)
@@ -1250,22 +1320,12 @@ class Admin::StandardEditionsControllerTest < ActionController::TestCase
       title: "Title",
       summary: "Summary",
     )
-
     patch :update, params: {
       id: edition.id,
-      edition: {
-        title: "",
-        summary: edition.summary,
-        configurable_document_type: "test_type",
-        block_content: { sidebar: "My sidebar content" },
-      },
+      edition: { title: edition.title, summary: edition.summary, configurable_document_type: "test_type" },
       current_tab: "extra_fields",
       save: "save",
     }
-
-    assert_template :edit
-    assert_select "input[type=hidden][name=current_tab][value=extra_fields]"
-    assert_select "textarea[name='edition[block_content][sidebar]']", text: "My sidebar content"
   end
 
   view_test "GET edit renders hidden current_tab field for the default tab when document type defines tabs" do
@@ -1309,6 +1369,54 @@ class Admin::StandardEditionsControllerTest < ActionController::TestCase
 
     assert_response :ok
     assert_select "input[type=hidden][name=current_tab][value=documents]"
+  end
+
+  view_test "GET edit shows validation errors on page load for an invalid tab" do
+    configurable_document_type = build_configurable_document_type("test_type", {
+      "forms" => {
+        "documents" => {
+          "label" => "Document",
+          "fields" => {
+            "body" => {
+              "title" => "Body",
+              "block" => "govspeak",
+              "attribute_path" => %w[block_content body],
+            },
+          },
+        },
+        "extra_fields" => {
+          "dynamic" => true,
+          "label" => "Extra fields",
+          "fields" => {
+            "sidebar" => {
+              "title" => "Sidebar",
+              "block" => "govspeak",
+              "attribute_path" => %w[block_content sidebar],
+            },
+          },
+        },
+      },
+      "schema" => {
+        "attributes" => {
+          "body" => { "type" => "string" },
+          "sidebar" => { "type" => "string" },
+        },
+        "validations" => {
+          "presence" => { "attributes" => %w[body] },
+        },
+      },
+    })
+    ConfigurableDocumentType.setup_test_types(configurable_document_type)
+
+    edition = create(:draft_standard_edition, :with_organisations,
+                     configurable_document_type: "test_type",
+                     block_content: { body: "Valid body" })
+    edition.translation.update_column(:block_content, { "body" => "" })
+
+    get :edit, params: { id: edition, current_tab: "documents" }
+
+    assert_response :ok
+    assert_select ".govuk-error-summary__body", text: "Body cannot be blank"
   end
 
   view_test "POST create surfaces Publishing API validation error if save_draft fails" do

--- a/test/functional/admin/standard_editions_controller_test.rb
+++ b/test/functional/admin/standard_editions_controller_test.rb
@@ -1155,47 +1155,9 @@ class Admin::StandardEditionsControllerTest < ActionController::TestCase
   end
 
   view_test "PATCH update redirects back to the same tab when saving from a non-default tab" do
-    configurable_document_type = build_configurable_document_type("test_type", {
-      "forms" => {
-        "documents" => {
-          "label" => "Document",
-          "fields" => {
-            "body" => {
-              "title" => "Body",
-              "block" => "govspeak",
-              "attribute_path" => %w[block_content body],
-            },
-          },
-        },
-        "extra_fields" => {
-          "dynamic" => true,
-          "label" => "Extra fields",
-          "fields" => {
-            "sidebar" => {
-              "title" => "Sidebar",
-              "block" => "govspeak",
-              "attribute_path" => %w[block_content sidebar],
-            },
-          },
-        },
-      },
-      "schema" => {
-        "attributes" => {
-          "body" => { "type" => "string" },
-          "sidebar" => { "type" => "string" },
-        },
-      },
-    })
-    ConfigurableDocumentType.setup_test_types(configurable_document_type)
-
-    edition = create(
-      :draft_standard_edition,
-      :with_organisations,
-      configurable_document_type: "test_type",
-      title: "Title",
-      summary: "Summary",
-    )
-
+    ConfigurableDocumentType.setup_test_types(tabbed_document_type)
+    edition = create(:draft_standard_edition, :with_organisations, configurable_document_type: "test_type",
+                                                                   title: "Title", summary: "Summary")
     @controller.stubs(:updater).returns(stub(can_perform?: true, perform!: true, failure_reason: nil))
     StandardEdition.any_instance.stubs(:save_as).with(current_user, validate: false).returns(true)
 
@@ -1210,50 +1172,13 @@ class Admin::StandardEditionsControllerTest < ActionController::TestCase
   end
 
   view_test "PATCH update preserves the current tab when re-rendering after validation failure" do
-    configurable_document_type = build_configurable_document_type("test_type", {
-      "forms" => {
-        "documents" => {
-          "label" => "Document",
-          "fields" => {
-            "body" => {
-              "title" => "Body",
-              "block" => "govspeak",
-              "attribute_path" => %w[block_content body],
-            },
-          },
-        },
-        "extra_fields" => {
-          "dynamic" => true,
-          "label" => "Extra fields",
-          "fields" => {
-            "sidebar" => {
-              "title" => "Sidebar",
-              "block" => "govspeak",
-              "attribute_path" => %w[block_content sidebar],
-            },
-          },
-        },
+    ConfigurableDocumentType.setup_test_types(tabbed_document_type(validations: {
+      "presence" => {
+        "attributes" => %w[sidebar],
       },
-      "schema" => {
-        "attributes" => {
-          "body" => { "type" => "string" },
-          "sidebar" => { "type" => "string" },
-        },
-        "validations" => {
-          "presence" => { "attributes" => %w[sidebar] },
-        },
-      },
-    })
-    ConfigurableDocumentType.setup_test_types(configurable_document_type)
-
-    edition = create(
-      :draft_standard_edition,
-      :with_organisations,
-      configurable_document_type: "test_type",
-      title: "Title",
-      summary: "Summary",
-      block_content: { "sidebar" => "My sidebar content" },
-    )
+    }))
+    edition = create(:draft_standard_edition, :with_organisations, configurable_document_type: "test_type",
+                                                                   title: "Title", summary: "Summary", block_content: { "sidebar" => "My sidebar content" })
 
     get :edit, params: { id: edition, current_tab: "extra_fields" }
     assert_select "textarea[name='edition[block_content][sidebar]']", text: "My sidebar content"
@@ -1280,46 +1205,10 @@ class Admin::StandardEditionsControllerTest < ActionController::TestCase
     updater.expects(:perform!).once
     @controller.stubs(:updater).returns(updater)
 
-    configurable_document_type = build_configurable_document_type("test_type", {
-      "forms" => {
-        "documents" => {
-          "label" => "Document",
-          "fields" => {
-            "body" => {
-              "title" => "Body",
-              "block" => "govspeak",
-              "attribute_path" => %w[block_content body],
-            },
-          },
-        },
-        "extra_fields" => {
-          "dynamic" => true,
-          "label" => "Extra fields",
-          "fields" => {
-            "sidebar" => {
-              "title" => "Sidebar",
-              "block" => "govspeak",
-              "attribute_path" => %w[block_content sidebar],
-            },
-          },
-        },
-      },
-      "schema" => {
-        "attributes" => {
-          "body" => { "type" => "string" },
-          "sidebar" => { "type" => "string" },
-        },
-      },
-    })
-    ConfigurableDocumentType.setup_test_types(configurable_document_type)
+    ConfigurableDocumentType.setup_test_types(tabbed_document_type)
+    edition = create(:draft_standard_edition, :with_organisations, configurable_document_type: "test_type",
+                                                                   title: "Title", summary: "Summary")
 
-    edition = create(
-      :draft_standard_edition,
-      :with_organisations,
-      configurable_document_type: "test_type",
-      title: "Title",
-      summary: "Summary",
-    )
     patch :update, params: {
       id: edition.id,
       edition: { title: edition.title, summary: edition.summary, configurable_document_type: "test_type" },
@@ -1329,42 +1218,9 @@ class Admin::StandardEditionsControllerTest < ActionController::TestCase
   end
 
   view_test "GET edit renders hidden current_tab field for the default tab when document type defines tabs" do
-    configurable_document_type = build_configurable_document_type("test_type", {
-      "forms" => {
-        "documents" => {
-          "label" => "Document",
-          "fields" => {
-            "body" => {
-              "title" => "Body",
-              "block" => "govspeak",
-              "attribute_path" => %w[block_content body],
-            },
-          },
-        },
-        "extra_fields" => {
-          "dynamic" => true,
-          "label" => "Extra fields",
-          "fields" => {
-            "sidebar" => {
-              "title" => "Sidebar",
-              "block" => "govspeak",
-              "attribute_path" => %w[block_content sidebar],
-            },
-          },
-        },
-      },
-      "schema" => {
-        "attributes" => {
-          "body" => { "type" => "string" },
-          "sidebar" => { "type" => "string" },
-        },
-      },
-    })
-    ConfigurableDocumentType.setup_test_types(configurable_document_type)
-
+    ConfigurableDocumentType.setup_test_types(tabbed_document_type)
     edition = create(:draft_standard_edition, :with_organisations, configurable_document_type: "test_type")
 
-    # Visit the edit page without a current_tab param (i.e. the default tab)
     get :edit, params: { id: edition }
 
     assert_response :ok
@@ -1372,45 +1228,13 @@ class Admin::StandardEditionsControllerTest < ActionController::TestCase
   end
 
   view_test "GET edit shows validation errors on page load for an invalid tab" do
-    configurable_document_type = build_configurable_document_type("test_type", {
-      "forms" => {
-        "documents" => {
-          "label" => "Document",
-          "fields" => {
-            "body" => {
-              "title" => "Body",
-              "block" => "govspeak",
-              "attribute_path" => %w[block_content body],
-            },
-          },
-        },
-        "extra_fields" => {
-          "dynamic" => true,
-          "label" => "Extra fields",
-          "fields" => {
-            "sidebar" => {
-              "title" => "Sidebar",
-              "block" => "govspeak",
-              "attribute_path" => %w[block_content sidebar],
-            },
-          },
-        },
+    ConfigurableDocumentType.setup_test_types(tabbed_document_type(validations: {
+      "presence" => {
+        "attributes" => %w[body],
       },
-      "schema" => {
-        "attributes" => {
-          "body" => { "type" => "string" },
-          "sidebar" => { "type" => "string" },
-        },
-        "validations" => {
-          "presence" => { "attributes" => %w[body] },
-        },
-      },
-    })
-    ConfigurableDocumentType.setup_test_types(configurable_document_type)
-
-    edition = create(:draft_standard_edition, :with_organisations,
-                     configurable_document_type: "test_type",
-                     block_content: { body: "Valid body" })
+    }))
+    edition = create(:draft_standard_edition, :with_organisations, configurable_document_type: "test_type",
+                                                                   block_content: { body: "Valid body" })
     edition.translation.update_column(:block_content, { "body" => "" })
 
     get :edit, params: { id: edition, current_tab: "documents" }
@@ -1661,5 +1485,43 @@ class Admin::StandardEditionsControllerTest < ActionController::TestCase
     get :show, params: { id: edition }
 
     assert_select "a", text: "Extra tab tab is invalid"
+  end
+
+  def tabbed_document_type(validations: {})
+    config = {
+      "forms" => {
+        "documents" => {
+          "label" => "Document",
+          "fields" => {
+            "body" => {
+              "title" => "Body",
+              "block" => "govspeak",
+              "attribute_path" => %w[block_content body],
+            },
+          },
+        },
+        "extra_fields" => {
+          "dynamic" => true,
+          "label" => "Extra fields",
+          "fields" => {
+            "sidebar" => {
+              "title" => "Sidebar",
+              "block" => "govspeak",
+              "attribute_path" => %w[block_content sidebar],
+            },
+          },
+        },
+      },
+      "schema" => {
+        "attributes" => {
+          "body" => { "type" => "string" },
+          "sidebar" => { "type" => "string" },
+        },
+      },
+    }
+
+    config["schema"]["validations"] = validations if validations.any?
+
+    build_configurable_document_type("test_type", config)
   end
 end

--- a/test/functional/admin/standard_editions_controller_test.rb
+++ b/test/functional/admin/standard_editions_controller_test.rb
@@ -1519,4 +1519,147 @@ class Admin::StandardEditionsControllerTest < ActionController::TestCase
     assert_select "a[href=\"#edition_test_attribute\"]", text: "Test attribute cannot be blank"
     assert_select ".govuk-error-message", text: "Error: Test attribute cannot be blank"
   end
+
+  test "GET show sets @invalid_tab_forms with the keys and labels of tabs that fail validation" do
+    configurable_document_type = build_configurable_document_type("test_type", {
+      "forms" => {
+        "documents" => {
+          "fields" => {
+            "body" => {
+              "title" => "Body",
+              "block" => "govspeak",
+              "attribute_path" => %w[block_content body],
+            },
+          },
+        },
+        "extra_tab" => {
+          "dynamic" => true,
+          "label" => "Extra tab",
+          "fields" => {
+            "sidebar" => {
+              "title" => "Sidebar",
+              "block" => "govspeak",
+              "attribute_path" => %w[block_content sidebar],
+            },
+          },
+        },
+      },
+      "schema" => {
+        "attributes" => {
+          "body" => { "type" => "string" },
+          "sidebar" => { "type" => "string" },
+        },
+        "validations" => {
+          "presence" => { "attributes" => %w[body sidebar] },
+        },
+      },
+    })
+    ConfigurableDocumentType.setup_test_types(configurable_document_type)
+
+    edition = create(:draft_standard_edition, :with_organisations,
+                     configurable_document_type: "test_type",
+                     title: "Title", summary: "Summary",
+                     block_content: { body: "Content", sidebar: "Content" })
+    edition.translations.update_all(block_content: { body: "", sidebar: "" }) # needed to put the data in bad state
+
+    get :show, params: { id: edition }
+
+    invalid_tab_keys = assigns(:invalid_tab_forms).map { |tab| tab[:tab_key] }
+    assert_includes invalid_tab_keys, "documents"
+    assert_includes invalid_tab_keys, "extra_tab"
+  end
+
+  test "GET show sets @invalid_tab_forms as empty when all form tabs are valid" do
+    configurable_document_type = build_configurable_document_type("test_type", {
+      "forms" => {
+        "documents" => {
+          "fields" => {
+            "body" => {
+              "title" => "Body",
+              "block" => "govspeak",
+              "attribute_path" => %w[block_content body],
+            },
+          },
+        },
+        "extra_tab" => {
+          "dynamic" => true,
+          "label" => "Extra tab",
+          "fields" => {
+            "sidebar" => {
+              "title" => "Sidebar",
+              "block" => "govspeak",
+              "attribute_path" => %w[block_content sidebar],
+            },
+          },
+        },
+      },
+      "schema" => {
+        "attributes" => {
+          "body" => { "type" => "string" },
+          "sidebar" => { "type" => "string" },
+        },
+        "validations" => {
+          "presence" => { "attributes" => %w[body sidebar] },
+        },
+      },
+    })
+    ConfigurableDocumentType.setup_test_types(configurable_document_type)
+
+    edition = create(:draft_standard_edition, :with_organisations,
+                     configurable_document_type: "test_type",
+                     title: "Title", summary: "Summary",
+                     block_content: { body: "Some content", sidebar: "Some sidebar" })
+    edition.save!
+
+    get :show, params: { id: edition }
+
+    assert_empty assigns(:invalid_tab_forms)
+  end
+
+  view_test "GET show renders errors in the summary sidebar when there are invalid tab forms" do
+    configurable_document_type = build_configurable_document_type("test_type", {
+      "forms" => {
+        "documents" => {
+          "fields" => {
+            "body" => {
+              "title" => "Body",
+              "block" => "govspeak",
+              "attribute_path" => %w[block_content body],
+            },
+          },
+        },
+        "extra_tab" => {
+          "dynamic" => true,
+          "label" => "Extra tab",
+          "fields" => {
+            "sidebar" => {
+              "title" => "Sidebar",
+              "block" => "govspeak",
+              "attribute_path" => %w[block_content sidebar],
+            },
+          },
+        },
+      },
+      "schema" => {
+        "attributes" => {
+          "body" => { "type" => "string" },
+          "sidebar" => { "type" => "string" },
+        },
+        "validations" => {
+          "presence" => { "attributes" => %w[body sidebar] },
+        },
+      },
+    })
+    ConfigurableDocumentType.setup_test_types(configurable_document_type)
+
+    edition = create(:draft_standard_edition, :with_organisations,
+                     configurable_document_type: "test_type",
+                     title: "Title", summary: "Summary",
+                     block_content: { body: "Some content", sidebar: "Some sidebar" })
+    edition.translations.update_all(block_content: { body: "", sidebar: "" }) # needed to put the data in bad state
+
+    get :show, params: { id: edition }
+
+    assert_select "a", text: "Extra tab tab is invalid"
+  end
 end

--- a/test/unit/app/models/concerns/standard_edition/tab_form_test.rb
+++ b/test/unit/app/models/concerns/standard_edition/tab_form_test.rb
@@ -116,4 +116,15 @@ class StandardEdition::TabFormTest < ActiveSupport::TestCase
     assert tab_form.valid?
     assert tab_form.errors.where(:body).none?
   end
+
+  test "it does not duplicate block_content errors on the default tab" do
+    edition = build(:standard_edition, :with_organisations,
+                    configurable_document_type: "test_type",
+                    title: "Title", summary: "Summary",
+                    block_content: { body: "" })
+    tab_form = StandardEdition::TabForm.new(edition, edition.default_tab)
+
+    assert tab_form.invalid?
+    assert_equal(1, tab_form.errors.full_messages.count { |message| message == "Body cannot be blank" })
+  end
 end

--- a/test/unit/app/models/concerns/standard_edition/tab_form_test.rb
+++ b/test/unit/app/models/concerns/standard_edition/tab_form_test.rb
@@ -1,0 +1,119 @@
+require "test_helper"
+
+class StandardEdition::TabFormTest < ActiveSupport::TestCase
+  setup do
+    @test_type = build_configurable_document_type(
+      "test_type", {
+        "forms" => {
+          "documents" => {
+            "fields" => {
+              "body" => {
+                "title" => "Body",
+                "block" => "govspeak",
+                "attribute_path" => %w[block_content body],
+              },
+              "lead_organisations" => {
+                "title": "Lead organisations",
+                "required" => true,
+                "block" => "ordered_select_with_search_tagging",
+                "attribute_path" => %w[lead_organisation_ids],
+              },
+            },
+          },
+          "extra_tab" => {
+            "label" => "Extra tab",
+            "dynamic" => true,
+            "fields" => {
+              "sidebar" => {
+                "title" => "Sidebar",
+                "block" => "govspeak",
+                "attribute_path" => %w[block_content sidebar],
+              },
+            },
+          },
+        },
+        "schema" => {
+          "attributes" => {
+            "body" => { "type" => "string" },
+            "sidebar" => { "type" => "string" },
+          },
+          "validations" => {
+            "presence" => { "attributes" => %w[body sidebar] },
+          },
+        },
+      }
+    )
+    ConfigurableDocumentType.setup_test_types(@test_type)
+  end
+
+  test "it is valid when all fields on a particular tab are present" do
+    edition = build(:standard_edition, :with_organisations,
+                    configurable_document_type: "test_type",
+                    title: "Title", summary: "Summary",
+                    block_content: { body: "Some body" })
+    tab_form = StandardEdition::TabForm.new(edition, "documents")
+
+    assert tab_form.valid?
+  end
+
+  test "it is invalid and adds an error when a required block_content field is blank" do
+    edition = build(:standard_edition, :with_organisations,
+                    configurable_document_type: "test_type",
+                    title: "Title", summary: "Summary",
+                    block_content: { body: "" })
+    documents_tab_form = StandardEdition::TabForm.new(edition, "documents")
+    extra_tab_form = StandardEdition::TabForm.new(edition, "extra_tab")
+
+    assert documents_tab_form.invalid?
+    assert_includes documents_tab_form.errors.full_messages, "Body cannot be blank"
+    assert extra_tab_form.invalid?
+    assert_includes extra_tab_form.errors.full_messages, "Sidebar cannot be blank"
+  end
+
+  test "it is invalid and adds an error when a required edition attribute field is blank" do
+    edition = build(:standard_edition,
+                    configurable_document_type: "test_type",
+                    title: "Title", summary: "Summary",
+                    block_content: { body: "Some body" })
+    edition.lead_organisations = []
+
+    tab_form = StandardEdition::TabForm.new(edition, "documents")
+    assert tab_form.invalid?
+    assert tab_form.errors.where(:lead_organisation_ids).any?
+  end
+
+  test "it validates title and summary on the default tab" do
+    edition = build(:standard_edition,
+                    configurable_document_type: "test_type",
+                    title: "", summary: "",
+                    block_content: { body: "Some body" })
+    tab_form = StandardEdition::TabForm.new(edition, edition.default_tab)
+
+    assert tab_form.invalid?
+    assert tab_form.errors.where(:title).any?
+    assert tab_form.errors.where(:summary).any?
+  end
+
+  test "it does not validate title and summary on non-default tabs" do
+    edition = build(:standard_edition, :with_organisations,
+                    configurable_document_type: "test_type",
+                    title: "", summary: "",
+                    block_content: { body: "Some body", sidebar: "Sidebar content" })
+
+    tab_form = StandardEdition::TabForm.new(edition, "extra_tab")
+
+    assert tab_form.valid?
+  end
+
+  test "it does not hold errors from fields on other tabs" do
+    edition = build(:standard_edition, :with_organisations,
+                    configurable_document_type: "test_type",
+                    title: "Title", summary: "Summary",
+                    block_content: { body: "", sidebar: "Sidebar content" })
+
+    tab_form = StandardEdition::TabForm.new(edition, "extra_tab")
+
+    assert tab_form.valid?
+    assert tab_form.errors.where(:body).none?
+  end
+end

--- a/test/unit/app/models/configurable_document_type_test.rb
+++ b/test/unit/app/models/configurable_document_type_test.rb
@@ -329,6 +329,32 @@ class ConfigurableDocumentTypeTest < ActiveSupport::TestCase
     assert_equal %w[field_a], result["validations"]["presence"]["attributes"]
   end
 
+  test "#form_keys returns the keys of all forms defined for the document type" do
+    configurable_document_type = build_configurable_document_type(
+      "test_type",
+      {
+        "forms" => {
+          "documents" => {
+            "fields" => {
+              "body" => { "title" => "Body", "block" => "govspeak" },
+            },
+          },
+          "social_media_accounts" => {
+            "label" => "Social media accounts",
+            "dynamic" => true,
+            "fields" => {
+              "social_media_links" => { "title" => "Social media links", "block" => "default_string" },
+            },
+          },
+        },
+      },
+    )
+    ConfigurableDocumentType.setup_test_types(configurable_document_type)
+    document_type = ConfigurableDocumentType.find("test_type")
+
+    assert_equal %w[documents social_media_accounts], document_type.form_keys
+  end
+
   test "#schema" do
     configurable_document_type = build_configurable_document_type(
       "test_type",

--- a/test/unit/app/models/edition/workflow_test.rb
+++ b/test/unit/app/models/edition/workflow_test.rb
@@ -102,6 +102,12 @@ class Edition::WorkflowTest < ActiveSupport::TestCase
     edition.save_as(create(:user))
   end
 
+  test "#save_as passes options to save" do
+    edition = create(:publication)
+    edition.expects(:save).with(validate: false)
+    edition.save_as(create(:user), validate: false)
+  end
+
   test "#save_as records the new creator if save succeeds" do
     edition = create(:publication)
     edition.stubs(:save).returns(true)

--- a/test/unit/app/models/edition_test.rb
+++ b/test/unit/app/models/edition_test.rb
@@ -1007,6 +1007,11 @@ class EditionTest < ActiveSupport::TestCase
     assert_not edition.valid?
   end
 
+  test "#invalid_tab_reasons returns an empty array" do
+    publication = create(:publication)
+    assert_equal [], publication.invalid_tab_messages
+  end
+
   def decoded_token_payload(token)
     payload, _header = JWT.decode(
       token,

--- a/test/unit/app/models/standard_edition_test.rb
+++ b/test/unit/app/models/standard_edition_test.rb
@@ -971,6 +971,63 @@ class StandardEditionTest < ActiveSupport::TestCase
     end
   end
 
+  describe "current_tab_context_includes_field?" do
+    setup do
+      type = build_configurable_document_type(
+        "test_type_with_org_field", {
+          "forms" => {
+            "documents" => {
+              "fields" => {
+                "lead_organisations" => {
+                  "title" => "Lead organisations",
+                  "attribute_path" => %w[lead_organisation_ids],
+                },
+              },
+            },
+            "extra_tab" => {
+              "dynamic" => true,
+              "label" => "Extra tab",
+              "fields" => {
+                "sidebar" => {
+                  "title" => "Sidebar",
+                  "block" => "govspeak",
+                  "attribute_path" => %w[block_content sidebar],
+                },
+              },
+            },
+          },
+          "schema" => { "attributes" => { "sidebar" => { "type" => "string" } } },
+        }
+      )
+      ConfigurableDocumentType.setup_test_types(type)
+      @edition = build(:standard_edition, configurable_document_type: "test_type_with_org_field")
+    end
+
+    it "returns true when current_tab_context is nil" do
+      @edition.current_tab_context = nil
+
+      assert @edition.send(:current_tab_context_includes_field?, "lead_organisation_ids")
+    end
+
+    it "returns true when the attribute is a field on the current tab" do
+      @edition.current_tab_context = "documents"
+
+      assert @edition.send(:current_tab_context_includes_field?, "lead_organisation_ids")
+    end
+
+    it "returns false when the attribute is not a field on the current tab" do
+      @edition.current_tab_context = "extra_tab"
+
+      assert_not @edition.send(:current_tab_context_includes_field?, "lead_organisation_ids")
+    end
+
+    it "returns true when no form exists for the current tab contexts" do
+      @edition.current_tab_context = "nonexistent_tab"
+
+      assert @edition.send(:current_tab_context_includes_field?, "lead_organisation_ids")
+    end
+  end
+
   test "permitted_image_usages passes caption_enabled through from config" do
     ConfigurableDocumentType.setup_test_types(build_configurable_document_type("test_type", {
       "settings" => {

--- a/test/unit/app/models/standard_edition_test.rb
+++ b/test/unit/app/models/standard_edition_test.rb
@@ -1091,4 +1091,58 @@ class StandardEditionTest < ActiveSupport::TestCase
   test ".human_attribute_name falls back to the Rails default when no base edition is provided" do
     assert_equal "Title", StandardEdition.human_attribute_name("title")
   end
+
+  describe "#invalid_tab_messages" do
+    setup do
+      type = build_configurable_document_type(
+        "test_type", {
+          "forms" => {
+            "documents" => {
+              "fields" => {
+                "body" => {
+                  "title" => "Body",
+                  "block" => "govspeak",
+                  "attribute_path" => %w[block_content body],
+                },
+              },
+            },
+            "extra_tab" => {
+              "dynamic" => true,
+              "label" => "Extra",
+              "fields" => {
+                "sidebar" => {
+                  "title" => "Sidebar",
+                  "block" => "govspeak",
+                  "attribute_path" => %w[block_content sidebar],
+                },
+              },
+            },
+          },
+          "schema" => {
+            "attributes" => {
+              "body" => { "type" => "string" },
+              "sidebar" => { "type" => "string" },
+            },
+            "validations" => {
+              "presence" => { "attributes" => %w[body sidebar] },
+            },
+          },
+        }
+      )
+      ConfigurableDocumentType.setup_test_types(type)
+      @edition = create(:draft_standard_edition, :with_organisations,
+                        configurable_document_type: "test_type",
+                        block_content: { body: "Some content", sidebar: "Some sidebar content" })
+    end
+    test "it returns an empty array when all tabs are valid" do
+      assert_equal [], @edition.invalid_tab_messages
+    end
+
+    test "it returns a reason for each invalid tab" do
+      @edition.translation.update_column(:block_content, { "body" => "", "sidebar" => nil })
+
+      assert_includes @edition.invalid_tab_messages, "Documents tab is invalid"
+      assert_includes @edition.invalid_tab_messages, "Extra tab is invalid"
+    end
+  end
 end

--- a/test/unit/app/services/edition_publisher_test.rb
+++ b/test/unit/app/services/edition_publisher_test.rb
@@ -51,6 +51,56 @@ class EditionPublisherTest < ActiveSupport::TestCase
     assert_equal "This edition is invalid: Title cannot be blank", publisher.failure_reason
   end
 
+  test "#perform! with an invalid form tab on a standard edition refuses to publish" do
+    configurable_document_type = build_configurable_document_type("test_type", {
+      "forms" => {
+        "documents" => {
+          "fields" => {
+            "body" => {
+              "title" => "Body",
+              "block" => "govspeak",
+              "attribute_path" => %w[block_content body],
+            },
+          },
+        },
+        "extra_tab" => {
+          "dynamic" => true,
+          "label" => "Extra",
+          "fields" => {
+            "sidebar" => {
+              "title" => "Sidebar",
+              "block" => "govspeak",
+              "attribute_path" => %w[block_content sidebar],
+            },
+          },
+        },
+      },
+      "schema" => {
+        "attributes" => {
+          "body" => { "type" => "string" },
+          "sidebar" => { "type" => "string" },
+        },
+        "validations" => {
+          "presence" => { "attributes" => %w[body sidebar] },
+        },
+      },
+    })
+    ConfigurableDocumentType.setup_test_types(configurable_document_type)
+
+    edition = create(:submitted_standard_edition, :with_organisations,
+                     configurable_document_type: "test_type",
+                     title: "Title", summary: "Summary",
+                     block_content: { body: "Content", sidebar: "Sidebar content" })
+    edition.translations.update_all(block_content: { body: "New content", sidebar: "" })
+    edition.reload
+
+    publisher = EditionPublisher.new(edition)
+
+    assert_not publisher.perform!
+    assert_not edition.published?
+    assert_includes publisher.failure_reasons, "Extra tab is invalid"
+  end
+
   test "#perform! with a re-editioned document updates the version numbers" do
     published_edition = create(:published_edition, major_change_published_at: 1.week.ago)
     edition = published_edition.create_draft(create(:writer))

--- a/test/unit/app/services/edition_scheduler_test.rb
+++ b/test/unit/app/services/edition_scheduler_test.rb
@@ -61,4 +61,54 @@ class EditionSchedulerTest < ActiveSupport::TestCase
       assert_match %r{Scheduled publication date must be at least 15 minutes from now}, scheduler.failure_reason
     end
   end
+
+  test "#perform! with an invalid form tab on a standard edition cannot be scheduled" do
+    configurable_document_type = build_configurable_document_type("test_type", {
+      "forms" => {
+        "documents" => {
+          "fields" => {
+            "body" => {
+              "title" => "Body",
+              "block" => "govspeak",
+              "attribute_path" => %w[block_content body],
+            },
+          },
+        },
+        "extra_tab" => {
+          "dynamic" => true,
+          "label" => "Extra",
+          "fields" => {
+            "sidebar" => {
+              "title" => "Sidebar",
+              "block" => "govspeak",
+              "attribute_path" => %w[block_content sidebar],
+            },
+          },
+        },
+      },
+      "schema" => {
+        "attributes" => {
+          "body" => { "type" => "string" },
+          "sidebar" => { "type" => "string" },
+        },
+        "validations" => {
+          "presence" => { "attributes" => %w[body sidebar] },
+        },
+      },
+    })
+    ConfigurableDocumentType.setup_test_types(configurable_document_type)
+
+    edition = create(:submitted_standard_edition, :with_organisations,
+                     configurable_document_type: "test_type",
+                     title: "Title", summary: "Summary",
+                     block_content: { body: "Content", sidebar: "Sidebar content" })
+    edition.translations.update_all(block_content: { body: "New content", sidebar: "" })
+    edition.reload
+
+    scheduler = EditionScheduler.new(edition)
+
+    assert_not scheduler.perform!
+    assert_not edition.scheduled?
+    assert_includes scheduler.failure_reasons, "Extra tab is invalid"
+  end
 end


### PR DESCRIPTION
## What
Move the edition validation off of the edition model on to the configurable form object, and validate each form independently. Make sure that all forms are validated before the edition can be published.

In the scope of this implementation:

- Errors for the form are rendered to the user at the top of the page and next to the invalid form field, with a link from the top of the page to the invalid form
- Any edition tab’s form can be saved regardless of the validity of the other tabs
- All edition forms are validated before the “Publish” button is displayed to the user, and any errors are displayed to the user on the summary page. 
- Only a globally valid edition is updated in Publishing API
- Users can see a hint text letting them know draft previews may be out of date if an edition has invalid tabs


## Why

- Accelerates future development of configurable document types with a more appropriate abstraction
- Decouples form validation and attributes from the Edition model


## Visual Changes

### Edition summary page with invalid tab errors

<img width="1241" height="817" alt="Screenshot 2026-06-09 at 16 51 39" src="https://github.com/user-attachments/assets/dcf2fd34-d6fd-466e-8cbd-bf4b550b27d8" />

### Clicking through the error link
<img width="1320" height="1052" alt="image" src="https://github.com/user-attachments/assets/276506a4-9b39-412a-917d-8c56321e5f34" />




## Testing
Experiencing the full benefit of this work is tricky, because you will almost never have a saved multi-tab edition in bad state unless you manually manipulate the data. 
Currently, the only way to access dynamic tabs is by saving the document tab first, which means the draft is fully valid before any subsequent updates can be made. Therefore, it's not inherently clear that we are scoping validations per tab. 

For anyone that wants to give it a go locally, an easy way is to configure a document type (like topical event) with ` "send_change_history": true`, then: 
- Redraft a published topical event - this should surface the change history form on the document tab. 
- Without filling the change history form, try to save another tab (i.e Social media links) with invalid data. You should only see errors related to social media tab and nothing about the invalid change history should be displayed. Also you will be able to see a summary of the invalid tabs on the edition summary page.
- Alternatively, you can grab a draft edition and manipulate the data by doing the following:

```
# Grab the edition
edition = Edition.find(INSERT_EDITION_ID)

# Manipulate the block content by setting the body to nil and storing an invalid social media link
new_content = edition.translation[:block_content].merge("body" => nil, "social_media_links" => [{ "url" => nil, "social_media_service_name" => "Facebook" }])

# Persist the data
edition.translation.update_column(:block_content, new_content)
``` 


## Future Improvements:
- Before or after [migrating other tabs to be config-driven tab forms](https://gov-uk.atlassian.net/browse/WHIT-3241), we should be able to remove `validate_block_content` and `scoped_block_content` from [has_block_content.rb](https://github.com/alphagov/whitehall/blob/cf2bb1655575689f339dca40707e5c5633fae229/app/models/concerns/standard_edition/has_block_content.rb#L29-L49). 
TabForm will then be the single point for handling all `block_content` validation. For now, it's fine to keep the validation in both places because `edition.valid?` is called in several places that don't go through TabForm. Created [WHIT-3591](https://gov-uk.atlassian.net/browse/WHIT-3591). 
- Add `title` and `summary` to the documents schema of all config driven document types Created [WHIT-3590](https://gov-uk.atlassian.net/browse/WHIT-3590) 
- In the spirit of maintaining consistency, enforce adding a `label` to each form in document type configurations. Added to [WHIT-3241](https://gov-uk.atlassian.net/browse/WHIT-3241). 
- Maintain a single way of accessing the Documents tab. Currently, it is accessible via `/standard-editions/:id/edit` and `/standard-editions/:id/edit?current_tab=documents`. The latter is necessary for validating only the documents tab while the former will assume full edition validation. Added to [WHIT-3241](https://gov-uk.atlassian.net/browse/WHIT-3241) .


[JIRA](https://gov-uk.atlassian.net/browse/WHIT-3214)

---
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.


[WHIT-3591]: https://gov-uk.atlassian.net/browse/WHIT-3591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ