### PR TITLE
WIP: Add an "Approved" state to Whitehall

### DIFF
--- a/app/helpers/admin/editions_helper.rb
+++ b/app/helpers/admin/editions_helper.rb
@@ -59,6 +59,7 @@ module Admin::EditionsHelper
       ["All states", "active"],
       %w[Draft draft],
       %w[Submitted submitted],
+      %w[Approved approved],
       %w[Rejected rejected],
       %w[Scheduled scheduled],
       %w[Published published],

--- a/app/models/concerns/edition/workflow.rb
+++ b/app/models/concerns/edition/workflow.rb
@@ -11,7 +11,7 @@ module Edition::Workflow
     end
 
     def valid_state?(state)
-      %w[active draft submitted rejected published scheduled force_published withdrawn not_published unpublished].include?(state)
+      %w[active draft submitted rejected approved published scheduled force_published withdrawn not_published unpublished].include?(state)
     end
   end
 
@@ -24,6 +24,7 @@ module Edition::Workflow
       state :draft
       state :submitted
       state :rejected
+      state :approved
       state :scheduled
       state :published
       state :superseded
@@ -44,7 +45,7 @@ module Edition::Workflow
       end
 
       event :schedule do
-        transitions from: :submitted, to: :scheduled
+        transitions from: :approved, to: :scheduled
       end
 
       event :force_schedule do
@@ -56,7 +57,7 @@ module Edition::Workflow
       end
 
       event :publish do
-        transitions from: %i[submitted scheduled], to: :published
+        transitions from: %i[approved scheduled], to: :published
       end
 
       event :force_publish do
@@ -65,6 +66,19 @@ module Edition::Workflow
 
       event :unpublish do
         transitions from: %i[published unpublished], to: :unpublished
+      end
+
+      # TODO: presumably we need some governance around how an edition can become
+      # approved. I guess whoever has the power to 'reject' a submitted edition
+      # should also have the power to 'approve'.
+      #
+      # And there should be implications for the publishing workflow, i.e. right now
+      # it is possible to publish (not force publish) a submitted edition), but
+      # we're saying that an edition that is merely 'submitted' should now only have
+      # the force-publish/force-schedule options available to it. Only "approved"
+      # editions should be able to be published or scheduled normally.
+      event :approve do
+        transitions from: %i[submitted], to: :approved
       end
 
       event :supersede, success: :destroy_associations_with_edition_dependencies_and_dependants do

--- a/test/functional/admin/edition_workflow_controller_test.rb
+++ b/test/functional/admin/edition_workflow_controller_test.rb
@@ -217,13 +217,14 @@ class Admin::EditionWorkflowControllerTest < ActionController::TestCase
     assert_equal "All workflow actions require a lock version", response.body
   end
 
-  test "approve_retrospectively marks the document as having been approved retrospectively and redirects back to he edition" do
+  test "approve_retrospectively marks the document as having been approved retrospectively and redirects back to the edition" do
     editor = create(:departmental_editor)
     acting_as(editor) { force_publish(draft_edition) }
     post :approve_retrospectively, params: { id: draft_edition, lock_version: draft_edition.lock_version }
 
     assert_redirected_to admin_publication_path(draft_edition)
     assert_equal "Thanks for reviewing; this document is no longer marked as force-published", flash[:notice]
+    # Missing assertion here. Should check `force_published` is now false,
   end
 
   test "approve_retrospectively responds with 422 if missing a lock version" do


### PR DESCRIPTION
It's always been confusing that one can submit an edition for 2i, and that it can be rejected, but that there is no concept of 'approving' it. A submitted edition can be immediately published by anyone else, provided they weren't the person who submitted it for 2i. The sidebar options are "Publish" or "Reject". The proposal here is that the options instead are "Approve" or "Reject".

On approval, the options would then become "Publish" and "Dismiss approval" (much like it's possible to dismiss a PR review in GitHub). We wouldn't want a draft to get 'stuck' in an approved state with no means of requesting 2i again even after a major draft edit. Dismissing the approval would put it back into "draft" state and the publisher could then go through the normal 2i flow again.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
