### PR TITLE
[WHIT-3385] Link HTML attachment previews to live site when post-publication

### DIFF
--- a/app/helpers/admin/url_options_helper.rb
+++ b/app/helpers/admin/url_options_helper.rb
@@ -40,4 +40,13 @@ module Admin::UrlOptionsHelper
   def show_url_with_auth_bypass_options(edition, options = {})
     edition.public_url(auth_bypass_options(edition).merge(options))
   end
+
+  def attachable_post_publication?(attachable)
+    edition = case attachable
+              when Edition then attachable
+              when ConsultationResponse then attachable.consultation
+              when CallForEvidenceResponse then attachable.call_for_evidence
+              end
+    Edition::POST_PUBLICATION_STATES.include?(edition&.state)
+  end
 end

--- a/app/models/html_attachment.rb
+++ b/app/models/html_attachment.rb
@@ -52,7 +52,11 @@ class HtmlAttachment < Attachment
   end
 
   def url(options = {})
-    options[:preview] = id if options[:preview]
+    if options[:preview]
+      options[:preview] = id
+    else
+      options.delete(:preview)
+    end
 
     if options[:full_url]
       public_url(options)

--- a/app/views/admin/attachments/_attachments.html.erb
+++ b/app/views/admin/attachments/_attachments.html.erb
@@ -14,7 +14,7 @@
           <strong>Type: </strong><%= attachment.is_a?(HtmlAttachment) ? attachment.readable_type : attachment.readable_type.capitalize %>
         </p>
         <p class="govuk-body">
-          <strong>Attachment: </strong><%= link_to_attachment(attachment, preview: true, full_url: true, class: "govuk-link govuk-link--no-visited-state") %>
+          <strong>Attachment: </strong><%= link_to_attachment(attachment, preview: !attachable_post_publication?(attachable), full_url: true, class: "govuk-link govuk-link--no-visited-state") %>
         </p>
         <% if attachable.allows_inline_attachments? && attachment.is_a?(FileAttachment) %>
           <%= render "govuk_publishing_components/components/copy_to_clipboard", {

--- a/app/views/admin/editions/show/_main.html.erb
+++ b/app/views/admin/editions/show/_main.html.erb
@@ -187,7 +187,7 @@
           rows: @edition.attachments.map do | attachment |
             [
               { text: attachment[:title] },
-              { text: link_to_attachment(attachment, preview: !@edition.published?, full_url: true, class: "govuk-link") },
+              { text: link_to_attachment(attachment, preview: !attachable_post_publication?(attachment.attachable), full_url: true, class: "govuk-link") },
               @edition.editable? ? { text: link_to("Edit", [:edit, :admin, @edition.becomes(Edition), attachment], class: "govuk-link") } : nil,
             ].compact
           end,

--- a/app/views/admin/html_attachments/_fields.html.erb
+++ b/app/views/admin/html_attachments/_fields.html.erb
@@ -51,7 +51,7 @@
       } do %>
       <p class="govuk-body">
         <%= link_to("Preview on website (opens in new tab)",
-        attachment.url(preview: true, full_url: true),
+        attachment.url(preview: !attachable_post_publication?(attachment.attachable), full_url: true),
         class: "govuk-link",
         target: "_blank", rel: "noopener") %>
       </p>

--- a/test/functional/admin/attachments_controller_test.rb
+++ b/test/functional/admin/attachments_controller_test.rb
@@ -38,6 +38,23 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
     assert_select "p.govuk-body", text: "Title: An HTML attachment"
   end
 
+  view_test "GET :index links HTML attachments to the draft preview host when the edition is a draft" do
+    attachment = create(:html_attachment, title: "An HTML attachment", attachable: @edition)
+
+    get :index, params: { edition_id: @edition }
+
+    assert_select "a[href=?]", attachment.url(preview: true, full_url: true)
+  end
+
+  view_test "GET :index links HTML attachments to the live site when the edition is published" do
+    published_edition = create(:published_publication)
+    attachment = create(:html_attachment, title: "An HTML attachment", attachable: published_edition)
+
+    get :index, params: { edition_id: published_edition }
+
+    assert_select "a[href=?]", attachment.url(full_url: true)
+  end
+
   view_test "GET :index renders the uploading banner when an attachment hasn't been uploaded to asset manager" do
     create(:html_attachment, title: "An HTML attachment", attachable: @edition)
     create(:file_attachment, title: "An uploaded file attachment", attachable: @edition)

