### PR TITLE
[WHIT-3425] Add Welsh translation for non-ministerial department pages

### DIFF
--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -10,6 +10,17 @@ module OrganisationHelper
     /building law and hygiene/,
   ].freeze
 
+  SPONSORED_TYPE_KEYS = %i[
+    advisory_ndpb
+    executive_agency
+    executive_ndpb
+    special_health_authority
+  ].freeze
+
+  IDENTIFICATION_ONLY_TYPE_KEYS = %i[
+    non_ministerial_department
+  ].freeze
+
   def organisation_relationship_display_name(organisation)
     if organisation.acronym.present?
       tag.abbr(organisation.acronym, title: organisation.name)
@@ -33,29 +44,46 @@ module OrganisationHelper
   end
 
   def organisation_display_name_and_parental_relationship(organisation)
-    name = ERB::Util.h(organisation_relationship_display_name(organisation)).strip
-    type_name = organisation_type_name(organisation)
-    relationship = ERB::Util.h(add_indefinite_article(type_name))
-    parents = organisation.parent_organisations.map { |parent| organisation_relationship_html(parent) }
+    type_key = organisation.organisation_type_key
+    parent_organisations = organisation.parent_organisations
 
-    description = if parents.any?
-                    case type_name
-                    when "other"
-                      "#{name} works with #{parents.to_sentence}."
-                    when "non-ministerial department"
-                      "#{name} is #{relationship}."
-                    when "sub-organisation"
-                      "#{name} is part of #{parents.to_sentence}."
-                    when "executive non-departmental public body", "advisory non-departmental public body", "executive agency", "special health authority"
-                      "#{name} is #{relationship}, sponsored by #{parents.to_sentence}."
-                    else
-                      "#{name} is #{relationship} of #{parents.to_sentence}."
-                    end
-                  else
-                    type_name != "other" ? "#{name} is #{relationship}." : name.to_s
-                  end
+    relationship_description(organisation, type_key, parent_organisations).html_safe
+  end
 
-    description.html_safe
+  def relationship_description(organisation, type_key, parent_organisations)
+    key = relationship_i18n_key(type_key, parent_organisations)
+    args = relationship_template_args(organisation, type_key)
+    args[:parents] = parents_sentence(parent_organisations) if display_parent_relationships?(type_key, parent_organisations)
+    I18n.t(key, **args)
+  end
+
+  def relationship_i18n_key(type_key, parent_organisations)
+    return "organisation.relationship.none_html" if type_key == :other && parent_organisations.empty?
+    return "organisation.relationship.identification_html" unless display_parent_relationships?(type_key, parent_organisations)
+
+    case type_key
+    when :other then "organisation.relationship.works_with_html"
+    when :sub_organisation then "organisation.relationship.part_of_html"
+    when *SPONSORED_TYPE_KEYS then "organisation.relationship.sponsored_html"
+    else "organisation.relationship.default_with_parents_html"
+    end
+  end
+
+  def display_parent_relationships?(type_key, parent_organisations)
+    parent_organisations.any? && IDENTIFICATION_ONLY_TYPE_KEYS.exclude?(type_key)
+  end
+
+  def relationship_template_args(organisation, type_key)
+    localised_type_name = I18n.t("organisation.type.#{type_key}", default: organisation_type_name(organisation))
+    {
+      name: ERB::Util.h(organisation_relationship_display_name(organisation)).strip,
+      type_name: ERB::Util.h(localised_type_name),
+      relationship: ERB::Util.h(add_indefinite_article(localised_type_name)),
+    }
+  end
+
+  def parents_sentence(parent_organisations)
+    parent_organisations.map { |parent| organisation_relationship_html(parent) }.to_sentence
   end
 
   def organisation_display_name_including_parental_and_child_relationships(organisation)

--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -46,7 +46,7 @@ module OrganisationHelper
                       "#{name} is #{relationship}."
                     when "sub-organisation"
                       "#{name} is part of #{parents.to_sentence}."
-                    when "executive non-departmental public body", "advisory non-departmental public body", "tribunal non-departmental public body", "executive agency", "special health authority"
+                    when "executive non-departmental public body", "advisory non-departmental public body", "executive agency", "special health authority"
                       "#{name} is #{relationship}, sponsored by #{parents.to_sentence}."
                     else
                       "#{name} is #{relationship} of #{parents.to_sentence}."

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -37,6 +37,10 @@ cy:
       jobs: Swyddi
       jobs_and_contacts: Swyddi a chontractau
       organisation_chart: Ein siart sefydliadol
