### PR TITLE
[WHIT-3550] - Switchover to access_limiting enum

### DIFF
--- a/app/controllers/admin/edition_access_limited_controller.rb
+++ b/app/controllers/admin/edition_access_limited_controller.rb
@@ -47,7 +47,7 @@ private
     @edition_params ||= params
     .fetch(:edition, {})
     .permit(
-      :access_limited,
+      :access_limiting,
       :editorial_remark,
       {
         lead_organisation_ids: [],

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -228,7 +228,7 @@ private
       :publication_type_id,
       :scheduled_publication,
       :lock_version,
-      :access_limited,
+      :access_limiting,
       :alternative_format_provider_id,
       :opening_at,
       :closing_at,

--- a/app/helpers/admin/editions_helper.rb
+++ b/app/helpers/admin/editions_helper.rb
@@ -219,7 +219,7 @@ module Admin::EditionsHelper
       )
     end
 
-    if can?(:perform_administrative_tasks, Edition) && edition.access_limited
+    if can?(:perform_administrative_tasks, Edition) && edition.access_limited?
       actions << link_to(
         sanitize("Edit access #{tag.span("for #{edition.title}", class: 'govuk-visually-hidden')}"),
         edit_access_limited_admin_edition_path(edition),

--- a/app/models/concerns/edition/limited_access.rb
+++ b/app/models/concerns/edition/limited_access.rb
@@ -22,19 +22,13 @@ module Edition::LimitedAccess
   end
 
   def access_limited?
-    self[:access_limited]
-  end
-
-  # TODO: Remove once nothing reads or writes `access_limited` (drop-column ticket).
-  def access_limited=(value)
-    super
-    self.access_limiting = self[:access_limited] ? "organisations" : "none"
+    access_limiting_organisations? || access_limiting_individuals?
   end
 
   # TODO: Remove once nothing reads or writes `access_limited` (drop-column ticket).
   def access_limiting=(value)
     super
-    self[:access_limited] = !access_limiting_none?
+    self.access_limited = !access_limiting_none?
   end
 
   delegate :access_limited_by_default?, to: :class
@@ -42,8 +36,8 @@ module Edition::LimitedAccess
   def set_access_limited
     return if access_limited_by_default?.nil?
 
-    if new_record? && access_limited.nil?
-      self.access_limited = access_limited_by_default?
+    if new_record? && access_limited_by_default? && access_limiting_none?
+      self.access_limiting = :organisations
     end
   end
 

--- a/app/services/edition_publisher.rb
+++ b/app/services/edition_publisher.rb
@@ -26,7 +26,7 @@ private
 
   def prepare_edition
     flag_if_political_content!
-    edition.access_limited = false
+    edition.access_limiting = :none
     edition.major_change_published_at = Time.zone.now unless edition.minor_change?
     edition.make_public_at(edition.major_change_published_at)
     edition.increment_version_number

--- a/app/validators/unmodifiable_validator.rb
+++ b/app/validators/unmodifiable_validator.rb
@@ -12,7 +12,7 @@ class UnmodifiableValidator < ActiveModel::Validator
   def modifiable_attributes(previous_state, current_state)
     modifiable = %w[state updated_at force_published]
     if previous_state == "scheduled"
-      modifiable += %w[major_change_published_at first_published_at access_limited]
+      modifiable += %w[major_change_published_at first_published_at access_limited access_limiting]
     end
     if Edition::PRE_PUBLICATION_STATES.include?(previous_state) || being_unpublished?(previous_state, current_state)
       modifiable += %w[published_major_version published_minor_version]

--- a/app/views/admin/editions/_access_limiting_fields.html.erb
+++ b/app/views/admin/editions/_access_limiting_fields.html.erb
@@ -4,17 +4,17 @@
     heading_level: 3,
     heading_size: "m",
   } do %>
-    <%= form.hidden_field :access_limited, value: "0" %>
+    <%= form.hidden_field :access_limiting, value: "none" %>
 
     <%= render "govuk_publishing_components/components/checkboxes", {
-      name: "edition[access_limited]",
-      id: "edition_access_limited",
-      error_items: errors_for(edition.errors, :access_limited),
+      name: "edition[access_limiting]",
+      id: "edition_access_limiting",
+      error_items: errors_for(edition.errors, :access_limiting),
       items: [
         {
           label: "Limit access to publishers from organisations associated with this document before you publish",
-          value: 1,
-          checked: edition.access_limited,
+          value: "organisations",
+          checked: edition.access_limited?,
         },
       ],
     } %>

--- a/db/migrate/20260604120000_default_access_limited_to_false.rb
+++ b/db/migrate/20260604120000_default_access_limited_to_false.rb
@@ -1,0 +1,5 @@
+class DefaultAccessLimitedToFalse < ActiveRecord::Migration[8.1]
+  def change
+    change_column_default :editions, :access_limited, from: nil, to: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_03_141011) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_04_120000) do
   create_table "access_limiting_organisations", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.bigint "edition_id", null: false
