### PR TITLE
[WHIT-3323] Set slug columns to null for all `CorporateInformationPages`

### DIFF
--- a/db/data_migration/20260514130725_set_all_slug_related_columns_for_corporate_information_pages_to_null.rb
+++ b/db/data_migration/20260514130725_set_all_slug_related_columns_for_corporate_information_pages_to_null.rb
@@ -1,0 +1,1 @@
+Edition.where(type: "CorporateInformationPage").update_all(slug: nil, slug_from_title: nil, slug_override: nil)


### PR DESCRIPTION
The values in the slug-related columns  (`slug`, `slug_from_title`, `slug_override`) are never used by this model. This migration sets the columns to null to better signal the fact that they are not used.

Originally, code in the document model ensured slugs were always set to the Document ID, if not otherwise set via the slug setting logic (in the identifiable concern). CorporateInformationPages (CIP) historically had such document-ID-based slug values. Recent migrations to populate `slug` and `slug_from_title` have also overwritten the CIP columns with all sorts of values that are now misleading.

That document-ID-setting does not exist anymore, so, for models such as CIP where the slug setting logic is skipped, the slug will be set to nil on new drafts. This means that setting nil for historical slug will ensure all slugs, new and old, will have and retain nil slug columns.

CIPs exit the slug setting logic in the identifiable callback because they override the `string_for_slug` method to return nil. This is a way of saying "manages own slug". Better implementations to signal this might be possible, as well as more intentional slug setting - CIPs could use the slug_override logic to handle this. These changes would require additional FE changes. For now, making the columns null seems like the cheapest step to make CIP data clearer.

[Jira](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-3323)
