### PR TITLE
[WHIT-3592] Enqueue role publishing jobs from after_commit

### DIFF
--- a/app/models/ministerial_role.rb
+++ b/app/models/ministerial_role.rb
@@ -6,7 +6,7 @@ class MinisterialRole < Role
   has_many :consultations, -> { where("editions.type" => "Consultation").distinct }, through: :role_appointments
   has_many :speeches, through: :role_appointments
 
-  after_save :patch_links_ministers_index_page_to_publishing_api, :republish_how_government_works_page_to_publishing_api
+  after_commit :patch_links_ministers_index_page_to_publishing_api, :republish_how_government_works_page_to_publishing_api, on: %i[create update]
 
   scope :cabinet_members,
         -> { where(cabinet_member: true) }

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -36,8 +36,8 @@ class Person < ApplicationRecord
   translates :biography
 
   before_destroy :prevent_destruction_if_appointed
-  after_update :republish_past_prime_ministers_page_to_publishing_api
-  after_update :patch_links_ministers_index_page_to_publishing_api, :republish_how_government_works_page_to_publishing_api, if: :has_ministerial_appointments?
+  after_commit :republish_past_prime_ministers_page_to_publishing_api, on: :update
+  after_commit :patch_links_ministers_index_page_to_publishing_api, :republish_how_government_works_page_to_publishing_api, on: :update, if: :has_ministerial_appointments?
 
   def biography_without_markup
     Govspeak::Document.new(biography).to_text

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -57,7 +57,7 @@ class Role < ApplicationRecord
   validates_with SafeHtmlValidator
 
   before_destroy :prevent_destruction_unless_destroyable
-  after_save :republish_associated_editions_to_publishing_api, :republish_organisations_to_publishing_api
+  after_commit :republish_associated_editions_to_publishing_api, :republish_organisations_to_publishing_api, on: %i[create update]
 
   accepts_nested_attributes_for :edition_roles
 

--- a/app/models/role_appointment.rb
+++ b/app/models/role_appointment.rb
@@ -70,9 +70,8 @@ class RoleAppointment < ApplicationRecord
   after_create :make_other_current_appointments_non_current
   before_destroy :prevent_destruction_unless_destroyable
 
-  after_save :patch_links_ministers_index_page_to_publishing_api, :republish_how_government_works_page_to_publishing_api, if: :ministerial?
-  after_save :republish_associated_editions_to_publishing_api, :republish_organisation_to_publishing_api, :republish_prime_ministers_index_page_to_publishing_api, :republish_role_to_publishing_api
-  after_destroy :republish_associated_editions_to_publishing_api, :republish_organisation_to_publishing_api, :republish_prime_ministers_index_page_to_publishing_api, :republish_role_to_publishing_api
+  after_commit :patch_links_ministers_index_page_to_publishing_api, :republish_how_government_works_page_to_publishing_api, on: %i[create update], if: :ministerial?
+  after_commit :republish_associated_editions_to_publishing_api, :republish_organisation_to_publishing_api, :republish_prime_ministers_index_page_to_publishing_api, :republish_role_to_publishing_api
 
   def republish_associated_editions_to_publishing_api
     role.edition_roles.each do |edition_role|

--- a/test/unit/app/models/ministerial_role_test.rb
+++ b/test/unit/app/models/ministerial_role_test.rb
@@ -77,6 +77,17 @@ class MinisterialRoleTest < ActiveSupport::TestCase
     end
   end
 
+  test "does not patch the ministers index page when a ministerial role update is rolled back before commit" do
+    role = create(:ministerial_role)
+
+    PatchLinksPublishingApiJob.expects(:perform_async).never
+
+    ActiveRecord::Base.transaction do
+      role.update!(name: "New name")
+      raise ActiveRecord::Rollback
+    end
+  end
+
   test "does not send the ministerial index pages to publishing api when a non-ministerial role is updated" do
     role = create(:non_ministerial_role_without_organisations)
     create(:role_appointment, role:)

--- a/test/unit/app/models/person_test.rb
+++ b/test/unit/app/models/person_test.rb
@@ -249,4 +249,27 @@ class PersonTest < ActiveSupport::TestCase
       person.update(forename: "New first name")
     end
   end
+
+  test "does not patch the ministers index page when a person update is rolled back before commit" do
+    person = create(:person)
+    create(:ministerial_role_appointment, person:)
+
+    PatchLinksPublishingApiJob.expects(:perform_async).never
+
+    ActiveRecord::Base.transaction do
+      person.update!(forename: "New first name")
+      raise ActiveRecord::Rollback
+    end
+  end
+
+  test "does not republish the past prime ministers page when a prime minister update is rolled back before commit" do
+    person = create(:pm)
+
+    PresentPageToPublishingApiJob.expects(:perform_async).with("PublishingApi::HistoricalAccountsIndexPresenter").never
+
+    ActiveRecord::Base.transaction do
+      person.update!(forename: "New first name")
+      raise ActiveRecord::Rollback
+    end
+  end
 end

