### PR TITLE
Fix definitive article [WHIT-3396]

### DIFF
--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -1,7 +1,7 @@
 module OrganisationHelper
   include ApplicationHelper
 
-  def organisation_display_name(organisation)
+  def organisation_relationship_display_name(organisation)
     if organisation.acronym.present?
       tag.abbr(organisation.acronym, title: organisation.name)
     else
@@ -22,7 +22,7 @@ module OrganisationHelper
   end
 
   def organisation_display_name_and_parental_relationship(organisation)
-    name = ERB::Util.h(organisation_display_name(organisation)).strip
+    name = ERB::Util.h(organisation_relationship_display_name(organisation)).strip
     type_name = organisation_type_name(organisation)
     relationship = ERB::Util.h(add_indefinite_article(type_name))
     parents = organisation.parent_organisations.map { |parent| organisation_relationship_html(parent) }

--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -1,9 +1,20 @@
 module OrganisationHelper
   include ApplicationHelper
 
+  PATTERNS_EXEMPT_FROM_DEFINITIVE_ARTICLE = [
+    /civil service resourcing/,
+    /^hm/,
+    /ordnance survey/,
+    /homes england/,
+    /british wool/,
+    /building law and hygiene/,
+  ].freeze
+
   def organisation_relationship_display_name(organisation)
     if organisation.acronym.present?
       tag.abbr(organisation.acronym, title: organisation.name)
+    elsif needs_definite_article?(organisation.name)
+      "The #{organisation.name}"
     else
       organisation.name
     end
@@ -79,8 +90,7 @@ module OrganisationHelper
   end
 
   def needs_definite_article?(phrase)
-    exceptions = [/civil service resourcing/, /^hm/, /ordnance survey/, /homes england/]
-    !has_definite_article?(phrase) && exceptions.none? { |e| e =~ phrase.downcase }
+    !has_definite_article?(phrase) && PATTERNS_EXEMPT_FROM_DEFINITIVE_ARTICLE.none? { |e| e =~ phrase.downcase }
   end
 
   def has_definite_article?(phrase)

--- a/app/models/corporate_information_page_type.rb
+++ b/app/models/corporate_information_page_type.rb
@@ -1,6 +1,7 @@
 class CorporateInformationPageType
   include ActiveRecordLikeInterface
   include TranslationHelper
+  include OrganisationHelper
 
   attr_accessor :id, :title_template, :slug, :menu_heading
 
@@ -112,8 +113,9 @@ private
   def organisation_name(organisation)
     if organisation.respond_to?(:acronym) && organisation.acronym.present?
       organisation.acronym
-    else
-      organisation.try(:name).to_s
+    elsif organisation.respond_to?(:name)
+      prefix = needs_definite_article?(organisation.name) ? "the " : ""
+      prefix + organisation.name
     end
   end
 end

--- a/test/functional/admin/worldwide_organisation_pages_controller_test.rb
+++ b/test/functional/admin/worldwide_organisation_pages_controller_test.rb
@@ -17,7 +17,7 @@ class Admin::WorldwideOrganisationPagesControllerTest < ActionController::TestCa
     assert_select "h1", "British Antarctic Territory"
     assert_select "h2", "Pages within this organisation"
     assert_select "h2", "Publication scheme"
-    assert_select "h2", "Working for British Antarctic Territory"
+    assert_select "h2", "Working for the British Antarctic Territory"
   end
 
   view_test "GET :new displays the worldwide organisation page fields" do

--- a/test/unit/app/helpers/organisation_helper_test.rb
+++ b/test/unit/app/helpers/organisation_helper_test.rb
@@ -5,17 +5,17 @@ class OrganisationHelperTest < ActionView::TestCase
 
   test "returns acronym in abbr tag if present" do
     organisation = build(:organisation, acronym: "BLAH", name: "Building Law and Hygiene")
