### PR TITLE
[WHIT-3385] Auto-refresh cachebust on preview link interaction

### DIFF
--- a/app/assets/javascripts/admin/modules/cachebust-link.js
+++ b/app/assets/javascripts/admin/modules/cachebust-link.js
@@ -1,0 +1,28 @@
+'use strict'
+/* Refreshes the `cachebust` query param on a link to the current unix-epoch
+ * the moment the user is about to activate it, so the URL never carries a
+ * stale timestamp from page load.
+ *
+ * Listens on `pointerdown` (mouse, touch, pen) and `focus` (keyboard, AT).
+ * Usage: add `data-module="CachebustLink"` to the <a> tag.
+ */
+;(function (Modules) {
+  function CachebustLink(link) {
+    this.link = link
+  }
+
+  CachebustLink.prototype.init = function () {
+    const refresh = this.refresh.bind(this)
+    this.link.addEventListener('pointerdown', refresh)
+    this.link.addEventListener('focus', refresh)
+  }
+
+  CachebustLink.prototype.refresh = function () {
+    const url = new URL(this.link.href)
+    if (!url.searchParams.has('cachebust')) return
+    url.searchParams.set('cachebust', Math.floor(Date.now() / 1000))
+    this.link.href = url.toString()
+  }
+
+  Modules.CachebustLink = CachebustLink
+})(window.GOVUK.Modules)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -26,6 +26,7 @@
 //= require admin/analytics-modules/ga4-finder-setup.js
 //= require admin/analytics-modules/ga4-form-setup.js
 
+//= require admin/modules/cachebust-link
 //= require admin/modules/document-history-paginator
 //= require admin/modules/locale-switcher
 //= require admin/modules/navbar-toggle

--- a/app/components/admin/editions/show/preview_component.rb
+++ b/app/components/admin/editions/show/preview_component.rb
@@ -23,7 +23,8 @@ private
     link_to(link_text,
             href,
             class: "govuk-link",
-            target: "_blank", rel: "noopener")
+            target: "_blank", rel: "noopener",
+            data: { module: "CachebustLink" })
   end
 
   def primary_locale_link_text

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -46,8 +46,9 @@ module ApplicationHelper
 
     name = attachment.name_for_link
     html_class = options.delete(:class)
+    data = options.delete(:data)
 
