### PR TITLE
[WHIT-3631] Fall back to draft content store for unpublished document collection links

### DIFF
--- a/app/models/document_collection_non_whitehall_link/govuk_url.rb
+++ b/app/models/document_collection_non_whitehall_link/govuk_url.rb
@@ -41,7 +41,7 @@ class DocumentCollectionNonWhitehallLink::GovukUrl
   def content_item_from_content_store
     path = parsed_url.path
 
-    item = Services.content_store.content_item(path).to_h
+    item = content_item_for(path)
 
     if item["base_path"] != path && item["document_type"] != "guide"
       raise GdsApi::HTTPNotFound, 404
@@ -50,5 +50,12 @@ class DocumentCollectionNonWhitehallLink::GovukUrl
     item
   rescue GdsApi::ContentStore::ItemNotFound
     raise GdsApi::HTTPNotFound, 404
+  end
+
+  def content_item_for(path)
+    Services.content_store.content_item(path).to_h
+  rescue GdsApi::ContentStore::ItemNotFound
+    # Fall back to the draft content store for unpublished content
+    Services.draft_content_store.content_item(path).to_h
   end
 end

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -16,6 +16,13 @@ module Services
     @content_store ||= GdsApi::ContentStore.new(Plek.find("content-store"))
   end
 
+  def self.draft_content_store
+    @draft_content_store ||= GdsApi::ContentStore.new(
+      Plek.find("draft-content-store"),
+      bearer_token: ENV.fetch("DRAFT_CONTENT_STORE_BEARER_TOKEN", "example"),
+    )
+  end
+
   def self.asset_manager
     @asset_manager ||= GdsApi::AssetManager.new(
       Plek.find("asset-manager"),

--- a/test/unit/app/models/document_collection_non_whitehall_link/govuk_url_test.rb
+++ b/test/unit/app/models/document_collection_non_whitehall_link/govuk_url_test.rb
@@ -98,8 +98,27 @@ class DocumentCollectionNonWhitehallLink::GovukUrlTest < ActiveSupport::TestCase
     assert url.valid?
   end
 
-  test "should be invalid when content store returns a 404" do
+  test "should be valid for an unpublished URL found only in the draft content store" do
+    draft_content_id = SecureRandom.uuid
+    Services.content_store.stubs(:content_item).with("/unpublished").raises(GdsApi::ContentStore::ItemNotFound.new(404))
+    Services.draft_content_store.stubs(:content_item).with("/unpublished").returns(
+      "content_id" => draft_content_id,
+      "title" => "Unpublished",
+      "base_path" => "/unpublished",
+      "publishing_app" => "whitehall",
+    )
+
+    url = DocumentCollectionNonWhitehallLink::GovukUrl.new(
+      url: "https://www.gov.uk/unpublished",
+      document_collection_group: build(:document_collection_group),
+    )
+
+    assert url.valid?
+  end
+
+  test "should be invalid when neither content store has the path" do
     Services.content_store.stubs(:content_item).raises(GdsApi::ContentStore::ItemNotFound.new(404))
+    Services.draft_content_store.stubs(:content_item).raises(GdsApi::ContentStore::ItemNotFound.new(404))
 
     url = DocumentCollectionNonWhitehallLink::GovukUrl.new(
       url: "https://www.gov.uk/test",


### PR DESCRIPTION
## What

Adding a not-yet-published GOV.UK URL to a document collection group (`/government/admin/collections/:id/groups/:id/add_by_url`) fails with **"Url must reference a GOV.UK page"**.

The link validation only queries the **live** content store, which holds published content only. This was a regression from WHIT-3436 (#11442), which replaced the previous Publishing API lookup (`lookup_content_id` with `with_drafts: true`) with the live content store to fix Welsh/locale resolution — but in doing so dropped draft awareness.

## How

- Query the live content store first (preserves the WHIT-3436 locale-agnostic fix for published pages, e.g. Welsh).
- Fall back to the **draft content store** when the live store returns a 404, so unpublished URLs resolve again. The draft store is also locale-agnostic, so it covers Welsh drafts too.
- Only raise "must reference a GOV.UK page" when *both* stores 404.
- Add `Services.draft_content_store`, authenticated with a dedicated `DRAFT_CONTENT_STORE_BEARER_TOKEN` — the draft content store serves non-public content and requires a Signon bearer token (unlike the live store, which Whitehall reads without one).

## ⚠️ Infra provisioning required before this works in real environments

The code defaults the token to `"example"` (local dev). Integration/staging/production need a real token provisioning:

- [ ] **Signon** — grant Whitehall's API user access to **Draft Content Store** and issue an access token, per environment (superadmin task; see [Manage Signon accounts](https://docs.publishing.service.gov.uk/manual/manage-sign-on-accounts.html)).
- [ ] **govuk-secrets** — store the token as `DRAFT_CONTENT_STORE_BEARER_TOKEN`.
- [ ] **govuk-helm-charts** — inject it into whitehall-admin pods.
- [ ] **Confirm with platform/publishing** whether server-to-server `GdsApi::ContentStore` reads against draft-content-store return `access_limited` items, or only non-limited drafts (per the [draft stack docs](https://docs.publishing.service.gov.uk/manual/content-preview.html)).
- [ ] **Verify on integration** — retry the original failing URL.

## Test plan

- [ ] On integration (once the token is wired), add an draft statistics URL to a collection group and confirm it succeeds.