--- a/test/functional/admin/html_attachments_controller_test.rb
+++ b/test/functional/admin/html_attachments_controller_test.rb
@@ -79,6 +79,23 @@ class Admin::HtmlAttachmentsControllerTest < ActionController::TestCase
     assert_select "option[value='#{Attachment.parliamentary_sessions.first}']"
   end
 
+  view_test "GET :edit links the preview to the draft host when the edition is a draft" do
+    attachment = create(:html_attachment, attachable: @edition)
+
+    get :edit, params: { edition_id: @edition, id: attachment.id }
+
+    assert_select "a[href=?]", attachment.url(preview: true, full_url: true), text: "Preview on website (opens in new tab)"
+  end
+
+  view_test "GET :edit links the preview to the live site when the edition is published" do
+    published_edition = create(:published_publication)
+    attachment = create(:html_attachment, attachable: published_edition)
+
+    get :edit, params: { edition_id: published_edition, id: attachment.id }
+
+    assert_select "a[href=?]", attachment.url(full_url: true), text: "Preview on website (opens in new tab)"
+  end
+
   test "POST :create with bad data does not save the attachment and re-renders the new template" do
     post :create, params: { edition_id: @edition, attachment: { attachment_data_attributes: {} } }
     assert_template :new

--- a/test/functional/admin/publications_controller_test.rb
+++ b/test/functional/admin/publications_controller_test.rb
@@ -162,6 +162,36 @@ class Admin::PublicationsControllerTest < ActionController::TestCase
     assert_select ".app-view-summary__taxonomy-topics .govuk-link", "Add tags"
   end
 
+  view_test "GET :show links a draft publication's HTML attachment to the draft host" do
+    publication = create(:draft_publication, :with_html_attachment)
+    attachment = publication.attachments.first
+    publication_has_no_expanded_links(publication.content_id)
+
+    get :show, params: { id: publication }
+
+    assert_select "a.govuk-link[href=?]", attachment.url(preview: true, full_url: true)
+  end
+
+  view_test "GET :show links a published publication's HTML attachment to the live site" do
+    publication = create(:published_publication, :with_html_attachment)
+    attachment = publication.attachments.first
+    publication_has_no_expanded_links(publication.content_id)
+
+    get :show, params: { id: publication }
+
+    assert_select "a.govuk-link[href=?]", attachment.url(full_url: true)
+  end
+
+  view_test "GET :show links a withdrawn publication's HTML attachment to the live site" do
+    publication = create(:withdrawn_publication, :with_html_attachment)
+    attachment = publication.attachments.first
+    publication_has_no_expanded_links(publication.content_id)
+
+    get :show, params: { id: publication }
+
+    assert_select "a.govuk-link[href=?]", attachment.url(full_url: true)
+  end
+
   view_test "when edition is tagged to the new taxonomy" do
     world_tagging_organisation = create(:organisation, content_id: "f323e83c-868b-4bcb-b6e2-a8f9bb40397e")
 

--- a/test/unit/app/helpers/admin/url_options_helper_test.rb
+++ b/test/unit/app/helpers/admin/url_options_helper_test.rb
@@ -1,0 +1,57 @@
+require "test_helper"
+
+class Admin::UrlOptionsHelperTest < ActionView::TestCase
+  test "#attachable_post_publication? returns true when the attachable is a published Edition" do
+    edition = create(:published_publication)
+    assert attachable_post_publication?(edition)
+  end
+
+  test "#attachable_post_publication? returns true when the attachable is a withdrawn Edition" do
+    edition = create(:withdrawn_publication)
+    assert attachable_post_publication?(edition)
+  end
+
+  test "#attachable_post_publication? returns true when the attachable is a superseded Edition" do
+    edition = create(:superseded_publication)
+    assert attachable_post_publication?(edition)
+  end
+
+  test "#attachable_post_publication? returns true when the attachable is an unpublished Edition" do
+    edition = create(:unpublished_publication)
+    assert attachable_post_publication?(edition)
+  end
+
+  test "#attachable_post_publication? returns false when the attachable is a draft Edition" do
+    edition = create(:draft_publication)
+    assert_not attachable_post_publication?(edition)
+  end
+
+  test "#attachable_post_publication? returns true when the attachable is a ConsultationResponse whose consultation is published" do
+    consultation = create(:published_consultation)
+    response = build(:consultation_outcome, consultation:)
+    assert attachable_post_publication?(response)
+  end
+
+  test "#attachable_post_publication? returns false when the attachable is a ConsultationResponse whose consultation is a draft" do
+    consultation = create(:draft_consultation)
+    response = build(:consultation_outcome, consultation:)
+    assert_not attachable_post_publication?(response)
+  end
+
+  test "#attachable_post_publication? returns true when the attachable is a CallForEvidenceResponse whose call for evidence is published" do
+    call_for_evidence = create(:published_call_for_evidence)
+    response = build(:call_for_evidence_outcome, call_for_evidence:)
+    assert attachable_post_publication?(response)
+  end
+
+  test "#attachable_post_publication? returns false when the attachable is a CallForEvidenceResponse whose call for evidence is a draft" do
+    call_for_evidence = create(:draft_call_for_evidence)
+    response = build(:call_for_evidence_outcome, call_for_evidence:)
+    assert_not attachable_post_publication?(response)
+  end
+
+  test "#attachable_post_publication? returns false when the attachable is a PolicyGroup" do
+    policy_group = create(:policy_group)
+    assert_not attachable_post_publication?(policy_group)
+  end
+end

