### PR TITLE
[WHIT-3466] Bubble up other 422 errors from AM

### DIFF
--- a/app/services/asset_manager/asset_updater.rb
+++ b/app/services/asset_manager/asset_updater.rb
@@ -43,7 +43,9 @@ private
         asset_manager.update_asset(asset_manager_id, new_attributes)
       end
     rescue GdsApi::HTTPUnprocessableEntity
-      Rails.logger.info("Attempted to update Asset with asset_manager_id: '#{asset_manager_id}' that is live, with a draft 'parent_document_url'") if new_attributes["parent_document_url"].include?("draft-origin") && !new_attributes["draft"]
+      return Rails.logger.info("Attempted to update Asset with asset_manager_id: '#{asset_manager_id}' that is live, with a draft 'parent_document_url'") if new_attributes["parent_document_url"]&.include?("draft-origin") && attributes["draft"] == false
+
+      raise
     end
   end
 end

--- a/test/unit/app/services/asset_manager/asset_updater_test.rb
+++ b/test/unit/app/services/asset_manager/asset_updater_test.rb
@@ -37,11 +37,20 @@ class AssetManager::AssetUpdaterTest < ActiveSupport::TestCase
 
   test "rescues and logs if attempting to update a live asset with a draft `parent_document_url`" do
     @asset_updater.stubs(:find_asset_by_id).with(@asset_manager_id).returns("id" => @asset_manager_id, "parent_document_url" => "gov.uk/live-parent", "draft" => false)
-    Services.asset_manager.expects(:update_asset).with(@asset_manager_id, { "parent_document_url" => "draft-origin/parent", "draft" => false }).raises(GdsApi::HTTPUnprocessableEntity, "Parent document url must be a public GOV.UK URL")
+    Services.asset_manager.expects(:update_asset).with(@asset_manager_id, { "parent_document_url" => "draft-origin/parent" }).raises(GdsApi::HTTPUnprocessableEntity, "Parent document url must be a public GOV.UK URL")
 
     Rails.logger.expects(:info).with("Attempted to update Asset with asset_manager_id: '#{@asset_manager_id}' that is live, with a draft 'parent_document_url'")
 
-    @asset_updater.call(@asset_manager_id, { "parent_document_url" => "draft-origin/parent", "draft" => false })
+    @asset_updater.call(@asset_manager_id, { "parent_document_url" => "draft-origin/parent" })
+  end
+
+  test "bubbles up unprocessable entity errors that are not about the 'parent_document_url'" do
+    @asset_updater.stubs(:find_asset_by_id).with(@asset_manager_id).returns("id" => @asset_manager_id)
+    Services.asset_manager.expects(:update_asset).raises(GdsApi::HTTPUnprocessableEntity, "Error")
+
+    assert_raises GdsApi::HTTPUnprocessableEntity, "Error" do
+      @asset_updater.call(@asset_manager_id, { draft: false })
+    end
   end
 
   test "marks draft asset as published" do


### PR DESCRIPTION
We've previously caught all `UnprocessableEntity` errors from the update call to asset manager, and specifically logged the ones where the data matches a scenario we know - trying to update an asset that is live, with a draft-origin parent url. There is no need to fail and retry in this case, as the state won't change. We missed a nil check, causing a sentry error https://govuk.sentry.io/issues/7509529391/?alert_rule_id=963054&alert_type=issue&notification_uuid=48ce1c78-b49a-4939-978d-78e0771e834b&project=202259&referrer=slack. The error also indicated that we are likely getting other type of 422 here, with a different payload. Those errors should still raise.

This commit allows those errors to bubble up, and adds a nil check to handle a missing parent_document_url. The check has also been changed to use the `draft` value being returned from AM rather than the one being sent.

We could alternatively continue to raise this with a known WH error like we do for the other cases such as empty attributes and deleted asset, but while we don't really expect those scenarios, the parent document url one is a known thing we haven't yet fixed. It happens for assets on new drafts from unpublished. The asset is live with a redirect, and then ends up being queued for an update, on the draft edition, with a draft parent document url. One naive way to fix this would be to just set the `draft: true` when we make this call, but that's not desirable since the asset needs to keep redirecting on the live site. The current way AM handles drafts and redirects won't work. 

Here's the logic in `AttachmentUpdater` that actively prohibits setting the draft to true in this case: `"draft" => attachment_data.draft? && !(attachment_data.replaced? || attachment_data.unpublished?)`. 

Another known bug is that the asset is not previewable in draft at all, when on a draft edition from unpublished. There already is a [backlog card](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/433?issueType=10243&search=asset&selectedIssue=WHIT-1948) for this.

[Jira](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-3466)
