### PR TITLE
[WHIT-3020] Make preview token generation opt-in

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -77,7 +77,6 @@ class Edition < ApplicationRecord
   POST_PUBLICATION_STATES = %w[published superseded withdrawn unpublished].freeze
   PUBLICLY_VISIBLE_STATES = %w[published withdrawn].freeze
 
-  before_create :set_auth_bypass_id
   before_save :set_public_timestamp
   after_validation :update_revalidated_at, if: -> { validation_context == :publish }
   after_create :update_document_edition_references

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -187,7 +187,8 @@ class Edition < ApplicationRecord
                                     change_note
                                     minor_change
                                     force_published
-                                    scheduled_publication]
+                                    scheduled_publication
+                                    auth_bypass_id]
       draft_attributes = attributes.except(*ignorable_attribute_keys)
         .merge("state" => "draft", "creator" => user, "previously_published" => previously_published)
 

--- a/test/components/admin/editions/show/preview_component_test.rb
+++ b/test/components/admin/editions/show/preview_component_test.rb
@@ -62,7 +62,7 @@ class Admin::Editions::Show::PreviewComponentTest < ViewComponent::TestCase
   end
 
   test "renders the copy link, regenerate and delete controls when the edition has a preview token" do
-    edition = build_stubbed(:publication, document: @document)
+    edition = build_stubbed(:publication, :with_auth_bypass_id, document: @document)
 
     render_inline(Admin::Editions::Show::PreviewComponent.new(edition:))
 

--- a/test/factories/editions.rb
+++ b/test/factories/editions.rb
@@ -8,7 +8,10 @@ FactoryBot.define do
     change_note { "change-note" }
     summary { "edition-summary" }
     previously_published { false }
-    auth_bypass_id { SecureRandom.uuid }
+
+    trait(:with_auth_bypass_id) do
+      auth_bypass_id { SecureRandom.uuid }
+    end
 
     trait(:with_organisations) do
       transient do

--- a/test/functional/admin/edition_images_controller_test.rb
+++ b/test/functional/admin/edition_images_controller_test.rb
@@ -700,7 +700,7 @@ class Admin::EditionImagesControllerTest < ActionController::TestCase
 
   test "POST :create passes the edition's auth_bypass_id to the new image assets" do
     login_authorised_user
-    edition = create(:draft_fatality_notice)
+    edition = create(:draft_fatality_notice, :with_auth_bypass_id)
     file = upload_fixture("images/960x640_jpeg.jpg")
 
     AssetManagerCreateAssetJob
@@ -713,7 +713,7 @@ class Admin::EditionImagesControllerTest < ActionController::TestCase
   test "POST :update passes the edition's auth_bypass_id to the cropped image assets" do
     login_authorised_user
     image = build(:image)
-    edition = create(:draft_fatality_notice, images: [image])
+    edition = create(:draft_fatality_notice, :with_auth_bypass_id, images: [image])
 
     AssetManagerCreateAssetJob
       .expects(:perform_async)

--- a/test/functional/admin/editions_controller_test.rb
+++ b/test/functional/admin/editions_controller_test.rb
@@ -369,20 +369,18 @@ class Admin::EditionsControllerTest < ActionController::TestCase
     assert_not flash["html_safe"]
   end
 
-  test "update_bypass_id generates a new preview token and redirects with a notice" do
+  test "update_bypass_id generates a preview token and redirects with a notice" do
     edition = create(:draft_publication)
-    previous_auth_bypass_id = edition.auth_bypass_id
 
     patch :update_bypass_id, params: { id: edition }
 
     assert_not_nil edition.reload.auth_bypass_id
-    assert_not_equal previous_auth_bypass_id, edition.auth_bypass_id
     assert_redirected_to admin_publication_path(edition)
     assert_equal "New document preview link generated", flash[:notice]
   end
 
   test "destroy_bypass_id deletes the preview token and redirects with a notice" do
-    edition = create(:draft_publication)
+    edition = create(:draft_publication, :with_auth_bypass_id)
     assert_not_nil edition.auth_bypass_id
 
     delete :destroy_bypass_id, params: { id: edition }

--- a/test/functional/admin/file_attachments_controller_test.rb
+++ b/test/functional/admin/file_attachments_controller_test.rb
@@ -84,7 +84,13 @@ class Admin::FileAttachmentsControllerTest < ActionController::TestCase
     attachment = create(:file_attachment, attachable: @edition)
     model_type = attachment.attachment_data.class.to_s
 
