### PR TITLE
[WHIT-3170] Override social media display text

### DIFF
--- a/app/components/admin/error_summary_component.rb
+++ b/app/components/admin/error_summary_component.rb
@@ -83,8 +83,14 @@ private
   end
 
   def format_dotted_attribute_message(error)
+    model_key = object.class.try(:model_name)&.i18n_key
     attribute_label = error.attribute.to_s.split(".").map { |part|
-      part.match?(/\A\d+\z/) ? (part.to_i + 1).to_s : part.humanize.downcase
+      if part.match?(/\A\d+\z/)
+        (part.to_i + 1).to_s
+      else
+        i18n_key = "activerecord.attributes.#{model_key}.#{part}"
+        I18n.t(i18n_key, default: nil) || part.humanize.downcase
+      end
     }.join(" ").capitalize
     "#{attribute_label} #{error.message}"
   end

--- a/app/models/configurable_document_types/topical_event.json
+++ b/app/models/configurable_document_types/topical_event.json
@@ -106,6 +106,12 @@
                 }
               ]
             },
+            "title": {
+              "title": "Title",
+              "block": "default_string",
+              "attribute_path": ["title"],
+              "translatable": true
+            },
             "url": {
               "title": "URL",
               "block": "default_string",
@@ -129,6 +135,9 @@
             "type": "string"
           },
           "url": {
+            "type": "string"
+          },
+          "title": {
             "type": "string"
           }
         }
@@ -156,7 +165,8 @@
         "attributes": ["social_media_links"],
         "fields": {
           "service_field": "social_media_service_name",
-          "url_field": "url"
+          "url_field": "url",
+          "title_field": "title"
         }
       }
     }

--- a/app/presenters/publishing_api/payload_builder/block_content.rb
+++ b/app/presenters/publishing_api/payload_builder/block_content.rb
@@ -44,11 +44,12 @@ module PublishingApi
         return [] if content.blank?
 
         content.map do |item|
-          # `item` looks something like `{"url"=>"foo", "social_media_service_name"=>"Facebook"}`
+          # `item` looks something like `{"url"=>"foo", "social_media_service_name"=>"Facebook", "title"=> "Optional title"}`
           service_name = item["social_media_service_name"]
           service_url = item["url"]
+          title = item["title"]
           {
-            title: service_name,
+            title: title.presence || service_name,
             service_type: service_name.parameterize, # "Google Plus" => "google-plus"
             href: service_url,
           }

--- a/app/validators/social_media_links_validator.rb
+++ b/app/validators/social_media_links_validator.rb
@@ -3,6 +3,8 @@ class SocialMediaLinksValidator < ActiveModel::Validator
     @attributes = opts[:attributes]
     @channel_field = opts[:fields]["service_field"]
     @url_field = opts[:fields]["url_field"]
+    @title_field = opts[:fields]["title_field"]
+
     super
   end
 
@@ -11,12 +13,16 @@ class SocialMediaLinksValidator < ActiveModel::Validator
       arr = record.send(attribute_name.to_sym) || []
       @channels_seen = []
       @urls_seen = []
+      @titles_seen = []
 
       arr.each_with_index do |social_media_account, index|
         channel_name = social_media_account[@channel_field]
         url = social_media_account[@url_field]
+        title = social_media_account[@title_field]
+        channel = { channel_name: channel_name, title: title }
 
-        validate_social_media_channel(channel_name, index, record, attribute_name)
+        validate_social_media_channel(channel, index, record, attribute_name)
+        validate_social_media_title(title, index, record, attribute_name)
         validate_social_media_url(url, index, record, attribute_name)
       end
     end
@@ -24,21 +30,35 @@ class SocialMediaLinksValidator < ActiveModel::Validator
 
 private
 
-  def validate_social_media_channel(channel_name, index, record, attribute_name)
-    if channel_name.blank?
+  def validate_social_media_channel(channel, index, record, attribute_name)
+    if channel[:channel_name].blank?
       record.errors.add(
         :"#{attribute_name}.#{index}.#{@channel_field}",
         :blank,
         message: "cannot be blank",
       )
