### PR TITLE
Only render access limiting fields when organisations are enabled

### DIFF
--- a/app/views/admin/standard_editions/_document_form_fields.html.erb
+++ b/app/views/admin/standard_editions/_document_form_fields.html.erb
@@ -67,7 +67,7 @@
 
   <%= render Admin::Editions::LanguageSelectFormControl.new(edition) %>
   <%= render "accessible_attachment_field", form: form, edition: edition if edition.allows_file_attachments? %>
-  <%= render "access_limiting_fields", form: form, edition: edition %>
+  <%= render "access_limiting_fields", form: form, edition: edition if edition.organisation_association_enabled? %>
   <%= render "scheduled_publication_fields", form: form, edition: edition %>
   <%= render "review_reminder_fields", form: form, review_reminder: edition.document.review_reminder %>
 </div>

--- a/test/functional/admin/standard_editions_controller_test.rb
+++ b/test/functional/admin/standard_editions_controller_test.rb
@@ -248,9 +248,41 @@ class Admin::StandardEditionsControllerTest < ActionController::TestCase
     assert_response :ok
     assert_select "label", text: "Title (required)"
     assert_select "label", text: "Summary (required)"
-    assert_select "legend", text: "Limit access"
     assert_select "legend", text: "Schedule publication"
     assert_select "legend", text: "Review date"
+    refute_select "legend", text: "Limit access"
+  end
+
+  view_test "GET edit renders access limiting fields when organisations are enabled" do
+    configurable_document_type = build_configurable_document_type(
+      "test_type",
+      {
+        "forms" => {
+          "documents" => {
+            "fields" => {
+              "lead_organisations" => {
+                "title" => "Lead organisations",
+                "required" => false,
+                "block" => "ordered_select_with_search_tagging",
+                "container" => "organisations",
+                "attribute_path" => %w[lead_organisation_ids],
+                "size" => 4,
+                "translatable" => false,
+              },
+            },
+          },
+        },
+      },
+    )
+    ConfigurableDocumentType.setup_test_types(configurable_document_type)
+
+    edition = build(:standard_edition, :with_organisations)
+    edition.save!
+
+    get :edit, params: { id: edition }
+
+    assert_response :ok
+    assert_select "legend", text: "Limit access"
   end
 
   view_test "GET edit shows the current GOV.UK URL as a link when the edition has a live edition" do


### PR DESCRIPTION
For config-driven types that do not support organisation associations, such as world news stories, access limiting would cause a permission error, blocking the user from further editing.

This hides the fields if there is no organisation.  Was missed in the original PR, due to assuming that the `_settings_fields.html.erb` partial serves standard edition too. It does not, the standard edition uses `_document_form_fields.html.erb`.

Follows from https://github.com/alphagov/whitehall/pull/11550