--- a/test/unit/app/models/html_attachment_test.rb
+++ b/test/unit/app/models/html_attachment_test.rb
@@ -57,6 +57,17 @@ class HtmlAttachmentTest < ActiveSupport::TestCase
     assert_equal expected, actual
   end
 
+  test "#url omits the preview query parameter when preview is explicitly false" do
+    edition = create(:published_publication, :with_html_attachment)
+    attachment = edition.attachments.first
+
+    expected = "https://www.test.gov.uk/government/publications/"
+    expected += "#{edition.slug}/#{attachment.slug}"
+    actual = attachment.url(preview: false, full_url: true)
+
+    assert_equal expected, actual
+  end
+
   test "#url returns relative path by default" do
     edition = create(:published_publication, :with_html_attachment)
     attachment = edition.attachments.first


### PR DESCRIPTION
## Why

Prep work for [WHIT-3385](https://gov-uk.atlassian.net/browse/WHIT-3385) (auto-append cachebust to preview links). Cachebust is applicable for draft URLs. The existing HTML attachment links on the edition summary, attachments index, and HTML attachment edit form sent editors to the draft host even for already-live editions, so cachebust would have ended up on live URLs too. Fixing the host selection here means the follow-up cachebust change can be applied unconditionally on the URLs it touches.

## Summary

- Editors viewing the edition summary, the attachments index, or the HTML attachment edit form for a **post-publication** edition (published, withdrawn, superseded or unpublished) were sent to a `draft-origin` preview URL that may no longer serve this edition. This PR routes those links to the live site instead, while keeping draft editions on the preview host.
- The four post-publication states all map to a meaningful live URL:
  - **published**: live URL serves this edition
  - **withdrawn**: live URL serves this edition with the withdrawal notice
  - **superseded**: live URL serves the current edition (a newer version of the document); the draft-origin URL would also serve that newer edition, so neither host shows the superseded content — live is the more stable choice
  - **unpublished**: live URL serves the unpublishing notice or redirect; the draft-origin URL no longer serves this edition either
- Introduces `Admin::UrlOptionsHelper#attachable_post_publication?`, which resolves the owning Edition for each attachable type that can have HTML attachments (Edition, ConsultationResponse, CallForEvidenceResponse) and returns false for PolicyGroup, which has no owning edition.
- Fixes a related latent bug in `HtmlAttachment#url`: passing `preview: false` previously leaked `?preview=false` into the URL. Falsy preview options are now dropped.

## Test plan

For each of the three call-sites — the HTML attachment row on the edition summary page, the HTML attachment row on the attachments index, and the "Preview on website" link on the HTML attachment edit form — confirm the link target:

- [x] points to the **live URL** when the edition is published, withdrawn, superseded, or unpublished
- [x] points to **`draft-origin`** when the edition is still a draft

Plus the non-Edition attachables:

- [x] ConsultationResponse HTML attachment: live URL when the consultation is published, `draft-origin` when it's a draft
- [x] CallForEvidenceResponse HTML attachment: live URL when the call for evidence is published, `draft-origin` when it's a draft

[WHIT-3385]: https://gov-uk.atlassian.net/browse/WHIT-3385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
