### PR TITLE
Allow Welsh-language mainstream URLs [WHIT-3436]

### DIFF
--- a/app/models/document_collection_non_whitehall_link/govuk_url.rb
+++ b/app/models/document_collection_non_whitehall_link/govuk_url.rb
@@ -31,24 +31,24 @@ class DocumentCollectionNonWhitehallLink::GovukUrl
   end
 
   def content_item
-    @content_item ||= Services.publishing_api.get_content(content_id).to_h
+    @content_item ||= content_item_from_content_store
   end
 
   def content_id
-    @content_id ||= Services.publishing_api.lookup_content_id(base_path: parsed_url.path, with_drafts: true)
+    @content_id ||= content_item["content_id"]
+  end
 
-    if @content_id.blank?
-      toplevel_path_segment = parsed_url.path.split("/").second
-      @content_id = Services.publishing_api.lookup_content_id(base_path: "/#{toplevel_path_segment}", with_drafts: true)
-      if @content_id.blank?
-        raise GdsApi::HTTPNotFound, 404
-      else
-        unless content_item["document_type"] == "guide"
-          raise GdsApi::HTTPNotFound, 404
-        end
-      end
+  def content_item_from_content_store
+    path = parsed_url.path
+
+    item = Services.content_store.content_item(path).to_h
+
+    if item["base_path"] != path && item["document_type"] != "guide"
+      raise GdsApi::HTTPNotFound, 404
     end
 
-    @content_id
+    item
+  rescue GdsApi::ContentStore::ItemNotFound
+    raise GdsApi::HTTPNotFound, 404
   end
 end

