### PR TITLE
[WHIT-3020] Fix preview-token propagation for response forms and cropped images

### DIFF
--- a/app/controllers/admin/edition_images_controller.rb
+++ b/app/controllers/admin/edition_images_controller.rb
@@ -47,6 +47,8 @@ class Admin::EditionImagesController < Admin::BaseController
       new_image_data.to_replace_id = image_data.id
       new_image_data.assign_attributes(image_data_params)
       new_image_data.file.download! image_data.file.url
+      # so that auth_bypass_id is discoverable by AssetManagerStorage
+      new_image_data.images << image
       new_image_data.save!
       image.image_data = new_image_data
     end

--- a/app/services/edition_auth_bypass_updater.rb
+++ b/app/services/edition_auth_bypass_updater.rb
@@ -15,6 +15,7 @@ class EditionAuthBypassUpdater
     update_file_attachments(@edition)
     update_image_attachments(@edition)
     update_consultation_attachments(@edition)
+    update_call_for_evidence_attachments(@edition)
   end
 
 private
@@ -59,6 +60,26 @@ private
 
     if edition.public_feedback.present?
       edition.public_feedback.attachments.files.each do |file_attachment|
+        new_attributes = { "auth_bypass_ids" => [edition.auth_bypass_id] }
+        attachment_data_id = file_attachment.attachment_data.id
+        AssetManagerUpdateAssetJob.perform_async_in_queue("asset_manager_updater", "AttachmentData", attachment_data_id, new_attributes)
+      end
+    end
+  end
+
+  def update_call_for_evidence_attachments(edition)
+    return unless edition.is_a?(CallForEvidence)
+
+    if edition.call_for_evidence_participation&.call_for_evidence_response_form.present?
+      response_form = edition.call_for_evidence_participation.call_for_evidence_response_form
+      response_form_data_id = response_form.call_for_evidence_response_form_data.id
+      new_attributes = { "auth_bypass_ids" => [edition.auth_bypass_id] }
+
+      AssetManagerUpdateAssetJob.perform_async_in_queue("asset_manager_updater", "CallForEvidenceResponseFormData", response_form_data_id, new_attributes)
+    end
+
+    if edition.outcome.present?
+      edition.outcome.attachments.files.each do |file_attachment|
         new_attributes = { "auth_bypass_ids" => [edition.auth_bypass_id] }
         attachment_data_id = file_attachment.attachment_data.id
         AssetManagerUpdateAssetJob.perform_async_in_queue("asset_manager_updater", "AttachmentData", attachment_data_id, new_attributes)

--- a/test/functional/admin/edition_images_controller_test.rb
+++ b/test/functional/admin/edition_images_controller_test.rb
@@ -698,6 +698,36 @@ class Admin::EditionImagesControllerTest < ActionController::TestCase
     post :create, params: { edition_id: edition.id, usage: "govspeak_embed", image_kind: "default", images: [{ image_data_attributes: { file: } }] }
   end
 
+  test "POST :create passes the edition's auth_bypass_id to the new image assets" do
+    login_authorised_user
+    edition = create(:draft_fatality_notice)
+    file = upload_fixture("images/960x640_jpeg.jpg")
+
+    AssetManagerCreateAssetJob
+      .expects(:perform_async)
+      .with(anything, anything, anything, anything, anything, [edition.auth_bypass_id]).times(7)
+
+    post :create, params: { edition_id: edition.id, usage: "govspeak_embed", image_kind: "default", images: [{ image_data_attributes: { file: } }] }
+  end
+
+  test "POST :update passes the edition's auth_bypass_id to the cropped image assets" do
+    login_authorised_user
+    image = build(:image)
+    edition = create(:draft_fatality_notice, images: [image])
+
+    AssetManagerCreateAssetJob
+      .expects(:perform_async)
+      .with(anything, anything, anything, anything, anything, [edition.auth_bypass_id]).times(7)
+
+    post :update, params: {
+      edition_id: edition.id,
+      id: image.id,
+      usage: "govspeak_embed",
+      image_kind: "default",
+      image: { image_data: { image_kind: "default", crop_data: { x: 0, y: 0, width: 960, height: 640 } } },
+    }
+  end
+
   test "POST :create shows success message when all image assets are uploaded" do
     login_authorised_user
     edition = create(:draft_fatality_notice)

--- a/test/unit/app/services/editon_auth_bypass_updater_test.rb
+++ b/test/unit/app/services/editon_auth_bypass_updater_test.rb
@@ -165,5 +165,54 @@ class EditionAuthBypassUpdaterTest < ActiveSupport::TestCase
 
       service.call
     end
+
+    test "updates a call for evidence response form asset with auth_bypass_id" do
+      edition = create(:call_for_evidence)
+      participation = create(:call_for_evidence_participation, call_for_evidence: edition)
+      call_for_evidence_response_form = create(:call_for_evidence_response_form, call_for_evidence_participation: participation)
+
+      edition.reload
+      SecureRandom.stubs(uuid: uid)
+      expected_attributes = { "auth_bypass_ids" => [uid] }
+
+      service = EditionAuthBypassUpdater.new(
+        edition:,
+        current_user: user,
+        updater:,
+      )
+
+      AssetManagerUpdateAssetJob.expects(:perform_async_in_queue).with(
+        "asset_manager_updater",
+        "CallForEvidenceResponseFormData",
+        call_for_evidence_response_form.call_for_evidence_response_form_data.id,
+        expected_attributes,
+      )
+
+      service.call
+    end
+
+    test "updates a call for evidence outcome's attachments with auth_bypass_id" do
+      edition = create(:draft_call_for_evidence)
+      outcome = create(:call_for_evidence_outcome, call_for_evidence: edition)
+      file_attachment = create(:file_attachment, attachable: outcome)
+
+      SecureRandom.stubs(uuid: uid)
+      expected_attributes = { "auth_bypass_ids" => [uid] }
+
+      service = EditionAuthBypassUpdater.new(
+        edition:,
+        current_user: user,
+        updater:,
+      )
+
+      AssetManagerUpdateAssetJob.expects(:perform_async_in_queue).with(
+        "asset_manager_updater",
+        "AttachmentData",
+        file_attachment.attachment_data.id,
+        expected_attributes,
+      )
+
+      service.call
+    end
   end
 end


### PR DESCRIPTION
Part 1 of 3 for [WHIT-3020 (opt-in preview tokens)](https://gov-uk.atlassian.net/browse/WHIT-3020). **Base of the stack** — #11543 and #11542 build on this.

## What

Fixes two pre-existing gaps where a draft edition's `auth_bypass_id` was never written to some of its assets in Asset Manager, so the token was not propagated to them.

1. **Call for evidence response forms.** When a preview link is generated/regenerated, the `auth_bypass_id` was propagated to attachment and image assets, and to consultation response forms, but **not** to call for evidence response form (or outcome attachment) assets. The fix adds the call for evidence branch to `EditionAuthBypassUpdater`, mirroring the existing consultation handling.

2. **Cropped images.** Uploading via the create path already snapshots the token onto new image assets. But cropping/replacing an image builds a fresh `ImageData` and saves it *before* linking it to the image, so `ImageData#auth_bypass_ids` (which walks `images` to the edition) returns `[]` and the cropped asset is created token-less. Since single-usage and oversized images are forced through cropping, the displayed asset ended up without the token. The fix links the image before saving, mirroring the create path's existing workaround.

[WHIT-3580]: https://gov-uk.atlassian.net/browse/WHIT-3580