-    return link_to name, attachment.url(options), class: html_class if !attachment.file? || attachment.attachment_data.all_asset_variants_uploaded?
+    return link_to name, attachment.url(options), class: html_class, data: data if !attachment.file? || attachment.attachment_data.all_asset_variants_uploaded?
 
     tag.span(name)
   end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -14,7 +14,6 @@ class ApplicationRecord < ActiveRecord::Base
 
     permitted_query_params = %i[
       cachebust
-      preview
       token
       utm_campaign
       utm_medium

--- a/app/models/html_attachment.rb
+++ b/app/models/html_attachment.rb
@@ -52,12 +52,6 @@ class HtmlAttachment < Attachment
   end
 
   def url(options = {})
-    if options[:preview]
-      options[:preview] = id
-    else
-      options.delete(:preview)
-    end
-
     if options[:full_url]
       public_url(options)
     else

--- a/app/views/admin/attachments/_attachments.html.erb
+++ b/app/views/admin/attachments/_attachments.html.erb
@@ -14,7 +14,7 @@
           <strong>Type: </strong><%= attachment.is_a?(HtmlAttachment) ? attachment.readable_type : attachment.readable_type.capitalize %>
         </p>
         <p class="govuk-body">
-          <strong>Attachment: </strong><%= link_to_attachment(attachment, full_url: true, class: "govuk-link govuk-link--no-visited-state", **attachment_preview_options(attachable)) %>
+          <strong>Attachment: </strong><%= link_to_attachment(attachment, full_url: true, class: "govuk-link govuk-link--no-visited-state", data: { module: "CachebustLink" }, **attachment_preview_options(attachable)) %>
         </p>
         <% if attachable.allows_inline_attachments? && attachment.is_a?(FileAttachment) %>
           <%= render "govuk_publishing_components/components/copy_to_clipboard", {

--- a/app/views/admin/editions/show/_main.html.erb
+++ b/app/views/admin/editions/show/_main.html.erb
@@ -187,7 +187,7 @@
           rows: @edition.attachments.map do | attachment |
             [
               { text: attachment[:title] },
-              { text: link_to_attachment(attachment, full_url: true, class: "govuk-link", **attachment_preview_options(attachment.attachable)) },
+              { text: link_to_attachment(attachment, full_url: true, class: "govuk-link", data: { module: "CachebustLink" }, **attachment_preview_options(attachment.attachable)) },
               @edition.editable? ? { text: link_to("Edit", [:edit, :admin, @edition.becomes(Edition), attachment], class: "govuk-link") } : nil,
             ].compact
           end,

--- a/app/views/admin/html_attachments/_fields.html.erb
+++ b/app/views/admin/html_attachments/_fields.html.erb
@@ -53,7 +53,8 @@
         <%= link_to("Preview on website (opens in new tab)",
         attachment.url(full_url: true, **attachment_preview_options(attachment.attachable)),
         class: "govuk-link",
-        target: "_blank", rel: "noopener") %>
+        target: "_blank", rel: "noopener",
+        data: { module: "CachebustLink" }) %>
       </p>
       <p class="govuk-body">
         To preview your document on GOV.UK you must save it first.

--- a/spec/javascripts/admin/modules/cachebust-link.spec.js
+++ b/spec/javascripts/admin/modules/cachebust-link.spec.js
@@ -1,0 +1,70 @@
+describe('GOVUK.Modules.CachebustLink', function () {
+  let link, module
+
+  beforeEach(function () {
+    jasmine.clock().install()
+    jasmine.clock().mockDate(new Date(1_700_000_000_000))
+
+    link = document.createElement('a')
+    link.setAttribute('data-module', 'CachebustLink')
+    link.href =
+      'https://draft-origin.test.gov.uk/government/publications/foo?cachebust=1&locale=en'
+
+    module = new GOVUK.Modules.CachebustLink(link)
+    module.init()
+  })
+
+  afterEach(function () {
+    jasmine.clock().uninstall()
+  })
+
+  it('rewrites the cachebust query param to the current unix-epoch on pointerdown', function () {
+    link.dispatchEvent(new Event('pointerdown'))
+
+    const url = new URL(link.href)
+    expect(url.searchParams.get('cachebust')).toEqual('1700000000')
+  })
+
+  it('rewrites the cachebust query param to the current unix-epoch on focus', function () {
+    link.dispatchEvent(new Event('focus'))
+
+    const url = new URL(link.href)
+    expect(url.searchParams.get('cachebust')).toEqual('1700000000')
+  })
+
+  it('preserves other query params when refreshing the cachebust', function () {
+    link.dispatchEvent(new Event('pointerdown'))
+
+    const url = new URL(link.href)
+    expect(url.searchParams.get('locale')).toEqual('en')
+  })
+
+  it('preserves the path and host when refreshing the cachebust', function () {
+    link.dispatchEvent(new Event('pointerdown'))
+
+    const url = new URL(link.href)
+    expect(url.host).toEqual('draft-origin.test.gov.uk')
+    expect(url.pathname).toEqual('/government/publications/foo')
+  })
+
+  it('reflects the latest current time on each interaction', function () {
+    link.dispatchEvent(new Event('focus'))
+    jasmine.clock().tick(60_000)
+    link.dispatchEvent(new Event('pointerdown'))
+
+    const url = new URL(link.href)
+    expect(url.searchParams.get('cachebust')).toEqual('1700000060')
+  })
+
+  it('leaves the href untouched when there is no cachebust query param', function () {
+    const liveLink = document.createElement('a')
+    liveLink.href = 'https://www.test.gov.uk/government/publications/foo'
+    const originalHref = liveLink.href
+
+    new GOVUK.Modules.CachebustLink(liveLink).init()
+    liveLink.dispatchEvent(new Event('pointerdown'))
+    liveLink.dispatchEvent(new Event('focus'))
+
+    expect(liveLink.href).toEqual(originalHref)
+  })
+})

--- a/test/components/admin/editions/show/preview_component_test.rb
+++ b/test/components/admin/editions/show/preview_component_test.rb
@@ -80,6 +80,14 @@ class Admin::Editions::Show::PreviewComponentTest < ViewComponent::TestCase
     assert_selector ".govuk-inset-text", text: "To see the changes and share a document preview link, add a change note or mark the change type to minor."
   end
 
+  test "tags every preview link with the CachebustLink JS module" do
+    edition = create(:publication, translated_into: %i[fr], document: @document)
+
+    render_inline(Admin::Editions::Show::PreviewComponent.new(edition:))
+
+    assert_selector "a[data-module='CachebustLink'][href*='cachebust=']", visible: :all, count: 2
+  end
+
   test "renders the correct primary locale link text for non-English primary locale editions with translations" do
     edition = build(:detailed_guide, id: 1, primary_locale: :fr, document: @document)
     edition.translations.build(locale: :fr)

--- a/test/functional/admin/attachments_controller_test.rb
+++ b/test/functional/admin/attachments_controller_test.rb
@@ -57,6 +57,14 @@ class Admin::AttachmentsControllerTest < ActionController::TestCase
     assert_select "a[href=?]", attachment.url(full_url: true)
   end
 
+  view_test "GET :index tags HTML attachment preview links with the CachebustLink JS module" do
+    create(:html_attachment, title: "An HTML attachment", attachable: @edition)
+
+    get :index, params: { edition_id: @edition }
+
+    assert_select "a[data-module='CachebustLink'][href*='cachebust=']"
+  end
+
   view_test "GET :index renders the uploading banner when an attachment hasn't been uploaded to asset manager" do
     create(:html_attachment, title: "An HTML attachment", attachable: @edition)
     create(:file_attachment, title: "An uploaded file attachment", attachable: @edition)

--- a/test/functional/admin/html_attachments_controller_test.rb
+++ b/test/functional/admin/html_attachments_controller_test.rb
@@ -98,6 +98,14 @@ class Admin::HtmlAttachmentsControllerTest < ActionController::TestCase
     assert_select "a[href=?]", attachment.url(full_url: true), text: "Preview on website (opens in new tab)"
   end
 
+  view_test "GET :edit tags the preview link with the CachebustLink JS module" do
+    attachment = create(:html_attachment, attachable: @edition)
+
+    get :edit, params: { edition_id: @edition, id: attachment.id }
+
+    assert_select "a[data-module='CachebustLink']", text: "Preview on website (opens in new tab)"
+  end
+
   test "POST :create with bad data does not save the attachment and re-renders the new template" do
     post :create, params: { edition_id: @edition, attachment: { attachment_data_attributes: {} } }
     assert_template :new

--- a/test/functional/admin/publications_controller_test.rb
+++ b/test/functional/admin/publications_controller_test.rb
@@ -194,6 +194,16 @@ class Admin::PublicationsControllerTest < ActionController::TestCase
     assert_select "a.govuk-link[href=?]", attachment.url(full_url: true)
   end
 
+  view_test "GET :show tags HTML attachment preview links with the CachebustLink JS module" do
+    publication = create(:draft_publication, :with_html_attachment)
+    attachment = publication.attachments.first
+    publication_has_no_expanded_links(publication.content_id)
+
+    get :show, params: { id: publication }
+
+    assert_select "a[data-module='CachebustLink'][href*='#{attachment.identifier}'][href*='cachebust=']"
+  end
+
   view_test "when edition is tagged to the new taxonomy" do
     world_tagging_organisation = create(:organisation, content_id: "f323e83c-868b-4bcb-b6e2-a8f9bb40397e")
 

--- a/test/unit/app/helpers/application_helper_test.rb
+++ b/test/unit/app/helpers/application_helper_test.rb
@@ -26,6 +26,14 @@ class ApplicationHelperTest < ActionView::TestCase
     assert_equal %(<span>#{attachment.filename}</span>), link_to_attachment(attachment)
   end
 
+  test "#link_to_attachment forwards data attributes to the rendered link without leaking them into the URL" do
+    attachment = build(:external_attachment)
+    rendered = link_to_attachment(attachment, data: { module: "CachebustLink" })
+
+    assert_match %r{data-module="CachebustLink"}, rendered
+    assert_no_match %r{data=}, attachment.url
+  end
+
   test "#link_to_attachment_data returns a link if file attachment has all asset variants" do
     attachment_data = build(:attachment_data)
     assert_equal %(<a class="govuk-link" href="#{attachment_data.url}">#{attachment_data.filename}</a>), link_to_attachment_data(attachment_data)

--- a/test/unit/app/models/html_attachment_test.rb
+++ b/test/unit/app/models/html_attachment_test.rb
@@ -29,7 +29,7 @@ class HtmlAttachmentTest < ActiveSupport::TestCase
     attachment = edition.attachments.first
 
     expected = "https://draft-origin.test.gov.uk/government/publications/"
-    expected += "#{edition.slug}/#{attachment.slug}?preview=#{attachment.id}"
+    expected += "#{edition.slug}/#{attachment.slug}"
     actual = attachment.url(preview: true, full_url: true)
 
     assert_equal expected, actual
@@ -40,7 +40,7 @@ class HtmlAttachmentTest < ActiveSupport::TestCase
     attachment = edition.attachments.first
 
     expected = "https://draft-origin.test.gov.uk/government/publications/"
-    expected += "#{edition.slug}/#{attachment.slug}?cachebust=123&preview=#{attachment.id}"
+    expected += "#{edition.slug}/#{attachment.slug}?cachebust=123"
     actual = attachment.url(preview: true, full_url: true, cachebust: "123")
 
     assert_equal expected, actual
@@ -53,17 +53,6 @@ class HtmlAttachmentTest < ActiveSupport::TestCase
     expected = "https://www.test.gov.uk/government/publications/"
     expected += "#{edition.slug}/#{attachment.slug}"
     actual = attachment.url(full_url: true)
-
-    assert_equal expected, actual
-  end
-
-  test "#url omits the preview query parameter when preview is explicitly false" do
-    edition = create(:published_publication, :with_html_attachment)
-    attachment = edition.attachments.first
-
-    expected = "https://www.test.gov.uk/government/publications/"
-    expected += "#{edition.slug}/#{attachment.slug}"
-    actual = attachment.url(preview: false, full_url: true)
 
     assert_equal expected, actual
   end


### PR DESCRIPTION
## What

Automatically refresh the cachebust value to the current Unix timestamp whenever the user interacts with a preview link.

## Why

The server-rendered cachebust on a draft preview link is frozen at page-load time. If the user clicks "Preview" and the preview is not ready, then clicks again, they will use the same cachebust value which could end up returning a cached version.

## How it works

The JS module (`CachebustPreviewLink`) listens on each preview link for:

- **`pointerdown`** — fires before `click` for mouse, touch and pen. Ensures the cachebust is refreshed before any speculative request the browser might start on mousedown..
- **`focus`** — fires when keyboard or assistive-tech users Tab onto the link, so the `href` is fresh by the time they press Enter.

These will cover input methods: mouse, touch, pen, keyboard and screen reader.

The module is defensive: if the link's `href` has no `cachebust` query param (e.g. a post-publication HTML attachment that links straight to live), it does nothing so can be attached to draft and live URLs.

## What's covered

All five draft preview link call-sites — wired via `data-module="CachebustPreviewLink"`:

- Primary-locale link rendered by `PreviewComponent`
- Per-locale translation links inside "Preview translated pages"
- HTML attachment row on the edition summary "Attachments" table
- HTML attachment row on `/admin/editions/<id>/attachments`
- "Preview on website" link on the HTML attachment edit form

## Accessibility

- No-JS users: the server-rendered cachebust still works
- Keyboard users: handled with `focus` listener
- Screen readers / virtual cursors: handled with `focus` listener
- Touch users: handled with `pointerdown` listener

## Test plan

- [x] On a draft publication's admin summary page, leave the tab idle for ~30s, then click "Preview on website" — devtools shows the request `cachebust=` value matches "now", not page-load
- [x] Same for an HTML attachment row on that page
- [x] Same for `/admin/editions/<id>/attachments` HTML attachment link
- [x] Same for the HTML attachment edit form's "Preview on website" link
- [x] On a multi-language draft, expand "Preview translated pages" and tab-Enter onto a translation link — `cachebust=` reflects activation time
- [x] With JS disabled in devtools, all five links still work and carry the server-rendered cachebust
- [x] On a published edition's HTML attachment edit form, the "Preview on website" link points to the live URL with no `cachebust` param (defensive JS no-ops)


[WHIT-3385]: https://gov-uk.atlassian.net/browse/WHIT-3385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