### PR TITLE
Auto-append a cachebust URL to preview links [WHIT-3385]

### DIFF
--- a/app/assets/javascripts/admin/modules/cachebust-link.js
+++ b/app/assets/javascripts/admin/modules/cachebust-link.js
@@ -1,0 +1,28 @@
+'use strict'
+/* Refreshes the `cachebust` query param on a link to the current unix-epoch
+ * the moment the user is about to activate it, so the URL never carries a
+ * stale timestamp from page load.
+ *
+ * Listens on `pointerdown` (mouse, touch, pen) and `focus` (keyboard, AT).
+ * Usage: add `data-module="CachebustLink"` to the <a> tag.
+ */
+;(function (Modules) {
+  function CachebustLink(link) {
+    this.link = link
+  }
+
+  CachebustLink.prototype.init = function () {
+    const refresh = this.refresh.bind(this)
+    this.link.addEventListener('pointerdown', refresh)
+    this.link.addEventListener('focus', refresh)
+  }
+
+  CachebustLink.prototype.refresh = function () {
+    const url = new URL(this.link.href)
+    if (!url.searchParams.has('cachebust')) return
+    url.searchParams.set('cachebust', Math.floor(Date.now() / 1000))
+    this.link.href = url.toString()
+  }
+
+  Modules.CachebustLink = CachebustLink
+})(window.GOVUK.Modules)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -26,6 +26,7 @@
 //= require admin/analytics-modules/ga4-finder-setup.js
 //= require admin/analytics-modules/ga4-form-setup.js
 
+//= require admin/modules/cachebust-link
 //= require admin/modules/document-history-paginator
 //= require admin/modules/locale-switcher
 //= require admin/modules/navbar-toggle

--- a/app/components/admin/editions/show/preview_component.html.erb
+++ b/app/components/admin/editions/show/preview_component.html.erb
@@ -9,14 +9,14 @@
 
   <% if versioning_completed %>
     <p class="govuk-body">
-      <%= preview_link(primary_locale_link_text, local_edition.public_url(draft: true)) %>
+      <%= preview_link(primary_locale_link_text, preview_url) %>
     </p>
 
     <% if available_in_multiple_languages %>
       <% translation_preview_links = local_edition.non_primary_translation_locales.map do |locale|
         preview_link(
           "Preview on website - #{locale.native_and_english_language_name} (opens in new tab)",
-          local_edition.public_url(locale: locale.code, draft: true),
+          preview_url(locale: locale.code),
           )
       end %>
       <%= render "govuk_publishing_components/components/details", {

--- a/app/components/admin/editions/show/preview_component.rb
+++ b/app/components/admin/editions/show/preview_component.rb
@@ -34,6 +34,12 @@ private
     end
   end
 
+  def preview_url(locale: nil)
+    options = { draft: true, **cachebust_url_options }
+    options[:locale] = locale if locale
+    edition.public_url(options)
+  end
+
   def available_in_multiple_languages
     @available_in_multiple_languages ||= edition.translatable? && edition.available_in_multiple_languages?
   end

--- a/app/components/admin/editions/show/preview_component.rb
+++ b/app/components/admin/editions/show/preview_component.rb
@@ -23,7 +23,8 @@ private
     link_to(link_text,
             href,
             class: "govuk-link",
-            target: "_blank", rel: "noopener")
+            target: "_blank", rel: "noopener",
+            data: { module: "CachebustLink" })
   end
 
   def primary_locale_link_text

--- a/app/helpers/admin/url_options_helper.rb
+++ b/app/helpers/admin/url_options_helper.rb
@@ -41,6 +41,14 @@ module Admin::UrlOptionsHelper
     edition.public_url(auth_bypass_options(edition).merge(options))
   end
 
+  def attachment_preview_options(attachable)
+    return {} if attachable_post_publication?(attachable)
+
+    { preview: true, **cachebust_url_options }
+  end
+
+private
+
   def attachable_post_publication?(attachable)
     edition = case attachable
               when Edition then attachable

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -46,8 +46,9 @@ module ApplicationHelper
 
     name = attachment.name_for_link
     html_class = options.delete(:class)
+    data = options.delete(:data)
 
