### PR TITLE
[WHIT-3633] - Only apply access limiting default at instantiation

### DIFF
--- a/app/models/concerns/edition/limited_access.rb
+++ b/app/models/concerns/edition/limited_access.rb
@@ -6,7 +6,7 @@ module Edition::LimitedAccess
       none: "none",
       organisations: "organisations",
       individuals: "individuals",
-    }, prefix: true
+    }, prefix: true, default: nil
 
     after_initialize :set_access_limited
   end
@@ -34,11 +34,9 @@ module Edition::LimitedAccess
   delegate :access_limited_by_default?, to: :class
 
   def set_access_limited
-    return if access_limited_by_default?.nil?
+    return unless new_record? && access_limiting.nil?
 
-    if new_record? && access_limited_by_default? && access_limiting_none?
-      self.access_limiting = :organisations
-    end
+    self.access_limiting = access_limited_by_default? ? :organisations : :none
   end
 
   def accessible_to?(user)

--- a/test/unit/app/models/publication_test.rb
+++ b/test/unit/app/models/publication_test.rb
@@ -113,11 +113,11 @@ class PublicationTest < ActiveSupport::TestCase
   end
 
   test "new instances are access_limited based on their publication_type" do
-    limit_by_default, dont_limit_by_default = PublicationType.all.partition(&:access_limited_by_default?).map(&:first)
-    e = build(:draft_publication, publication_type: limit_by_default)
-    assert e.access_limited?
-    e = build(:draft_publication, publication_type: dont_limit_by_default)
-    assert_not e.access_limited?
+    limit_by_default, dont_limit_by_default =
+      PublicationType.all.partition(&:access_limited_by_default?).map(&:first)
+
+    assert Publication.new(publication_type: limit_by_default).access_limited?
+    assert_not Publication.new(publication_type: dont_limit_by_default).access_limited?
   end
 
   test "new instances respect local access_limiting over their publication_type" do


### PR DESCRIPTION
Only apply access limiting default at instantiation
Introduce a default nil value for the access_limiting enum to match how the access_limited boolean worked.

Flow:
- Instantiate a new document from its class
- Have access_limited/access_limiting set to nil
- Replace the nil value with the default set by the document's class
- Ignore any attempts to set the default where a valid value has been set

This allows `set_access_limited` to determine it should assign a default and the value set by a user will be honoured when the form is submitted and the record is first saved.

As per the old behaviour, this will only apply when the document is first created (before being persisted to the DB). It will not apply when creating a new edition on a published document. Instead a new edition will have access limiting disabled.

Model test in unit/app/models/publication_test.rb updated to mimic a newly instantiated model to replicate what would be used on the form fields.