-    elsif channel_name != "Other" && @channels_seen.include?(channel_name)
+    elsif @channels_seen.select { |c| c[:channel_name] == channel[:channel_name] && c[:title] == channel[:title] && c[:title].blank? }.any?
       record.errors.add(
         :"#{attribute_name}.#{index}.#{@channel_field}",
         :taken,
         message: "must be unique",
       )
     else
-      @channels_seen << channel_name
+      @channels_seen << channel
+    end
+  end
+
+  def validate_social_media_title(title, index, record, attribute_name)
+    return if title.blank?
+
+    if @titles_seen.include?(title)
+      record.errors.add(
+        :"#{attribute_name}.#{index}.#{@title_field}",
+        :taken,
+        message: "must be unique",
+      )
+    else
+      @titles_seen << title
     end
   end
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,6 +20,9 @@ en:
       edition:
         html_attachments: HTML attachments
         nation_inapplicabilities: Excluded nations
+      standard_edition:
+        social_media_links: Social media account
+        social_media_service_name: channel
       image_data:
         file: Image
       policy_group/policy_group_attachments/attachment/attachment_data:

--- a/features/fixtures/test_configurable_document_type.json
+++ b/features/fixtures/test_configurable_document_type.json
@@ -138,6 +138,12 @@
               "block": "default_string",
               "attribute_path": ["url"],
               "translatable": true
+            },
+            "title": {
+              "title": "Title",
+              "block": "default_string",
+              "attribute_path": ["title"],
+              "translatable": true
             }
           }
         }
@@ -183,6 +189,9 @@
             "type": "string"
           },
           "url": {
+            "type": "string"
+          },
+          "title": {
             "type": "string"
           }
         }

--- a/test/components/admin/error_summary_component_test.rb
+++ b/test/components/admin/error_summary_component_test.rb
@@ -154,7 +154,7 @@ class Admin::ErrorSummaryComponentTest < ViewComponent::TestCase
     assert_equal third_link[:href], "#labelled_error_summary_test_object_date"
   end
 
-  test "renders full_message for dotted attributes" do
+  test "renders full message for dotted attributes" do
     object = DottedAttributeErrorSummaryTestObject.new("title", Time.zone.today)
     object.errors.add("social_media_links.0.url".to_sym, :blank, message: "cannot be blank")
     render_inline(Admin::ErrorSummaryComponent.new(object:))
@@ -162,6 +162,21 @@ class Admin::ErrorSummaryComponentTest < ViewComponent::TestCase
     link = page.find(".gem-c-error-summary__list-item a")
     assert_equal "Social media links 1 url cannot be blank", link.text
     assert_equal "#dotted_attribute_error_summary_test_object_social_media_links_0_url", link[:href]
+  end
+
+  test "renders full message with locale labels for dotted attributes" do
+    object = DottedAttributeErrorSummaryTestObject.new("title", Time.zone.today)
+    original_i18n_key = DottedAttributeErrorSummaryTestObject.model_name.i18n_key
+    object.class.model_name.define_singleton_method(:i18n_key) { :standard_edition }
+    object.errors.add("social_media_links.0.url".to_sym, :blank, message: "cannot be blank")
+    object.errors.add("social_media_links.0.social_media_service_name".to_sym, :blank, message: "cannot be blank")
+    render_inline(Admin::ErrorSummaryComponent.new(object:))
+
+    links = page.find_all(".gem-c-error-summary__list-item a")
+    assert_equal "Social media account 1 url cannot be blank", links[0].text
+    assert_equal "Social media account 1 channel cannot be blank", links[1].text
+  ensure
+    object.class.model_name.define_singleton_method(:i18n_key) { original_i18n_key }
   end
 end
 

--- a/test/unit/app/presenters/publishing_api/payload_builder/block_content_test.rb
+++ b/test/unit/app/presenters/publishing_api/payload_builder/block_content_test.rb
@@ -161,6 +161,36 @@ class PublishingApi::PayloadBuilder::BlockContentTest < ActiveSupport::TestCase
     end
 
     test "social_media_links returns array of social media links" do