-    return link_to name, attachment.url(options), class: html_class if !attachment.file? || attachment.attachment_data.all_asset_variants_uploaded?
+    return link_to name, attachment.url(options), class: html_class, data: data if !attachment.file? || attachment.attachment_data.all_asset_variants_uploaded?
 
     tag.span(name)
   end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -14,7 +14,6 @@ class ApplicationRecord < ActiveRecord::Base
 
     permitted_query_params = %i[
       cachebust
-      preview
       token
       utm_campaign
       utm_medium

--- a/app/models/html_attachment.rb
+++ b/app/models/html_attachment.rb
@@ -52,12 +52,6 @@ class HtmlAttachment < Attachment
   end
 
   def url(options = {})
-    if options[:preview]
-      options[:preview] = id
-    else
-      options.delete(:preview)
-    end
-
     if options[:full_url]
       public_url(options)
     else

--- a/app/views/admin/attachments/_attachments.html.erb
+++ b/app/views/admin/attachments/_attachments.html.erb
@@ -14,7 +14,7 @@
           <strong>Type: </strong><%= attachment.is_a?(HtmlAttachment) ? attachment.readable_type : attachment.readable_type.capitalize %>
         </p>
         <p class="govuk-body">
-          <strong>Attachment: </strong><%= link_to_attachment(attachment, preview: !attachable_post_publication?(attachable), full_url: true, class: "govuk-link govuk-link--no-visited-state") %>
+          <strong>Attachment: </strong><%= link_to_attachment(attachment, full_url: true, class: "govuk-link govuk-link--no-visited-state", **attachment_preview_options(attachable)) %>
         </p>
         <% if attachable.allows_inline_attachments? && attachment.is_a?(FileAttachment) %>
           <%= render "govuk_publishing_components/components/copy_to_clipboard", {

--- a/app/views/admin/attachments/_attachments.html.erb
+++ b/app/views/admin/attachments/_attachments.html.erb
@@ -14,7 +14,7 @@
           <strong>Type: </strong><%= attachment.is_a?(HtmlAttachment) ? attachment.readable_type : attachment.readable_type.capitalize %>
         </p>
         <p class="govuk-body">
-          <strong>Attachment: </strong><%= link_to_attachment(attachment, full_url: true, class: "govuk-link govuk-link--no-visited-state", **attachment_preview_options(attachable)) %>
+          <strong>Attachment: </strong><%= link_to_attachment(attachment, full_url: true, class: "govuk-link govuk-link--no-visited-state", data: { module: "CachebustLink" }, **attachment_preview_options(attachable)) %>
         </p>
         <% if attachable.allows_inline_attachments? && attachment.is_a?(FileAttachment) %>
           <%= render "govuk_publishing_components/components/copy_to_clipboard", {

--- a/app/views/admin/editions/show/_main.html.erb
+++ b/app/views/admin/editions/show/_main.html.erb
@@ -187,7 +187,7 @@
           rows: @edition.attachments.map do | attachment |
             [
               { text: attachment[:title] },
-              { text: link_to_attachment(attachment, preview: !attachable_post_publication?(attachment.attachable), full_url: true, class: "govuk-link") },
+              { text: link_to_attachment(attachment, full_url: true, class: "govuk-link", **attachment_preview_options(attachment.attachable)) },
               @edition.editable? ? { text: link_to("Edit", [:edit, :admin, @edition.becomes(Edition), attachment], class: "govuk-link") } : nil,
             ].compact
           end,

--- a/app/views/admin/editions/show/_main.html.erb
+++ b/app/views/admin/editions/show/_main.html.erb
@@ -187,7 +187,7 @@
           rows: @edition.attachments.map do | attachment |
             [
               { text: attachment[:title] },
-              { text: link_to_attachment(attachment, full_url: true, class: "govuk-link", **attachment_preview_options(attachment.attachable)) },
+              { text: link_to_attachment(attachment, full_url: true, class: "govuk-link", data: { module: "CachebustLink" }, **attachment_preview_options(attachment.attachable)) },
               @edition.editable? ? { text: link_to("Edit", [:edit, :admin, @edition.becomes(Edition), attachment], class: "govuk-link") } : nil,
             ].compact
           end,

--- a/app/views/admin/html_attachments/_fields.html.erb
+++ b/app/views/admin/html_attachments/_fields.html.erb
@@ -51,7 +51,7 @@
       } do %>
       <p class="govuk-body">
         <%= link_to("Preview on website (opens in new tab)",
-        attachment.url(preview: !attachable_post_publication?(attachment.attachable), full_url: true),
+        attachment.url(full_url: true, **attachment_preview_options(attachment.attachable)),
         class: "govuk-link",
         target: "_blank", rel: "noopener") %>
       </p>

--- a/app/views/admin/html_attachments/_fields.html.erb
+++ b/app/views/admin/html_attachments/_fields.html.erb
@@ -53,7 +53,8 @@
         <%= link_to("Preview on website (opens in new tab)",
         attachment.url(full_url: true, **attachment_preview_options(attachment.attachable)),
         class: "govuk-link",
-        target: "_blank", rel: "noopener") %>
+        target: "_blank", rel: "noopener",
+        data: { module: "CachebustLink" }) %>
       </p>
       <p class="govuk-body">
         To preview your document on GOV.UK you must save it first.

--- a/features/step_definitions/edition_update_slug_steps.rb
+++ b/features/step_definitions/edition_update_slug_steps.rb
@@ -1,6 +1,6 @@
 Then(/^I can see the preview URL of the publication "([^"]*)" contains "([^"]*)"$/) do |title, new_slug|
   visit admin_edition_path(Publication.latest_edition.find_by!(title:))
-  expect(page).to have_link "Preview on website (opens in new tab)", href: "https://draft-origin.test.gov.uk/government/publications/#{new_slug}"
+  expect(page).to have_link "Preview on website (opens in new tab)", href: %r{\Ahttps://draft-origin\.test\.gov\.uk/government/publications/#{Regexp.escape(new_slug)}\?cachebust=\d+\z}
 end
 
 Then(/^I cannot see the option to keep the current page URL$/) do

--- a/features/step_definitions/policy_steps.rb
+++ b/features/step_definitions/policy_steps.rb
@@ -1,7 +1,7 @@
 Then(/^I should see a link to the preview version of the publication "([^"]*)"$/) do |publication_title|
   publication = Publication.find_by!(title: publication_title)
   visit admin_edition_path(publication)
-  expected_preview_url = "https://draft-origin.test.gov.uk/government/publications/#{publication.slug}"
+  expected_preview_url = %r{\Ahttps://draft-origin\.test\.gov\.uk/government/publications/#{Regexp.escape(publication.slug)}\?cachebust=\d+\z}
 
-  expect(expected_preview_url).to eq(find("a[target='_blank']")[:href])
+  expect(find("a[target='_blank']")[:href]).to match(expected_preview_url)
 end

--- a/spec/javascripts/admin/modules/cachebust-link.spec.js
+++ b/spec/javascripts/admin/modules/cachebust-link.spec.js
@@ -1,0 +1,70 @@
+describe('GOVUK.Modules.CachebustLink', function () {
+  let link, module
+
+  beforeEach(function () {
+    jasmine.clock().install()
+    jasmine.clock().mockDate(new Date(1_700_000_000_000))
+
+    link = document.createElement('a')
+    link.setAttribute('data-module', 'CachebustLink')
+    link.href =
+      'https://draft-origin.test.gov.uk/government/publications/foo?cachebust=1&locale=en'
+
+    module = new GOVUK.Modules.CachebustLink(link)
+    module.init()
+  })
+
+  afterEach(function () {
+    jasmine.clock().uninstall()
+  })
+
+  it('rewrites the cachebust query param to the current unix-epoch on pointerdown', function () {
+    link.dispatchEvent(new Event('pointerdown'))
+
+    const url = new URL(link.href)
+    expect(url.searchParams.get('cachebust')).toEqual('1700000000')
+  })
+
+  it('rewrites the cachebust query param to the current unix-epoch on focus', function () {
+    link.dispatchEvent(new Event('focus'))
+
+    const url = new URL(link.href)
+    expect(url.searchParams.get('cachebust')).toEqual('1700000000')
+  })
+
+  it('preserves other query params when refreshing the cachebust', function () {
+    link.dispatchEvent(new Event('pointerdown'))
+
+    const url = new URL(link.href)
+    expect(url.searchParams.get('locale')).toEqual('en')
+  })
+
+  it('preserves the path and host when refreshing the cachebust', function () {
+    link.dispatchEvent(new Event('pointerdown'))
+
+    const url = new URL(link.href)
+    expect(url.host).toEqual('draft-origin.test.gov.uk')
+    expect(url.pathname).toEqual('/government/publications/foo')
+  })
+
+  it('reflects the latest current time on each interaction', function () {
+    link.dispatchEvent(new Event('focus'))
+    jasmine.clock().tick(60_000)
+    link.dispatchEvent(new Event('pointerdown'))
+
+    const url = new URL(link.href)
+    expect(url.searchParams.get('cachebust')).toEqual('1700000060')
+  })
+
+  it('leaves the href untouched when there is no cachebust query param', function () {
+    const liveLink = document.createElement('a')
+    liveLink.href = 'https://www.test.gov.uk/government/publications/foo'
+    const originalHref = liveLink.href
+
+    new GOVUK.Modules.CachebustLink(liveLink).init()
+    liveLink.dispatchEvent(new Event('pointerdown'))
+    liveLink.dispatchEvent(new Event('focus'))
+
+    expect(liveLink.href).toEqual(originalHref)
+  })
+})

--- a/test/components/admin/editions/show/preview_component_test.rb
+++ b/test/components/admin/editions/show/preview_component_test.rb
@@ -80,6 +80,14 @@ class Admin::Editions::Show::PreviewComponentTest < ViewComponent::TestCase
     assert_selector ".govuk-inset-text", text: "To see the changes and share a document preview link, add a change note or mark the change type to minor."
   end
 
+  test "tags every preview link with the CachebustLink JS module" do
+    edition = create(:publication, translated_into: %i[fr], document: @document)
+
+    render_inline(Admin::Editions::Show::PreviewComponent.new(edition:))
+
+    assert_selector "a[data-module='CachebustLink'][href*='cachebust=']", visible: :all, count: 2
+  end
+
   test "renders the correct primary locale link text for non-English primary locale editions with translations" do
     edition = build(:detailed_guide, id: 1, primary_locale: :fr, document: @document)
     edition.translations.build(locale: :fr)

--- a/test/components/admin/editions/show/preview_component_test.rb
+++ b/test/components/admin/editions/show/preview_component_test.rb
@@ -24,24 +24,33 @@ class Admin::Editions::Show::PreviewComponentTest < ViewComponent::TestCase
   test "renders a link with tracking to preview the document when the edition is english only" do
     edition = build_stubbed(:publication, document: @document)
 
-    render_inline(Admin::Editions::Show::PreviewComponent.new(edition:))
-    assert_selector "a[href='#{edition.public_url(draft: true)}']", text: "Preview on website (opens in new tab)"
+    travel_to(Time.zone.local(2026, 5, 27, 12, 0, 0)) do
+      render_inline(Admin::Editions::Show::PreviewComponent.new(edition:))
+      cachebust = Time.zone.now.getutc.to_i
+      assert_selector "a[href='#{edition.public_url(draft: true, cachebust:)}']", text: "Preview on website (opens in new tab)"
+    end
   end
 
   test "renders a link with tracking to preview the document when the edition is a foreign language only edition" do
     edition = build_stubbed(:publication, document: @document, primary_locale: :fr)
 
-    render_inline(Admin::Editions::Show::PreviewComponent.new(edition:))
-    assert_selector "a[href='#{edition.public_url(draft: true)}']", text: "Preview on website (opens in new tab)"
+    travel_to(Time.zone.local(2026, 5, 27, 12, 0, 0)) do
+      render_inline(Admin::Editions::Show::PreviewComponent.new(edition:))
+      cachebust = Time.zone.now.getutc.to_i
+      assert_selector "a[href='#{edition.public_url(draft: true, cachebust:)}']", text: "Preview on website (opens in new tab)"
+    end
   end
 
   test "renders a link with tracking to preview the document for each translation when there are multiple translations" do
     edition = create(:publication, translated_into: %i[fr es], document: @document)
 
-    render_inline(Admin::Editions::Show::PreviewComponent.new(edition:))
-    assert_selector "a[href='#{edition.public_url(draft: true)}']", text: "Preview on website - English (opens in new tab)"
-    assert_selector "a[href='#{edition.public_url(locale: 'fr', draft: true)}']", visible: false, text: "Preview on website - French (Français) (opens in new tab)"
-    assert_selector "a[href='#{edition.public_url(locale: 'es', draft: true)}']", visible: false, text: "Preview on website - Spanish (Español) (opens in new tab)"
+    travel_to(Time.zone.local(2026, 5, 27, 12, 0, 0)) do
+      render_inline(Admin::Editions::Show::PreviewComponent.new(edition:))
+      cachebust = Time.zone.now.getutc.to_i
+      assert_selector "a[href='#{edition.public_url(draft: true, cachebust:)}']", text: "Preview on website - English (opens in new tab)"
+      assert_selector "a[href='#{edition.public_url(locale: 'fr', draft: true, cachebust:)}']", visible: false, text: "Preview on website - French (Français) (opens in new tab)"
+      assert_selector "a[href='#{edition.public_url(locale: 'es', draft: true, cachebust:)}']", visible: false, text: "Preview on website - Spanish (Español) (opens in new tab)"
+    end
   end
 
   test "renders sharable preview functionality when edition is a pre-publication state" do

--- a/test/functional/admin/attachments_controller_test.rb
+++ b/test/functional/admin/attachments_controller_test.rb
@@ -38,12 +38,14 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
     assert_select "p.govuk-body", text: "Title: An HTML attachment"
   end
 
-  view_test "GET :index links HTML attachments to the draft preview host when the edition is a draft" do
+  view_test "GET :index links HTML attachments to the draft preview host with a cachebust query param when the edition is a draft" do
     attachment = create(:html_attachment, title: "An HTML attachment", attachable: @edition)
 
-    get :index, params: { edition_id: @edition }
-
-    assert_select "a[href=?]", attachment.url(preview: true, full_url: true)
+    travel_to(Time.zone.local(2026, 5, 27, 12, 0, 0)) do
+      get :index, params: { edition_id: @edition }
+      cachebust = Time.zone.now.getutc.to_i
+      assert_select "a[href=?]", attachment.url(preview: true, full_url: true, cachebust:)
+    end
   end
 
   view_test "GET :index links HTML attachments to the live site when the edition is published" do

--- a/test/functional/admin/attachments_controller_test.rb
+++ b/test/functional/admin/attachments_controller_test.rb
@@ -57,6 +57,14 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
     assert_select "a[href=?]", attachment.url(full_url: true)
   end
 
+  view_test "GET :index tags HTML attachment preview links with the CachebustLink JS module" do
+    create(:html_attachment, title: "An HTML attachment", attachable: @edition)
+
+    get :index, params: { edition_id: @edition }
+
+    assert_select "a[data-module='CachebustLink'][href*='cachebust=']"
+  end
+
   view_test "GET :index renders the uploading banner when an attachment hasn't been uploaded to asset manager" do
     create(:html_attachment, title: "An HTML attachment", attachable: @edition)
     create(:file_attachment, title: "An uploaded file attachment", attachable: @edition)

--- a/test/functional/admin/html_attachments_controller_test.rb
+++ b/test/functional/admin/html_attachments_controller_test.rb
@@ -98,6 +98,14 @@ class Admin::HtmlAttachmentsControllerTest < ActionController::TestCase
     assert_select "a[href=?]", attachment.url(full_url: true), text: "Preview on website (opens in new tab)"
   end
 
+  view_test "GET :edit tags the preview link with the CachebustLink JS module" do
+    attachment = create(:html_attachment, attachable: @edition)
+
+    get :edit, params: { edition_id: @edition, id: attachment.id }
+
+    assert_select "a[data-module='CachebustLink']", text: "Preview on website (opens in new tab)"
+  end
+
   test "POST :create with bad data does not save the attachment and re-renders the new template" do
     post :create, params: { edition_id: @edition, attachment: { attachment_data_attributes: {} } }
     assert_template :new

--- a/test/functional/admin/html_attachments_controller_test.rb
+++ b/test/functional/admin/html_attachments_controller_test.rb
@@ -79,12 +79,14 @@ class Admin::HtmlAttachmentsControllerTest < ActionController::TestCase
     assert_select "option[value='#{Attachment.parliamentary_sessions.first}']"
   end
 
-  view_test "GET :edit links the preview to the draft host when the edition is a draft" do
+  view_test "GET :edit links the preview to the draft host with a cachebust query param when the edition is a draft" do
     attachment = create(:html_attachment, attachable: @edition)
 
-    get :edit, params: { edition_id: @edition, id: attachment.id }
-
-    assert_select "a[href=?]", attachment.url(preview: true, full_url: true), text: "Preview on website (opens in new tab)"
+    travel_to(Time.zone.local(2026, 5, 27, 12, 0, 0)) do
+      get :edit, params: { edition_id: @edition, id: attachment.id }
+      cachebust = Time.zone.now.getutc.to_i
+      assert_select "a[href=?]", attachment.url(preview: true, full_url: true, cachebust:), text: "Preview on website (opens in new tab)"
+    end
   end
 
   view_test "GET :edit links the preview to the live site when the edition is published" do

--- a/test/functional/admin/publications_controller_test.rb
+++ b/test/functional/admin/publications_controller_test.rb
@@ -194,6 +194,16 @@ class Admin::PublicationsControllerTest < ActionController::TestCase
     assert_select "a.govuk-link[href=?]", attachment.url(full_url: true)
   end
 
+  view_test "GET :show tags HTML attachment preview links with the CachebustLink JS module" do
+    publication = create(:draft_publication, :with_html_attachment)
+    attachment = publication.attachments.first
+    publication_has_no_expanded_links(publication.content_id)
+
+    get :show, params: { id: publication }
+
+    assert_select "a[data-module='CachebustLink'][href*='#{attachment.identifier}'][href*='cachebust=']"
+  end
+
   view_test "when edition is tagged to the new taxonomy" do
     world_tagging_organisation = create(:organisation, content_id: "f323e83c-868b-4bcb-b6e2-a8f9bb40397e")
 

--- a/test/functional/admin/publications_controller_test.rb
+++ b/test/functional/admin/publications_controller_test.rb
@@ -162,14 +162,16 @@ class Admin::PublicationsControllerTest < ActionController::TestCase
     assert_select ".app-view-summary__taxonomy-topics .govuk-link", "Add tags"
   end
 
-  view_test "GET :show links a draft publication's HTML attachment to the draft host" do
+  view_test "GET :show links a draft publication's HTML attachment to the draft host with a cachebust query param" do
     publication = create(:draft_publication, :with_html_attachment)
     attachment = publication.attachments.first
     publication_has_no_expanded_links(publication.content_id)
 
-    get :show, params: { id: publication }
-
-    assert_select "a.govuk-link[href=?]", attachment.url(preview: true, full_url: true)
+    travel_to(Time.zone.local(2026, 5, 27, 12, 0, 0)) do
+      get :show, params: { id: publication }
+      cachebust = Time.zone.now.getutc.to_i
+      assert_select "a.govuk-link[href=?]", attachment.url(preview: true, full_url: true, cachebust:)
+    end
   end
 
   view_test "GET :show links a published publication's HTML attachment to the live site" do

--- a/test/support/css_selectors.rb
+++ b/test/support/css_selectors.rb
@@ -102,7 +102,7 @@ module CssSelectors
   end
 
   def link_to_preview_version_selector(document)
-    "a[href='#{document.public_url(draft: true)}']"
+    "a[href^='#{document.public_url(draft: true)}?']"
   end
 
   def policy_group_selector

--- a/test/unit/app/helpers/admin/url_options_helper_test.rb
+++ b/test/unit/app/helpers/admin/url_options_helper_test.rb
@@ -1,57 +1,69 @@
 require "test_helper"
 
 class Admin::UrlOptionsHelperTest < ActionView::TestCase
-  test "#attachable_post_publication? returns true when the attachable is a published Edition" do
+  test "#attachment_preview_options returns an empty hash when the attachable is a published Edition" do
     edition = create(:published_publication)
-    assert attachable_post_publication?(edition)
+    assert_equal({}, attachment_preview_options(edition))
   end
 
-  test "#attachable_post_publication? returns true when the attachable is a withdrawn Edition" do
+  test "#attachment_preview_options returns an empty hash when the attachable is a withdrawn Edition" do
     edition = create(:withdrawn_publication)
-    assert attachable_post_publication?(edition)
+    assert_equal({}, attachment_preview_options(edition))
   end
 
-  test "#attachable_post_publication? returns true when the attachable is a superseded Edition" do
+  test "#attachment_preview_options returns an empty hash when the attachable is a superseded Edition" do
     edition = create(:superseded_publication)
-    assert attachable_post_publication?(edition)
+    assert_equal({}, attachment_preview_options(edition))
   end
 
-  test "#attachable_post_publication? returns true when the attachable is an unpublished Edition" do
+  test "#attachment_preview_options returns an empty hash when the attachable is an unpublished Edition" do
     edition = create(:unpublished_publication)
-    assert attachable_post_publication?(edition)
+    assert_equal({}, attachment_preview_options(edition))
   end
 
-  test "#attachable_post_publication? returns false when the attachable is a draft Edition" do
+  test "#attachment_preview_options returns preview and cachebust options when the attachable is a draft Edition" do
     edition = create(:draft_publication)
-    assert_not attachable_post_publication?(edition)
+    travel_to(Time.zone.local(2026, 5, 27, 12, 0, 0)) do
+      cachebust = Time.zone.now.getutc.to_i
+      assert_equal({ preview: true, cachebust: }, attachment_preview_options(edition))
+    end
   end
 
-  test "#attachable_post_publication? returns true when the attachable is a ConsultationResponse whose consultation is published" do
+  test "#attachment_preview_options returns an empty hash when the attachable is a ConsultationResponse whose consultation is published" do
     consultation = create(:published_consultation)
     response = build(:consultation_outcome, consultation:)
-    assert attachable_post_publication?(response)
+    assert_equal({}, attachment_preview_options(response))
   end
 
-  test "#attachable_post_publication? returns false when the attachable is a ConsultationResponse whose consultation is a draft" do
+  test "#attachment_preview_options returns preview and cachebust options when the attachable is a ConsultationResponse whose consultation is a draft" do
     consultation = create(:draft_consultation)
     response = build(:consultation_outcome, consultation:)
-    assert_not attachable_post_publication?(response)
+    travel_to(Time.zone.local(2026, 5, 27, 12, 0, 0)) do
+      cachebust = Time.zone.now.getutc.to_i
+      assert_equal({ preview: true, cachebust: }, attachment_preview_options(response))
+    end
   end
 
-  test "#attachable_post_publication? returns true when the attachable is a CallForEvidenceResponse whose call for evidence is published" do
+  test "#attachment_preview_options returns an empty hash when the attachable is a CallForEvidenceResponse whose call for evidence is published" do
     call_for_evidence = create(:published_call_for_evidence)
     response = build(:call_for_evidence_outcome, call_for_evidence:)
-    assert attachable_post_publication?(response)
+    assert_equal({}, attachment_preview_options(response))
   end
 
-  test "#attachable_post_publication? returns false when the attachable is a CallForEvidenceResponse whose call for evidence is a draft" do
+  test "#attachment_preview_options returns preview and cachebust options when the attachable is a CallForEvidenceResponse whose call for evidence is a draft" do
     call_for_evidence = create(:draft_call_for_evidence)
     response = build(:call_for_evidence_outcome, call_for_evidence:)
-    assert_not attachable_post_publication?(response)
+    travel_to(Time.zone.local(2026, 5, 27, 12, 0, 0)) do
+      cachebust = Time.zone.now.getutc.to_i
+      assert_equal({ preview: true, cachebust: }, attachment_preview_options(response))
+    end
   end
 
-  test "#attachable_post_publication? returns false when the attachable is a PolicyGroup" do
+  test "#attachment_preview_options returns preview and cachebust options when the attachable is a PolicyGroup" do
     policy_group = create(:policy_group)
-    assert_not attachable_post_publication?(policy_group)
+    travel_to(Time.zone.local(2026, 5, 27, 12, 0, 0)) do
+      cachebust = Time.zone.now.getutc.to_i
+      assert_equal({ preview: true, cachebust: }, attachment_preview_options(policy_group))
+    end
   end
 end

--- a/test/unit/app/helpers/application_helper_test.rb
+++ b/test/unit/app/helpers/application_helper_test.rb
@@ -26,6 +26,14 @@ class ApplicationHelperTest < ActionView::TestCase
     assert_equal %(<span>#{attachment.filename}</span>), link_to_attachment(attachment)
   end
 
+  test "#link_to_attachment forwards data attributes to the rendered link without leaking them into the URL" do
+    attachment = build(:external_attachment)
+    rendered = link_to_attachment(attachment, data: { module: "CachebustLink" })
+
+    assert_match %r{data-module="CachebustLink"}, rendered
+    assert_no_match %r{data=}, attachment.url
+  end
+
   test "#link_to_attachment_data returns a link if file attachment has all asset variants" do
     attachment_data = build(:attachment_data)
     assert_equal %(<a class="govuk-link" href="#{attachment_data.url}">#{attachment_data.filename}</a>), link_to_attachment_data(attachment_data)

--- a/test/unit/app/models/html_attachment_test.rb
+++ b/test/unit/app/models/html_attachment_test.rb
@@ -29,7 +29,7 @@ class HtmlAttachmentTest < ActiveSupport::TestCase
     attachment = edition.attachments.first
 
     expected = "https://draft-origin.test.gov.uk/government/publications/"
-    expected += "#{edition.slug}/#{attachment.slug}?preview=#{attachment.id}"
+    expected += "#{edition.slug}/#{attachment.slug}"
     actual = attachment.url(preview: true, full_url: true)
 
     assert_equal expected, actual
@@ -40,7 +40,7 @@ class HtmlAttachmentTest < ActiveSupport::TestCase
     attachment = edition.attachments.first
 
     expected = "https://draft-origin.test.gov.uk/government/publications/"
-    expected += "#{edition.slug}/#{attachment.slug}?cachebust=123&preview=#{attachment.id}"
+    expected += "#{edition.slug}/#{attachment.slug}?cachebust=123"
     actual = attachment.url(preview: true, full_url: true, cachebust: "123")
 
     assert_equal expected, actual
@@ -53,17 +53,6 @@ class HtmlAttachmentTest < ActiveSupport::TestCase
     expected = "https://www.test.gov.uk/government/publications/"
     expected += "#{edition.slug}/#{attachment.slug}"
     actual = attachment.url(full_url: true)
-
-    assert_equal expected, actual
-  end
-
-  test "#url omits the preview query parameter when preview is explicitly false" do
-    edition = create(:published_publication, :with_html_attachment)
-    attachment = edition.attachments.first
-
-    expected = "https://www.test.gov.uk/government/publications/"
-    expected += "#{edition.slug}/#{attachment.slug}"
-    actual = attachment.url(preview: false, full_url: true)
 
     assert_equal expected, actual
   end


### PR DESCRIPTION
## What

Auto-appends `?cachebust=<unix-epoch-seconds>` to admin preview links for draft documents so publishers viewing the same draft don't see stale cached versions.

## Why

Support tickets often show two publishers collaborating on the same document seeing different content because one has an older version cached. Forcing a fresh URL on every preview click eliminates that type of issue.

## What's covered?

All five draft preview links across the admin document screens:

- Primary-locale link rendered by `PreviewComponent`
- Per-locale translation links inside "Preview translated pages"
- HTML attachment row on the edition summary "Attachments" table
- HTML attachment row on `/admin/editions/<id>/attachments`
- "Preview on website" link on the HTML attachment edit form

[Jira](https://gov-uk.atlassian.net/browse/WHIT-3385)

## Follow-up PRs

- **JS auto-increment** — re-incrementing the timestamp every second so the URL stays fresh on long-lived pages.
- **Remove obsolete `?preview=<id>` query param on HTML attachment URLs** — [Jira](https://gov-uk.atlassian.net/browse/WHIT-3384)

## Test plan

- [x] On a draft publication's admin summary page, click "Preview on website" — URL has `?cachebust=<timestamp>`
- [x] Refresh the page and click again — timestamp is newer
- [x] On a multi-language draft edition's summary page, expand "Preview translated pages" and click a translation link — URL has cachebust
- [x] Click an HTML attachment row on the same page — URL has cachebust
- [x] On `/admin/editions/<id>/attachments`, click the HTML attachment link — URL has cachebust
- [x] On an HTML attachment's edit form, click "Preview on website" — URL has cachebust
- [x] On a published edition's summary page, "Preview on website" still points to the live URL with no cachebust query param
