### PR TITLE
Add Welsh support for sponsored executive agencies

### DIFF
--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -31,6 +31,14 @@ module OrganisationHelper
     end
   end
 
+  def organisation_display_name_without_definite_article(organisation)
+    if organisation.acronym.present?
+      tag.abbr(organisation.acronym, title: organisation.name)
+    else
+      organisation.name
+    end
+  end
+
   def organisation_logo_name(organisation, stacked: true)
     if stacked
       format_with_html_line_breaks(ERB::Util.html_escape(organisation.logo_formatted_name))
@@ -54,8 +62,10 @@ module OrganisationHelper
     localised_organisation_type_with_fallback = I18n.t("organisation.type.#{organisation_type_key}", default: organisation_type_name(organisation))
 
     # org_type_with_no_indefinite_article is only used for Welsh, and it should be provided with a capital letter in the locale file.
+    # display_name_without_article is also only used for Welsh. The locale file always inserts the article.
     locale_template_args = {
       display_name: ERB::Util.h(organisation_display_name_with_definite_article(organisation)).strip,
+      display_name_without_article: ERB::Util.h(organisation_display_name_without_definite_article(organisation)).strip,
       org_type_with_no_indefinite_article: ERB::Util.h(localised_organisation_type_with_fallback),
       org_type: ERB::Util.h(add_indefinite_article(localised_organisation_type_with_fallback)),
       parents: parents_sentence(organisation_type_key, parent_organisations),

--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -99,7 +99,7 @@ module OrganisationHelper
       temp_org_sentence += supporting_organisation_text(organisation)
 
       child_relationships_link_text = supporting_bodies.size.to_s
-      child_relationships_link_text += supporting_bodies.size == 1 ? " public body" : " agencies and public bodies"
+      child_relationships_link_text += supporting_bodies.size == 1 ? " #{I18n.t('organisation.child_relationships.public_body')}" : " #{I18n.t('organisation.child_relationships.agencies_and_public_bodies')}"
 
       temp_org_sentence += link_to(child_relationships_link_text, organisation.link_to_section_on_organisation_list_page, class: "brand__color")
 
@@ -110,10 +110,10 @@ module OrganisationHelper
   end
 
   def supporting_organisation_text(organisation)
-    return ", supported by " if organisation_type_name(organisation) != "other"
-    return " and is supported by " if organisation.parent_organisations.any?
+    return ", #{I18n.t('organisation.child_relationships.supported_by')} " if organisation_type_name(organisation) != "other"
+    return " #{I18n.t('organisation.child_relationships.and_is_supported_by')} " if organisation.parent_organisations.any?
 
-    " is supported by "
+    " #{I18n.t('organisation.child_relationships.is_supported_by')} "
   end
 
   def organisation_relationship_html(organisation)

--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -43,7 +43,12 @@ module OrganisationHelper
     ActiveSupport::Inflector.singularize(organisation.organisation_type.name.downcase)
   end
 
-  def organisation_display_name_and_parental_relationship(organisation)
+  def organisation_with_parental_and_child_relationships_sentence(organisation)
+    parental_relationship_sentence = organisation_display_name_with_parental_relationship_sentence(organisation)
+    child_relationships_sentence(parental_relationship_sentence, organisation).html_safe
+  end
+
+  def organisation_display_name_with_parental_relationship_sentence(organisation)
     organisation_type_key = organisation.organisation_type_key
     parent_organisations = organisation.parent_organisations
     localised_organisation_type_with_fallback = I18n.t("organisation.type.#{organisation_type_key}", default: organisation_type_name(organisation))
@@ -86,23 +91,22 @@ module OrganisationHelper
     parent_organisations.map { |parent| organisation_relationship_html(parent) }.to_sentence
   end
 
-  def organisation_display_name_including_parental_and_child_relationships(organisation)
-    org_temp_name = organisation_display_name_and_parental_relationship(organisation)
+  def child_relationships_sentence(temp_org_sentence, organisation)
     supporting_bodies = organisation.supporting_bodies
 
     if supporting_bodies.any?
-      org_temp_name.chomp!(".")
-      org_temp_name += supporting_organisation_text(organisation)
+      temp_org_sentence.chomp!(".")
+      temp_org_sentence += supporting_organisation_text(organisation)
 
       child_relationships_link_text = supporting_bodies.size.to_s
       child_relationships_link_text += supporting_bodies.size == 1 ? " public body" : " agencies and public bodies"
 
-      org_temp_name += link_to(child_relationships_link_text, organisation.link_to_section_on_organisation_list_page, class: "brand__color")
+      temp_org_sentence += link_to(child_relationships_link_text, organisation.link_to_section_on_organisation_list_page, class: "brand__color")
 
-      org_temp_name += "."
+      temp_org_sentence += "."
     end
 
-    org_temp_name.html_safe
+    temp_org_sentence
   end
 
   def supporting_organisation_text(organisation)

--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -10,18 +10,18 @@ module OrganisationHelper
     /building law and hygiene/,
   ].freeze
 
