### PR TITLE
Update links to guidance [WHIT-3134]

### DIFF
--- a/app/components/admin/edition_images/image_upload_component.html.erb
+++ b/app/components/admin/edition_images/image_upload_component.html.erb
@@ -4,7 +4,7 @@
 
   hint_text = ["#{image_usage_title.articleize.upcase_first} must be at least <strong>#{image_kind.valid_width}x#{image_kind.valid_height}</strong>."]
   unless image_usage.multiple
-    hint_text << " If you are uploading more than one #{image_usage_title}, <a class=\"govuk-link\" href=\"https://www.gov.uk/guidance/how-to-publish-on-gov-uk/images-and-videos\">read the image guidance</a> on using unique file names."
+    hint_text << " If you are uploading more than one #{image_usage_title}, <a class=\"govuk-link\" href=\"https://guidance.publishing.service.gov.uk/formatting-content/images-videos/formatting-images/#image-file-names\">read the image guidance</a> on using unique file names."
   end
 %>
 
@@ -50,7 +50,7 @@
       } do %>
         SVGs allow users to magnify images without losing quality.
         Find out <%= link_to "how to create an SVG file (opens in new tab)",
-                            "https://www.gov.uk/guidance/how-to-publish-on-gov-uk/images-and-videos#creating-an-svg-file",
+                            "https://guidance.publishing.service.gov.uk/formatting-content/images-videos/formatting-images/#how-to-create-an-svg-file",
                             class: "govuk-link",
                             target: "_blank",
                             rel: "noopener" %>.

--- a/app/components/admin/editions/history_mode_form_controls.erb
+++ b/app/components/admin/editions/history_mode_form_controls.erb
@@ -26,6 +26,6 @@
     ],
   } %>
 
-  <p class="govuk-body"><%= link_to "Read the history mode guidance", "https://www.gov.uk/guidance/how-to-publish-on-gov-uk/creating-and-updating-pages#history-mode", class: "govuk-link" %>
+  <p class="govuk-body"><%= link_to "Read the history mode guidance", "https://guidance.publishing.service.gov.uk/writing-to-gov-uk-standards/plan-manage-content/retire-content/#when-history-mode-gets-applied", class: "govuk-link" %>
     for more information as to what this means.</p>
 </div>

--- a/app/controllers/concerns/historic_content_concern.rb
+++ b/app/controllers/concerns/historic_content_concern.rb
@@ -18,6 +18,6 @@ module HistoricContentConcern
 private
 
   def forbidden_flash_msg
-    { flash: { alert: "This document is in <a href='https://www.gov.uk/guidance/how-to-publish-on-gov-uk/creating-and-updating-pages#history-mode' class='govuk-link'>history mode</a>. Please contact your GOV.UK lead or managing editor if you need to change it.", html_safe: true } }
+    { flash: { alert: "This document is in <a href='https://guidance.publishing.service.gov.uk/writing-to-gov-uk-standards/plan-manage-content/retire-content/#when-history-mode-gets-applied' class='govuk-link'>history mode</a>. Please contact your GOV.UK lead or managing editor if you need to change it.", html_safe: true } }
   end
 end

--- a/app/models/publication_type.rb
+++ b/app/models/publication_type.rb
@@ -6,7 +6,7 @@ class PublicationType
   include ActiveRecordLikeInterface
 
   FORMAT_ADVICE = {
-    1 => "<p>A policy paper explains the government’s position on something. It doesn’t include instructions on how to carry out a task, only the policy itself and how it’ll be implemented.</p><p>Read the <a href=\"https://www.gov.uk/guidance/content-design/content-types#policy-paper\" target=\"_blank\" class=\"govuk-link\">policy papers guidance</a> in full.</p>",
+    1 => "<p>A policy paper explains the government’s position on something. It doesn’t include instructions on how to carry out a task, only the policy itself and how it’ll be implemented.</p>",
     2 => "<p>Cost-benefit analyses and other assessments of the impact of proposed initiatives, or changes to regulations or legislation.</p>",
     3 => "<p>Non-statutory guidance publications. Includes: manuals, handbooks and other documents that offer advice.</p><p>Do not use for: statutory guidance (use the ‘statutory guidance’ publication type) or guidance about completing a form (attach to same publication as the form itself).</p>",
     4 => "<p>Pro-forma or form documents that need to be completed by the user. Can include guidance on how to fill in forms (ie no need to create a separate ‘guidance’ publication for form instructions).</p>",

--- a/app/views/admin/attachments/_add.html.erb
+++ b/app/views/admin/attachments/_add.html.erb
@@ -24,7 +24,7 @@
         title: "You must upload attachments in an open standards format.",
       } do %>
         <p>For example, if an attachment is text-based and designed to be edited it should be uploaded to GOV.UK as an .odt (OpenDocument text) file instead of a closed format like .docx.</p>
