### PR TITLE
Create `AccessLimitingOrganisation` [WHIT-3505]

### DIFF
--- a/app/models/access_limiting_organisation.rb
+++ b/app/models/access_limiting_organisation.rb
@@ -1,0 +1,6 @@
+class AccessLimitingOrganisation < ApplicationRecord
+  belongs_to :edition
+  belongs_to :organisation, inverse_of: :access_limiting_organisations
+
+  validates :edition, :organisation, presence: true
+end

--- a/app/models/concerns/edition/organisations.rb
+++ b/app/models/concerns/edition/organisations.rb
@@ -11,6 +11,8 @@ module Edition::Organisations
 
   included do
     has_many :edition_organisations, foreign_key: :edition_id, dependent: :destroy, autosave: true, validate: false
+    has_many :access_limiting_organisations, foreign_key: :edition_id, dependent: :destroy, autosave: true, validate: false
+
     has_many :organisations, -> { includes(:translations) }, through: :edition_organisations, validate: false
 
     validate :at_least_one_lead_organisation, if: :organisation_association_enabled?

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -29,6 +29,7 @@ class Organisation < ApplicationRecord
            through: :parent_organisational_relationships
 
   has_many :edition_organisations, dependent: :destroy, inverse_of: :organisation
+  has_many :access_limiting_organisations, dependent: :destroy, inverse_of: :organisation
   has_many :corporate_information_pages, through: "edition_#{table_name}".to_sym, source: :edition, class_name: "CorporateInformationPage"
   before_destroy do |record|
     record.corporate_information_pages.map(&:document).uniq.each(&:destroy)

--- a/db/migrate/20260527105725_create_access_limiting_organisation.rb
+++ b/db/migrate/20260527105725_create_access_limiting_organisation.rb
@@ -1,0 +1,9 @@
+class CreateAccessLimitingOrganisation < ActiveRecord::Migration[8.1]
+  def change
+    create_table :access_limiting_organisations do |t|
+      t.timestamps
+      t.references :edition, null: false
+      t.references :organisation, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_03_161913) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_27_105725) do
+  create_table "access_limiting_organisations", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.bigint "edition_id", null: false
+    t.bigint "organisation_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["edition_id"], name: "index_access_limiting_organisations_on_edition_id"
+    t.index ["organisation_id"], name: "index_access_limiting_organisations_on_organisation_id"
+  end
+
   create_table "assets", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "asset_manager_id", null: false
     t.bigint "assetable_id"


### PR DESCRIPTION
## What

Create `AccessLimitingOrganisation` 

## Why

Required step to improve experience of limiting access of a document to specific organisations. 

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