-    AssetManagerCreateAssetJob.expects(:perform_async).with(anything, has_entries("assetable_id" => kind_of(Integer), "asset_variant" => Asset.variants[:original], "assetable_type" => model_type), anything, @edition.class.to_s, @edition.id, [@edition.auth_bypass_id])
+    AssetManagerCreateAssetJob.expects(:perform_async).with do |_path, asset_params, _draft, attachable_class, attachable_id, _auth_bypass_ids|
+      asset_params["assetable_id"].is_a?(Integer) &&
+        asset_params["asset_variant"] == Asset.variants[:original] &&
+        asset_params["assetable_type"] == model_type &&
+        attachable_class == @edition.class.to_s &&
+        attachable_id == @edition.id
+    end
 
     put :update,
         params: {

--- a/test/functional/admin/uploads_controller_test.rb
+++ b/test/functional/admin/uploads_controller_test.rb
@@ -120,7 +120,13 @@ class Admin::UploadsControllerTest < ActionController::TestCase
   test "POST :create triggers a job to be queued to store the attachments in Asset Manager" do
     model_type = AttachmentData.to_s
 
-    AssetManagerCreateAssetJob.expects(:perform_async).with(anything, has_entries("assetable_id" => kind_of(Integer), "asset_variant" => Asset.variants[:original], "assetable_type" => model_type), anything, @edition.class.to_s, @edition.id, [@edition.auth_bypass_id]).twice
+    AssetManagerCreateAssetJob.expects(:perform_async).with { |_path, asset_params, _draft, attachable_class, attachable_id, _auth_bypass_ids|
+      asset_params["assetable_id"].is_a?(Integer) &&
+        asset_params["asset_variant"] == Asset.variants[:original] &&
+        asset_params["assetable_type"] == model_type &&
+        attachable_class == @edition.class.to_s &&
+        attachable_id == @edition.id
+    }.twice
 
     post :create, params: { edition_id: @edition, upload: valid_create_params }
   end

--- a/test/integration/asset_access_options_integration_test.rb
+++ b/test/integration/asset_access_options_integration_test.rb
@@ -23,23 +23,51 @@ class AssetAccessOptionsIntegrationTest < ActionDispatch::IntegrationTest
       stub_asset(asset_manager_id, draft: true)
     end
 
-    context "given a draft document with file attachment" do
-      let(:edition) { create(:detailed_guide, organisations: [organisation]) }
-
+    context "forwarding the preview token to Asset Manager" do
       before do
-        add_file_attachment_with_asset("sample.docx", to: edition)
+        add_file_attachment_with_asset("logo.png", to: edition)
         edition.save!
       end
 
-      context "when document is marked as access limited in Whitehall" do
+      context "when the draft has a preview token" do
+        let(:edition) { create(:detailed_guide, :with_auth_bypass_id) }
+
+        it "sends the attachment with the document's auth_bypass_id" do
+          Services.asset_manager.expects(:create_asset).at_least_once.with(
+            has_entries(auth_bypass_ids: [edition.auth_bypass_id]),
+          ).returns(asset_manager_response)
+
+          AssetManagerCreateAssetJob.drain
+        end
+      end
+
+      context "when the draft has no preview token" do
+        let(:edition) { create(:detailed_guide) }
+
+        it "sends the attachment with an empty auth_bypass_ids" do
+          Services.asset_manager.expects(:create_asset).at_least_once.with(
+            has_entries(auth_bypass_ids: []),
+          ).returns(asset_manager_response)
+
+          AssetManagerCreateAssetJob.drain
+        end
+      end
+    end
+
+    context "applying access limiting to a draft's attachments" do
+      context "when a draft is marked as access limited" do
+        let(:edition) { create(:detailed_guide, organisations: [organisation]) }
+
         before do
+          add_file_attachment_with_asset("sample.docx", to: edition)
+          edition.save!
           visit edit_admin_edition_path(edition)
           check "Limit access"
           click_button "Save"
           assert_text "Your document has been saved"
         end
 
-        it "marks attachment as access limited in Asset Manager" do
+        it "marks the attachment as access limited in Asset Manager" do
           Services.asset_manager
                   .expects(:update_asset)
                   .at_least_once.with(asset_manager_id, has_entry("access_limited_organisation_ids", [organisation.content_id]))
@@ -47,33 +75,31 @@ class AssetAccessOptionsIntegrationTest < ActionDispatch::IntegrationTest
           AssetManagerAttachmentMetadataJob.drain
         end
       end
-    end
 
-    context "given a draft document with an image attachment" do
-      let(:edition) { create(:draft_detailed_guide) }
+      context "when a draft is unmarked as access limited" do
+        let(:edition) { create(:detailed_guide, organisations: [organisation], access_limiting: "organisations") }
 
-      before do
-        visit admin_edition_path(edition)
-        click_link "Edit draft"
-        click_link "Images"
-        attach_file "images[][image_data_attributes][file]", path_to_attachment("minister-of-funk.960x640.jpg")
-        click_button "Upload"
+        before do
+          add_file_attachment_with_asset("sample.docx", to: edition)
+          edition.save!
+          visit edit_admin_edition_path(edition)
+          uncheck "Limit access"
+          click_button "Save"
+          assert_text "Your document has been saved"
+        end
+
+        it "unmarks the attachment as access limited in Asset Manager" do
+          Services.asset_manager
+                  .expects(:update_asset)
+                  .at_least_once.with(asset_manager_id, has_entry("access_limited_organisation_ids", []))
+
+          AssetManagerAttachmentMetadataJob.drain
+        end
       end
 
-      # Note that there is no access limiting applied to non attachments. This is existing behaviour that probably needs changing.
-      it "sends an image to asset manager with the document's auth_bypass_id" do
-        Services.asset_manager.expects(:create_asset).at_least_once.with(
-          has_entry(auth_bypass_ids: [edition.auth_bypass_id]),
-        ).returns(asset_manager_response)
+      context "when an attachment is added to an access-limited draft" do
+        let(:edition) { create(:detailed_guide, organisations: [organisation], access_limiting: "organisations") }
 
-        AssetManagerCreateAssetJob.drain
-      end
-    end
-
-    context "given an access-limited draft document" do
-      let(:edition) { create(:detailed_guide, organisations: [organisation], access_limiting: "organisations") }
-
-      context "when an attachment is added to the draft document" do
         before do
           visit admin_edition_path(edition)
           click_link "Add attachments"
@@ -84,46 +110,18 @@ class AssetAccessOptionsIntegrationTest < ActionDispatch::IntegrationTest
           assert_text "Attachment 'logo.png' uploaded"
         end
 
-        it "marks attachment as access limited and sends it with an auth_bypass_id in Asset Manager" do
+        it "marks the attachment as access limited in Asset Manager" do
           Services.asset_manager.expects(:create_asset).with(
-            has_entries(
-              access_limited_organisation_ids: [organisation.content_id],
-              auth_bypass_ids: [edition.auth_bypass_id],
-            ),
+            has_entries(access_limited_organisation_ids: [organisation.content_id]),
           ).returns(asset_manager_response)
 
           AssetManagerCreateAssetJob.drain
         end
       end
 
-      context "when an html attachment is added to the draft document" do
-        let(:edition) { create(:publication, :policy_paper) }
+      context "when multiple files are uploaded to an access-limited draft" do
+        let(:edition) { create(:detailed_guide, organisations: [organisation], access_limiting: "organisations") }
 
-        before do
-          visit admin_edition_path(edition)
-          click_link "Edit attachments"
-          click_link "Add new HTML attachment"
-          fill_in "Title", with: "html-attachment"
-          fill_in "Body", with: "some html content"
-        end
-
-        it "sends an html attachment to publishing api with its edition's auth_bypass_id" do
-          Services.publishing_api.expects(:put_content)
-                  .with(anything, has_entries(title: edition.title))
-          Services.publishing_api.expects(:put_content)
-                  .with(anything, has_entries(title: edition.attachments.first.title))
-
-          Services.publishing_api.expects(:put_content).at_least_once
-                  .with(anything, has_entries(
-                                    title: "html-attachment",
-                                    auth_bypass_ids: [edition.auth_bypass_id],
-                                  ))
-
-          click_button "Save"
-        end
-      end
-
-      context "when uploaded to draft document" do
         before do
           visit admin_edition_path(edition)
           click_link "Add attachments"
@@ -136,49 +134,24 @@ class AssetAccessOptionsIntegrationTest < ActionDispatch::IntegrationTest
           assert find("li", text: "logo.png")
         end
 
-        it "marks attachment as access limited in Asset Manager" do
+        it "marks each attachment as access limited in Asset Manager" do
           Services.asset_manager
                   .expects(:create_asset)
                   .at_least(2)
                   .with(
-                    has_entries(
-                      access_limited_organisation_ids: [organisation.content_id],
-                      auth_bypass_ids: [edition.auth_bypass_id],
-                    ),
+                    has_entries(access_limited_organisation_ids: [organisation.content_id]),
                   ).returns(asset_manager_response)
 
           AssetManagerCreateAssetJob.drain
         end
       end
-    end
 
-    context "given an access-limited draft document and a file attachment" do
-      let(:edition) { create(:detailed_guide, organisations: [organisation], access_limiting: "organisations") }
+      context "when an attachment is replaced on an access-limited draft" do
+        let(:edition) { create(:detailed_guide, organisations: [organisation], access_limiting: "organisations") }
 
-      before do
-        add_file_attachment_with_asset("sample.docx", to: edition)
-        edition.save!
-      end
-
-      context "when document is unmarked as access limited in Whitehall" do
         before do
-          visit edit_admin_edition_path(edition)
-          uncheck "Limit access"
-          click_button "Save"
-          assert_text "Your document has been saved"
-        end
-
-        it "unmarks attachment as access limited in Asset Manager" do
-          Services.asset_manager
-                  .expects(:update_asset)
-                  .at_least_once.with(asset_manager_id, has_entry("access_limited_organisation_ids", []))
-
-          AssetManagerAttachmentMetadataJob.drain
-        end
-      end
-
-      context "when attachment is replaced" do
-        before do
+          add_file_attachment_with_asset("sample.docx", to: edition)
+          edition.save!
           visit admin_edition_path(edition)
           click_link "Edit attachments"
           click_link "Edit"
@@ -187,25 +160,20 @@ class AssetAccessOptionsIntegrationTest < ActionDispatch::IntegrationTest
           assert_text "Attachment 'sample.docx' updated"
         end
 
-        it "marks replacement attachment as access limited in Asset Manager" do
+        it "marks the replacement attachment as access limited in Asset Manager" do
           Services.asset_manager.stubs(:create_asset).returns(asset_manager_response)
-          Services.asset_manager.expects(:create_asset).with { |params|
-            params[:access_limited_organisation_ids] == [organisation.content_id] &&
-              params[:auth_bypass_ids] == [edition.auth_bypass_id]
-          }.returns(asset_manager_response)
+          Services.asset_manager.expects(:create_asset).with { |params| params[:access_limited_organisation_ids] == [organisation.content_id] }.returns(asset_manager_response)
 
           AssetManagerCreateAssetJob.drain
         end
       end
-    end
 
-    context "given a draft access-limited consultation" do
-      # the edition has to have same organisation as logged in user, otherwise it's not visible when access_limited = true
-      let(:edition) { create(:consultation, organisations: [organisation], access_limiting: "organisations") }
-      let(:outcome_attributes) { FactoryBot.attributes_for(:consultation_outcome) }
-      let!(:outcome) { edition.create_outcome!(outcome_attributes) }
+      context "when an attachment is added to an access-limited consultation outcome" do
+        # the edition has to have same organisation as logged in user, otherwise it's not visible when access_limited = true
+        let(:edition) { create(:consultation, organisations: [organisation], access_limiting: "organisations") }
+        let(:outcome_attributes) { FactoryBot.attributes_for(:consultation_outcome) }
+        let!(:outcome) { edition.create_outcome!(outcome_attributes) }
 
-      context "when an attachment is added to the consultation's outcome" do
         before do
           visit admin_consultation_path(edition)
           click_link "Edit draft"
@@ -217,32 +185,12 @@ class AssetAccessOptionsIntegrationTest < ActionDispatch::IntegrationTest
           assert_text "Attachment 'asset-title' uploaded"
         end
 
-        it "marks attachment as access limited in Asset Manager and sends with the consultation's auth_bypass_id" do
+        it "marks the attachment as access limited in Asset Manager" do
           Services.asset_manager.expects(:create_asset).with(
-            has_entries(
-              access_limited_organisation_ids: [organisation.content_id],
-              auth_bypass_ids: [edition.auth_bypass_id],
-            ),
+            has_entries(access_limited_organisation_ids: [organisation.content_id]),
           ).returns(asset_manager_response)
           AssetManagerCreateAssetJob.drain
         end
-      end
-
-      it "sends a consultation form to asset manager with the consultation's auth_bypass_id" do
-        visit admin_consultation_path(edition)
-        click_link "Edit draft"
-        name_of_form_uploader = "edition[consultation_participation_attributes][consultation_response_form_attributes][consultation_response_form_data_attributes][file]"
-        fill_in "edition[consultation_participation_attributes][consultation_response_form_attributes][title]", with: "Consultation response form"
-        attach_file name_of_form_uploader, path_to_attachment("simple.pdf")
-        click_button "Save"
-
-        # Note that there is no access limiting applied to non attachments. This is existing behaviour that probably needs changing.
-        Services.asset_manager.expects(:create_asset).with { |args|
-          args[:file].path =~ /simple\.pdf/
-          args[:auth_bypass_ids] == [edition.auth_bypass_id]
-        }.returns(asset_manager_response)
-
-        AssetManagerCreateAssetJob.drain
       end
     end
 

--- a/test/integration/jobs/publishing_api_document_republishing_job_integration_test.rb
+++ b/test/integration/jobs/publishing_api_document_republishing_job_integration_test.rb
@@ -84,9 +84,10 @@ class PublishingApiDocumentRepublishingJobIntegrationTest < ActiveSupport::TestC
       publication_presenter = PublishingApiPresenters.presenter_for(edition, update_type: "republish")
       draft_publication_presenter = PublishingApiPresenters.presenter_for(draft_edition, update_type: "republish")
       html_attachment_presenter = PublishingApiPresenters.presenter_for(edition.attachments.first, update_type: "republish")
-      draft_html_attachment_presenter = PublishingApiPresenters.presenter_for(draft_edition.attachments.first, update_type: "republish")
 
       WebMock.reset!
+
+      html_attachment_content_request = stub_publishing_api_put_content(html_attachment_presenter.content_id, html_attachment_presenter.content)
 
       requests = [
         stub_publishing_api_patch_links(publication_presenter.content_id, links: publication_presenter.links),
@@ -94,17 +95,16 @@ class PublishingApiDocumentRepublishingJobIntegrationTest < ActiveSupport::TestC
         stub_publishing_api_put_content(publication_presenter.content_id, with_locale(:es) { publication_presenter.content }),
         stub_publishing_api_publish(publication_presenter.content_id, locale: "en", update_type: nil),
         stub_publishing_api_publish(publication_presenter.content_id, locale: "es", update_type: nil),
-        stub_publishing_api_put_content(html_attachment_presenter.content_id, html_attachment_presenter.content),
         stub_publishing_api_patch_links(html_attachment_presenter.content_id, links: html_attachment_presenter.links),
         stub_publishing_api_publish(html_attachment_presenter.content_id, locale: "en", update_type: nil),
         stub_publishing_api_put_content(draft_publication_presenter.content_id, with_locale(:en) { draft_publication_presenter.content }),
         stub_publishing_api_put_content(draft_publication_presenter.content_id, with_locale(:es) { draft_publication_presenter.content }),
-        stub_publishing_api_put_content(draft_html_attachment_presenter.content_id, draft_html_attachment_presenter.content),
       ]
 
       PublishingApiDocumentRepublishingJob.new.perform(edition.document.id, false)
 
       assert_all_requested(requests)
+      assert_requested(html_attachment_content_request, times: 2)
     end
 
     test "Should only publish live edition when document is published with invalid draft" do
@@ -195,9 +195,10 @@ class PublishingApiDocumentRepublishingJobIntegrationTest < ActiveSupport::TestC
       publication_presenter = PublishingApiPresenters.presenter_for(edition, update_type: "republish")
       draft_publication_presenter = PublishingApiPresenters.presenter_for(draft_edition, update_type: "republish")
       html_attachment_presenter = PublishingApiPresenters.presenter_for(edition.attachments.first, update_type: "republish")
-      draft_html_attachment_presenter = PublishingApiPresenters.presenter_for(draft_edition.attachments.first, update_type: "republish")
 
       WebMock.reset!
+
+      html_attachment_content_request = stub_publishing_api_put_content(html_attachment_presenter.content_id, html_attachment_presenter.content)
 
       requests = [
         stub_publishing_api_put_content(publication_presenter.content_id, publication_presenter.content),
@@ -212,7 +213,6 @@ class PublishingApiDocumentRepublishingJobIntegrationTest < ActiveSupport::TestC
           locale: "es",
           allow_draft: true,
         }),