@@ -356,7 +356,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_03_141011) do
   end
 
   create_table "editions", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.boolean "access_limited", null: false
+    t.boolean "access_limited", default: false, null: false
     t.string "access_limiting", default: "none", null: false
     t.string "additional_related_mainstream_content_title"
     t.string "additional_related_mainstream_content_url"

--- a/features/step_definitions/admin_statistics_announcements_steps.rb
+++ b/features/step_definitions/admin_statistics_announcements_steps.rb
@@ -6,7 +6,7 @@ Given(/^a draft statistics publication called "(.*?)"$/) do |title|
   @statistics_publication = create(
     :publication,
     :draft,
-    access_limited: false,
+    access_limiting: "none",
     publication_type_id: PublicationType::OfficialStatistics.id,
     title:,
   )
@@ -16,7 +16,7 @@ Given(/^a published statistics publication called "(.*?)"$/) do |title|
   @statistics_publication = create(
     :publication,
     :published,
-    access_limited: false,
+    access_limiting: "none",
     publication_type_id: PublicationType::OfficialStatistics.id,
     title:,
   )

--- a/features/step_definitions/most_recent_editions_steps.rb
+++ b/features/step_definitions/most_recent_editions_steps.rb
@@ -10,7 +10,7 @@ When(/^someone else creates a new edition of the published document "([^"]*)" an
   current = Edition.find_by(title:).document.latest_edition
   new_draft = current.create_draft(random_editor)
   new_draft.organisations << org
-  new_draft.access_limited = true
+  new_draft.access_limiting = "organisations"
   new_draft.change_note = "Limited to #{org.name}"
   new_draft.save!
 end

--- a/test/components/admin/editions/tags_component_test.rb
+++ b/test/components/admin/editions/tags_component_test.rb
@@ -66,7 +66,7 @@ class Admin::Editions::TagsComponentTest < ViewComponent::TestCase
   end
 
   test "adds an access limited tag if edition has limited access" do
-    edition = build(:edition, access_limited: true)
+    edition = build(:edition, access_limiting: "organisations")
 
     expected_output = "<span class=\"govuk-tag govuk-tag--s govuk-tag--blue\">Draft</span> " \
       "<span class=\"govuk-tag govuk-tag--s govuk-tag--red\">Limited access</span>"

--- a/test/factories/editions.rb
+++ b/test/factories/editions.rb
@@ -120,7 +120,7 @@ FactoryBot.define do
       scheduled_publication { 7.days.from_now }
     end
 
-    trait(:access_limited) { access_limited { true } }
+    trait(:access_limited) { access_limiting { "organisations" } }
 
     trait(:with_alternative_format_provider) do
       association :alternative_format_provider, factory: :organisation_with_alternative_format_contact_email

--- a/test/functional/admin/edition_access_limited_controller_test.rb
+++ b/test/functional/admin/edition_access_limited_controller_test.rb
@@ -19,7 +19,7 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
 
     edition = create(
       :consultation,
-      access_limited: true,
+      access_limiting: "organisations",
       create_default_organisation: false,
       lead_organisations: [organisation],
     )
@@ -27,7 +27,7 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
     get :edit, params: { id: edition }
 
     assert_select "form[action='#{update_access_limited_admin_edition_path(edition.id)}']" do
-      assert_select "input[name='edition[access_limited]'][type=checkbox][checked=checked]"
+      assert_select "input[name='edition[access_limiting]'][type=checkbox][value=organisations][checked=checked]"
       assert_select "textarea[name='edition[editorial_remark]']"
 
       (1..4).each do |i|
@@ -58,7 +58,7 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
 
     edition = create(
       :consultation,
-      access_limited: true,
+      access_limiting: "organisations",
       create_default_organisation: false,
       lead_organisations: [first_organisation],
       supporting_organisations: [second_organisation],
@@ -75,7 +75,7 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
             lead_organisation_ids: [second_organisation.id],
             supporting_organisation_ids: [third_organisation.id],
             editorial_remark:,
-            access_limited: "1",
+            access_limiting: "organisations",
           },
         }
 
