### PR TITLE
Add a link on the 'Permissions error' page to allow GDS Admins to go straight to 'Update access'  [WHIT-3284]

### DIFF
--- a/app/views/admin/errors/forbidden.html.erb
+++ b/app/views/admin/errors/forbidden.html.erb
@@ -5,8 +5,16 @@
 <div class="govuk-grid-row govuk-!-margin-bottom-0">
   <div class="govuk-grid-column-two-thirds">
     <p class="govuk-body">You do not have permission to access this page.</p>
-    <p class="govuk-body">If you need to:</p>
-
+    <% if @edition && can?(:perform_administrative_tasks, Edition) %>
+      <p class="govuk-body">
+        <a href="<%= edit_access_limited_admin_edition_path(@edition) %>" class="govuk-link">
+          As an administrator, you can update the access permissions of the page.
+        </a>
+      </p>
+      <p class="govuk-body">Alternatively, if you need to:</p>
+    <% else %>
+      <p class="govuk-body">If you need to:</p>
+    <% end %>
     <%= render "govuk_publishing_components/components/list", {
       visible_counters: true,
       items: [

--- a/features/admin-limit-access-editions.feature
+++ b/features/admin-limit-access-editions.feature
@@ -1,0 +1,17 @@
+Feature: Viewing most recent editions in admin
+
+  Scenario: Viewing a current edition that has since been access limited as an editor
+    Given I am an editor
+    Given a published document "Road accidents" exists
+    When someone else creates a new edition of the published document "Road accidents" and limits access to members of "Department of Secrecy"
+    And I view the current edition of document "Road accidents"
+    Then I am told I do not have permissions to access this page
+    And I should not see a link to edit the access
+
+  Scenario: Viewing a current edition that has since been access limited as a GDS admin
+    Given I am a GDS admin
+    Given a published document "Road accidents" exists
+    When someone else creates a new edition of the published document "Road accidents" and limits access to members of "Department of Secrecy"
+    And I view the current edition of document "Road accidents"
+    Then I am told I do not have permissions to access this page
+    And I should see a link to edit the access

--- a/features/step_definitions/admin_limit_access_steps.rb
+++ b/features/step_definitions/admin_limit_access_steps.rb
@@ -1,0 +1,16 @@
+When(/^I view the current edition of document "([^"]*)"$/) do |title|
+  @edition = Edition.find_by(title:).document.editions.last
+  visit admin_edition_path(@edition)
+end
+
+Then(/^I am told I do not have permissions to access this page/) do
+  expect(page).to have_content "You do not have permission to access this page."
+end
+
+Then(/^I should not see a link to edit the access/) do
+  expect(page).not_to have_link("As an administrator, you can update the access permissions of the page.", href: edit_access_limited_admin_edition_path(@edition))
+end
+
+Then(/^I should see a link to edit the access/) do
+  expect(page).to have_link("As an administrator, you can update the access permissions of the page.", href: edit_access_limited_admin_edition_path(@edition))
+end

--- a/features/step_definitions/edition_update_slug_steps.rb
+++ b/features/step_definitions/edition_update_slug_steps.rb
@@ -18,7 +18,3 @@ Then(/^I can see the preview URL of the publication "([^"]*)" contains "([^"]*)"
   visit admin_edition_path(Publication.find_by(title:))
   expect(page).to have_link "Preview on website (opens in new tab)", href: "https://draft-origin.test.gov.uk/government/publications/#{new_slug}"
 end
-
-Then(/^I am told I do not have permissions to access this page/) do
-  expect(page).to have_content "You do not have permission to access this page."
-end


### PR DESCRIPTION
## What

Add link to the Permission Error page to the edit the access of the edition (if an edition is causing the permission error).

## Why

Makes it easier for change access of the document for an admin than having to know the URL to use.

### Visual Differences

<img width="1069" height="552" alt="Screenshot 2026-05-13 at 14 30 20" src="https://github.com/user-attachments/assets/6fed5d93-c28d-4eb9-8284-279551d25e4d" />


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
