### PR TITLE
Block supporting org editors from locking themselves out [WHIT - 3458]

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -106,9 +106,17 @@ class Admin::EditionsController < Admin::BaseController
   end
 
   def update
-    @edition.assign_attributes(edition_params)
+    saved = ApplicationRecord.transaction do
+      @edition.assign_attributes(edition_params)
 
-    if updater.can_perform? && @edition.save_as(current_user)
+      if updater.can_perform? && @edition.save_as(current_user)
+        true
+      else
+        raise ActiveRecord::Rollback
+      end
+    end
+
+    if saved
       updater.perform!
 
       if @edition.link_check_report
@@ -409,6 +417,8 @@ private
     end
     if edition_params[:supporting_organisation_ids]
       edition_params[:supporting_organisation_ids] = edition_params[:supporting_organisation_ids].reject(&:blank?)
+    elsif edition_params.key?(:lead_organisation_ids)
+      edition_params[:supporting_organisation_ids] = []
     end
   end
 

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -106,17 +106,9 @@ class Admin::EditionsController < Admin::BaseController
   end
 
   def update
-    saved = ApplicationRecord.transaction do
-      @edition.assign_attributes(edition_params)
+    @edition.assign_attributes(edition_params)
 
-      if updater.can_perform? && @edition.save_as(current_user)
-        true
-      else
-        raise ActiveRecord::Rollback
-      end
-    end
-
-    if saved
+    if updater.can_perform? && @edition.save_as(current_user)
       updater.perform!
 
       if @edition.link_check_report
@@ -409,16 +401,32 @@ private
     end
   end
 
+  # TODO: not sure this is the way forward. We can't reset orgs to [] because some update calls will
+  # naturally omit orgs, and we get a whole bunch of failing tests.
+  # I'm also not convinced we should set supporting orgs to [] if lead_orgs association is present.
+  # Feels a bit unclean - if we wanted to configure 'supporting orgs only' then that should perhaps
+  # be possible.
+  # Instead it feels like we should have some mechanism for saying:
+  # - Here's the current edition
+  # - Here's what the edition will be if the save completes
+  # - Has the current user lost access in this transition? If so, raise validation error
   def delete_absent_edition_organisations
     return if edition_params.empty?
 
-    if edition_params[:lead_organisation_ids]
-      edition_params[:lead_organisation_ids] = edition_params[:lead_organisation_ids].reject(&:blank?)
+    if @edition.respond_to?(:lead_organisation_ids)
+      edition_params[:lead_organisation_ids] = if edition_params[:lead_organisation_ids].blank?
+                                                 []
+                                               else
+                                                 edition_params[:lead_organisation_ids].reject(&:blank?)
+                                               end
     end
-    if edition_params[:supporting_organisation_ids]
-      edition_params[:supporting_organisation_ids] = edition_params[:supporting_organisation_ids].reject(&:blank?)
-    elsif edition_params.key?(:lead_organisation_ids)
-      edition_params[:supporting_organisation_ids] = []
+
+    if @edition.respond_to?(:supporting_organisation_ids)
+      edition_params[:supporting_organisation_ids] = if edition_params[:supporting_organisation_ids].blank?
+                                                       []
+                                                     else
+                                                       edition_params[:supporting_organisation_ids].reject(&:blank?)
+                                                     end
     end
   end
 

--- a/test/functional/admin/standard_editions_controller_test.rb
+++ b/test/functional/admin/standard_editions_controller_test.rb
@@ -1181,6 +1181,45 @@ class Admin::StandardEditionsControllerTest < ActionController::TestCase
     assert_select "textarea[name='edition[block_content][sidebar]']", text: "My sidebar content"
   end
 
+  test "treats absence of supporting_organisation_ids as an empty array" do
+    login_as create(:user, organisation: nil)
+
+    configurable_document_type = build_configurable_document_type(
+      "test_type",
+      {
+        "forms" => {
+          "documents" => {
+            "fields" => {
+              "supporting_organisations" => {
+                "title" => "Supporting organisations",
+                "block" => "select_with_search_tagging",
+                "container" => "organisations",
+                "attribute_path" => %w[supporting_organisation_ids],
+                "translatable" => false,
+              },
+            },
+          },
+        },
+      },
+    )
+    ConfigurableDocumentType.setup_test_types(configurable_document_type)
+
+    edition = create(:standard_edition, configurable_document_type: "test_type", supporting_organisation_ids: [create(:organisation).id])
+    assert_not edition.supporting_organisation_ids.empty?
+
+    patch :update, params: {
+      id: edition,
+      edition: {
+        # minimal permitted attrs to avoid strong params rejection
+        title: edition.title,
+        summary: edition.summary,
+      },
+      save: "save",
+    }
+    assert_response :redirect
+    assert edition.reload.supporting_organisation_ids.empty?
+  end
+
   view_test "GET edit renders hidden current_tab field for the default tab when document type defines tabs" do
     configurable_document_type = build_configurable_document_type("test_type", {
       "forms" => {


### PR DESCRIPTION

Fixes a bug where users could unintentionally remove their own organisation’s access to a draft without receiving a warning, due to how empty multi-select fields are handled in HTML forms.

---

### Problem

While working on support, I encountered the following scenario:

1. An Org B user creates a draft publication with:
   - Org A as the lead organisation  
   - Org B as a supporting organisation  

2. The user later edits the draft and:
   - Enables "Limit access"
   - Changes the lead organisation to Org A only
   - Removes Org B from supporting organisations  

3. Due to HTML behavior:
   - `<select multiple>` fields submit nothing when empty
   - `supporting_organisation_ids` is missing from the payload entirely

---

### Root Cause

- In the controller:
  - `delete_absent_edition_organisations` detects the missing key
  - It skips processing
  - Org B remains in the in-memory `edition_organisations`

- In `DraftEditionUpdater`:
  - The "will this user retain access?" check runs against this in-memory state
  - Org B is still present, so access is assumed to be retained

- The save is allowed:
  - `access_limited = true`
  - Only Org A is persisted as the lead organisation

---

### Result

- The Org B user loses access
- No warning is shown during the edit process

---

### Fix

1. Handle missing multi-select params explicitly  
   - Treat absence of `supporting_organisation_ids` as "clear all values", not "no change"  

2. Wrap update flow in a transaction  
   - Encloses `assign_attributes` and `save`  
   - Ensures that if `can_perform?` returns false, all changes are rolled back, including side effects from attribute assignment  

[JIRA](https://gov-uk.atlassian.net/browse/WHIT-3458)