@@ -92,7 +92,7 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
 
     edition = create(
       :consultation,
-      access_limited: true,
+      access_limiting: "organisations",
       create_default_organisation: false,
       lead_organisations: [first_organisation],
       supporting_organisations: [second_organisation],
@@ -107,13 +107,13 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
             lead_organisation_ids: [first_organisation.id],
             supporting_organisation_ids: [second_organisation.id],
             editorial_remark:,
-            access_limited: "0",
+            access_limiting: "none",
           },
         }
 
     assert_equal [first_organisation], edition.reload.lead_organisations
     assert_equal [second_organisation], edition.supporting_organisations
-    assert_not edition.access_limited
+    assert_not edition.access_limited?
     assert_redirected_to admin_editions_path
     assert_equal "Access updated for #{edition.title}", flash[:notice]
     assert_equal "Access options updated by GDS Admin: #{editorial_remark}", edition.editorial_remarks.last.body
@@ -125,7 +125,7 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
 
     edition = create(
       :consultation,
-      access_limited: true,
+      access_limiting: "organisations",
       create_default_organisation: false,
       lead_organisations: [first_organisation],
       supporting_organisations: [second_organisation],
@@ -138,13 +138,13 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
             lead_organisation_ids: [first_organisation.id],
             supporting_organisation_ids: [second_organisation.id],
             editorial_remark: "",
-            access_limited: "0",
+            access_limiting: "none",
           },
         }
 
     assert_template :edit
     assert_equal ["Editorial remark cannot be blank"], assigns(:edition).errors.full_messages
-    assert edition.reload.access_limited
+    assert edition.reload.access_limited?
   end
 
   test "PATCH :update doesn't create an editorial remark or re-render with an error when nothing has changed" do
@@ -153,7 +153,7 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
 
     edition = create(
       :consultation,
-      access_limited: true,
+      access_limiting: "organisations",
       create_default_organisation: false,
       lead_organisations: [first_organisation],
       supporting_organisations: [second_organisation],
@@ -166,7 +166,7 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
             lead_organisation_ids: [first_organisation.id],
             supporting_organisation_ids: [second_organisation.id],
             editorial_remark: "",
-            access_limited: "1",
+            access_limiting: "organisations",
           },
         }
 

--- a/test/functional/admin/editions_controller_test.rb
+++ b/test/functional/admin/editions_controller_test.rb
@@ -286,10 +286,10 @@ class Admin::EditionsControllerTest < ActionController::TestCase
     login_as create(:writer, organisation: my_organisation)
     accessible = [
       create(:draft_publication),
-      create(:draft_publication, publication_type: PublicationType::NationalStatistics, access_limited: true, organisations: [my_organisation]),
-      create(:draft_publication, publication_type: PublicationType::NationalStatistics, access_limited: false, organisations: [other_organisation]),
+      create(:draft_publication, publication_type: PublicationType::NationalStatistics, access_limiting: "organisations", organisations: [my_organisation]),
+      create(:draft_publication, publication_type: PublicationType::NationalStatistics, access_limiting: "none", organisations: [other_organisation]),
     ]
-    inaccessible = create(:draft_publication, publication_type: PublicationType::NationalStatistics, access_limited: true, organisations: [other_organisation])
+    inaccessible = create(:draft_publication, publication_type: PublicationType::NationalStatistics, access_limiting: "organisations", organisations: [other_organisation])
 
     get :index, params: { state: :active }
 
@@ -302,7 +302,7 @@ class Admin::EditionsControllerTest < ActionController::TestCase
   view_test "index should indicate the protected status of limited access editions which I do have access to" do
     my_organisation = create(:organisation)
     login_as create(:writer, organisation: my_organisation)
-    publication = create(:draft_publication, publication_type: PublicationType::NationalStatistics, access_limited: true, organisations: [my_organisation])
+    publication = create(:draft_publication, publication_type: PublicationType::NationalStatistics, access_limiting: "organisations", organisations: [my_organisation])
 
     get :index, params: { state: :active }
 
@@ -314,7 +314,7 @@ class Admin::EditionsControllerTest < ActionController::TestCase
 
   view_test "GET :index admin do not see a view link, but are given a link to edit acccess controls when an access limited edition doesn't belong to their org" do
     login_as create(:gds_admin)
-    publication = create(:draft_publication, access_limited: true)
+    publication = create(:draft_publication, access_limiting: "organisations")
 
     get :index, params: { state: :active }
 
@@ -330,7 +330,7 @@ class Admin::EditionsControllerTest < ActionController::TestCase
     my_organisation = create(:organisation)
     other_organisation = create(:organisation)
     login_as create(:writer, organisation: my_organisation)
