### PR TITLE
Org access limiting: Add feature-flagged radio UI for access-limiting organisations [WHIT-3543] [WHIT-3583]

### DIFF
--- a/app/controllers/admin/edition_access_limited_controller.rb
+++ b/app/controllers/admin/edition_access_limited_controller.rb
@@ -6,30 +6,26 @@ class Admin::EditionAccessLimitedController < Admin::BaseController
   def edit; end
 
   def update
-    editorial_remark = edition_params.delete(:editorial_remark)
+    @editorial_remark = edition_params.delete(:editorial_remark)
     @edition.assign_attributes(edition_params)
 
-    if changed?
-      if editorial_remark.blank?
-        @edition.errors.add(:editorial_remark, t("errors.messages.blank"))
+    if @editorial_remark.blank?
+      @edition.errors.add(:editorial_remark, t("errors.messages.blank"))
+      return render :edit
+    end
 
-        render :edit
-      else
-        @edition.save!
-        PublishingApiDocumentRepublishingJob.perform_async(@edition.document_id, false)
-
-        EditorialRemark.create!(
-          edition: @edition,
-          body: "Access options updated by GDS Admin: #{editorial_remark}",
-          author: current_user,
-          created_at: Time.zone.now,
-          updated_at: Time.zone.now,
-        )
-
-        redirect_to admin_editions_path, notice: "Access updated for #{@edition.title}"
-      end
-    else
+    if @edition.save
+      PublishingApiDocumentRepublishingJob.perform_async(@edition.document_id, false)
+      EditorialRemark.create!(
+        edition: @edition,
+        body: "Access options updated by GDS Admin: #{@editorial_remark}",
+        author: current_user,
+        created_at: Time.zone.now,
+        updated_at: Time.zone.now,
+      )
       redirect_to admin_editions_path, notice: "Access updated for #{@edition.title}"
+    else
+      render :edit
     end
   end
 
@@ -45,15 +41,16 @@ private
 
   def edition_params
     @edition_params ||= params
-    .fetch(:edition, {})
-    .permit(
-      :access_limiting,
-      :editorial_remark,
-      {
-        lead_organisation_ids: [],
-        supporting_organisation_ids: [],
-      },
-    )
+      .fetch(:edition, {})
+      .permit(
+        :access_limiting,
+        :editorial_remark,
+        {
+          lead_organisation_ids: [],
+          supporting_organisation_ids: [],
+          access_limiting_organisation_ids: [],
+        },
+      )
   end
 
   def clean_organisation_params
@@ -63,13 +60,7 @@ private
     if edition_params[:supporting_organisation_ids]
       edition_params[:supporting_organisation_ids] = edition_params[:supporting_organisation_ids].reject(&:blank?)
     end
-  end
 
-  def changed?
-    if @edition.organisation_association_enabled?
-      @edition.changed? || @edition.edition_organisations != Edition.find(params[:id]).edition_organisations
-    else
-      @edition.changed?
-    end
+    edition_params[:access_limiting_organisation_ids] = [] if edition_params[:access_limiting] == "none"
   end
 end

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -247,6 +247,7 @@ private
         all_nation_applicability: [],
         lead_organisation_ids: [],
         supporting_organisation_ids: [],
+        access_limiting_organisation_ids: [],
         organisation_ids: [],
         role_ids: [],
         world_location_ids: [],
@@ -468,6 +469,8 @@ private
     if params[:review_reminder].blank? && edition_params.dig("document_attributes", "review_reminder_attributes").present?
       edition_params["document_attributes"]["review_reminder_attributes"]["_destroy"] = "1"
     end
+
+    edition_params[:access_limiting_organisation_ids] = [] if edition_params[:access_limiting] == "none"
   end
 
   def clear_scheduled_publication_if_not_activated

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -15,6 +15,7 @@ class Admin::EditionsController < Admin::BaseController
   before_action :detect_other_active_editors, only: %i[edit update]
   before_action :set_edition_defaults, only: :new
   before_action :build_edition_dependencies, only: %i[new edit]
+  before_action :set_current_user_for_validation, only: %i[create update]
   before_action :forbid_editing_of_historic_content!, only: %i[create edit update destroy revise]
   before_action :enforce_permissions!
   before_action :limit_edition_access!, only: %i[show edit update revise diff destroy]
@@ -346,6 +347,10 @@ private
     I18n.with_locale(edition_locale) do
       @edition = LocalisedModel.new(new_edition, edition_locale)
     end
+  end
+
+  def set_current_user_for_validation
+    @edition.current_user_for_validation = current_user
   end
 
   def find_edition

--- a/app/models/concerns/edition/limited_access.rb
+++ b/app/models/concerns/edition/limited_access.rb
@@ -8,6 +8,16 @@ module Edition::LimitedAccess
       individuals: "individuals",
     }, prefix: true, default: nil
 
+    has_many :edition_access_limiting_organisations,
+             class_name: "AccessLimitingOrganisation",
+             dependent: :destroy,
+             autosave: true,
+             validate: false
+
+    has_many :access_limiting_organisations,
+             through: :edition_access_limiting_organisations,
+             source: :organisation
+
     after_initialize :set_access_limited
   end
 

--- a/app/models/concerns/edition/limited_access.rb
+++ b/app/models/concerns/edition/limited_access.rb
@@ -19,6 +19,7 @@ module Edition::LimitedAccess
              source: :organisation
 
     after_initialize :set_access_limited
+    validate :access_limiting_organisations_required, if: -> { Flipflop.access_limiting_organisations_ui? && access_limiting_organisations? }
   end
 
   module ClassMethods
@@ -51,5 +52,9 @@ module Edition::LimitedAccess
 
   def accessible_to?(user)
     user.present? && Whitehall::Authority::Enforcer.new(user, self).can?(:see)
+  end
+
+  def access_limiting_organisations_required
+    errors.add(:access_limiting_organisation_ids, "must include at least one organisation when access limiting is enabled") if access_limiting_organisations.empty?
   end
 end

--- a/app/models/concerns/edition/limited_access.rb
+++ b/app/models/concerns/edition/limited_access.rb
@@ -19,6 +19,8 @@ module Edition::LimitedAccess
              source: :organisation
 
     after_initialize :set_access_limited
+    after_save :clear_pending_access_limiting_organisation_ids
+
     validate :access_limiting_organisations_required, if: -> { Flipflop.access_limiting_organisations_ui? && access_limiting_organisations? }
   end
 
@@ -55,6 +57,32 @@ module Edition::LimitedAccess
   end
 
   def access_limiting_organisations_required
-    errors.add(:access_limiting_organisation_ids, "must include at least one organisation when access limiting is enabled") if access_limiting_organisations.empty?
+    errors.add(:access_limiting_organisation_ids, "must include at least one organisation") if edition_access_limiting_organisations.reject(&:marked_for_destruction?).empty?
+  end
+
+  def access_limiting_organisation_ids=(new_ids)
+    ids = Array(new_ids).reject(&:blank?).map(&:to_i).uniq
+    @pending_access_limiting_organisation_ids = ids
+
+    # Manually update the in-memory association to reflect the submitted IDs.
+    # This prevents immediate database writes and ensures the form re-renders correctly.
+    edition_access_limiting_organisations.each(&:mark_for_destruction)
+    ids.each do |org_id|
+      edition_access_limiting_organisations.build(organisation_id: org_id)
+    end
+  end
+
+  def access_limiting_organisation_ids
+    if defined?(@pending_access_limiting_organisation_ids)
+      return @pending_access_limiting_organisation_ids.dup
+    end
+
+    super
+  end
+
+private
+
+  def clear_pending_access_limiting_organisation_ids
+    remove_instance_variable(:@pending_access_limiting_organisation_ids) if defined?(@pending_access_limiting_organisation_ids)
   end
 end

--- a/app/models/concerns/edition/limited_access.rb
+++ b/app/models/concerns/edition/limited_access.rb
@@ -2,6 +2,8 @@ module Edition::LimitedAccess
   extend ActiveSupport::Concern
 
   included do
