### PR TITLE
Add access_limiting column to editions

### DIFF
--- a/db/migrate/20260603141011_add_access_limiting_to_editions.rb
+++ b/db/migrate/20260603141011_add_access_limiting_to_editions.rb
@@ -1,0 +1,5 @@
+class AddAccessLimitingToEditions < ActiveRecord::Migration[8.1]
+  def change
+    add_column :editions, :access_limiting, :string, default: "none", null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_27_105725) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_03_141011) do
   create_table "access_limiting_organisations", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.bigint "edition_id", null: false
@@ -357,6 +357,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_27_105725) do
 
   create_table "editions", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.boolean "access_limited", null: false
+    t.string "access_limiting", default: "none", null: false
     t.string "additional_related_mainstream_content_title"
     t.string "additional_related_mainstream_content_url"
     t.boolean "all_nation_applicability", default: true


### PR DESCRIPTION
First step of the access_limited → access_limiting enum migration. Schema-only change: adds the column with default "none", null: false. No backfill and no application code reads from it yet - they happen in later commits.