### PR TITLE
Ensure access limiting applies to historic content

### DIFF
--- a/lib/whitehall/authority/rules/edition_rules.rb
+++ b/lib/whitehall/authority/rules/edition_rules.rb
@@ -87,6 +87,8 @@ module Whitehall::Authority::Rules
     end
 
     def can_with_a_historic_instance?(action)
+      return false if access_limit_enforced?
+
       action == :see || actor.gds_editor? || actor.gds_admin?
     end
 


### PR DESCRIPTION
This follows #10523.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