-        stub_publishing_api_put_content(html_attachment_presenter.content_id, html_attachment_presenter.content),
         stub_publishing_api_patch_links(html_attachment_presenter.content_id, links: html_attachment_presenter.links),
         stub_publishing_api_unpublish(html_attachment_presenter.content_id, body: {
           type: "redirect",
@@ -222,12 +222,12 @@ class PublishingApiDocumentRepublishingJobIntegrationTest < ActiveSupport::TestC
         }),
         stub_publishing_api_put_content(draft_publication_presenter.content_id, with_locale(:en) { draft_publication_presenter.content }),
         stub_publishing_api_put_content(draft_publication_presenter.content_id, with_locale(:es) { draft_publication_presenter.content }),
-        stub_publishing_api_put_content(draft_html_attachment_presenter.content_id, draft_html_attachment_presenter.content),
       ]
 
       PublishingApiDocumentRepublishingJob.new.perform(edition.document.id, false)
 
       assert_all_requested(requests)
+      assert_requested(html_attachment_content_request, times: 2)
     end
 
     test "Should only unpublish live edition when document is unpublished with invalid draft" do

--- a/test/integration/shareable_preview_test.rb
+++ b/test/integration/shareable_preview_test.rb
@@ -17,7 +17,7 @@ class ShareablePreviewIntegrationTest < ActionDispatch::IntegrationTest
     end
 
     context "for a draft with a preview link" do
