### PR TITLE
Add DefaultTextarea component

### DIFF
--- a/app/models/configurable_content_blocks/default_textarea.rb
+++ b/app/models/configurable_content_blocks/default_textarea.rb
@@ -1,0 +1,9 @@
+module ConfigurableContentBlocks
+  class DefaultTextarea < BaseBlock
+  private
+
+    def template_name
+      "default_textarea"
+    end
+  end
+end

--- a/app/models/configurable_document_type.rb
+++ b/app/models/configurable_document_type.rb
@@ -3,6 +3,7 @@ class ConfigurableDocumentType
 
   CONTENT_BLOCKS = {
     "default_string" => ConfigurableContentBlocks::DefaultString,
+    "default_textarea" => ConfigurableContentBlocks::DefaultTextarea,
     "govspeak" => ConfigurableContentBlocks::Govspeak,
     "default_date" => ConfigurableContentBlocks::DefaultDate,
     "default_select" => ConfigurableContentBlocks::DefaultSelect,

--- a/app/views/admin/configurable_content_blocks/default_textarea.html.erb
+++ b/app/views/admin/configurable_content_blocks/default_textarea.html.erb
@@ -1,0 +1,19 @@
+<%= render "govuk_publishing_components/components/textarea", {
+  textarea_id: block.path.form_control_id,
+  label: {
+    text: block.title + (block.required ? " (required)" : ""),
+    heading_size: "m",
+  },
+  name: block.path.form_control_name,
+  value: block.value,
+  hint: block.hint_text,
+  right_to_left: block.edition.translation_locale.rtl?,
+  error_items: errors_for(block.edition.errors, block.path.validation_error_attribute.to_sym),
+} %>
+<% if block.primary_locale_value.present? %>
+  <%= render "govuk_publishing_components/components/details", {
+    title: "Primary locale content for #{block.title}",
+  } do %>
+    <%= block.primary_locale_value %>
+  <% end %>
+<% end %>

--- a/public/configurable-document-type.schema.json
+++ b/public/configurable-document-type.schema.json
@@ -67,6 +67,7 @@
             "default_date",
             "default_object",
             "default_string",
+            "default_textarea",
             "govspeak",
             "default_select",
             "select_with_search_tagging",

--- a/test/unit/app/models/configurable_content_blocks/default_textarea_test.rb
+++ b/test/unit/app/models/configurable_content_blocks/default_textarea_test.rb
@@ -1,0 +1,86 @@
+require "test_helper"
+
+class ConfigurableContentBlocks::DefaultTextareaRenderingTest < ActionView::TestCase
+  include ConfigurableContentBlockSharedTests
+
+  setup do
+    @field = {
+      "block" => "default_textarea",
+      "title" => "Test attribute",
+      "description" => "A test attribute",
+      "attribute_path" => %w[block_content test_attribute],
+      "translatable" => true,
+    }
+    @path = Path.new(%w[block_content test_attribute])
+    ConfigurableDocumentType.setup_test_types(build_configurable_document_type("test_type", {
+      "forms" => {
+        "documents" => {
+          "fields" => {
+            "test_attribute" => @field,
+          },
+        },
+      },
+      "schema" => {
+        "attributes" => {
+          "test_attribute" => {
+            "type" => "string",
+          },
+        },
+      },
+    }))
+    @edition = StandardEdition.new(
+      configurable_document_type: "test_type",
+      block_content: { "test_attribute" => "foo" },
+    )
+    @block = ConfigurableContentBlocks::DefaultTextarea.new(@edition, @field, @path)
+  end
+
+  test "the form label is equal to the attribute title" do
+    render @block
+    assert_dom "label", text: @field["title"]
+  end
+
+  test "it adds a required message to the label when the attribute is required" do
+    @field["required"] = true
+    render @block
+    assert_dom "label", text: "#{@field['title']} (required)"
+  end
+
+  test "it sets the textarea name correctly" do
+    render @block
+    assert_dom "textarea[name=?]", "edition[block_content][test_attribute]"
+  end
+
+  test "it sets the textarea value based on the content" do
+    render @block
+    assert_dom "textarea", text: @edition.block_content["test_attribute"]
+  end
+
+  test "it sets the hint text based on the description" do
+    render @block
+    assert_dom ".govuk-hint", text: @field["description"]
+  end
+
+  test "it sets the direction on the input to right to left when the current locale is Arabic" do
+    with_locale(:ar) do
+      render @block
+    end
+    assert_dom "textarea[dir=\"rtl\"]"
+  end
+
+  test "it renders the primary locale content under the textarea when the current locale is different from the primary locale" do
+    with_locale(:es) do
+      render @block
+    end
+
+    assert_dom ".govuk-details__text", text: @edition.block_content["test_attribute"]
+  end
+
+  test "it renders any validation errors when they are present" do
+    messages = %w[foo bar]
+    messages.each { |m| @edition.errors.add(:test_attribute, m) }
+
+    render @block
+    assert_dom ".govuk-error-message", "Error: #{messages.map { |m| "Test attribute #{m}" }.join}"
+  end
+end


### PR DESCRIPTION
Sometimes we want a multi-line input that isn't Govspeak and should not have the 'inline preview' feature.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
