### PR TITLE
Display only publications in `in_pre_publication_state` in `EditionFilter` of `StatisticsAnnouncementPublicationController` [WHIT-3132]

### DIFF
--- a/app/controllers/admin/statistics_announcement_publications_controller.rb
+++ b/app/controllers/admin/statistics_announcement_publications_controller.rb
@@ -25,7 +25,7 @@ private
   end
 
   def edition_scope
-    Edition.with_translations(I18n.locale)
+    Edition.with_translations(I18n.locale).in_pre_publication_state
   end
 
   def params_filters

--- a/features/admin-statistics-announcements.feature
+++ b/features/admin-statistics-announcements.feature
@@ -55,7 +55,13 @@ Feature: Statistical release announcements
     Then I should see a warning that there are upcoming releases without a linked publication
     And I should be able to view these upcoming releases without a linked publication
 
-  Scenario: linking a document to a statistics announcement
+  Scenario: attempting to link a document to a published statistics announcement
+    Given I am a GDS editor in the organisation "Department for Beards"
+    And a published statistics publication called "Beard statistics - January 2014"
+    And a statistics announcement called "January's beard statistics" exists
+    Then I should not be able to link the announcement to the publication
+
+  Scenario: linking a document to a draft statistics announcement
     Given I am a GDS editor in the organisation "Department for Beards"
     And a draft statistics publication called "Beard statistics - January 2014"
     And a statistics announcement called "January's beard statistics" exists

--- a/features/step_definitions/admin_statistics_announcements_steps.rb
+++ b/features/step_definitions/admin_statistics_announcements_steps.rb
@@ -12,6 +12,16 @@ Given(/^a draft statistics publication called "(.*?)"$/) do |title|
   )
 end
 
+Given(/^a published statistics publication called "(.*?)"$/) do |title|
+  @statistics_publication = create(
+    :publication,
+    :published,
+    access_limited: false,
+    publication_type_id: PublicationType::OfficialStatistics.id,
+    title:,
+  )
+end
+
 Given(/^there is a statistics announcement by my organisation$/) do
   @organisation_announcement = create(:statistics_announcement, organisation_ids: [@user.organisation.id])
 end
@@ -95,6 +105,17 @@ When(/^I link the announcement to the publication$/) do
   click_on "Search"
 
   find(".govuk-link", text: "Connect").click
+end
+
+Then("I should not be able to link the announcement to the publication") do
+  visit admin_statistics_announcement_path(@statistics_announcement)
+
+  click_on "Add existing document"
+
+  fill_in "title", with: "statistics"
+  click_on "Search"
+
+  expect(page).to_not have_selector(".govuk-link", text: "Connect")
 end
 
 Then(/^I should see that the announcement is linked to the publication$/) do

--- a/test/functional/admin/statistics_announcement_publications_controller_test.rb
+++ b/test/functional/admin/statistics_announcement_publications_controller_test.rb
@@ -33,7 +33,7 @@ class Admin::StatisticsAnnouncementPublicationsControllerTest < ActionController
   test "GET :index with search value passes title and default params to filter" do
     default_filter_params_with_title = @default_filter_params.merge(title: @title)
 
-    Admin::EditionFilter.expects(:new).with([@official_statistics_publication], @user, default_filter_params_with_title)
+    Admin::EditionFilter.expects(:new).with(Edition.with_translations(I18n.locale).in_pre_publication_state, @user, default_filter_params_with_title)
 
     get :index, params: { statistics_announcement_id: @official_statistics_announcement, title: @title }
   end


### PR DESCRIPTION
## What

- Update filter of `StatisticsAnnouncementPublicationController`

## Why

Only present to the user unpublished editions in the results page for filtering documents to connect to a `StatisticsAnnouncement`. This prevents a user connecting a published edition which had unintended consequences.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
