### PR TITLE
Remove Pact dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,8 +63,6 @@ gem "whenever", require: false
 group :development, :test do
   gem "erb_lint", require: false
   gem "flog"
-  gem "pact", require: false
-  gem "pact_broker-client"
   gem "pry-byebug"
   gem "pry-rails"
   gem "rubocop-govuk", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,7 +87,6 @@ GEM
       activerecord (>= 4.2)
       activesupport
     ast (2.4.3)
-    awesome_print (1.9.2)
     babosa (2.0.0)
     base64 (0.3.0)
     better_errors (2.10.1)
@@ -191,7 +190,6 @@ GEM
     debug_inspector (1.2.0)
     diff-lcs (1.6.2)
     diffy (3.4.4)
-    dig_rb (1.0.1)
     docile (1.4.0)
     domain_name (0.6.20240107)
     drb (2.2.3)
@@ -211,8 +209,6 @@ GEM
     excon (1.4.2)
       logger
     execjs (2.10.0)
-    expgen (0.1.1)
-      parslet
     factory_bot (6.5.6)
       activesupport (>= 6.1.0)
     fakeredis (0.9.2)
@@ -226,7 +222,6 @@ GEM
     ffi (1.17.3-aarch64-linux-gnu)
     ffi (1.17.3-arm64-darwin)
     ffi (1.17.3-x86_64-linux-gnu)
-    find_a_port (1.0.1)
     flipflop (2.8.0)
       activesupport (>= 4.0)
       terminal-table (>= 1.8)
@@ -353,10 +348,6 @@ GEM
     http-accept (1.7.0)
     http-cookie (1.1.6)
       domain_name (~> 0.5)
-    httparty (0.24.0)
-      csv
-      mini_mime (>= 1.0.0)
-      multi_xml (>= 0.5.2)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     i18n-coverage (0.2.0)
@@ -397,8 +388,6 @@ GEM
       hana (~> 1.3)
       regexp_parser (~> 2.0)
       simpleidn (~> 0.2)
-    jsonpath (1.1.5)
-      multi_json
     jwt (2.10.2)
       base64
     kaminari (1.2.2)
@@ -681,48 +670,10 @@ GEM
     opentelemetry-semantic_conventions (1.37.1)
       opentelemetry-api (~> 1.0)
     ostruct (0.6.3)
-    pact (1.67.5)
-      pact-mock_service (~> 3.0, >= 3.3.1)
-      pact-support (~> 1.21, >= 1.21.2)
-      rack
-      rack-proxy
-      rack-test (>= 0.6.3, < 3.0.0)
-      rainbow (~> 3.1)
-      rspec (~> 3.0)
-      thor (>= 0.20, < 2.0)
-      webrick (~> 1.8)
-      zeitwerk (~> 2.3)
-    pact-mock_service (3.12.4)
-      find_a_port (~> 1.0.1)
-      json
-      logger (< 2.0)
-      pact-support (~> 1.16, >= 1.16.4)
-      rack (>= 3.0, < 4.0)
-      rackup (~> 2.0)
-      rspec (>= 2.14)
-      thor (>= 0.19, < 2.0)
-      webrick (~> 1.8)
-    pact-support (1.21.2)
-      awesome_print (~> 1.9)
-      diff-lcs (~> 1.5)
-      expgen (~> 0.1)
-      jsonpath (~> 1.0)
-      rainbow (~> 3.1.1)
-      string_pattern (~> 2.0)
-    pact_broker-client (1.77.0)
-      base64 (~> 0.2)
-      dig_rb (~> 1.0)
-      httparty (>= 0.21.0, < 1.0.0)
-      ostruct
-      rake (~> 13.0)
-      table_print (~> 1.5)
-      term-ansicolor (~> 1.7)
-      thor (>= 0.20, < 2.0)
     parallel (1.28.0)
     parser (3.3.11.1)
       ast (~> 2.4.1)
       racc
-    parslet (2.0.0)
     path_expander (2.0.1)
     pdf-reader (2.15.1)
       Ascii85 (>= 1.0, < 3.0, != 2.0.0)
@@ -842,19 +793,6 @@ GEM
     rexml (3.4.4)
     rinku (2.0.6)
     rouge (4.7.0)
-    rspec (3.13.2)
-      rspec-core (~> 3.13.0)
-      rspec-expectations (~> 3.13.0)
-      rspec-mocks (~> 3.13.0)
-    rspec-core (3.13.6)
-      rspec-support (~> 3.13.0)
-    rspec-expectations (3.13.5)
-      diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.13.0)
-    rspec-mocks (3.13.7)
-      diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.13.0)
-    rspec-support (3.13.7)
     rubocop (1.86.0)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
@@ -957,18 +895,12 @@ GEM
       sprockets (>= 3.0.0)
     ssrf_filter (1.2.0)
     statsd-ruby (1.5.0)
-    string_pattern (2.4.0)
-      regexp_parser (~> 2.5, >= 2.5.0)
     stringio (3.2.0)
     strong_migrations (2.6.0)
       activerecord (>= 7.2)
-    sync (0.5.0)
     sys-uname (1.5.1)
       ffi (~> 1.1)
       memoist3 (~> 1.0.0)
-    table_print (1.5.7)
-    term-ansicolor (1.11.2)
-      tins (~> 1.0)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     terser (1.2.7)
@@ -976,9 +908,6 @@ GEM
     thor (1.5.0)
     timecop (0.9.11)
     timeout (0.6.1)
-    tins (1.37.0)
-      bigdecimal
-      sync
     transitions (1.3.0)
     tsort (0.2.0)
     ttfunk (1.8.0)
@@ -1080,8 +1009,6 @@ DEPENDENCIES
   mocha
   mysql2
   nokogiri
-  pact
-  pact_broker-client
   pdf-reader
   plek
   pry-byebug


### PR DESCRIPTION
This was added back in https://github.com/alphagov/whitehall/pull/6203, but was never actually used in subsequent commits.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