+    attr_accessor :current_user_for_validation
+
     enum :access_limiting, {
       none: "none",
       organisations: "organisations",
@@ -22,6 +24,7 @@ module Edition::LimitedAccess
     after_save :clear_pending_access_limiting_organisation_ids
 
     validate :access_limiting_organisations_required, if: -> { Flipflop.access_limiting_organisations_ui? && access_limiting_organisations? }
+    validate :access_limiting_must_include_current_user_organisation
   end
 
   module ClassMethods
@@ -84,5 +87,21 @@ private
 
   def clear_pending_access_limiting_organisation_ids
     remove_instance_variable(:@pending_access_limiting_organisation_ids) if defined?(@pending_access_limiting_organisation_ids)
+  end
+
+  def access_limiting_must_include_current_user_organisation
+    return unless current_user_for_validation.present? && access_limited?
+
+    if Flipflop.access_limiting_organisations_ui? && access_limiting_organisations?
+      org_ids = edition_access_limiting_organisations
+                  .reject(&:marked_for_destruction?)
+                  .map(&:organisation_id)
+
+      if org_ids.any? && org_ids.exclude?(current_user_for_validation.organisation&.id)
+        errors.add(:access_limiting_organisation_ids, "must include your own organisation")
+      end
+    elsif organisation_association_enabled? && edition_organisations.map(&:organisation_id).exclude?(current_user_for_validation.organisation&.id)
+      errors.add(:base, "Lead or supporting organisations must include your own organisation")
+    end
   end
 end

--- a/app/models/concerns/edition/organisations.rb
+++ b/app/models/concerns/edition/organisations.rb
@@ -11,7 +11,6 @@ module Edition::Organisations
 
   included do
     has_many :edition_organisations, foreign_key: :edition_id, dependent: :destroy, autosave: true, validate: false
-    has_many :access_limiting_organisations, foreign_key: :edition_id, dependent: :destroy, autosave: true, validate: false
 
     has_many :organisations, -> { includes(:translations) }, through: :edition_organisations, validate: false
 

--- a/app/presenters/publishing_api/payload_builder/access_limitation.rb
+++ b/app/presenters/publishing_api/payload_builder/access_limitation.rb
@@ -4,7 +4,13 @@ module PublishingApi
       def self.for(item)
         return {} unless item.access_limited? && !item.publicly_visible?
 
-        { access_limited: { organisations: item.organisations.pluck(:content_id).uniq } }
+        organisations = if Flipflop.access_limiting_organisations_ui? && item.access_limiting_organisations?
+                          item.access_limiting_organisations.pluck(:content_id).uniq
+                        else
+                          item.organisations.pluck(:content_id).uniq
+                        end
+
+        { access_limited: { organisations: } }
       end
     end
   end

--- a/app/services/draft_edition_updater.rb
+++ b/app/services/draft_edition_updater.rb
@@ -10,8 +10,6 @@ class DraftEditionUpdater < EditionService
   def failure_reason
     if !edition.pre_publication?
       "A #{edition.state} edition may not be updated."
-    elsif should_check_current_user_will_retain_access? && access_limit_excludes_current_user?
-      "Access can only be limited by users belonging to an organisation tagged to the document"
     elsif !edition.valid?
       "This edition is invalid: #{edition.errors.full_messages.to_sentence}"
     end
@@ -19,18 +17,5 @@ class DraftEditionUpdater < EditionService
 
   def verb
     "update_draft"
-  end
-
-private
-
-  def should_check_current_user_will_retain_access?
-    @options[:current_user].present? && edition.access_limited?
-  end
-
-  def access_limit_excludes_current_user?
-    # Some users may not necessarily belong to an organisation. We should fail-closed for them.
-    return true unless @options[:current_user].organisation
-
-    edition.organisation_association_enabled? && edition.edition_organisations.map(&:organisation_id).exclude?(@options[:current_user].organisation.id)
   end
 end

--- a/app/services/edition_publisher.rb
+++ b/app/services/edition_publisher.rb
@@ -28,6 +28,7 @@ private
   def prepare_edition
     flag_if_political_content!
     edition.access_limiting = :none
+    edition.access_limiting_organisations.clear
     edition.major_change_published_at = Time.zone.now unless edition.minor_change?
     edition.make_public_at(edition.major_change_published_at)
     edition.increment_version_number

--- a/app/views/admin/edition_access_limited/edit.html.erb
+++ b/app/views/admin/edition_access_limited/edit.html.erb
@@ -27,6 +27,7 @@
         name: "edition[editorial_remark]",
         textarea_id: "edition_editorial_remark",
         error_items: errors_for(@edition.errors, :editorial_remark),
+        value: @editorial_remark,
         hint: "Please explain why this change is required",
         rows: 20,
       } %>

--- a/app/views/admin/editions/_access_limiting_fields.html.erb
+++ b/app/views/admin/editions/_access_limiting_fields.html.erb
@@ -5,18 +5,39 @@
     heading_size: "m",
   } do %>
     <%= form.hidden_field :access_limiting, value: "none" %>
+    <% if Flipflop.access_limiting_organisations_ui? %>
+      <%= render "govuk_publishing_components/components/radio", {
+        name: "edition[access_limiting]",
+        id_prefix: "edition_access_limiting",
+        error_items: errors_for(edition.errors, :access_limiting_organisation_ids),
+        items: [
+          {
+            value: "none",
+            text: "No access limiting",
+            checked: edition.access_limiting_none?,
+          },
+          {
+            value: "organisations",
+            text: "Organisation access limiting",
+            checked: edition.access_limiting_organisations?,
+            conditional: render("admin/editions/access_limiting_organisation_select", form: form, edition: edition),
+          },
+        ],
+      } %>
+    <% else %>
 
-    <%= render "govuk_publishing_components/components/checkboxes", {
-      name: "edition[access_limiting]",
-      id: "edition_access_limiting",
-      error_items: errors_for(edition.errors, :access_limiting),
-      items: [
-        {
-          label: "Limit access to publishers from organisations associated with this document before you publish",
-          value: "organisations",
-          checked: edition.access_limited?,
-        },
-      ],
-    } %>
+      <%= render "govuk_publishing_components/components/checkboxes", {
+        name: "edition[access_limiting]",
+        id: "edition_access_limiting",
+        error_items: errors_for(edition.errors, :access_limiting),
+        items: [
+          {
+            label: "Limit access to publishers from organisations associated with this document before you publish",
+            value: "organisations",
+            checked: edition.access_limited?,
+          },
+        ],
+      } %>
+    <% end %>
   <% end %>
 </div>

--- a/app/views/admin/editions/_access_limiting_organisation_select.html.erb
+++ b/app/views/admin/editions/_access_limiting_organisation_select.html.erb
@@ -1,0 +1,9 @@
+<%= render "govuk_publishing_components/components/select_with_search", {
+  id: "edition_access_limiting_organisation_ids",
+  name: "edition[access_limiting_organisation_ids][]",
+  label: "Organisations",
+  multiple: true,
+  heading_size: "s",
+  include_blank: true,
+  options: taggable_organisations_container(edition.access_limiting_organisation_ids),
+} %>

--- a/config/features.rb
+++ b/config/features.rb
@@ -33,4 +33,7 @@ Flipflop.configure do
   feature :configurable_document_types,
           description: "Enable 'in development' config-driven document types (alongside the 'live' ones)",
           default: Rails.env.development?
+  feature :access_limiting_organisations_ui,
+          description: "Replace the access-limiting checkbox with radio + organisation selector UI",
+          default: false
 end

--- a/features/admin-limit-access-editions.feature
+++ b/features/admin-limit-access-editions.feature
@@ -22,4 +22,4 @@ Feature: Viewing most recent editions in admin
     And I set the Lead organisation to an org I am not in
     And I check the "Limit access to publishers from organisations associated with this document before you publish" box
     When I click "Save"
-    Then I should see the validation error "Access can only be limited by users belonging to an organisation tagged to the document"
+    Then I should see the validation error "Access limiting organisations must include your organisation"

--- a/features/admin-limit-access-editions.feature
+++ b/features/admin-limit-access-editions.feature
@@ -22,4 +22,4 @@ Feature: Viewing most recent editions in admin
     And I set the Lead organisation to an org I am not in
     And I check the "Limit access to publishers from organisations associated with this document before you publish" box
     When I click "Save"
-    Then I should see the validation error "Access limiting organisations must include your organisation"
+    Then I should see the validation error "Lead or supporting organisations must include your own organisation"

--- a/lib/whitehall/authority/rules/edition_rules.rb
+++ b/lib/whitehall/authority/rules/edition_rules.rb
@@ -101,10 +101,14 @@ module Whitehall::Authority::Rules
     end
 
     def access_limit_enforced?
-      if subject.access_limited?
-        organisations = subject.organisations
-        organisations += subject.edition_organisations.map(&:organisation) if subject.respond_to?(:edition_organisations)
-        organisations.exclude?(actor.organisation)
+      if subject.access_limiting_organisations?
+        if Flipflop.access_limiting_organisations_ui?
+          subject.access_limiting_organisations.any? && subject.access_limiting_organisations.exclude?(actor.organisation)
+        else
+          organisations = subject.organisations
+          organisations += subject.edition_organisations.map(&:organisation) if subject.respond_to?(:edition_organisations)
+          organisations.exclude?(actor.organisation)
+        end
       else
         false
       end

--- a/lib/whitehall/authority/rules/edition_rules.rb
+++ b/lib/whitehall/authority/rules/edition_rules.rb
@@ -103,6 +103,8 @@ module Whitehall::Authority::Rules
     def access_limit_enforced?
       if subject.access_limiting_organisations?
         if Flipflop.access_limiting_organisations_ui?
+          return true if subject.access_limiting_organisations.empty?
+
           subject.access_limiting_organisations.any? && subject.access_limiting_organisations.exclude?(actor.organisation)
         else
           organisations = subject.organisations

--- a/test/functional/admin/calls_for_evidence_controller_test.rb
+++ b/test/functional/admin/calls_for_evidence_controller_test.rb
@@ -18,6 +18,7 @@ class Admin::CallsForEvidenceControllerTest < ActionController::TestCase
   should_allow_alternative_format_provider_for :call_for_evidence
   should_allow_scheduled_publication_of :call_for_evidence
   should_allow_access_limiting_of :call_for_evidence
+  access_limiting_organisations_ui_on_should_allow_access_limiting_of :call_for_evidence
   should_render_govspeak_history_and_fact_checking_tabs_for :call_for_evidence
 
   view_test "new displays call for evidence fields" do

--- a/test/functional/admin/calls_for_evidence_controller_test.rb
+++ b/test/functional/admin/calls_for_evidence_controller_test.rb
@@ -17,7 +17,7 @@ class Admin::CallsForEvidenceControllerTest < ActionController::TestCase
   should_allow_lead_and_supporting_organisations_for :call_for_evidence
   should_allow_alternative_format_provider_for :call_for_evidence
   should_allow_scheduled_publication_of :call_for_evidence
-  should_allow_access_limiting_of :call_for_evidence
+  access_limiting_organisations_ui_off_should_allow_access_limiting_of :call_for_evidence
   access_limiting_organisations_ui_on_should_allow_access_limiting_of :call_for_evidence
   should_render_govspeak_history_and_fact_checking_tabs_for :call_for_evidence
 

