### PR TITLE
Remove references to news articles in edition-form.spec.js

### DIFF
--- a/spec/javascripts/admin/modules/edition-form.spec.js
+++ b/spec/javascripts/admin/modules/edition-form.spec.js
@@ -15,7 +15,7 @@ describe('GOVUK.Modules.EditionForm', function () {
     })
 
     it('should render subtype guidance based when the subtype format select changes value', function () {
-      const select = form.querySelector('#edition_news_article_type_id')
+      const select = form.querySelector('#edition_group_type_id')
 
       select.value = '1'
       select.dispatchEvent(new Event('change'))
@@ -24,12 +24,12 @@ describe('GOVUK.Modules.EditionForm', function () {
       )
 
       expect(subtypeAdvice.innerHTML).toBe(
-        '<strong>Use this subformat for…</strong> <p>News written exclusively for GOV.UK which users need, can act on and can’t get from other sources. Avoid duplicating press releases.</p>'
+        '<strong>Use this subformat for…</strong> <p>First subtype.</p>'
       )
     })
 
     it('should remove subtype guidance when the subtype format select is unselected', function () {
-      const select = form.querySelector('#edition_news_article_type_id')
+      const select = form.querySelector('#edition_group_type_id')
 
       select.value = '1'
       select.dispatchEvent(new Event('change'))
@@ -213,15 +213,15 @@ describe('GOVUK.Modules.EditionForm', function () {
 
   function subtypeFields() {
     return (
-      '<div class="app-view-edition-form__subtype-fields js-app-view-edition-form__subtype-fields" data-format-advice="{&quot;1&quot;:&quot;\u003cp\u003eNews written exclusively for GOV.UK which users need, can act on and can’t get from other sources. Avoid duplicating press releases.\u003c/p\u003e&quot;,&quot;2&quot;:&quot;\u003cp\u003eUnedited press releases as sent to the media, and official statements from the organisation or a minister.\u003c/p\u003e\u003cp\u003eDo \u003cem\u003enot\u003c/em\u003e use for: statements to Parliament. Use the ‘Speech’ format for those.\u003c/p\u003e&quot;,&quot;3&quot;:&quot;\u003cp\u003eGovernment statements in response to media coverage, such as rebuttals and ‘myth busters’.\u003c/p\u003e\u003cp\u003eDo \u003cem\u003enot\u003c/em\u003e use for: statements to Parliament. Use the \'Speech\' format for those.\u003c/p\u003e&quot;,&quot;4&quot;:&quot;\u003cp\u003eAnnouncements specific to one or more world location. Do not duplicate news published by another department.\u003c/p\u003e&quot;}">' +
+      '<div class="app-view-edition-form__subtype-fields js-app-view-edition-form__subtype-fields" data-format-advice="{&quot;1&quot;:&quot;\u003cp\u003eFirst subtype.\u003c/p\u003e&quot;,&quot;2&quot;:&quot;\u003cp\u003eSecond subtype.\u003c/p\u003e&quot;,&quot;3&quot;:&quot;\u003cp\u003eThird subtype.\u003c/p\u003e&quot;,&quot;4&quot;:&quot;\u003cp\u003eFourth subtype\u003c/p\u003e&quot;}">' +
       '<div class="govuk-form-group gem-c-select">' +
-      '<label class="govuk-label govuk-label--s" for="edition_news_article_type_id">News article type</label>' +
-      '<select name="edition[news_article_type_id]" id="edition_news_article_type_id" class="govuk-select gem-c-select__select--full-width">' +
+      '<label class="govuk-label govuk-label--s" for="edition_group_type_id">Document subtype</label>' +
+      '<select name="edition[group_type_id]" id="edition_group_type_id" class="govuk-select gem-c-select__select--full-width">' +
       '<option value=""></option>' +
-      '<option value="1">News story</option>' +
-      '<option value="2">Press release</option>' +
-      '<option value="3">Government response</option>' +
-      '<option value="4">World news story</option></select>' +
+      '<option value="1">Option 1</option>' +
+      '<option value="2">Option 2</option>' +
+      '<option value="3">Option 3</option>' +
+      '<option value="4">Option 4</option></select>' +
       '</div>' +
       '</div>'
     )


### PR DESCRIPTION
It is only fixture data but it's still confusing / worrying to see references to News Article subtypes when we've gone to a lot of effort to remove them! This commit updates the fixture data to be more generic.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
