### PR TITLE
Org access limiting: Add feature-flagged radio UI for access-limiting organisations [WHIT-3543]

### DIFF
--- a/app/controllers/admin/edition_access_limited_controller.rb
+++ b/app/controllers/admin/edition_access_limited_controller.rb
@@ -3,19 +3,53 @@ class Admin::EditionAccessLimitedController < Admin::BaseController
   before_action :enforce_permissions!
   before_action :clean_organisation_params, only: %i[update]
 
-  def edit; end
+  def edit
+    if Flipflop.access_limiting_organisations_ui? &&
+        @edition.access_limited_by_default? &&
+        @edition.access_limiting_organisations.empty?
+      @edition.access_limiting_organisations = @edition.lead_organisations
+    end
+  end
 
   def update
     editorial_remark = edition_params.delete(:editorial_remark)
-    @edition.assign_attributes(edition_params)
 
-    if changed?
+    permitted = edition_params.except(
+      :access_limiting_organisation_ids,
+      :access_limiting_radio,
+      :access_limited,
+    )
+    @edition.assign_attributes(permitted)
+
+    if Flipflop.access_limiting_organisations_ui?
+      case edition_params[:access_limiting_radio]
+      when "no_access_limiting"
+        @edition.access_limited = false
+      when "organisation_access_limiting"
+        @edition.access_limited = true
+      end
+
+      @edition.access_limiting_organisation_ids =
+        Array(edition_params[:access_limiting_organisation_ids]).reject(&:blank?)
+    else
+      @edition.access_limited = edition_params[:access_limited] == "1"
+    end
+
+    something_changed = changed?
+
+    unless @edition.valid?
+      render :edit
+      return
+    end
+
+    if something_changed
       if editorial_remark.blank?
         @edition.errors.add(:editorial_remark, t("errors.messages.blank"))
-
         render :edit
-      else
-        @edition.save!
+        return
+      end
+
+      if @edition.save
         PublishingApiDocumentRepublishingJob.perform_async(@edition.document_id, false)
 
         EditorialRemark.create!(
@@ -27,6 +61,8 @@ class Admin::EditionAccessLimitedController < Admin::BaseController
         )
 
         redirect_to admin_editions_path, notice: "Access updated for #{@edition.title}"
+      else
+        render :edit
       end
     else
       redirect_to admin_editions_path, notice: "Access updated for #{@edition.title}"
@@ -45,31 +81,43 @@ private
 
   def edition_params
     @edition_params ||= params
-    .fetch(:edition, {})
-    .permit(
-      :access_limited,
-      :editorial_remark,
-      {
-        lead_organisation_ids: [],
-        supporting_organisation_ids: [],
-      },
-    )
+      .fetch(:edition, {})
+      .permit(
+        :access_limited,
+        :access_limiting_radio,
+        :editorial_remark,
+        {
+          lead_organisation_ids: [],
+          supporting_organisation_ids: [],
+          access_limiting_organisation_ids: [],
+        },
+      )
   end
 
   def clean_organisation_params
     if edition_params[:lead_organisation_ids]
-      edition_params[:lead_organisation_ids] = edition_params[:lead_organisation_ids].reject(&:blank?)
+      edition_params[:lead_organisation_ids] =
+        edition_params[:lead_organisation_ids].reject(&:blank?)
     end
+
     if edition_params[:supporting_organisation_ids]
-      edition_params[:supporting_organisation_ids] = edition_params[:supporting_organisation_ids].reject(&:blank?)
+      edition_params[:supporting_organisation_ids] =
+        edition_params[:supporting_organisation_ids].reject(&:blank?)
     end
+  end
+
+  def original_edition
+    @original_edition ||= Edition.find(params[:id])
   end
 
   def changed?
     if @edition.organisation_association_enabled?
-      @edition.changed? || @edition.edition_organisations != Edition.find(params[:id]).edition_organisations
+      @edition.changed? ||
+        @edition.edition_organisations != original_edition.edition_organisations ||
+        @edition.access_limiting_organisation_ids.sort != original_edition.access_limiting_organisation_ids.sort
     else
-      @edition.changed?
+      @edition.changed? ||
+        @edition.access_limiting_organisation_ids.sort != original_edition.access_limiting_organisation_ids.sort
     end
   end
 end

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -113,7 +113,25 @@ class Admin::EditionsController < Admin::BaseController
   end
 
   def update
