### PR TITLE
[WHIT-3384] Remove preview query param from HTML attachment URLs

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -14,7 +14,6 @@ class ApplicationRecord < ActiveRecord::Base
 
     permitted_query_params = %i[
       cachebust
-      preview
       token
       utm_campaign
       utm_medium

--- a/app/models/html_attachment.rb
+++ b/app/models/html_attachment.rb
@@ -52,12 +52,6 @@ class HtmlAttachment < Attachment
   end
 
   def url(options = {})
-    if options[:preview]
-      options[:preview] = id
-    else
-      options.delete(:preview)
-    end
-
     if options[:full_url]
       public_url(options)
     else

--- a/test/unit/app/models/html_attachment_test.rb
+++ b/test/unit/app/models/html_attachment_test.rb
@@ -29,7 +29,7 @@ class HtmlAttachmentTest < ActiveSupport::TestCase
     attachment = edition.attachments.first
 
     expected = "https://draft-origin.test.gov.uk/government/publications/"
-    expected += "#{edition.slug}/#{attachment.slug}?preview=#{attachment.id}"
+    expected += "#{edition.slug}/#{attachment.slug}"
     actual = attachment.url(preview: true, full_url: true)
 
     assert_equal expected, actual
@@ -40,7 +40,7 @@ class HtmlAttachmentTest < ActiveSupport::TestCase
     attachment = edition.attachments.first
 
     expected = "https://draft-origin.test.gov.uk/government/publications/"
-    expected += "#{edition.slug}/#{attachment.slug}?cachebust=123&preview=#{attachment.id}"
+    expected += "#{edition.slug}/#{attachment.slug}?cachebust=123"
     actual = attachment.url(preview: true, full_url: true, cachebust: "123")
 
     assert_equal expected, actual
@@ -53,17 +53,6 @@ class HtmlAttachmentTest < ActiveSupport::TestCase
     expected = "https://www.test.gov.uk/government/publications/"
     expected += "#{edition.slug}/#{attachment.slug}"
     actual = attachment.url(full_url: true)
-
-    assert_equal expected, actual
-  end
-
-  test "#url omits the preview query parameter when preview is explicitly false" do
-    edition = create(:published_publication, :with_html_attachment)
-    attachment = edition.attachments.first
-
-    expected = "https://www.test.gov.uk/government/publications/"
-    expected += "#{edition.slug}/#{attachment.slug}"
-    actual = attachment.url(preview: false, full_url: true)
 
     assert_equal expected, actual
   end


### PR DESCRIPTION
## Summary

- Stop emitting `?preview={id}` on HTML attachment URLs shown on the document summary page.
- Drop `preview` from `ApplicationRecord#append_url_options` permitted query params, since nothing reads it.

The `preview` query parameter dates from when Whitehall served both the frontend and the backend, and was used to switch between the live and draft stacks. It no longer has any effect — no code reads `params[:preview]` — so removing it simplifies Whitehall without changing behaviour.

`HtmlAttachment#url` still uses the `preview: true` param to choose the draft-origin host vs the live host; only the URL-level query string is gone.

[Jira](https://gov-uk.atlassian.net/browse/WHIT-3384)

## Test plan

- [x] On a draft publication's document summary page in admin, click the "Preview on website" link for an HTML attachment and confirm the URL has no `preview=` query param (it should still resolve on draft-origin and carry the existing `cachebust=` param).
- [x] On a published publication's document summary page, confirm the equivalent link still points at the live site and is unchanged.