-  SPONSORED_TYPE_KEYS = %i[
+  SPONSORED_ORGANISATION_TYPE_KEYS = %i[
     advisory_ndpb
     executive_agency
     executive_ndpb
     special_health_authority
   ].freeze
 
-  IDENTIFICATION_ONLY_TYPE_KEYS = %i[
+  ORGANISATIONS_WITH_NO_PARENT_RELATIONSHIP_TYPE_KEYS = %i[
     non_ministerial_department
   ].freeze
 
-  def organisation_relationship_display_name(organisation)
+  def organisation_display_name_with_definite_article(organisation)
     if organisation.acronym.present?
       tag.abbr(organisation.acronym, title: organisation.name)
     elsif needs_definite_article?(organisation.name)
@@ -44,65 +44,65 @@ module OrganisationHelper
   end
 
   def organisation_display_name_and_parental_relationship(organisation)
-    type_key = organisation.organisation_type_key
+    organisation_type_key = organisation.organisation_type_key
     parent_organisations = organisation.parent_organisations
+    localised_organisation_type_with_fallback = I18n.t("organisation.type.#{organisation_type_key}", default: organisation_type_name(organisation))
 
-    relationship_description(organisation, type_key, parent_organisations).html_safe
+    # org_type_with_no_indefinite_article is only used for Welsh, and it should be provided with a capital letter in the locale file.
+    locale_template_args = {
+      display_name: ERB::Util.h(organisation_display_name_with_definite_article(organisation)).strip,
+      org_type_with_no_indefinite_article: ERB::Util.h(localised_organisation_type_with_fallback),
+      org_type: ERB::Util.h(add_indefinite_article(localised_organisation_type_with_fallback)),
+      parents: parents_sentence(organisation_type_key, parent_organisations),
+    }.compact
+
+    locale_key = display_name_and_parental_relationship_i18n_key(organisation_type_key, parent_organisations)
+    I18n.t(locale_key, **locale_template_args).html_safe
   end
 
-  def relationship_description(organisation, type_key, parent_organisations)
-    key = relationship_i18n_key(type_key, parent_organisations)
-    args = relationship_template_args(organisation, type_key)
-    args[:parents] = parents_sentence(parent_organisations) if display_parent_relationships?(type_key, parent_organisations)
-    I18n.t(key, **args)
-  end
+  def display_name_and_parental_relationship_i18n_key(organisation_type_key, parent_organisations)
+    return "organisation.display_name_and_parental_relationship.display_name_html" if organisation_type_key == :other && parent_organisations.empty?
+    return "organisation.display_name_and_parental_relationship.is_organisation_type_html" unless display_parent_relationships?(organisation_type_key, parent_organisations)
 
-  def relationship_i18n_key(type_key, parent_organisations)
-    return "organisation.relationship.none_html" if type_key == :other && parent_organisations.empty?
-    return "organisation.relationship.identification_html" unless display_parent_relationships?(type_key, parent_organisations)
-
-    case type_key
-    when :other then "organisation.relationship.works_with_html"
-    when :sub_organisation then "organisation.relationship.part_of_html"
-    when *SPONSORED_TYPE_KEYS then "organisation.relationship.sponsored_html"
-    else "organisation.relationship.default_with_parents_html"
+    case organisation_type_key
+    when :other
+      "organisation.display_name_and_parental_relationship.works_with_html"
+    when :sub_organisation
+      "organisation.display_name_and_parental_relationship.part_of_html"
+    when *SPONSORED_ORGANISATION_TYPE_KEYS
+      "organisation.display_name_and_parental_relationship.sponsored_html"
+    else
+      "organisation.display_name_and_parental_relationship.default_with_parents_html"
     end
   end
 
-  def display_parent_relationships?(type_key, parent_organisations)
-    parent_organisations.any? && IDENTIFICATION_ONLY_TYPE_KEYS.exclude?(type_key)
+  def display_parent_relationships?(organisation_type_key, parent_organisations)
+    parent_organisations.any? && ORGANISATIONS_WITH_NO_PARENT_RELATIONSHIP_TYPE_KEYS.exclude?(organisation_type_key)
   end
 
-  def relationship_template_args(organisation, type_key)
-    localised_type_name = I18n.t("organisation.type.#{type_key}", default: organisation_type_name(organisation))
-    {
-      name: ERB::Util.h(organisation_relationship_display_name(organisation)).strip,
-      type_name: ERB::Util.h(localised_type_name),
-      relationship: ERB::Util.h(add_indefinite_article(localised_type_name)),
-    }
-  end
+  def parents_sentence(organisation_type_key, parent_organisations)
+    return unless display_parent_relationships?(organisation_type_key, parent_organisations)
 
-  def parents_sentence(parent_organisations)
     parent_organisations.map { |parent| organisation_relationship_html(parent) }.to_sentence
   end
 
   def organisation_display_name_including_parental_and_child_relationships(organisation)
-    organisation_name = organisation_display_name_and_parental_relationship(organisation)
-    child_organisations = organisation.supporting_bodies
+    org_temp_name = organisation_display_name_and_parental_relationship(organisation)
+    supporting_bodies = organisation.supporting_bodies
 
-    if child_organisations.any?
-      organisation_name.chomp!(".")
-      organisation_name += supporting_organisation_text(organisation)
+    if supporting_bodies.any?
+      org_temp_name.chomp!(".")
+      org_temp_name += supporting_organisation_text(organisation)
 
-      child_relationships_link_text = child_organisations.size.to_s
-      child_relationships_link_text += child_organisations.size == 1 ? " public body" : " agencies and public bodies"
+      child_relationships_link_text = supporting_bodies.size.to_s
+      child_relationships_link_text += supporting_bodies.size == 1 ? " public body" : " agencies and public bodies"
 
-      organisation_name += link_to(child_relationships_link_text, organisation.link_to_section_on_organisation_list_page, class: "brand__color")
+      org_temp_name += link_to(child_relationships_link_text, organisation.link_to_section_on_organisation_list_page, class: "brand__color")
 
-      organisation_name += "."
+      org_temp_name += "."
     end
 
-    organisation_name.html_safe
+    org_temp_name.html_safe
   end
 
   def supporting_organisation_text(organisation)

--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -1,6 +1,7 @@
 module OrganisationHelper
   include ApplicationHelper
 
+  # TODO: - we should also have Welsh equivalents
   PATTERNS_EXEMPT_FROM_DEFINITIVE_ARTICLE = [
     /civil service resourcing/,
     /^hm/,
@@ -127,15 +128,36 @@ module OrganisationHelper
   end
 
   def organisation_relationship_html(organisation)
-    prefix = needs_definite_article?(organisation.name.strip) ? "the " : ""
-    (prefix + link_to(organisation.name.strip, organisation.public_path, class: "brand__color"))
+    org_name = organisation.name.strip
+    prefix = needs_definite_article?(org_name) ? "#{definite_article_for(org_name)} " : ""
+    (prefix + link_to(org_name, organisation.public_path, class: "brand__color"))
+  end
+
+  # Returns the correct definite article for the given phrase in the current locale.
+  # In Welsh: "yr" before vowels (a, e, i, o, u, w, y) and "h"; "y" before consonants.
+  # In English: "the".
+  def definite_article_for(org_name, capitalised: false)
+    article = if I18n.locale == :cy
+                welsh_definite_article(org_name)
+              else
+                "the"
+              end
+
+    capitalised ? article.upcase : article
+  end
+
+  def welsh_definite_article(phrase)
+    phrase.strip[0].to_s =~ /\A[aeiouwyh]/i ? "yr" : "y"
   end
 
   def needs_definite_article?(phrase)
     !has_definite_article?(phrase) && PATTERNS_EXEMPT_FROM_DEFINITIVE_ARTICLE.none? { |e| e =~ phrase.downcase }
   end
 
+  # Checks whether the phrase already begins with a definite article.
+  # Handles both English ("the") and Welsh ("y", "yr").
   def has_definite_article?(phrase)
-    phrase.downcase.strip[0..2] == "the"
+    downcased = phrase.downcase.strip
+    downcased.start_with?("the ") || downcased.start_with?("yr ") || downcased.start_with?("y ")
   end
 end

--- a/app/presenters/publishing_api/organisation_presenter.rb
+++ b/app/presenters/publishing_api/organisation_presenter.rb
@@ -136,7 +136,7 @@ module PublishingApi
       return if item.organisation_type.executive_office? || item.organisation_type.civil_service? || item.closed?
       return if item.parent_organisations.empty? && item.supporting_bodies.empty?
 
-      "\n\n#{organisation_display_name_including_parental_and_child_relationships(item)}"
+      "\n\n#{organisation_with_parental_and_child_relationships_sentence(item)}"
     end
 
     def brand

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -37,8 +37,8 @@ cy:
       jobs: Swyddi
       jobs_and_contacts: Swyddi a chontractau
       organisation_chart: Ein siart sefydliadol
-    relationship:
-      identification_html: "%{type_name} yw'r %{name}."
+    display_name_and_parental_relationship:
+      is_organisation_type_html: "%{org_type_with_no_indefinite_article} yw'r %{display_name}."
     type:
       non_ministerial_department: Adran anweinidogol
   worldwide_organisation:

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -39,8 +39,10 @@ cy:
       organisation_chart: Ein siart sefydliadol
     display_name_and_parental_relationship:
       is_organisation_type_html: "%{org_type_with_no_indefinite_article} yw'r %{display_name_without_article}."
+      sponsored_html: "Mae %{display_name_without_article} yn %{org_type_with_no_indefinite_article}, a noddir gan %{parents}."
     type:
       non_ministerial_department: Adran anweinidogol
+      executive_agency: asiantaeth weithredol
   worldwide_organisation:
     corporate_information:
       about_our_services_html: Darganfod %{link}.

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -38,7 +38,7 @@ cy:
       jobs_and_contacts: Swyddi a chontractau
       organisation_chart: Ein siart sefydliadol
     display_name_and_parental_relationship:
-      is_organisation_type_html: "%{org_type_with_no_indefinite_article} yw'r %{display_name}."
+      is_organisation_type_html: "%{org_type_with_no_indefinite_article} yw'r %{display_name_without_article}."
     type:
       non_ministerial_department: Adran anweinidogol
   worldwide_organisation:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -401,13 +401,13 @@ en:
       organisation_chart: Our organisation chart
     embassies:
       find_an_embassy_title: Find a British embassy, high commission or consulate
-    relationship:
-      none_html: "%{name}"
-      identification_html: "%{name} is %{relationship}."
-      works_with_html: "%{name} works with %{parents}."
-      part_of_html: "%{name} is part of %{parents}."
-      sponsored_html: "%{name} is %{relationship}, sponsored by %{parents}."
-      default_with_parents_html: "%{name} is %{relationship} of %{parents}."
+    display_name_and_parental_relationship:
+      display_name_html: "%{display_name}"
+      is_organisation_type_html: "%{display_name} is %{org_type}."
+      works_with_html: "%{display_name} works with %{parents}."
+      part_of_html: "%{display_name} is part of %{parents}."
+      sponsored_html: "%{display_name} is %{org_type}, sponsored by %{parents}."
+      default_with_parents_html: "%{display_name} is %{org_type} of %{parents}."
     type:
       adhoc_advisory_group: ad-hoc advisory group
       advisory_ndpb: advisory non-departmental public body

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -425,6 +425,12 @@ en:
       special_health_authority: special health authority
       sub_organisation: sub-organisation
       tribunal: tribunal
+    child_relationships:
+      supported_by: "supported by"
+      and_is_supported_by: "and is supported by"
+      is_supported_by: "is supported by"
+      public_body: "public body"
+      agencies_and_public_bodies: "agencies and public bodies"
   roles:
     unassigned: No one is assigned to this role
   support:

--- a/test/unit/app/helpers/organisation_helper_test.rb
+++ b/test/unit/app/helpers/organisation_helper_test.rb
@@ -179,41 +179,41 @@ class OrganisationHelperDisplayNameWithParentalRelationshipTest < ActionView::Te
   end
 
   test "non-ministerial department renders Welsh identification sentence" do
-    org = create(:organisation, acronym: "CC", name: "Comisiwn Elusennau", organisation_type: OrganisationType.non_ministerial_department)
+    org = create(:organisation, name: "Comisiwn Elusennau", organisation_type: OrganisationType.non_ministerial_department)
 
     I18n.with_locale(:cy) do
-      assert_display_name_text org, "Adran anweinidogol yw'r CC."
+      assert_display_name_text org, "Adran anweinidogol yw'r The Comisiwn Elusennau."
     end
   end
 
   test "non-ministerial department with parents renders Welsh identification sentence" do
     parent = create(:ministerial_department, name: "Department of Testing")
-    org = create(:organisation, acronym: "CC", name: "Comisiwn Elusennau", organisation_type: OrganisationType.non_ministerial_department, parent_organisations: [parent])
+    org = create(:organisation, name: "Comisiwn Elusennau", organisation_type: OrganisationType.non_ministerial_department, parent_organisations: [parent])
 
     I18n.with_locale(:cy) do
-      assert_display_name_text org, "Adran anweinidogol yw'r CC."
+      assert_display_name_text org, "Adran anweinidogol yw'r The Comisiwn Elusennau."
     end
   end
 
   # TODO: delete test once we have full Welsh translations
   test "non-ministerial department with supporting bodies renders mixed Welsh/English sentence in Welsh" do
     child = create(:organisation, acronym: "CO", name: "Child Organisation One")
-    org = create(:organisation, acronym: "CC", name: "Comisiwn Elusennau", organisation_type: OrganisationType.non_ministerial_department)
+    org = create(:organisation, name: "Comisiwn Elusennau", organisation_type: OrganisationType.non_ministerial_department)
     org.stubs(:supporting_bodies).returns([child])
 
     I18n.with_locale(:cy) do
       description = organisation_with_parental_and_child_relationships_sentence(org)
-      assert_equal "Adran anweinidogol yw'r CC, supported by 1 public body.", strip_html_tags(description)
+      assert_equal "Adran anweinidogol yw'r The Comisiwn Elusennau, supported by 1 public body.", strip_html_tags(description)
     end
   end
 
   # TODO: delete test once we have full Welsh translations
   test "non-Welsh-translated type falls back to English in Welsh locale" do
     parent = create(:ministerial_department, name: "Department of Testing")
-    org = create(:organisation, acronym: "EA", name: "Executive Agency Example", organisation_type: OrganisationType.executive_agency, parent_organisations: [parent])
+    org = create(:organisation, name: "Executive Agency Example", organisation_type: OrganisationType.executive_agency, parent_organisations: [parent])
 
     I18n.with_locale(:cy) do
-      assert_display_name_text org, "EA is an executive agency, sponsored by the Department of Testing."
+      assert_display_name_text org, "The Executive Agency Example is an executive agency, sponsored by the Department of Testing."
     end
   end
 end

--- a/test/unit/app/helpers/organisation_helper_test.rb
+++ b/test/unit/app/helpers/organisation_helper_test.rb
@@ -207,12 +207,31 @@ class OrganisationHelperDisplayNameWithParentalRelationshipTest < ActionView::Te
     end
   end
 
-  test "sponsored executive agency with parents renders Welsh sponsored sentence" do
+  test "sponsored executive agency with parents renders Welsh sponsored sentence (consonant starting org)" do
     parent = create(:ministerial_department, name: "Department of Testing")
     org = create(:organisation, acronym: "CC", name: "Comisiwn Elusennau", organisation_type: OrganisationType.executive_agency, parent_organisations: [parent])
 
     I18n.with_locale(:cy) do
-      assert_display_name_text org, "Mae CC yn asiantaeth weithredol, a noddir gan the Department of Testing."
+      assert_display_name_text org, "Mae CC yn asiantaeth weithredol, a noddir gan y Department of Testing."
+    end
+  end
+
+  test "sponsored executive agency with parents renders Welsh sponsored sentence (vowel starting org)" do
+    parent = create(:ministerial_department, name: "Agency for fun")
+    org = create(:organisation, acronym: "CC", name: "Comisiwn Elusennau", organisation_type: OrganisationType.executive_agency, parent_organisations: [parent])
+
+    I18n.with_locale(:cy) do
+      assert_display_name_text org, "Mae CC yn asiantaeth weithredol, a noddir gan yr Agency for fun."
+    end
+  end
+
+  test "sponsored executive agency with parents renders Welsh sponsored sentence (mixed orgs)" do
+    vowel_starting_parent = create(:ministerial_department, name: "Agency for fun")
+    consonant_starting_parent = create(:ministerial_department, name: "Department for fun")
+    org = create(:organisation, acronym: "CC", name: "Comisiwn Elusennau", organisation_type: OrganisationType.executive_agency, parent_organisations: [vowel_starting_parent, consonant_starting_parent])
+
+    I18n.with_locale(:cy) do
+      assert_display_name_text org, "Mae CC yn asiantaeth weithredol, a noddir gan yr Agency for fun a y Department for fun."
     end
   end
 
@@ -222,7 +241,7 @@ class OrganisationHelperDisplayNameWithParentalRelationshipTest < ActionView::Te
     org = create(:organisation, name: "Executive Agency Example", organisation_type: OrganisationType.other, parent_organisations: [parent])
 
     I18n.with_locale(:cy) do
-      assert_display_name_text org, "The Executive Agency Example works with the Department of Testing."
+      assert_display_name_text org, "The Executive Agency Example works with y Department of Testing."
     end
   end
 end

--- a/test/unit/app/helpers/organisation_helper_test.rb
+++ b/test/unit/app/helpers/organisation_helper_test.rb
@@ -35,19 +35,19 @@ class OrganisationHelperDisplayNameWithParentalRelationshipTest < ActionView::Te
   def assert_relationship_type_is_described_as(type_key, expected_description, org_name, parent_org_name)
     parent = create(:organisation, name: parent_org_name)
     child = create(:organisation, parent_organisations: [parent], organisation_type: OrganisationType.get(type_key), name: org_name)
-    actual_html = organisation_display_name_and_parental_relationship(child)
+    actual_html = organisation_display_name_with_parental_relationship_sentence(child)
     assert_equal expected_description, strip_html_tags(actual_html)
   end
 
   def assert_definite_article_skipped(parent_organisation_name)
     parent = create(:organisation, name: parent_organisation_name)
     child = create(:organisation, parent_organisations: [parent], organisation_type: OrganisationType.ministerial_department)
-    actual_html = organisation_display_name_and_parental_relationship(child)
+    actual_html = organisation_display_name_with_parental_relationship_sentence(child)
     assert_match %r{of #{parent.name}}, strip_html_tags(actual_html)
   end
 
   def assert_display_name_text(organisation, expected_text)
-    actual_html = organisation_display_name_and_parental_relationship(organisation)
+    actual_html = organisation_display_name_with_parental_relationship_sentence(organisation)
     assert_equal expected_text, strip_html_tags(actual_html)
   end
 
@@ -75,7 +75,7 @@ class OrganisationHelperDisplayNameWithParentalRelationshipTest < ActionView::Te
     )
     expected = %(B&amp;B is an executive agency, sponsored by the Department of Economy &amp; Trade.)
     assert_display_name_text child, expected
-    assert organisation_display_name_and_parental_relationship(child).html_safe?
+    assert organisation_display_name_with_parental_relationship_sentence(child).html_safe?
   end
 
   test "description of parent organisations" do
@@ -87,7 +87,7 @@ class OrganisationHelperDisplayNameWithParentalRelationshipTest < ActionView::Te
   test "links to parent organisation" do
     parent = create(:organisation, name: "Testing Agency")
     child = create(:organisation, name: "Department of Testing", parent_organisations: [parent])
-    assert_match %r{the <a class="brand__color" href="/government/organisations/#{parent.to_param}">#{parent.name}</a>}, organisation_display_name_and_parental_relationship(child)
+    assert_match %r{the <a class="brand__color" href="/government/organisations/#{parent.to_param}">#{parent.name}</a>}, organisation_display_name_with_parental_relationship_sentence(child)
   end
 
   test "relationship types are described correctly and trailing spaces are removed" do
@@ -122,7 +122,7 @@ class OrganisationHelperDisplayNameWithParentalRelationshipTest < ActionView::Te
     parent1 = create(:organisation)
     parent2 = create(:organisation)
     child = create(:organisation, parent_organisations: [parent1, parent2])
-    result = organisation_display_name_and_parental_relationship(child)
+    result = organisation_display_name_with_parental_relationship_sentence(child)
 
     assert_match parent1.name, result
     assert_match parent2.name, result
@@ -131,7 +131,7 @@ class OrganisationHelperDisplayNameWithParentalRelationshipTest < ActionView::Te
   test "single child organisation reflected as in copy" do
     child = create(:organisation)
     parent = create(:ministerial_department, acronym: "PAN", name: "Parent Organisation Name", child_organisations: [child])
-    description = organisation_display_name_including_parental_and_child_relationships(parent)
+    description = organisation_with_parental_and_child_relationships_sentence(parent)
     assert description.include? "1 public body"
   end
 
@@ -139,7 +139,7 @@ class OrganisationHelperDisplayNameWithParentalRelationshipTest < ActionView::Te
     child1 = create(:organisation)
     child2 = create(:organisation)
     parent = create(:ministerial_department, acronym: "PAN", name: "Parent Organisation Name", child_organisations: [child1, child2])
-    description = organisation_display_name_including_parental_and_child_relationships(parent)
+    description = organisation_with_parental_and_child_relationships_sentence(parent)
     assert description.include? "2 agencies and public bodies"
   end
 
@@ -147,7 +147,7 @@ class OrganisationHelperDisplayNameWithParentalRelationshipTest < ActionView::Te
     child = create(:organisation, acronym: "COO", name: "Child Organisation One")
     parent = create(:ministerial_department, acronym: "PAN", name: "Parent Organisation Name", child_organisations: [child])
 
-    description = organisation_display_name_including_parental_and_child_relationships(parent)
+    description = organisation_with_parental_and_child_relationships_sentence(parent)
     assert_equal "PAN is a ministerial department, supported by 1 public body.", strip_html_tags(description)
   end
 
@@ -155,7 +155,7 @@ class OrganisationHelperDisplayNameWithParentalRelationshipTest < ActionView::Te
     child = create(:organisation, acronym: "CO", name: "Child Organisation")
     parent = create(:organisation, organisation_type_key: "other", acronym: "OON", name: "Other Organisation Name", child_organisations: [child])
 
-    description = organisation_display_name_including_parental_and_child_relationships(parent)
+    description = organisation_with_parental_and_child_relationships_sentence(parent)
     assert_equal "OON is supported by 1 public body.", strip_html_tags(description)
   end
 
@@ -163,7 +163,7 @@ class OrganisationHelperDisplayNameWithParentalRelationshipTest < ActionView::Te
     organisation = create(:organisation, organisation_type_key: "other", acronym: "OON", name: "Other Organisation Name")
     organisation.stubs(:supporting_bodies).returns([])
 
-    description = organisation_display_name_including_parental_and_child_relationships(organisation)
+    description = organisation_with_parental_and_child_relationships_sentence(organisation)
     assert description.include? "Other Organisation Name"
     assert_equal "OON", strip_html_tags(description)
   end
@@ -174,7 +174,7 @@ class OrganisationHelperDisplayNameWithParentalRelationshipTest < ActionView::Te
     parent = create(:organisation, acronym: "PO", name: "Department of Testing")
     org = create(:organisation, organisation_type_key: "other", acronym: "TO", name: "This Organisation", child_organisations: [child1, child2], parent_organisations: [parent])
 
-    description = organisation_display_name_including_parental_and_child_relationships(org)
+    description = organisation_with_parental_and_child_relationships_sentence(org)
     assert_equal "TO works with the Department of Testing and is supported by 2 agencies and public bodies.", strip_html_tags(description)
   end
 
@@ -202,7 +202,7 @@ class OrganisationHelperDisplayNameWithParentalRelationshipTest < ActionView::Te
     org.stubs(:supporting_bodies).returns([child])
 
     I18n.with_locale(:cy) do
-      description = organisation_display_name_including_parental_and_child_relationships(org)
+      description = organisation_with_parental_and_child_relationships_sentence(org)
       assert_equal "Adran anweinidogol yw'r CC, supported by 1 public body.", strip_html_tags(description)
     end
   end

--- a/test/unit/app/helpers/organisation_helper_test.rb
+++ b/test/unit/app/helpers/organisation_helper_test.rb
@@ -207,13 +207,22 @@ class OrganisationHelperDisplayNameWithParentalRelationshipTest < ActionView::Te
     end
   end
 
+  test "sponsored executive agency with parents renders Welsh sponsored sentence" do
+    parent = create(:ministerial_department, name: "Department of Testing")
+    org = create(:organisation, acronym: "CC", name: "Comisiwn Elusennau", organisation_type: OrganisationType.executive_agency, parent_organisations: [parent])
+
+    I18n.with_locale(:cy) do
+      assert_display_name_text org, "Mae CC yn asiantaeth weithredol, a noddir gan the Department of Testing."
+    end
+  end
+
   # TODO: delete test once we have full Welsh translations
   test "non-Welsh-translated type falls back to English in Welsh locale" do
     parent = create(:ministerial_department, name: "Department of Testing")
-    org = create(:organisation, name: "Executive Agency Example", organisation_type: OrganisationType.executive_agency, parent_organisations: [parent])
+    org = create(:organisation, name: "Executive Agency Example", organisation_type: OrganisationType.other, parent_organisations: [parent])
 
     I18n.with_locale(:cy) do
-      assert_display_name_text org, "The Executive Agency Example is an executive agency, sponsored by the Department of Testing."
+      assert_display_name_text org, "The Executive Agency Example works with the Department of Testing."
     end
   end
 end

--- a/test/unit/app/helpers/organisation_helper_test.rb
+++ b/test/unit/app/helpers/organisation_helper_test.rb
@@ -182,7 +182,7 @@ class OrganisationHelperDisplayNameWithParentalRelationshipTest < ActionView::Te
     org = create(:organisation, name: "Comisiwn Elusennau", organisation_type: OrganisationType.non_ministerial_department)
 
     I18n.with_locale(:cy) do
-      assert_display_name_text org, "Adran anweinidogol yw'r The Comisiwn Elusennau."
+      assert_display_name_text org, "Adran anweinidogol yw'r Comisiwn Elusennau."
     end
   end
 
@@ -191,7 +191,7 @@ class OrganisationHelperDisplayNameWithParentalRelationshipTest < ActionView::Te
     org = create(:organisation, name: "Comisiwn Elusennau", organisation_type: OrganisationType.non_ministerial_department, parent_organisations: [parent])
 
     I18n.with_locale(:cy) do
-      assert_display_name_text org, "Adran anweinidogol yw'r The Comisiwn Elusennau."
+      assert_display_name_text org, "Adran anweinidogol yw'r Comisiwn Elusennau."
     end
   end
 
@@ -203,7 +203,7 @@ class OrganisationHelperDisplayNameWithParentalRelationshipTest < ActionView::Te
 
     I18n.with_locale(:cy) do
       description = organisation_with_parental_and_child_relationships_sentence(org)
-      assert_equal "Adran anweinidogol yw'r The Comisiwn Elusennau, supported by 1 public body.", strip_html_tags(description)
+      assert_equal "Adran anweinidogol yw'r Comisiwn Elusennau, supported by 1 public body.", strip_html_tags(description)
     end
   end
 

--- a/test/unit/app/helpers/organisation_helper_test.rb
+++ b/test/unit/app/helpers/organisation_helper_test.rb
@@ -5,17 +5,17 @@ class OrganisationHelperTest < ActionView::TestCase
 
   test "returns acronym in abbr tag if present" do
     organisation = build(:organisation, acronym: "BLAH", name: "Building Law and Hygiene")
-    assert_equal %(<abbr title="Building Law and Hygiene">BLAH</abbr>), organisation_relationship_display_name(organisation)
+    assert_equal %(<abbr title="Building Law and Hygiene">BLAH</abbr>), organisation_display_name_with_definite_article(organisation)
   end
 
   test "returns name when acronym is nil" do
     organisation = build(:organisation, acronym: nil, name: "Building Law and Hygiene")
-    assert_equal "Building Law and Hygiene", organisation_relationship_display_name(organisation)
+    assert_equal "Building Law and Hygiene", organisation_display_name_with_definite_article(organisation)
   end
 
   test "returns name when acronym is empty" do
     organisation = build(:organisation, acronym: "", name: "Building Law and Hygiene")
-    assert_equal "Building Law and Hygiene", organisation_relationship_display_name(organisation)
+    assert_equal "Building Law and Hygiene", organisation_display_name_with_definite_article(organisation)
   end
 
   test "returns name formatted for logos" do


### PR DESCRIPTION
## What

- Add a Welsh translation for the "sponsored by" phrase that shows on an organisation's 'What we do' section. 
- Add a Welsh translation for an "executive_agency` type. Currently, this is the only translation we have out of all the sponsored types that would render the "sponsored by" phrase.
- Compute Welsh article for sponsored org phrase - so it correctly adds `y` or `yr`.
- Refactor the existing code for a better view of the bigger picture, including renaming the methods related to organisation parental and child relationships and many of the local variables. This helped clean up some of the locale template vars.
- Extract supporting organisations strings into the locale file, to make it more obvious where we have translation gaps.

## Why

There was no Welsh translation for the relationship text for this type of org.  See point (1) on https://govuk.zendesk.com/agent/tickets/6639754.

The addition of the Welsh translation for the sponsored executive agency relationship text revealed an issue where the definitive article in the string was always in English:

> `DVLA is an executive agency, sponsored by the Department for Transport`

would be translated into 

> `Mae DVLA yn an asiantaeth gweithredol, a noddir gan _the_ <Department for Transport in Welsh>`.

### Before

<img width="990" height="352" alt="image" src="https://github.com/user-attachments/assets/f30016d9-1c15-4cbd-847d-effc34c3b531" />


### After

<img width="996" height="300" alt="Screenshot 2026-06-05 at 16 04 21" src="https://github.com/user-attachments/assets/385a91e3-274a-4b25-9fde-778413cd18af" />


### Known issues

- We still have some Welsh where we always include a definite article, outside the sponsored phrase.
- The exemption set we have in the codebase, `PATTERNS_EXEMPT_FROM_DEFINITIVE_ARTICLE`, may not be the same in Welsh, and it should be updated.
- In this current implementation, when a new text does not have a Welsh translation, such as the "works with" example in the test, the article will always be fetched in Welsh, causing a mixed broken sentence.
- When adding future translations we might need to revisit the implementation - while this logic works for the `parents` phrase, it might not work in a different syntactical context.

Jira: 
https://gov-uk.atlassian.net/browse/WHIT-3545
https://gov-uk.atlassian.net/browse/WHIT-3544

Co-authored by @davidsauntson 

