### PR TITLE
Remove extraneous 'Back' link [WHIT-3169]

### DIFF
--- a/app/views/admin/standard_editions/choose_type.html.erb
+++ b/app/views/admin/standard_editions/choose_type.html.erb
@@ -20,9 +20,7 @@
 
       <div class="govuk-button-group">
         <%= render "govuk_publishing_components/components/button", { text: "Next" } %>
-        <%= link_to("Back", admin_new_document_path, class: "govuk-link govuk-link--no-visited-state") %>
         <%= link_to("Cancel", root_path, class: "govuk-link govuk-link--no-visited-state") %>
-
       </div>
     <% end %>
   </div>


### PR DESCRIPTION
The UI is cluttered. We only need a 'Cancel' link - not both.

Jira: https://gov-uk.atlassian.net/browse/WHIT-3169

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
