### PR TITLE
Prevent superseded or deleted editions from causing slug clashes [WHIT-3475] 

### DIFF
--- a/app/models/concerns/edition/identifiable.rb
+++ b/app/models/concerns/edition/identifiable.rb
@@ -51,6 +51,7 @@ module Edition::Identifiable
       edition_with_conflicting_slug = Edition.where_base_path_prefix_matches(self)
                                              .where(slug: candidate_slug)
                                              .where("document_id != ?", document_id)
+                                             .where.not(state: Edition::FROZEN_STATES)
 
       if edition_with_conflicting_slug.exists?
         attempt += 1

--- a/test/unit/app/models/edition/identifiable_test.rb
+++ b/test/unit/app/models/edition/identifiable_test.rb
@@ -173,6 +173,22 @@ class Edition::SluggingTest < ActiveSupport::TestCase
       assert_equal "same-title--3", third_edition.slug
     end
 
+    test "it does not treat a superseded edition as a slug conflict" do
+      superseded_edition = SluggableEdition.create!(title: "Same Title", state: "superseded")
+      assert_equal "same-title", superseded_edition.slug
+
+      new_draft = SluggableEdition.create!(title: "Same Title")
+      assert_equal "same-title", new_draft.slug
+    end
+
+    test "it does not treat a deleted edition as a slug conflict" do
+      deleted_edition = SluggableEdition.create!(title: "Same Title", state: "deleted")
+      assert_equal "same-title", deleted_edition.slug
+
+      new_draft = SluggableEdition.create!(title: "Same Title")
+      assert_equal "same-title", new_draft.slug
+    end
+
     test "it reuses a slug if it becomes available" do
       clashing_draft = SluggableEdition.create!(title: "Original Title")
       draft_edition = SluggableEdition.create!(title: "Original Title")


### PR DESCRIPTION
We had a case where a superseded edition had the same slug as a new document. This meant that the new document could not be published under the ideal slug until the superseded edition frees the slug. The new document's slug had had `--2` appended to it, which is not ideal.

I've now added an update to ensure we now ignore superseded and deleted editions when checking for slug conflicts in Whitehall.


[JIRA](https://gov-uk.atlassian.net/browse/WHIT-3475)

---
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
