### PR TITLE
[WHIT-3439] Harden link-checker-api callback endpoint

### DIFF
--- a/app/controllers/admin/errors_controller.rb
+++ b/app/controllers/admin/errors_controller.rb
@@ -1,4 +1,6 @@
 class Admin::ErrorsController < Admin::BaseController
+  skip_before_action :authenticate_user!
+
   def bad_request
     render(status: :bad_request)
   end

--- a/app/controllers/admin/link_checker_api_controller.rb
+++ b/app/controllers/admin/link_checker_api_controller.rb
@@ -18,14 +18,27 @@ class Admin::LinkCheckerApiController < ApplicationController
 private
 
   def verify_signature
-    return unless webhook_secret_token
+    return unless webhook_configured?
+    return head :bad_request unless signature_present?
 
-    given_signature = request.headers["X-LinkCheckerApi-Signature"]
-    return head :bad_request unless given_signature
+    head :bad_request unless signature_valid?
+  end
 
-    body = request.raw_post
-    signature = OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new("sha1"), webhook_secret_token, body)
-    head :bad_request unless Rack::Utils.secure_compare(signature, given_signature)
+  def webhook_configured?
+    webhook_secret_token.present?
+  end
+
+  def signature_present?
+    request_signature.present?
+  end
+
+  def signature_valid?
+    expected = OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new("sha1"), webhook_secret_token, request.raw_post)
+    Rack::Utils.secure_compare(expected, request_signature)
+  end
+
+  def request_signature
+    request.headers["X-LinkCheckerApi-Signature"]
   end
 
   def webhook_secret_token

--- a/app/controllers/admin/link_checker_api_controller.rb
+++ b/app/controllers/admin/link_checker_api_controller.rb
@@ -18,7 +18,7 @@ class Admin::LinkCheckerApiController < ApplicationController
 private
 
   def verify_signature
-    return unless webhook_configured?
+    return head :service_unavailable unless webhook_configured?
     return head :bad_request unless signature_present?
 
     head :bad_request unless signature_valid?

--- a/app/controllers/admin/link_checker_api_controller.rb
+++ b/app/controllers/admin/link_checker_api_controller.rb
@@ -21,7 +21,7 @@ private
     return head :service_unavailable unless webhook_configured?
     return head :bad_request unless signature_present?
 
-    head :bad_request unless signature_valid?
+    reject_unauthorized unless signature_valid?
   end
 
   def webhook_configured?
@@ -35,6 +35,13 @@ private
   def signature_valid?
     expected = OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new("sha1"), webhook_secret_token, request.raw_post)
     Rack::Utils.secure_compare(expected, request_signature)
+  end
+
+  def reject_unauthorized
+    # Opt out of gds-sso's Warden intercept_401, which would otherwise turn
+    # this response into a redirect to /auth/gds.
+    request.env["warden"].custom_failure!
+    head :unauthorized
   end
 
   def request_signature

--- a/test/functional/admin/errors_controller_test.rb
+++ b/test/functional/admin/errors_controller_test.rb
@@ -24,6 +24,17 @@ class Admin::ErrorsControllerTest < ActionDispatch::IntegrationTest
       assert_template error
     end
 
+    it "should render the #{error} page when not authenticated" do
+      logout
+      ENV["GDS_SSO_MOCK_INVALID"] = "true"
+
+      get "/#{error_code}"
+
+      assert_template error
+    ensure
+      ENV.delete("GDS_SSO_MOCK_INVALID")
+    end
+
     it "should render the correct headers" do
       get "/#{error_code}"
 

--- a/test/functional/admin/link_checker_api_controller_test.rb
+++ b/test/functional/admin/link_checker_api_controller_test.rb
@@ -38,6 +38,16 @@ class Admin::LinkCheckerApiControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  test "POST :callback returns 503 when the webhook secret is not configured" do
+    Rails.application.credentials.stubs(:link_checker_api_secret_token).returns(nil)
+    LinkCheckerApiReport.any_instance.expects(:mark_report_as_completed).never
+
+    body = link_checker_api_batch_report_hash(id: 5, links: [{ uri: @link, status: "ok" }])
+    post :callback, params: body
+
+    assert_response :service_unavailable
+  end
+
   test "POST :callback returns 400 when the signature header is missing" do
     LinkCheckerApiReport.any_instance.expects(:mark_report_as_completed).never
 