-    assert_equal %(<abbr title="Building Law and Hygiene">BLAH</abbr>), organisation_display_name(organisation)
+    assert_equal %(<abbr title="Building Law and Hygiene">BLAH</abbr>), organisation_relationship_display_name(organisation)
   end
 
   test "returns name when acronym is nil" do
     organisation = build(:organisation, acronym: nil, name: "Building Law and Hygiene")
-    assert_equal "Building Law and Hygiene", organisation_display_name(organisation)
+    assert_equal "Building Law and Hygiene", organisation_relationship_display_name(organisation)
   end
 
   test "returns name when acronym is empty" do
     organisation = build(:organisation, acronym: "", name: "Building Law and Hygiene")
-    assert_equal "Building Law and Hygiene", organisation_display_name(organisation)
+    assert_equal "Building Law and Hygiene", organisation_relationship_display_name(organisation)
   end
 
   test "returns name formatted for logos" do

--- a/test/unit/app/helpers/organisation_helper_test.rb
+++ b/test/unit/app/helpers/organisation_helper_test.rb
@@ -85,22 +85,22 @@ class OrganisationHelperDisplayNameWithParentalRelationshipTest < ActionView::Te
   end
 
   test "links to parent organisation" do
-    parent = create(:organisation)
-    child = create(:organisation, parent_organisations: [parent])
+    parent = create(:organisation, name: "Testing Agency")
+    child = create(:organisation, name: "Department of Testing", parent_organisations: [parent])
     assert_match %r{the <a class="brand__color" href="/government/organisations/#{parent.to_param}">#{parent.name}</a>}, organisation_display_name_and_parental_relationship(child)
   end
 
   test "relationship types are described correctly and trailing spaces are removed" do
-    assert_relationship_type_is_described_as(:ministerial_department, "org1 is a ministerial department of the parent org1.", "org1 ", "parent org1 ")
-    assert_relationship_type_is_described_as(:non_ministerial_department, "org2 is a non-ministerial department.", "org2 ", "parent org2 ")
-    assert_relationship_type_is_described_as(:executive_agency, "org3 is an executive agency, sponsored by the parent org3.", "org3 ", "parent org3 ")
-    assert_relationship_type_is_described_as(:executive_ndpb, "org4 is an executive non-departmental public body, sponsored by the parent org4.", "org4 ", "parent org4 ")
-    assert_relationship_type_is_described_as(:advisory_ndpb, "org5 is an advisory non-departmental public body, sponsored by the parent org5.", "org5 ", "parent org5 ")
-    assert_relationship_type_is_described_as(:special_health_authority, "org6 is a special health authority, sponsored by the parent org6.", "org6 ", "parent org6 ")
-    assert_relationship_type_is_described_as(:tribunal, "org7 is a tribunal of the parent org7.", "org7 ", "parent org7 ")
-    assert_relationship_type_is_described_as(:public_corporation, "org8 is a public corporation of the parent org8.", "org8 ", "parent org8 ")
-    assert_relationship_type_is_described_as(:independent_monitoring_body, "org9 is an independent monitoring body of the parent org9.", "org9 ", "parent org9 ")
-    assert_relationship_type_is_described_as(:other, "org10 works with the parent org10.", "org10 ", "parent org10 ")
+    assert_relationship_type_is_described_as(:ministerial_department, "The Department of Testing is a ministerial department of the Testing Agency.", "Department of Testing ", "Testing Agency ")
+    assert_relationship_type_is_described_as(:non_ministerial_department, "The Department of Testing 2 is a non-ministerial department.", "Department of Testing 2", "doesn't matter ")
+    assert_relationship_type_is_described_as(:executive_agency, "The Department of Testing 3 is an executive agency, sponsored by the Testing Agency 3.", "Department of Testing 3 ", "Testing Agency 3 ")
+    assert_relationship_type_is_described_as(:executive_ndpb, "The Department of Testing 4 is an executive non-departmental public body, sponsored by the Testing Agency 4.", "Department of Testing 4", "Testing Agency 4 ")
+    assert_relationship_type_is_described_as(:advisory_ndpb, "The Department of Testing 5 is an advisory non-departmental public body, sponsored by the Testing Agency 5.", "Department of Testing 5", "Testing Agency 5 ")
+    assert_relationship_type_is_described_as(:special_health_authority, "The Department of Testing 6 is a special health authority, sponsored by the Testing Agency 6.", "Department of Testing 6 ", "Testing Agency 6 ")
+    assert_relationship_type_is_described_as(:tribunal, "The Department of Testing 7 is a tribunal of the Testing Agency 7.", "Department of Testing 7 ", "Testing Agency 7 ")
+    assert_relationship_type_is_described_as(:public_corporation, "The Department of Testing 8 is a public corporation of the Testing Agency 8.", "Department of Testing 8", "Testing Agency 8 ")
+    assert_relationship_type_is_described_as(:independent_monitoring_body, "The Department of Testing 9 is an independent monitoring body of the Testing Agency 9.", "Department of Testing 9 ", "Testing Agency 9 ")
+    assert_relationship_type_is_described_as(:other, "The Department of Testing 10 works with the Testing Agency 10.", "Department of Testing 10 ", "Testing Agency 10  ")
   end
 
   test "definite article skipped for certain parent organisations" do
@@ -108,6 +108,10 @@ class OrganisationHelperDisplayNameWithParentalRelationshipTest < ActionView::Te
     assert_definite_article_skipped "HM Treasury"
     assert_definite_article_skipped "Ordnance Survey"
     assert_definite_article_skipped "Homes England"
+  end
+
+  test "definite article added for certain organisations" do
+    assert needs_definite_article?("Environment Agency")
   end
 
   test 'definite article skipped if name starts with "The"' do
@@ -167,10 +171,10 @@ class OrganisationHelperDisplayNameWithParentalRelationshipTest < ActionView::Te
   test "organisations of type other with parent and multiple children are described correctly" do
     child1 = create(:organisation, acronym: "CO", name: "Child Organisation 1")
     child2 = create(:organisation, acronym: "CO", name: "Child Organisation 2")
-    parent = create(:organisation, acronym: "PO", name: "Parent Organisation Name")
+    parent = create(:organisation, acronym: "PO", name: "Department of Testing")
     org = create(:organisation, organisation_type_key: "other", acronym: "TO", name: "This Organisation", child_organisations: [child1, child2], parent_organisations: [parent])
 
     description = organisation_display_name_including_parental_and_child_relationships(org)
-    assert_equal "TO works with the Parent Organisation Name and is supported by 2 agencies and public bodies.", strip_html_tags(description)
+    assert_equal "TO works with the Department of Testing and is supported by 2 agencies and public bodies.", strip_html_tags(description)
   end
 end

--- a/test/unit/app/models/corporate_information_page_test.rb
+++ b/test/unit/app/models/corporate_information_page_test.rb
@@ -160,7 +160,7 @@ class CorporateInformationPageTest < ActiveSupport::TestCase
   test "should derive title from type and interpolate organisation name if no acronym" do
     organisation = build(:organisation, acronym: nil, name: "Department for Communities and Local Government")
     corporate_information_page = build(:corporate_information_page, organisation:, corporate_information_page_type: CorporateInformationPageType::Recruitment)
-    assert_equal "Working for Department for Communities and Local Government", corporate_information_page.title
+    assert_equal "Working for the Department for Communities and Local Government", corporate_information_page.title
   end
 
   test "should derive slug from type" do

--- a/test/unit/app/models/corporate_information_page_type_test.rb
+++ b/test/unit/app/models/corporate_information_page_type_test.rb
@@ -27,7 +27,7 @@ class CorporateInformationPageTypeTest < ActiveSupport::TestCase
       organisation: @organisation,
     )
 
