### PR TITLE
Whit 2073 access limit documents to named editors

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -229,6 +229,7 @@ private
       :scheduled_publication,
       :lock_version,
       :access_limited,
+      :access_limited_named_users,
       :alternative_format_provider_id,
       :opening_at,
       :closing_at,

--- a/app/models/concerns/edition/limited_access.rb
+++ b/app/models/concerns/edition/limited_access.rb
@@ -2,6 +2,8 @@ module Edition::LimitedAccess
   extend ActiveSupport::Concern
 
   included do
+    enum :access_limited, { disabled: 0, organisations: 1, named_users: 2 }
+    has_many :edition_user_accesses, dependent: :destroy, inverse_of: :edition
     after_initialize :set_access_limited
   end
 
@@ -16,15 +18,22 @@ module Edition::LimitedAccess
   end
 
   def access_limited?
-    self[:access_limited]
+    organisations? || named_users?
   end
 
   delegate :access_limited_by_default?, to: :class
 
+  def access_limited=(value)
+    @_access_limited_explicitly_set = true
+    super
+  end
+
   def set_access_limited
-    if new_record? && access_limited.nil?
-      self.access_limited = access_limited_by_default?
-    end
+    return unless new_record?
+    return if @_access_limited_explicitly_set
+
+    self.access_limited = access_limited_by_default? ? :organisations : :disabled
+    @_access_limited_explicitly_set = false
   end
 
   def accessible_to?(user)

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -472,6 +472,16 @@ class Edition < ApplicationRecord
     end
   end
 
+  def access_limited_named_users=(users)
+    return unless Flipflop.enabled?(:access_limited_named_users)
+
+    user_emails = users.split(",").map(&:strip).reject(&:empty?)
+
+    user_emails.each do |email|
+      edition_user_accesses.create!(email: email)
+    end
+  end
+
 private
 
   def date_for_government

--- a/app/models/edition_user_access.rb
+++ b/app/models/edition_user_access.rb
@@ -1,0 +1,16 @@
+class EditionUserAccess < ApplicationRecord
+  belongs_to :edition, inverse_of: :edition_user_accesses
+
+  validates :email,
+            presence: true,
+            uniqueness: { scope: :edition_id, case_sensitive: false },
+            format: { with: URI::MailTo::EMAIL_REGEXP }
+
+  before_destroy :prevent_destroy_if_locked
+
+private
+
+  def prevent_destroy_if_locked
+    throw(:abort) if locked?
+  end
+end

--- a/app/services/edition_publisher.rb
+++ b/app/services/edition_publisher.rb
@@ -26,7 +26,7 @@ private
 
   def prepare_edition
     flag_if_political_content!
-    edition.access_limited = false
+    edition.access_limited = :disabled
     edition.major_change_published_at = Time.zone.now unless edition.minor_change?
     edition.make_public_at(edition.major_change_published_at)
     edition.increment_version_number

--- a/app/views/admin/editions/_access_limiting_fields.html.erb
+++ b/app/views/admin/editions/_access_limiting_fields.html.erb
@@ -1,22 +1,42 @@
 <div class="govuk-!-margin-bottom-6">
-  <%= render "govuk_publishing_components/components/fieldset", {
-    legend_text: "Limit access",
-    heading_level: 3,
-    heading_size: "m",
-  } do %>
-    <%= form.hidden_field :access_limited, value: "0" %>
-
-    <%= render "govuk_publishing_components/components/checkboxes", {
+    <%= render "govuk_publishing_components/components/radio", {
+      heading: "Limit access",
       name: "edition[access_limited]",
       id: "edition_access_limited",
-      error_items: errors_for(edition.errors, :access_limited),
       items: [
         {
-          label: "Limit access to publishers from organisations associated with this document before you publish",
-          value: 1,
-          checked: edition.access_limited,
+          value: :disabled,
+          text: "No – This document should be available to all publishers",
+          bold: true,
+          checked: edition.disabled?,
         },
-      ],
+        {
+          value: :organisations,
+          text: "Limit access to publishers from organisations associated with this document",
+          bold: true,
+          checked: edition.organisations?,
+        },
+        (
+          Flipflop.enabled?(:access_limited_named_users) ?
+          {
+            value: :named_users,
+            text: "Limit access to named publishers",
+            bold: true,
+            checked: edition.named_users?,
+            conditional: render("govuk_publishing_components/components/textarea", {
+              label: {
+                text: "Add publishers who will have access",
+                bold: true,
+              },
+              name: "edition[access_limited_named_users]",
+              textarea_id: "edition_access_limited_named_users",
+              error_message: nil,
+              value: nil,
+              hint: "Add the emails of the publishers who will have access to this document before publishing. After publishing the document will be available to all publishers in the organisation associated with this document",
+            }),
+          }
+          : nil
+        ),
+      ].compact,
     } %>
