### PR TITLE
Make "requires_taxon?" a StandardEdition configurable thing [WHIT-3341]

### DIFF
--- a/app/models/concerns/standard_edition/taxon.rb
+++ b/app/models/concerns/standard_edition/taxon.rb
@@ -1,0 +1,7 @@
+module StandardEdition::Taxon
+  extend ActiveSupport::Concern
+
+  def requires_taxon?
+    type_instance.settings["taxon_required"]
+  end
+end

--- a/app/models/configurable_document_types/case_study.json
+++ b/app/models/configurable_document_types/case_study.json
@@ -110,6 +110,7 @@
     "organisations": null,
     "backdating_enabled": true,
     "history_mode_enabled": true,
+    "taxon_required": true,
     "translations_enabled": true
   }
 }

--- a/app/models/configurable_document_types/government_response.json
+++ b/app/models/configurable_document_types/government_response.json
@@ -126,6 +126,7 @@
     "organisations": null,
     "backdating_enabled": true,
     "history_mode_enabled": true,
+    "taxon_required": true,
     "translations_enabled": true
   }
 }

--- a/app/models/configurable_document_types/history_page.json
+++ b/app/models/configurable_document_types/history_page.json
@@ -88,6 +88,7 @@
     "backdating_enabled": false,
     "history_mode_enabled": false,
     "file_attachments_enabled": false,
+    "taxon_required": true,
     "translations_enabled": false
   }
 }

--- a/app/models/configurable_document_types/news_story.json
+++ b/app/models/configurable_document_types/news_story.json
@@ -126,6 +126,7 @@
     "organisations": null,
     "backdating_enabled": true,
     "history_mode_enabled": true,
+    "taxon_required": true,
     "translations_enabled": true
   }
 }

--- a/app/models/configurable_document_types/press_release.json
+++ b/app/models/configurable_document_types/press_release.json
@@ -126,6 +126,7 @@
     "organisations": null,
     "backdating_enabled": true,
     "history_mode_enabled": true,
+    "taxon_required": true,
     "translations_enabled": true
   }
 }

--- a/app/models/configurable_document_types/topical_event.json
+++ b/app/models/configurable_document_types/topical_event.json
@@ -199,6 +199,7 @@
     "organisations": null,
     "backdating_enabled": false,
     "history_mode_enabled": false,
+    "taxon_required": true,
     "translations_enabled": false
   }
 }

--- a/app/models/configurable_document_types/world_news_story.json
+++ b/app/models/configurable_document_types/world_news_story.json
@@ -111,6 +111,7 @@
     "organisations": null,
     "backdating_enabled": true,
     "history_mode_enabled": true,
+    "taxon_required": true,
     "translations_enabled": true
   }
 }

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -60,7 +60,7 @@ class Edition < ApplicationRecord
   validates_with LinkCheckReportValidator, on: :publish # TODO: make this a configurable StandardEdition property
   validates_with InternalPathLinksValidator, attribute: :body, on: :publish # TODO: make this a configurable StandardEdition property
   validates_with GovspeakContactEmbedValidator, attribute: :body, on: :publish, unless: ->(record) { record.is_a?(StandardEdition) }
-  validates_with TaxonValidator, on: :publish, if: :requires_taxon? # TODO: make this a configurable StandardEdition property
+  validates_with TaxonValidator, on: :publish, if: :requires_taxon?
 
   validates :creator, presence: true
   validates :title, presence: true, if: :title_required?, length: { maximum: 255 }

--- a/app/models/standard_edition.rb
+++ b/app/models/standard_edition.rb
@@ -11,6 +11,7 @@ class StandardEdition < Edition
   include Edition::WorldwideOrganisations
   include HasBlockContent
   include StandardEdition::LeadImage
+  include StandardEdition::Taxon
 
   FEATURED_DOCUMENTS_DISPLAY_LIMIT = 6
 

--- a/features/fixtures/test_configurable_document_type.json
+++ b/features/fixtures/test_configurable_document_type.json
@@ -196,6 +196,7 @@
     "rendering_app": "frontend",
     "organisations": null,
     "backdating_enabled": false,
+    "taxon_required": false,
     "translations_enabled": true,
     "file_attachments_enabled": true,
     "features_enabled": true,

