### PR TITLE
[WHIT-3424] Restore Welsh translations for corporate information

### DIFF
--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -37,3 +37,10 @@ cy:
       jobs: Swyddi
       jobs_and_contacts: Swyddi a chontractau
       organisation_chart: Ein siart sefydliadol
+  worldwide_organisation:
+    corporate_information:
+      about_our_services_html: Darganfod %{link}.
+      personal_information_charter_html: Mae ein %{link} yn esbonio sut rydyn ni'n ymdrin â'ch gwybodaeth bersonol.
+      publication_scheme_html: Darllenwch am y mathau o wybodaeth rydyn ni'n eu cyhoeddi'n rheolaidd yn ein %{link}.
+      social_media_use_html: Darllenwch ein polisi ar %{link}.
+      welsh_language_scheme_html: Dysgwch am ein hymrwymiad i %{link}.


### PR DESCRIPTION
A bulk cleanup (3b7e550a (https://github.com/alphagov/whitehall/commit/3b7e550a22)) deleted cy.yml and 64 other locale files on the basis that Whitehall's UI is hardcoded English and the files were considered unused. This assumption was incorrect and we have restored most of the Welsh back. These were missed from earlier restorations:

  - about_our_services_html
  - personal_information_charter_html
  - publication_scheme_html
  - social_media_use_html
  - welsh_language_scheme_html

This PR brings those back to fix missing translations in the corporate information section.