-  <% end %>
 </div>

--- a/config/features.rb
+++ b/config/features.rb
@@ -33,4 +33,7 @@ Flipflop.configure do
   feature :configurable_document_types,
           description: "Enable 'in development' config-driven document types (alongside the 'live' ones)",
           default: Rails.env.development?
+  feature :access_limited_named_users,
+          description: "Allow documents to be access-limited to specific named editors by email",
+          default: false
 end

--- a/db/migrate/20260506100009_migrate_access_limited_to_integer_enum.rb
+++ b/db/migrate/20260506100009_migrate_access_limited_to_integer_enum.rb
@@ -1,0 +1,13 @@
+class MigrateAccessLimitedToIntegerEnum < ActiveRecord::Migration[8.0]
+  def up
+    safety_assured do
+      change_column :editions, :access_limited, :integer, null: false, default: 0
+    end
+  end
+
+  def down
+    safety_assured do
+      change_column :editions, :access_limited, :boolean, null: false
+    end
+  end
+end

--- a/db/migrate/20260507120000_create_edition_user_accesses.rb
+++ b/db/migrate/20260507120000_create_edition_user_accesses.rb
@@ -1,0 +1,12 @@
+class CreateEditionUserAccesses < ActiveRecord::Migration[8.0]
+  def change
+    create_table :edition_user_accesses do |t|
+      t.references :edition, type: :integer, null: false, foreign_key: true
+      t.string :email, null: false
+      t.boolean :locked, null: false, default: false
+      t.timestamps
+    end
+
+    add_index :edition_user_accesses, %i[edition_id email], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_03_161913) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_07_120000) do
   create_table "assets", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.bigint "assetable_id"
@@ -327,6 +327,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_03_161913) do
     t.index ["locale"], name: "index_edition_translations_on_locale"
   end
 
+  create_table "edition_user_accesses", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "edition_id", null: false
+    t.string "email", null: false
+    t.boolean "locked", default: false, null: false
+    t.datetime "updated_at", null: false
+    t.index ["edition_id", "email"], name: "index_edition_user_accesses_on_edition_id_and_email", unique: true
+    t.index ["edition_id"], name: "index_edition_user_accesses_on_edition_id"
+  end
+
   create_table "edition_world_locations", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.datetime "created_at", precision: nil
     t.integer "edition_id"
@@ -347,7 +357,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_03_161913) do
   end
 
   create_table "editions", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.boolean "access_limited", null: false
+    t.integer "access_limited", default: 0, null: false
     t.string "additional_related_mainstream_content_title"
     t.string "additional_related_mainstream_content_url"
     t.boolean "all_nation_applicability", default: true
@@ -1228,6 +1238,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_03_161913) do
 
   add_foreign_key "documents", "editions", column: "latest_edition_id", on_update: :cascade, on_delete: :nullify
   add_foreign_key "documents", "editions", column: "live_edition_id", on_update: :cascade, on_delete: :nullify
+  add_foreign_key "edition_user_accesses", "editions"
   add_foreign_key "editions", "governments", on_delete: :nullify
   add_foreign_key "link_checker_api_report_links", "link_checker_api_reports"
   add_foreign_key "link_checker_api_reports", "editions"

--- a/features/admin-limit-access-editions.feature
+++ b/features/admin-limit-access-editions.feature
@@ -20,6 +20,6 @@ Feature: Viewing most recent editions in admin
     Given I am an editor
     When I begin drafting a new document
     And I set the Lead organisation to an org I am not in
-    And I check the "Limit access to publishers from organisations associated with this document before you publish" box
+    When I pick the "Limit access to publishers from organisations associated with this document" radio button
     When I click "Save"
     Then I should see the validation error "Access can only be limited by users belonging to an organisation tagged to the document"

--- a/features/step_definitions/admin_limit_access_steps.rb
+++ b/features/step_definitions/admin_limit_access_steps.rb
@@ -30,8 +30,8 @@ When(/^I set the Lead organisation to an org I am not in$/) do
   select @org.name, from: "edition_lead_organisation_ids_1"
 end
 
-When(/^I check the "(.+)" box$/) do |box_name|
-  check box_name
+When(/^I pick the "(.+)" radio button$/) do |radio_label|
+  choose radio_label
 end
 
 When(/^I click "(.+)"$/) do |button_name|