-    assert_equal "Procurement at Department of Alphabet", corporate_information_page.title
+    assert_equal "Procurement at the Department of Alphabet", corporate_information_page.title
   end
 
   test ".title_lang returns lang=en if the title translation does not exist" do
@@ -55,6 +55,6 @@ class CorporateInformationPageTypeTest < ActiveSupport::TestCase
       organisation: @organisation,
     )
 
-    assert_equal "Procurement at Department of Alphabet", corporate_information_page.title
+    assert_equal "Procurement at the Department of Alphabet", corporate_information_page.title
   end
 end

--- a/test/unit/app/models/worldwide_organisation_page_test.rb
+++ b/test/unit/app/models/worldwide_organisation_page_test.rb
@@ -78,7 +78,7 @@ class WorldwideOrganisationPageTest < ActiveSupport::TestCase
   test "should derive title from type and interpolate organisation name" do
     worldwide_organisation = build(:worldwide_organisation, title: "British Antarctic Territory")
     page = build(:worldwide_organisation_page, edition: worldwide_organisation, corporate_information_page_type: CorporateInformationPageType::Recruitment)
-    assert_equal "Working for British Antarctic Territory", page.title
+    assert_equal "Working for the British Antarctic Territory", page.title
   end
 
   test "#missing_translations should only include worldwide organisation translations" do

