### PR TITLE
[WHIT-3565] Validate associations only when required flag is present in config

### DIFF
--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -397,7 +397,7 @@ private
   end
 
   def build_default_organisation
-    if @edition.organisation_association_enabled? && current_user.organisation
+    if @edition.organisation_association_enabled? && @edition.lead_organisation_association_required? && current_user.organisation
       @edition.edition_organisations.build(lead_ordering: 0, lead: true, organisation: current_user.organisation)
     end
   end

--- a/app/models/concerns/edition/base_permission_methods.rb
+++ b/app/models/concerns/edition/base_permission_methods.rb
@@ -12,8 +12,6 @@ module Edition::BasePermissionMethods
     can_be_grouped_in_collections?
     can_be_tagged_to_worldwide_taxonomy?
     is_associated_with_a_minister?
-    worldwide_organisation_association_required?
-    world_location_association_required?
   ].each do |method|
     define_method(method) { false }
   end

--- a/app/models/concerns/edition/base_permission_methods.rb
+++ b/app/models/concerns/edition/base_permission_methods.rb
@@ -12,7 +12,6 @@ module Edition::BasePermissionMethods
     can_be_grouped_in_collections?
     can_be_tagged_to_worldwide_taxonomy?
     is_associated_with_a_minister?
-    organisation_association_enabled?
     worldwide_organisation_association_required?
     world_location_association_required?
   ].each do |method|

--- a/app/models/concerns/edition/organisations.rb
+++ b/app/models/concerns/edition/organisations.rb
@@ -15,7 +15,8 @@ module Edition::Organisations
 
     has_many :organisations, -> { includes(:translations) }, through: :edition_organisations, validate: false
 
-    validate :at_least_one_lead_organisation, if: :organisation_association_enabled?
+    validate :at_least_one_lead_organisation, if: -> { organisation_association_enabled? && lead_organisation_association_required? }
+    validate :at_least_one_supporting_organisation, if: -> { organisation_association_enabled? && supporting_organisation_association_required? }
     validate :no_duplication_of_organisations, if: :organisation_association_enabled?
 
     add_trait Trait
@@ -73,6 +74,14 @@ module Edition::Organisations
     true
   end
 