-      let(:edition) { create(:draft_publication) }
+      let(:edition) { create(:draft_publication, :with_auth_bypass_id) }
 
       test "it shows the preview link with copy, regenerate and delete controls" do
         open_share_preview_section

--- a/test/unit/app/models/edition_test.rb
+++ b/test/unit/app/models/edition_test.rb
@@ -38,13 +38,8 @@ class EditionTest < ActiveSupport::TestCase
     edition.unpublish!
   end
 
-  test "adds auth bypass id to a newly created edition" do
-    edition = create(:edition)
-    assert_not_nil edition.auth_bypass_id
-  end
-
   test "generates auth bypass token for edition" do
-    edition = create(:edition)
+    edition = create(:edition, :with_auth_bypass_id)
     payload = decoded_token_payload(edition.auth_bypass_token)
 
     assert_equal payload["sub"], edition.auth_bypass_id
@@ -55,7 +50,6 @@ class EditionTest < ActiveSupport::TestCase
 
   test "refuses to generate an auth bypass token without an auth bypass id" do
     edition = create(:edition)
-    edition.update_column(:auth_bypass_id, nil)
 
     error = assert_raises(RuntimeError) { edition.auth_bypass_token }
     assert_match(/no auth_bypass_id/, error.message)

--- a/test/unit/app/models/edition_test.rb
+++ b/test/unit/app/models/edition_test.rb
@@ -95,6 +95,15 @@ class EditionTest < ActiveSupport::TestCase
     assert Edition.latest_edition.include?(new_draft)
   end
 
+  test "#create_draft does not copy the auth bypass id to the new draft" do
+    published_edition = create(:published_edition, :with_auth_bypass_id)
+    assert_not_nil published_edition.auth_bypass_id
+
+    new_draft = published_edition.create_draft(create(:writer))
+
+    assert_nil new_draft.auth_bypass_id
+  end
+
   test ".latest_edition ignores deleted editions" do
     document = create(:document)
     original_edition = create(:published_edition, document:)

--- a/test/unit/app/models/image_data_test.rb
+++ b/test/unit/app/models/image_data_test.rb
@@ -36,8 +36,8 @@ class ImageDataTest < ActiveSupport::TestCase
   end
 
   test "returns unique auth_bypass_ids from its image's editions" do
-    fatality_notice_1 =  create(:fatality_notice)
-    fatality_notice_2 =  create(:fatality_notice)
+    fatality_notice_1 =  create(:fatality_notice, :with_auth_bypass_id)
+    fatality_notice_2 =  create(:fatality_notice, :with_auth_bypass_id)
     images_from_first_edition = (1..3).map { |i| build(:image, id: i, edition: fatality_notice_1) }
     images_from_second_edition = (4..6).map { |i| build(:image, id: i, edition: fatality_notice_2) }
 
@@ -47,7 +47,7 @@ class ImageDataTest < ActiveSupport::TestCase
   end
 
   test "excludes editions that have no auth_bypass_id" do