--- a/features/step_definitions/admin_statistics_announcements_steps.rb
+++ b/features/step_definitions/admin_statistics_announcements_steps.rb
@@ -6,7 +6,7 @@ Given(/^a draft statistics publication called "(.*?)"$/) do |title|
   @statistics_publication = create(
     :publication,
     :draft,
-    access_limited: false,
+    access_limited: :disabled,
     publication_type_id: PublicationType::OfficialStatistics.id,
     title:,
   )
@@ -16,9 +16,10 @@ Given(/^a published statistics publication called "(.*?)"$/) do |title|
   @statistics_publication = create(
     :publication,
     :published,
-    access_limited: false,
+    :statistics,
+    access_limited: :disabled,
     publication_type_id: PublicationType::OfficialStatistics.id,
-    title:,
+    title: title,
   )
 end
 

--- a/features/step_definitions/most_recent_editions_steps.rb
+++ b/features/step_definitions/most_recent_editions_steps.rb
@@ -10,7 +10,7 @@ When(/^someone else creates a new edition of the published document "([^"]*)" an
   current = Edition.find_by(title:).document.latest_edition
   new_draft = current.create_draft(random_editor)
   new_draft.organisations << org
-  new_draft.access_limited = true
+  new_draft.access_limited = :organisations
   new_draft.change_note = "Limited to #{org.name}"
   new_draft.save!
 end

--- a/test/components/admin/editions/tags_component_test.rb
+++ b/test/components/admin/editions/tags_component_test.rb
@@ -66,7 +66,7 @@ class Admin::Editions::TagsComponentTest < ViewComponent::TestCase
   end
 
   test "adds an access limited tag if edition has limited access" do
-    edition = build(:edition, access_limited: true)
+    edition = build(:edition, access_limited: 1)
 
     expected_output = "<span class=\"govuk-tag govuk-tag--s govuk-tag--blue\">Draft</span> " \
       "<span class=\"govuk-tag govuk-tag--s govuk-tag--red\">Limited access</span>"

--- a/test/factories/editions.rb
+++ b/test/factories/editions.rb
@@ -120,7 +120,7 @@ FactoryBot.define do
       scheduled_publication { 7.days.from_now }
     end
 
-    trait(:access_limited) { access_limited { true } }
+    trait(:access_limited) { access_limited { :organisations } }
 
     trait(:with_alternative_format_provider) do
       association :alternative_format_provider, factory: :organisation_with_alternative_format_contact_email

--- a/test/functional/admin/edition_access_limited_controller_test.rb
+++ b/test/functional/admin/edition_access_limited_controller_test.rb
@@ -19,7 +19,7 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
 
     edition = create(
       :consultation,
-      access_limited: true,
+      access_limited: :organisations,
       create_default_organisation: false,
       lead_organisations: [organisation],
     )
@@ -27,7 +27,7 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
     get :edit, params: { id: edition }
 
     assert_select "form[action='#{update_access_limited_admin_edition_path(edition.id)}']" do
-      assert_select "input[name='edition[access_limited]'][type=checkbox][checked=checked]"
+      assert_select "input[name='edition[access_limited]'][type=radio][checked=checked]"
       assert_select "textarea[name='edition[editorial_remark]']"
 
       (1..4).each do |i|
@@ -58,7 +58,7 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
 
     edition = create(
       :consultation,
-      access_limited: true,
+      access_limited: :organisations,
       create_default_organisation: false,
       lead_organisations: [first_organisation],
       supporting_organisations: [second_organisation],
@@ -75,7 +75,7 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
             lead_organisation_ids: [second_organisation.id],
             supporting_organisation_ids: [third_organisation.id],
             editorial_remark:,
-            access_limited: "1",
+            access_limited: :organisations,
           },
         }
 
@@ -92,7 +92,7 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
 
     edition = create(
       :consultation,
-      access_limited: true,
+      access_limited: :organisations,
       create_default_organisation: false,
       lead_organisations: [first_organisation],
       supporting_organisations: [second_organisation],
@@ -107,13 +107,13 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
             lead_organisation_ids: [first_organisation.id],
             supporting_organisation_ids: [second_organisation.id],
             editorial_remark:,
-            access_limited: "0",
+            access_limited: :disabled,
           },
         }
 
     assert_equal [first_organisation], edition.reload.lead_organisations
     assert_equal [second_organisation], edition.supporting_organisations
-    assert_not edition.access_limited
+    assert_not edition.reload.access_limited?
     assert_redirected_to admin_editions_path
     assert_equal "Access updated for #{edition.title}", flash[:notice]
     assert_equal "Access options updated by GDS Admin: #{editorial_remark}", edition.editorial_remarks.last.body