--- a/test/functional/admin/link_checker_api_controller_test.rb
+++ b/test/functional/admin/link_checker_api_controller_test.rb
@@ -37,4 +37,13 @@ class Admin::LinkCheckerApiControllerTest < ActionController::TestCase
 
     assert_response :success
   end
+
+  test "POST :callback returns 400 when the signature header is missing" do
+    LinkCheckerApiReport.any_instance.expects(:mark_report_as_completed).never
+
+    body = link_checker_api_batch_report_hash(id: 5, links: [{ uri: @link, status: "ok" }])
+    post :callback, params: body
+
+    assert_response :bad_request
+  end
 end

--- a/test/integration/admin/link_checker_api_callback_test.rb
+++ b/test/integration/admin/link_checker_api_callback_test.rb
@@ -1,0 +1,14 @@
+require "test_helper"
+
+class Admin::LinkCheckerApiCallbackTest < ActionDispatch::IntegrationTest
+  test "returns 400 when the signature does not match the body" do
+    post admin_link_checker_api_callback_path,
+         params: { id: 5 }.to_json,
+         headers: {
+           "Content-Type" => "application/json",
+           "X-LinkCheckerApi-Signature" => "invalid",
+         }
+
+    assert_response :bad_request
+  end
+end

--- a/test/integration/admin/link_checker_api_callback_test.rb
+++ b/test/integration/admin/link_checker_api_callback_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 class Admin::LinkCheckerApiCallbackTest < ActionDispatch::IntegrationTest
-  test "returns 400 when the signature does not match the body" do
+  test "returns 401 (not a redirect) when the signature is invalid" do
     post admin_link_checker_api_callback_path,
          params: { id: 5 }.to_json,
          headers: {
@@ -9,6 +9,6 @@ class Admin::LinkCheckerApiCallbackTest < ActionDispatch::IntegrationTest
            "X-LinkCheckerApi-Signature" => "invalid",
          }
 
-    assert_response :bad_request
+    assert_response :unauthorized
   end
 end


### PR DESCRIPTION
## Summary

Three independent fixes to the `/government/admin/link-checker-api-callback` endpoint:

- **Skip auth filter on `Admin::ErrorsController`.** Error pages inherited `authenticate_user!` from `Admin::BaseController`, so when Rails routed an unhandled exception through `exceptions_app` to an error action, the filter ran during error rendering and surfaced as a bare 500 for unauthenticated clients (e.g. `GET` on this URL).
- **Fail closed when the webhook secret is missing.** `verify_signature` returned silently when the configured secret was `nil`, letting any unsigned `POST` mark a `LinkCheckerApiReport` as completed. Reply 503 instead so the callback action never runs without a secret.
- **Return 401 for an invalid signature.** A correctly-formed request with the wrong signature is an authentication failure, not a malformed request. gds-sso mounts Warden with `intercept_401`, which would otherwise turn the 401 into a redirect to `/auth/gds`; the controller opts out via `warden.custom_failure!`. Added an integration test so the full middleware stack is exercised.

[Jira](https://gov-uk.atlassian.net/browse/WHIT-3439)

## Test plan

Run against integration (`whitehall-admin.integration.publishing.service.gov.uk`).

- [x] **GET on the callback URL (errors-controller fix).** Before: `HTTP/2 500`. After: `HTTP/2 404`.

  ```sh
  curl -sI \
    https://whitehall-admin.integration.publishing.service.gov.uk/government/admin/link-checker-api-callback
  ```

  Expected: status `404`, body is the admin "There is a mistake in the URL" page.

- [x] **POST with no signature header (existing 400, unchanged).**

  ```sh
  curl -si -X POST -H 'Content-Type: application/json' \
    -d '{"id":99999999}' \
    https://whitehall-admin.integration.publishing.service.gov.uk/government/admin/link-checker-api-callback
  ```

  Expected: status `400`, empty body.

- [x] **POST with a wrong signature (was 400, now 401).**

  ```sh
  curl -si -X POST -H 'Content-Type: application/json' \
    -H 'X-LinkCheckerApi-Signature: invalid' \
    -d '{"id":99999999}' \
    https://whitehall-admin.integration.publishing.service.gov.uk/government/admin/link-checker-api-callback
  ```

  Expected: status `401`, empty body.

- [x] **POST with a valid signature (happy path, unchanged).** Trigger a real link-check from the Whitehall integration admin UI (edit a publication, save). In the link-checker-api logs, confirm the outbound webhook returns `204` and the corresponding `LinkCheckerApiReport` row updates to `status: "completed"`.