-    inaccessible = create(:draft_publication, publication_type: PublicationType::NationalStatistics, access_limited: true, organisations: [other_organisation])
+    inaccessible = create(:draft_publication, publication_type: PublicationType::NationalStatistics, access_limiting: "organisations", organisations: [other_organisation])
 
     post :revise, params: { id: inaccessible }
     assert_response :forbidden

--- a/test/functional/admin/editorial_remarks_controller_test.rb
+++ b/test/functional/admin/editorial_remarks_controller_test.rb
@@ -52,7 +52,7 @@ class Admin::EditorialRemarksControllerTest < ActionController::TestCase
   end
 
   test "should prevent access to inaccessible editions" do
-    protected_edition = create(:submitted_publication, access_limited: true)
+    protected_edition = create(:submitted_publication, access_limiting: "organisations")
 
     get :new, params: { edition_id: protected_edition.id }
     assert_response :forbidden

--- a/test/functional/admin/external_attachments_controller_test.rb
+++ b/test/functional/admin/external_attachments_controller_test.rb
@@ -26,7 +26,7 @@ class Admin::ExternalAttachmentsControllerTest < ActionController::TestCase
   end
 
   test "POST :create ignores external attachments when attachable does not allow them" do
-    attachable = create(:statistical_data_set, access_limited: false)
+    attachable = create(:statistical_data_set, access_limiting: "none")
 
     post :create, params: { edition_id: attachable, attachment: valid_external_attachment_params }
 

--- a/test/functional/admin/html_attachments_controller_test.rb
+++ b/test/functional/admin/html_attachments_controller_test.rb
@@ -54,7 +54,7 @@ class Admin::HtmlAttachmentsControllerTest < ActionController::TestCase
   end
 
   test "POST :create ignores html attachments when attachable does not allow them" do
-    attachable = create(:statistical_data_set, access_limited: false)
+    attachable = create(:statistical_data_set, access_limiting: "none")
 
     post :create, params: { edition_id: attachable, attachment: valid_html_attachment_params }
 

--- a/test/functional/admin/publications_controller_test.rb
+++ b/test/functional/admin/publications_controller_test.rb
@@ -31,7 +31,7 @@ class Admin::PublicationsControllerTest < ActionController::TestCase
     assert_select "form#new_edition" do
       assert_select "input[name*='edition[first_published_at']", count: 3
       assert_select "select[name='edition[publication_type_id]']"
-      assert_select "input[name='edition[access_limited]']"
+      assert_select "input[name='edition[access_limiting]']"
     end
   end
 
@@ -138,7 +138,7 @@ class Admin::PublicationsControllerTest < ActionController::TestCase
     my_organisation = create(:organisation)
     other_organisation = create(:organisation)
     @user = login_as(create(:user, organisation: my_organisation))
-    inaccessible = create(:draft_publication, publication_type: PublicationType::NationalStatistics, access_limited: true, organisations: [other_organisation])
+    inaccessible = create(:draft_publication, publication_type: PublicationType::NationalStatistics, access_limiting: "organisations", organisations: [other_organisation])
 
     get :show, params: { id: inaccessible }
     assert_response :forbidden

--- a/test/integration/asset_access_options_integration_test.rb
+++ b/test/integration/asset_access_options_integration_test.rb
@@ -71,7 +71,7 @@ class AssetAccessOptionsIntegrationTest < ActionDispatch::IntegrationTest
     end
 
     context "given an access-limited draft document" do
-      let(:edition) { create(:detailed_guide, organisations: [organisation], access_limited: true) }
+      let(:edition) { create(:detailed_guide, organisations: [organisation], access_limiting: "organisations") }
 
       context "when an attachment is added to the draft document" do
         before do
@@ -153,7 +153,7 @@ class AssetAccessOptionsIntegrationTest < ActionDispatch::IntegrationTest
     end
 
     context "given an access-limited draft document and a file attachment" do
-      let(:edition) { create(:detailed_guide, organisations: [organisation], access_limited: true) }
+      let(:edition) { create(:detailed_guide, organisations: [organisation], access_limiting: "organisations") }
 
       before do
         add_file_attachment_with_asset("sample.docx", to: edition)
@@ -201,7 +201,7 @@ class AssetAccessOptionsIntegrationTest < ActionDispatch::IntegrationTest
 
     context "given a draft access-limited consultation" do
       # the edition has to have same organisation as logged in user, otherwise it's not visible when access_limited = true