+    relationship:
+      identification_html: "%{type_name} yw'r %{name}."
+    type:
+      non_ministerial_department: Adran anweinidogol
   worldwide_organisation:
     corporate_information:
       about_our_services_html: Darganfod %{link}.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -398,6 +398,30 @@ en:
       organisation_chart: Our organisation chart
     embassies:
       find_an_embassy_title: Find a British embassy, high commission or consulate
+    relationship:
+      none_html: "%{name}"
+      identification_html: "%{name} is %{relationship}."
+      works_with_html: "%{name} works with %{parents}."
+      part_of_html: "%{name} is part of %{parents}."
+      sponsored_html: "%{name} is %{relationship}, sponsored by %{parents}."
+      default_with_parents_html: "%{name} is %{relationship} of %{parents}."
+    type:
+      adhoc_advisory_group: ad-hoc advisory group
+      advisory_ndpb: advisory non-departmental public body
+      civil_service: civil service
+      court: court
+      devolved_administration: devolved government
+      executive_agency: executive agency
+      executive_ndpb: executive non-departmental public body
+      executive_office: executive office
+      independent_monitoring_body: independent monitoring body
+      ministerial_department: ministerial department
+      non_ministerial_department: non-ministerial department
+      other: other
+      public_corporation: public corporation
+      special_health_authority: special health authority
+      sub_organisation: sub-organisation
+      tribunal: tribunal
   roles:
     unassigned: No one is assigned to this role
   support:

--- a/test/unit/app/helpers/organisation_helper_test.rb
+++ b/test/unit/app/helpers/organisation_helper_test.rb
@@ -177,4 +177,43 @@ class OrganisationHelperDisplayNameWithParentalRelationshipTest < ActionView::Te
     description = organisation_display_name_including_parental_and_child_relationships(org)
     assert_equal "TO works with the Department of Testing and is supported by 2 agencies and public bodies.", strip_html_tags(description)
   end
+
+  test "non-ministerial department renders Welsh identification sentence" do
+    org = create(:organisation, acronym: "CC", name: "Comisiwn Elusennau", organisation_type: OrganisationType.non_ministerial_department)
+
+    I18n.with_locale(:cy) do
+      assert_display_name_text org, "Adran anweinidogol yw'r CC."
+    end
+  end
+
+  test "non-ministerial department with parents renders Welsh identification sentence" do
+    parent = create(:ministerial_department, name: "Department of Testing")
+    org = create(:organisation, acronym: "CC", name: "Comisiwn Elusennau", organisation_type: OrganisationType.non_ministerial_department, parent_organisations: [parent])
+
+    I18n.with_locale(:cy) do
+      assert_display_name_text org, "Adran anweinidogol yw'r CC."
+    end
+  end
+
+  # TODO: delete test once we have full Welsh translations
+  test "non-ministerial department with supporting bodies renders mixed Welsh/English sentence in Welsh" do
+    child = create(:organisation, acronym: "CO", name: "Child Organisation One")
+    org = create(:organisation, acronym: "CC", name: "Comisiwn Elusennau", organisation_type: OrganisationType.non_ministerial_department)
+    org.stubs(:supporting_bodies).returns([child])
+
+    I18n.with_locale(:cy) do
+      description = organisation_display_name_including_parental_and_child_relationships(org)
+      assert_equal "Adran anweinidogol yw'r CC, supported by 1 public body.", strip_html_tags(description)
+    end
+  end
+
+  # TODO: delete test once we have full Welsh translations
+  test "non-Welsh-translated type falls back to English in Welsh locale" do
+    parent = create(:ministerial_department, name: "Department of Testing")
+    org = create(:organisation, acronym: "EA", name: "Executive Agency Example", organisation_type: OrganisationType.executive_agency, parent_organisations: [parent])
+
+    I18n.with_locale(:cy) do
+      assert_display_name_text org, "EA is an executive agency, sponsored by the Department of Testing."
+    end
+  end
 end


### PR DESCRIPTION
This PR lays the foundation on which to translate organisations and their relationships to Welsh. The text had been all hard-coded and built dynamically before. Initially we just have the single org and relationship translated.

- Added Welsh translation for "About us" section on non-ministerial departments' organisation pages.
- Refactored organisation parental relationship templates for better locale-specific grammar within YAML files.

[Jira](https://gov-uk.atlassian.net/browse/WHIT-3425)
