### PR TITLE
Make label for default_string component bold for consistency

### DIFF
--- a/app/views/admin/configurable_content_blocks/default_string.html.erb
+++ b/app/views/admin/configurable_content_blocks/default_string.html.erb
@@ -1,6 +1,9 @@
 <%= render "govuk_publishing_components/components/input", {
   id: block.path.form_control_id,
-  label: { text: block.title + (block.required ? " (required)" : "") },
+  label: {
+    text: block.title + (block.required ? " (required)" : ""),
+    heading_size: "m",
+  },
   name: block.path.form_control_name,
   value: block.value,
   hint: block.hint_text,


### PR DESCRIPTION
Other fields on the page render like this, so why not default_string?

Screenshot of the sort of thing this enables (Ministers is an association block, separate to this, whereas Navigation in this example is a default_string block - it should be bolded):

> <img width="845" height="369" alt="Screenshot 2026-05-26 at 15 43 53" src="https://github.com/user-attachments/assets/603c4cc0-f9e7-44a7-b875-106cee5fb6a0" />

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
