### PR TITLE
Navigation spike [WHIT-3342]

### DIFF
--- a/app/models/configurable_document_types/navigation.json
+++ b/app/models/configurable_document_types/navigation.json
@@ -1,0 +1,59 @@
+{
+  "key": "navigation",
+  "title": "Navigation",
+  "description": "Spiking a navigation object. In the future this would likely live as a separate artefact in a tab on a given configurable document type. But this spike allows us to hard code a blob of JSON and send to Publishing API without having to worry about the lifecycle of the associated edition.",
+  "forms": {
+    "documents": {
+      "fields": {
+        "menu_items": {
+          "title": "Menu items",
+          "description": "JSON hash to be sent as part of the Navigation's `details` - for spike purposes only. The intention is to use this to describe the _structure_ of the navigation (e.g. nesting).",
+          "block": "default_textarea",
+          "attribute_path": ["block_content", "menu_items"],
+          "translatable": false
+        },
+        "navigation_items": {
+          "title": "Linked navigation documents",
+          "description": "JSON hash of content IDs of documents to be linked to this navigation document as `links.navigation_items` in the Publishing API payload. Should map to the same menu items referenced in the `menu_items` field. For spike purposes only.",
+          "block": "default_textarea",
+          "attribute_path": ["block_content", "navigation_items"],
+          "translatable": false
+        }
+      }
+    }
+  },
+  "schema": {
+    "attributes": {
+      "menu_items": {
+        "type": "string"
+      },
+      "navigation_items": {
+        "type": "string"
+      }
+    }
+  },
+  "presenters": {
+    "publishing_api": {
+      "details": {
+        "menu_items": "parsed_as_hash"
+      },
+      "links": [
+        "navigation_items"
+      ]
+    }
+  },
+  "settings": {
+    "publishing_api_schema_name": "shared_navigation",
+    "publishing_api_document_type": "shared_navigation",
+    "send_change_history": false,
+    "file_attachments_enabled": false,
+    "images": {
+      "enabled": false
+    },
+    "organisations": null,
+    "backdating_enabled": false,
+    "history_mode_enabled": false,
+    "taxon_required": false,
+    "translations_enabled": false
+  }
+}

--- a/app/presenters/publishing_api/payload_builder/block_content.rb
+++ b/app/presenters/publishing_api/payload_builder/block_content.rb
@@ -28,6 +28,13 @@ module PublishingApi
         item.block_content&.public_send(attribute)
       end
 
+      def parsed_as_hash(attribute)
+        content = item.block_content&.public_send(attribute)
+        return nil if content.nil?
+
+        JSON.parse(content)
+      end
+
       def govspeak(attribute)
         content = item.block_content&.public_send(attribute)
         return nil if content.nil?

--- a/app/presenters/publishing_api/payload_builder/configurable_document_links.rb
+++ b/app/presenters/publishing_api/payload_builder/configurable_document_links.rb
@@ -52,5 +52,19 @@ module PublishingApi::PayloadBuilder
     def self.government(item)
       { government: [item.government&.content_id].compact }
     end
+
+    def self.navigation_items(item)
+      content = item.block_content["navigation_items"]
+      return nil if content.nil?
+
+      # TODO: simplify. This originally was going to be an array of objects but is now just a list of content IDs
+      # e.g.
+      # [
+      #   "05c902c3-8272-4940-be0c-2c71e36e538d"
+      # ]
+      # All we're doing is parsing the JSON above, but we could probably make this
+      # a comma separated list, or even better, use the array / add-another component
+      { navigation_items: JSON.parse(content) }
+    end
   end
 end

--- a/public/configurable-document-type.schema.json
+++ b/public/configurable-document-type.schema.json
@@ -285,6 +285,7 @@
                     "govspeak",
                     "rfc3339_date",
                     "image",
+                    "parsed_as_hash",
                     "raw",
                     "social_media_links"
                   ]
