### PR TITLE
Increase timeout for ImageProcessingChecker spec

### DIFF
--- a/spec/javascripts/admin/modules/image-processing-checker.spec.js
+++ b/spec/javascripts/admin/modules/image-processing-checker.spec.js
@@ -68,7 +68,7 @@ describe('GOVUK.Modules.ImageProcessingChecker', function () {
         'http://assets.gov.uk/media/960x640.png'
       )
       done()
-    }, imageProcessingTimeout * 2)
+    }, 100)
   })
 
   it('should replace the processing status with a specific image if `variant` specified', (done) => {
@@ -86,7 +86,7 @@ describe('GOVUK.Modules.ImageProcessingChecker', function () {
         'http://assets.gov.uk/media/s960_960x640.png'
       )
       done()
-    }, imageProcessingTimeout * 2)
+    }, 100)
   })
 
   it('should replace the processing status with the image preview after multiple attempts', (done) => {


### PR DESCRIPTION
## What

Increase the timeout for the ImageProcessingChecker spec.

## Why

Previously the tests that waited [a shorter amount of time would fail in CI](https://github.com/alphagov/whitehall/actions/runs/26026642235/job/76501569663). So therefore all the tests now wait the same amount of time.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
