### PR TITLE
Change `taxon_required` to `taxon` [WHIT-3564]

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -77,7 +77,7 @@ class Admin::EditionsController < Admin::BaseController
   def show
     fetch_version_and_remark_trails
 
-    @edition_taxons = if @edition.requires_taxon?
+    @edition_taxons = if @edition.supports_taxon?
                         EditionTaxonsFetcher.new(@edition.content_id).fetch
                       else
                         []

--- a/app/models/concerns/standard_edition/taxon.rb
+++ b/app/models/concerns/standard_edition/taxon.rb
@@ -2,6 +2,12 @@ module StandardEdition::Taxon
   extend ActiveSupport::Concern
 
   def requires_taxon?
-    type_instance.settings["taxon_required"]
+    return unless supports_taxon?
+
+    type_instance.settings["taxon"]["required"]
+  end
+
+  def supports_taxon?
+    type_instance.settings["taxon"]["enabled"]
   end
 end

--- a/app/models/configurable_document_types/case_study.json
+++ b/app/models/configurable_document_types/case_study.json
@@ -110,7 +110,10 @@
     "organisations": null,
     "backdating_enabled": true,
     "history_mode_enabled": true,
-    "taxon_required": true,
+    "taxon": {
+      "enabled": true,
+      "required": true
+    },
     "translations_enabled": true
   }
 }

--- a/app/models/configurable_document_types/government_response.json
+++ b/app/models/configurable_document_types/government_response.json
@@ -126,7 +126,10 @@
     "organisations": null,
     "backdating_enabled": true,
     "history_mode_enabled": true,
-    "taxon_required": true,
+    "taxon": {
+      "enabled": true,
+      "required": true
+    },
     "translations_enabled": true
   }
 }

--- a/app/models/configurable_document_types/history_page.json
+++ b/app/models/configurable_document_types/history_page.json
@@ -88,7 +88,10 @@
     "backdating_enabled": false,
     "history_mode_enabled": false,
     "file_attachments_enabled": false,
-    "taxon_required": true,
+    "taxon": {
+      "enabled": true,
+      "required": true
+    },
     "translations_enabled": false
   }
 }

--- a/app/models/configurable_document_types/news_story.json
+++ b/app/models/configurable_document_types/news_story.json
@@ -126,7 +126,10 @@
     "organisations": null,
     "backdating_enabled": true,
     "history_mode_enabled": true,
-    "taxon_required": true,
+    "taxon": {
+      "enabled": true,
+      "required": true
+    },
     "translations_enabled": true
   }
 }

--- a/app/models/configurable_document_types/press_release.json
+++ b/app/models/configurable_document_types/press_release.json
@@ -126,7 +126,10 @@
     "organisations": null,
     "backdating_enabled": true,
     "history_mode_enabled": true,
-    "taxon_required": true,
+    "taxon": {
+      "enabled": true,
+      "required": true
+    },
     "translations_enabled": true
   }
 }

--- a/app/models/configurable_document_types/topical_event.json
+++ b/app/models/configurable_document_types/topical_event.json
@@ -209,7 +209,10 @@
     "organisations": null,
     "backdating_enabled": false,
     "history_mode_enabled": false,
-    "taxon_required": true,
+    "taxon": {
+      "enabled": true,
+      "required": true
+    },
     "translations_enabled": false
   }
 }

--- a/app/models/configurable_document_types/world_news_story.json
+++ b/app/models/configurable_document_types/world_news_story.json
@@ -111,7 +111,10 @@
     "organisations": null,
     "backdating_enabled": true,
     "history_mode_enabled": true,
-    "taxon_required": true,
+    "taxon": {
+      "enabled": true,
+      "required": true
+    },
     "translations_enabled": true
   }
 }

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -322,6 +322,10 @@ class Edition < ApplicationRecord
     true
   end
 
+  def supports_taxon?
+    true
+  end
+
   # 'previously_published' is a transient attribute populated
   # by request parameters, and because it's not persisted it's
   # not converted to a boolean, hence this manual attr writer method.

--- a/app/models/worldwide_organisation.rb
+++ b/app/models/worldwide_organisation.rb
@@ -188,6 +188,10 @@ class WorldwideOrganisation < Edition
     false
   end
 
+  def supports_taxon?
+    false
+  end
+
   def republish_dependent_documents
     documents = StandardEdition
                   .with_news_article_document_type

--- a/app/views/admin/editions/show/_main.html.erb
+++ b/app/views/admin/editions/show/_main.html.erb
@@ -58,7 +58,7 @@
     </section>
   <% end %>
 