-      let(:edition) { create(:consultation, organisations: [organisation], access_limited: true) }
+      let(:edition) { create(:consultation, organisations: [organisation], access_limiting: "organisations") }
       let(:outcome_attributes) { FactoryBot.attributes_for(:consultation_outcome) }
       let!(:outcome) { edition.create_outcome!(outcome_attributes) }
 

--- a/test/integration/asset_manager_test.rb
+++ b/test/integration/asset_manager_test.rb
@@ -34,7 +34,7 @@ class AssetManagerIntegrationTest
 
     test "sends the user ids of authorised users to Asset Manager" do
       organisation = FactoryBot.create(:organisation)
-      consultation = FactoryBot.create(:consultation, access_limited: true, organisations: [organisation])
+      consultation = FactoryBot.create(:consultation, access_limiting: "organisations", organisations: [organisation])
       @attachment.attachable = consultation
       @attachment.attachment_data.attachable = consultation
       @attachment.save!

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -943,7 +943,7 @@ module AdminEditionControllerTestHelpers
     def should_allow_access_limiting_of(edition_type)
       edition_class = class_for(edition_type)
 
-      test "create should record the access_limited flag" do
+      test "create should record the access_limiting flag" do
         organisation = create(:organisation)
         controller.current_user.organisation = organisation
         controller.current_user.save!
@@ -952,7 +952,7 @@ module AdminEditionControllerTestHelpers
              params: {
                edition: controller_attributes_for(edition_type).merge(
                  first_published_at: Date.parse("2010-10-21"),
-                 access_limited: "1",
+                 access_limiting: "organisations",
                  lead_organisation_ids: [organisation.id],
                ),
              }
@@ -962,27 +962,27 @@ module AdminEditionControllerTestHelpers
         assert created_publication.access_limited?
       end
 
-      view_test "edit displays persisted access_limited flag" do
-        publication = create(edition_type, access_limited: false)
+      view_test "edit displays persisted access_limiting flag" do
+        publication = create(edition_type, access_limiting: "none")
 
         get :edit, params: { id: publication }
 
         assert_select "form#edit_edition" do
-          assert_select "input[name='edition[access_limited]'][type=checkbox]"
-          assert_select "input[name='edition[access_limited]'][type=checkbox][checked=checked]", count: 0
+          assert_select "input[name='edition[access_limiting]'][type=checkbox]"
+          assert_select "input[name='edition[access_limiting]'][type=checkbox][checked=checked]", count: 0
         end
       end
 
-      test "update records new value of access_limited flag" do
+      test "update records new value of access_limiting flag" do
         controller.current_user.organisation = create(:organisation)
         controller.current_user.save!
-        publication = create(edition_type, access_limited: false, organisations: [controller.current_user.organisation])
+        publication = create(edition_type, access_limiting: "none", organisations: [controller.current_user.organisation])
 
         put :update,
             params: {
               id: publication,
               edition: {
-                access_limited: "1",
+                access_limiting: "organisations",
               },
             }
 
@@ -993,13 +993,13 @@ module AdminEditionControllerTestHelpers
         controller.current_user.organisation = create(:organisation)
         controller.current_user.save!
         organisation = create(:organisation)
-        edition = create(edition_type, access_limited: false, organisations: [organisation])
+        edition = create(edition_type, access_limiting: "none", organisations: [organisation])
 
         put :update,
             params: {
               id: edition,
               edition: {
-                access_limited: "1",
+                access_limiting: "organisations",
               },
             }
 

--- a/test/unit/app/models/admin/edition_filter_test.rb
+++ b/test/unit/app/models/admin/edition_filter_test.rb
@@ -9,7 +9,7 @@ class Admin::EditionFilterTest < ActiveSupport::TestCase
     user = create(:user)
     edition = create(
       :publication,
-      access_limited: true,
+      access_limiting: "organisations",
     )
     edition.organisations.first.users << user
 
@@ -18,14 +18,14 @@ class Admin::EditionFilterTest < ActiveSupport::TestCase
   end
 
   test "should not return editions which have limited access for other orgs for non-gds admins" do
-    create(:publication, access_limited: true)
+    create(:publication, access_limiting: "organisations")
 
     filter = Admin::EditionFilter.new(Edition, build(:user))
     assert_equal 0, filter.editions.count
   end
 
   test "should return limited access editions for GDS admins" do
-    edition = create(:publication, access_limited: true)
+    edition = create(:publication, access_limiting: "organisations")
 
     filter = Admin::EditionFilter.new(Edition, build(:gds_admin))
     assert_equal edition, filter.editions.first