-    edition_with_token = create(:fatality_notice)
+    edition_with_token = create(:fatality_notice, :with_auth_bypass_id)
     edition_without_token = create(:fatality_notice)
     edition_without_token.auth_bypass_id = nil
     images = [

--- a/test/unit/app/presenters/publishing_api/call_for_evidence_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/call_for_evidence_presenter_test.rb
@@ -160,11 +160,11 @@ module PublishingApi::CallForEvidencePresenterTest
     end
 
     test "auth bypass id" do
-      assert_attribute :auth_bypass_ids, [call_for_evidence.auth_bypass_id]
+      call_for_evidence.auth_bypass_id = "auth-bypass-id"
+      assert_attribute :auth_bypass_ids, %w[auth-bypass-id]
     end
 
     test "auth bypass ids are empty when the edition has no token" do
-      call_for_evidence.auth_bypass_id = nil
       assert_attribute :auth_bypass_ids, []
     end
 

--- a/test/unit/app/presenters/publishing_api/consultation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/consultation_presenter_test.rb
@@ -161,11 +161,11 @@ module PublishingApi::ConsultationPresenterTest
     end
 
     test "auth bypass id" do
-      assert_attribute :auth_bypass_ids, [consultation.auth_bypass_id]
+      consultation.auth_bypass_id = "auth-bypass-id"
+      assert_attribute :auth_bypass_ids, %w[auth-bypass-id]
     end
 
     test "auth bypass ids are empty when the edition has no token" do
-      consultation.auth_bypass_id = nil
       assert_attribute :auth_bypass_ids, []
     end
 

--- a/test/unit/app/presenters/publishing_api/corporate_information_page_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/corporate_information_page_presenter_test.rb
@@ -124,11 +124,11 @@ module PublishingApi::CorporateInformationPagePresenterTest
     end
 
     test "auth bypass id" do
-      assert_attribute :auth_bypass_ids, [corporate_information_page.auth_bypass_id]
+      corporate_information_page.auth_bypass_id = "auth-bypass-id"
+      assert_attribute :auth_bypass_ids, %w[auth-bypass-id]
     end
 
     test "auth bypass ids are empty when the edition has no token" do
-      corporate_information_page.auth_bypass_id = nil
       assert_attribute :auth_bypass_ids, []
     end
 

--- a/test/unit/app/presenters/publishing_api/document_collection_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/document_collection_presenter_test.rb
@@ -70,13 +70,13 @@ class PublishingApi::DocumentCollectionPresenterTest < ActiveSupport::TestCase
   end
 
   test "it presents the auth bypass id" do
-    assert_equal [@document_collection.auth_bypass_id], @presented_content[:auth_bypass_ids]
+    @document_collection.auth_bypass_id = "auth-bypass-id"
+    presented = PublishingApi::DocumentCollectionPresenter.new(@document_collection)
+    assert_equal %w[auth-bypass-id], presented.content[:auth_bypass_ids]
   end
 
   test "it presents an empty auth bypass id array when the edition has no token" do
-    @document_collection.auth_bypass_id = nil
-    presented = PublishingApi::DocumentCollectionPresenter.new(@document_collection)
-    assert_equal [], presented.content[:auth_bypass_ids]
+    assert_equal [], @presented_content[:auth_bypass_ids]
   end
 
   test "it includes headers when headers are present in body" do

--- a/test/unit/app/presenters/publishing_api/fatality_notice_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/fatality_notice_presenter_test.rb
@@ -68,13 +68,13 @@ class PublishingApi::FatalityNoticePresenterTest < ActiveSupport::TestCase
   end
 
   test "it presents the auth bypass id" do
-    assert_equal [@fatality_notice.auth_bypass_id], @presented_content[:auth_bypass_ids]
+    @fatality_notice.auth_bypass_id = "auth-bypass-id"
+    presented = PublishingApi::FatalityNoticePresenter.new(@fatality_notice)
+    assert_equal %w[auth-bypass-id], presented.content[:auth_bypass_ids]
   end
 
   test "it presents an empty auth bypass id array when the edition has no token" do
-    @fatality_notice.auth_bypass_id = nil
-    presented = PublishingApi::FatalityNoticePresenter.new(@fatality_notice)
-    assert_equal [], presented.content[:auth_bypass_ids]
+    assert_equal [], @presented_content[:auth_bypass_ids]
   end
 
   test "it presents edition links" do

--- a/test/unit/app/presenters/publishing_api/html_attachment_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/html_attachment_presenter_test.rb
@@ -42,7 +42,7 @@ class PublishingApi::HtmlAttachmentPresenterTest < ActiveSupport::TestCase
         first_published_version: html_attachment.attachable.first_published_version?,
         political: true,
       },
-      auth_bypass_ids: [edition.auth_bypass_id],
+      auth_bypass_ids: [],
     }
     presented_item = present(html_attachment)
 
@@ -61,11 +61,11 @@ class PublishingApi::HtmlAttachmentPresenterTest < ActiveSupport::TestCase
     %i[organisations parent primary_publishing_organisation government].each { |k| assert_includes(expected_content[:links].keys, k) }
   end
 
-  test "presents an empty auth_bypass_ids array when the parent edition has no token" do
+  test "presents the parent edition's auth_bypass_id" do
     html_attachment = create(:html_attachment)
-    html_attachment.attachable.auth_bypass_id = nil
+    html_attachment.attachable.auth_bypass_id = "auth-bypass-id"
 
-    assert_equal [], present(html_attachment).content[:auth_bypass_ids]
+    assert_equal %w[auth-bypass-id], present(html_attachment).content[:auth_bypass_ids]
   end
 
   test "it includes auto-numbered headers when headers are present in body" do
@@ -185,14 +185,14 @@ class PublishingApi::HtmlAttachmentPresenterTest < ActiveSupport::TestCase
   end
 
   test "HtmlAttachment presents primary_publishing_organisation from 1st org when lead_organisations is not implemented" do
-    outcome = create(:consultation_outcome, :with_html_attachment)
+    create(:consultation_outcome, :with_html_attachment)
 
     html_attachment = HtmlAttachment.last
     # if an organisation has multiple translations, pluck returns
     # duplicate content_ids because it constructs a left outer join
 
     presenter = present(html_attachment)
-    assert_hash_includes presenter.content, { auth_bypass_ids: [outcome.auth_bypass_id] }
+    assert_hash_includes presenter.content, { auth_bypass_ids: [] }
     assert_equal [html_attachment.attachable.organisations.first.content_id],
                  presenter.links[:primary_publishing_organisation]
   end

--- a/test/unit/app/presenters/publishing_api/plan_for_change_landing_page_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/plan_for_change_landing_page_presenter_test.rb
@@ -69,13 +69,13 @@ class PublishingApi::PlanForChangeLandingPagePresenterTest < ActiveSupport::Test
   end
 
   test "it presents the auth bypass id" do
-    assert_equal [@plan_for_change_landing_page.auth_bypass_id], @presented_content[:auth_bypass_ids]
+    @plan_for_change_landing_page.auth_bypass_id = "auth-bypass-id"
+    presented = PublishingApi::PlanForChangeLandingPagePresenter.new(@plan_for_change_landing_page)
+    assert_equal %w[auth-bypass-id], presented.content[:auth_bypass_ids]
   end
 
   test "it presents an empty auth bypass id array when the edition has no token" do
-    @plan_for_change_landing_page.auth_bypass_id = nil
-    presented = PublishingApi::PlanForChangeLandingPagePresenter.new(@plan_for_change_landing_page)
-    assert_equal [], presented.content[:auth_bypass_ids]
+    assert_equal [], @presented_content[:auth_bypass_ids]
   end
 
   test "it presents edition links" do

--- a/test/unit/app/presenters/publishing_api/publication_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/publication_presenter_test.rb
@@ -2,17 +2,16 @@ require "test_helper"
 
 class PublishingApi::PublicationPresenterTest < ActiveSupport::TestCase
   def present(edition)
-    edition.auth_bypass_id = "52db85fc-0f30-42a6-afdd-c2b31ecc6a67"
     PublishingApi::PublicationPresenter.new(edition)
   end
 
-  test "presents an empty auth_bypass_ids array when the edition has no token" do
+  test "presents the edition's auth_bypass_id" do
     publication = create(:publication)
