### PR TITLE
[WHIT-3511] Store `slug_override` when redrafting editions with custom slugs and no override set

### DIFF
--- a/app/models/concerns/edition/identifiable.rb
+++ b/app/models/concerns/edition/identifiable.rb
@@ -8,6 +8,7 @@ module Edition::Identifiable
     before_validation :propagate_type_to_document
     before_save :set_slug_from_title, if: -> { title_changed? }
     before_save :nullify_redundant_slug_override, if: -> { slug_override.present? }
+    before_save :set_slug_override
     before_save :set_slug, if: -> { slug_from_title_changed? || slug_override_changed? }
 
     scope :latest_edition, -> { joins(:document).where("editions.id = documents.latest_edition_id") }
@@ -60,6 +61,13 @@ module Edition::Identifiable
         self[:slug_from_title] = candidate_slug
       end
     end
+  end
+
+  def set_slug_override
+    return unless new_record? && document.live_edition_id
+
+    live_slug = Edition.where(id: document.live_edition_id).pick(:slug)
+    self[:slug_override] = live_slug if live_slug.present? && slug_override.blank? && slug_from_title != live_slug
   end
 
   def set_slug

--- a/test/functional/admin/standard_editions_controller_test.rb
+++ b/test/functional/admin/standard_editions_controller_test.rb
@@ -230,7 +230,10 @@ class Admin::StandardEditionsControllerTest < ActionController::TestCase
     ConfigurableDocumentType.setup_test_types(configurable_document_type)
 
     published_edition = create(:published_standard_edition, configurable_document_type: "test_type", title: "Original title")
-    edition = create(:draft_standard_edition, configurable_document_type: "test_type", document: published_edition.document, title: "Renamed title", slug_override: published_edition.slug)
+    edition = published_edition.create_draft(published_edition.authors.first)
+    edition.title = "Renamed title"
+    edition.slug_override = published_edition.slug
+    edition.save!(validate: false)
 
     get :edit, params: { id: edition }
 
@@ -245,7 +248,10 @@ class Admin::StandardEditionsControllerTest < ActionController::TestCase
     ConfigurableDocumentType.setup_test_types(configurable_document_type)
 
     published_edition = create(:published_standard_edition, configurable_document_type: "test_type", title: "Shared title")
-    edition = create(:draft_standard_edition, configurable_document_type: "test_type", document: published_edition.document, title: "Shared title")
+    edition = published_edition.create_draft(published_edition.authors.first)
+
+    assert_nil edition.slug_override
+    assert_equal published_edition.slug, edition.slug
 
     get :edit, params: { id: edition }
 
@@ -260,8 +266,12 @@ class Admin::StandardEditionsControllerTest < ActionController::TestCase
     ConfigurableDocumentType.setup_test_types(configurable_document_type)
 
     published_edition = create(:published_standard_edition, configurable_document_type: "test_type", title: "Shared title")
-    edition = create(:draft_standard_edition, configurable_document_type: "test_type", document: published_edition.document, title: "Shared title")
-    edition.update!(slug_override: "")
+    edition = published_edition.create_draft(published_edition.authors.first)
+    edition.slug_override = ""
+    edition.save!(validate: false)
+
+    assert_equal "", edition.slug_override
+    assert_equal published_edition.slug, edition.slug
 
     get :edit, params: { id: edition }
 
@@ -271,7 +281,7 @@ class Admin::StandardEditionsControllerTest < ActionController::TestCase
     refute_select "input[type=radio][name=?][value=''][checked]", "edition[slug_override]"
   end
 
-  view_test "GET edit pre-selects the 'Update URL to match title' option when the draft slug differs from the live slug and slug_override is nil" do
+  view_test "GET edit pre-selects the 'Update URL to match title' option when slug_override is nil and the draft slug differs from the live slug" do
     configurable_document_type = build_configurable_document_type("test_type")
     ConfigurableDocumentType.setup_test_types(configurable_document_type)
 
@@ -292,13 +302,18 @@ class Admin::StandardEditionsControllerTest < ActionController::TestCase
     refute_select "input[type=radio][name=?][value=?][checked]", "edition[slug_override]", published_edition.slug
   end
 
-  view_test "GET edit pre-selects the 'Update URL to match title' option when the draft slug differs from the live slug and slug_override is blank" do
+  view_test "GET edit pre-selects the 'Update URL to match title' option when slug_override is blank and the draft slug differs from the live slug" do
     configurable_document_type = build_configurable_document_type("test_type")
     ConfigurableDocumentType.setup_test_types(configurable_document_type)
 
     published_edition = create(:published_standard_edition, configurable_document_type: "test_type")
-    edition = create(:draft_standard_edition, configurable_document_type: "test_type", document: published_edition.document)
-    edition.update!(title: "Different title", slug_override: "")
+    edition = published_edition.create_draft(published_edition.authors.first)
+    edition.title = "Different title"
+    edition.slug_override = ""
+    edition.save!(validate: false)
+
+    assert_equal "", edition.slug_override
+    assert_not_equal published_edition.slug, edition.slug
 
     get :edit, params: { id: edition }
 
@@ -313,7 +328,7 @@ class Admin::StandardEditionsControllerTest < ActionController::TestCase
     ConfigurableDocumentType.setup_test_types(configurable_document_type)
 
     published_edition = create(:published_standard_edition, configurable_document_type: "test_type")
-    edition = create(:draft_standard_edition, configurable_document_type: "test_type", document: published_edition.document)
+    edition = published_edition.create_draft(published_edition.authors.first)
 
     get :edit, params: { id: edition }
 