--- a/test/functional/admin/consultations_controller_test.rb
+++ b/test/functional/admin/consultations_controller_test.rb
@@ -18,6 +18,7 @@ class Admin::ConsultationsControllerTest < ActionController::TestCase
   should_allow_alternative_format_provider_for :consultation
   should_allow_scheduled_publication_of :consultation
   should_allow_access_limiting_of :consultation
+  access_limiting_organisations_ui_on_should_allow_access_limiting_of :consultation
   should_render_govspeak_history_and_fact_checking_tabs_for :consultation
 
   view_test "new displays consultation fields" do

--- a/test/functional/admin/consultations_controller_test.rb
+++ b/test/functional/admin/consultations_controller_test.rb
@@ -17,7 +17,7 @@ class Admin::ConsultationsControllerTest < ActionController::TestCase
   should_allow_lead_and_supporting_organisations_for :consultation
   should_allow_alternative_format_provider_for :consultation
   should_allow_scheduled_publication_of :consultation
-  should_allow_access_limiting_of :consultation
+  access_limiting_organisations_ui_off_should_allow_access_limiting_of :consultation
   access_limiting_organisations_ui_on_should_allow_access_limiting_of :consultation
   should_render_govspeak_history_and_fact_checking_tabs_for :consultation
 

--- a/test/functional/admin/detailed_guides_controller_test.rb
+++ b/test/functional/admin/detailed_guides_controller_test.rb
@@ -24,6 +24,7 @@ class Admin::DetailedGuidesControllerTest < ActionController::TestCase
   should_allow_scheduled_publication_of :detailed_guide
   should_allow_overriding_of_first_published_at_for :detailed_guide
   should_allow_access_limiting_of :detailed_guide
+  access_limiting_organisations_ui_on_should_allow_access_limiting_of :detailed_guide
   should_render_govspeak_history_and_fact_checking_tabs_for :detailed_guide
 
 private

--- a/test/functional/admin/detailed_guides_controller_test.rb
+++ b/test/functional/admin/detailed_guides_controller_test.rb
@@ -23,7 +23,7 @@ class Admin::DetailedGuidesControllerTest < ActionController::TestCase
   should_allow_alternative_format_provider_for :detailed_guide
   should_allow_scheduled_publication_of :detailed_guide
   should_allow_overriding_of_first_published_at_for :detailed_guide
-  should_allow_access_limiting_of :detailed_guide
+  access_limiting_organisations_ui_off_should_allow_access_limiting_of :detailed_guide
   access_limiting_organisations_ui_on_should_allow_access_limiting_of :detailed_guide
   should_render_govspeak_history_and_fact_checking_tabs_for :detailed_guide
 

--- a/test/functional/admin/edition_access_limited_controller_test.rb
+++ b/test/functional/admin/edition_access_limited_controller_test.rb
@@ -7,6 +7,7 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
 
   should_be_an_admin_controller
 
+  # access_limiting_organisations_ui flag agnostic
   test "GET :edit should be forbidden unless user is a GDS Admin" do
     edition = create(:consultation)
     login_as :gds_editor
@@ -14,6 +15,7 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
     assert_response :forbidden
   end
 
+  # access_limiting_organisations_ui flag is off
   view_test "GET :edit should display the correct fields" do
     organisation = create(:organisation)
 
@@ -45,14 +47,75 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
     end
   end
 
+  # access_limiting_organisations_ui is on
+  view_test "GET :edit should show radio buttons instead of checkbox when access_limiting_organisations_ui flag is on" do
+    feature_flags.switch! :access_limiting_organisations_ui, true
+
+    organisation = create(:organisation)
+    edition = create(
+      :consultation,
+      access_limiting: "none",
+      create_default_organisation: false,
+      lead_organisations: [organisation],
+    )
+
+    get :edit, params: { id: edition }
+
+    assert_select "input[name='edition[access_limiting]'][type=radio]"
+    assert_select "input[name='edition[access_limited]'][type=checkbox]", count: 0
+  end
+
+  # access_limiting_organisations_ui is on
+  view_test "GET :edit shows the persisted editions's access limiting value when flag is on" do
+    feature_flags.switch! :access_limiting_organisations_ui, true
+
+    organisation = create(:organisation)
+    edition = create(
+      :consultation,
+      access_limiting: "organisations",
+      create_default_organisation: false,
+      lead_organisations: [organisation],
+      access_limiting_organisation_ids: [organisation.id],
+    )
+
+    get :edit, params: { id: edition }
+
+    assert_select "input[name='edition[access_limiting]'][value='organisations'][checked=checked]"
+    assert_select "select[name='edition[access_limiting_organisation_ids][]']" do
+      assert_select "option[selected='selected'][value='#{organisation.id}']"
+    end
+  end
+
+  # Flag reversal scenario, access_limiting_organisations_ui turned on and then off
+  view_test "GET :edit shows the persisted editions's access limiting value, and preserves already set access limiting organisations, when flag is turned off" do
+    organisation = create(:organisation)
+    edition = create(
+      :consultation,
+      access_limiting: "organisations",
+      create_default_organisation: false,
+      lead_organisations: [organisation],
+      access_limiting_organisation_ids: [organisation.id],
+    )
+
+    get :edit, params: { id: edition }
+
+    assert edition.access_limited?
+    assert_equal "organisations", edition.access_limiting
+    assert edition.access_limiting_organisations.exists?(id: organisation.id)
+    assert_select "input[name='edition[access_limiting]'][value='organisations'][checked=checked]"
+    refute_select "select[name='edition[access_limiting_organisation_ids][]']"
+  end
+
+  # access_limiting_organisations_ui flag agnostic
   test "PATCH :update should be forbidden unless user is a GDS Admin" do
     edition = create(:consultation)
     login_as :gds_editor
-    get :edit, params: { id: edition }
+    patch :update, params: { id: edition }
     assert_response :forbidden
   end
 
-  test "PATCH :update should update editions organisations correctly and creates an editorial remark" do
+  # access_limiting_organisations_ui flag agnostic
+  test "PATCH :update should update editions organisations and create an editorial remark" do
     first_organisation = create(:organisation)
     second_organisation = create(:organisation)
     third_organisation = create(:organisation)
@@ -69,16 +132,16 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
 
     editorial_remark = "Updating the organisations at the users request."
 
-    put :update,
-        params: {
-          id: edition,
-          edition: {
-            lead_organisation_ids: [second_organisation.id],
-            supporting_organisation_ids: [third_organisation.id],
-            editorial_remark:,
-            access_limiting: "organisations",
-          },
-        }
+    patch :update,
+          params: {
+            id: edition,
+            edition: {
+              lead_organisation_ids: [second_organisation.id],
+              supporting_organisation_ids: [third_organisation.id],
+              editorial_remark:,
+              access_limiting: "organisations",
+            },
+          }
 
     assert_equal [second_organisation], edition.reload.lead_organisations
     assert_equal [third_organisation], edition.supporting_organisations
@@ -87,7 +150,8 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
     assert_equal "Access options updated by GDS Admin: #{editorial_remark}", edition.editorial_remarks.last.body
   end
 
-  test "PATCH :update allows access_limited to be updated and creates an editorial remark" do
+  # access_limiting_organisations_ui flag is off
+  test "PATCH :update should update access_limited and create an editorial remark" do
     first_organisation = create(:organisation)
     second_organisation = create(:organisation)
 
@@ -101,16 +165,16 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
 
     editorial_remark = "Removing access limited at the users request."
 
-    put :update,
-        params: {
-          id: edition,
-          edition: {
-            lead_organisation_ids: [first_organisation.id],
-            supporting_organisation_ids: [second_organisation.id],
-            editorial_remark:,
-            access_limiting: "none",
-          },
-        }
+    patch :update,
+          params: {
+            id: edition,
+            edition: {
+              lead_organisation_ids: [first_organisation.id],
+              supporting_organisation_ids: [second_organisation.id],
+              editorial_remark:,
+              access_limiting: "none",
+            },
+          }
 
     assert_equal [first_organisation], edition.reload.lead_organisations
     assert_equal [second_organisation], edition.supporting_organisations
@@ -120,7 +184,72 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
     assert_equal "Access options updated by GDS Admin: #{editorial_remark}", edition.editorial_remarks.last.body
   end
 
-  test "PATCH :update re-renders edit template if editorial remark is not provided" do
+  # access_limiting_organisations_ui is on
+  test "PATCH :update changes access limiting from 'none' to 'organisations' and creates an editorial remark" do
+    feature_flags.switch! :access_limiting_organisations_ui, true
+
+    organisation = create(:organisation)
+    edition = create(
+      :consultation,
+      access_limiting: "none",
+      create_default_organisation: false,
+      lead_organisations: [organisation],
+    )
+
+    editorial_remark = "Update access limiting to custom organisations."
+
+    patch :update,
+          params: {
+            id: edition,
+            edition: {
+              lead_organisation_ids: [organisation.id],
+              access_limiting: "organisations",
+              access_limiting_organisation_ids: [organisation.id.to_s],
+              editorial_remark: editorial_remark,
+            },
+          }
+
+    assert_redirected_to admin_editions_path
+    assert_equal "organisations", edition.reload.access_limiting
+    assert edition.access_limiting_organisations.exists?(id: organisation.id)
+    assert_equal "Access updated for #{edition.title}", flash[:notice]
+    assert_equal "Access options updated by GDS Admin: #{editorial_remark}", edition.editorial_remarks.last.body
+  end
+
+  # access_limiting_organisations_ui is on
+  test "PATCH :update changes access limiting from 'organisations' to 'none', clears access limiting organisations, and creates an editorial remark" do
+    feature_flags.switch! :access_limiting_organisations_ui, true
+
+    organisation = create(:organisation)
+    edition = create(
+      :consultation,
+      access_limiting: "organisations",
+      create_default_organisation: false,
+      lead_organisations: [organisation],
+      access_limiting_organisation_ids: [organisation.id],
+    )
+    editorial_remark = "Removing access limited at the users request."
+
+    patch :update,
+          params: {
+            id: edition,
+            edition: {
+              lead_organisation_ids: [organisation.id],
+              access_limiting: "none",
+              access_limiting_organisation_ids: [organisation.id],
+              editorial_remark: editorial_remark,
+            },
+          }
+
+    assert_redirected_to admin_editions_path
+    assert_equal "none", edition.reload.access_limiting
+    assert_empty edition.access_limiting_organisations
+    assert_equal "Access updated for #{edition.title}", flash[:notice]
+    assert_equal "Access options updated by GDS Admin: #{editorial_remark}", edition.editorial_remarks.last.body
+  end
+
+  # access_limiting_organisations_ui flag is off
+  test "PATCH :update fails and re-renders edit template if editorial remark is not provided" do
     first_organisation = create(:organisation)
     second_organisation = create(:organisation)
 