-    @edition.assign_attributes(edition_params)
+    @edition.assign_attributes(edition_params.except(:access_limiting_radio, :access_limiting_organisation_ids))
+
+    # When the access_limiting_organisations_ui flag is on, translate the radio value
+    # into access_limited and access_limiting_organisation_ids before saving.
+    # NOTE: This duplicates logic from EditionAccessLimitedController and is not ideal —
+    # ideally access limiting would only be managed via the edit_access_limited form.
+    # This is a pragmatic interim solution to avoid confusing users who set access
+    # limiting via the main edit form.
+    if Flipflop.access_limiting_organisations_ui?
+      case edition_params[:access_limiting_radio]
+      when "no_access_limiting"
+        @edition.access_limited = false
+      when "organisation_access_limiting"
+        @edition.access_limited = true
+      end
+
+      @edition.access_limiting_organisation_ids =
+        Array(edition_params[:access_limiting_organisation_ids]).reject(&:blank?)
+    end
 
     if updater.can_perform? && @edition.save_as(current_user)
       updater.perform!
@@ -254,10 +272,17 @@ private
       :all_nation_applicability,
       :speaker_radios,
       :logo_formatted_name,
+      :access_limiting_radio,
+      # access_limiting_radio is a UI-only param — it is a form control whose value
+      # is translated into access_limited and access_limiting_organisation_ids by
+      # edition_access_limited_controller. It is permitted here to avoid
+      # UnpermittedParameters errors since the access limiting partial renders on
+      # the main edition form, but must not be assigned directly to the edition.
       {
         all_nation_applicability: [],
         lead_organisation_ids: [],
         supporting_organisation_ids: [],
+        access_limiting_organisation_ids: [],
         organisation_ids: [],
         role_ids: [],
         world_location_ids: [],

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -114,6 +114,7 @@ class Admin::EditionsController < Admin::BaseController
 
   def update
     @edition.assign_attributes(edition_params.except(:access_limiting_radio, :access_limiting_organisation_ids))
+    # :access_limiting_organisation_ids is temporary — remove when access limiting is consolidated to the one form at edit_access_limited
 
     # When the access_limiting_organisations_ui flag is on, translate the radio value
     # into access_limited and access_limiting_organisation_ids before saving.
@@ -349,7 +350,7 @@ private
   end
 
   def new_edition_params
-    edition_params.merge(creator: current_user)
+    edition_params.except(:access_limiting_radio).merge(creator: current_user)
   end
 
   def show_or_edit_path

--- a/app/models/concerns/edition/limited_access.rb
+++ b/app/models/concerns/edition/limited_access.rb
@@ -3,6 +3,8 @@ module Edition::LimitedAccess
 
   included do
     after_initialize :set_access_limited
+    validate :access_limiting_organisations_required,
+             if: -> { validate_access_limiting_organisations? && persisted? }
   end
 
   module ClassMethods
@@ -29,5 +31,18 @@ module Edition::LimitedAccess
 
   def accessible_to?(user)
     user.present? && Whitehall::Authority::Enforcer.new(user, self).can?(:see)
+  end
+
+private
+
+  def validate_access_limiting_organisations?
+    Flipflop.access_limiting_organisations_ui? && access_limited?
+  end
+
+  def access_limiting_organisations_required
+    if access_limited? && access_limiting_organisations.empty?
+      errors.add(:access_limiting_organisation_ids,
+                 "must include at least one organisation when access limiting is enabled")
+    end
   end
 end

--- a/app/models/concerns/edition/organisations.rb
+++ b/app/models/concerns/edition/organisations.rb
@@ -11,7 +11,6 @@ module Edition::Organisations
 
   included do
     has_many :edition_organisations, foreign_key: :edition_id, dependent: :destroy, autosave: true, validate: false
-    has_many :access_limiting_organisations, foreign_key: :edition_id, dependent: :destroy, autosave: true, validate: false
 
     has_many :organisations, -> { includes(:translations) }, through: :edition_organisations, validate: false
 

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -51,6 +51,16 @@ class Edition < ApplicationRecord
   has_many :depended_upon_contacts, through: :edition_dependencies, source: :dependable, source_type: "Contact"
   has_many :depended_upon_editions, through: :edition_dependencies, source: :dependable, source_type: "Edition"
 
+  has_many :edition_access_limiting_organisations,
+           class_name: "AccessLimitingOrganisation",
+           dependent: :destroy,
+           autosave: true,
+           validate: false
+
+  has_many :access_limiting_organisations,
+           through: :edition_access_limiting_organisations,
+           source: :organisation
+
   # Add validation rules on legacy Edition content types, but opt out of them on StandardEdition
   # types whose validation rules are configured via JSON and applied via StandardEdition::BlockContent.
   validates_with SafeHtmlValidator, unless: ->(record) { record.is_a?(StandardEdition) }

--- a/app/views/admin/editions/_access_limiting_fields.html.erb
+++ b/app/views/admin/editions/_access_limiting_fields.html.erb
@@ -4,19 +4,41 @@
     heading_level: 3,
     heading_size: "m",
   } do %>