--- a/test/unit/app/presenters/publishing_api/organisation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/organisation_presenter_test.rb
@@ -39,7 +39,7 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
     expected_hash = {
       base_path: public_path,
       title: "Organisation of Things",
-      description: "This org is a thing! Organisation of Things works with the Department for Stuff .",
+      description: "This org is a thing! The Organisation of Things works with the Department for Stuff .",
       schema_name: "organisation",
       document_type: "organisation",
       locale: "en",
@@ -54,7 +54,7 @@ class PublishingApi::OrganisationPresenterTest < ActionView::TestCase
       details: {
         acronym: nil,
         alternative_format_contact_email: nil,
-        body: govspeak_to_html("This org is a thing!\n\nOrganisation of Things works with the <a class=\"brand__color\" href=\"/government/organisations/department-for-stuff\">Department for Stuff</a>."),
+        body: govspeak_to_html("This org is a thing!\n\nThe Organisation of Things works with the <a class=\"brand__color\" href=\"/government/organisations/department-for-stuff\">Department for Stuff</a>."),
         brand: nil,
         logo: {
           formatted_title: "Organisation<br/>of<br/>Things",

--- a/test/unit/app/presenters/publishing_api/worldwide_organisation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/worldwide_organisation_presenter_test.rb
@@ -74,7 +74,7 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
           },
           {
             content_id: worldwide_org.pages[3].content_id,
-            title: "Working for Worldwide organisation title",
+            title: "Working for the Worldwide organisation title",
           },
         ],
         secondary_corporate_information_pages: "Read about the types of information we routinely publish in our <a class=\"govuk-link\" href=\"/world/organisations/worldwide-organisation-title/about/publication-scheme\">Publication scheme</a>. Find out about our commitment to <a class=\"govuk-link\" href=\"/world/organisations/worldwide-organisation-title/about/welsh-language-scheme\">publishing in Welsh</a>. Our <a class=\"govuk-link\" href=\"/world/organisations/worldwide-organisation-title/about/personal-information-charter\">Personal information charter</a> explains how we treat your personal information.",


### PR DESCRIPTION
## what

Changes how organisation names are displayed in:
- corporate information page titles and links (eg `Working at Environment Agency` -> `Working at the Environment Agency`
- organisation / parent organisation relationship text

## why

Corporate information page titles and text on the organisation home page was missing the definitive article.  Raised as a support ticket https://govuk.zendesk.com/agent/tickets/6543938

Before (current prod):
<img width="1582" height="1035" alt="image" src="https://github.com/user-attachments/assets/7780c5a6-56ea-462f-919b-2a0aa72aff6f" />
<img width="1582" height="1035" alt="image" src="https://github.com/user-attachments/assets/67432cc4-3f1b-423a-827d-a8b7dce354ed" />


After: (tested on integration)

<img width="3124" height="2030" alt="image" src="https://github.com/user-attachments/assets/e5834d10-d0a9-4fa9-aae5-a48201ddfa61" />
<img width="3124" height="2030" alt="image" src="https://github.com/user-attachments/assets/ad3bf87f-de7b-4bb4-b730-21eacaccef36" />

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