-        <p>Read more about <%= link_to "open standards formats", "https://www.gov.uk/guidance/content-design/planning-content#open-formats", class: "govuk-link govuk-link--no-visited-state" %>.</p>
+        <p>Read more about <%= link_to "open standards formats", "https://guidance.publishing.service.gov.uk/publish-update-retire-content/standard-content-types/consultations/" %>.</p>
       <% end %>
     </div>
   <% end %>

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -15,8 +15,7 @@
       items: [
         link_to("Content Data", content_data_home_url, class: "govuk-link"),
         link_to("GOV.UK style guide", "https://www.gov.uk/guidance/style-guide", class: "govuk-link"),
-        link_to("How to publish content on GOV.UK", "https://www.gov.uk/guidance/how-to-publish-on-gov-uk" , class: "govuk-link"),
-        link_to("Planning, writing and managing content", "https://www.gov.uk/guidance/content-design", class: "govuk-link"),
+        link_to("GOV.UK content and publishing guidance", "https://guidance.publishing.service.gov.uk/" , class: "govuk-link"),
       ],
     } %>
   </div>

--- a/app/views/admin/detailed_guides/_form.html.erb
+++ b/app/views/admin/detailed_guides/_form.html.erb
@@ -1,6 +1,6 @@
 <div class="format-advice">
   <p class="govuk-body">Detailed guides tell users the steps they need to take to complete a specific task. They are usually aimed at specialist or professional audiences.</p>
-  <p class="govuk-body">Read the <%= link_to "detailed guides guidance", "https://www.gov.uk/guidance/content-design/content-types#detailed-guide", class: "govuk-link", target: "_blank", rel: "noopener" %> in full.</p>
+  <p class="govuk-body">Read the <%= link_to "detailed guides guidance", "https://guidance.publishing.service.gov.uk/publish-update-retire-content/standard-content-types/detailed-guides/", class: "govuk-link", target: "_blank", rel: "noopener" %> in full.</p>
 </div>
 
 <%= standard_edition_form(edition) do |form| %>

--- a/app/views/admin/edition_images/edit.html.erb
+++ b/app/views/admin/edition_images/edit.html.erb
@@ -50,7 +50,7 @@
             textarea_id: "image_caption",
             value: image.caption,
             rows: 2,
-            hint: raw("Name a person in a photo or add image credit. <a class='govuk-link' href='https://www.gov.uk/guidance/content-design/images'>Read the image copyright standards</a>. The text appears next to the image."),
+            hint: raw("Name a person in a photo or add image credit. <a class='govuk-link' href='https://guidance.publishing.service.gov.uk/formatting-content/images-videos/formatting-images/#copyright-standards-and-attributing-images'>Read the image copyright standards</a>. The text appears next to the image."),
             margin_bottom: 4,
           } %>
           <p class="govuk-body"><a href="https://www.gov.uk/guidance/content-design/images" class="govuk-link" target="_blank">Using informative and decorative images on GOV.UK (opens in new tab)</a></p>

