### PR TITLE
Allow unpublishing of historic content in `HistoricContentConcern` [WHIT-3402]

### DIFF
--- a/app/controllers/admin/edition_workflow_controller.rb
+++ b/app/controllers/admin/edition_workflow_controller.rb
@@ -2,7 +2,8 @@ class Admin::EditionWorkflowController < Admin::BaseController
   include HistoricContentConcern
 
   before_action :find_edition
-  before_action :forbid_editing_of_historic_content!
+  before_action :forbid_editing_of_historic_content!, except: %i[confirm_unpublish unpublish]
+  before_action :forbid_unpublishing_of_historic_content!, only: %i[confirm_unpublish unpublish]
   before_action :enforce_permissions!
   before_action :limit_edition_access!
   before_action :lock_edition

--- a/app/controllers/concerns/historic_content_concern.rb
+++ b/app/controllers/concerns/historic_content_concern.rb
@@ -5,8 +5,19 @@ module HistoricContentConcern
     # We do this rather than relying on `enforce_permissions!` to be able
     # to redirect with a nice message rather than just "permission denied".
     if @edition.historic? && !can?(:update, @edition)
-      redirect_to [:admin, @edition],
-                  { flash: { alert: "This document is in <a href='https://www.gov.uk/guidance/how-to-publish-on-gov-uk/creating-and-updating-pages#history-mode' class='govuk-link'>history mode</a>. Please contact your GOV.UK lead or managing editor if you need to change it.", html_safe: true } }
+      redirect_to [:admin, @edition], forbidden_flash_msg
     end
+  end
+
+  def forbid_unpublishing_of_historic_content!
+    if @edition.historic? && !can?(:unpublish, @edition)
+      redirect_to [:admin, @edition], forbidden_flash_msg
+    end
+  end
+
+private
+
+  def forbidden_flash_msg
+    { flash: { alert: "This document is in <a href='https://www.gov.uk/guidance/how-to-publish-on-gov-uk/creating-and-updating-pages#history-mode' class='govuk-link'>history mode</a>. Please contact your GOV.UK lead or managing editor if you need to change it.", html_safe: true } }
   end
 end

--- a/test/functional/admin/edition_workflow_controller_test.rb
+++ b/test/functional/admin/edition_workflow_controller_test.rb
@@ -419,6 +419,29 @@ class Admin::EditionWorkflowControllerTest < ActionController::TestCase
     assert_response :forbidden
   end
 
+  test "historic content unpublishers can confirm the unpublishing" do
+    login_as(create(:historic_content_unpublisher))
+    edition = historic_edition
+    get :confirm_unpublish, params: { id: edition.id, lock_version: edition.lock_version }
+
+    assert_response :success
+    assert_template :confirm_unpublish
+    assert_equal edition, assigns(:edition)
+  end
+
+  test "historic content unpublishers can unpublish" do
+    login_as create(:historic_content_unpublisher)
+    unpublish_params = {
+      unpublishing_reason_id: UnpublishingReason::PublishedInError.id,
+      explanation: "test reason",
+    }
+    post :unpublish, params: { id: historic_edition.id, lock_version: historic_edition.lock_version, unpublishing: unpublish_params }
+
+    assert_response :redirect
+    assert_equal "This document has been unpublished and will no longer appear on the public website", flash[:notice]
+    assert_equal "test reason", historic_edition.reload.unpublishing.explanation
+  end
+
 private
 
   def submitted_edition(options = {})
@@ -435,5 +458,11 @@ private
 
   def withdrawn_edition
     @withdrawn_edition ||= create(:withdrawn_publication, major_change_published_at: Time.zone.now)
+  end
+
+  def historic_edition
+    previous_government = create(:previous_government)
+    create(:current_government)
+    @historic_edition ||= create(:published_publication, { political: true, first_published_at: previous_government.start_date, government_id: previous_government.id })
   end
 end


### PR DESCRIPTION
The `HistoricContentConcern` previously prevented any user without permission to `update` a historical edition from doing anything to it at all, since the `before_action` was called for every action.

This was correct (and mostly still is), but now we want some users to be able to unpublish historical content but not otherwise edit it.

This change (along with #11456) allows that by
- creating a new `before_action` restriction that checks the user can unpublish (rather than update) historical content
- applies the new restriction only for the unpublish and confirmation routes
- applies the existing editing restriction to the other, non-unpublishing related routes

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