@@ -125,7 +125,7 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
 
     edition = create(
       :consultation,
-      access_limited: true,
+      access_limited: :organisations,
       create_default_organisation: false,
       lead_organisations: [first_organisation],
       supporting_organisations: [second_organisation],
@@ -138,13 +138,13 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
             lead_organisation_ids: [first_organisation.id],
             supporting_organisation_ids: [second_organisation.id],
             editorial_remark: "",
-            access_limited: "0",
+            access_limited: :disabled,
           },
         }
 
     assert_template :edit
     assert_equal ["Editorial remark cannot be blank"], assigns(:edition).errors.full_messages
-    assert edition.reload.access_limited
+    assert edition.reload.access_limited?
   end
 
   test "PATCH :update doesn't create an editorial remark or re-render with an error when nothing has changed" do
@@ -153,7 +153,7 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
 
     edition = create(
       :consultation,
-      access_limited: true,
+      access_limited: :organisations,
       create_default_organisation: false,
       lead_organisations: [first_organisation],
       supporting_organisations: [second_organisation],
@@ -166,7 +166,7 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
             lead_organisation_ids: [first_organisation.id],
             supporting_organisation_ids: [second_organisation.id],
             editorial_remark: "",
-            access_limited: "1",
+            access_limited: :organisations,
           },
         }
 

--- a/test/functional/admin/editions_controller_test.rb
+++ b/test/functional/admin/editions_controller_test.rb
@@ -286,10 +286,10 @@ class Admin::EditionsControllerTest < ActionController::TestCase
     login_as create(:writer, organisation: my_organisation)
     accessible = [
       create(:draft_publication),
-      create(:draft_publication, publication_type: PublicationType::NationalStatistics, access_limited: true, organisations: [my_organisation]),
-      create(:draft_publication, publication_type: PublicationType::NationalStatistics, access_limited: false, organisations: [other_organisation]),
+      create(:draft_publication, publication_type: PublicationType::NationalStatistics, access_limited: :organisations, organisations: [my_organisation]),
+      create(:draft_publication, publication_type: PublicationType::NationalStatistics, access_limited: :disabled, organisations: [other_organisation]),
     ]
-    inaccessible = create(:draft_publication, publication_type: PublicationType::NationalStatistics, access_limited: true, organisations: [other_organisation])
+    inaccessible = create(:draft_publication, publication_type: PublicationType::NationalStatistics, access_limited: :organisations, organisations: [other_organisation])
 
     get :index, params: { state: :active }
 
@@ -302,7 +302,7 @@ class Admin::EditionsControllerTest < ActionController::TestCase
   view_test "index should indicate the protected status of limited access editions which I do have access to" do
     my_organisation = create(:organisation)
     login_as create(:writer, organisation: my_organisation)
-    publication = create(:draft_publication, publication_type: PublicationType::NationalStatistics, access_limited: true, organisations: [my_organisation])
+    publication = create(:draft_publication, publication_type: PublicationType::NationalStatistics, access_limited: :organisations, organisations: [my_organisation])
 
     get :index, params: { state: :active }
 
@@ -314,7 +314,7 @@ class Admin::EditionsControllerTest < ActionController::TestCase
 
   view_test "GET :index admin do not see a view link, but are given a link to edit acccess controls when an access limited edition doesn't belong to their org" do
     login_as create(:gds_admin)
-    publication = create(:draft_publication, access_limited: true)
+    publication = create(:draft_publication, access_limited: :organisations)
 
     get :index, params: { state: :active }
 
@@ -330,7 +330,7 @@ class Admin::EditionsControllerTest < ActionController::TestCase
     my_organisation = create(:organisation)
     other_organisation = create(:organisation)
     login_as create(:writer, organisation: my_organisation)
-    inaccessible = create(:draft_publication, publication_type: PublicationType::NationalStatistics, access_limited: true, organisations: [other_organisation])
+    inaccessible = create(:draft_publication, publication_type: PublicationType::NationalStatistics, access_limited: :organisations, organisations: [other_organisation])
 
     post :revise, params: { id: inaccessible }
     assert_response :forbidden

--- a/test/functional/admin/editorial_remarks_controller_test.rb
+++ b/test/functional/admin/editorial_remarks_controller_test.rb
@@ -52,7 +52,7 @@ class Admin::EditorialRemarksControllerTest < ActionController::TestCase
   end
 
   test "should prevent access to inaccessible editions" do
-    protected_edition = create(:submitted_publication, access_limited: true)
+    protected_edition = create(:submitted_publication, access_limited: :organisations)
 
     get :new, params: { edition_id: protected_edition.id }
     assert_response :forbidden

--- a/test/functional/admin/external_attachments_controller_test.rb
+++ b/test/functional/admin/external_attachments_controller_test.rb
@@ -26,7 +26,7 @@ class Admin::ExternalAttachmentsControllerTest < ActionController::TestCase
   end
 
   test "POST :create ignores external attachments when attachable does not allow them" do
