### PR TITLE
[WHIT-3323] Keep current url on rename

### DIFF
--- a/app/assets/javascripts/admin/views/edition-form.js
+++ b/app/assets/javascripts/admin/views/edition-form.js
@@ -160,25 +160,25 @@
   EditionForm.prototype.setupTitleInputEventListener = function () {
     const form = this.module
     const titleInput = form.querySelector('#edition_title')
-    const checkboxContainer = form.querySelector('.js-keep-slug-form-group')
+    const urlRadioGroup = form.querySelector('.js-url-radio-group')
 
-    if (!titleInput || !checkboxContainer) {
+    if (!titleInput || !urlRadioGroup) {
       return
     }
 
     const originalTitle = titleInput.value
 
-    const setCheckboxVisibility = () => {
+    const setUrlRadioGroupVisibility = () => {
       const titleHasChanged = originalTitle !== titleInput.value
       if (titleHasChanged) {
-        checkboxContainer.removeAttribute('hidden')
+        urlRadioGroup.removeAttribute('hidden')
       } else {
-        checkboxContainer.setAttribute('hidden', 'hidden')
+        urlRadioGroup.setAttribute('hidden', 'hidden')
       }
     }
 
-    titleInput.addEventListener('input', () => setCheckboxVisibility())
-    setCheckboxVisibility()
+    titleInput.addEventListener('input', () => setUrlRadioGroupVisibility())
+    setUrlRadioGroupVisibility()
   }
 
   Modules.EditionForm = EditionForm

--- a/app/models/concerns/edition/identifiable.rb
+++ b/app/models/concerns/edition/identifiable.rb
@@ -7,6 +7,7 @@ module Edition::Identifiable
     before_validation :ensure_presence_of_document, on: :create
     before_validation :propagate_type_to_document
     before_save :set_slug_from_title, if: -> { title_changed? }
+    before_save :nullify_redundant_slug_override, if: -> { slug_override.present? }
     before_save :set_slug, if: -> { slug_from_title_changed? || slug_override_changed? }
 
     scope :latest_edition, -> { joins(:document).where("editions.id = documents.latest_edition_id") }
@@ -62,6 +63,10 @@ module Edition::Identifiable
 
   def set_slug
     self[:slug] = slug_override.presence || slug_from_title
+  end
+
+  def nullify_redundant_slug_override
+    self.slug_override = nil if slug_override == slug_from_title
   end
 
   def linkable?

--- a/app/views/admin/editions/_page_address_controls.html.erb
+++ b/app/views/admin/editions/_page_address_controls.html.erb
@@ -13,18 +13,25 @@
     </p>
   </div>
 
-  <div class="<%= (edition.document.live_edition.slug == edition.slug_from_title) && "js-keep-slug-form-group" %> govuk-!-margin-bottom-6">
-    <%= render "govuk_publishing_components/components/hint", {
-      text: "The title of this document has changed since the page URL was generated. Check the box below to keep the existing URL, or leave it unchecked to update the URL for this page to match the new title when you publish this edition.",
-    } %>
-    <%= hidden_field(:edition, :slug_override, value: "") %>
-    <%= render "govuk_publishing_components/components/checkboxes", {
+  <% live_slug = edition.document.live_edition.slug %>
+  <% keep_current_url_checked = edition.slug_override.present? || edition.slug == live_slug %>
+  <div class="<%= (live_slug == edition.slug_from_title) && "js-url-radio-group" %> govuk-!-margin-bottom-6">
+    <p class="govuk-body">
+      The title has changed since this URL was created. Choose whether to keep the current URL or update it to match the title.
+    </p>
+
+    <%= render "govuk_publishing_components/components/radio", {
       name: "edition[slug_override]",
       items: [
         {
-          label: "Keep the current page URL",
-          value: edition.document.live_edition.slug,
-          checked: edition.slug_override.present?,
+          value: live_slug,
+          text: "Keep current URL",
+          checked: keep_current_url_checked,
+        },
+        {
+          value: "",
+          text: "Update URL to match title",
+          checked: !keep_current_url_checked,
         },
       ],
     } %>

--- a/app/views/admin/editions/_page_address_controls.html.erb
+++ b/app/views/admin/editions/_page_address_controls.html.erb
@@ -1,15 +1,16 @@
 <% if edition.document&.live_edition.present? %>
   <div class="app-view-edit-edition__page-address govuk-!-margin-bottom-4">
     <%= render "govuk_publishing_components/components/heading", {
-      text: "Live page address",
+      text: "URL",
       heading_level: 3,
       font_size: "m",
       margin_bottom: 2,
     } %>
 
-    <%= render "govuk_publishing_components/components/hint", {
-      text: edition.document&.live_edition.public_url,
-    } %>
+    <p class="govuk-body">
+      Current GOV.UK URL:<br>
+      <%= link_to edition.document.live_edition.public_url, edition.document.live_edition.public_url, class: "govuk-link" %>
+    </p>
   </div>
 
   <div class="<%= (edition.document.live_edition.slug == edition.slug_from_title) && "js-keep-slug-form-group" %> govuk-!-margin-bottom-6">

--- a/features/edition-update-slug.feature
+++ b/features/edition-update-slug.feature
@@ -1,18 +1,33 @@
 Feature: Edition update slug
-  Scenario: Writer updates the title of a document
-    Given I am a writer
-    And a published publication "You will never guess" exists
-    When I edit the publication "You will never guess"
-    And I change the title to "Ten facts that will shock you"
-    And I save the edition and go to the document summary
-    Then I can see the preview URL of the publication "Ten facts that will shock you" contains "ten-facts-that-will-shock-you"
 
-  @javascript
-  Scenario: Writer updates the title of a document and opts out of slug update
-    Given I am a writer
-    And a published publication "You will never guess" exists
-    When I edit the publication "You will never guess"
-    And I change the title to "Ten facts that will shock you"
-    And I opt out of updating the slug
-    And I save the edition and go to the document summary
-    Then I can see the preview URL of the publication "Ten facts that will shock you" contains "you-will-never-guess"
+  Rule: The URL control only appears when the title changes
+
+    @javascript
+    Scenario: The URL control is revealed when the title changes
+      Given I am a writer
+      And a published publication "You will never guess" exists
+      When I edit the publication "You will never guess"
+      Then I cannot see the option to keep the current page URL
+      When I change the title to "Ten facts that will shock you"
+      Then I can see the option to keep the current page URL
+
+  Rule: Renaming a draft keeps the live URL unless an editor opts out
+
+    Scenario: Renaming a draft keeps the live URL by default
+      Given I am a writer
+      And a published publication "You will never guess" exists
+      When I edit the publication "You will never guess"
+      And I change the title to "Ten facts that will shock you"
+      And I save the edition and go to the document summary
+      Then I can see the preview URL of the publication "Ten facts that will shock you" contains "you-will-never-guess"
+      And the saved URL choice for "Ten facts that will shock you" is reflected when revisiting the edit page
+
+    Scenario: Opting to use the title based slug updates the URL to match the title
+      Given I am a writer
+      And a published publication "You will never guess" exists
+      When I edit the publication "You will never guess"
+      And I change the title to "Ten facts that will shock you"
+      And I opt out of keeping the live slug
+      And I save the edition and go to the document summary
+      Then I can see the preview URL of the publication "Ten facts that will shock you" contains "ten-facts-that-will-shock-you"
+      And the saved URL choice for "Ten facts that will shock you" is reflected when revisiting the edit page

--- a/features/step_definitions/edition_update_slug_steps.rb
+++ b/features/step_definitions/edition_update_slug_steps.rb
@@ -1,20 +1,19 @@
-And(/^I visit the edit slug page for "([^"]*)"$/) do |edition_title|
-  @edition = Edition.find_by!(title: edition_title)
-  visit edit_slug_admin_edition_path(@edition)
-end
-
-And(/^I update the slug to "([^"]*)"$/) do |new_slug|
-  fill_in "Slug", with: new_slug
-  click_button "Update"
-end
-
-Then(/^I can see the edition's public URL contains "([^"]*)"$/) do |new_slug|
-  visit admin_edition_path(@edition)
-  click_button "Create new edition"
-  expect(page.find(".app-view-edit-edition__page-address .govuk-hint")).to have_content new_slug
-end
-
 Then(/^I can see the preview URL of the publication "([^"]*)" contains "([^"]*)"$/) do |title, new_slug|
-  visit admin_edition_path(Publication.find_by(title:))
+  visit admin_edition_path(Publication.latest_edition.find_by!(title:))
   expect(page).to have_link "Preview on website (opens in new tab)", href: "https://draft-origin.test.gov.uk/government/publications/#{new_slug}"
+end
+
+Then(/^I cannot see the option to keep the current page URL$/) do
+  expect(page).not_to have_field("Keep current URL")
+end
+
+Then(/^I can see the option to keep the current page URL$/) do
+  expect(page).to have_css(".js-url-radio-group:not([hidden])")
+end
+
+Then(/^the saved URL choice for "([^"]*)" is reflected when revisiting the edit page$/) do |title|
+  draft = Publication.latest_edition.find_by!(title:)
+  visit edit_admin_edition_path(draft)
+  expected_choice = draft.slug_override.present? ? "Keep current URL" : "Update URL to match title"
+  expect(page).to have_checked_field(expected_choice)
 end

--- a/features/step_definitions/publication_steps.rb
+++ b/features/step_definitions/publication_steps.rb
@@ -52,12 +52,8 @@ When(/^I change the title to "([^"]*)"$/) do |new_title|
   fill_in "Title", with: new_title
 end
 
