### PR TITLE
Whit 3538 access limiting bridge and backfill

### DIFF
--- a/app/models/concerns/edition/limited_access.rb
+++ b/app/models/concerns/edition/limited_access.rb
@@ -2,6 +2,12 @@ module Edition::LimitedAccess
   extend ActiveSupport::Concern
 
   included do
+    enum :access_limiting, {
+      none: "none",
+      organisations: "organisations",
+      individuals: "individuals",
+    }, prefix: true
+
     after_initialize :set_access_limited
   end
 
@@ -17,6 +23,18 @@ module Edition::LimitedAccess
 
   def access_limited?
     self[:access_limited]
+  end
+
+  # TODO: Remove once nothing reads or writes `access_limited` (drop-column ticket).
+  def access_limited=(value)
+    super
+    self.access_limiting = self[:access_limited] ? "organisations" : "none"
+  end
+
+  # TODO: Remove once nothing reads or writes `access_limited` (drop-column ticket).
+  def access_limiting=(value)
+    super
+    self[:access_limited] = !access_limiting_none?
   end
 
   delegate :access_limited_by_default?, to: :class

--- a/app/models/concerns/edition/limited_access.rb
+++ b/app/models/concerns/edition/limited_access.rb
@@ -22,6 +22,8 @@ module Edition::LimitedAccess
   delegate :access_limited_by_default?, to: :class
 
   def set_access_limited
+    return if access_limited_by_default?.nil?
+
     if new_record? && access_limited.nil?
       self.access_limited = access_limited_by_default?
     end

--- a/db/data_migration/20260603143000_backfill_access_limiting_from_access_limited.rb
+++ b/db/data_migration/20260603143000_backfill_access_limiting_from_access_limited.rb
@@ -1,0 +1,9 @@
+update_sql = <<~SQL
+  UPDATE editions
+  SET access_limiting = 'organisations'
+  WHERE access_limited = true
+    AND access_limiting = 'none';
+SQL
+updated_editions = ActiveRecord::Base.connection.update(update_sql)
+
+puts "Set access_limiting to 'organisations' for #{updated_editions} editions"

--- a/test/unit/app/models/edition/limited_access_test.rb
+++ b/test/unit/app/models/edition/limited_access_test.rb
@@ -61,4 +61,54 @@ class Edition::LimitedAccessTest < ActiveSupport::TestCase
 
     assert edition.accessible_to?(user)
   end
+
+  test "setting access_limited = true bridges to access_limiting = 'organisations'" do
+    edition = build(:limited_access_edition)
+    edition.access_limited = true
+    assert_equal "organisations", edition.access_limiting
+  end
+
+  test "setting access_limited = false bridges to access_limiting = 'none'" do
+    edition = build(:limited_access_edition)
+    edition.access_limited = false
+    assert_equal "none", edition.access_limiting
+  end
+
+  test "setting access_limiting = 'organisations' bridges to access_limited = true" do
+    edition = build(:limited_access_edition)
+    edition.access_limiting = "organisations"
+    assert edition.access_limited?
+  end
+
+  test "setting access_limiting = 'individuals' bridges to access_limited = true" do
+    edition = build(:limited_access_edition)
+    edition.access_limiting = "individuals"
+    assert edition.access_limited?
+  end
+
+  test "setting access_limiting = 'none' bridges to access_limited = false" do
+    edition = build(:limited_access_edition)
+    edition.access_limiting = "organisations"
+    edition.access_limiting = "none"
+    assert_not edition.access_limited?
+  end
+
+  test "bridge writers persist both columns" do
+    edition = build(:limited_access_edition)
+    edition.access_limited = true
+    edition.save!
+    edition.reload
+    assert edition.access_limited?
+    assert_equal "organisations", edition.access_limiting
+
+    edition.access_limiting = "individuals"
+    edition.save!
+    edition.reload
+    assert edition.access_limited?
+    assert_equal "individuals", edition.access_limiting
+  end
+
+  test "new instance of default-limited edition has access_limiting = 'organisations'" do
+    assert_equal "organisations", build(:limited_by_default_edition).access_limiting
+  end
 end


### PR DESCRIPTION
- Bridge the old and new access limit fields
- Backfill the data to the new field
- Fix a bug that will prevent a valid default on the new string enum field