### PR TITLE
Fix review reminder fields disappearing on tabbed edit pages [WHIT-3214]

### DIFF
--- a/app/controllers/admin/standard_editions_controller.rb
+++ b/app/controllers/admin/standard_editions_controller.rb
@@ -41,7 +41,7 @@ class Admin::StandardEditionsController < Admin::EditionsController
     super
     return if @current_tab_context.blank?
 
-    tab_form = StandardEdition::TabForm.new(@edition.reload, @current_tab_context)
+    tab_form = StandardEdition::TabForm.new(load_edition_from_database(@edition), @current_tab_context)
     apply_tab_errors_to_edition(tab_form) unless tab_form.valid?
   end
 
@@ -120,6 +120,10 @@ private
     else
       super
     end
+  end
+
+  def load_edition_from_database(edition)
+    LocalisedModel.new(edition_class.find(edition.id), edition.primary_locale)
   end
 
   def apply_tab_errors_to_edition(tab_form)

--- a/test/functional/admin/standard_editions_controller_test.rb
+++ b/test/functional/admin/standard_editions_controller_test.rb
@@ -1249,14 +1249,17 @@ class Admin::StandardEditionsControllerTest < ActionController::TestCase
                      configurable_document_type: "test_type",
                      block_content: { body: "original" })
 
+    edition.translation.update_column(:block_content, { "body" => "updated in db" })
+
+    db_edition = @controller.send(:load_edition_from_database, edition)
+    assert_equal "updated in db", db_edition.block_content["body"]
+
     get :edit, params: { id: edition, current_tab: "documents" }
 
-    # Tab validation runs on a fresh DB copy via edition.reload,
-    # so the in-memory placeholder fields built by build_edition_dependencies eg review_reminder
-    # should never be validated if untouched and should send no errors when loading the edit view.
-    reminder = assigns(:edition).document.review_reminder
-    assert reminder.nil? || reminder.errors.empty?,
-           "Expected no review_reminder errors but found: #{reminder&.errors&.full_messages}"
+    # build_edition_dependencies action on the edit route creates an in-memory review_reminder placeholder.
+    # Tab validation must not call edition.valid? on @edition directly, otherwise
+    # that placeholder gets validated and its errors leak into the rendered form.
+    assert assigns(:edition).document.review_reminder.errors.empty?
   end
 
   view_test "POST create surfaces Publishing API validation error if save_draft fails" do


### PR DESCRIPTION
A fix-up for a late change in https://github.com/alphagov/whitehall/pull/11436, specifically [this comment](https://github.com/alphagov/whitehall/pull/11436#discussion_r3403439751).

This replaces `@edition.reload` with a separate DB-loaded copy for tab validation on the edit page, and updates the test to cover this.

`@edition.reload` clears the association cache, which removes the in-memory placeholders that `build_edition_dependencies` sets up for rendering, including the review_reminder. This caused the review reminder fields to disappear when a current_tab param was present.

`load_edition_from_database` creates a separate LocalisedModel from a fresh DB query, leaving `@edition` and its in-memory state untouched. Tab validation runs against that clean copy, so the rendered form still has the placeholders it needs.

This is a follow-up fix to b9d1b7a, which introduced the fresh-copy approach.

[JIRA](https://gov-uk.atlassian.net/browse/WHIT-3214)

--- 

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