-When("I opt out of updating the slug") do
-  check "Keep the current page URL"
-end
-
-Then("I cannot opt out of updating the slug") do
-  expect(page).not_to have_selector("label", text: "Keep the current page URL")
+When("I opt out of keeping the live slug") do
+  choose "Update URL to match title"
 end
 
 When("I save the edition and go to the document summary") do

--- a/spec/javascripts/admin/modules/edition-form.spec.js
+++ b/spec/javascripts/admin/modules/edition-form.spec.js
@@ -189,25 +189,25 @@ describe('GOVUK.Modules.EditionForm', function () {
       editionForm.init()
     })
 
-    it('hides the checkbox on page load', function () {
-      const checkboxContainer = form.querySelector('.js-keep-slug-form-group')
+    it('hides the URL radio group on page load', function () {
+      const urlRadioGroup = form.querySelector('.js-url-radio-group')
 
-      expect(checkboxContainer.hidden).toEqual(true)
+      expect(urlRadioGroup.hidden).toEqual(true)
     })
 
-    it('shows the checkbox when the title is edited, and hides it if the title is reset', function () {
+    it('shows the URL radio group when the title is edited, and hides it if the title is reset', function () {
       const titleInput = form.querySelector('#edition_title')
-      const checkboxContainer = form.querySelector('.js-keep-slug-form-group')
+      const urlRadioGroup = form.querySelector('.js-url-radio-group')
 
       titleInput.value = 'Some new title'
       titleInput.dispatchEvent(new Event('input'))
 
-      expect(checkboxContainer.hidden).toEqual(false)
+      expect(urlRadioGroup.hidden).toEqual(false)
 
       titleInput.value = newEditionTitle
       titleInput.dispatchEvent(new Event('input'))
 
-      expect(checkboxContainer.hidden).toEqual(true)
+      expect(urlRadioGroup.hidden).toEqual(true)
     })
   })
 
@@ -328,11 +328,19 @@ describe('GOVUK.Modules.EditionForm', function () {
               </div>
             </div>
             <div id="hint-f0e80744" class="gem-c-hint govuk-hint">http://www.dev.gov.uk/guidance/test-document</div>
-            <input type="hidden" value="" />
-            <div id="checkboxes-ab8fa8f0" data-module="gem-checkboxes govuk-checkboxes" class="gem-c-checkboxes govuk-form-group js-keep-slug-form-group">
-              <div class="govuk-checkboxes__item">
-                <input type="checkbox" name="slug_override" id="checkboxes-ab8fa8f0-0" value="${liveEditionTitle}" class="govuk-checkboxes__input"><label for="checkboxes-ab8fa8f0-0" class="govuk-label govuk-checkboxes__label">Keep current page URL</label>
-              </div>
+            <div class="gem-c-radio govuk-form-group js-url-radio-group">
+              <fieldset class="govuk-fieldset">
+                <div class="govuk-radios">
+                  <div class="gem-c-radio govuk-radios__item">
+                    <input type="radio" name="edition[slug_override]" id="radio-ab8fa8f0-0" value="${liveEditionTitle}" class="govuk-radios__input" checked>
+                    <label for="radio-ab8fa8f0-0" class="govuk-label govuk-radios__label">Keep current URL</label>
+                  </div>
+                  <div class="gem-c-radio govuk-radios__item">
+                    <input type="radio" name="edition[slug_override]" id="radio-ab8fa8f0-1" value="" class="govuk-radios__input">
+                    <label for="radio-ab8fa8f0-1" class="govuk-label govuk-radios__label">Update URL to match title</label>
+                  </div>
+                </div>
+              </fieldset>
             </div>`
   }
 })

--- a/test/functional/admin/document_collections_controller_test.rb
+++ b/test/functional/admin/document_collections_controller_test.rb
@@ -72,7 +72,6 @@ class Admin::DocumentCollectionsControllerTest < ActionController::TestCase
     get :edit, params: { id: document_collection }
 
     assert_select "form[action=?]", admin_document_collection_path(document_collection) do
-      assert_select ".app-view-edit-edition__page-address .govuk-hint", document_collection.public_url
       assert_select "textarea[name='edition[title]']", document_collection.title
       assert_select "textarea[name='edition[summary]']", text: document_collection.summary
       assert_select "textarea[name='edition[body]']", text: document_collection.body

--- a/test/functional/admin/standard_editions_controller_test.rb
+++ b/test/functional/admin/standard_editions_controller_test.rb
@@ -203,6 +203,121 @@ class Admin::StandardEditionsControllerTest < ActionController::TestCase
     end
   end
 
+  view_test "GET new does not show the URL controls" do
+    configurable_document_type = build_configurable_document_type("test_type")
+    ConfigurableDocumentType.setup_test_types(configurable_document_type)
+
+    get :new, params: { configurable_document_type: "test_type" }
+
+    assert_response :ok
+    refute_select "label", text: /Keep current URL/
+  end
+
+  view_test "GET edit does not show the URL controls for a draft with no live edition" do
+    configurable_document_type = build_configurable_document_type("test_type")
+    ConfigurableDocumentType.setup_test_types(configurable_document_type)
+
+    edition = create(:draft_standard_edition, configurable_document_type: "test_type")
+
+    get :edit, params: { id: edition }
+
+    assert_response :ok
+    refute_select "label", text: /Keep current URL/
+  end
+
+  view_test "GET edit pre-selects the 'Keep current URL' option when slug_override is set" do
+    configurable_document_type = build_configurable_document_type("test_type")
+    ConfigurableDocumentType.setup_test_types(configurable_document_type)
+
+    published_edition = create(:published_standard_edition, configurable_document_type: "test_type", title: "Original title")
+    edition = create(:draft_standard_edition, configurable_document_type: "test_type", document: published_edition.document, title: "Renamed title", slug_override: published_edition.slug)
+
+    get :edit, params: { id: edition }
+
+    assert_response :ok
+    assert_select "input[type=radio][name=?]", "edition[slug_override]", count: 2
+    assert_select "input[type=radio][name=?][value=?][checked]", "edition[slug_override]", published_edition.slug
+    refute_select "input[type=radio][name=?][value=''][checked]", "edition[slug_override]"
+  end
+
+  view_test "GET edit pre-selects the 'Keep current URL' option when slug_override is nil and the draft slug matches the live slug" do
+    configurable_document_type = build_configurable_document_type("test_type")
+    ConfigurableDocumentType.setup_test_types(configurable_document_type)
+
+    published_edition = create(:published_standard_edition, configurable_document_type: "test_type", title: "Shared title")
+    edition = create(:draft_standard_edition, configurable_document_type: "test_type", document: published_edition.document, title: "Shared title")
+
+    get :edit, params: { id: edition }
+
+    assert_response :ok
+    assert_select "input[type=radio][name=?]", "edition[slug_override]", count: 2
+    assert_select "input[type=radio][name=?][value=?][checked]", "edition[slug_override]", published_edition.slug
+    refute_select "input[type=radio][name=?][value=''][checked]", "edition[slug_override]"
+  end
+
+  view_test "GET edit pre-selects the 'Keep current URL' option when slug_override is blank and the draft slug matches the live slug" do
+    configurable_document_type = build_configurable_document_type("test_type")
+    ConfigurableDocumentType.setup_test_types(configurable_document_type)
+
+    published_edition = create(:published_standard_edition, configurable_document_type: "test_type", title: "Shared title")
+    edition = create(:draft_standard_edition, configurable_document_type: "test_type", document: published_edition.document, title: "Shared title")
+    edition.update!(slug_override: "")
+
+    get :edit, params: { id: edition }
+
+    assert_response :ok
+    assert_select "input[type=radio][name=?]", "edition[slug_override]", count: 2
+    assert_select "input[type=radio][name=?][value=?][checked]", "edition[slug_override]", published_edition.slug
+    refute_select "input[type=radio][name=?][value=''][checked]", "edition[slug_override]"
+  end
+
+  view_test "GET edit pre-selects the 'Update URL to match title' option when the draft slug differs from the live slug and slug_override is nil" do
+    configurable_document_type = build_configurable_document_type("test_type")
+    ConfigurableDocumentType.setup_test_types(configurable_document_type)
+
+    published_edition = create(:published_standard_edition, configurable_document_type: "test_type")
+    edition = create(:draft_standard_edition, configurable_document_type: "test_type", document: published_edition.document)
+    edition.update!(title: "Different title")
+
+    get :edit, params: { id: edition }
+
+    assert_response :ok
+    assert_select "input[type=radio][name=?]", "edition[slug_override]", count: 2
+    assert_select "input[type=radio][name=?][value=''][checked]", "edition[slug_override]"
+    refute_select "input[type=radio][name=?][value=?][checked]", "edition[slug_override]", published_edition.slug
+  end
+
+  view_test "GET edit pre-selects the 'Update URL to match title' option when the draft slug differs from the live slug and slug_override is blank" do
+    configurable_document_type = build_configurable_document_type("test_type")
+    ConfigurableDocumentType.setup_test_types(configurable_document_type)
+
+    published_edition = create(:published_standard_edition, configurable_document_type: "test_type")
+    edition = create(:draft_standard_edition, configurable_document_type: "test_type", document: published_edition.document)
+    edition.update!(title: "Different title", slug_override: "")
+
+    get :edit, params: { id: edition }
+
+    assert_response :ok
+    assert_select "input[type=radio][name=?]", "edition[slug_override]", count: 2
+    assert_select "input[type=radio][name=?][value=''][checked]", "edition[slug_override]"
+    refute_select "input[type=radio][name=?][value=?][checked]", "edition[slug_override]", published_edition.slug
+  end
+
+  view_test "GET edit shows the URL change explanation and option labels" do
+    configurable_document_type = build_configurable_document_type("test_type")
+    ConfigurableDocumentType.setup_test_types(configurable_document_type)
+
+    published_edition = create(:published_standard_edition, configurable_document_type: "test_type")
+    edition = create(:draft_standard_edition, configurable_document_type: "test_type", document: published_edition.document)
+
+    get :edit, params: { id: edition }
+
+    assert_response :ok
+    assert_select "p", text: "The title has changed since this URL was created. Choose whether to keep the current URL or update it to match the title."
+    assert_select "label", text: "Keep current URL"
+    assert_select "label", text: "Update URL to match title"
+  end
+
   view_test "GET edit renders only the fields for the selected tab" do
     configurable_document_type = build_configurable_document_type("test_type", {
       "forms" => {

--- a/test/functional/admin/standard_editions_controller_test.rb
+++ b/test/functional/admin/standard_editions_controller_test.rb
@@ -186,6 +186,23 @@ class Admin::StandardEditionsControllerTest < ActionController::TestCase
     assert_select "legend", text: "Review date"
   end
 
+  view_test "GET edit shows the current GOV.UK URL as a link when the edition has a live edition" do
+    configurable_document_type = build_configurable_document_type("test_type")
+    ConfigurableDocumentType.setup_test_types(configurable_document_type)
+
+    published_edition = create(:published_standard_edition, configurable_document_type: "test_type")
+    edition = create(:draft_standard_edition, configurable_document_type: "test_type", document: published_edition.document)
+
+    get :edit, params: { id: edition }
+
+    assert_response :ok
+    assert_select ".app-view-edit-edition__page-address" do
+      assert_select "h3", "URL"
+      assert_select "p", text: /Current GOV\.UK URL:/
+      assert_select "a.govuk-link[href=?]", published_edition.public_url, text: published_edition.public_url
+    end
+  end
+
   view_test "GET edit renders only the fields for the selected tab" do
     configurable_document_type = build_configurable_document_type("test_type", {
       "forms" => {

--- a/test/unit/app/models/edition/identifiable_test.rb
+++ b/test/unit/app/models/edition/identifiable_test.rb
@@ -129,6 +129,34 @@ class Edition::SluggingTest < ActiveSupport::TestCase
       assert_equal "original-title-override", draft_edition.slug
     end
 
+    test "it clears slug_override when the new title makes it redundant" do
+      edition = SluggableEdition.create!(title: "Original Title", slug_override: "chosen-slug")
+      assert_equal "chosen-slug", edition.slug
+
+      edition.update!(title: "Chosen slug")
+
+      assert_nil edition.slug_override
+      assert_equal "chosen-slug", edition.slug
+    end
+
+    test "it clears slug_override if it matches slug_from_title" do
+      edition = SluggableEdition.create_published!(title: "Klingons rule")
+      draft = edition.create_draft(create(:writer))
+      draft.update!(slug_override: "klingons-rule", change_note: "Important change")
+
+      assert_nil draft.slug_override
+      assert_equal "klingons-rule", draft.slug
+    end
+
+    test "it clears slug_override for whitespace stripped title that matches original title" do
+      title_with_whitespace = "Klingons rule "
+      edition = SluggableEdition.create!(title: "Klingons rule", slug_override: "klingons-rule")
+      edition.update!(title: title_with_whitespace)
+
+      assert_nil edition.slug_override
+      assert_equal "klingons-rule", edition.slug
+    end
+
     test "it generates a unique slug when a duplicate exists of the same edition type" do
       first_edition = SluggableEdition.create!(title: "Same Title", slug: nil)
       second_edition = SluggableEdition.create!(title: "Same Title", slug: nil)


### PR DESCRIPTION
## What and why

Previously, when the user changed the title of an edition in Whitehall, they were presented with a checkbox allowing them to preserve the document’s current live URL. If they did not check the box, the URL was updated to match the new title of the edition. Several departments have requested that we only update the edition's URL if the publisher specifically selects that behaviour.

The previous checkbox has been replaced by radio buttons, to better express what options the user has:
- keeping live url
- using the new title-based url

Keeping the live url is always our pre-checked option, unless the user has actively selected the title-based option. 
The copy has been updated to reflect the new functionality. Feature tests now provide extensive coverage.


## UI changes

| Before | After |
| --- | --- |
| <img width="546" height="284" alt="image" src="https://github.com/user-attachments/assets/89afaec9-231f-493c-97c7-4543cd806f87" /> | <img width="617" height="335" alt="image" src="https://github.com/user-attachments/assets/2769712b-a3e7-4b7f-b455-93ea4984c37a" /> |

Related PRs:
https://github.com/alphagov/whitehall/pull/11371
https://github.com/alphagov/whitehall/pull/11424
https://github.com/alphagov/whitehall/pull/11359

[Jira](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-3323)