### PR TITLE
Organisation relationship translations [WHIT-3544] [WHIT-3545]

### DIFF
--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -10,22 +10,30 @@ module OrganisationHelper
     /building law and hygiene/,
   ].freeze
 
-  SPONSORED_TYPE_KEYS = %i[
+  SPONSORED_ORGANISATION_TYPE_KEYS = %i[
     advisory_ndpb
     executive_agency
     executive_ndpb
     special_health_authority
   ].freeze
 
-  IDENTIFICATION_ONLY_TYPE_KEYS = %i[
+  ORGANISATIONS_WITH_NO_PARENT_RELATIONSHIP_KEYS = %i[
     non_ministerial_department
   ].freeze
 
-  def organisation_relationship_display_name(organisation)
+  def organisation_english_display_name_with_article(organisation)
     if organisation.acronym.present?
       tag.abbr(organisation.acronym, title: organisation.name)
     elsif needs_definite_article?(organisation.name)
-      "#{I18n.t('organisation.the').capitalize} #{organisation.name}"
+      "The #{organisation.name}"
+    else
+      organisation.name
+    end
+  end
+
+  def organisation_welsh_display_name_lowercased_with_no_article(organisation)
+    if organisation.acronym.present?
+      tag.abbr(organisation.acronym, title: organisation.name)
     else
       organisation.name
     end
@@ -44,45 +52,45 @@ module OrganisationHelper
   end
 
   def organisation_display_name_and_parental_relationship(organisation)
-    type_key = organisation.organisation_type_key
+    organisation_type_key = organisation.organisation_type_key
     parent_organisations = organisation.parent_organisations
+    locale_key = display_name_and_parental_relationship_i18n_key(organisation_type_key, parent_organisations)
+    localised_organisation_type_name_with_fallback = I18n.t("organisation.type.#{organisation_type_key}", default: organisation_type_name(organisation))
 
-    relationship_description(organisation, type_key, parent_organisations).html_safe
+    locale_template_args = {
+      parents: parents_sentence(organisation_type_key, parent_organisations),
+      english_display_name: ERB::Util.h(organisation_english_display_name_with_article(organisation)).strip,
+      welsh_display_name: organisation_welsh_display_name_lowercased_with_no_article(organisation).strip,
+      english_org_type: ERB::Util.h(add_indefinite_article(localised_organisation_type_name_with_fallback)),
+      welsh_org_type: ERB::Util.h(localised_organisation_type_name_with_fallback),
+    }.compact
+
+    I18n.t(locale_key, **locale_template_args).html_safe
   end
 
-  def relationship_description(organisation, type_key, parent_organisations)
-    key = relationship_i18n_key(type_key, parent_organisations)
-    args = relationship_template_args(organisation, type_key)
-    args[:parents] = parents_sentence(parent_organisations) if display_parent_relationships?(type_key, parent_organisations)
-    I18n.t(key, **args)
-  end
+  def display_name_and_parental_relationship_i18n_key(organisation_type_key, parent_organisations)
+    return "organisation.display_name_and_parental_relationship.display_name_html" if organisation_type_key == :other && parent_organisations.empty?
+    return "organisation.display_name_and_parental_relationship.is_organisation_type_html" unless display_parent_relationships?(organisation_type_key, parent_organisations)
 
-  def relationship_i18n_key(type_key, parent_organisations)
-    return "organisation.relationship.none_html" if type_key == :other && parent_organisations.empty?
-    return "organisation.relationship.identification_html" unless display_parent_relationships?(type_key, parent_organisations)
-
-    case type_key
-    when :other then "organisation.relationship.works_with_html"
-    when :sub_organisation then "organisation.relationship.part_of_html"
-    when *SPONSORED_TYPE_KEYS then "organisation.relationship.sponsored_html"
-    else "organisation.relationship.default_with_parents_html"
+    case organisation_type_key
+    when :other
+      "organisation.display_name_and_parental_relationship.works_with_html"
+    when :sub_organisation
+      "organisation.display_name_and_parental_relationship.part_of_html"
+    when *SPONSORED_ORGANISATION_TYPE_KEYS
+      "organisation.display_name_and_parental_relationship.sponsored_html"
+    else
+      "organisation.display_name_and_parental_relationship.default_with_parents_html"
     end
   end
 
-  def display_parent_relationships?(type_key, parent_organisations)
-    parent_organisations.any? && IDENTIFICATION_ONLY_TYPE_KEYS.exclude?(type_key)
+  def display_parent_relationships?(organisation_type_key, parent_organisations)
+    parent_organisations.any? && ORGANISATIONS_WITH_NO_PARENT_RELATIONSHIP_KEYS.exclude?(organisation_type_key)
   end
 
-  def relationship_template_args(organisation, type_key)
-    localised_type_name = I18n.t("organisation.type.#{type_key}", default: organisation_type_name(organisation))
-    {
-      name: ERB::Util.h(organisation_relationship_display_name(organisation)).strip,
-      type_name: ERB::Util.h(localised_type_name),
-      relationship: ERB::Util.h(add_indefinite_article(localised_type_name)),
-    }
-  end
+  def parents_sentence(organisation_type_key, parent_organisations)
+    return unless display_parent_relationships?(organisation_type_key, parent_organisations)
 
-  def parents_sentence(parent_organisations)
     parent_organisations.map { |parent| organisation_relationship_html(parent) }.to_sentence
   end
 

--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -25,7 +25,7 @@ module OrganisationHelper
     if organisation.acronym.present?
       tag.abbr(organisation.acronym, title: organisation.name)
     elsif needs_definite_article?(organisation.name)
-      "The #{organisation.name}"
+      "#{I18n.t('organisation.the').capitalize} #{organisation.name}"
     else
       organisation.name
     end
@@ -113,7 +113,7 @@ module OrganisationHelper
   end
 
   def organisation_relationship_html(organisation)
-    prefix = needs_definite_article?(organisation.name.strip) ? "the " : ""
+    prefix = needs_definite_article?(organisation.name.strip) ? "#{I18n.t('organisation.the')} " : ""
     (prefix + link_to(organisation.name.strip, organisation.public_path, class: "brand__color"))
   end
 

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -38,11 +38,11 @@ cy:
       jobs: Swyddi
       jobs_and_contacts: Swyddi a chontractau
       organisation_chart: Ein siart sefydliadol
-    relationship:
-      identification_html: "%{type_name} yw'r %{name}."
-      sponsored_html: "Mae %{name} yn %{relationship}, a noddir gan %{parents}."
+    display_name_and_parental_relationship:
+      is_organisation_type_html: "Mae %{welsh_display_name} yn %{welsh_org_type}."
+      sponsored_html: "Mae %{welsh_display_name} yn %{welsh_org_type}, a noddir gan %{parents}."
     type:
-      non_ministerial_department: Adran anweinidogol
+      non_ministerial_department: adran anweinidogol
       executive_agency: asiantaeth gweithredol
   worldwide_organisation:
     corporate_information:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -39,8 +39,10 @@ cy:
       organisation_chart: Ein siart sefydliadol
     relationship:
       identification_html: "%{type_name} yw'r %{name}."
+      sponsored_html: "Mae %{name} yn %{relationship}, a noddir gan %{parents}."
     type:
       non_ministerial_department: Adran anweinidogol
+      executive_agency: asiantaeth gweithredol
   worldwide_organisation:
     corporate_information:
       about_our_services_html: Darganfod %{link}.

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -32,6 +32,7 @@ cy:
         terms_of_reference: Cylch gorchwyl
         welsh_language_scheme: Cynllun iaith Gymraeg
   organisation:
+    the: y
     corporate_information:
       access_our_info: Cael mynediad at ein gwybodaeth
       jobs: Swyddi

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -402,13 +402,13 @@ en:
       organisation_chart: Our organisation chart
     embassies:
       find_an_embassy_title: Find a British embassy, high commission or consulate
-    relationship:
-      none_html: "%{name}"
-      identification_html: "%{name} is %{relationship}."
-      works_with_html: "%{name} works with %{parents}."
-      part_of_html: "%{name} is part of %{parents}."
-      sponsored_html: "%{name} is %{relationship}, sponsored by %{parents}."
-      default_with_parents_html: "%{name} is %{relationship} of %{parents}."
+    display_name_and_parental_relationship:
+      display_name_html: "%{english_display_name}"
+      is_organisation_type_html: "%{english_display_name} is %{english_org_type}."
+      works_with_html: "%{english_display_name} works with %{parents}."
+      part_of_html: "%{english_display_name} is part of %{parents}."
+      sponsored_html: "%{english_display_name} is %{english_org_type}, sponsored by %{parents}."
+      default_with_parents_html: "%{english_display_name} is %{english_org_type} of %{parents}."
     type:
       adhoc_advisory_group: ad-hoc advisory group
       advisory_ndpb: advisory non-departmental public body

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -394,6 +394,7 @@ en:
       not_deployed: The emergency banner is not currently deployed.
     update_information: Changes to the emergency banner appear instantly on the live site, subject to a cache period of 5 minutes per page.
   organisation:
+    the: the
     corporate_information:
       access_our_info: Access our information
       jobs: Jobs

--- a/test/unit/app/helpers/organisation_helper_test.rb
+++ b/test/unit/app/helpers/organisation_helper_test.rb
@@ -197,7 +197,7 @@ class OrganisationHelperDisplayNameWithParentalRelationshipTest < ActionView::Te
 
   test "sponsored executive agency with parents renders Welsh identification sentence" do
     parent = create(:ministerial_department, name: "Department of Testing")
-    org = create(:organisation, acronym: "CC", name: "Comisiwn Elusennau", organisation_type: OrganisationType.executive_agency, parent_organisations: [parent])
+    org = create(:organisation, name: "Comisiwn Elusennau", organisation_type: OrganisationType.executive_agency, parent_organisations: [parent])
 
     I18n.with_locale(:cy) do
       assert_display_name_text org, "Mae CC yn an asiantaeth gweithredol, a noddir gan y Department of Testing."

--- a/test/unit/app/helpers/organisation_helper_test.rb
+++ b/test/unit/app/helpers/organisation_helper_test.rb
@@ -195,6 +195,15 @@ class OrganisationHelperDisplayNameWithParentalRelationshipTest < ActionView::Te
     end
   end
 
+  test "sponsored executive agency with parents renders Welsh identification sentence" do
+    parent = create(:ministerial_department, name: "Department of Testing")
+    org = create(:organisation, acronym: "CC", name: "Comisiwn Elusennau", organisation_type: OrganisationType.executive_agency, parent_organisations: [parent])
+
+    I18n.with_locale(:cy) do
+      assert_display_name_text org, "Mae CC yn an asiantaeth gweithredol, a noddir gan y Department of Testing."
+    end
+  end
+
   # TODO: delete test once we have full Welsh translations
   test "non-ministerial department with supporting bodies renders mixed Welsh/English sentence in Welsh" do
     child = create(:organisation, acronym: "CO", name: "Child Organisation One")
@@ -210,10 +219,10 @@ class OrganisationHelperDisplayNameWithParentalRelationshipTest < ActionView::Te
   # TODO: delete test once we have full Welsh translations
   test "non-Welsh-translated type falls back to English in Welsh locale" do
     parent = create(:ministerial_department, name: "Department of Testing")
-    org = create(:organisation, acronym: "EA", name: "Executive Agency Example", organisation_type: OrganisationType.executive_agency, parent_organisations: [parent])
+    org = create(:organisation, acronym: "EO", name: "Executive Office Example", organisation_type: OrganisationType.executive_office, parent_organisations: [parent])
 
     I18n.with_locale(:cy) do
-      assert_display_name_text org, "EA is an executive agency, sponsored by the Department of Testing."
+      assert_display_name_text org, "EO is an executive office of y Department of Testing."
     end
   end
 end

--- a/test/unit/app/helpers/organisation_helper_test.rb
+++ b/test/unit/app/helpers/organisation_helper_test.rb
@@ -5,17 +5,17 @@ class OrganisationHelperTest < ActionView::TestCase
 
   test "returns acronym in abbr tag if present" do
     organisation = build(:organisation, acronym: "BLAH", name: "Building Law and Hygiene")
-    assert_equal %(<abbr title="Building Law and Hygiene">BLAH</abbr>), organisation_relationship_display_name(organisation)
+    assert_equal %(<abbr title="Building Law and Hygiene">BLAH</abbr>), organisation_english_display_name(organisation)
   end
 
   test "returns name when acronym is nil" do
     organisation = build(:organisation, acronym: nil, name: "Building Law and Hygiene")
-    assert_equal "Building Law and Hygiene", organisation_relationship_display_name(organisation)
+    assert_equal "Building Law and Hygiene", organisation_english_display_name(organisation)
   end
 
   test "returns name when acronym is empty" do
     organisation = build(:organisation, acronym: "", name: "Building Law and Hygiene")
-    assert_equal "Building Law and Hygiene", organisation_relationship_display_name(organisation)
+    assert_equal "Building Law and Hygiene", organisation_english_display_name(organisation)
   end
 
   test "returns name formatted for logos" do
@@ -179,19 +179,19 @@ class OrganisationHelperDisplayNameWithParentalRelationshipTest < ActionView::Te
   end
 
   test "non-ministerial department renders Welsh identification sentence" do
-    org = create(:organisation, acronym: "CC", name: "Comisiwn Elusennau", organisation_type: OrganisationType.non_ministerial_department)
+    org = create(:organisation, name: "Comisiwn Elusennau", organisation_type: OrganisationType.non_ministerial_department)
 
     I18n.with_locale(:cy) do
-      assert_display_name_text org, "Adran anweinidogol yw'r CC."
+      assert_display_name_text org, "Mae Comisiwn Elusennau yn adran anweinidogol."
     end
   end
 
   test "non-ministerial department with parents renders Welsh identification sentence" do
     parent = create(:ministerial_department, name: "Department of Testing")
-    org = create(:organisation, acronym: "CC", name: "Comisiwn Elusennau", organisation_type: OrganisationType.non_ministerial_department, parent_organisations: [parent])
+    org = create(:organisation, name: "Comisiwn Elusennau", organisation_type: OrganisationType.non_ministerial_department, parent_organisations: [parent])
 
     I18n.with_locale(:cy) do
-      assert_display_name_text org, "Adran anweinidogol yw'r CC."
+      assert_display_name_text org, "Mae Comisiwn Elusennau yn adran anweinidogol."
     end
   end
 
@@ -200,7 +200,7 @@ class OrganisationHelperDisplayNameWithParentalRelationshipTest < ActionView::Te
     org = create(:organisation, name: "Comisiwn Elusennau", organisation_type: OrganisationType.executive_agency, parent_organisations: [parent])
 
     I18n.with_locale(:cy) do
-      assert_display_name_text org, "Mae CC yn an asiantaeth gweithredol, a noddir gan y Department of Testing."
+      assert_display_name_text org, "Mae Comisiwn Elusennau yn asiantaeth gweithredol, a noddir gan y Department of Testing."
     end
   end
 
@@ -212,7 +212,7 @@ class OrganisationHelperDisplayNameWithParentalRelationshipTest < ActionView::Te
 
     I18n.with_locale(:cy) do
       description = organisation_display_name_including_parental_and_child_relationships(org)
-      assert_equal "Adran anweinidogol yw'r CC, supported by 1 public body.", strip_html_tags(description)
+      assert_equal "Mae CC yn adran anweinidogol, supported by 1 public body.", strip_html_tags(description)
     end
   end
 


### PR DESCRIPTION
## What

Add a Welsh translation for the organisation relationship text, when the org is a sponsored exec agency

Also adds 'the' into the I18n dictionaries and uses that translation in the helper (as this is now surfaced in the Welsh relationship string).  Unfortunately, there are three Welsh words for 'the' (y, yr and 'r).  'y' is the most commonly applicable and the least grammatically incorrect when it is wrong.  Accepting that this will be incorrect some of the time seems more proportionate than writing a custom translation helper that handles this mutation.

## Why

There was no Welsh translation for the relationship text for this type of org.  See point (1) on https://govuk.zendesk.com/agent/tickets/6639754.

The addition of the Welsh translation sponsored executive agency relationship text revealed an issue where the definitive article in the string was always in English, eg 

`DVLA is an executive agency, sponsored by the Department for Transport`

would be translated into 

`Mae DVLA yn an asiantaeth gweithredol, a noddir gan _the_ <Department for Transport in Welsh>`.

### Before

<img width="990" height="352" alt="image" src="https://github.com/user-attachments/assets/f30016d9-1c15-4cbd-847d-effc34c3b531" />


### After

<img width="1003" height="356" alt="image" src="https://github.com/user-attachments/assets/193af9ee-7937-40b6-82b0-a70211d6ff29" />



---
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