--- a/app/views/admin/edition_workflow/confirm_unpublish.html.erb
+++ b/app/views/admin/edition_workflow/confirm_unpublish.html.erb
@@ -50,7 +50,7 @@
     <%= render "govuk_publishing_components/components/radio", {
       name: "unpublishing_reason",
       heading: "Do you want to unpublish or withdraw this document?",
-      description: sanitize('Learn more about withdrawing and unpublishing content on our <a href="https://www.gov.uk/guidance/how-to-publish-on-gov-uk/unpublishing-and-archiving" class="govuk-link" target="_blank">publishing guide</a>.'),
+      description: sanitize('Learn more about withdrawing and unpublishing content on our <a href="https://guidance.publishing.service.gov.uk/writing-to-gov-uk-standards/plan-manage-content/retire-content/" class="govuk-link" target="_blank">publishing guide</a>.'),
       items: [
         {
           value: unpublish_reasons[:published_in_error][:id],

--- a/app/views/admin/editions/_change_notes.html.erb
+++ b/app/views/admin/editions/_change_notes.html.erb
@@ -38,7 +38,7 @@
           error_message: errors_for_input(edition.errors, :change_note),
           value: edition.change_note,
           hint: (tag.p('Tell users what has changed, where and why. Write in full sentences, leading with the most important words. For example, "College A has been removed from the registered sponsors list because its licence has been suspended."', class: "govuk-!-margin-bottom-0 govuk-!-margin-top-0") +
-                link_to("Guidance about change notes (opens in a new tab)", "https://www.gov.uk/guidance/content-design/writing-for-gov-uk#change-notes", target: "_blank", class: "govuk-link", rel: "noopener")).html_safe,
+                link_to("Guidance about change notes (opens in a new tab)", "https://guidance.publishing.service.gov.uk/writing-to-gov-uk-standards/tone-of-voice/change-notes/", target: "_blank", class: "govuk-link", rel: "noopener")).html_safe,
         }),
       },
       {

--- a/app/views/admin/editions/_govspeak_help.html.erb
+++ b/app/views/admin/editions/_govspeak_help.html.erb
@@ -128,7 +128,7 @@
     title: "Abbreviations and acronyms",
   } do %>
     <p class='govuk-body'>The first time you use an abbreviation or acroynm, write it out in full.</p>
-    <p class='govuk-body'>Add the <a class="govuk-link" href='https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown#acronyms'>acronym Markdown</a> at the end of the body copy leaving one empty line space above it, as in the following example.</p>
+    <p class='govuk-body'>Add the <a class="govuk-link" href='https://guidance.publishing.service.gov.uk/formatting-content/text-formatting/acronyms/'>acronym Markdown</a> at the end of the body copy leaving one empty line space above it, as in the following example.</p>
     <pre class='govspeak-help__pre'>Example content that includes a three-letter acronym (TLA).<br><br>*[TLA]: three-letter acronym</pre>
     <p class='govuk-body'>When a user hovers their mouse over a <abbr title='three-letter acronym'>TLA</abbr>, they will see it written in full.</p>
   <% end %>

--- a/app/views/admin/editions/_style_guidance.html.erb
+++ b/app/views/admin/editions/_style_guidance.html.erb
@@ -1,6 +1,6 @@
 <h3 class="govuk-heading-m">Use plain English</h3>
 
-<p class="govuk-body">For details, see the <%= link_to "guideline on using plain English", "https://www.gov.uk/guidance/content-design/writing-for-gov-uk#plain-english", class: "govuk-link" %>
+<p class="govuk-body">For details, see the <%= link_to "guideline on using plain English", "https://guidance.publishing.service.gov.uk/writing-to-gov-uk-standards/tone-of-voice/clear-language/", class: "govuk-link" %>
 
 <%= render "govuk_publishing_components/components/details", {
   title: "List of words to avoid",
@@ -52,4 +52,4 @@
 
 <h3 class="govuk-heading-m">Style</h3>
 
-<p class="govuk-body">For style, see the <%= link_to "style guide", "https://www.gov.uk/guidance/style-guide", class: "govuk-link" %>
+<p class="govuk-body">For style, see the <%= link_to "style guide", "https://guidance.publishing.service.gov.uk/writing-to-gov-uk-standards/tone-of-voice/clear-language/", class: "govuk-link" %>

--- a/app/views/admin/file_attachments/_fields.html.erb
+++ b/app/views/admin/file_attachments/_fields.html.erb
@@ -19,7 +19,7 @@
       },
       name: "#{name}[attachment_data_attributes][file]",
       id: "#{name}_attachment_data_file",