-    attachable = create(:statistical_data_set, access_limited: false)
+    attachable = create(:statistical_data_set, access_limited: :disabled)
 
     post :create, params: { edition_id: attachable, attachment: valid_external_attachment_params }
 

--- a/test/functional/admin/html_attachments_controller_test.rb
+++ b/test/functional/admin/html_attachments_controller_test.rb
@@ -54,7 +54,7 @@ class Admin::HtmlAttachmentsControllerTest < ActionController::TestCase
   end
 
   test "POST :create ignores html attachments when attachable does not allow them" do
-    attachable = create(:statistical_data_set, access_limited: false)
+    attachable = create(:statistical_data_set, access_limited: :disabled)
 
     post :create, params: { edition_id: attachable, attachment: valid_html_attachment_params }
 

--- a/test/functional/admin/publications_controller_test.rb
+++ b/test/functional/admin/publications_controller_test.rb
@@ -138,7 +138,7 @@ class Admin::PublicationsControllerTest < ActionController::TestCase
     my_organisation = create(:organisation)
     other_organisation = create(:organisation)
     @user = login_as(create(:user, organisation: my_organisation))
-    inaccessible = create(:draft_publication, publication_type: PublicationType::NationalStatistics, access_limited: true, organisations: [other_organisation])
+    inaccessible = create(:draft_publication, publication_type: PublicationType::NationalStatistics, access_limited: :organisations, organisations: [other_organisation])
 
     get :show, params: { id: inaccessible }
     assert_response :forbidden

--- a/test/integration/asset_access_options_integration_test.rb
+++ b/test/integration/asset_access_options_integration_test.rb
@@ -34,7 +34,7 @@ class AssetAccessOptionsIntegrationTest < ActionDispatch::IntegrationTest
       context "when document is marked as access limited in Whitehall" do
         before do
           visit edit_admin_edition_path(edition)
-          check "Limit access"
+          choose "Limit access to publishers from organisations associated with this document"
           click_button "Save"
           assert_text "Your document has been saved"
         end
@@ -71,7 +71,7 @@ class AssetAccessOptionsIntegrationTest < ActionDispatch::IntegrationTest
     end
 
     context "given an access-limited draft document" do
-      let(:edition) { create(:detailed_guide, organisations: [organisation], access_limited: true) }
+      let(:edition) { create(:detailed_guide, organisations: [organisation], access_limited: :organisations) }
 
       context "when an attachment is added to the draft document" do
         before do
@@ -153,7 +153,7 @@ class AssetAccessOptionsIntegrationTest < ActionDispatch::IntegrationTest
     end
 
     context "given an access-limited draft document and a file attachment" do
-      let(:edition) { create(:detailed_guide, organisations: [organisation], access_limited: true) }
+      let(:edition) { create(:detailed_guide, organisations: [organisation], access_limited: :organisations) }
 
       before do
         add_file_attachment_with_asset("sample.docx", to: edition)
@@ -163,7 +163,7 @@ class AssetAccessOptionsIntegrationTest < ActionDispatch::IntegrationTest
       context "when document is unmarked as access limited in Whitehall" do
         before do
           visit edit_admin_edition_path(edition)
-          uncheck "Limit access"
+          choose "No – This document should be available to all publishers"
           click_button "Save"
           assert_text "Your document has been saved"
         end
@@ -201,7 +201,7 @@ class AssetAccessOptionsIntegrationTest < ActionDispatch::IntegrationTest
 
     context "given a draft access-limited consultation" do
       # the edition has to have same organisation as logged in user, otherwise it's not visible when access_limited = true
-      let(:edition) { create(:consultation, organisations: [organisation], access_limited: true) }
+      let(:edition) { create(:consultation, organisations: [organisation], access_limited: :organisations) }
       let(:outcome_attributes) { FactoryBot.attributes_for(:consultation_outcome) }
       let!(:outcome) { edition.create_outcome!(outcome_attributes) }
 

--- a/test/integration/asset_manager_test.rb
+++ b/test/integration/asset_manager_test.rb
@@ -34,7 +34,7 @@ class AssetManagerIntegrationTest
 
     test "sends the user ids of authorised users to Asset Manager" do
       organisation = FactoryBot.create(:organisation)
