### PR TITLE
Revert "Allow publishing of conflicting topical events to one base_path - attempt two" [WHIT-3270]

### DIFF
--- a/lib/whitehall/publishing_api.rb
+++ b/lib/whitehall/publishing_api.rb
@@ -182,10 +182,6 @@ module Whitehall
     end
 
     def self.ensure_base_path_is_associated_with_this_content_id!(base_path, content_id)
-      # Temporary hack to allow both legacy and config-driven topical events to co-exist,
-      # to aid in the migration. This early return should be removed once the migration is finished.
-      return if base_path.nil? || base_path.match?(%r{^/government/topical-events/})
-
       existing_content_id = Services.publishing_api.lookup_content_id(base_path:)
       return if existing_content_id.nil? || existing_content_id == content_id
 

--- a/test/unit/lib/whitehall/publishing_api_test.rb
+++ b/test/unit/lib/whitehall/publishing_api_test.rb
@@ -288,23 +288,6 @@ class Whitehall::PublishingApiTest < ActiveSupport::TestCase
     )
   end
 
-  test ".save_draft does not raise exception if there is a live content item with the same base path but different content ID, if the base path indicates it is a topical event. This is a temporary loophole to allow both legacy and config-driven topical events to co-exist, which will de-risk the migration, as we will be able to trivially publish either version as needed." do
-    ConfigurableDocumentType.setup_test_types(build_configurable_document_type("topical_event", { "settings" => { "base_path_prefix" => "/government/topical-events" } }))
-    edition = create(:draft_standard_edition, configurable_document_type: "topical_event", slug: "slug-for-topical-event")
-    Whitehall::PublishingApi.unstub(:ensure_base_path_is_associated_with_this_content_id!)
-    Services.publishing_api.expects(:lookup_content_id).with(base_path: edition.public_path).never
-
-    Whitehall::PublishingApi.save_draft(edition)
-  end
-
-  test "#ensure_base_path_is_associated_with_this_content_id! skips Publishing API lookup if no base_path provided" do
-    Whitehall::PublishingApi.unstub(:ensure_base_path_is_associated_with_this_content_id!)
-
-    Services.publishing_api.expects(:lookup_content_id).with(base_path: nil).never
-
-    Whitehall::PublishingApi.ensure_base_path_is_associated_with_this_content_id!(nil, "any-content-id")
-  end
-
   test ".publish_redirect_async publishes a redirect to the Publishing API" do
     document = create(:document)
     destination = "/government/people/milli-vanilli"


### PR DESCRIPTION
Reverts alphagov/whitehall#11210

On closer inspection, because TopicalEvent and Document are separate tables, there's nothing stopping us using the same content_id in each. Meaning we don't need this extra logic.