--- a/features/fixtures/test_configurable_document_type_group.json
+++ b/features/fixtures/test_configurable_document_type_group.json
@@ -39,6 +39,7 @@
       "rendering_app": "frontend",
       "organisations": null,
       "backdating_enabled": false,
+      "taxon_required": false,
       "translations_enabled": true,
       "images": {
         "enabled": true,
@@ -96,6 +97,7 @@
       "organisations": null,
       "backdating_enabled": false,
       "translations_enabled": true,
+      "taxon_required": false,
       "images": {
         "enabled": true,
         "usages": {

--- a/features/step_definitions/standard_edition_steps.rb
+++ b/features/step_definitions/standard_edition_steps.rb
@@ -169,7 +169,7 @@ end
 Then(/^I am on the summary page of the draft titled "([^"]*)"$/) do |title|
   expect(page).to_not have_css(".govuk-error-summary")
   expect(page.find("h1")).to have_content(title)
-  expect(page).to have_content("Your document has been saved.")
+  expect(page).to have_content("Your document has been saved")
   expect(page).to have_content("Test configurable document type")
 end
 

--- a/public/configurable-document-type.schema.json
+++ b/public/configurable-document-type.schema.json
@@ -456,6 +456,10 @@
           "type": "boolean",
           "description": "Whether file attachments are allowed for this document type. When enabled, it renders the Attachments tab."
         },
+        "taxon_required": {
+          "type": "boolean",
+          "description": "Whether a taxon (topic or world) is required for this document type."
+        },
         "translations_enabled": {
           "type": "boolean",
           "description": "Whether translations are supported for this document type."
@@ -472,6 +476,7 @@
         "backdating_enabled",
         "history_mode_enabled",
         "file_attachments_enabled",
+        "taxon_required",
         "translations_enabled"
       ]
     }

--- a/test/fixtures/test_schema.json
+++ b/test/fixtures/test_schema.json
@@ -44,6 +44,7 @@
     "organisations": null,
     "backdating_enabled": true,
     "history_mode_enabled": true,
+    "taxon_required": true,
     "translations_enabled": true
   }
 }

--- a/test/unit/app/models/concerns/standard_edition/taxon_test.rb
+++ b/test/unit/app/models/concerns/standard_edition/taxon_test.rb
@@ -1,0 +1,29 @@
+require "test_helper"
+
+class StandardEdition::TaxonTest < ActiveSupport::TestCase
+  test "requires_taxon? returns true when taxon is required for the document type" do
+    test_type = build_configurable_document_type("test_type_with_taxon_required", {
+      "settings" => {
+        "taxon_required" => true,
+      },
+    })
+    ConfigurableDocumentType.setup_test_types(test_type)
+
+    edition = create(:standard_edition, configurable_document_type: "test_type_with_taxon_required")
+
+    assert edition.requires_taxon?
+  end
+
+  test "requires_taxon? returns false when taxon is not required for the document type" do
+    test_type = build_configurable_document_type("test_type_with_taxon_not_required", {
+      "settings" => {
+        "taxon_required" => false,
+      },
+    })
+    ConfigurableDocumentType.setup_test_types(test_type)
+
+    edition = create(:standard_edition, configurable_document_type: "test_type_with_taxon_not_required")
+
+    assert_not edition.requires_taxon?
+  end
+end


### PR DESCRIPTION
Topical Event About pages are not expected to be associated with any topic/world taxonomies. We therefore need a way of opting out of having to choose a topic taxon.

Having to stub the taxon validator is also a regular source of pain in local development. With this configuration option, devs can opt the content type out of taxons entirely.

NB: because Admin::EditionsController has the following code, I had to tweak the text that some tests were searching for, since previously the banner would say "Your document has been saved." (with period) and now says "Your document has been saved" (no period). See https://github.com/alphagov/whitehall/actions/runs/25808298805/job/75817207492?pr=11431

https://github.com/alphagov/whitehall/blob/995582dc9fe7e379ea352371e85d37f95074b105/app/controllers/admin/editions_controller.rb#L331-L341

Jira: https://gov-uk.atlassian.net/browse/WHIT-3341

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