-      consultation = FactoryBot.create(:consultation, access_limited: true, organisations: [organisation])
+      consultation = FactoryBot.create(:consultation, access_limited: :organisations, organisations: [organisation])
       @attachment.attachable = consultation
       @attachment.attachment_data.attachable = consultation
       @attachment.save!

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -952,7 +952,7 @@ module AdminEditionControllerTestHelpers
              params: {
                edition: controller_attributes_for(edition_type).merge(
                  first_published_at: Date.parse("2010-10-21"),
-                 access_limited: "1",
+                 access_limited: :organisations,
                  lead_organisation_ids: [organisation.id],
                ),
              }
@@ -963,26 +963,27 @@ module AdminEditionControllerTestHelpers
       end
 
       view_test "edit displays persisted access_limited flag" do
-        publication = create(edition_type, access_limited: false)
+        publication = create(edition_type, access_limited: :disabled)
 
         get :edit, params: { id: publication }
 
         assert_select "form#edit_edition" do
-          assert_select "input[name='edition[access_limited]'][type=checkbox]"
-          assert_select "input[name='edition[access_limited]'][type=checkbox][checked=checked]", count: 0
+          assert_select "input[name='edition[access_limited]'][type=radio]"
+          assert_select "input[name='edition[access_limited]'][type=radio][checked=checked]", count: 1
+          assert_select "input[name='edition[access_limited]'][type=radio][value=disabled][checked=checked]"
         end
       end
 
       test "update records new value of access_limited flag" do
         controller.current_user.organisation = create(:organisation)
         controller.current_user.save!
-        publication = create(edition_type, access_limited: false, organisations: [controller.current_user.organisation])
+        publication = create(edition_type, access_limited: :disabled, organisations: [controller.current_user.organisation])
 
         put :update,
             params: {
               id: publication,
               edition: {
-                access_limited: "1",
+                access_limited: :organisations,
               },
             }
 
@@ -993,13 +994,13 @@ module AdminEditionControllerTestHelpers
         controller.current_user.organisation = create(:organisation)
         controller.current_user.save!
         organisation = create(:organisation)
-        edition = create(edition_type, access_limited: false, organisations: [organisation])
+        edition = create(edition_type, access_limited: :disabled, organisations: [organisation])
 
         put :update,
             params: {
               id: edition,
               edition: {
-                access_limited: "1",
+                access_limited: :organisations,
               },
             }
 

--- a/test/unit/app/models/admin/edition_filter_test.rb
+++ b/test/unit/app/models/admin/edition_filter_test.rb
@@ -9,7 +9,7 @@ class Admin::EditionFilterTest < ActiveSupport::TestCase
     user = create(:user)
     edition = create(
       :publication,
-      access_limited: true,
+      access_limited: :organisations,
     )
     edition.organisations.first.users << user
 
@@ -18,14 +18,14 @@ class Admin::EditionFilterTest < ActiveSupport::TestCase
   end
 
   test "should not return editions which have limited access for other orgs for non-gds admins" do
-    create(:publication, access_limited: true)
+    create(:publication, access_limited: :organisations)
 
     filter = Admin::EditionFilter.new(Edition, build(:user))
     assert_equal 0, filter.editions.count
   end
 
   test "should return limited access editions for GDS admins" do
-    edition = create(:publication, access_limited: true)
+    edition = create(:publication, access_limited: :organisations)
 
     filter = Admin::EditionFilter.new(Edition, build(:gds_admin))
     assert_equal edition, filter.editions.first

--- a/test/unit/app/models/attachment_data_visibility_test.rb
+++ b/test/unit/app/models/attachment_data_visibility_test.rb
@@ -53,7 +53,7 @@ class AttachmentDataVisibilityTest < ActiveSupport::TestCase
 
         context "edition is access-limited" do
           before do
-            edition.access_limited = true
+            edition.access_limited = :organisations
             edition.save!
           end
 
@@ -85,7 +85,7 @@ class AttachmentDataVisibilityTest < ActiveSupport::TestCase
               context "new edition is access-limited" do
                 before do
                   new_edition.change_note = "change-note"
-                  new_edition.access_limited = true
+                  new_edition.access_limited = :organisations
                   new_edition.save!
                 end
 
@@ -221,7 +221,7 @@ class AttachmentDataVisibilityTest < ActiveSupport::TestCase
             context "new edition is access-limited" do
               before do
                 new_edition.change_note = "change-note"
-                new_edition.access_limited = true
+                new_edition.access_limited = :organisations
                 new_edition.save!
               end
 
@@ -359,7 +359,7 @@ class AttachmentDataVisibilityTest < ActiveSupport::TestCase
 
         context "consultation is access-limited" do
           before do
-            consultation.update!(access_limited: true)
+            consultation.update!(access_limited: :organisations)
           end
 
           it "is not accessible to anonymous user" do