--- a/test/unit/app/models/role_appointment_test.rb
+++ b/test/unit/app/models/role_appointment_test.rb
@@ -510,6 +510,18 @@ class RoleAppointmentTest < ActiveSupport::TestCase
     end
   end
 
+  test "does not patch the ministers index page when the appointment is rolled back before commit" do
+    role = create(:ministerial_role)
+    person = create(:person)
+
+    PatchLinksPublishingApiJob.expects(:perform_async).never
+
+    ActiveRecord::Base.transaction do
+      create(:role_appointment, person:, role:)
+      raise ActiveRecord::Rollback
+    end
+  end
+
   test "should not send the related pages to publishing api when someone is appointed to a non-ministerial role" do
     role = create(:non_ministerial_role_without_organisations)
 
@@ -566,6 +578,29 @@ class RoleAppointmentTest < ActiveSupport::TestCase
     role_appointment = create(:role_appointment, role:)
     Whitehall::PublishingApi.expects(:republish_async).with(role)
     role_appointment.update!(ended_at: Time.zone.now)
+  end
+
+  test "does not republish related content to publishing api when a role appointment create is rolled back before commit" do
+    role = create(:role_without_organisations)
+
+    Whitehall::PublishingApi.expects(:republish_async).never
+
+    ActiveRecord::Base.transaction do
+      create(:role_appointment, role:)
+      raise ActiveRecord::Rollback
+    end
+  end
+
+  test "does not republish related content to publishing api when a role appointment destroy is rolled back before commit" do
+    role = create(:role_without_organisations)
+    role_appointment = create(:role_appointment, role:)
+
+    Whitehall::PublishingApi.expects(:republish_async).never
+
+    ActiveRecord::Base.transaction do
+      role_appointment.destroy!
+      raise ActiveRecord::Rollback
+    end
   end
 
   test "republishes a role when a role appointment is destroyed" do

--- a/test/unit/app/models/role_test.rb
+++ b/test/unit/app/models/role_test.rb
@@ -227,6 +227,17 @@ class RoleTest < ActiveSupport::TestCase
     role.update!(organisations: [])
   end
 
+  test "does not republish associated content to publishing api when a role create is rolled back before commit" do
+    organisation = create(:organisation)
+
+    Whitehall::PublishingApi.expects(:republish_async).never
+
+    ActiveRecord::Base.transaction do
+      create(:role, organisations: [organisation])
+      raise ActiveRecord::Rollback
+    end
+  end
+
   test "republishes a worldwide organisation when a role is updated" do
     worldwide_organisation = create(:worldwide_organisation)
     role = create(:role_without_organisations)


### PR DESCRIPTION
### What

Move the Publishing API republish callbacks on `Role`, `RoleAppointment`, `Person` and `MinisterialRole` from `after_save`/`after_update`/`after_destroy` to `after_commit`.

### Why

A new cabinet minister appeared under *Departmental ministers* but not *Cabinet ministers* on the live Ministers page until an editor manually re-ordered the list.

The Cabinet ministers section is rebuilt from a single `PatchLinkSet` on the `ministers_index` content item, derived from live appointment data. That patch was enqueued from an `after_save` callback, which runs **inside** the DB transaction. Publishing API event logs confirmed the appointment committed at `20:06:52 UTC` and the `PatchLinkSet` at that same second rebuilt the list of 21 ministers *without* the new appointment — the Sidekiq worker read the row before the transaction committed. Nothing re-patched until the manual re-order.

[Jira](https://gov-uk.atlassian.net/browse/WHIT-3592)

### Fix

Enqueue these jobs from `after_commit` so they only run once the change is durably committed and any worker is guaranteed to read it. No change to the payloads sent; only the timing and the failure semantics (a failed enqueue no longer rolls back the editorial save — consistent with `Organisation`'s existing `after_save_commit`).

Each moved callback has a commit-timing test (a rolled-back save enqueues nothing)

### Test plan

Manual testing on integration. Every path below updates the live page reliably and unattended, with **no manual "Reorder list → Update order" step**.

**Tooling**
- Live page: `https://www.integration.publishing.service.gov.uk/government/ministers`

**Cases**
- [x] **Appoint a new cabinet minister** (core fix). End the current holder of a `cabinet_member: true` role, then appoint a test person (set current) — without reordering. ⇒ Person appears in **Cabinet ministers** automatically, in seniority position.
- [x] **End a cabinet minister appointment.** ⇒ Person removed from **Cabinet ministers** automatically.
- [x] **Update a person holding a ministerial role** (e.g. forename/biography). ⇒ Live page reflects the change; no errors.
- [x] **Update a ministerial role** (e.g. rename). ⇒ Reflected automatically.
- [x] **Reorder still works** (regression). Use Reorder list → Update order. ⇒ Ordering updates as before.
- [x] **Departmental ministers** (regression). Appoint to a non-cabinet departmental role. ⇒ Person appears under the department in **Ministers by department**.
- [x] **Role ↔ organisation link** (regression on `Role` base-class change). Link then unlink an organisation on a role. ⇒ Saves succeed and the organisation page republishes without error.
- [x] **Whips** (regression). Reorder a whip role. ⇒ **Whips** section updates automatically.