@@ -132,47 +261,118 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
       supporting_organisations: [second_organisation],
     )
 
-    put :update,
-        params: {
-          id: edition,
-          edition: {
-            lead_organisation_ids: [first_organisation.id],
-            supporting_organisation_ids: [second_organisation.id],
-            editorial_remark: "",
-            access_limiting: "none",
-          },
-        }
+    patch :update,
+          params: {
+            id: edition,
+            edition: {
+              lead_organisation_ids: [first_organisation.id],
+              supporting_organisation_ids: [second_organisation.id],
+              editorial_remark: "",
+              access_limiting: "none",
+            },
+          }
 
     assert_template :edit
     assert_equal ["Editorial remark cannot be blank"], assigns(:edition).errors.full_messages
     assert edition.reload.access_limited?
   end
 
-  test "PATCH :update doesn't create an editorial remark or re-render with an error when nothing has changed" do
-    first_organisation = create(:organisation)
-    second_organisation = create(:organisation)
-
+  # access_limiting_organisations_ui is on
+  test "PATCH :update fails and re-renders edit template when editorial remark is not provided" do
+    feature_flags.switch! :access_limiting_organisations_ui, true
+    organisation = create(:organisation)
     edition = create(
       :consultation,
       access_limiting: "organisations",
       create_default_organisation: false,
-      lead_organisations: [first_organisation],
-      supporting_organisations: [second_organisation],
+      lead_organisations: [organisation],
+      access_limiting_organisation_ids: [organisation.id],
     )
 
-    put :update,
-        params: {
-          id: edition,
-          edition: {
-            lead_organisation_ids: [first_organisation.id],
-            supporting_organisation_ids: [second_organisation.id],
-            editorial_remark: "",
-            access_limiting: "organisations",
-          },
-        }
+    patch :update,
+          params: {
+            id: edition,
+            edition: {
+              lead_organisation_ids: [organisation.id],
+              editorial_remark: "",
+              access_limiting: "none",
+            },
+          }
 
-    assert_redirected_to admin_editions_path
-    assert_equal "Access updated for #{edition.title}", flash[:notice]
-    assert_equal 0, edition.editorial_remarks.count
+    assert_template :edit
+    assert_equal "organisations", edition.reload.access_limiting
+    assert_equal ["Editorial remark cannot be blank"], assigns(:edition).errors.full_messages
+  end
+
+  # access_limiting_organisations_ui is on
+  view_test "PATCH :update fails and renders edit template with submitted access limiting organisations, when access limiting organisations empty" do
+    feature_flags.switch! :access_limiting_organisations_ui, true
+
+    organisation = create(:organisation)
+    edition = create(
+      :consultation,
+      access_limiting: "organisations",
+      create_default_organisation: false,
+      lead_organisations: [organisation],
+      access_limiting_organisation_ids: [organisation.id],
+    )
+
+    patch :update,
+          params: {
+            id: edition,
+            edition: {
+              lead_organisation_ids: [organisation.id],
+              access_limiting: "organisations",
+              access_limiting_organisation_ids: [""],
+              editorial_remark: "Test",
+            },
+          }
+
+    assert_template :edit
+    assert_select ".govuk-error-summary a", text: "Access limiting organisation ids must include at least one organisation", href: "#access_limiting_organisation_ids"
+    assert_select "form#edit_edition" do
+      assert_select "input[name='edition[access_limiting]'][value='organisations'][checked=checked]"
+      assert_select "select[name='edition[access_limiting_organisation_ids][]']" do
+        refute_select "option[selected='selected'][value='#{organisation.id}']"
+      end
+    end
+    assert_equal "organisations", edition.reload.access_limiting
+    assert edition.access_limiting_organisations.exists?(id: organisation.id)
+  end
+
+  # access_limiting_organisations_ui is on
+  view_test "PATCH :update re-renders the edit template with the submitted access limiting organisations and editorial remark, when unrelated field fails validation" do
+    feature_flags.switch! :access_limiting_organisations_ui, true
+
+    organisation = create(:organisation)
+    new_organisation = create(:organisation)
+    edition = create(
+      :consultation,
+      access_limiting: "organisations",
+      create_default_organisation: false,
+      lead_organisations: [organisation],
+      access_limiting_organisation_ids: [organisation.id],
+    )
+
+    patch :update,
+          params: {
+            id: edition,
+            edition: {
+              lead_organisation_ids: [""],
+              access_limiting: "organisations",
+              access_limiting_organisation_ids: [organisation.id, new_organisation.id],
+              editorial_remark: "Test",
+            },
+          }
+
+    assert_template :edit
+    assert_equal ["Lead organisation ids at least one required"], assigns(:edition).errors.full_messages
+    assert_select "input[name='edition[access_limiting]'][value='organisations'][checked=checked]"
+    assert_select "select[name='edition[access_limiting_organisation_ids][]']" do
+      assert_select "option[selected='selected'][value='#{organisation.id}']"
+      assert_select "option[selected='selected'][value='#{new_organisation.id}']"
+    end
+    assert_select "textarea[name='edition[editorial_remark]']", text: "Test"
+    assert_equal [organisation.id], edition.reload.access_limiting_organisation_ids
   end
 end

--- a/test/functional/admin/fatality_notices_controller_test.rb
+++ b/test/functional/admin/fatality_notices_controller_test.rb
@@ -18,7 +18,7 @@ class Admin::FatalityNoticesControllerTest < ActionController::TestCase
   should_allow_overriding_of_first_published_at_for :fatality_notice
   should_have_summary :fatality_notice
   should_allow_scheduled_publication_of :fatality_notice
-  should_allow_access_limiting_of :fatality_notice
+  access_limiting_organisations_ui_off_should_allow_access_limiting_of :fatality_notice
   access_limiting_organisations_ui_on_should_allow_access_limiting_of :fatality_notice
   should_render_govspeak_history_and_fact_checking_tabs_for :fatality_notice
 

--- a/test/functional/admin/fatality_notices_controller_test.rb
+++ b/test/functional/admin/fatality_notices_controller_test.rb
@@ -19,6 +19,7 @@ class Admin::FatalityNoticesControllerTest < ActionController::TestCase
   should_have_summary :fatality_notice
   should_allow_scheduled_publication_of :fatality_notice
   should_allow_access_limiting_of :fatality_notice
+  access_limiting_organisations_ui_on_should_allow_access_limiting_of :fatality_notice
   should_render_govspeak_history_and_fact_checking_tabs_for :fatality_notice
 
   view_test "show renders the summary" do

--- a/test/functional/admin/publications_controller_test.rb
+++ b/test/functional/admin/publications_controller_test.rb
@@ -22,6 +22,7 @@ class Admin::PublicationsControllerTest < ActionController::TestCase
   should_allow_alternative_format_provider_for :publication
   should_allow_scheduled_publication_of :publication
   should_allow_access_limiting_of :publication
+  access_limiting_organisations_ui_on_should_allow_access_limiting_of :publication
   should_render_govspeak_history_and_fact_checking_tabs_for :publication
   should_allow_overriding_of_first_published_at_for :publication
 

--- a/test/functional/admin/publications_controller_test.rb
+++ b/test/functional/admin/publications_controller_test.rb
@@ -21,7 +21,7 @@ class Admin::PublicationsControllerTest < ActionController::TestCase
   should_allow_association_between_world_locations_and :publication
   should_allow_alternative_format_provider_for :publication
   should_allow_scheduled_publication_of :publication
-  should_allow_access_limiting_of :publication
+  access_limiting_organisations_ui_off_should_allow_access_limiting_of :publication
   access_limiting_organisations_ui_on_should_allow_access_limiting_of :publication
   should_render_govspeak_history_and_fact_checking_tabs_for :publication
   should_allow_overriding_of_first_published_at_for :publication

--- a/test/functional/admin/speeches_controller_test.rb
+++ b/test/functional/admin/speeches_controller_test.rb
@@ -13,6 +13,7 @@ class Admin::SpeechesControllerTest < ActionController::TestCase
   should_allow_association_between_world_locations_and :speech
   should_allow_scheduled_publication_of :speech
   should_allow_access_limiting_of :speech
+  access_limiting_organisations_ui_on_should_allow_access_limiting_of :speech
   should_allow_association_with_topical_events :speech
   should_allow_association_with_topical_event_documents :speech
 

--- a/test/functional/admin/speeches_controller_test.rb
+++ b/test/functional/admin/speeches_controller_test.rb
@@ -12,7 +12,7 @@ class Admin::SpeechesControllerTest < ActionController::TestCase
 
   should_allow_association_between_world_locations_and :speech
   should_allow_scheduled_publication_of :speech
-  should_allow_access_limiting_of :speech
+  access_limiting_organisations_ui_off_should_allow_access_limiting_of :speech
   access_limiting_organisations_ui_on_should_allow_access_limiting_of :speech
   should_allow_association_with_topical_events :speech
   should_allow_association_with_topical_event_documents :speech