-    <%= form.hidden_field :access_limited, value: "0" %>
+    <% if Flipflop.access_limiting_organisations_ui? %>
+      <% access_limiting_radio_value = edition.access_limited? ? "organisation_access_limiting" : "no_access_limiting" %>
+      <%= render "govuk_publishing_components/components/radio", {
+        name: "edition[access_limiting_radio]",
+        id_prefix: "edition_access_limiting_radio",
+        error_items: errors_for(edition.errors, :access_limiting_organisation_ids),
+        items: [
+          {
+            value: "no_access_limiting",
+            text: "No access limiting",
+            checked: access_limiting_radio_value == "no_access_limiting",
+          },
+          {
+            value: "organisation_access_limiting",
+            text: "Organisation access limiting",
+            checked: access_limiting_radio_value == "organisation_access_limiting",
+            conditional: render("admin/editions/access_limiting_organisation_select", form: form, edition: edition),
+          },
+        ],
+      } %>
+    <% else %>
+      <%= form.hidden_field :access_limited, value: "0" %>
 
-    <%= render "govuk_publishing_components/components/checkboxes", {
-      name: "edition[access_limited]",
-      id: "edition_access_limited",
-      error_items: errors_for(edition.errors, :access_limited),
-      items: [
-        {
-          label: "Limit access to publishers from organisations associated with this document before you publish",
-          value: 1,
-          checked: edition.access_limited,
-        },
-      ],
-    } %>
+      <%= render "govuk_publishing_components/components/checkboxes", {
+        name: "edition[access_limited]",
+        id: "edition_access_limited",
+        error_items: errors_for(edition.errors, :access_limited),
+        items: [
+          {
+            label: "Limit access to publishers from organisations associated with this document before you publish",
+            value: 1,
+            checked: edition.access_limited,
+          },
+        ],
+      } %>
+    <% end %>
   <% end %>
 </div>

--- a/app/views/admin/editions/_access_limiting_organisation_select.html.erb
+++ b/app/views/admin/editions/_access_limiting_organisation_select.html.erb
@@ -1,0 +1,8 @@
+<%= render "govuk_publishing_components/components/select_with_search", {
+  id: "edition_access_limiting_organisation_ids",
+  name: "edition[access_limiting_organisation_ids][]",
+  label: "Organisations",
+  heading_size: "s",
+  include_blank: true,
+  options: taggable_organisations_container(edition.access_limiting_organisations.map(&:id)),
+} %>

--- a/config/features.rb
+++ b/config/features.rb
@@ -33,4 +33,7 @@ Flipflop.configure do
   feature :configurable_document_types,
           description: "Enable 'in development' config-driven document types (alongside the 'live' ones)",
           default: Rails.env.development?
+  feature :access_limiting_organisations_ui,
+          description: "Replace the access-limiting checkbox with radio + organisation selector UI",
+          default: false
 end

--- a/test/functional/admin/edition_access_limited_controller_test.rb
+++ b/test/functional/admin/edition_access_limited_controller_test.rb
@@ -20,6 +20,7 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
     edition = create(
       :consultation,
       access_limited: true,
+      access_limiting_organisation_ids: [organisation.id],
       create_default_organisation: false,
       lead_organisations: [organisation],
     )
@@ -41,6 +42,61 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
 
       refute_select "#edition_lead_organisation_ids_5"
       assert_select("#edition_supporting_organisation_ids")
