### PR TITLE
Fix crash when republishing features for deleted editions [WHIT-3490]

### DIFF
--- a/app/models/feature_list.rb
+++ b/app/models/feature_list.rb
@@ -49,7 +49,7 @@ class FeatureList < ApplicationRecord
   delegate :empty?, to: :current
 
   def republish_featurable_to_publishing_api
-    if featurable.persisted?
+    if featurable&.persisted?
       if featurable.is_a?(Organisation) || featurable.is_a?(WorldLocationNews)
         Whitehall::PublishingApi.republish_async(featurable)
       else

--- a/test/unit/app/models/standard_edition_test.rb
+++ b/test/unit/app/models/standard_edition_test.rb
@@ -540,6 +540,29 @@ class StandardEditionTest < ActiveSupport::TestCase
     featured_edition.publish!
   end
 
+  test "changing the state of the edition (e.g. DetailedGuide) causes a republish of any documents the edition is featured on (e.g. topical event) - but skips over deleted documents (e.g. deleted topical event) that USED to feature the edition" do
+    deleted_featuring_edition = create(:deleted_standard_edition)
+    redundant_feature_list = create(:feature_list, featurable: deleted_featuring_edition)
+
+    featuring_edition = create(:published_standard_edition)
+    feature_list = create(:feature_list, featurable: featuring_edition)
+
+    featured_edition = create(:submitted_standard_edition, major_change_published_at: 1.day.ago)
+
+    # deleted document's featuring
+    redundant_feature = redundant_feature_list.features.build(document: featured_edition.document, started_at: 3.days.ago)
+    redundant_feature.image = build(:featured_image_data, featured_imageable: redundant_feature)
+    redundant_feature.save!
+    # live document's featuring
+    feature = feature_list.features.build(document: featured_edition.document, started_at: 1.day.ago)
+    feature.image = build(:featured_image_data, featured_imageable: feature)
+    feature.save!
+
+    Whitehall::PublishingApi.expects(:republish_document_async).with(deleted_featuring_edition.document).never
+    Whitehall::PublishingApi.expects(:republish_document_async).with(featuring_edition.document)
+    featured_edition.publish!
+  end
+
   test "changing anything else about StandardEdition does NOT cause a republish of any documents the StandardEdition is featured on" do
     featuring_edition = create(:published_standard_edition)
     feature_list = create(:feature_list, featurable: featuring_edition)


### PR DESCRIPTION
Previously, republishing a featurable edition would raise an error if any associated FeatureList still pointed at a deleted Edition, resulting in a nil featurable during `republish_featurable_to_publishing_api`.

This happened because deleted editions are not automatically removed from FeatureList associations, so `featurable.persisted?` could be called on `nil`.

Fixed by safely handling missing featurables.
Added regression test ensuring that republishing skips feature lists whose featurable editions have been deleted while still processing valid ones.

Jira: https://gov-uk.atlassian.net/browse/WHIT-3490

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