--- a/test/functional/admin/statistical_data_sets_controller_test.rb
+++ b/test/functional/admin/statistical_data_sets_controller_test.rb
@@ -15,7 +15,7 @@ class Admin::StatisticalDataSetsControllerTest < ActionController::TestCase
   should_allow_alternative_format_provider_for :statistical_data_set
   should_allow_overriding_of_first_published_at_for :statistical_data_set
   should_allow_scheduled_publication_of :statistical_data_set
-  should_allow_access_limiting_of :statistical_data_set
+  access_limiting_organisations_ui_off_should_allow_access_limiting_of :statistical_data_set
   access_limiting_organisations_ui_on_should_allow_access_limiting_of :statistical_data_set
 
   def controller_attributes_for(edition_type, attributes = {})

--- a/test/functional/admin/statistical_data_sets_controller_test.rb
+++ b/test/functional/admin/statistical_data_sets_controller_test.rb
@@ -16,6 +16,7 @@ class Admin::StatisticalDataSetsControllerTest < ActionController::TestCase
   should_allow_overriding_of_first_published_at_for :statistical_data_set
   should_allow_scheduled_publication_of :statistical_data_set
   should_allow_access_limiting_of :statistical_data_set
+  access_limiting_organisations_ui_on_should_allow_access_limiting_of :statistical_data_set
 
   def controller_attributes_for(edition_type, attributes = {})
     super.except(:alternative_format_provider).reverse_merge(

--- a/test/functional/admin/worldwide_organisations_controller_test.rb
+++ b/test/functional/admin/worldwide_organisations_controller_test.rb
@@ -11,7 +11,7 @@ class Admin::WorldwideOrganisationsControllerTest < ActionController::TestCase
   should_allow_editing_of :worldwide_organisation
   should_allow_only_lead_organisations_for :worldwide_organisation
   should_allow_scheduled_publication_of :worldwide_organisation
-  should_allow_access_limiting_of :worldwide_organisation
+  access_limiting_organisations_ui_off_should_allow_access_limiting_of :worldwide_organisation
   access_limiting_organisations_ui_on_should_allow_access_limiting_of :worldwide_organisation
   should_allow_association_between_roles_and :worldwide_organisation
   should_allow_association_between_world_locations_and :worldwide_organisation

--- a/test/functional/admin/worldwide_organisations_controller_test.rb
+++ b/test/functional/admin/worldwide_organisations_controller_test.rb
@@ -12,6 +12,7 @@ class Admin::WorldwideOrganisationsControllerTest < ActionController::TestCase
   should_allow_only_lead_organisations_for :worldwide_organisation
   should_allow_scheduled_publication_of :worldwide_organisation
   should_allow_access_limiting_of :worldwide_organisation
+  access_limiting_organisations_ui_on_should_allow_access_limiting_of :worldwide_organisation
   should_allow_association_between_roles_and :worldwide_organisation
   should_allow_association_between_world_locations_and :worldwide_organisation
 

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -962,6 +962,243 @@ module AdminEditionControllerTestHelpers
       end
     end
 
+    def access_limiting_organisations_ui_on_should_allow_access_limiting_of(edition_type)
+      edition_class = class_for(edition_type)
+
+      view_test "new should preselect the 'none' radio button option for access limiting" do
+        feature_flags.switch! :access_limiting_organisations_ui, true
+
+        organisation = create(:organisation)
+        controller.current_user.organisation = organisation
+        controller.current_user.save!
+
+        get :new
+
+        assert_select "form#new_edition" do
+          assert_select "input[name='edition[access_limiting]'][type=radio][value='none'][checked='checked']", count: 1
+          assert_select "input[name='edition[access_limiting]'][type=radio][value='organisations'][checked='checked']", count: 0
+        end
+      end
+
+      test "create should save with access limiting set to 'none'" do
+        feature_flags.switch! :access_limiting_organisations_ui, true
+
+        post :create,
+             params: {
+               edition: controller_attributes_for(edition_type).merge(
+                 access_limiting: "none",
+               ),
+             }
+
+        created_edition = edition_class.last
+        assert_equal "none", created_edition.access_limiting
+        assert_empty created_edition.access_limiting_organisations
+      end
+
+      test "create should save with access limiting set to 'organisations'" do
+        feature_flags.switch! :access_limiting_organisations_ui, true
+
+        organisation = create(:organisation)
+        controller.current_user.organisation = organisation
+        controller.current_user.save!
+
+        post :create,
+             params: {
+               edition: controller_attributes_for(edition_type).merge(
+                 lead_organisation_ids: [organisation.id],
+                 access_limiting: "organisations",
+                 access_limiting_organisation_ids: [organisation.id],
+               ),
+             }
+
+        created_edition = edition_class.last
+        assert_equal "organisations", created_edition.access_limiting
+        assert created_edition.access_limiting_organisations.exists?(id: organisation.id)
+      end
+
+      view_test "create fails and rerenders new template, when access limiting organisations invalid" do
+        feature_flags.switch! :access_limiting_organisations_ui, true
+
+        user_organisation = create(:organisation)
+        controller.current_user.organisation = user_organisation
+        controller.current_user.save!
+
+        assert_no_difference -> { edition_class.count } do
+          post :create,
+               params: {
+                 edition: controller_attributes_for(edition_type).merge(
+                   lead_organisation_ids: [user_organisation.id],
+                   access_limiting: "organisations",
+                   access_limiting_organisation_ids: [""],
+                 ),
+               }
+        end
+
+        assert_template :new
+        assert_select ".govuk-error-summary a", text: "Access limiting organisation ids must include at least one organisation", href: "#access_limiting_organisation_ids"
+        assert_select "form#new_edition" do
+          assert_select "input[name='edition[access_limiting]'][value='organisations'][checked=checked]"
+          assert_select "select[name='edition[access_limiting_organisation_ids][]']" do
+            refute_select "option[selected='selected']"
+          end
+        end
+      end
+
+      view_test "create fails and rerenders with submitted access limiting organisations, when failing validation of unrelated field" do
+        feature_flags.switch! :access_limiting_organisations_ui, true
+
+        user_organisation = create(:organisation)
+        controller.current_user.organisation = user_organisation
+        controller.current_user.save!
+
+        assert_no_difference -> { edition_class.count } do
+          post :create,
+               params: {
+                 edition: controller_attributes_for(edition_type).merge(
+                   lead_organisation_ids: [user_organisation.id],
+                   access_limiting: "organisations",
+                   access_limiting_organisation_ids: [user_organisation.id],
+                   title: "",
+                 ),
+               }
+        end
+
+        assert_template :new
+        assert_select "form#new_edition" do
+          assert_select "input[name='edition[access_limiting]'][value='organisations'][checked=checked]"
+          assert_select "select[name='edition[access_limiting_organisation_ids][]']" do
+            assert_select "option[selected='selected'][value='#{user_organisation.id}']"
+          end
+        end
+      end
+
+      view_test "edit should display persisted access limiting value" do
+        feature_flags.switch! :access_limiting_organisations_ui, true
+
+        organisation = create(:organisation)
+        controller.current_user.organisation = organisation
+        controller.current_user.save!
+
+        edition = create(edition_type, access_limiting: "organisations", access_limiting_organisation_ids: [organisation.id])
+
+        get :edit, params: { id: edition }
+
+        assert_select "form#edit_edition" do
+          assert_select "input[name='edition[access_limiting]'][type=radio][value='organisations'][checked='checked']", count: 1
+          assert_select "input[name='edition[access_limiting]'][type=radio][value='none'][checked='checked']", count: 0
+        end
+      end
+
+      test "update should change access limiting, from 'none' to 'organisations'" do
+        feature_flags.switch! :access_limiting_organisations_ui, true
+
+        organisation = create(:organisation)
+        controller.current_user.organisation = organisation
+        controller.current_user.save!
+
+        edition = create(edition_type, access_limiting: "none")
+
+        put :update,
+            params: {
+              id: edition,
+              edition: {
+                lead_organisation_ids: [organisation.id],
+                access_limiting: "organisations",
+                access_limiting_organisation_ids: [organisation.id],
+              },
+            }
+
+        assert_equal "organisations", edition.reload.access_limiting
+        assert edition.access_limiting_organisations.exists?(id: organisation.id)
+      end
+
+      test "update should change access limiting, from 'organisations' to 'none', and clear the organisations" do
+        feature_flags.switch! :access_limiting_organisations_ui, true
+
+        organisation = create(:organisation)
+        controller.current_user.organisation = organisation
+        controller.current_user.save!
+
+        edition = create(edition_type, access_limiting: "organisations", access_limiting_organisation_ids: [organisation.id])
+
+        # The form still submits the old organisation ids when switching radio button selection. We clear them in the controller.
+        put :update,
+            params: {
+              id: edition,
+              edition: {
+                lead_organisation_ids: [organisation.id],
+                access_limiting: "none",
+                access_limiting_organisation_ids: [organisation.id],
+              },
+            }
+
+        assert_equal "none", edition.reload.access_limiting
+        assert edition.access_limiting_organisations.empty?
+      end
+
+      view_test "update fails and rerenders with submitted access limiting organisations, when access limiting organisations invalid" do
+        feature_flags.switch! :access_limiting_organisations_ui, true
+
+        organisation = create(:organisation)
+        controller.current_user.organisation = organisation
+        controller.current_user.save!
+
+        edition = create(edition_type, access_limiting: "organisations", access_limiting_organisation_ids: [organisation.id])
+
+        put :update,
+            params: {
+              id: edition,
+              edition: {
+                access_limiting: "organisations",
+                access_limiting_organisation_ids: [""],
+                lead_organisation_ids: [organisation.id],
+              },
+            }
+
+        assert_template :edit
+        assert_select "form#edit_edition" do
+          assert_select "input[name='edition[access_limiting]'][value='organisations'][checked=checked]"
+          assert_select "select[name='edition[access_limiting_organisation_ids][]']" do
+            refute_select "option[selected='selected'][value='#{organisation.id}']"
+          end
+        end
+        assert_select ".govuk-error-summary a", text: "Access limiting organisation ids must include at least one organisation", href: "#access_limiting_organisation_ids"
+        assert_equal "organisations", edition.reload.access_limiting
+        assert edition.reload.access_limiting_organisations.exists?(id: organisation.id)
+      end
+
+      view_test "update fails and re-renders with the submitted access limiting organisations, when unrelated field fails validation" do
+        feature_flags.switch! :access_limiting_organisations_ui, true
+
+        organisation = create(:organisation)
+        new_organisation = create(:organisation)
+        controller.current_user.organisation = organisation
+        controller.current_user.save!
+
+        edition = create(edition_type, access_limiting: "organisations", access_limiting_organisation_ids: [organisation.id])
+
+        put :update,
+            params: {
+              id: edition,
+              edition: {
+                title: "",
+                access_limiting: "organisations",
+                access_limiting_organisation_ids: [organisation.id, new_organisation.id],
+                lead_organisation_ids: [organisation.id],
+              },
+            }
+
+        assert_select "form#edit_edition" do
+          assert_select "input[name='edition[access_limiting]'][value='organisations'][checked=checked]"
+          assert_select "select[name='edition[access_limiting_organisation_ids][]']" do
+            assert_select "option[selected='selected'][value='#{organisation.id}']"
+            assert_select "option[selected='selected'][value='#{new_organisation.id}']"
+          end
+        end
+        assert_equal [organisation.id], edition.reload.access_limiting_organisation_ids
+      end
+    end
+
     def should_allow_access_limiting_of(edition_type)
       edition_class = class_for(edition_type)
 

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -1257,7 +1257,7 @@ module AdminEditionControllerTestHelpers
       end
     end
 
-    def should_allow_access_limiting_of(edition_type)
+    def access_limiting_organisations_ui_off_should_allow_access_limiting_of(edition_type)
       edition_class = class_for(edition_type)
 
       test "create should record the access_limiting flag" do

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -1072,6 +1072,35 @@ module AdminEditionControllerTestHelpers
         end
       end
 
+      view_test "create fails and rerenders with submitted access limiting organisations, when user does not belong to one of the access limiting organisations" do
+        feature_flags.switch! :access_limiting_organisations_ui, true
+
+        user_organisation = create(:organisation)
+        controller.current_user.organisation = user_organisation
+        controller.current_user.save!
+        access_limiting_organisation = create(:organisation)
+
+        assert_no_difference -> { edition_class.count } do
+          post :create,
+               params: {
+                 edition: controller_attributes_for(edition_type).merge(
+                   lead_organisation_ids: [user_organisation.id],
+                   access_limiting: "organisations",
+                   access_limiting_organisation_ids: [access_limiting_organisation.id],
+                 ),
+               }
+        end
+
+        assert_template :new
+        assert_select ".govuk-error-summary a", text: "Access limiting organisation ids must include your own organisation", href: "#access_limiting_organisation_ids"
+        assert_select "form#new_edition" do
+          assert_select "input[name='edition[access_limiting]'][value='organisations'][checked=checked]"
+          assert_select "select[name='edition[access_limiting_organisation_ids][]']" do
+            assert_select "option[selected='selected'][value='#{access_limiting_organisation.id}']"
+          end
+        end
+      end
+
       view_test "edit should display persisted access limiting value" do
         feature_flags.switch! :access_limiting_organisations_ui, true
 
@@ -1197,6 +1226,35 @@ module AdminEditionControllerTestHelpers
         end
         assert_equal [organisation.id], edition.reload.access_limiting_organisation_ids
       end
+
+      view_test "update fails and rerenders with submitted access limiting organisations, when user does not belong to one of the access limiting organisations" do
+        feature_flags.switch! :access_limiting_organisations_ui, true
+
+        user_organisation = create(:organisation)
+        controller.current_user.organisation = user_organisation
+        controller.current_user.save!
+        access_limiting_organisation = create(:organisation)
+
+        edition = create(edition_type, access_limiting: "organisations", access_limiting_organisation_ids: [user_organisation.id])
+
+        put :update,
+            params: {
+              id: edition,
+              edition: {
+                lead_organisation_ids: [user_organisation.id],
+                access_limiting: "organisations",
+                access_limiting_organisation_ids: [access_limiting_organisation.id],
+              },
+            }
+
+        assert_template :edit
+        assert_select "form#edit_edition" do
+          assert_select "select[name='edition[access_limiting_organisation_ids][]']" do
+            assert_select "option[selected='selected'][value='#{access_limiting_organisation.id}']"
+          end
+        end
+        assert_equal user_organisation.id, edition.reload.access_limiting_organisation_ids.first
+      end
     end
 
     def should_allow_access_limiting_of(edition_type)
@@ -1263,7 +1321,7 @@ module AdminEditionControllerTestHelpers
             }
 
         assert_not edition.reload.access_limited?
