### PR TITLE
[WHIT-3439] Gate /component-guide behind GOV.UK Signon

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -453,5 +453,7 @@ Whitehall::Application.routes.draw do
 
   mount Flipflop::Engine => "/flipflop"
 
-  mount GovukPublishingComponents::Engine, at: "/component-guide"
+  constraints(GDS::SSO::AuthorisedUserConstraint.new(User::Permissions::SIGNIN)) do
+    mount GovukPublishingComponents::Engine, at: "/component-guide"
+  end
 end

--- a/test/integration/component_guide_test.rb
+++ b/test/integration/component_guide_test.rb
@@ -1,0 +1,15 @@
+require "test_helper"
+
+class ComponentGuideTest < ActionDispatch::IntegrationTest
+  test "redirects unauthenticated users to signon" do
+    ENV["GDS_SSO_MOCK_INVALID"] = "1"
+    get "/component-guide"
+    assert_redirected_to "/auth/gds"
+  end
+
+  test "allows access when signed in" do
+    login_as_admin
+    get "/component-guide"
+    assert_response :success
+  end
+end


### PR DESCRIPTION
## Summary

Wraps the `GovukPublishingComponents::Engine` mount in a `GDS::SSO::AuthorisedUserConstraint` so `/component-guide` requires a signed-in Whitehall user.

This keeps the guide available in all environments — per [commit `8b3a40aad6`](https://github.com/alphagov/whitehall/commit/8b3a40aad6) (Feb 2025) that removed the dev-only gate — while ensuring it is no longer publicly accessible. The `signin` permission is the universal "logged in and authorised for this app" permission, so was used for the route constraint.

[Jira](https://gov-uk.atlassian.net/browse/WHIT-3439)
## Test plan

- [x] After deploy to integration: confirm 302→signon for anonymous and 200 for authenticated, including sub-routes (`/component-guide/button`, `/component-guide/button/preview`)