+  def lead_organisation_association_required?
+    true
+  end
+
+  def supporting_organisation_association_required?
+    false
+  end
+
   def error_labels
     super.merge({
       "lead_organisation_ids" => "Lead organisations",
@@ -85,6 +94,12 @@ private
   def at_least_one_lead_organisation
     unless edition_organisations.detect(&:lead?)
       errors.add(:lead_organisation_ids, "at least one required")
+    end
+  end
+
+  def at_least_one_supporting_organisation
+    unless edition_organisations.detect { |eo| !eo.lead? }
+      errors.add(:supporting_organisation_ids, "at least one required")
     end
   end
 

--- a/app/models/corporate_information_page.rb
+++ b/app/models/corporate_information_page.rb
@@ -113,6 +113,10 @@ class CorporateInformationPage < Edition
     PublishingApi::CorporateInformationPagePresenter
   end
 
+  def organisation_association_enabled?
+    false
+  end
+
 private
 
   def string_for_slug

--- a/app/models/speech.rb
+++ b/app/models/speech.rb
@@ -52,7 +52,7 @@ class Speech < Edition
     PublishingApi::SpeechPresenter
   end
 
-  def organisation_association_enabled?
+  def lead_organisation_association_required?
     !can_have_some_invalid_data? && person_override.blank?
   end
 

--- a/app/models/standard_edition.rb
+++ b/app/models/standard_edition.rb
@@ -118,6 +118,14 @@ class StandardEdition < Edition
     field_paths.include?(ConfigurableContentBlocks::Path.new("lead_organisation_ids"))
   end
 
+  def lead_organisation_association_required?
+    required_field_paths.include?(ConfigurableContentBlocks::Path.new("lead_organisation_ids"))
+  end
+
+  def supporting_organisation_association_required?
+    required_field_paths.include?(ConfigurableContentBlocks::Path.new("supporting_organisation_ids"))
+  end
+
   def worldwide_organisation_association_required?
     required_field_paths.include?(ConfigurableContentBlocks::Path.new("worldwide_organisation_document_ids"))
   end

--- a/app/views/admin/editions/_organisation_fields.html.erb
+++ b/app/views/admin/editions/_organisation_fields.html.erb
@@ -1,18 +1,19 @@
 <% if edition.organisation_association_enabled? %>
   <%= render "govuk_publishing_components/components/fieldset", {
-    legend_text: "Lead organisations",
+    legend_text: "Lead organisations#{edition.lead_organisation_association_required? ? ' (required)' : ''}",
     heading_level: 3,
     heading_size: "m",
     id: "edition_organisations",
     error_message: errors_for_input(edition.errors, :lead_organisation_ids, "Organisations"),
     } do %>
     <div class="govuk-!-margin-bottom-6">
-      <% 0.upto(3) do |index| %>
-        <% lead_organisation_id = lead_organisation_id_at_index(edition, index) %>
+      <% 1.upto(4) do |index| %>
+        <% lead_organisation_id = lead_organisation_id_at_index(edition, index-1) %>
+        <% select_label = "Lead organisation #{index}" %>
         <%= render "govuk_publishing_components/components/select_with_search", {
-            id: "edition_lead_organisation_ids_#{index + 1}",
+            id: "edition_lead_organisation_ids_#{index}",
             name: "edition[lead_organisation_ids][]",
-            label: "Lead organisation #{index + 1}",
+            label: (index == 1 && edition.lead_organisation_association_required?) ? (select_label + " (required)") : select_label,
             heading_size: "s",
             include_blank: true,
             options: taggable_organisations_container([lead_organisation_id]),

--- a/test/functional/admin/edition_access_limited_controller_test.rb
+++ b/test/functional/admin/edition_access_limited_controller_test.rb
@@ -31,7 +31,8 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
       assert_select "textarea[name='edition[editorial_remark]']"
 
       (1..4).each do |i|
-        assert_select "label[for=edition_lead_organisation_ids_#{i}]", text: "Lead organisation #{i}"
+        select_label = i == 1 && assigns(:edition).lead_organisation_association_required? ? "Lead organisation #{i} (required)" : "Lead organisation #{i}"
+        assert_select "label[for=edition_lead_organisation_ids_#{i}]", text: select_label
         assert_select("#edition_lead_organisation_ids_#{i}")
       end
 

--- a/test/functional/admin/standard_editions_controller_test.rb
+++ b/test/functional/admin/standard_editions_controller_test.rb
@@ -48,6 +48,73 @@ class Admin::StandardEditionsControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  view_test "GET new pre-selects the user's organisation in the lead organisations field, if lead organisations are required" do
+    configurable_document_type = build_configurable_document_type(
+      "test_type",
+      {
+        "forms" => {
+          "documents" => {
+            "fields" => {
+              "lead_organisations" => {
+                "title" => "Lead organisations",
+                "required" => true,
+                "block" => "ordered_select_with_search_tagging",
+                "container" => "organisations",
+                "attribute_path" => %w[lead_organisation_ids],
+                "size" => 4,
+                "translatable" => false,
+              },
+            },
+          },
+        },
+      },
+    )
+    ConfigurableDocumentType.setup_test_types(configurable_document_type)
+    organisation = create(:organisation)
+    login_as create(:gds_admin, organisation:)
+
+    get :new, params: { configurable_document_type: "test_type" }
+
+    assert assigns(:edition).lead_organisation_association_required?
+    assert_select "select[name='edition[lead_organisation_ids][]']" do
+      assert_select "option[selected='selected']", text: organisation.name
+    end
+  end
+
+  view_test "GET new does not pre-select the user's organisation in the lead organisations field, if organisation are only enabled" do
+    configurable_document_type = build_configurable_document_type(
+      "test_type",
+      {
+        "forms" => {
+          "documents" => {
+            "fields" => {
+              "lead_organisations" => {
+                "title" => "Lead organisations",
+                "required" => false,
+                "block" => "ordered_select_with_search_tagging",
+                "container" => "organisations",
+                "attribute_path" => %w[lead_organisation_ids],
+                "size" => 4,
+                "translatable" => false,
+              },
+            },
+          },
+        },
+      },
+    )
+    ConfigurableDocumentType.setup_test_types(configurable_document_type)
+    organisation = create(:organisation)
+    login_as create(:gds_admin, organisation:)
+
+    get :new, params: { configurable_document_type: "test_type" }
+
+    assert assigns(:edition).organisation_association_enabled?
+    assert_not assigns(:edition).lead_organisation_association_required?
+    assert_select "select[name='edition[lead_organisation_ids][]']" do
+      refute_select "option[selected='selected']"
+    end
+  end
+
   test "GET new returns a not_found response when no configurable_document_type parameter is provided" do
     get :new
     assert_response :not_found

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -448,8 +448,11 @@ module AdminEditionControllerTestHelpers
         get :new
 
         assert_select "form#new_edition" do
+          assert_select "legend", text: "Lead organisations (required)"
+
           (1..4).each do |i|
-            assert_select "label[for=edition_lead_organisation_ids_#{i}]", text: "Lead organisation #{i}"
+            select_label = i == 1 && assigns(:edition).lead_organisation_association_required? ? "Lead organisation #{i} (required)" : "Lead organisation #{i}"
+            assert_select "label[for=edition_lead_organisation_ids_#{i}]", text: select_label
 
             assert_select("#edition_lead_organisation_ids_#{i}") do |elements|
               assert_equal 1, elements.length
@@ -497,8 +500,11 @@ module AdminEditionControllerTestHelpers
         get :edit, params: { id: edition }
 
         assert_select "form#edit_edition" do
+          assert_select "legend", text: "Lead organisations (required)"
+
           (1..4).each do |i|
-            assert_select "label[for=edition_lead_organisation_ids_#{i}]", text: "Lead organisation #{i}"
+            select_label = i == 1 && assigns(:edition).lead_organisation_association_required? ? "Lead organisation #{i} (required)" : "Lead organisation #{i}"
+            assert_select "label[for=edition_lead_organisation_ids_#{i}]", text: select_label
 
             assert_select("#edition_lead_organisation_ids_#{i}") do |elements|
               assert_equal 1, elements.length
@@ -577,8 +583,11 @@ module AdminEditionControllerTestHelpers
         get :new
 
         assert_select "form#new_edition" do
+          assert_select "legend", text: "Lead organisations (required)"
+
           (1..4).each do |i|
-            assert_select "label[for=edition_lead_organisation_ids_#{i}]", text: "Lead organisation #{i}"
+            select_label = i == 1 && assigns(:edition).lead_organisation_association_required? ? "Lead organisation #{i} (required)" : "Lead organisation #{i}"
+            assert_select "label[for=edition_lead_organisation_ids_#{i}]", text: select_label
 
             assert_select("#edition_lead_organisation_ids_#{i}") do |elements|
               assert_equal 1, elements.length
@@ -626,8 +635,11 @@ module AdminEditionControllerTestHelpers
         get :edit, params: { id: edition }
 
         assert_select "form#edit_edition" do
+          assert_select "legend", text: "Lead organisations (required)"
+
           (1..4).each do |i|
-            assert_select "label[for=edition_lead_organisation_ids_#{i}]", text: "Lead organisation #{i}"
+            select_label = i == 1 && assigns(:edition).lead_organisation_association_required? ? "Lead organisation #{i} (required)" : "Lead organisation #{i}"
+            assert_select "label[for=edition_lead_organisation_ids_#{i}]", text: select_label
 
             assert_select("#edition_lead_organisation_ids_#{i}") do |elements|
               assert_equal 1, elements.length

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -460,14 +460,19 @@ module AdminEditionControllerTestHelpers
         end
       end
 
-      test "new should set first lead organisation to users organisation" do
+      view_test "new should set and pre-select the first lead organisation as the user's organisation" do
         editors_org = create(:organisation)
-        @user = login_as create(:departmental_editor, organisation: editors_org)
+        @user = login_as create(:gds_editor, organisation: editors_org)
+
         get :new
 
+        assert assigns(:edition).lead_organisation_association_required?
         assert_equal assigns(:edition).edition_organisations.first.organisation, editors_org
         assert_equal assigns(:edition).edition_organisations.first.lead, true
         assert_equal assigns(:edition).edition_organisations.first.lead_ordering, 0
+        assert_select "select[name='edition[lead_organisation_ids][]']" do
+          assert_select "option[selected='selected']", text: editors_org.name
+        end
       end
 
       test "create should associate organisations with edition" do
@@ -584,14 +589,19 @@ module AdminEditionControllerTestHelpers
         end
       end
 
-      test "new should set first lead organisation to users organisation" do
+      view_test "new should set and pre-select the first lead organisation as the user's organisation" do
         editors_org = create(:organisation)
-        @user = login_as create(:departmental_editor, organisation: editors_org)
+        @user = login_as create(:gds_editor, organisation: editors_org)
+
         get :new
 
+        assert assigns(:edition).lead_organisation_association_required?
         assert_equal assigns(:edition).edition_organisations.first.organisation, editors_org
         assert_equal assigns(:edition).edition_organisations.first.lead, true
         assert_equal assigns(:edition).edition_organisations.first.lead_ordering, 0
+        assert_select "select[name='edition[lead_organisation_ids][]']" do
+          assert_select "option[selected='selected']", text: editors_org.name
+        end
       end
 
       test "create should associate organisations with edition" do

--- a/test/unit/app/models/edition/organisations_test.rb
+++ b/test/unit/app/models/edition/organisations_test.rb
@@ -76,4 +76,49 @@ class Edition::OrganisationsTest < ActiveSupport::TestCase
 
     assert_equal [organisation2, organisation3, organisation1], edition.sorted_organisations
   end
+
+  test "validates lead organisations for presence for non-configurable types" do
+    edition = create(:publication)
+    edition.lead_organisations = []
+
+    assert_not edition.valid?
+    assert edition.errors.include?(:lead_organisation_ids)
+  end
+
+  test "does not validate supporting organisations for presence for non-configurable types" do
+    edition = create(:publication)
+    edition.supporting_organisations = []
+
+    assert edition.valid?
+    assert_not edition.errors.include?(:supporting_organisation_ids)
+  end
+
+  test "does not validate lead and supporting organisations for presence when configured to not be required on a standard edition" do
+    edition = create(:standard_edition, lead_organisations: [], supporting_organisations: [])
+    edition.stubs(:organisation_association_enabled?).returns(true)
+    edition.stubs(:lead_organisation_association_required?).returns(false)
+    edition.stubs(:supporting_organisation_association_required?).returns(false)
+
+    assert edition.valid?
+    assert_not edition.errors.include?(:lead_organisation_ids)
+    assert_not edition.errors.include?(:supporting_organisation_ids)
+  end
+
+  test "validates lead organisations for presence when configured to be required on a standard edition" do
+    edition = create(:standard_edition, lead_organisations: [])
+    edition.stubs(:organisation_association_enabled?).returns(true)
+    edition.stubs(:lead_organisation_association_required?).returns(true)
+
+    assert_not edition.valid?
+    assert edition.errors.include?(:lead_organisation_ids)
+  end
+
+  test "validates supporting organisations for presence when configured to be required on a standard edition" do
+    edition = create(:standard_edition, supporting_organisations: [])
+    edition.stubs(:organisation_association_enabled?).returns(true)
+    edition.stubs(:supporting_organisation_association_required?).returns(true)
+
+    assert_not edition.valid?
+    assert edition.errors.include?(:supporting_organisation_ids)
+  end
 end

--- a/test/unit/app/models/speech_test.rb
+++ b/test/unit/app/models/speech_test.rb
@@ -44,11 +44,21 @@ class SpeechTest < ActiveSupport::TestCase
     assert_not speech.valid?
   end
 
-  test "does not require an organisation or role appointment if a person_override is given" do
+  test "requires an organisation and displays organisation fields, if a person_override and role_appointment are not given" do
+    speech = build(:speech, person_override: nil, role_appointment: nil, create_default_organisation: false)
+
+    assert_not speech.valid?
+    assert speech.errors.include?(:lead_organisation_ids)
+    assert speech.organisation_association_enabled?
+    assert speech.lead_organisation_association_required?
+  end
+
+  test "does not require an organisation or role appointment if a person_override is given, and displays org fields" do
     speech = build(:speech, person_override: "The Queen", role_appointment: nil, create_default_organisation: false)
-    assert speech.person_override?
-    speech.save!
-    assert_equal [], speech.reload.organisations
+
+    assert speech.valid?
+    assert speech.organisation_association_enabled?
+    assert_not speech.lead_organisation_association_required?
   end
 
   test "#display_type returns en locale values" do

--- a/test/unit/app/models/standard_edition_test.rb
+++ b/test/unit/app/models/standard_edition_test.rb
@@ -485,22 +485,34 @@ class StandardEditionTest < ActiveSupport::TestCase
     assert StandardEdition.new(configurable_document_type: "test_type_with_legacy_topical_events").can_be_associated_with_topical_events?
   end
 
-  test "conditionally requires worldwide organisation and world location associations" do
+  test "requires organisations, worldwide organisations, and world locations associations when configured with the required flag set to true" do
     test_type = build_configurable_document_type(
       "test_type", {
         "forms" => {
           "documents" => {
             "fields" => {
+              "lead_organisations" => {
+                "required" => true,
+                "attribute_path" => %w[lead_organisation_ids],
+                "translatable" => false,
+                "block" => "ordered_select_with_search_tagging",
+              },
+              "supporting_organisations" => {
+                "required" => true,
+                "attribute_path" => %w[supporting_organisation_ids],
+                "translatable" => false,
+                "block" => "select_with_search_tagging",
+              },
               "worldwide_organisations" => {
                 "required" => true,
                 "attribute_path" => %w[worldwide_organisation_document_ids],
-                "translatable" => true,
+                "translatable" => false,
                 "block" => "select_with_search_tagging",
               },
               "world_locations" => {
-                "required" => false,
+                "required" => true,
                 "attribute_path" => %w[world_location_ids],
-                "translatable" => true,
+                "translatable" => false,
                 "block" => "select_with_search_tagging",
               },
             },
@@ -510,9 +522,92 @@ class StandardEditionTest < ActiveSupport::TestCase
     )
     ConfigurableDocumentType.setup_test_types(test_type)
     page = StandardEdition.new(configurable_document_type: "test_type")
+    assert page.lead_organisation_association_required?
+    assert page.supporting_organisation_association_required?
     assert page.worldwide_organisation_association_required?
+    assert page.world_location_association_required?
+  end
+
+  test "does not require organisations, worldwide organisations, and world locations associations when configured with the required flag set to false" do
+    test_type = build_configurable_document_type(
+      "test_type", {
+        "forms" => {
+          "documents" => {
+            "fields" => {
+              "lead_organisations" => {
+                "required" => false,
+                "attribute_path" => %w[lead_organisation_ids],
+                "translatable" => false,
+                "block" => "ordered_select_with_search_tagging",
+              },
+              "supporting_organisations" => {
+                "required" => false,
+                "attribute_path" => %w[supporting_organisation_ids],
+                "translatable" => false,
+                "block" => "select_with_search_tagging",
+              },
+              "worldwide_organisations" => {
+                "required" => false,
+                "attribute_path" => %w[worldwide_organisation_document_ids],
+                "translatable" => false,
+                "block" => "select_with_search_tagging",
+              },
+              "world_locations" => {
+                "required" => false,
+                "attribute_path" => %w[world_location_ids],
+                "translatable" => false,
+                "block" => "select_with_search_tagging",
+              },
+            },
+          },
+        },
+      }
+    )
+    ConfigurableDocumentType.setup_test_types(test_type)
+    page = StandardEdition.new(configurable_document_type: "test_type")
+    assert_not page.lead_organisation_association_required?
+    assert_not page.supporting_organisation_association_required?
+    assert_not page.worldwide_organisation_association_required?
     assert_not page.world_location_association_required?
-    assert_not page.respond_to?(:organisation_association_required?) # ignores required value for other associations
+  end
+
+  test "interprets required flag missing as 'not required' for organisations, worldwide organisations, and world locations associations" do
+    test_type = build_configurable_document_type(
+      "test_type", {
+        "forms" => {
+          "documents" => {
+            "fields" => {
+              "lead_organisations" => {
+                "attribute_path" => %w[lead_organisation_ids],
+                "translatable" => false,
+                "block" => "ordered_select_with_search_tagging",
+              },
+              "supporting_organisations" => {
+                "attribute_path" => %w[supporting_organisation_ids],
+                "translatable" => false,
+                "block" => "select_with_search_tagging",
+              },
+              "worldwide_organisations" => {
+                "attribute_path" => %w[worldwide_organisation_document_ids],
+                "translatable" => false,
+                "block" => "select_with_search_tagging",
+              },
+              "world_locations" => {
+                "attribute_path" => %w[world_location_ids],
+                "translatable" => false,
+                "block" => "select_with_search_tagging",
+              },
+            },
+          },
+        },
+      }
+    )
+    ConfigurableDocumentType.setup_test_types(test_type)
+    page = StandardEdition.new(configurable_document_type: "test_type")
+    assert_not page.lead_organisation_association_required?
+    assert_not page.supporting_organisation_association_required?
+    assert_not page.worldwide_organisation_association_required?
+    assert_not page.world_location_association_required?
   end
 
   test "features are copied over to new edition of document if the featurable is editionable" do


### PR DESCRIPTION
# What & why

Previously, topical events failed validation when submitted with blank lead organisations, despite the config not having the required flag, and the form not rendering said flag to the user.

Changes:
- Ensure that validations only run when the flag is present. 
- We can now also validate supporting orgs.
- The config is now consistent, and works in the same way for any association with a `required` field.
- Also cleaned up some historical issues with speeches, and made it cleared what association logic applies to corporate information pages. See test screenshots below.

# Testing

| Scenario | Changed/Explanation | Before | After |
| --- | --- | --- | --- |
| Required label does not show for lead organisations if required: false or required flag missing (TE example) | No | <img width="535" height="421" alt="image" src="https://github.com/user-attachments/assets/aaba1537-b13f-4e16-ac4c-40a4003c1c41" /> | <img width="535" height="421" alt="image" src="https://github.com/user-attachments/assets/0d112ff2-2ac1-4d25-b5db-f1767a55153b" /> |
| Lead organisations do not get validated when required: false (TE example) | Yes - previously it validated although it should not have | <img width="535" height="360" alt="image" src="https://github.com/user-attachments/assets/33a5cf2a-1170-4724-8598-4c2122057928" /> | <img width="535" height="360" alt="image" src="https://github.com/user-attachments/assets/c95681bb-3eb3-40e6-9e9f-3218a1b3d351" /> |
| Supporting orgs do not get validated when required: false (TE example, applied to all config driven types we currently have) | No | <img width="535" height="82" alt="image" src="https://github.com/user-attachments/assets/2cf0e6c3-7675-4328-9a28-26b517f0600c" /> | <img width="535" height="82" alt="image" src="https://github.com/user-attachments/assets/c8e6473a-d6bf-43da-9a49-8692936cc082" /> |
| Lead organisations get validated and show label when required: true (news article example) | No | <img width="535" height="137" alt="image" src="https://github.com/user-attachments/assets/1ed76c6b-8499-4683-a024-35d3d7a8fa5f" /> | <img width="535" height="137" alt="image" src="https://github.com/user-attachments/assets/e5aedd86-6ea2-4703-8dab-3cc23f9c61be" /> |
| Supporting orgs can also be individually validated and they show required label, on config-driven types where required: true (no current doc type, example with made up type)  | Yes | N/A | <img width="535" height="117" alt="image" src="https://github.com/user-attachments/assets/568bf152-65c5-49d0-957e-65ecc36d3904" /> |
| Lead organisations always get validated for non-config-driven types (example publication), and they don't show a required label | No | <img width="410" height="277" alt="image" src="https://github.com/user-attachments/assets/335daeb1-fdaa-42e7-9a4e-354b25f66fb4" /> | <img width="410" height="277" alt="image" src="https://github.com/user-attachments/assets/86d55ea7-0233-45d1-8024-48a9d611da64" /> |
| Supporting orgs never get validated for non-config-driven types (example publication) | No |  <img width="410" height="66" alt="image" src="https://github.com/user-attachments/assets/3ae192c2-b5b6-4da3-a990-f93416fbe382" /> | <img width="410" height="66" alt="image" src="https://github.com/user-attachments/assets/4f9f20bf-11c3-4cdd-a943-4b663f8fca58" /> |
| Speech continues to render org fields when person override provided | Yes - the fields previously disappeared when providing a person override | <img width="295" height="566" alt="image" src="https://github.com/user-attachments/assets/0adc7f94-1c79-49e6-a562-f53eea57f7b2" /> | <img width="360" height="765" alt="image" src="https://github.com/user-attachments/assets/7792cf1f-384d-494c-b872-b23762aeef06" /> |
| Corporate information pages do not render org fields | No | <img width="410" height="826" alt="image" src="https://github.com/user-attachments/assets/53c7e7ed-6745-4aa2-9ffa-6a652382a8e5" /> | <img width="398" height="796" alt="image" src="https://github.com/user-attachments/assets/18e1019b-d65d-4247-a138-e5d92fc75d73" /> |
| Lead organisation required label shows on legacy models and the value is pre-selected (example: publication) | Yes, previously there was no label | <img width="410" height="264" alt="image" src="https://github.com/user-attachments/assets/28b9a15c-a751-4556-b782-51fd90ca752d" /> | <img width="410" height="264" alt="image" src="https://github.com/user-attachments/assets/a35ed8e7-93bd-4a7d-83f8-49b322fe1322" /> |
| Lead organisation is not pre-selected if not required (example: topical event) | Yes, previously it would be pre-selected | <img width="410" height="82" alt="image" src="https://github.com/user-attachments/assets/d60450f1-57d8-4e7d-8303-5f58804705e2" /> | <img width="410" height="82" alt="image" src="https://github.com/user-attachments/assets/a1cba714-32db-44dc-8df4-8fd39e0bb05b" /> |
| Lead organisation continues to be pre-selected when required on config driven (example: news story) | No | <img width="410" height="82" alt="image" src="https://github.com/user-attachments/assets/b5ab66b7-42d7-4f96-8aa4-a8c2dc4c97ce" /> | <img width="410" height="82" alt="image" src="https://github.com/user-attachments/assets/663ea049-34e3-4f68-b733-08a46f662195" /> |


[Jira](https://gov-uk.atlassian.net/browse/WHIT-3565) 

