### PR TITLE
Update GTM container ID [WHIT-3365]

### DIFF
--- a/app/assets/javascripts/admin/domain-config.js
+++ b/app/assets/javascripts/admin/domain-config.js
@@ -4,7 +4,7 @@ window.GOVUK.vars.extraDomains = [
     name: 'production',
     domains: ['whitehall-admin.publishing.service.gov.uk'],
     initialiseGA4: true,
-    id: 'GTM-P93SHJ4Z',
+    id: 'GTM-KHZP7S7Q',
     gaProperty: 'UA-26179049-6'
   },
   {
@@ -16,7 +16,7 @@ window.GOVUK.vars.extraDomains = [
     name: 'integration',
     domains: ['whitehall-admin.integration.publishing.service.gov.uk'],
     initialiseGA4: true,
-    id: 'GTM-P93SHJ4Z',
+    id: 'GTM-KHZP7S7Q',
     auth: '8jHx-VNEguw67iX9TBC6_g',
     preview: 'env-50'
   }


### PR DESCRIPTION
## What

Update GTM container ID

## Why

Request from PAs

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
