### PR TITLE
Fix URL mapping for CaseStudy now it's migrated to StandardEdition

### DIFF
--- a/app/helpers/admin/base_path_helper.rb
+++ b/app/helpers/admin/base_path_helper.rb
@@ -3,7 +3,7 @@ require "uri"
 module Admin::BasePathHelper
   MAPPINGS = [
     { "CallForEvidence" => "/government/calls-for-evidence" },
-    { "CaseStudy" => "/government/case-studies" },
+    { "StandardEdition" => "/government/case-studies" },
     { "Consultation" => "/government/consultations" },
     { "DetailedGuide" => "/guidance" },
     { "DocumentCollection" => "/government/collections" },

--- a/test/unit/app/helpers/admin/base_path_helper_test.rb
+++ b/test/unit/app/helpers/admin/base_path_helper_test.rb
@@ -8,7 +8,7 @@ class Admin::BasePathHelperTest < ActionView::TestCase
   describe "#url_to_document_type" do
     test "it maps a URL to a document type" do
       assert_equal CallForEvidence, url_to_document_type("/government/calls-for-evidence/slug")
-      assert_equal CaseStudy, url_to_document_type("/government/case-studies/slug")
+      assert_equal StandardEdition, url_to_document_type("/government/case-studies/slug")
       assert_equal Consultation, url_to_document_type("/government/consultations/slug")
       assert_equal DetailedGuide, url_to_document_type("/guidance/slug")
       assert_equal DocumentCollection, url_to_document_type("/government/collections/slug")


### PR DESCRIPTION
When we bulk update the organisations that are tagged to a given CSV of documents, we use this BasePathHelper to help with looking up the Edition based on the document's URL. It saves the publisher from having to provide the document types ahead of time.

CaseStudy was recently moved to StandardEdition so its mapping needs updating accordingly.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