-      hint: raw(attachment_data_fields.object.filename ? "You must replace the attachment markdown in the body text" : "You must upload attachments in an <a class='govuk-link' href='https://www.gov.uk/guidance/content-design/planning-content#open-formats'>open standards format</a>."),
+      hint: raw(attachment_data_fields.object.filename ? "You must replace the attachment markdown in the body text" : "You must upload attachments in an <a class='govuk-link' href='https://guidance.publishing.service.gov.uk/formatting-content/attachments/choose-attachment-type-name/'>open standards format</a>."),
       error_items: errors_for(attachment_data_fields.object.errors, :file),
     } %>
   <% else %>

--- a/app/views/admin/shared/tagging/_taxonomy_group_description.html.erb
+++ b/app/views/admin/shared/tagging/_taxonomy_group_description.html.erb
@@ -4,7 +4,7 @@
       <p>The topic taxonomy groups content based on what it’s about.</p>
       <p>Choose the tag or tags that best describe what this content is about.</p>
       <p>You can use the whole topic taxonomy. There's no limit to the number of tags you can choose.</p>
-      <p><%= link_to "Find out more about tagging to the topic taxonomy", "https://www.gov.uk/guidance/how-to-publish-on-gov-uk/creating-and-updating-pages#add-topic-tagging", class: "govuk-link", target: "_blank", rel: "noopener" %> (open in new tab)</p>
+      <p><%= link_to "Find out more about tagging to the topic taxonomy", "https://guidance.publishing.service.gov.uk/writing-to-gov-uk-standards/plan-manage-content/organise-group-govuk-content/", class: "govuk-link", target: "_blank", rel: "noopener" %> (open in new tab)</p>
     </div>
     <div class="govuk-!-margin-bottom-8 govuk-body">
       <p><%= link_to "Suggest a new tag", "#{Whitehall.support_url}/taxonomy_new_topic_request/new", class: "govuk-link", target: "_blank", rel: "noopener" %> (open in new tab)</p>

--- a/app/views/mail_notifications/consultation_deadline_upcoming.text.erb
+++ b/app/views/mail_notifications/consultation_deadline_upcoming.text.erb
@@ -4,4 +4,4 @@ Consultation responses must be published within 12 weeks of being closed, please
 https://www.gov.uk/government/publications/consultation-principles-guidance
 
 Read how to write good consultation pages here:
-https://www.gov.uk/guidance/content-design/content-types#consultation
+https://guidance.publishing.service.gov.uk/publish-update-retire-content/standard-content-types/consultations/

--- a/app/views/mail_notifications/edition_published.text.erb
+++ b/app/views/mail_notifications/edition_published.text.erb
@@ -2,7 +2,7 @@ Hello,
 
 The <%= @edition.format_name %> '<%= @edition.title %>' is published. It's now available at the following url: <%= @public_url %>
 
-New content goes live immediately but changes to previously published content can take up to 15 minutes. The GOV.UK publishing manual has more detail: https://www.gov.uk/guidance/how-to-publish-on-gov-uk/reviewing-and-approving-content#publishing-times
+New content goes live immediately but changes to previously published content can take up to 5 minutes. The GOV.UK publishing manual has more detail: https://guidance.publishing.service.gov.uk/publish-update-retire-content/standard-content-types/publish-standard/#how-long-content-takes-to-go-live
 
 All the best,
 

--- a/app/views/mail_notifications/review_reminder.text.erb
+++ b/app/views/mail_notifications/review_reminder.text.erb
@@ -11,7 +11,7 @@ You should review your content and either:
 - set a new review date if the content is up to date
 
 The GOV.UK publishing manual has more detail:
-https://www.gov.uk/guidance/content-design/content-maintenance
+https://guidance.publishing.service.gov.uk/writing-to-gov-uk-standards/plan-manage-content/manage-existing-govuk-content/
 
 Best wishes
 GOV.UK publishing

