### PR TITLE
Disable SQL query logs locally

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -9,6 +9,9 @@ Rails.application.configure do
   # Do not eager load code on boot.
   config.eager_load = false
 
+  # Disable noisy SQL query logs
+  config.log_level = :info
+
   # Show full error reports.
   config.consider_all_requests_local = true
   config.action_controller.action_on_unpermitted_parameters = :raise


### PR DESCRIPTION
These are VERY noisy and make it difficult to spot debug / puts statements when manually testing things.

We should disable this by default and only re-enable it when debugging database queries / bottlenecks.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