+    end
+  end
+
+  view_test "GET :edit should show radio buttons instead of checkbox when access_limiting_organisations_ui flag is on" do
+    feature_flags.switch! :access_limiting_organisations_ui, true
+
+    organisation = create(:organisation)
+    edition = create(
+      :consultation,
+      access_limited: false,
+      create_default_organisation: false,
+      lead_organisations: [organisation],
+    )
+
+    get :edit, params: { id: edition }
+
+    assert_select "input[name='edition[access_limiting_radio]'][type=radio]"
+    assert_select "input[name='edition[access_limited]'][type=checkbox]", count: 0
+  end
+
+  view_test "GET :edit should pre-select organisation_access_limiting radio and populate org select when access_limiting_organisations_ui flag is on" do
+    feature_flags.switch! :access_limiting_organisations_ui, true
+
+    organisation = create(:organisation)
+    edition = create(
+      :consultation,
+      access_limited: true,
+      create_default_organisation: false,
+      lead_organisations: [organisation],
+      access_limiting_organisation_ids: [organisation.id],
+    )
+
+    get :edit, params: { id: edition }
+
+    assert_select "input[name='edition[access_limiting_radio]'][value='organisation_access_limiting'][checked=checked]"
+    assert_select "select[name='edition[access_limiting_organisation_ids][]']" do
+      assert_select "option[selected='selected'][value='#{organisation.id}']"
+    end
+  end
+
+  view_test "GET :edit should pre-select organisation_access_limiting radio and pre-fill lead organisations for default-access-limited edition types when access_limiting_organisations_ui flag is on" do
+    feature_flags.switch! :access_limiting_organisations_ui, true
+
+    organisation = create(:organisation)
+    edition = create(
+      :statistical_data_set,
+      create_default_organisation: false,
+      lead_organisations: [organisation],
+    )
+
+    get :edit, params: { id: edition }
+
+    assert_select "input[name='edition[access_limiting_radio]'][value='organisation_access_limiting'][checked=checked]"
+    assert_select "select[name='edition[access_limiting_organisation_ids][]']" do
+      assert_select "option[selected='selected'][value='#{organisation.id}']"
     end
   end
 
@@ -96,6 +152,7 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
       create_default_organisation: false,
       lead_organisations: [first_organisation],
       supporting_organisations: [second_organisation],
+      access_limiting_organisation_ids: [first_organisation.id],
     )
 
     editorial_remark = "Removing access limited at the users request."
@@ -129,6 +186,7 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
       create_default_organisation: false,
       lead_organisations: [first_organisation],
       supporting_organisations: [second_organisation],
+      access_limiting_organisation_ids: [first_organisation.id],
     )
 
     put :update,
@@ -157,6 +215,7 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
       create_default_organisation: false,
       lead_organisations: [first_organisation],
       supporting_organisations: [second_organisation],
+      access_limiting_organisation_ids: [first_organisation.id],
     )
 
     put :update,
@@ -173,5 +232,142 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
     assert_redirected_to admin_editions_path
     assert_equal "Access updated for #{edition.title}", flash[:notice]
     assert_equal 0, edition.editorial_remarks.count
+  end
+
+  test "PATCH :update should save without access_limiting_organisations when access_limiting_organisations_ui flag is off" do
+    organisation = create(:organisation)
+    edition = create(
+      :consultation,
+      access_limited: false,
+      create_default_organisation: false,
+      lead_organisations: [organisation],
+    )
+
+    put :update,
+        params: {
+          id: edition,
+          edition: {
+            lead_organisation_ids: [organisation.id],
+            access_limited: "1",
+            editorial_remark: "Enabling access limiting",
+          },
+        }
+
+    assert_redirected_to admin_editions_path
+    assert edition.reload.access_limited?
+    assert_empty edition.access_limiting_organisations
+  end
+
+  test "PATCH :update should save access_limiting_organisation_ids and set access_limited when access_limiting_organisations_ui flag is on" do
+    feature_flags.switch! :access_limiting_organisations_ui, true
+
+    organisation = create(:organisation)
+    edition = create(
+      :consultation,
+      access_limited: false,
+      create_default_organisation: false,
+      lead_organisations: [organisation],
+    )
+
+    editorial_remark = "Setting access limiting organisations at the user's request."
+
+    put :update,
+        params: {
+          id: edition,
+          edition: {
+            lead_organisation_ids: [organisation.id],
+            access_limiting_radio: "organisation_access_limiting",
+            access_limiting_organisation_ids: [organisation.id.to_s],
+            editorial_remark:,
+          },
+        }
+
+    assert_redirected_to admin_editions_path
+    assert edition.reload.access_limited?
+    assert edition.access_limiting_organisations.exists?(id: organisation.id)
+  end
+
+  test "PATCH :update should render a validation error when access_limited is set without access_limiting_organisations and access_limiting_organisations_ui flag is on" do
+    feature_flags.switch! :access_limiting_organisations_ui, true
+
+    organisation = create(:organisation)
+    edition = create(
+      :consultation,
+      access_limited: false,
+      create_default_organisation: false,
+      lead_organisations: [organisation],
+    )
+
+    put :update,
+        params: {
+          id: edition,
+          edition: {
+            lead_organisation_ids: [organisation.id],
+            access_limiting_radio: "organisation_access_limiting",
+            access_limiting_organisation_ids: [],
+            editorial_remark: "Test",
+          },
+        }
+
+    assert_template :edit
+    assert_includes assigns(:edition).errors[:access_limiting_organisation_ids],
+                    "must include at least one organisation when access limiting is enabled"
+  end
+
+  test "PATCH :update should render a validation error when access_limiting_organisations are cleared on an existing access-limited edition and access_limiting_organisations_ui flag is on" do
+    feature_flags.switch! :access_limiting_organisations_ui, true
+
+    organisation = create(:organisation)
+    edition = create(
+      :consultation,
+      access_limited: true,
+      create_default_organisation: false,
+      lead_organisations: [organisation],
+      access_limiting_organisation_ids: [organisation.id],
+    )
+
+    put :update,
+        params: {
+          id: edition,
+          edition: {
+            lead_organisation_ids: [organisation.id],
+            access_limiting_radio: "organisation_access_limiting",
+            access_limiting_organisation_ids: [],
+            editorial_remark: "Test",
+          },
+        }
+
+    assert_template :edit
+    assert edition.reload.access_limited?
+    assert_includes assigns(:edition).errors[:access_limiting_organisation_ids],
+                    "must include at least one organisation when access limiting is enabled"
+  end
+
+  test "PATCH :update should clear access_limiting_organisations when access_limited is set to false and access_limiting_organisations_ui flag is on" do
+    feature_flags.switch! :access_limiting_organisations_ui, true
+
+    organisation = create(:organisation)
+    edition = create(
+      :consultation,
+      access_limited: true,
+      create_default_organisation: false,
+      lead_organisations: [organisation],
+      access_limiting_organisation_ids: [organisation.id],
+    )
+
+    put :update,
+        params: {
+          id: edition,
+          edition: {
+            lead_organisation_ids: [organisation.id],
+            access_limiting_radio: "no_access_limiting",
+            access_limiting_organisation_ids: [],
+            editorial_remark: "Removing access limiting",
+          },
+        }
+
+    assert_redirected_to admin_editions_path
+    assert_not edition.reload.access_limited?
+    assert_empty edition.access_limiting_organisations
   end
 end