-        assert_select "div[role='alert']", text: "Access can only be limited by users belonging to an organisation tagged to the document"
+        assert_select ".gem-c-error-summary__list-item", text: "Lead or supporting organisations must include your own organisation"
       end
     end
 

--- a/test/unit/app/models/edition/creating_draft_test.rb
+++ b/test/unit/app/models/edition/creating_draft_test.rb
@@ -156,4 +156,19 @@ class Edition::WorkflowTest < ActiveSupport::TestCase
 
     assert_equal "logos/flag.jpeg", draft_edition.logo_url
   end
+
+  test "should not set access limiting on new drafts of a live document" do
+    organisation = create(:organisation)
+    published_edition = create(
+      :consultation,
+      :published,
+      access_limiting: :none,
+      create_default_organisation: false,
+      lead_organisations: [organisation],
+    )
+    new_draft = published_edition.create_draft(create(:writer))
+
+    assert new_draft.access_limiting_none?
+    assert_empty new_draft.access_limiting_organisations
+  end
 end

--- a/test/unit/app/models/edition/limited_access_test.rb
+++ b/test/unit/app/models/edition/limited_access_test.rb
@@ -62,6 +62,51 @@ class Edition::LimitedAccessTest < ActiveSupport::TestCase
     assert edition.accessible_to?(user)
   end
 
+  test "is invalid when access_limiting is set to 'organisations' and no access limiting organisations are selected" do
+    @feature_flags.switch!(:access_limiting_organisations_ui, true)
+
+    edition = create(:edition)
+    edition.access_limiting = :organisations
+    edition.access_limiting_organisation_ids = []
+
+    assert_not edition.valid?
+    assert_includes edition.errors[:access_limiting_organisation_ids],
+                    "must include at least one organisation when access limiting is enabled"
+  end
+
+  test "is valid when access_limiting is set to 'organisations' and access limiting organisations are present" do
+    @feature_flags.switch!(:access_limiting_organisations_ui, true)
+    org = create(:organisation)
+
+    edition = create(:edition)
+    edition.access_limiting = :organisations
+    edition.access_limiting_organisation_ids = [org.id]
+
+    assert edition.valid?
+  end
+
+  test "is valid when access_limiting is set to 'none' regardless of access limiting organisations" do
+    @feature_flags.switch!(:access_limiting_organisations_ui, true)
+
+    edition = create(:limited_access_edition, access_limiting: :none)
+    edition.access_limiting_organisation_ids = []
+    assert edition.valid?
+  end
+
+  test "is valid when access_limiting is set to 'organisations' and no access limiting organisations are selected when flag is off" do
+    edition = create(:consultation, access_limiting: :organisations)
+    edition.access_limiting_organisation_ids = []
+    assert edition.valid?
+  end
+
+  test "is invalid when access_limiting is set to 'organisations' and no edition organisations are selected when flag is off" do
+    edition = create(:consultation, access_limiting: :organisations)
+    edition.organisation_ids = []
+
+    assert_not edition.valid?
+    assert_includes edition.errors[:lead_organisation_ids], "at least one required"
+  end
+
   test "setting access_limiting writes through to the legacy access_limited column" do
     edition = build(:limited_access_edition)
 

--- a/test/unit/app/models/edition/limited_access_test.rb
+++ b/test/unit/app/models/edition/limited_access_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class Edition::LimitedAccessTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
   class LimitedAccessEdition < Edition
     include Edition::LimitedAccess
     include Edition::Organisations
@@ -62,49 +64,126 @@ class Edition::LimitedAccessTest < ActiveSupport::TestCase
     assert edition.accessible_to?(user)
   end
 
-  test "is invalid when access_limiting is set to 'organisations' and no access limiting organisations are selected" do
-    @feature_flags.switch!(:access_limiting_organisations_ui, true)
+  context "with access_limiting_organisations_ui flag on" do
+    test "is valid when access_limiting is set to 'organisations' and access limiting organisations are present" do
+      @feature_flags.switch!(:access_limiting_organisations_ui, true)
+      org = create(:organisation)
 
-    edition = create(:edition)
-    edition.access_limiting = :organisations
-    edition.access_limiting_organisation_ids = []
+      edition = build(:edition)
+      edition.access_limiting = :organisations
+      edition.access_limiting_organisation_ids = [org.id]
 