--- a/test/unit/app/models/attachment_data_visibility_test.rb
+++ b/test/unit/app/models/attachment_data_visibility_test.rb
@@ -53,7 +53,7 @@ class AttachmentDataVisibilityTest < ActiveSupport::TestCase
 
         context "edition is access-limited" do
           before do
-            edition.access_limited = true
+            edition.access_limiting = "organisations"
             edition.save!
           end
 
@@ -85,7 +85,7 @@ class AttachmentDataVisibilityTest < ActiveSupport::TestCase
               context "new edition is access-limited" do
                 before do
                   new_edition.change_note = "change-note"
-                  new_edition.access_limited = true
+                  new_edition.access_limiting = "organisations"
                   new_edition.save!
                 end
 
@@ -221,7 +221,7 @@ class AttachmentDataVisibilityTest < ActiveSupport::TestCase
             context "new edition is access-limited" do
               before do
                 new_edition.change_note = "change-note"
-                new_edition.access_limited = true
+                new_edition.access_limiting = "organisations"
                 new_edition.save!
               end
 
@@ -359,7 +359,7 @@ class AttachmentDataVisibilityTest < ActiveSupport::TestCase
 
         context "consultation is access-limited" do
           before do
-            consultation.update!(access_limited: true)
+            consultation.update!(access_limiting: "organisations")
           end
 
           it "is not accessible to anonymous user" do

--- a/test/unit/app/models/edition/edition_taggable_organisations_test.rb
+++ b/test/unit/app/models/edition/edition_taggable_organisations_test.rb
@@ -11,7 +11,7 @@ class EditionTaggableOrganisationTestForWorldOrganisations < ActiveSupport::Test
     edition = create(
       :publication,
       :draft,
-      access_limited: false,
+      access_limiting: "none",
       publication_type_id: PublicationType::Guidance.id,
       organisations: [@lead_org],
     )
@@ -23,7 +23,7 @@ class EditionTaggableOrganisationTestForWorldOrganisations < ActiveSupport::Test
     edition = create(
       :publication,
       :draft,
-      access_limited: false,
+      access_limiting: "none",
       publication_type_id: PublicationType::Form.id,
       organisations: [@lead_org],
     )
@@ -42,7 +42,7 @@ class EditionTaggableOrganisationTestForWorldOrganisations < ActiveSupport::Test
         :publication,
         :draft,
         title: "Title #{index}",
-        access_limited: false,
+        access_limiting: "none",
         publication_type_id: publication_type.id,
         organisations: [@lead_org],
       )

--- a/test/unit/app/models/edition/limited_access_test.rb
+++ b/test/unit/app/models/edition/limited_access_test.rb
@@ -26,10 +26,10 @@ class Edition::LimitedAccessTest < ActiveSupport::TestCase
 
   test "can persist limited access flag (regardless of <class>.access_limited_by_default?)" do
     e = build(:limited_by_default_edition)
-    e.access_limited = true
+    e.access_limiting = "organisations"
     e.save!
     assert e.reload.access_limited?
-    e.access_limited = false
+    e.access_limiting = "none"
     e.save!
     assert_not e.reload.access_limited?
   end
@@ -49,7 +49,7 @@ class Edition::LimitedAccessTest < ActiveSupport::TestCase
   test "is not accessible if edition is not accessible to user" do
     user = build(:user)
     edition_id = 123
-    edition = LimitedAccessEdition.new(id: edition_id, access_limited: true)
+    edition = LimitedAccessEdition.new(id: edition_id, access_limiting: "organisations")
 
     assert_not edition.accessible_to?(user)
   end
@@ -62,53 +62,66 @@ class Edition::LimitedAccessTest < ActiveSupport::TestCase
     assert edition.accessible_to?(user)
   end
 
-  test "setting access_limited = true bridges to access_limiting = 'organisations'" do
+  test "setting access_limiting writes through to the legacy access_limited column" do
     edition = build(:limited_access_edition)
-    edition.access_limited = true
-    assert_equal "organisations", edition.access_limiting
-  end
 
-  test "setting access_limited = false bridges to access_limiting = 'none'" do
-    edition = build(:limited_access_edition)
-    edition.access_limited = false
-    assert_equal "none", edition.access_limiting
-  end
-
-  test "setting access_limiting = 'organisations' bridges to access_limited = true" do
-    edition = build(:limited_access_edition)
     edition.access_limiting = "organisations"
-    assert edition.access_limited?
-  end
+    assert_equal true, edition[:access_limited]
 
-  test "setting access_limiting = 'individuals' bridges to access_limited = true" do
-    edition = build(:limited_access_edition)
     edition.access_limiting = "individuals"