--- a/config/locales/en/admin/whats_new.yml
+++ b/config/locales/en/admin/whats_new.yml
@@ -187,11 +187,7 @@ en:
       guidance:
         heading: Publishing guidance, updates and support
         body_govspeak: |
-          For support using Whitehall Publisher, read the guidance about:
-
-          - [how to publish content on GOV.UK](https://www.gov.uk/guidance/how-to-publish-on-gov-uk)
-          - [planning, writing and managing content](https://www.gov.uk/guidance/content-design)
-          - [how to contact the Government Digital Service (GDS) to request or report something](https://www.gov.uk/guidance/contact-the-government-digital-service)
+          For support using Whitehall Publisher, read the [GOV.UK content and publishing guidance](https://guidance.publishing.service.gov.uk/).
 
           The [GOV.UK style guide](https://www.gov.uk/guidance/style-guide) covers style, spelling and grammar conventions for content published on GOV.UK.
 

--- a/spec/javascripts/admin/modules/unpublish-display-conditions.spec.js
+++ b/spec/javascripts/admin/modules/unpublish-display-conditions.spec.js
@@ -8,7 +8,7 @@ describe('GOVUK.Modules.UnpublishDisplayConditions', function () {
         <div class="govuk-form-group govuk-!-margin-bottom-6">
           <fieldset class="govuk-fieldset">
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--m"><h2 class="govuk-fieldset__heading">Do you want to unpublish or withdraw this document?</h2> </legend>
-            <div class="govuk-body">Learn more about withdrawing and unpublishing content on our <a href="https://www.gov.uk/guidance/how-to-publish-on-gov-uk/unpublishing-and-archiving" class="govuk-link">publishing guide</a>.</div>
+            <div class="govuk-body">Learn more about withdrawing and unpublishing content on our <a href="https://guidance.publishing.service.gov.uk/writing-to-gov-uk-standards/plan-manage-content/retire-content/" class="govuk-link">publishing guide</a>.</div>
             <div class="govuk-radios">
               <div class="gem-c-radio govuk-radios__item">
                 <input type="radio" name="unpublishing_reason" id="radio-published-in-error" value="1" class="govuk-radios__input">

--- a/test/functional/admin/publications_controller_test.rb
+++ b/test/functional/admin/publications_controller_test.rb
@@ -99,7 +99,7 @@ class Admin::PublicationsControllerTest < ActionController::TestCase
     assert_select "form#edit_edition" do
       assert_select "select[name='edition[publication_type_id]']"
       assert_select "input[name*='edition[first_published_at']", count: 3
-      assert_select ".js-app-view-edition-form__subtype-format-advice", text: "Use this subformat for… A policy paper explains the government’s position on something. It doesn’t include instructions on how to carry out a task, only the policy itself and how it’ll be implemented.Read the policy papers guidance in full."
+      assert_select ".js-app-view-edition-form__subtype-format-advice", text: "Use this subformat for… A policy paper explains the government’s position on something. It doesn’t include instructions on how to carry out a task, only the policy itself and how it’ll be implemented."
     end
   end
 

--- a/test/functional/notifications_review_reminder_test.rb
+++ b/test/functional/notifications_review_reminder_test.rb
@@ -24,6 +24,6 @@ class NotificationsReviewReminderTest < ActionMailer::TestCase
   test "email body should include details of the document being reviwed, a link to the summary page and a link to the relevant guidance" do
     assert @mail.body.raw_source.include?("A review date for the #{@edition.format_name} \"#{@title}\" has been set. The review date is today.")
     assert @mail.body.raw_source.include?(admin_edition_url(@edition))
-    assert @mail.body.raw_source.include?("https://www.gov.uk/guidance/content-design/content-maintenance")
+    assert @mail.body.raw_source.include?("https://guidance.publishing.service.gov.uk/writing-to-gov-uk-standards/plan-manage-content/manage-existing-govuk-content")
   end
 end


### PR DESCRIPTION
## What

Update links to the new guidance for publishing content.

## Why

Request from content team.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