--- a/features/step_definitions/document_collection_steps.rb
+++ b/features/step_definitions/document_collection_steps.rb
@@ -157,7 +157,8 @@ And(/^a GovUK Url exists "([^"]*)" with title "([^"]*)"$/) do |url, title|
   content_id = SecureRandom.uuid
 
   stub_publishing_api_has_lookups(base_path => content_id)
-  stub_publishing_api_has_item(
+  stub_content_store_has_item(
+    base_path,
     content_id:,
     base_path:,
     publishing_app: "content-publisher",

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -1,5 +1,6 @@
 require "gds_api/publishing_api"
 require "gds_api/asset_manager"
+require "gds_api/content_store"
 require "gds_api/search"
 
 module Services
@@ -9,6 +10,10 @@ module Services
 
   def self.publishing_api_with_huge_timeout
     @publishing_api_with_huge_timeout ||= publishing_api_client_with_timeout(60)
+  end
+
+  def self.content_store
+    @content_store ||= GdsApi::ContentStore.new(Plek.find("content-store"))
   end
 
   def self.asset_manager

--- a/test/unit/app/models/document_collection_non_whitehall_link/govuk_url_test.rb
+++ b/test/unit/app/models/document_collection_non_whitehall_link/govuk_url_test.rb
@@ -3,16 +3,15 @@ require "test_helper"
 class DocumentCollectionNonWhitehallLink::GovukUrlTest < ActiveSupport::TestCase
   setup do
     @content_id = SecureRandom.uuid
-    stub_publishing_api_has_lookups("/test" => @content_id)
-    stub_publishing_api_has_item(
-      content_id: @content_id,
-      title: "Test",
-      base_path: "/test",
-      publishing_app: "content-publisher",
+    Services.content_store.stubs(:content_item).with("/test").returns(
+      "content_id" => @content_id,
+      "title" => "Test",
+      "base_path" => "/test",
+      "publishing_app" => "content-publisher",
     )
   end
 
-  test "should be valid without a GOV.UK url that Publishing API knows" do
+  test "should be valid when content store has the path" do
     url = DocumentCollectionNonWhitehallLink::GovukUrl.new(
       url: "https://www.gov.uk/test",
       document_collection_group: build(:document_collection_group),
@@ -32,12 +31,13 @@ class DocumentCollectionNonWhitehallLink::GovukUrlTest < ActiveSupport::TestCase
 
   test "should be valid when a mainstream guide sub-page url is used" do
     content_id = SecureRandom.uuid
-    stub_publishing_api_has_lookups("/foo" => content_id)
-    stub_publishing_api_has_item(content_id:,
-                                 title: "Foo Bar",
-                                 base_path: "/foo",
-                                 document_type: "guide",
-                                 publishing_app: "content-publisher")
+    Services.content_store.stubs(:content_item).with("/foo/subpage").returns(
+      "content_id" => content_id,
+      "title" => "Foo Bar",
+      "base_path" => "/foo",
+      "publishing_app" => "content-publisher",
+      "document_type" => "guide",
+    )
 
     url = DocumentCollectionNonWhitehallLink::GovukUrl.new(
       url: "https://www.gov.uk/foo/subpage",
@@ -85,18 +85,21 @@ class DocumentCollectionNonWhitehallLink::GovukUrlTest < ActiveSupport::TestCase
     assert url.errors.full_messages.include?("Url must be a valid GOV.UK URL")
   end
 
-  test "should be invalid when a GOV.UK URL that isn't in the Publishing API" do
+  test "should be valid for a Welsh-only GOV.UK page (locale: cy)" do
+    welsh_content_id = SecureRandom.uuid
+    content_store_response = { "content_id" => welsh_content_id, "title" => "Talu TWE y cyflogwr", "base_path" => "/talu-treth-twe", "publishing_app" => "publisher", "locale" => "cy" }
+    Services.content_store.stubs(:content_item).with("/talu-treth-twe").returns(content_store_response)
+
     url = DocumentCollectionNonWhitehallLink::GovukUrl.new(
-      url: "https://www.gov.uk/different-path",
+      url: "https://www.gov.uk/talu-treth-twe",
       document_collection_group: build(:document_collection_group),
     )
 
-    assert_not url.valid?
-    assert url.errors.full_messages.include?("Url must reference a GOV.UK page")
+    assert url.valid?
   end
 
-  test "should be invalid when Publishing API returns a 404" do
-    stub_any_publishing_api_call_to_return_not_found
+  test "should be invalid when content store returns a 404" do
+    Services.content_store.stubs(:content_item).raises(GdsApi::ContentStore::ItemNotFound.new(404))
 
     url = DocumentCollectionNonWhitehallLink::GovukUrl.new(
       url: "https://www.gov.uk/test",
@@ -109,12 +112,13 @@ class DocumentCollectionNonWhitehallLink::GovukUrlTest < ActiveSupport::TestCase
 
   test "should be invalid when a non-mainstream guide sub-page url is used" do
     content_id = SecureRandom.uuid
-    stub_publishing_api_has_lookups("/foo" => content_id)
-    stub_publishing_api_has_item(content_id:,
-                                 title: "Foo Bar",
-                                 base_path: "/foo",
-                                 document_type: "other",
-                                 publishing_app: "content-publisher")
+    Services.content_store.stubs(:content_item).with("/foo/subpage").returns(
+      "content_id" => content_id,
+      "title" => "Foo Bar",
+      "base_path" => "/foo",
+      "publishing_app" => "content-publisher",
+      "document_type" => "other",
+    )
 
     url = DocumentCollectionNonWhitehallLink::GovukUrl.new(
       url: "https://www.gov.uk/foo/subpage",
@@ -124,8 +128,8 @@ class DocumentCollectionNonWhitehallLink::GovukUrlTest < ActiveSupport::TestCase
     assert_not url.valid?
   end
 
-  test "should be invalid when Publishing API is down" do
-    stub_publishing_api_isnt_available
+  test "should be invalid when Content Store is unavailable" do
+    Services.content_store.stubs(:content_item).raises(GdsApi::HTTPIntermittentServerError.new(503))
 
     url = DocumentCollectionNonWhitehallLink::GovukUrl.new(
       url: "https://www.gov.uk/test",


### PR DESCRIPTION
Welsh-only GOV.UK pages (e.g. /talu-treth-twe) were failing validation with "Url must reference a GOV.UK page" when added to document collection groups. The root cause was that get_content in the Publishing API defaults to locale: en, so Welsh-only content — which only exists in locale: cy — returned a 404.

This PR replaces get_content with the Content Store for fetching content items. The Content Store serves content regardless of locale, so Welsh URLs now resolve correctly.

The guide sub-page check (which validates that a two-segment path like /guidance/subpage belongs to a guide) continues to work because the Content Store returns the parent guide's content item for sub-page paths, making [document_type](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) available directly from that response.

**BEFORE**


https://github.com/user-attachments/assets/6afa595b-7db7-4b94-ab02-4aa3d1531de4


**AFTER**


https://github.com/user-attachments/assets/6d77a1e9-56e7-4fb1-9d7d-a3dca9d3c5a0


[Jira](https://gov-uk.atlassian.net/browse/WHIT-3436)