--- a/test/functional/admin/standard_editions_controller_test.rb
+++ b/test/functional/admin/standard_editions_controller_test.rb
@@ -276,8 +276,13 @@ class Admin::StandardEditionsControllerTest < ActionController::TestCase
     ConfigurableDocumentType.setup_test_types(configurable_document_type)
 
     published_edition = create(:published_standard_edition, configurable_document_type: "test_type")
-    edition = create(:draft_standard_edition, configurable_document_type: "test_type", document: published_edition.document)
-    edition.update!(title: "Different title")
+    edition = published_edition.create_draft(published_edition.authors.first)
+    edition.title = "Different title"
+    edition.slug_override = nil
+    edition.save!(validate: false)
+
+    assert_nil edition.slug_override
+    assert_not_equal published_edition.slug, edition.slug
 
     get :edit, params: { id: edition }
 

--- a/test/unit/app/models/edition/identifiable_test.rb
+++ b/test/unit/app/models/edition/identifiable_test.rb
@@ -302,5 +302,28 @@ class Edition::SluggingTest < ActiveSupport::TestCase
       assert_equal "original-title-override", draft_edition_with_slug_override.slug
       assert_equal "original-title-override", draft_edition_with_slug_override.slug_override
     end
+
+    test "it sets an override on new drafts from published, where a custom slug is set, but not saved as an override" do
+      published_edition = SluggableEdition.create_published!(title: "Original Title")
+      published_edition.update_columns(slug: "original-title-override", slug_from_title: "original-title-override")
+      assert_nil published_edition.slug_override
+
+      draft_edition = published_edition.create_draft(create(:writer))
+
+      assert_equal "original-title-override", published_edition.slug
+      assert_equal "original-title-override", draft_edition.slug_override
+    end
+
+    test "it preserves a blank override on drafts from published, where a custom slug is set, but not saved as an override" do
+      published_edition = SluggableEdition.create_published!(title: "Original Title")
+      published_edition.update_columns(slug: "original-title-override", slug_from_title: "original-title-override")
+      assert_nil published_edition.slug_override
+
+      draft_edition = published_edition.create_draft(create(:writer))
+      draft_edition.slug_override = nil
+      draft_edition.save!(validate: false)
+
+      assert_nil draft_edition.slug_override
+    end
   end
 end


### PR DESCRIPTION
## What and why

Store `slug_override` when redrafting editions with custom slugs and no override set

There are live editions where slugs are custom but have not been saved as `slug_overrides`. In the normal run of the app, it is also likely that such data will continue being generated. The URL radio buttons on the edition form expect all custom slugs of a live edition to have been stored as `slug_override`s. Where live editions have a custom slug, we always want to pre-select the "use live URL" option when redrafting. These changes introduce another slug callback to ensure this is the case.

Previous to these changes, for such editions, the "use title-based slug" option would have been selected, which is not in line with the behaviour we typically see on the form.

A custom slug can be a proper "vanity" slug, or any slug that diverges from what the `slug_from_title` of a new draft would be generated as, in the current version of the code, with the current DB data. Divergences can occur when we delete clashing DB drafts (so --2 suffixes are dropped), when we change the slug generation logic (usually how we handle slashed or dashes), or when live editions are intentionally reslugged through programmatic means.

In order to avoid future scenarios where those assumptions are invalidated, we set the `slug_override` to the document's `live_slug`, on fresh drafts from publish, when the live slug does not match the title.

There are a few tests in the commit that needed fixing. The value of the `live_edition` association on the `document` now gets cached, because we use it in the `set_slug_override` callback. We need to force the tests to do a fresh DB fetch by reloading.


## Testing 

Covered flow:
- new draft
- publish
- redraft
- change title and keep live slug
- change title and keep title slug 

Covered a few types:
- news article
- publication
- sanity checked a CIP and a foreign locale

States - covered draft from:
- published
- withdrawn 
- unpublished

Specific bug scenarios - published or withdrawn editions where the live slug was different from a new candidate slug from title due to:
- suffix
- slug generation rules changes
- plain reslug

### Testing Outcome

- Published and withdrawn editions are now working as expected: the correct radio button is selected
- There was an issue before whereby drafting withdrawn editions simply ignored a custom slug if there was no override. Now that we store the override, they get republished at the same slug. The user will get the option to choose URL upon redrafting the edition.


### Other things spotted during testing

Also found some interesting babosa slug generation output:

> Edition 216522 (Publication)
  Title:           Reaching Out to Carers Innovation Fund 2010/2011
  Current slug:    reaching-out-to-carers-innovation-fund-2010-2011
  Candidate slug:  reaching-out-to-carers-innovation-fund-20102011

> Edition 9855 (StandardEdition)
  Title:           Response to the Local Government Chronicle's factually inaccurate analysis of spending over £500 that the Department publishes as part of its commitment to transparency
  Current slug:    response-to-the-local-government-chronicles-factually-inaccurate-analysis-of-spending-over-500-that-the-department-publishes-as-part-of-its-commitment-to-transparency
  Candidate slug:  response-to-the-local-government-chronicles-factually-inaccurate-analysis-of-spending-over-500-that-the-department-publishes-as-part-of-its-commitment

These are the sort of cases where the URL check indicates a slug difference - but it looks like the slug generation was doing a better job before (whatever that version of the code may have been).
Seems more reasonable to put a "-" instead of a "/", rather than just drop it. 
And the truncation is something we specify, but maybe we need a bigger number: https://github.com/alphagov/whitehall/blob/e8b25a97a41b4b811babf56e5af09c8550dd51cd/app/models/concerns/edition/identifiable.rb#L34
Maybe in the future we can move away from babosa as we know it also has all those limitations around foreign languages as well. Noted these in this [future card](https://gov-uk.atlassian.net/browse/WHIT-3457).

[Jira](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-3511)
Related PRs: https://github.com/alphagov/whitehall/pull/11445 https://github.com/alphagov/whitehall/pull/11371