--- a/test/unit/app/models/edition/limited_access_test.rb
+++ b/test/unit/app/models/edition/limited_access_test.rb
@@ -61,4 +61,40 @@ class Edition::LimitedAccessTest < ActiveSupport::TestCase
 
     assert edition.accessible_to?(user)
   end
+
+  test "is invalid when access_limited is true and no access limiting organisations are selected" do
+    @feature_flags.switch!(:access_limiting_organisations_ui, true)
+
+    edition = create(:limited_access_edition, access_limited: true)
+    edition.access_limiting_organisation_ids = []
+
+    assert_not edition.valid?
+    assert_includes edition.errors[:access_limiting_organisation_ids],
+                    "must include at least one organisation when access limiting is enabled"
+  end
+
+  test "is valid when access_limited is true and access limiting organisations are present" do
+    @feature_flags.switch!(:access_limiting_organisations_ui, true)
+    org = create(:organisation)
+
+    edition = create(:limited_access_edition, access_limited: true)
+    edition.access_limiting_organisation_ids = [org.id]
+
+    assert edition.valid?
+  end
+
+  test "is valid when access_limited is false regardless of access limiting organisations" do
+    @feature_flags.switch!(:access_limiting_organisations_ui, true)
+
+    edition = create(:limited_access_edition, access_limited: false)
+    edition.access_limiting_organisation_ids = []
+    assert edition.valid?
+  end
+
+  test "is valid when access_limited is true and no access limiting organisations are selected when flag is off" do
+    edition = create(:consultation, access_limited: true)
+    edition.access_limiting_organisation_ids = []
+
+    assert edition.valid?
+  end
 end

--- a/test/unit/app/models/edition/limited_access_test.rb
+++ b/test/unit/app/models/edition/limited_access_test.rb
@@ -94,8 +94,9 @@ class Edition::LimitedAccessTest < ActiveSupport::TestCase
   test "is valid when access_limited is true and no access limiting organisations are selected when flag is off" do
     edition = create(:consultation, access_limited: true)
     edition.access_limiting_organisation_ids = []
-
     assert edition.valid?
+  end
+  
   test "setting access_limited = true bridges to access_limiting = 'organisations'" do
     edition = build(:limited_access_edition)
     edition.access_limited = true

--- a/test/unit/app/models/edition/limited_access_test.rb
+++ b/test/unit/app/models/edition/limited_access_test.rb
@@ -96,7 +96,7 @@ class Edition::LimitedAccessTest < ActiveSupport::TestCase
     edition.access_limiting_organisation_ids = []
     assert edition.valid?
   end
-  
+
   test "setting access_limited = true bridges to access_limiting = 'organisations'" do
     edition = build(:limited_access_edition)
     edition.access_limited = true


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
