### PR TITLE
Gracefully handle base_path conflicts with Publishing API [WHIT-3507]

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -99,6 +99,12 @@ class Admin::EditionsController < Admin::BaseController
       build_edition_dependencies
       render :new
     end
+  rescue Whitehall::UnpublishableInstanceError => e
+    # We were unable to save the draft to Publishing API, presumably because of a
+    # base_path conflict. Surface the error message to the user and re-render the form.
+    flash.now[:alert] = e.message
+    build_edition_dependencies
+    render :new
   end
 
   def edit

--- a/test/functional/admin/standard_editions_controller_test.rb
+++ b/test/functional/admin/standard_editions_controller_test.rb
@@ -1224,6 +1224,68 @@ class Admin::StandardEditionsControllerTest < ActionController::TestCase
     assert_select "input[type=hidden][name=current_tab][value=documents]"
   end
 
+  view_test "POST create surfaces Publishing API validation error if save_draft fails" do
+    error_hash = {
+      "error" => {
+        "code" => 422,
+        "message" => "Base path /guidance/test is already reserved by manuals-publisher",
+        "error_code" => "base_path_already_in_use",
+        "fields" => {
+          "base_path" => [
+            {
+              "error" => "/guidance/test is already reserved by manuals-publisher",
+              "code" => "base_path_already_in_use",
+            },
+          ],
+        },
+      },
+    }
+    Whitehall::PublishingApi.expects(:save_draft).raises(Whitehall::UnpublishableInstanceError.new(error_hash["error"]["message"]))
+
+    configurable_document_type = build_configurable_document_type("test_type", {
+      "forms" => {
+        "documents" => {
+          "fields" => {
+            "test_attribute" => {
+              "title" => "Test attribute",
+              "block" => "default_string",
+              "attribute_path" => %w[block_content test_attribute],
+              "translatable" => true,
+            },
+          },
+        },
+      },
+      "schema" => {
+        "attributes" => {
+          "test_attribute" => {
+            "type" => "string",
+          },
+        },
+        "validations" => {
+          "presence" => {
+            "attributes" => %w[test_attribute],
+          },
+        },
+      },
+    })
+    ConfigurableDocumentType.setup_test_types(configurable_document_type)
+
+    post :create, params: {
+      edition: {
+        configurable_document_type: "test_type",
+        title: "Foo",
+        summary: "Bar",
+        block_content: {
+          "test_attribute" => "foo",
+        },
+        previously_published: false,
+      },
+    }
+
+    assert_template "admin/editions/new"
+    assert_select ".gem-c-error-alert", text: "Base path /guidance/test is already reserved by manuals-publisher"
+  end
+
   view_test "POST create re-renders the new edition template with the submitted block content and errors if the form is invalid" do
     configurable_document_type = build_configurable_document_type("test_type", {
       "forms" => {


### PR DESCRIPTION
Currently, when trying to save a new draft of Whitehall content whose base_path resolves to an existing/reserved base_path in Publishing API, Publishing API returns a 422 response and Whitehall catches this (in `Whitehall::PublishingApi.save_draft_translation`) and raises an UnpublishableInstanceError. The draft creation workflow does not catch this exception, and thus we show the user a Server Error page.

This commit adds error handling for UnpublishableInstanceError, such that the error is surfaced as a validation-error-style message instead, which at least gives the user a clue as to next steps.

Note that as of recent changes to Publishing API, there is now an error_code we can hook into if we want to reliably detect a certain category of error and display a customised error message to the user. For example, instead of "/guidance/test is already reserved by manuals-publisher" we may want to say something like "The /guidance/test base path is already reserved by another application. Try editing your title to generate a different base path."

But that would involve making changes more widely, e.g. to the bit in `Whitehall::PublishingApi` that swallows the GdsApi exception and raises an UnpublishableInstanceError. So that refinement can come in a [future ticket](https://gov-uk.atlassian.net/browse/WHIT-3508).

Jira: https://gov-uk.atlassian.net/browse/WHIT-3507

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