-    assert_not edition.valid?
-    assert_includes edition.errors[:access_limiting_organisation_ids],
-                    "must include at least one organisation when access limiting is enabled"
+      assert edition.valid?
+    end
+
+    test "is valid when access_limiting is set to 'none' regardless of access limiting organisations" do
+      @feature_flags.switch!(:access_limiting_organisations_ui, true)
+
+      edition = build(:limited_access_edition, access_limiting: :none)
+      edition.access_limiting_organisation_ids = []
+      assert edition.valid?
+    end
+
+    test "is invalid when access_limiting is set to 'organisations' and no access limiting organisations are present" do
+      @feature_flags.switch!(:access_limiting_organisations_ui, true)
+
+      edition = build(:limited_access_edition, access_limiting: :organisations)
+      edition.access_limiting_organisation_ids = []
+
+      assert_not edition.valid?
+      assert_includes edition.errors[:access_limiting_organisation_ids], "must include at least one organisation"
+    end
+
+    test "create does not persist edition with invalid access_limiting_organisations" do
+      @feature_flags.switch!(:access_limiting_organisations_ui, true)
+      edition = build(:limited_access_edition, access_limiting: "organisations")
+      edition.access_limiting_organisation_ids = []
+
+      assert_no_changes -> { AccessLimitingOrganisation.count } do
+        assert_not edition.save
+      end
+      assert_equal [], edition.access_limiting_organisation_ids
+    end
+
+    test "create does not persist edition with valid access_limiting_organisations when another field is invalid" do
+      @feature_flags.switch!(:access_limiting_organisations_ui, true)
+      org = create(:organisation)
+      edition = build(:limited_access_edition, access_limiting: "organisations", access_limiting_organisation_ids: [org.id])
+      edition.title = ""
+
+      assert_no_changes -> { AccessLimitingOrganisation.count } do
+        assert_not edition.save
+      end
+      assert_equal [org.id], edition.access_limiting_organisation_ids
+    end
+
+    test "creates and updates edition with access limiting organisations" do
+      @feature_flags.switch!(:access_limiting_organisations_ui, true)
+      original_org = create(:organisation)
+      edition = create(:limited_access_edition, access_limiting: "organisations", access_limiting_organisation_ids: [original_org.id])
+
+      assert_equal [original_org.id], edition.reload.edition_access_limiting_organisations.map(&:organisation_id)
+
+      new_org = create(:organisation)
+      edition.access_limiting_organisation_ids = [new_org.id]
+      edition.save!
+
+      assert_equal [new_org.id], edition.reload.edition_access_limiting_organisations.map(&:organisation_id)
+    end
+
+    test "update does not persist valid access_limiting_organisations on assignment" do
+      @feature_flags.switch!(:access_limiting_organisations_ui, true)
+      original_org = create(:organisation)
+      edition = create(:limited_access_edition, access_limiting: "organisations", access_limiting_organisation_ids: [original_org.id])
+
+      updated_org = create(:organisation)
+      edition.access_limiting_organisation_ids = [updated_org.id]
+
+      assert_equal [original_org.id], edition.reload.edition_access_limiting_organisations.map(&:organisation_id)
+    end
+
+    test "update does not persist invalid assigned access_limiting_organisations" do
+      @feature_flags.switch!(:access_limiting_organisations_ui, true)
+
+      old_org = create(:organisation)
+      edition = create(:limited_access_edition, access_limiting: "organisations", access_limiting_organisation_ids: [old_org.id])
+      edition.access_limiting_organisation_ids = []
+
+      assert_not edition.save
+      assert_includes edition.errors[:access_limiting_organisation_ids], "must include at least one organisation"
+      assert_equal [], edition.access_limiting_organisation_ids # In-memory should show the cleared value the user set
+      assert_equal [old_org.id], edition.reload.edition_access_limiting_organisations.map(&:organisation_id) # DB should remain unchanged (still the original org)
+    end
+
+    test "update does not persist valid assigned access_limiting_organisations when another field is invalid" do
+      @feature_flags.switch!(:access_limiting_organisations_ui, true)
+
+      old_org = create(:organisation)
+      edition = create(:limited_access_edition, access_limiting: "organisations", access_limiting_organisation_ids: [old_org.id])
+      new_org = create(:organisation)
+      edition.access_limiting_organisation_ids = [new_org.id]
+      edition.title = ""
+
+      assert_not edition.save
+      assert_equal [new_org.id], edition.access_limiting_organisation_ids # In-memory should reflect the newly assigned orgs
+      assert_equal [old_org.id], edition.reload.edition_access_limiting_organisations.map(&:organisation_id) # DB should remain unchanged (still the original org)
+    end
   end
 
-  test "is valid when access_limiting is set to 'organisations' and access limiting organisations are present" do
-    @feature_flags.switch!(:access_limiting_organisations_ui, true)
-    org = create(:organisation)
+  context "with access_limiting_organisations_ui flag off" do
+    test "is valid when access_limiting is set to 'organisations' and no access limiting organisations are selected" do
+      edition = create(:consultation, access_limiting: :organisations)
+      edition.access_limiting_organisation_ids = []
+      assert edition.valid?
+    end
 
-    edition = create(:edition)
-    edition.access_limiting = :organisations
-    edition.access_limiting_organisation_ids = [org.id]
+    test "is invalid when access_limiting is set to 'organisations' and no edition organisations are selected" do
+      edition = create(:consultation, access_limiting: :organisations)
+      edition.organisation_ids = []
 
-    assert edition.valid?
-  end
-
-  test "is valid when access_limiting is set to 'none' regardless of access limiting organisations" do
-    @feature_flags.switch!(:access_limiting_organisations_ui, true)
-
-    edition = create(:limited_access_edition, access_limiting: :none)
-    edition.access_limiting_organisation_ids = []
-    assert edition.valid?
-  end
-
-  test "is valid when access_limiting is set to 'organisations' and no access limiting organisations are selected when flag is off" do
-    edition = create(:consultation, access_limiting: :organisations)
-    edition.access_limiting_organisation_ids = []
-    assert edition.valid?
-  end
-
-  test "is invalid when access_limiting is set to 'organisations' and no edition organisations are selected when flag is off" do
-    edition = create(:consultation, access_limiting: :organisations)
-    edition.organisation_ids = []
-
-    assert_not edition.valid?
-    assert_includes edition.errors[:lead_organisation_ids], "at least one required"
+      assert_not edition.valid?
+      assert_includes edition.errors[:lead_organisation_ids], "at least one required"
+    end
   end
 
   test "setting access_limiting writes through to the legacy access_limited column" do

--- a/test/unit/app/models/edition/limited_access_test.rb
+++ b/test/unit/app/models/edition/limited_access_test.rb
@@ -94,6 +94,30 @@ class Edition::LimitedAccessTest < ActiveSupport::TestCase
       assert_includes edition.errors[:access_limiting_organisation_ids], "must include at least one organisation"
     end
 
+    test "is invalid when user does not have an organisation" do
+      @feature_flags.switch!(:access_limiting_organisations_ui, true)
+      user = build(:user, organisation: nil)
+      edition = build(:limited_access_edition, access_limiting: "organisations", access_limiting_organisation_ids: [create(:organisation).id])
+      edition.current_user_for_validation = user
+
+      assert_invalid edition
+      assert_includes edition.errors[:access_limiting_organisation_ids], "must include your own organisation"
+    end
+
+    test "is invalid when the user's organisation is not included in the access limiting organisations" do
+      @feature_flags.switch!(:access_limiting_organisations_ui, true)
+      user_org = create(:organisation)
+      access_limiting_org = create(:organisation)
+      user = build(:user, organisation: user_org)
+
+      edition = build(:limited_access_edition, access_limiting: "organisations")
+      edition.access_limiting_organisation_ids = [access_limiting_org.id]
+      edition.current_user_for_validation = user
+
+      assert_not edition.valid?
+      assert_includes edition.errors[:access_limiting_organisation_ids], "must include your own organisation"
+    end
+
     test "create does not persist edition with invalid access_limiting_organisations" do
       @feature_flags.switch!(:access_limiting_organisations_ui, true)
       edition = build(:limited_access_edition, access_limiting: "organisations")
@@ -131,7 +155,7 @@ class Edition::LimitedAccessTest < ActiveSupport::TestCase
       assert_equal [new_org.id], edition.reload.edition_access_limiting_organisations.map(&:organisation_id)
     end
 
-    test "update does not persist valid access_limiting_organisations on assignment" do
+    test "update: does not persist valid access_limiting_organisations on assignment" do
       @feature_flags.switch!(:access_limiting_organisations_ui, true)
       original_org = create(:organisation)
       edition = create(:limited_access_edition, access_limiting: "organisations", access_limiting_organisation_ids: [original_org.id])
@@ -183,6 +207,26 @@ class Edition::LimitedAccessTest < ActiveSupport::TestCase
 
       assert_not edition.valid?
       assert_includes edition.errors[:lead_organisation_ids], "at least one required"
+    end
+
+    test "is invalid when user does not have an organisation" do
+      user = build(:user, organisation: nil)
+      edition = build(:limited_access_edition, access_limiting: "organisations")
+      edition.lead_organisation_ids = [create(:organisation).id]
+      edition.current_user_for_validation = user
+
+      assert_invalid edition
+      assert_includes edition.errors[:base], "Lead or supporting organisations must include your own organisation"
+    end
+
+    test "is invalid when the user's organisation is not included in the edition organisations" do
+      user_org = create(:organisation)
+      user = build(:user, organisation: user_org)
+      edition = build(:limited_access_edition, access_limiting: "organisations", lead_organisation_ids: [create(:organisation).id])
+      edition.current_user_for_validation = user
+
+      assert_not edition.valid?
+      assert_includes edition.errors[:base], "Lead or supporting organisations must include your own organisation"
     end
   end
 