-    assert edition.access_limited?
+    assert_equal true, edition[:access_limited]
+
+    edition.access_limiting = "none"
+    assert_equal false, edition[:access_limited]
   end
 
-  test "setting access_limiting = 'none' bridges to access_limited = false" do
+  test "access_limiting persists across save/reload and keeps both columns in sync" do
     edition = build(:limited_access_edition)
     edition.access_limiting = "organisations"
-    edition.access_limiting = "none"
-    assert_not edition.access_limited?
-  end
-
-  test "bridge writers persist both columns" do
-    edition = build(:limited_access_edition)
-    edition.access_limited = true
     edition.save!
     edition.reload
     assert edition.access_limited?
     assert_equal "organisations", edition.access_limiting
+    assert_equal true, edition[:access_limited]
 
     edition.access_limiting = "individuals"
     edition.save!
     edition.reload
     assert edition.access_limited?
     assert_equal "individuals", edition.access_limiting
+    assert_equal true, edition[:access_limited]
   end
 
   test "new instance of default-limited edition has access_limiting = 'organisations'" do
     assert_equal "organisations", build(:limited_by_default_edition).access_limiting
+  end
+
+  test "access_limited? reads from access_limiting, not the legacy boolean" do
+    edition = create(:limited_access_edition, access_limiting: "organisations")
+    # Force the legacy and new columns out of sync via raw SQL (bypasses bridge)
+    Edition.where(id: edition.id).update_all(access_limited: true, access_limiting: "none")
+    edition.reload
+    assert_not edition.access_limited?, "access_limited? should reflect the new column"
+
+    Edition.where(id: edition.id).update_all(access_limited: false, access_limiting: "organisations")
+    edition.reload
+    assert edition.access_limited?, "access_limited? should reflect the new column"
+  end
+
+  test "access_limited? is true for organisations and individuals modes" do
+    edition = build(:limited_access_edition)
+    edition.access_limiting = "organisations"
+    assert edition.access_limited?
+    edition.access_limiting = "individuals"
+    assert edition.access_limited?
+  end
+
+  test "access_limited? is false when access_limiting is none or nil" do
+    edition = build(:limited_access_edition)
+    edition.access_limiting = "none"
+    assert_not edition.access_limited?
+
+    edition.access_limiting = nil
+    assert_not edition.access_limited?
   end
 end

--- a/test/unit/app/models/publication_test.rb
+++ b/test/unit/app/models/publication_test.rb
@@ -120,20 +120,20 @@ class PublicationTest < ActiveSupport::TestCase
     assert_not e.access_limited?
   end
 
-  test "new instances respect local access_limited over their publication_type" do
+  test "new instances respect local access_limiting over their publication_type" do
     limit_by_default, dont_limit_by_default = PublicationType.all.partition(&:access_limited_by_default?).map(&:first)
-    e = build(:draft_publication, publication_type: limit_by_default, access_limited: false)
+    e = build(:draft_publication, publication_type: limit_by_default, access_limiting: "none")
     assert_not e.access_limited?
-    e = build(:draft_publication, publication_type: dont_limit_by_default, access_limited: true)
+    e = build(:draft_publication, publication_type: dont_limit_by_default, access_limiting: "organisations")
     assert e.access_limited?
   end
 
-  test "existing instances don't change access_limit when their publication_type does" do
+  test "existing instances don't change access_limiting when their publication_type does" do
     limit_by_default, dont_limit_by_default = PublicationType.all.partition(&:access_limited_by_default?).map(&:first)
-    e = create(:draft_publication, access_limited: false)
+    e = create(:draft_publication, access_limiting: "none")
     e.publication_type = limit_by_default
     assert_not e.access_limited?
-    e = create(:draft_publication, access_limited: true)
+    e = create(:draft_publication, access_limiting: "organisations")
     e.publication_type = dont_limit_by_default
     assert e.access_limited?
   end

--- a/test/unit/app/models/statistical_data_set_test.rb
+++ b/test/unit/app/models/statistical_data_set_test.rb
@@ -8,12 +8,12 @@ class StatisticalDataSetTest < ActiveSupport::TestCase
   end
 
   test "specifically limit access" do
-    data_set = build(:statistical_data_set, access_limited: true)
+    data_set = build(:statistical_data_set, access_limiting: "organisations")
     assert data_set.access_limited?
   end
 
   test "specifically do not limit access" do
-    data_set = build(:statistical_data_set, access_limited: false)
+    data_set = build(:statistical_data_set, access_limiting: "none")
     assert_not data_set.access_limited?
   end
 