+      value_of_links = [
+        { "social_media_service_name" => "Twitter", "url" => "https://twitter.com" },
+        { "social_media_service_name" => "Other", "title" => "Other 1", "url" => "https://example.com" },
+        { "social_media_service_name" => "Other", "title" => "Other 2", "url" => "https://personal.com" },
+      ]
+      @block_content.stubs(:some_attribute).returns(value_of_links)
+
+      builder = PublishingApi::PayloadBuilder::BlockContent.new(@item)
+
+      expected_payload = [
+        {
+          title: "Twitter",
+          service_type: "twitter",
+          href: "https://twitter.com",
+        },
+        {
+          title: "Other 1",
+          service_type: "other",
+          href: "https://example.com",
+        },
+        {
+          title: "Other 2",
+          service_type: "other",
+          href: "https://personal.com",
+        },
+      ]
+      assert_equal expected_payload, builder.send(:social_media_links, :some_attribute)
+    end
+
+    test "social_media_links defaults title to service name when no title provided" do
       value_of_links = [{ "social_media_service_name" => "twitter", "url" => "https://example.com" }]
       @block_content.stubs(:some_attribute).returns(value_of_links)
 
@@ -168,9 +198,41 @@ class PublishingApi::PayloadBuilder::BlockContentTest < ActiveSupport::TestCase
 
       expected_payload = [
         {
-          title: value_of_links.first["social_media_service_name"],
-          service_type: value_of_links.first["social_media_service_name"].parameterize,
-          href: value_of_links.first["url"],
+          title: "twitter",
+          service_type: "twitter",
+          href: "https://example.com",
+        },
+      ]
+      assert_equal expected_payload, builder.send(:social_media_links, :some_attribute)
+    end
+
+    test "social_media_links uses custom title when provided" do
+      value_of_links = [{ "social_media_service_name" => "Twitter", "url" => "https://twitter.com/govuk", "title" => "GOV.UK on Twitter" }]
+      @block_content.stubs(:some_attribute).returns(value_of_links)
+
+      builder = PublishingApi::PayloadBuilder::BlockContent.new(@item)
+
+      expected_payload = [
+        {
+          title: "GOV.UK on Twitter",
+          service_type: "twitter",
+          href: "https://twitter.com/govuk",
+        },
+      ]
+      assert_equal expected_payload, builder.send(:social_media_links, :some_attribute)
+    end
+
+    test "social_media_links falls back to service name when title is blank" do
+      value_of_links = [{ "social_media_service_name" => "Facebook", "url" => "https://facebook.com/govuk", "title" => "" }]
+      @block_content.stubs(:some_attribute).returns(value_of_links)
+
+      builder = PublishingApi::PayloadBuilder::BlockContent.new(@item)
+
+      expected_payload = [
+        {
+          title: "Facebook",
+          service_type: "facebook",
+          href: "https://facebook.com/govuk",
         },
       ]
       assert_equal expected_payload, builder.send(:social_media_links, :some_attribute)

--- a/test/unit/app/validators/social_media_links_validator_test.rb
+++ b/test/unit/app/validators/social_media_links_validator_test.rb
@@ -7,6 +7,7 @@ class SocialMediaLinksValidatorTest < ActiveSupport::TestCase
       fields: {
         "service_field" => "social_media_service_name",
         "url_field" => "url",
+        "title_field" => "title",
       },
     })
   end
@@ -78,18 +79,6 @@ class SocialMediaLinksValidatorTest < ActiveSupport::TestCase
     assert_includes block_content.errors["social_media_links.0.url".to_sym], "is invalid - use the full URL, including https://"
   end
 