--- a/test/unit/app/presenters/publishing_api/payload_builder/access_limitation_test.rb
+++ b/test/unit/app/presenters/publishing_api/payload_builder/access_limitation_test.rb
@@ -20,6 +20,39 @@ module PublishingApi
         assert_equal AccessLimitation.for(stubbed_item), expected_hash
       end
 
+      test "it returns access limiting organisations if access limiting is set to 'organisations', when feature flag is on" do
+        @feature_flags.switch!(:access_limiting_organisations_ui, true)
+        organisation = create(:organisation)
+
+        stubbed_item = stub(
+          access_limited?: true,
+          publicly_visible?: false,
+          access_limiting_organisations?: true,
+          access_limiting_organisations: [organisation],
+        )
+        expected_hash = {
+          access_limited: {
+            organisations: [organisation.content_id],
+          },
+        }
+
+        assert_equal AccessLimitation.for(stubbed_item), expected_hash
+      end
+
+      test "it returns an empty hash if access limiting is set to 'none', when feature flag is on" do
+        @feature_flags.switch!(:access_limiting_organisations_ui, true)
+        organisation = create(:organisation)
+
+        stubbed_item = stub(
+          access_limited?: false,
+          publicly_visible?: false,
+          access_limiting_organisations?: false,
+          access_limiting_organisations: [organisation],
+        )
+
+        assert_equal({}, AccessLimitation.for(stubbed_item))
+      end
+
       test "it returns an empty hash if the item is not access limited" do
         stubbed_item = stub(access_limited?: false, publicly_visible?: false)
 

--- a/test/unit/app/services/draft_edition_updater_test.rb
+++ b/test/unit/app/services/draft_edition_updater_test.rb
@@ -29,15 +29,6 @@ class DraftEditionUpdaterTest < ActiveSupport::TestCase
     updater.perform!
   end
 
-  test "cannot perform if user is limiting their own access" do
-    edition = create(:draft_publication, access_limiting: "organisations", organisations: [create(:organisation)])
-    updater = DraftEditionUpdater.new(edition, { current_user: create(:user, organisation: create(:organisation)) })
-    updater.expects(:notify!).never
-    updater.expects(:update_publishing_api!).never
-
-    updater.perform!
-  end
-
   test "updates editions that cannot be tagged to organisations" do
     organisation = create(:organisation)
     edition = create(:draft_corporate_information_page, organisation:, access_limiting: "organisations")

--- a/test/unit/app/services/edition_publisher_test.rb
+++ b/test/unit/app/services/edition_publisher_test.rb
@@ -19,6 +19,20 @@ class EditionPublisherTest < ActiveSupport::TestCase
     assert_not edition.access_limited?
   end
 
+  test "#perform! with an access limited edition sets access_limiting to 'none' and clears access_limiting_organisations" do
+    organisation = create(:organisation)
+    edition = create(
+      :submitted_edition,
+      :access_limited,
+      access_limiting_organisation_ids: [organisation.id],
+    )
+
+    assert EditionPublisher.new(edition).perform!
+    assert edition.published?
+    assert_equal "none", edition.access_limiting
+    assert_empty edition.access_limiting_organisations
+  end
+
   %w[published draft rejected superseded].each do |state|
     test "#{state} editions cannot be published" do
       edition = create(:"#{state}_edition")

--- a/test/unit/lib/whitehall/authority/edition_rules_test.rb
+++ b/test/unit/lib/whitehall/authority/edition_rules_test.rb
@@ -1,0 +1,91 @@
+require_relative "authority_test_helper"
+require "ostruct"
+
+class EditionRulesTest < ActiveSupport::TestCase
+  include AuthorityTestHelper
+
+  def user_in(organisation)
+    OpenStruct.new(
+      id: 1,
+      gds_editor?: false,
+      organisation:,
+    )
+  end
+
+  test "grants access when user's organisation is in access_limiting_organisations and flag is on" do
+    feature_flags.switch! :access_limiting_organisations_ui, true
+
+    org = build(:organisation)
+    user = user_in(org)
+
+    edition = build(:edition, access_limiting: "organisations")
+    edition.stubs(:access_limiting_organisations).returns([org])
+
+    assert enforcer_for(user, edition).can?(:see)
+  end
+
+  test "revokes access when the user's organisation is not in access_limiting_organisations and flag is on" do
+    feature_flags.switch! :access_limiting_organisations_ui, true
+
+    org1 = build(:organisation)
+    org2 = build(:organisation)
+    user = user_in(org1)
+
+    edition = build(:edition, access_limiting: "organisations")
+    edition.stubs(:access_limiting_organisations).returns([org2])
+
+    assert_not enforcer_for(user, edition).can?(:see)
+  end
+
+  test "grants access based on lead/supporting organisations when flag is off" do
+    org1 = build(:organisation)
+    org2 = build(:organisation)
+    user = user_in(org1)
+
+    edition = build(:consultation, access_limiting: "organisations")
+    edition.stubs(:organisations).returns([org1])
+    edition.stubs(:access_limiting_organisations).returns([org2])
+
+    assert enforcer_for(user, edition).can?(:see)
+  end
+
+  test "revokes access based on lead/supporting organisations when flag is off" do
+    org1 = build(:organisation)
+    org2 = build(:organisation)
+    user = user_in(org1)
+
+    edition = build(:consultation, access_limiting: "organisations")
+    edition.stubs(:organisations).returns([org2])
+
+    assert_not enforcer_for(user, edition).can?(:see)
+  end
+
+  test "grants access when access limiting is 'none'" do
+    edition = build(:edition, access_limiting: "none")
+    user = create(:user)
+
+    assert enforcer_for(user, edition).can?(:see)
+  end
+
+  test "revokes access when the user does not have an organisation, and flag is on" do
+    feature_flags.switch! :access_limiting_organisations_ui, true
+
+    org = build(:organisation)
+    user = create(:user, organisation: nil)
+
+    edition = build(:edition, access_limiting: "organisations")
+    edition.stubs(:access_limiting_organisations).returns([org])
+
+    assert_not enforcer_for(user, edition).can?(:see)
+  end
+
+  test "revokes access when the user does not have an organisation, and flag is off" do
+    org = create(:organisation)
+    user = create(:user, organisation: nil)
+
+    edition = build(:consultation, access_limiting: "organisations")
+    edition.stubs(:organisations).returns([org])
+
+    assert_not enforcer_for(user, edition).can?(:see)
+  end
+end

--- a/test/unit/lib/whitehall/authority/edition_rules_test.rb
+++ b/test/unit/lib/whitehall/authority/edition_rules_test.rb
@@ -88,4 +88,17 @@ class EditionRulesTest < ActiveSupport::TestCase
 
     assert_not enforcer_for(user, edition).can?(:see)
   end
+
+  test "revokes access when access_limiting it set to 'organisations', but there are no access_limiting_organisations on the edition, and flag is on" do
+    #  Special case to cover migration issues. In the latest validation this scenario is not really feasible.
+    feature_flags.switch! :access_limiting_organisations_ui, true
+
+    org1 = build(:organisation)
+    user = user_in(org1)
+
+    edition = build(:edition, access_limiting: "organisations")
+    edition.stubs(:access_limiting_organisations).returns([])
+
+    assert_not enforcer_for(user, edition).can?(:see)
+  end
 end


### PR DESCRIPTION
[JIRA 1](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?assignee=5caf4d888c2c1a75f3e46ef6&selectedIssue=WHIT-3543)
[JIRA 2](https://gov-uk.atlassian.net/browse/WHIT-3583)

**What**

Introduces a new radio-based access limiting UI for organisations, behind an :access_limiting_organisations_ui Flipflop feature flag, replacing the existing checkbox when the flag is enabled.

When the flag is off (default), existing behaviour is fully preserved — the checkbox renders and access limiting continues to use lead/supporting organisations.

When the flag is on:

- The checkbox is replaced with two radio options: "No access limiting" and "Organisation access limiting"
- Selecting "Organisation access limiting" reveals an organisation select with search

- For edition types that are access-limited by default (e.g. StatisticalDataSet, PlanForChangeLandingPage, official/national statistics Publication), the form pre-selects "Organisation access limiting" and pre-fills the org select with lead organisations

- Saving with "Organisation access limiting" and no org selected raises a validation error

- Switching to "No access limiting" clears any previously set access_limiting_organisations

**Why**

To prepare for a new workflow that prevents users getting locked out of documents. The feature flag allows safe rollout with the ability to revert instantly by flipping the flag back off.

**Testing**

To test, toggle it at /flipflop on integration or locally.

**Flag off**

-  Open any edition's main edit form — confirm checkbox renders, not radio buttons
-  Open any edition's edit_access_limited form — confirm checkbox renders
-  Save with access_limited checked and no access_limiting_organisations — confirm it saves successfully
-  Confirm existing behaviour is unchanged

**Flag on — main edit form (/edit)**

-  Confirm radio buttons replace the checkbox
-  Select "Organisation access limiting", pick an org, save — confirm access_limiting_organisations persists
-  Try saving with "Organisation access limiting" and no org — confirm validation error

**Flag on — edit_access_limited form**

-  Confirm radio buttons replace the checkbox
-  Select "Organisation access limiting", pick an org, add editorial remark, save — confirm redirect and data persists
-  Try saving with "Organisation access limiting" and no org — confirm validation error
-  Try saving with a change and no editorial remark — confirm blank remark error
-  Select "No access limiting", add remark, save — confirm access_limited is false and access_limiting_organisations is empty


**Flag on — default-access-limited types**

-  Open a StatisticalDataSet edit_access_limited form
-  Confirm "Organisation access limiting" is pre-selected automatically
-  Confirm org select is pre-filled with lead organisations

**Revert**

-  Disable access_limiting_organisations_ui at /flipflop
-  Confirm checkbox reappears immediately on both forms
-  Confirm existing access_limiting_organisations data is unaffected