@@ -302,6 +303,7 @@
                 "type": "string",
                 "description": "The builder methods to use for populating the links object when presenting to the Publishing API.",
                 "enum": [
+                  "navigation_items",
                   "ministerial_role_appointments",
                   "topical_events",
                   "world_locations",
@@ -345,7 +347,8 @@
             "history",
             "topical_event",
             "news_article",
-            "case_study"
+            "case_study",
+            "shared_navigation"
           ]
         },
         "publishing_api_document_type": {
@@ -358,7 +361,8 @@
             "world_news_story",
             "history",
             "topical_event",
-            "case_study"
+            "case_study",
+            "shared_navigation"
           ]
         },
         "rendering_app": {
@@ -467,10 +471,8 @@
         }
       },
       "required": [
-        "base_path_prefix",
         "publishing_api_schema_name",
         "publishing_api_document_type",
-        "rendering_app",
         "images",
         "send_change_history",
         "organisations",


### PR DESCRIPTION
## What

Spikes a means of creating a Navigation content item (`shared_navigation` content schema/document type) and linking 0..* Whitehall documents to it.

It defines a "Navigation" StandardEdition with two fields where we can include JSON in the payload for `details` and `links` respectively:

> <img width="811" height="553" alt="Screenshot 2026-05-26 at 15 43 48" src="https://github.com/user-attachments/assets/3c34f599-3731-4481-bff6-1227005c5178" />

The link is implemented as a [reverse link](https://github.com/alphagov/publishing-api/blob/7403170ad920bc0483669e12fb062c4def00ac21/docs/link-expansion.md#reverse-links), meaning we don't even have to touch any of the documents associated with the Navigation - they get the association by default.

See https://github.com/alphagov/publishing-api/pull/4085 for the counterpart PR.

## Why

So that we can test whether our intended approach to Navigation will work end-to-end.

Jira: https://gov-uk.atlassian.net/browse/WHIT-3342

### See it in action

`DownstreamPayload.new(Document.find_by(content_id: press_release_content_id, locale: "en").editions.last, 1, draft: true).expanded_links`

=>

```
{shared_navigations:
  [{content_id: "81392be0-5ccc-4a84-8431-79f1920b7242",
    title: "Chris shared navigation June",
    locale: "en",
    analytics_identifier: nil,
    api_path: "/api/content/chris-shared-navigation-june--2",
    base_path: "/chris-shared-navigation-june--2",
    document_type: "shared_navigation",
    public_updated_at: "2026-06-02T14:58:28Z",
    schema_name: "shared_navigation",
    withdrawn: false,
    details: {menu_items: [{type: "press_release", content_id: "26086fc1-fbd6-4291-b308-3f334d380d56"}, {type: "publication", content_id: "c6caa8d4-5557-42ea-935b-d45d640d4269"}]},
    links:
     {navigation_items:
       [{content_id: "26086fc1-fbd6-4291-b308-3f334d380d56",
         title: "Foreign Secretary statement on the situation in Lebanon",
         locale: "en",
         analytics_identifier: nil,
         api_path: "/api/content/government/news/foreign-secretary-statement-on-the-situation-in-lebanon--2",
         base_path: "/government/news/foreign-secretary-statement-on-the-situation-in-lebanon--2",
         document_type: "press_release",
         public_updated_at: "2026-03-15T23:02:00Z",
         schema_name: "news_article",
         withdrawn: false,
         links: {}},
        {content_id: "c6caa8d4-5557-42ea-935b-d45d640d4269",
         title: "Youth justice plans: guidance for youth justice services",
         locale: "en",
         analytics_identifier: nil,
         api_path: "/api/content/government/publications/youth-justice-plans-guidance-for-youth-justice-services",
         base_path: "/government/publications/youth-justice-plans-guidance-for-youth-justice-services",
         document_type: "guidance",
         public_updated_at: "2025-01-21T14:33:30Z",
         schema_name: "publication",
         withdrawn: false,
         links: {}}]}}],
```

### Further testing

Tested Navigation that includes some English-only documents and some English documents with Welsh translations. When requesting expanded_links for the `cy` locale (`DownstreamPayload.new(Document.find_by(content_id: publication_content_id, locale: "cy").editions.last, 1, draft: true).expanded_links`), the equivalent Welsh translations were automatically surfaced in the expanded links, falling back to the English translation if a Welsh version doesn't exist 🎉  

> <img width="1061" height="910" alt="Screenshot 2026-05-29 at 12 22 56" src="https://github.com/user-attachments/assets/c2ee45cf-4e02-4eaf-831c-48ea44ea9eff" />

Also tested including live and draft content in the navigation. Both live and draft content would be surfaced in the navigation when rendering the navigation in a draft context, but draft content is automatically **not** included when rendering in a live context 🎉 

Also tested making edits to a draft Navigation and confirmed that it does not alter the live Navigation 🎉 

### Caveat

Publishing API link expansion / dependency resolution does a lot of the work for us, but we did find one shortcoming: 

- Linking a draft doc A and a published doc B to navigation: the navigation is present in the content items for both, on draft stack. On live stack, published doc B only has navigation link to doc B, not doc A. Great! 🎉  Draft nav items automatically dropped from published docs.
- Unexpected and unfortunate bug: publishing doc A does not updated the linked navigation on doc B. Requires us to add a callback to Whitehall. Likely a symptom of [PTD-91: Whitehall has to manage republishing of linked items despite existence of link expansion in Publishing API](https://gov-uk.atlassian.net/browse/PTD-91) 😭 
- Similarly, updating a title of one of the docs in the navigation, does not re-present another doc in the navigation. Manually republishing the other doc sorts that. HOWEVER - it's easier than that - manually republishing the Navigation itself sorts it too.

In other words, whenever any Document in the Navigation is updated, we’ll need to callback and republish the Navigation. Publishing API will then handle the updating of all the other pages in the Navigation. So probably still a big win overall - just the one callback.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