--- a/test/unit/app/models/edition/edition_taggable_organisations_test.rb
+++ b/test/unit/app/models/edition/edition_taggable_organisations_test.rb
@@ -11,7 +11,7 @@ class EditionTaggableOrganisationTestForWorldOrganisations < ActiveSupport::Test
     edition = create(
       :publication,
       :draft,
-      access_limited: false,
+      access_limited: :disabled,
       publication_type_id: PublicationType::Guidance.id,
       organisations: [@lead_org],
     )
@@ -23,7 +23,7 @@ class EditionTaggableOrganisationTestForWorldOrganisations < ActiveSupport::Test
     edition = create(
       :publication,
       :draft,
-      access_limited: false,
+      access_limited: :disabled,
       publication_type_id: PublicationType::Form.id,
       organisations: [@lead_org],
     )
@@ -42,7 +42,7 @@ class EditionTaggableOrganisationTestForWorldOrganisations < ActiveSupport::Test
         :publication,
         :draft,
         title: "Title #{index}",
-        access_limited: false,
+        access_limited: :disabled,
         publication_type_id: publication_type.id,
         organisations: [@lead_org],
       )

--- a/test/unit/app/models/edition/limited_access_test.rb
+++ b/test/unit/app/models/edition/limited_access_test.rb
@@ -26,10 +26,10 @@ class Edition::LimitedAccessTest < ActiveSupport::TestCase
 
   test "can persist limited access flag (regardless of <class>.access_limited_by_default?)" do
     e = build(:limited_by_default_edition)
-    e.access_limited = true
+    e.access_limited = :organisations
     e.save!
     assert e.reload.access_limited?
-    e.access_limited = false
+    e.access_limited = :disabled
     e.save!
     assert_not e.reload.access_limited?
   end
@@ -49,7 +49,7 @@ class Edition::LimitedAccessTest < ActiveSupport::TestCase
   test "is not accessible if edition is not accessible to user" do
     user = build(:user)
     edition_id = 123
-    edition = LimitedAccessEdition.new(id: edition_id, access_limited: true)
+    edition = LimitedAccessEdition.new(id: edition_id, access_limited: :organisations)
 
     assert_not edition.accessible_to?(user)
   end

--- a/test/unit/app/models/edition_test.rb
+++ b/test/unit/app/models/edition_test.rb
@@ -1073,6 +1073,26 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal edition.other_editions, []
   end
 