-  test "social media links are invalid if two of the same channel are provided" do
-    block_content = SocialMediaLinksValidatorTestClass.new
-    block_content.social_media_links = [
-      { "social_media_service_name" => "Facebook", "url" => "http://facebook.com/govuk" },
-      { "social_media_service_name" => "Facebook", "url" => "http://facebook.com/govukpage2" },
-    ]
-    @validator.validate(block_content)
-
-    assert_empty block_content.errors["social_media_links.0.social_media_service_name".to_sym]
-    assert_includes block_content.errors["social_media_links.1.social_media_service_name".to_sym], "must be unique"
-  end
-
   test "social media links are invalid if two channels have the same URL" do
     block_content = SocialMediaLinksValidatorTestClass.new
     block_content.social_media_links = [
@@ -102,7 +91,63 @@ class SocialMediaLinksValidatorTest < ActiveSupport::TestCase
     assert_includes block_content.errors["social_media_links.1.url".to_sym], "must be unique"
   end
 
-  test "social media links are valid when multiple 'Other' channels are provided with different URLs" do
+  test "social media links are valid when a channel is chosen and a well-formed URL is provided" do
+    block_content = SocialMediaLinksValidatorTestClass.new
+    block_content.social_media_links = [
+      { "social_media_service_name" => "Facebook", "url" => "http://facebook.com/govuk" },
+      { "social_media_service_name" => "LinkedIn", "url" => "https://linkedin.com/company/govuk" },
+    ]
+    @validator.validate(block_content)
+
+    assert block_content.errors.empty?
+  end
+
+  test "social media links are valid when titles are unique" do
+    block_content = SocialMediaLinksValidatorTestClass.new
+    block_content.social_media_links = [
+      { "social_media_service_name" => "Facebook", "url" => "http://facebook.com/govuk", "title" => "GOV.UK on Facebook" },
+      { "social_media_service_name" => "Twitter", "url" => "http://twitter.com/govuk", "title" => "GOV.UK on Twitter" },
+    ]
+    @validator.validate(block_content)
+
+    assert block_content.errors.empty?
+  end
+
+  test "social media links are valid when titles are blank" do
+    block_content = SocialMediaLinksValidatorTestClass.new
+    block_content.social_media_links = [
+      { "social_media_service_name" => "Facebook", "url" => "http://facebook.com/govuk", "title" => "" },
+      { "social_media_service_name" => "Twitter", "url" => "http://twitter.com/govuk", "title" => "" },
+    ]
+    @validator.validate(block_content)
+
+    assert block_content.errors.empty?
+  end
+
+  test "social media links are invalid when any two accounts have the same title" do
+    block_content = SocialMediaLinksValidatorTestClass.new
+    block_content.social_media_links = [
+      { "social_media_service_name" => "Facebook", "title" => "Our updates", "url" => "http://facebook.com/govuk" },
+      { "social_media_service_name" => "Twitter", "title" => "Our updates", "url" => "http://twitter.com/govuk" },
+    ]
+    @validator.validate(block_content)
+
+    assert_includes block_content.errors["social_media_links.1.title".to_sym], "must be unique"
+  end
+
+  test "social media links are invalid when multiple instances of the same channel are provided, with no distinct titles" do
+    block_content = SocialMediaLinksValidatorTestClass.new
+    block_content.social_media_links = [
+      { "social_media_service_name" => "Facebook", "url" => "http://facebook.com/govuk" },
+      { "social_media_service_name" => "Facebook", "url" => "http://facebook.com/govukpage2" },
+    ]
+    @validator.validate(block_content)
+
+    assert_empty block_content.errors["social_media_links.0.social_media_service_name".to_sym]
+    assert_includes block_content.errors["social_media_links.1.social_media_service_name".to_sym], "must be unique"
+  end
+
+  test "social media links are invalid when multiple 'Other' channels are provided, with no distinct titles" do
     block_content = SocialMediaLinksValidatorTestClass.new
     block_content.social_media_links = [
       { "social_media_service_name" => "Other", "url" => "http://example.com/one" },
@@ -110,14 +155,26 @@ class SocialMediaLinksValidatorTest < ActiveSupport::TestCase
     ]
     @validator.validate(block_content)
 
-    assert block_content.errors.empty?
+    assert_includes block_content.errors["social_media_links.1.social_media_service_name".to_sym], "must be unique"
   end
 
-  test "social media links are valid when a channel is chosen and a well-formed URL is provided" do
+  test "social media links are invalid and only display title uniqueness error, if multiple instances of the same channel are provided, and their titles match" do
     block_content = SocialMediaLinksValidatorTestClass.new
     block_content.social_media_links = [
-      { "social_media_service_name" => "Facebook", "url" => "http://facebook.com/govuk" },
-      { "social_media_service_name" => "LinkedIn", "url" => "https://linkedin.com/company/govuk" },
+      { "social_media_service_name" => "Facebook", "title" => "Facebook", "url" => "http://facebook.com/govuk" },
+      { "social_media_service_name" => "Facebook", "title" => "Facebook", "url" => "http://facebook.com/govukpage2" },
+    ]
+    @validator.validate(block_content)
+
+    assert_includes block_content.errors["social_media_links.1.title".to_sym], "must be unique"
+    assert block_content.errors["social_media_links.1.social_media_service_name".to_sym].empty?
+  end
+
+  test "social media links are valid when multiple instances of the same channel are provided with different titles and different URLs" do
+    block_content = SocialMediaLinksValidatorTestClass.new
+    block_content.social_media_links = [
+      { "social_media_service_name" => "Facebook", "title" => "Facebook Corporate", "url" => "http://example.com/one" },
+      { "social_media_service_name" => "Facebook", "title" => "Facebook Fun", "url" => "http://example.com/two" },
     ]
     @validator.validate(block_content)
 


### PR DESCRIPTION
## Changes

Added a new optional title field to social media links. This title is primarily intended to be used for the "Other" service type. We need to be able to distinguish between the various channels. Nonetheless, the title input can also be used to provide multiple instances of any other channel type.

Validation changes:
- We now validate for unique title as well (URL must also be unique from before).
- Channel names can now be repeated, provided their titles are distinct.
- The "Other" channel does not behave in any way differently from the rest of the channels. We won't allow multiple "Other" entries unless they have different titles. A valid scenario is if one "Other" channel has no title and the other does.
- We do not validate title uniqueness scoped to the channel, but globally - we will not allow a repeated title even if it is across different channels.
- If there are channels that match, and their titles match, we'll only render a single error for the titles matching.

Generally followed approach in [previous PR](https://github.com/alphagov/whitehall/pull/11323), except for setting required on the schema - feels unnecessary since the validation for this is custom.

Also added a locale override for the error label. The previous code rendered the old model-attribute-based label in the error summary, which no longer matches what we show on the form, creating a confusing experience for the user. We could have just changed the json config to change the attribute, but we now have live data using `social_media_links`, so that's no longer possible.

## Testing

| Description | Screenshot |
| --- | --- |
| Valid - Two channels with different titles - valid | <img width="446" height="686" alt="valid channels with titles" src="https://github.com/user-attachments/assets/5b59ee81-03e3-426a-86f5-df23482d947c" /> |
| Valid - Two "Other" channels with different titles | <img width="598" height="803" alt="Valid other" src="https://github.com/user-attachments/assets/f0d0bd64-7cc0-40c2-96a7-599c29a36055" /> |
| Valid -  Title is optional | <img width="446" height="686" alt="title optional" src="https://github.com/user-attachments/assets/ac887503-b32b-46d9-83c8-15f38ac59647" /> |
| Invalid - Channel must be unique if no titles provided | <img width="446" height="686" alt="Channel uniq check when title not provided" src="https://github.com/user-attachments/assets/3d70a458-3ae9-43f2-9436-8d3a3ba30cbe" /> |
| Valid - Channel must be unique when "Other" selected, if no titles provided | <img width="446" height="686" alt="Cahnnel must be uniq other" src="https://github.com/user-attachments/assets/9b5c815a-534b-409c-b1f3-7a8e898570f9" /> |
| Valid - Title must be unique (same channel example) | <img width="446" height="686" alt="Uniq title" src="https://github.com/user-attachments/assets/979f459b-9a69-40ab-91eb-911eed9c64a9" /> |
| Valid - Title must be unique across all channels | <img width="446" height="686" alt="Uniq title across all accounts" src="https://github.com/user-attachments/assets/cbae7073-47e6-4a36-8447-a305e49628fd" /> |
| Frontend rendering | <img width="324" height="270" alt="Screenshot 2026-05-21 at 20 50 22" src="https://github.com/user-attachments/assets/d73b4886-dc65-4187-a46e-141a3d878eaf" /> |
| Content item payload | <img width="324" height="303" alt="Screenshot 2026-05-21 at 20 50 36" src="https://github.com/user-attachments/assets/7b948423-0123-4c70-ba2c-47328d639300" /> |
| Before / After label changes | <img width="397" height="104" alt="Screenshot 2026-05-21 at 23 06 46" src="https://github.com/user-attachments/assets/324d48d0-8aba-4b5a-bd98-840ae1b7768b" /> <br> <img width="397" height="104" alt="Screenshot 2026-05-21 at 23 06 54" src="https://github.com/user-attachments/assets/49539bfd-7ade-4043-9ec8-6e0528782282" /> |

[Jira](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-3170)