-  <% if @edition.requires_taxon? %>
+  <% if @edition.supports_taxon? %>
     <section class="app-view-summary__section app-view-summary__taxonomy-topics">
       <%= render "govuk_publishing_components/components/heading", {
         text: "Topic taxonomy tags",

--- a/features/fixtures/test_configurable_document_type.json
+++ b/features/fixtures/test_configurable_document_type.json
@@ -205,7 +205,10 @@
     "rendering_app": "frontend",
     "organisations": null,
     "backdating_enabled": false,
-    "taxon_required": false,
+    "taxon": {
+      "enabled": false,
+      "required": false
+    },
     "translations_enabled": true,
     "file_attachments_enabled": true,
     "features_enabled": true,

--- a/features/fixtures/test_configurable_document_type_group.json
+++ b/features/fixtures/test_configurable_document_type_group.json
@@ -39,7 +39,10 @@
       "rendering_app": "frontend",
       "organisations": null,
       "backdating_enabled": false,
-      "taxon_required": false,
+      "taxon": {
+        "enabled": false,
+        "required": false
+      },
       "translations_enabled": true,
       "images": {
         "enabled": true,
@@ -97,7 +100,10 @@
       "organisations": null,
       "backdating_enabled": false,
       "translations_enabled": true,
-      "taxon_required": false,
+      "taxon": {
+        "enabled": false,
+        "required": false
+      },
       "images": {
         "enabled": true,
         "usages": {

--- a/public/configurable-document-type.schema.json
+++ b/public/configurable-document-type.schema.json
@@ -457,9 +457,18 @@
           "type": "boolean",
           "description": "Whether file attachments are allowed for this document type. When enabled, it renders the Attachments tab."
         },
-        "taxon_required": {
-          "type": "boolean",
-          "description": "Whether a taxon (topic or world) is required for this document type."
+        "taxon": {
+          "type": "object",
+          "properties": {
+            "required": {
+              "type": "boolean",
+              "description": "Whether a taxon is required for this document type."
+            },
+            "enabled": {
+              "type": "boolean",
+              "description": "Whether a taxon can be set for this document type."
+            }
+          }
         },
         "translations_enabled": {
           "type": "boolean",
@@ -477,7 +486,7 @@
         "backdating_enabled",
         "history_mode_enabled",
         "file_attachments_enabled",
-        "taxon_required",
+        "taxon",
         "translations_enabled"
       ]
     }

--- a/test/fixtures/test_schema.json
+++ b/test/fixtures/test_schema.json
@@ -44,7 +44,10 @@
     "organisations": null,
     "backdating_enabled": true,
     "history_mode_enabled": true,
-    "taxon_required": true,
+    "taxon": {
+      "enabled": true,
+      "required": true
+    },
     "translations_enabled": true
   }
 }

--- a/test/support/configurable_document_type_helper.rb
+++ b/test/support/configurable_document_type_helper.rb
@@ -40,6 +40,10 @@ module ConfigurableDocumentTypeHelper
           "images" => {
             "enabled" => false,
           },
+          "taxon" => {
+            "enabled" => false,
+            "required" => false,
+          },
           "organisations" => nil,
           "backdating_enabled" => false,
           "history_mode_enabled" => false,

--- a/test/unit/app/models/concerns/standard_edition/taxon_test.rb
+++ b/test/unit/app/models/concerns/standard_edition/taxon_test.rb
@@ -4,7 +4,10 @@ class StandardEdition::TaxonTest < ActiveSupport::TestCase
   test "requires_taxon? returns true when taxon is required for the document type" do
     test_type = build_configurable_document_type("test_type_with_taxon_required", {
       "settings" => {
-        "taxon_required" => true,
+        "taxon" => {
+          "required" => true,
+          "enabled" => true,
+        },
       },
     })
     ConfigurableDocumentType.setup_test_types(test_type)
@@ -17,7 +20,57 @@ class StandardEdition::TaxonTest < ActiveSupport::TestCase
   test "requires_taxon? returns false when taxon is not required for the document type" do
     test_type = build_configurable_document_type("test_type_with_taxon_not_required", {
       "settings" => {
-        "taxon_required" => false,
+        "taxon" => {
+          "required" => false,
+          "enabled" => true,
+        },
+      },
+    })
+    ConfigurableDocumentType.setup_test_types(test_type)
+
+    edition = create(:standard_edition, configurable_document_type: "test_type_with_taxon_not_required")
+
+    assert_not edition.requires_taxon?
+  end
+
+  test "supports_taxon? returns false when taxon is not enabled for the document type" do
+    test_type = build_configurable_document_type("test_type_with_taxon_not_required", {
+      "settings" => {
+        "taxon" => {
+          "enabled" => false,
+        },
+      },
+    })
+    ConfigurableDocumentType.setup_test_types(test_type)
+
+    edition = create(:standard_edition, configurable_document_type: "test_type_with_taxon_not_required")
+
+    assert_not edition.supports_taxon?
+  end
+
+  test "supports_taxon? returns true when taxon is enabled for the document type" do
+    test_type = build_configurable_document_type("test_type_with_taxon_not_required", {
+      "settings" => {
+        "taxon" => {
+          "required" => false,
+          "enabled" => true,
+        },
+      },
+    })
+    ConfigurableDocumentType.setup_test_types(test_type)
+
+    edition = create(:standard_edition, configurable_document_type: "test_type_with_taxon_not_required")
+
+    assert edition.supports_taxon?
+  end
+
+  test "requires_taxon? returns false when taxon is not enabled for the document type" do
+    test_type = build_configurable_document_type("test_type_with_taxon_not_required", {
+      "settings" => {
+        "taxon" => {
+          "required" => true,
+          "enabled" => false,
+        },
       },
     })
     ConfigurableDocumentType.setup_test_types(test_type)


### PR DESCRIPTION
## What

- Change `taxon_required` to `taxon` in document configuration
  - Add support for `taxon` as optional with `enabled`
- Add new `supports_taxon?` method
  - Use `supports_taxon?` in `EditionController` and in view 

## Why

A document type might support `taxon` but it might not be required. Reworking `taxon_required` to `taxon` allows for this nuance to be described in the configuration.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

[Jira](https://gov-uk.atlassian.net/browse/WHIT-3564)