+  test "access_limited_named_users= creates EditionUserAccess records when feature is enabled" do
+    edition = create(:edition)
+    Flipflop.stubs(:enabled?).with(:access_limited_named_users).returns(true)
+
+    edition.access_limited_named_users = "user1@example.com, user2@example.com"
+
+    assert_equal 2, edition.edition_user_accesses.count
+    assert_equal ["user1@example.com", "user2@example.com"],
+                 edition.edition_user_accesses.pluck(:email).sort
+  end
+
+  test "access_limited_named_users= does nothing when feature is disabled" do
+    edition = create(:edition)
+    Flipflop.stubs(:enabled?).with(:access_limited_named_users).returns(false)
+
+    edition.access_limited_named_users = "user1@example.com, user2@example.com"
+
+    assert_equal 0, edition.edition_user_accesses.count
+  end
+
   def decoded_token_payload(token)
     payload, _header = JWT.decode(
       token,

--- a/test/unit/app/models/publication_test.rb
+++ b/test/unit/app/models/publication_test.rb
@@ -122,18 +122,18 @@ class PublicationTest < ActiveSupport::TestCase
 
   test "new instances respect local access_limited over their publication_type" do
     limit_by_default, dont_limit_by_default = PublicationType.all.partition(&:access_limited_by_default?).map(&:first)
-    e = build(:draft_publication, publication_type: limit_by_default, access_limited: false)
+    e = build(:draft_publication, publication_type: limit_by_default, access_limited: :disabled)
     assert_not e.access_limited?
-    e = build(:draft_publication, publication_type: dont_limit_by_default, access_limited: true)
+    e = build(:draft_publication, publication_type: dont_limit_by_default, access_limited: :organisations)
     assert e.access_limited?
   end
 
   test "existing instances don't change access_limit when their publication_type does" do
     limit_by_default, dont_limit_by_default = PublicationType.all.partition(&:access_limited_by_default?).map(&:first)
-    e = create(:draft_publication, access_limited: false)
+    e = create(:draft_publication, access_limited: :disabled)
     e.publication_type = limit_by_default
     assert_not e.access_limited?
-    e = create(:draft_publication, access_limited: true)
+    e = create(:draft_publication, access_limited: :organisations)
     e.publication_type = dont_limit_by_default
     assert e.access_limited?
   end

--- a/test/unit/app/models/statistical_data_set_test.rb
+++ b/test/unit/app/models/statistical_data_set_test.rb
@@ -8,12 +8,12 @@ class StatisticalDataSetTest < ActiveSupport::TestCase
   end
 
   test "specifically limit access" do
-    data_set = build(:statistical_data_set, access_limited: true)
+    data_set = build(:statistical_data_set, access_limited: :organisations)
     assert data_set.access_limited?
   end
 
   test "specifically do not limit access" do
-    data_set = build(:statistical_data_set, access_limited: false)
+    data_set = build(:statistical_data_set, access_limited: :disabled)
     assert_not data_set.access_limited?
   end
 

--- a/test/unit/app/services/draft_edition_updater_test.rb
+++ b/test/unit/app/services/draft_edition_updater_test.rb
@@ -30,7 +30,7 @@ class DraftEditionUpdaterTest < ActiveSupport::TestCase
   end
 
   test "cannot perform if user is limiting their own access" do
-    edition = create(:draft_publication, access_limited: true, organisations: [create(:organisation)])
+    edition = create(:draft_publication, access_limited: :organisations, organisations: [create(:organisation)])
     updater = DraftEditionUpdater.new(edition, { current_user: create(:user, organisation: create(:organisation)) })
     updater.expects(:notify!).never
     updater.expects(:update_publishing_api!).never
@@ -40,7 +40,7 @@ class DraftEditionUpdaterTest < ActiveSupport::TestCase
 
   test "updates editions that cannot be tagged to organisations" do
     organisation = create(:organisation)
-    edition = create(:draft_corporate_information_page, organisation:, access_limited: true)
+    edition = create(:draft_corporate_information_page, organisation:, access_limited: :organisations)
     updater = DraftEditionUpdater.new(edition, { current_user: create(:user, organisation:) })
     updater.expects(:update_publishing_api!).once
     updater.expects(:notify!).once

--- a/test/unit/app/sidekiq/asset_manager_create_asset_job_test.rb
+++ b/test/unit/app/sidekiq/asset_manager_create_asset_job_test.rb
@@ -48,7 +48,7 @@ class AssetManagerCreateAssetJobTest < ActiveSupport::TestCase
   end
 
   test "marks attachments belonging to consultations as access limited" do
-    consultation = FactoryBot.create(:consultation, organisations: [@organisation], access_limited: true)
+    consultation = FactoryBot.create(:consultation, organisations: [@organisation], access_limited: :organisations)
     attachment = FactoryBot.create(:file_attachment, attachable: consultation)
     attachment.attachment_data.attachable = consultation
 
@@ -58,7 +58,7 @@ class AssetManagerCreateAssetJobTest < ActiveSupport::TestCase
   end
 
   test "marks attachments belonging to consultation responses as access limited" do
-    consultation = FactoryBot.create(:consultation, organisations: [@organisation], access_limited: true)
+    consultation = FactoryBot.create(:consultation, organisations: [@organisation], access_limited: :organisations)
     response = FactoryBot.create(:consultation_outcome, consultation:)
     attachment = FactoryBot.create(:file_attachment, attachable: response)
     attachment.attachment_data.attachable = consultation
@@ -202,7 +202,7 @@ class AssetManagerCreateAssetJobTest < ActiveSupport::TestCase
   end
 
   test "should not process the file if the attachable has been deleted" do
-    consultation = FactoryBot.create(:consultation, organisations: [@organisation], access_limited: true)
+    consultation = FactoryBot.create(:consultation, organisations: [@organisation], access_limited: :organisations)
     consultation.delete
     consultation.save!(validate: false)
 

--- a/test/unit/lib/whitehall/authority/authority_test_helper.rb
+++ b/test/unit/lib/whitehall/authority/authority_test_helper.rb
@@ -30,7 +30,7 @@ module AuthorityTestHelper
       fpe
     end
     define_method("limited_#{edition_type}") do |orgs|
-      le = FactoryBot.build(edition_type, access_limited: true)
+      le = FactoryBot.build(edition_type, access_limited: :organisations)
       le.stubs(:organisations).returns(orgs)
       le
     end


### PR DESCRIPTION
## Summary

Adds support for restricting access to an edition by specific publisher emails and replaces the `access_limited` boolean with an enum:

- `not_limited` (0)  
- `organisations` (1)  
- `named_users` (2)  

Editors can now choose **“Limit access to named publishers”** and provide a list of email addresses. 

---

## Feature flag

The named-user access UI is gated behind the `access_limited_named_users` Flipflop feature flag (`features.rb`).

This allows a safe, incremental release without exposing the feature immediately to all users.

---




https://github.com/user-attachments/assets/2da50119-c9c3-48c3-8872-14a961756701


