### PR TITLE
Allow redrafting of unpublished `Consultation` editions [WHIT-3524]

### DIFF
--- a/app/models/consultation.rb
+++ b/app/models/consultation.rb
@@ -128,10 +128,6 @@ class Consultation < Edition
     attachables.flat_map(&:deleted_html_attachments)
   end
 
-  def previously_published
-    false
-  end
-
   def all_nation_applicability_selected?
     newly_created = document.nil? || document.new_record?
     newly_created ? false : all_nation_applicability

--- a/test/unit/app/models/consultation_test.rb
+++ b/test/unit/app/models/consultation_test.rb
@@ -435,10 +435,6 @@ class ConsultationTest < ActiveSupport::TestCase
     assert_equal [consultation, outcome, public_feedback], consultation.attachables
   end
 
-  test "consultations cannot be previously published" do
-    assert_not build(:consultation).previously_published
-  end
-
   test "#all_nation_applicability_selected? false if first draft and unsaved" do
     unsaved_publication = build(:consultation)
     unsaved_publication_with_document = build(:consultation, document: build(:document))


### PR DESCRIPTION

## Why

Previously, the `previously_published` (transient) attribute was managed with radio buttons (see /app/views/admin/editions/_first_published_at.html.erb in commit 6abd4d118d7dd95540e4016e079551428e74d420).  In order to simplify the validation for `first_published_at` and `previously_published`, `previously_published` was overriden to always be `false` for `Consultation` and `CorporateInformationPage` models.

At a later date, (see commit 313823fd2d23da8da993592008db909849ee8590), the `first_published_at` was moved behind a disclosure checkbox that is linked to `previously_published`.

These two changes combine to create the following bug:
1. a user unpublishes a Consultation
2. a user redrafts the unpublished Consultation, fills in the edit form, but because `previously_published` is overriden to `false`, its checkbox in the form is unchecked (although the `first_published_at` date fields have the correct values and it has actually been published previously)
3. the form is submitted, and `params[previousl_published]` is `false`
4. the `clean_edition_parameters` before_action removes the date elements of `first_published_at` because `previously_published` is `false` in the params
5. the `first_published_at` inclusion validation in the `Edition` model cannot construct the date correctly and throws the `First published at is not in the correct format` error.

## What

This change fixes the issue by removing the overriden, which feels correct given that:
- it is the root cause of the bug
- it was introduced to handle validation and UI that no longer exists
- it brings Consultations to be more inline with other doc types in this regard

`CorporateInformationPages` have not been changed since they do not surface `first_published_at` in their forms, so the problem does not exist for them.

I haven't added any tests - I was actually expecting to have to delete one that checks the special case for `Consultations`, but there isn't one.  I could add a test specifically for this model, but isn't a pattern we are following elsewhere and felt like over-testing.  Happy to add one if people think otherwise tho!

See JIRA https://gov-uk.atlassian.net/browse/WHIT-3524

### Before 
On load and refresh, the `previously_published` checkbox is unchecked despite it being previously published and having a `first_published_at` date:


https://github.com/user-attachments/assets/16bb33e4-9efe-4f89-8fb9-c8fd689ef548


### After
On load and refresh, the `previously_published` checkbox is checked and the `first_published_at` date is shown.


https://github.com/user-attachments/assets/b478376b-accf-406e-b566-427c95ebf9d6



⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