-    publication.auth_bypass_id = nil
+    publication.auth_bypass_id = "auth-bypass-id"
 
     presenter = PublishingApi::PublicationPresenter.new(publication)
 
-    assert_equal [], presenter.content[:auth_bypass_ids]
+    assert_equal %w[auth-bypass-id], presenter.content[:auth_bypass_ids]
   end
 
   test "publication presentation includes the correct values" do
@@ -41,7 +40,7 @@ class PublishingApi::PublicationPresenterTest < ActiveSupport::TestCase
         { path: public_path, type: "exact" },
       ],
       redirects: [],
-      auth_bypass_ids: %w[52db85fc-0f30-42a6-afdd-c2b31ecc6a67],
+      auth_bypass_ids: [],
       first_published_at: publication.first_public_at,
       update_type: "major",
       details: {

--- a/test/unit/app/presenters/publishing_api/speech_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/speech_presenter_test.rb
@@ -66,7 +66,7 @@ class PublishingApi::SpeechPresenterTest < ActiveSupport::TestCase
         assert_equal("The description", presented.content[:description])
         assert_equal(Whitehall::PublishingApp::WHITEHALL, presented.content[:publishing_app])
         assert_equal("frontend", presented.content[:rendering_app])
-        assert_equal([speech.auth_bypass_id], presented.content[:auth_bypass_ids])
+        assert_equal([], presented.content[:auth_bypass_ids])
 
         details = presented.content[:details]
         assert_not(details[:political])
@@ -78,9 +78,9 @@ class PublishingApi::SpeechPresenterTest < ActiveSupport::TestCase
         assert_match(/minister-of-funk.960x640.jpg$/, details[:image][:url])
       end
 
-      it "presents an empty auth_bypass_ids array when the speech has no token" do
-        speech.auth_bypass_id = nil
-        assert_equal([], presented.content[:auth_bypass_ids])
+      it "presents the auth bypass id" do
+        speech.auth_bypass_id = "auth-bypass-id"
+        assert_equal(%w[auth-bypass-id], presented.content[:auth_bypass_ids])
       end
     end
 

--- a/test/unit/app/presenters/publishing_api/standard_edition_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/standard_edition_presenter_test.rb
@@ -63,7 +63,7 @@ class PublishingApi::StandardEditionPresenterTest < ActiveSupport::TestCase
 
   test "it presents the edition's auth_bypass_id" do
     ConfigurableDocumentType.setup_test_types(build_configurable_document_type("test_type"))
-    page = create(:standard_edition)
+    page = create(:standard_edition, :with_auth_bypass_id)
     presenter = PublishingApi::StandardEditionPresenter.new(page)
 
     assert_equal [page.auth_bypass_id], presenter.content[:auth_bypass_ids]

--- a/test/unit/app/presenters/publishing_api/statistical_data_set_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/statistical_data_set_presenter_test.rb
@@ -61,13 +61,13 @@ class PublishingApi::StatisticalDataSetPresenterTest < ActiveSupport::TestCase
   end
 
   test "it presents the auth bypass id" do
-    assert_equal [@statistical_data_set.auth_bypass_id], @presented_content[:auth_bypass_ids]
+    @statistical_data_set.auth_bypass_id = "auth-bypass-id"
+    presented = PublishingApi::StatisticalDataSetPresenter.new(@statistical_data_set)
+    assert_equal %w[auth-bypass-id], presented.content[:auth_bypass_ids]
   end
 
   test "it presents an empty auth bypass id array when the edition has no token" do
-    @statistical_data_set.auth_bypass_id = nil
-    presented = PublishingApi::StatisticalDataSetPresenter.new(@statistical_data_set)
-    assert_equal [], presented.content[:auth_bypass_ids]
+    assert_equal [], @presented_content[:auth_bypass_ids]
   end
 
   test "it includes headers when headers are present in body" do

--- a/test/unit/app/presenters/publishing_api/worldwide_office_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/worldwide_office_presenter_test.rb
@@ -13,7 +13,7 @@ class PublishingApi::WorldwideOfficePresenterTest < ActiveSupport::TestCase
     public_path = worldwide_office.public_path
 
     expected_hash = {
-      auth_bypass_ids: [worldwide_office.edition.auth_bypass_id],
+      auth_bypass_ids: [],
       base_path: public_path,
       title: worldwide_office.worldwide_organisation.name,
       schema_name: "worldwide_office",
@@ -68,11 +68,10 @@ class PublishingApi::WorldwideOfficePresenterTest < ActiveSupport::TestCase
     assert_valid_against_links_schema({ links: presented_item.links }, "worldwide_office")
   end
 
-  test "presents an empty auth_bypass_ids array when the edition has no token" do
-    worldwide_office = build(:worldwide_office, edition: create(:worldwide_organisation))
-    worldwide_office.edition.auth_bypass_id = nil
+  test "presents the auth bypass id" do
+    worldwide_office = build(:worldwide_office, edition: create(:worldwide_organisation, :with_auth_bypass_id))
 
-    assert_equal [], present(worldwide_office).content[:auth_bypass_ids]
+    assert_equal [worldwide_office.edition.auth_bypass_id], present(worldwide_office).content[:auth_bypass_ids]
   end
 
   test "sets access_and_opening_times as nil when they are blank" do

--- a/test/unit/app/presenters/publishing_api/worldwide_organisation_page_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/worldwide_organisation_page_presenter_test.rb
@@ -18,7 +18,7 @@ module PublishingApi::WorldwideOrganisationPagePresenterTest
         public_path = page.public_path
 
         expected_hash = {
-          auth_bypass_ids: [page.edition.auth_bypass_id],
+          auth_bypass_ids: [],
           base_path: public_path,
           title: page.title,
           schema_name: "worldwide_corporate_information_page",
@@ -60,11 +60,10 @@ module PublishingApi::WorldwideOrganisationPagePresenterTest
         assert_valid_against_links_schema({ links: presented_item.edition_links }, "worldwide_corporate_information_page")
       end
 
-      test "presents an empty auth_bypass_ids array when the edition has no token" do
-        self.page = create(:worldwide_organisation_page)
-        page.edition.auth_bypass_id = nil
+      test "presents the auth bypass id" do
+        self.page = create(:worldwide_organisation_page, edition: create(:worldwide_organisation, :with_auth_bypass_id))
 
-        assert_equal [], presented_page.content[:auth_bypass_ids]
+        assert_equal [page.edition.auth_bypass_id], presented_page.content[:auth_bypass_ids]
       end
 
       test "presents the correct routes for a Worldwide Organisation Page with a translation" do

--- a/test/unit/app/presenters/publishing_api/worldwide_organisation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/worldwide_organisation_presenter_test.rb
@@ -5,11 +5,10 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
     PublishingApi::WorldwideOrganisationPresenter.new(...)
   end
 
-  test "presents an empty auth_bypass_ids array when the edition has no token" do
-    worldwide_org = create(:worldwide_organisation)
-    worldwide_org.auth_bypass_id = nil
+  test "presents the auth bypass id" do
+    worldwide_org = create(:worldwide_organisation, :with_auth_bypass_id)
 
-    assert_equal [], present(worldwide_org).content[:auth_bypass_ids]
+    assert_equal [worldwide_org.auth_bypass_id], present(worldwide_org).content[:auth_bypass_ids]
   end
 
   test "presents a Worldwide Organisation ready for adding to the publishing API" do
@@ -52,7 +51,7 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
     public_path = worldwide_org.public_path
 
     expected_hash = {
-      auth_bypass_ids: [worldwide_org.auth_bypass_id],
+      auth_bypass_ids: [],
       base_path: public_path,
       title: worldwide_org.title,
       schema_name: "worldwide_organisation",

--- a/test/unit/app/services/edition_auth_bypass_asset_propagator_test.rb
+++ b/test/unit/app/services/edition_auth_bypass_asset_propagator_test.rb
@@ -5,7 +5,7 @@ class EditionAuthBypassAssetPropagatorTest < ActiveSupport::TestCase
 
   describe "#propagate" do
     test "updates file attachments with the edition's auth_bypass_id" do
-      edition = create(:draft_edition)
+      edition = create(:draft_edition, :with_auth_bypass_id)
       file_attachment = create(:file_attachment, attachable: edition)
       expected_attributes = { "auth_bypass_ids" => [edition.auth_bypass_id] }
 
@@ -36,7 +36,7 @@ class EditionAuthBypassAssetPropagatorTest < ActiveSupport::TestCase
     end
 
     test "updates images with the edition's auth_bypass_id" do
-      edition = create(:draft_fatality_notice)
+      edition = create(:draft_fatality_notice, :with_auth_bypass_id)
       image = create(:image, edition:)
       expected_attributes = { "auth_bypass_ids" => [edition.auth_bypass_id] }
 
@@ -60,7 +60,7 @@ class EditionAuthBypassAssetPropagatorTest < ActiveSupport::TestCase
     end
 
     test "updates a consultation response form asset" do
-      edition = create(:consultation)
+      edition = create(:consultation, :with_auth_bypass_id)
       participation = create(:consultation_participation, consultation: edition)
       consultation_response_form = create(:consultation_response_form, consultation_participation: participation)
 
@@ -78,7 +78,7 @@ class EditionAuthBypassAssetPropagatorTest < ActiveSupport::TestCase
     end
 
     test "updates a consultation outcome's attachments" do
-      edition = create(:draft_consultation)
+      edition = create(:draft_consultation, :with_auth_bypass_id)
       outcome = create(:consultation_outcome, consultation: edition)
       file_attachment = create(:file_attachment, attachable: outcome)
       expected_attributes = { "auth_bypass_ids" => [edition.auth_bypass_id] }
@@ -94,7 +94,7 @@ class EditionAuthBypassAssetPropagatorTest < ActiveSupport::TestCase
     end
 
     test "updates a consultation's public feedback attachments" do
-      edition = create(:draft_consultation)
+      edition = create(:draft_consultation, :with_auth_bypass_id)
       feedback = create(:consultation_public_feedback, consultation: edition)
       file_attachment = create(:file_attachment, attachable: feedback)
       expected_attributes = { "auth_bypass_ids" => [edition.auth_bypass_id] }
@@ -110,7 +110,7 @@ class EditionAuthBypassAssetPropagatorTest < ActiveSupport::TestCase
     end
 
     test "updates a call for evidence response form asset" do
-      edition = create(:call_for_evidence)
+      edition = create(:call_for_evidence, :with_auth_bypass_id)
       participation = create(:call_for_evidence_participation, call_for_evidence: edition)
       call_for_evidence_response_form = create(:call_for_evidence_response_form, call_for_evidence_participation: participation)
 
@@ -128,7 +128,7 @@ class EditionAuthBypassAssetPropagatorTest < ActiveSupport::TestCase
     end
 
     test "updates a call for evidence outcome's attachments" do
-      edition = create(:draft_call_for_evidence)
+      edition = create(:draft_call_for_evidence, :with_auth_bypass_id)
       outcome = create(:call_for_evidence_outcome, call_for_evidence: edition)
       file_attachment = create(:file_attachment, attachable: outcome)
       expected_attributes = { "auth_bypass_ids" => [edition.auth_bypass_id] }

--- a/test/unit/app/services/edition_auth_bypass_revoker_test.rb
+++ b/test/unit/app/services/edition_auth_bypass_revoker_test.rb
@@ -12,7 +12,7 @@ class EditionAuthBypassRevokerTest < ActiveSupport::TestCase
     end
 
     test "clears the edition's auth_bypass_id, saves it with the current user and calls 'perform!' on the updater" do
-      edition = create(:draft_edition)
+      edition = create(:draft_edition, :with_auth_bypass_id)
       assert_not_nil edition.auth_bypass_id
 
       EditionAuthBypassRevoker.new(edition:, current_user: user, updater:).call

--- a/test/unit/app/services/editon_auth_bypass_updater_test.rb
+++ b/test/unit/app/services/editon_auth_bypass_updater_test.rb
@@ -13,7 +13,7 @@ class EditionAuthBypassUpdaterTest < ActiveSupport::TestCase
     end
 
     test "updates the editions auth_bypass_id, saves it with the current user and calls 'perform!' on the updater" do
-      edition = create(:draft_edition)
+      edition = create(:draft_edition, :with_auth_bypass_id)
       auth_bypass_id_to_revoke = edition.auth_bypass_id
       SecureRandom.stubs(uuid: uid)
 

--- a/test/unit/app/sidekiq/asset_manager_create_asset_job_test.rb
+++ b/test/unit/app/sidekiq/asset_manager_create_asset_job_test.rb
@@ -317,7 +317,7 @@ class AssetManagerCreateAssetJobTest < ActiveSupport::TestCase
     end
 
     test "sends an edition attachable's auth bypass ids to asset manager when these are passed through in the params" do
-      attachable = FactoryBot.create(:consultation)
+      attachable = FactoryBot.create(:consultation, :with_auth_bypass_id)
       file = FactoryBot.create(:file_attachment, attachable:)
       assetable = file.attachment_data
 
@@ -327,7 +327,7 @@ class AssetManagerCreateAssetJobTest < ActiveSupport::TestCase
     end
 
     test "sends an outcome attachable's auth bypass ids to asset manager when these are passed through in the params" do
-      consultation = FactoryBot.create(:consultation)
+      consultation = FactoryBot.create(:consultation, :with_auth_bypass_id)
       attachable = FactoryBot.create(:consultation_outcome, consultation:)
       file = FactoryBot.create(:file_attachment, attachable:)
       assetable = file.attachment_data


### PR DESCRIPTION
Part 3 of 3 for WHIT-3020. **Stacked on #11543**

[Jira](https://gov-uk.atlassian.net/browse/WHIT-3020)

## What

Makes preview-token generation **opt-in**. Previously every draft edition was auto-assigned a JWT auth-bypass token on creation, and the draft Content Store evaluates that token *before* access limits — granting access and skipping the allow-list if a token is present — so a document locked to named users was still viewable by anyone holding the share link. This removes the auto-generation, so a draft has **no token until a publisher generates one** (the generate/delete UI landed in #11543).

## How

- Remove the `before_create :set_auth_bypass_id` callback on `Edition` — a new draft no longer gets a token, and none is sent to the Publishing API.
- Exclude `auth_bypass_id` from the attributes `Edition#create_draft` copies, so redrafting a published document no longer carries its token forward — the new draft starts token-less.
- Move the factory's `auth_bypass_id` into a `:with_auth_bypass_id` trait so test editions match production (no token by default), applying it only where a token must be present.
- Update the affected tests for the token-less default (presenter payloads assert an empty `auth_bypass_ids` array; dedicated presence tests cover the token case).

## Acceptance criteria

- New draft → no token generated, none sent to Publishing API ✓
- Redraft of a published document → new draft starts token-less (the previous token is not copied over) ✓
- No token → the share section shows a "Generate link" button and no link ✓ (UI in #11543)
- Token present → copyable link, with regenerate and delete ✓ (#11543)
- Delete/regenerate → previous token removed from Whitehall, Publishing API and Asset Manager; old link 403s for unauthorised users ✓ (#11543)

## Screenshots

**Before** — a brand-new draft auto-shows a generated preview link

<img width="792" height="559" alt="Screenshot 2026-06-10 at 11 50 35" src="https://github.com/user-attachments/assets/73066ebc-f03f-4687-8595-4c8deca41ff2" />

**After** — a brand-new draft shows the empty state

<img width="773" height="314" alt="Screenshot 2026-06-09 at 16 23 36" src="https://github.com/user-attachments/assets/16e2371a-c29b-47cb-b4c5-e345663b3600" />

## Test plan

Two sessions: a **signed-in publisher** and a **signed-out** browser (incognito) for the preview links. "403" below means the signed-out browser is refused.

### A. Token lifecycle (once, on a Publication — representative of all types)

1. Create a new draft → the share section shows **only "Generate link"** (no link, no Copy/Delete). _(opt-in default)_
2. Click **Generate link** → a copy box with a preview link appears, plus **Generate new link** and **Delete link**.
3. Open the link signed-out → the draft renders. _(token grants preview)_
4. Click **Generate new link**, copy the new link. Old link signed-out → **403**; new link → renders. _(regenerate supersedes)_
5. Click **Delete link** → back to the empty state. Previous link signed-out → **403**. _(delete revokes)_

### B. Document-type coverage (section renders + generate/delete behave as in A)

- [x] Publication
- [x] Speech
- [x] Consultation
- [x] Call for evidence
- [x] Detailed guide
- [x] Document collection
- [x] Fatality notice
- [x] Statistical data set
- [x] Corporate information page
- [x] Plan for change page
- [x] Standard edition
- [x] Worldwide organisation

### C. Access limiting

1. Create an **access-limited** draft (limited to an org you are not in) with **no token** → a user outside the org / signed-out cannot preview it.
2. Generate a token, then delete it → the old link **403s** and access limiting is back in force.

### D. Asset propagation (upload to a draft with a token, then delete the token and re-check signed-out)

Assets are created either gated (`draft: true`, via `Storage::AttachmentStorage`) or live (`draft: false`, via `Storage::PreviewableStorage`). Only gated assets enforce the token; live assets are covered by WHIT-3580 below. Whitehall's Asset Manager API does not return `auth_bypass_ids`, so the stored value is checked in the Asset Manager console.

**Gated (`draft: true`) — token enforced, expect a 403 after deletion**

- [x] **File attachment** — with a token the asset fetches; after delete → **403**.
- [x] **HTML attachment** — its own content item, inheriting the edition's token; the token flips between `["<token>"]` and `[]` on generate/delete. The parent's access limit is not propagated to the attachment's content item, so it renders for any signed-in user and no 403 is observable.
- [x] **Consultation outcome attachment**
- [x] **Consultation public feedback attachment**
- [x] **Call-for-evidence outcome attachment**

**Live (`draft: false`) — token sent but not enforced, no 403 (WHIT-3580)**

- [x] **Consultation / call-for-evidence response form** — confirm the stored `auth_bypass_ids` flips between `["<token>"]` and `[]`.
- [x] **Edition image** (Images tab) — as above.
- [x] **Cropped image** — applying a crop creates a new asset; confirm it carries the token.
- [x] **Featured image / organisation logo** — default storage, no token applied.

> ⚠️ **Known limitation ([WHIT-3580](https://gov-uk.atlassian.net/browse/WHIT-3580)):** edition **images** and the consultation/call-for-evidence **response forms** are stored as **live** assets (`draft: false`), so the preview token is *sent* but **not enforced** — they stay reachable signed-out regardless of the token. Verify the payloads carry the right `auth_bypass_ids`, but do **not** expect a 403 on these until the live-asset ticket is fixed. Outcome and public feedback attachments are ordinary attachments and *are* gated.

### E. Other checks

- After regenerate/delete token, confirm the Publishing API draft and Asset Manager assets carry the updated `auth_bypass_ids` (`[token]` or `[]`).
- Redraft a published document that had a preview link → the new draft starts in the empty state (no token, no copyable link).

## Follow-ups (separate tickets/stories)

- Images & response documents are stored as **live** assets even for draft editions, so the preview token doesn't gate them ([WHIT-3580](https://gov-uk.atlassian.net/browse/WHIT-3580)).
- Drop `auth_bypass_ids` on publish — Currently if an edition has an `auth_bypass_id` it is propagated when the Edition is published. Once published the `auth_bypass_id` has no effect on the display of the content. Therefore `auth_bypass_id` should be removed from the edition and downstream services when the edition is published. ([WHIT-3585](https://gov-uk.atlassian.net/browse/WHIT-3585))

Found while testing, not addressed here:

- `PublishingApi::HtmlAttachmentPresenter` and `PublishingApi::WorldwideOrganisationPresenter` do not include `PayloadBuilder::AccessLimitation`, so an access-limited edition's HTML attachments and a limited worldwide organisation render for any signed-in user.
- `WorldwideOrganisationPage` has no `auth_bypass_id` (unlike `ConsultationResponse` and `CallForEvidenceResponse`, which delegate it) and is not covered by `EditionAuthBypassAssetPropagator`, so its attachments are gated but can never be unlocked by a preview link.
- Creating a `PlanForChangeLandingPage` with organisation access limiting selected returns a permissions error: `Admin::PlanForChangeLandingPagesController` enforces `:update` on the unsaved edition, whose `access_limiting_organisations` through-association is empty until save.

[WHIT-3580]: https://gov-uk.atlassian.net/browse/WHIT-3580?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
