### PR TITLE
Selectively allow unpublishing of historical editions [WHIT-3402]

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,6 +23,7 @@ class User < ApplicationRecord
     PUBLISH_SCHEDULED_EDITIONS = "Publish scheduled editions".freeze
     GDS_ADMIN = "GDS Admin".freeze
     SIDEKIQ_ADMIN = "Sidekiq Admin".freeze
+    UNPUBLISH_HISTORIC_CONTENT = "Unpublish historic content".freeze
   end
 
   def role
@@ -81,4 +82,8 @@ class User < ApplicationRecord
   end
 
   attr_writer :organisation_content_id
+
+  def can_unpublish_historic_content?
+    has_permission?(Permissions::UNPUBLISH_HISTORIC_CONTENT)
+  end
 end

--- a/lib/whitehall/authority/rules/edition_rules.rb
+++ b/lib/whitehall/authority/rules/edition_rules.rb
@@ -88,8 +88,16 @@ module Whitehall::Authority::Rules
 
     def can_with_a_historic_instance?(action)
       return false if access_limit_enforced?
+      return true if actor.gds_admin? || actor.gds_editor?
 
-      action == :see || actor.gds_editor? || actor.gds_admin?
+      case action
+      when :see
+        true
+      when :unpublish
+        actor.can_unpublish_historic_content?
+      else
+        false
+      end
     end
 
     def access_limit_enforced?

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -72,4 +72,12 @@ FactoryBot.define do
       ]
     end
   end
+
+  factory :historic_content_unpublisher, parent: :user do
+    permissions do
+      [
+        User::Permissions::UNPUBLISH_HISTORIC_CONTENT,
+      ]
+    end
+  end
 end

--- a/test/unit/lib/whitehall/authority/gds_admin_test.rb
+++ b/test/unit/lib/whitehall/authority/gds_admin_test.rb
@@ -35,8 +35,10 @@ class GDSAdminTest < ActiveSupport::TestCase
     assert enforcer_for(gds_admin, normal_edition).can?(:mark_political)
   end
 
-  test "can modify historic editions" do
-    assert enforcer_for(gds_admin, historic_edition).can?(:update)
+  test "can do anything to historic editions" do
+    Whitehall::Authority::Rules::EditionRules.actions.each do |action|
+      assert enforcer_for(gds_admin, historic_edition).can?(action)
+    end
   end
 
   test "can create social media accounts" do

--- a/test/unit/lib/whitehall/authority/gds_editor_test.rb
+++ b/test/unit/lib/whitehall/authority/gds_editor_test.rb
@@ -157,8 +157,10 @@ class GDSEditorTest < ActiveSupport::TestCase
     assert enforcer_for(gds_editor, normal_edition).can?(:mark_political)
   end
 
-  test "can modify historic editions" do
-    assert enforcer_for(gds_editor, historic_edition).can?(:update)
+  test "can do anything to historic editions" do
+    Whitehall::Authority::Rules::EditionRules.actions.each do |action|
+      assert enforcer_for(gds_editor, historic_edition).can?(action)
+    end
   end
 
   test "can create social media accounts" do

--- a/test/unit/lib/whitehall/authority/historic_content_unpublisher_test.rb
+++ b/test/unit/lib/whitehall/authority/historic_content_unpublisher_test.rb
@@ -1,0 +1,24 @@
+require_relative "authority_test_helper"
+
+class HistoricContentUnpublisherTest < ActiveSupport::TestCase
+  include AuthorityTestHelper
+
+  setup do
+    @user = create(:historic_content_unpublisher)
+  end
+
+  test "can see an historical document" do
+    assert enforcer_for(@user, historic_edition).can?(:see)
+  end
+
+  test "can unpublish an historical document" do
+    assert enforcer_for(@user, historic_edition).can?(:unpublish)
+  end
+
+  test "can't perform any other action on an historical document" do
+    denied_actions = Whitehall::Authority::Rules::EditionRules.actions - %i[see unpublish]
+    denied_actions.each do |action|
+      assert_not enforcer_for(@user, historic_edition).can?(action)
+    end
+  end
+end


### PR DESCRIPTION
Previously only GDS Editors and GDS Admins could unpublish historical content.  The DBT are about to unpublish and archive a lot of content, so an exception has been made to allow specific users outside of those two GDS roles to unpublish historic content.  See https://gov-uk.atlassian.net/browse/WHIT-3402

This change creates the relevant unpublishing permission and allows users with it to perform the unpublishing action for historic documents.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