--- a/test/unit/app/services/draft_edition_updater_test.rb
+++ b/test/unit/app/services/draft_edition_updater_test.rb
@@ -30,7 +30,7 @@ class DraftEditionUpdaterTest < ActiveSupport::TestCase
   end
 
   test "cannot perform if user is limiting their own access" do
-    edition = create(:draft_publication, access_limited: true, organisations: [create(:organisation)])
+    edition = create(:draft_publication, access_limiting: "organisations", organisations: [create(:organisation)])
     updater = DraftEditionUpdater.new(edition, { current_user: create(:user, organisation: create(:organisation)) })
     updater.expects(:notify!).never
     updater.expects(:update_publishing_api!).never
@@ -40,7 +40,7 @@ class DraftEditionUpdaterTest < ActiveSupport::TestCase
 
   test "updates editions that cannot be tagged to organisations" do
     organisation = create(:organisation)
-    edition = create(:draft_corporate_information_page, organisation:, access_limited: true)
+    edition = create(:draft_corporate_information_page, organisation:, access_limiting: "organisations")
     updater = DraftEditionUpdater.new(edition, { current_user: create(:user, organisation:) })
     updater.expects(:update_publishing_api!).once
     updater.expects(:notify!).once

--- a/test/unit/app/sidekiq/asset_manager_create_asset_job_test.rb
+++ b/test/unit/app/sidekiq/asset_manager_create_asset_job_test.rb
@@ -48,7 +48,7 @@ class AssetManagerCreateAssetJobTest < ActiveSupport::TestCase
   end
 
   test "marks attachments belonging to consultations as access limited" do
-    consultation = FactoryBot.create(:consultation, organisations: [@organisation], access_limited: true)
+    consultation = FactoryBot.create(:consultation, organisations: [@organisation], access_limiting: "organisations")
     attachment = FactoryBot.create(:file_attachment, attachable: consultation)
     attachment.attachment_data.attachable = consultation
 
@@ -58,7 +58,7 @@ class AssetManagerCreateAssetJobTest < ActiveSupport::TestCase
   end
 
   test "marks attachments belonging to consultation responses as access limited" do
-    consultation = FactoryBot.create(:consultation, organisations: [@organisation], access_limited: true)
+    consultation = FactoryBot.create(:consultation, organisations: [@organisation], access_limiting: "organisations")
     response = FactoryBot.create(:consultation_outcome, consultation:)
     attachment = FactoryBot.create(:file_attachment, attachable: response)
     attachment.attachment_data.attachable = consultation
@@ -202,7 +202,7 @@ class AssetManagerCreateAssetJobTest < ActiveSupport::TestCase
   end
 
   test "should not process the file if the attachable has been deleted" do
-    consultation = FactoryBot.create(:consultation, organisations: [@organisation], access_limited: true)
+    consultation = FactoryBot.create(:consultation, organisations: [@organisation], access_limiting: "organisations")
     consultation.delete
     consultation.save!(validate: false)
 

--- a/test/unit/lib/whitehall/authority/authority_test_helper.rb
+++ b/test/unit/lib/whitehall/authority/authority_test_helper.rb
@@ -30,7 +30,7 @@ module AuthorityTestHelper
       fpe
     end
     define_method("limited_#{edition_type}") do |orgs|
-      le = FactoryBot.build(edition_type, access_limited: true)
+      le = FactoryBot.build(edition_type, access_limiting: "organisations")
       le.stubs(:organisations).returns(orgs)
       le
     end


### PR DESCRIPTION
- Point all consumers of access_limit to the new access_limiting enum.
- Drop the forward access_limited= bridge writer as nothing will be pointing to that.
- Add a database default of false to access_limited. With consumers now writing access_limiting rather than access_limited, an edition can be saved without the access_limiting= bridge writer ever firing (e.g. relying on the column default "none"), leaving access_limited unset. The column is still null: false, so this would raise on save  defaulting it to false prevents that until the column is dropped.
- Update all tests to use the new field

**Why this is a single commit**

I tried to split this into a migration commit (defaulting access_limited) and a code commit (the consumer switch), but
the two are interdependent — neither passes in isolation:

- Migration alone: the old set_access_limited detects the "limit by default" case via access_limited.nil?. Adding a 
column default of false means new records are never nil, so default-limited types (Official/Accredited Statistics, 
statistical data sets) stop being access-limited.
- Code alone (no migration): the rewritten set_access_limited only sets access_limited (via the bridge writer) when 
access limiting applies. Non-limited new editions would then save with access_limited unset and violate the existing 
NOT NULL constraint.

The column default and the set_access_limited rewrite have to land together, so it stays one commit.
