### PR TITLE
Revert tmp 0.2.7 bump to unblock CI

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4221,9 +4221,9 @@ text-table@^0.2.0:
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
 tmp@^0.2.1:
-  version "0.2.7"
-  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.7.tgz#26f4db11d1601ce8012dcb8a798ece1c06a99059"
-  integrity sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.4.tgz#c6db987a2ccc97f812f17137b36af2b6521b0d13"
+  integrity sha512-UdiSoX6ypifLmrfQ/XfiawN6hkjSBpCjhKxxZcWlUUmoXLaCKQU0bx4HF/tdDK2uzRuchf1txGvrWBzYREssoQ==
 
 to-regex-range@^5.0.1:
   version "5.0.1"


### PR DESCRIPTION
Reverts the #11505 merge (tmp 0.2.4 → 0.2.7).

## Why

The tmp bump changed `yarn.lock`, which changed the Playwright browser cache key (`hashFiles('yarn.lock')`) on `main` from `8a32e8…` to `1eae0f…`.

- `8a32e8…` has a Playwright cache **scoped to `main`** (from late April), readable by every branch/PR — so the `Install Playwright Chromium browser (with deps)` step was always a cache hit and **skipped**.
- The only `1eae0f…` cache is **scoped to the Dependabot branch** that created it on 28 May, so `main` (and anything rebased on it) cannot read it.

After the merge, `main` got a cache **miss** and was forced to run `playwright install --with-deps` for the first time in weeks. That step currently hangs on the runner (the `--with-deps` apt/system-deps fetch, unrelated to the public Playwright CDN), blocking CI on `main`.

Reverting restores the `8a32e8…` `yarn.lock`, so CI hits the main-scoped cache and skips the step again — unblocking the pipeline while we investigate the underlying step-8 infra issue on a separate branch.

The tmp security bump will be re-applied via a fresh PR once the runner issue is resolved.