### PR TITLE
Prevent users from locking themselves out [WHIT-3583]

### DIFF
--- a/app/controllers/admin/edition_access_limited_controller.rb
+++ b/app/controllers/admin/edition_access_limited_controller.rb
@@ -1,4 +1,6 @@
 class Admin::EditionAccessLimitedController < Admin::BaseController
+  include AccessLimitingConcern
+
   before_action :find_edition
   before_action :enforce_permissions!
   before_action :clean_organisation_params, only: %i[update]
@@ -7,29 +9,35 @@ class Admin::EditionAccessLimitedController < Admin::BaseController
 
   def update
     editorial_remark = edition_params.delete(:editorial_remark)
-    @edition.assign_attributes(edition_params)
+    @edition.assign_attributes(edition_params.except(:access_limiting_organisation_ids))
 
-    if changed?
-      if editorial_remark.blank?
-        @edition.errors.add(:editorial_remark, t("errors.messages.blank"))
+    # Assign organisations to the in-memory edition for validation.
+    # Actual persistence is deferred to @edition.save below.
+    sync_access_limiting_organisations
 
-        render :edit
-      else
-        @edition.save!
-        PublishingApiDocumentRepublishingJob.perform_async(@edition.document_id, false)
+    return render :edit unless access_limiting_organisations_valid?
 
-        EditorialRemark.create!(
-          edition: @edition,
-          body: "Access options updated by GDS Admin: #{editorial_remark}",
-          author: current_user,
-          created_at: Time.zone.now,
-          updated_at: Time.zone.now,
-        )
+    # Unset organisation options if switching away from organisation access limiting.
+    # Must happen after validation so we don't wipe organisations on a failed save.
+    clear_access_limiting_organisations_unless_organisations_selected
 
-        redirect_to admin_editions_path, notice: "Access updated for #{@edition.title}"
-      end
-    else
+    if editorial_remark.blank?
+      @edition.errors.add(:editorial_remark, t("errors.messages.blank"))
+      return render :edit
+    end
+
+    if @edition.save
+      PublishingApiDocumentRepublishingJob.perform_async(@edition.document_id, false)
+      EditorialRemark.create!(
+        edition: @edition,
+        body: "Access options updated by GDS Admin: #{editorial_remark}",
+        author: current_user,
+        created_at: Time.zone.now,
+        updated_at: Time.zone.now,
+      )
       redirect_to admin_editions_path, notice: "Access updated for #{@edition.title}"
+    else
+      render :edit
     end
   end
 
@@ -45,15 +53,16 @@ private
 
   def edition_params
     @edition_params ||= params
-    .fetch(:edition, {})
-    .permit(
-      :access_limiting,
-      :editorial_remark,
-      {
-        lead_organisation_ids: [],
-        supporting_organisation_ids: [],
-      },
-    )
+      .fetch(:edition, {})
+      .permit(
+        :access_limiting,
+        :editorial_remark,
+        {
+          lead_organisation_ids: [],
+          supporting_organisation_ids: [],
+          access_limiting_organisation_ids: [],
+        },
+      )
   end
 
   def clean_organisation_params
@@ -62,14 +71,6 @@ private
     end
     if edition_params[:supporting_organisation_ids]
       edition_params[:supporting_organisation_ids] = edition_params[:supporting_organisation_ids].reject(&:blank?)
-    end
-  end
-
-  def changed?
-    if @edition.organisation_association_enabled?
-      @edition.changed? || @edition.edition_organisations != Edition.find(params[:id]).edition_organisations
-    else
-      @edition.changed?
     end
   end
 end

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -1,6 +1,7 @@
 class Admin::EditionsController < Admin::BaseController
   include HistoricContentConcern
   include Admin::EditionsHelper
+  include AccessLimitingConcern
 
   before_action :remove_blank_parameters
   before_action :clean_edition_parameters, only: %i[create update]
@@ -20,6 +21,7 @@ class Admin::EditionsController < Admin::BaseController
   before_action :limit_edition_access!, only: %i[show edit update revise diff destroy]
   before_action :redirect_to_controller_for_type, only: [:show]
   before_action :construct_similar_slug_warning_error, only: %i[edit]
+  before_action :prevent_access_limiting_lockout, only: %i[create update]
 
   rescue_from ActiveRecord::StaleObjectError, with: :handle_stale_object_error
 
@@ -93,6 +95,8 @@ class Admin::EditionsController < Admin::BaseController
   def new; end
 
   def create
+    process_access_limiting_organisations
+
     if updater.can_perform? && @edition.save
       updater.perform!
       redirect_to show_or_edit_path, saved_confirmation_notice
@@ -115,7 +119,8 @@ class Admin::EditionsController < Admin::BaseController
   end
 
   def update
-    @edition.assign_attributes(edition_params)
+    @edition.assign_attributes(edition_params.except(:access_limiting_organisation_ids))
+    process_access_limiting_organisations
 
     if updater.can_perform? && @edition.save_as(current_user)
 
@@ -548,5 +553,19 @@ private
     @edition.lock_version = @conflicting_edition.lock_version
     build_edition_dependencies
     render :edit
+  end
+
+  def prevent_access_limiting_lockout
+    return unless Flipflop.access_limiting_organisations_ui? && access_limiting_would_lock_out_current_user?
+
+    flash.now[:alert] = "Access can only be limited by users belonging to an organisation tagged to the document"
+
+    if @edition.new_record?
+      build_edition_dependencies
+      render :new
+    else
+      @edition.assign_attributes(edition_params.except(:access_limiting_organisation_ids))
+      render_edition_update_failure
+    end
   end
 end

--- a/app/controllers/admin/editions_controller.rb
+++ b/app/controllers/admin/editions_controller.rb
@@ -247,6 +247,7 @@ private
         all_nation_applicability: [],
         lead_organisation_ids: [],
         supporting_organisation_ids: [],
+        access_limiting_organisation_ids: [],
         organisation_ids: [],
         role_ids: [],
         world_location_ids: [],

--- a/app/controllers/admin/standard_editions_controller.rb
+++ b/app/controllers/admin/standard_editions_controller.rb
@@ -46,9 +46,11 @@ class Admin::StandardEditionsController < Admin::EditionsController
   end
 
   def update
-    @edition.assign_attributes(edition_params)
+    @edition.assign_attributes(edition_params.except(:access_limiting_organisation_ids))
 
     if @current_tab_context.present?
+      process_access_limiting_organisations
+
       tab_form = StandardEdition::TabForm.new(@edition, @current_tab_context)
 
       if tab_form.valid?

--- a/app/controllers/concerns/access_limiting_concern.rb
+++ b/app/controllers/concerns/access_limiting_concern.rb
@@ -35,17 +35,15 @@ module AccessLimitingConcern
     return unless Flipflop.access_limiting_organisations_ui?
     return unless submitted_access_limiting_organisation_ids.any?
 
-    @edition.edition_access_limiting_organisations.each(&:mark_for_destruction)
-    submitted_access_limiting_organisation_ids.each do |org_id|
-      @edition.edition_access_limiting_organisations.build(organisation_id: org_id.to_i)
-    end
+    @edition.access_limiting_organisation_ids = submitted_access_limiting_organisation_ids
   end
 
   def access_limiting_would_lock_out_current_user?
-    return false unless current_user.organisation && edition_params[:access_limiting] == "organisations"
+    return false unless edition_params[:access_limiting] == "organisations"
+    return false unless submitted_access_limiting_organisation_ids.any?
 
-    submitted_ids = submitted_access_limiting_organisation_ids.map(&:to_i)
-    submitted_ids.any? && submitted_ids.exclude?(current_user.organisation.id)
+    user_org_id = current_user.organisation&.id
+    user_org_id.nil? || submitted_access_limiting_organisation_ids.map(&:to_i).exclude?(user_org_id)
   end
 
   def process_access_limiting_organisations

--- a/app/controllers/concerns/access_limiting_concern.rb
+++ b/app/controllers/concerns/access_limiting_concern.rb
@@ -1,0 +1,33 @@
+module AccessLimitingConcern
+  extend ActiveSupport::Concern
+
+  def access_limiting_organisations_valid?
+    return true unless Flipflop.access_limiting_organisations_ui?
+    return true unless submitted_access_limiting_organisation_ids.empty?
+    return true unless @edition.access_limiting_organisations?
+
+    @edition.errors.add(:access_limiting_organisation_ids,
+                        "must include at least one organisation when access limiting is enabled")
+    false
+  end
+
+  def submitted_access_limiting_organisation_ids
+    @submitted_access_limiting_organisation_ids ||= Array(edition_params[:access_limiting_organisation_ids]).reject(&:blank?)
+  end
+
+  def clear_access_limiting_organisations_unless_organisations_selected
+    return unless Flipflop.access_limiting_organisations_ui?
+
+    @edition.access_limiting_organisation_ids = [] unless @edition.access_limiting == "organisations"
+  end
+
+  def sync_access_limiting_organisations
+    return unless Flipflop.access_limiting_organisations_ui?
+
+    if submitted_access_limiting_organisation_ids.any?
+      @edition.access_limiting_organisations = Organisation.where(id: submitted_access_limiting_organisation_ids)
+    else
+      @edition.edition_access_limiting_organisations.each(&:mark_for_destruction)
+    end
+  end
+end

--- a/app/controllers/concerns/access_limiting_concern.rb
+++ b/app/controllers/concerns/access_limiting_concern.rb
@@ -30,4 +30,28 @@ module AccessLimitingConcern
       @edition.edition_access_limiting_organisations.each(&:mark_for_destruction)
     end
   end
+
+  def assign_access_limiting_organisations
+    return unless Flipflop.access_limiting_organisations_ui?
+    return unless submitted_access_limiting_organisation_ids.any?
+
+    @edition.edition_access_limiting_organisations.each(&:mark_for_destruction)
+    submitted_access_limiting_organisation_ids.each do |org_id|
+      @edition.edition_access_limiting_organisations.build(organisation_id: org_id.to_i)
+    end
+  end
+
+  def access_limiting_would_lock_out_current_user?
+    return false unless current_user.organisation && edition_params[:access_limiting] == "organisations"
+
+    submitted_ids = submitted_access_limiting_organisation_ids.map(&:to_i)
+    submitted_ids.any? && submitted_ids.exclude?(current_user.organisation.id)
+  end
+
+  def process_access_limiting_organisations
+    return unless Flipflop.access_limiting_organisations_ui?
+
+    assign_access_limiting_organisations
+    access_limiting_organisations_valid?
+  end
 end

--- a/app/models/concerns/edition/limited_access.rb
+++ b/app/models/concerns/edition/limited_access.rb
@@ -19,6 +19,7 @@ module Edition::LimitedAccess
              source: :organisation
 
     after_initialize :set_access_limited
+    before_create :clear_access_limiting_organisations_if_not_by_organisations, if: -> { Flipflop.access_limiting_organisations_ui? }
     validate :access_limiting_organisations_required, if: -> { Flipflop.access_limiting_organisations_ui? && access_limiting_organisations? }
   end
 
@@ -56,5 +57,25 @@ module Edition::LimitedAccess
 
   def access_limiting_organisations_required
     errors.add(:access_limiting_organisation_ids, "must include at least one organisation when access limiting is enabled") if edition_access_limiting_organisations.empty?
+  end
+
+  # This will override the default has_many :through ids setter. The default setter writes
+  # through records with edition_id: nil, which causes a NotNullViolation during
+  # autosave on new records. Using the direct has_many instead defers all DB writes
+  # to when the edition is saved.
+  def access_limiting_organisation_ids=(new_organisation_ids)
+    edition_access_limiting_organisations.each(&:mark_for_destruction)
+
+    Array(new_organisation_ids).reject(&:blank?).each do |org_id|
+      edition_access_limiting_organisations.build(organisation_id: org_id.to_i)
+    end
+  end
+
+private
+
+  # Prevents org associations from being saved on a new record when the user
+  # submits "No access limiting" (e.g. after correcting a failed lockout attempt).
+  def clear_access_limiting_organisations_if_not_by_organisations
+    edition_access_limiting_organisations.each(&:mark_for_destruction) unless access_limiting_organisations?
   end
 end

--- a/app/models/concerns/edition/limited_access.rb
+++ b/app/models/concerns/edition/limited_access.rb
@@ -8,6 +8,16 @@ module Edition::LimitedAccess
       individuals: "individuals",
     }, prefix: true, default: nil
 
+    has_many :edition_access_limiting_organisations,
+             class_name: "AccessLimitingOrganisation",
+             dependent: :destroy,
+             autosave: true,
+             validate: false
+
+    has_many :access_limiting_organisations,
+             through: :edition_access_limiting_organisations,
+             source: :organisation
+
     after_initialize :set_access_limited
   end
 

--- a/app/models/concerns/edition/limited_access.rb
+++ b/app/models/concerns/edition/limited_access.rb
@@ -19,6 +19,7 @@ module Edition::LimitedAccess
              source: :organisation
 
     after_initialize :set_access_limited
+    validate :access_limiting_organisations_required, if: -> { Flipflop.access_limiting_organisations_ui? && access_limiting_organisations? }
   end
 
   module ClassMethods
@@ -51,5 +52,9 @@ module Edition::LimitedAccess
 
   def accessible_to?(user)
     user.present? && Whitehall::Authority::Enforcer.new(user, self).can?(:see)
+  end
+
+  def access_limiting_organisations_required
+    errors.add(:access_limiting_organisation_ids, "must include at least one organisation when access limiting is enabled") if access_limiting_organisations.empty?
   end
 end

--- a/app/models/concerns/edition/limited_access.rb
+++ b/app/models/concerns/edition/limited_access.rb
@@ -55,6 +55,6 @@ module Edition::LimitedAccess
   end
 
   def access_limiting_organisations_required
-    errors.add(:access_limiting_organisation_ids, "must include at least one organisation when access limiting is enabled") if access_limiting_organisations.empty?
+    errors.add(:access_limiting_organisation_ids, "must include at least one organisation when access limiting is enabled") if edition_access_limiting_organisations.empty?
   end
 end

--- a/app/models/concerns/edition/organisations.rb
+++ b/app/models/concerns/edition/organisations.rb
@@ -11,7 +11,6 @@ module Edition::Organisations
 
   included do
     has_many :edition_organisations, foreign_key: :edition_id, dependent: :destroy, autosave: true, validate: false
-    has_many :access_limiting_organisations, foreign_key: :edition_id, dependent: :destroy, autosave: true, validate: false
 
     has_many :organisations, -> { includes(:translations) }, through: :edition_organisations, validate: false
 

--- a/app/services/draft_edition_updater.rb
+++ b/app/services/draft_edition_updater.rb
@@ -31,6 +31,14 @@ private
     # Some users may not necessarily belong to an organisation. We should fail-closed for them.
     return true unless @options[:current_user].organisation
 
-    edition.organisation_association_enabled? && edition.edition_organisations.map(&:organisation_id).exclude?(@options[:current_user].organisation.id)
+    if Flipflop.access_limiting_organisations_ui?
+      org_ids = edition.edition_access_limiting_organisations
+                       .reject(&:marked_for_destruction?)
+                       .map(&:organisation_id)
+      org_ids.any? && org_ids.exclude?(@options[:current_user].organisation.id)
+    else
+      edition.organisation_association_enabled? &&
+        edition.edition_organisations.map(&:organisation_id).exclude?(@options[:current_user].organisation.id)
+    end
   end
 end

--- a/app/services/edition_publisher.rb
+++ b/app/services/edition_publisher.rb
@@ -28,6 +28,7 @@ private
   def prepare_edition
     flag_if_political_content!
     edition.access_limiting = :none
+    edition.access_limiting_organisations.clear
     edition.major_change_published_at = Time.zone.now unless edition.minor_change?
     edition.make_public_at(edition.major_change_published_at)
     edition.increment_version_number

--- a/app/views/admin/editions/_access_limiting_fields.html.erb
+++ b/app/views/admin/editions/_access_limiting_fields.html.erb
@@ -5,18 +5,39 @@
     heading_size: "m",
   } do %>
     <%= form.hidden_field :access_limiting, value: "none" %>
+    <% if Flipflop.access_limiting_organisations_ui? %>
+      <%= render "govuk_publishing_components/components/radio", {
+        name: "edition[access_limiting]",
+        id_prefix: "edition_access_limiting",
+        error_items: errors_for(edition.errors, :access_limiting_organisation_ids),
+        items: [
+          {
+            value: "none",
+            text: "No access limiting",
+            checked: edition.access_limiting_none?,
+          },
+          {
+            value: "organisations",
+            text: "Organisation access limiting",
+            checked: edition.access_limiting_organisations?,
+            conditional: render("admin/editions/access_limiting_organisation_select", form: form, edition: edition),
+          },
+        ],
+      } %>
+    <% else %>
 
-    <%= render "govuk_publishing_components/components/checkboxes", {
-      name: "edition[access_limiting]",
-      id: "edition_access_limiting",
-      error_items: errors_for(edition.errors, :access_limiting),
-      items: [
-        {
-          label: "Limit access to publishers from organisations associated with this document before you publish",
-          value: "organisations",
-          checked: edition.access_limited?,
-        },
-      ],
-    } %>
+      <%= render "govuk_publishing_components/components/checkboxes", {
+        name: "edition[access_limiting]",
+        id: "edition_access_limiting",
+        error_items: errors_for(edition.errors, :access_limiting),
+        items: [
+          {
+            label: "Limit access to publishers from organisations associated with this document before you publish",
+            value: "organisations",
+            checked: edition.access_limited?,
+          },
+        ],
+      } %>
+    <% end %>
   <% end %>
 </div>

--- a/app/views/admin/editions/_access_limiting_organisation_select.html.erb
+++ b/app/views/admin/editions/_access_limiting_organisation_select.html.erb
@@ -1,0 +1,9 @@
+<%= render "govuk_publishing_components/components/select_with_search", {
+  id: "edition_access_limiting_organisation_ids",
+  name: "edition[access_limiting_organisation_ids][]",
+  label: "Organisations",
+  multiple: true,
+  heading_size: "s",
+  include_blank: true,
+  options: taggable_organisations_container(edition.access_limiting_organisations.map(&:id)),
+} %>

--- a/config/features.rb
+++ b/config/features.rb
@@ -33,4 +33,7 @@ Flipflop.configure do
   feature :configurable_document_types,
           description: "Enable 'in development' config-driven document types (alongside the 'live' ones)",
           default: Rails.env.development?
+  feature :access_limiting_organisations_ui,
+          description: "Replace the access-limiting checkbox with radio + organisation selector UI",
+          default: false
 end

--- a/features/admin-limit-access-editions.feature
+++ b/features/admin-limit-access-editions.feature
@@ -23,3 +23,13 @@ Feature: Viewing most recent editions in admin
     And I check the "Limit access to publishers from organisations associated with this document before you publish" box
     When I click "Save"
     Then I should see the validation error "Access can only be limited by users belonging to an organisation tagged to the document"
+
+  Scenario: Attempting to access limit a new document against a different org via the new organisations UI
+    Given I am an editor
+    And the access_limiting_organisations_ui feature flag is enabled
+    When I begin drafting a new document
+    And I set the Lead organisation to an org I am not in
+    And I choose "Organisation access limiting"
+    And I select the lead organisation as an access limiting organisation
+    When I click "Save"
+    Then I should see the validation error "Access can only be limited by users belonging to an organisation tagged to the document"

--- a/features/step_definitions/admin_limit_access_steps.rb
+++ b/features/step_definitions/admin_limit_access_steps.rb
@@ -41,3 +41,29 @@ end
 Then(/^I should see the validation error "(.+)"$/) do |string|
   expect(page).to have_content string
 end
+
+Given(/^the access_limiting_organisations_ui feature flag is (enabled|disabled)$/) do |state|
+  @test_strategy ||= Flipflop::FeatureSet.current.test!
+  @test_strategy.switch!(:access_limiting_organisations_ui, state == "enabled")
+end
+
+When(/^I choose "([^"]*)"$/) do |option|
+  choose option
+end
+
+When(/^I select the lead organisation as an access limiting organisation$/) do
+  select @org.name, from: "edition_access_limiting_organisation_ids"
+end
+
+Given(/^I create an access limited document$/) do
+  step "I begin drafting a new document"
+  step "I check the \"Limit access to publishers from organisations associated with this document before you publish\" box"
+  step "I click \"Save\""
+end
+
+Then(/^I should still be able to access the document$/) do
+  visit current_url # refresh
+  expect(page).not_to have_content "You do not have permission to access this page."
+  expect(page).to have_content "Test publication"
+  expect(Edition.last.organisations).to eq([@user.organisation])
+end

--- a/lib/whitehall/authority/rules/edition_rules.rb
+++ b/lib/whitehall/authority/rules/edition_rules.rb
@@ -102,9 +102,13 @@ module Whitehall::Authority::Rules
 
     def access_limit_enforced?
       if subject.access_limited?
-        organisations = subject.organisations
-        organisations += subject.edition_organisations.map(&:organisation) if subject.respond_to?(:edition_organisations)
-        organisations.exclude?(actor.organisation)
+        if Flipflop.access_limiting_organisations_ui? && subject.access_limiting_organisations.any?
+          subject.access_limiting_organisations.exclude?(actor.organisation)
+        else
+          organisations = subject.organisations
+          organisations += subject.edition_organisations.map(&:organisation) if subject.respond_to?(:edition_organisations)
+          organisations.exclude?(actor.organisation)
+        end
       else
         false
       end

--- a/test/functional/admin/calls_for_evidence_controller_test.rb
+++ b/test/functional/admin/calls_for_evidence_controller_test.rb
@@ -18,6 +18,7 @@ class Admin::CallsForEvidenceControllerTest < ActionController::TestCase
   should_allow_alternative_format_provider_for :call_for_evidence
   should_allow_scheduled_publication_of :call_for_evidence
   should_allow_access_limiting_of :call_for_evidence
+  access_limiting_organisations_ui_on_should_allow_access_limiting_of :call_for_evidence
   should_render_govspeak_history_and_fact_checking_tabs_for :call_for_evidence
 
   view_test "new displays call for evidence fields" do

--- a/test/functional/admin/calls_for_evidence_controller_test.rb
+++ b/test/functional/admin/calls_for_evidence_controller_test.rb
@@ -17,7 +17,7 @@ class Admin::CallsForEvidenceControllerTest < ActionController::TestCase
   should_allow_lead_and_supporting_organisations_for :call_for_evidence
   should_allow_alternative_format_provider_for :call_for_evidence
   should_allow_scheduled_publication_of :call_for_evidence
-  should_allow_access_limiting_of :call_for_evidence
+  access_limiting_organisations_ui_off_should_allow_access_limiting_of :call_for_evidence
   access_limiting_organisations_ui_on_should_allow_access_limiting_of :call_for_evidence
   should_render_govspeak_history_and_fact_checking_tabs_for :call_for_evidence
 

--- a/test/functional/admin/consultations_controller_test.rb
+++ b/test/functional/admin/consultations_controller_test.rb
@@ -18,6 +18,7 @@ class Admin::ConsultationsControllerTest < ActionController::TestCase
   should_allow_alternative_format_provider_for :consultation
   should_allow_scheduled_publication_of :consultation
   should_allow_access_limiting_of :consultation
+  access_limiting_organisations_ui_on_should_allow_access_limiting_of :consultation
   should_render_govspeak_history_and_fact_checking_tabs_for :consultation
 
   view_test "new displays consultation fields" do

--- a/test/functional/admin/consultations_controller_test.rb
+++ b/test/functional/admin/consultations_controller_test.rb
@@ -17,7 +17,7 @@ class Admin::ConsultationsControllerTest < ActionController::TestCase
   should_allow_lead_and_supporting_organisations_for :consultation
   should_allow_alternative_format_provider_for :consultation
   should_allow_scheduled_publication_of :consultation
-  should_allow_access_limiting_of :consultation
+  access_limiting_organisations_ui_off_should_allow_access_limiting_of :consultation
   access_limiting_organisations_ui_on_should_allow_access_limiting_of :consultation
   should_render_govspeak_history_and_fact_checking_tabs_for :consultation
 

--- a/test/functional/admin/detailed_guides_controller_test.rb
+++ b/test/functional/admin/detailed_guides_controller_test.rb
@@ -24,6 +24,7 @@ class Admin::DetailedGuidesControllerTest < ActionController::TestCase
   should_allow_scheduled_publication_of :detailed_guide
   should_allow_overriding_of_first_published_at_for :detailed_guide
   should_allow_access_limiting_of :detailed_guide
+  access_limiting_organisations_ui_on_should_allow_access_limiting_of :detailed_guide
   should_render_govspeak_history_and_fact_checking_tabs_for :detailed_guide
 
 private

--- a/test/functional/admin/detailed_guides_controller_test.rb
+++ b/test/functional/admin/detailed_guides_controller_test.rb
@@ -23,7 +23,7 @@ class Admin::DetailedGuidesControllerTest < ActionController::TestCase
   should_allow_alternative_format_provider_for :detailed_guide
   should_allow_scheduled_publication_of :detailed_guide
   should_allow_overriding_of_first_published_at_for :detailed_guide
-  should_allow_access_limiting_of :detailed_guide
+  access_limiting_organisations_ui_off_should_allow_access_limiting_of :detailed_guide
   access_limiting_organisations_ui_on_should_allow_access_limiting_of :detailed_guide
   should_render_govspeak_history_and_fact_checking_tabs_for :detailed_guide
 

--- a/test/functional/admin/edition_access_limited_controller_test.rb
+++ b/test/functional/admin/edition_access_limited_controller_test.rb
@@ -7,6 +7,7 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
 
   should_be_an_admin_controller
 
+  # access_limiting_organisations_ui flag agnostic
   test "GET :edit should be forbidden unless user is a GDS Admin" do
     edition = create(:consultation)
     login_as :gds_editor
@@ -14,6 +15,7 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
     assert_response :forbidden
   end
 
+  # access_limiting_organisations_ui flag is off
   view_test "GET :edit should display the correct fields" do
     organisation = create(:organisation)
 
@@ -45,13 +47,74 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
     end
   end
 
+  # access_limiting_organisations_ui is on
+  view_test "GET :edit should show radio buttons instead of checkbox when access_limiting_organisations_ui flag is on" do
+    feature_flags.switch! :access_limiting_organisations_ui, true
+
+    organisation = create(:organisation)
+    edition = create(
+      :consultation,
+      access_limiting: "none",
+      create_default_organisation: false,
+      lead_organisations: [organisation],
+    )
+
+    get :edit, params: { id: edition }
+
+    assert_select "input[name='edition[access_limiting]'][type=radio]"
+    assert_select "input[name='edition[access_limited]'][type=checkbox]", count: 0
+  end
+
+  # access_limiting_organisations_ui is on
+  view_test "GET :edit shows the persisted editions's access limiting value when flag is on" do
+    feature_flags.switch! :access_limiting_organisations_ui, true
+
+    organisation = create(:organisation)
+    edition = create(
+      :consultation,
+      access_limiting: "organisations",
+      create_default_organisation: false,
+      lead_organisations: [organisation],
+      access_limiting_organisation_ids: [organisation.id],
+    )
+
+    get :edit, params: { id: edition }
+
+    assert_select "input[name='edition[access_limiting]'][value='organisations'][checked=checked]"
+    assert_select "select[name='edition[access_limiting_organisation_ids][]']" do
+      assert_select "option[selected='selected'][value='#{organisation.id}']"
+    end
+  end
+
+  # Flag reversal scenario, access_limiting_organisations_ui turned on and then off
+  view_test "GET :edit shows the persisted editions's access limiting value, and preserves already set access limiting organisations, when flag is turned off" do
+    organisation = create(:organisation)
+    edition = create(
+      :consultation,
+      access_limiting: "organisations",
+      create_default_organisation: false,
+      lead_organisations: [organisation],
+      access_limiting_organisation_ids: [organisation.id],
+    )
+
+    get :edit, params: { id: edition }
+
+    assert edition.access_limited?
+    assert_equal "organisations", edition.access_limiting
+    assert edition.access_limiting_organisations.exists?(id: organisation.id)
+    assert_select "input[name='edition[access_limiting]'][value='organisations'][checked=checked]"
+    refute_select "select[name='edition[access_limiting_organisation_ids][]']"
+  end
+
+  # access_limiting_organisations_ui flag agnostic
   test "PATCH :update should be forbidden unless user is a GDS Admin" do
     edition = create(:consultation)
     login_as :gds_editor
-    get :edit, params: { id: edition }
+    patch :update, params: { id: edition }
     assert_response :forbidden
   end
 
+  # access_limiting_organisations_ui flag agnostic
   test "PATCH :update should update editions organisations correctly and creates an editorial remark" do
     first_organisation = create(:organisation)
     second_organisation = create(:organisation)
@@ -69,16 +132,16 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
 
     editorial_remark = "Updating the organisations at the users request."
 
-    put :update,
-        params: {
-          id: edition,
-          edition: {
-            lead_organisation_ids: [second_organisation.id],
-            supporting_organisation_ids: [third_organisation.id],
-            editorial_remark:,
-            access_limiting: "organisations",
-          },
-        }
+    patch :update,
+          params: {
+            id: edition,
+            edition: {
+              lead_organisation_ids: [second_organisation.id],
+              supporting_organisation_ids: [third_organisation.id],
+              editorial_remark:,
+              access_limiting: "organisations",
+            },
+          }
 
     assert_equal [second_organisation], edition.reload.lead_organisations
     assert_equal [third_organisation], edition.supporting_organisations
@@ -87,6 +150,7 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
     assert_equal "Access options updated by GDS Admin: #{editorial_remark}", edition.editorial_remarks.last.body
   end
 
+  # access_limiting_organisations_ui flag is off
   test "PATCH :update allows access_limited to be updated and creates an editorial remark" do
     first_organisation = create(:organisation)
     second_organisation = create(:organisation)
@@ -101,16 +165,16 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
 
     editorial_remark = "Removing access limited at the users request."
 
-    put :update,
-        params: {
-          id: edition,
-          edition: {
-            lead_organisation_ids: [first_organisation.id],
-            supporting_organisation_ids: [second_organisation.id],
-            editorial_remark:,
-            access_limiting: "none",
-          },
-        }
+    patch :update,
+          params: {
+            id: edition,
+            edition: {
+              lead_organisation_ids: [first_organisation.id],
+              supporting_organisation_ids: [second_organisation.id],
+              editorial_remark:,
+              access_limiting: "none",
+            },
+          }
 
     assert_equal [first_organisation], edition.reload.lead_organisations
     assert_equal [second_organisation], edition.supporting_organisations
@@ -120,6 +184,71 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
     assert_equal "Access options updated by GDS Admin: #{editorial_remark}", edition.editorial_remarks.last.body
   end
 
+  # access_limiting_organisations_ui is on
+  test "PATCH :update changes access limiting from 'none' to 'organisations' and creates an editorial remark" do
+    feature_flags.switch! :access_limiting_organisations_ui, true
+
+    organisation = create(:organisation)
+    edition = create(
+      :consultation,
+      access_limiting: "none",
+      create_default_organisation: false,
+      lead_organisations: [organisation],
+    )
+
+    editorial_remark = "Update access limiting to custom organisations."
+
+    patch :update,
+          params: {
+            id: edition,
+            edition: {
+              lead_organisation_ids: [organisation.id],
+              access_limiting: "organisations",
+              access_limiting_organisation_ids: [organisation.id.to_s],
+              editorial_remark: editorial_remark,
+            },
+          }
+
+    assert_redirected_to admin_editions_path
+    assert_equal "organisations", edition.reload.access_limiting
+    assert edition.access_limiting_organisations.exists?(id: organisation.id)
+    assert_equal "Access updated for #{edition.title}", flash[:notice]
+    assert_equal "Access options updated by GDS Admin: #{editorial_remark}", edition.editorial_remarks.last.body
+  end
+
+  # access_limiting_organisations_ui is on
+  test "PATCH :update changes access limiting from 'organisations' to 'none', clears access limiting organisations, and creates an editorial remark" do
+    feature_flags.switch! :access_limiting_organisations_ui, true
+
+    organisation = create(:organisation)
+    edition = create(
+      :consultation,
+      access_limiting: "organisations",
+      create_default_organisation: false,
+      lead_organisations: [organisation],
+      access_limiting_organisation_ids: [organisation.id],
+    )
+    editorial_remark = "Removing access limited at the users request."
+
+    patch :update,
+          params: {
+            id: edition,
+            edition: {
+              lead_organisation_ids: [organisation.id],
+              access_limiting: "none",
+              access_limiting_organisation_ids: [],
+              editorial_remark: editorial_remark,
+            },
+          }
+
+    assert_redirected_to admin_editions_path
+    assert_equal "none", edition.reload.access_limiting
+    assert_empty edition.access_limiting_organisations
+    assert_equal "Access updated for #{edition.title}", flash[:notice]
+    assert_equal "Access options updated by GDS Admin: #{editorial_remark}", edition.editorial_remarks.last.body
+  end
+
+  # access_limiting_organisations_ui flag is off
   test "PATCH :update re-renders edit template if editorial remark is not provided" do
     first_organisation = create(:organisation)
     second_organisation = create(:organisation)
@@ -132,47 +261,144 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
       supporting_organisations: [second_organisation],
     )
 
-    put :update,
-        params: {
-          id: edition,
-          edition: {
-            lead_organisation_ids: [first_organisation.id],
-            supporting_organisation_ids: [second_organisation.id],
-            editorial_remark: "",
-            access_limiting: "none",
-          },
-        }
+    patch :update,
+          params: {
+            id: edition,
+            edition: {
+              lead_organisation_ids: [first_organisation.id],
+              supporting_organisation_ids: [second_organisation.id],
+              editorial_remark: "",
+              access_limiting: "none",
+            },
+          }
 
     assert_template :edit
     assert_equal ["Editorial remark cannot be blank"], assigns(:edition).errors.full_messages
     assert edition.reload.access_limited?
   end
 
-  test "PATCH :update doesn't create an editorial remark or re-render with an error when nothing has changed" do
-    first_organisation = create(:organisation)
-    second_organisation = create(:organisation)
-
+  # access_limiting_organisations_ui is on
+  test "PATCH :update re-renders edit template when editorial remark is not provided" do
+    feature_flags.switch! :access_limiting_organisations_ui, true
+    organisation = create(:organisation)
     edition = create(
       :consultation,
       access_limiting: "organisations",
       create_default_organisation: false,
-      lead_organisations: [first_organisation],
-      supporting_organisations: [second_organisation],
+      lead_organisations: [organisation],
+      access_limiting_organisation_ids: [organisation.id],
     )
 
-    put :update,
-        params: {
-          id: edition,
-          edition: {
-            lead_organisation_ids: [first_organisation.id],
-            supporting_organisation_ids: [second_organisation.id],
-            editorial_remark: "",
-            access_limiting: "organisations",
-          },
-        }
+    patch :update,
+          params: {
+            id: edition,
+            edition: {
+              lead_organisation_ids: [organisation.id],
+              editorial_remark: "",
+              access_limiting: "none",
+            },
+          }
 
-    assert_redirected_to admin_editions_path
-    assert_equal "Access updated for #{edition.title}", flash[:notice]
-    assert_equal 0, edition.editorial_remarks.count
+    assert_template :edit
+    assert_equal "organisations", edition.reload.access_limiting
+    assert_equal ["Editorial remark cannot be blank"], assigns(:edition).errors.full_messages
+  end
+
+  # access_limiting_organisations_ui is on
+  test "PATCH :update renders a validation error when access_limiting is set to organisations, but no organisations provided" do
+    feature_flags.switch! :access_limiting_organisations_ui, true
+
+    organisation = create(:organisation)
+    edition = create(
+      :consultation,
+      access_limiting: "none",
+      create_default_organisation: false,
+      lead_organisations: [organisation],
+    )
+
+    patch :update,
+          params: {
+            id: edition,
+            edition: {
+              lead_organisation_ids: [organisation.id],
+              access_limiting: "organisations",
+              access_limiting_organisation_ids: [],
+              editorial_remark: "Test",
+            },
+          }
+
+    assert_template :edit
+    assert_includes assigns(:edition).errors[:access_limiting_organisation_ids],
+                    "must include at least one organisation when access limiting is enabled"
+  end
+
+  # access_limiting_organisations_ui is on
+  # TODO - When future validation is added to the field, we also needs to cover the scenario where the field itself is invalid, but the submitted value is not empty.
+  # It should re-render the edit template with the submitted access limiting organisations, and not change the database association value.
+  test "PATCH :update does not clear access_limiting_organisations in DB when the access_limiting_organisations invalid" do
+    feature_flags.switch! :access_limiting_organisations_ui, true
+
+    organisation = create(:organisation)
+    edition = create(
+      :consultation,
+      access_limiting: "organisations",
+      create_default_organisation: false,
+      lead_organisations: [organisation],
+      access_limiting_organisation_ids: [organisation.id],
+    )
+
+    patch :update,
+          params: {
+            id: edition,
+            edition: {
+              lead_organisation_ids: [organisation.id],
+              access_limiting: "organisations",
+              access_limiting_organisation_ids: [],
+              editorial_remark: "Test",
+            },
+          }
+
+    assert_template :edit
+    assert_includes assigns(:edition).errors[:access_limiting_organisation_ids], "must include at least one organisation when access limiting is enabled"
+    assert_equal "organisations", edition.reload.access_limiting
+    assert edition.access_limiting_organisations.exists?(id: organisation.id)
+  end
+
+  # access_limiting_organisations_ui is on
+  # TODO - This is a characterisation test. The desired behaviour is that the access limiting organisations would not be persisted.
+  view_test "PATCH :update re-renders the edit template with the submitted access limiting organisations and persists the association, when unrelated field fails validation" do
+    feature_flags.switch! :access_limiting_organisations_ui, true
+
+    organisation = create(:organisation)
+    new_organisation = create(:organisation)
+    edition = create(
+      :consultation,
+      access_limiting: "organisations",
+      create_default_organisation: false,
+      lead_organisations: [organisation],
+      access_limiting_organisation_ids: [organisation.id],
+    )
+
+    patch :update,
+          params: {
+            id: edition,
+            edition: {
+              lead_organisation_ids: [organisation.id],
+              access_limiting: "organisations",
+              access_limiting_organisation_ids: [organisation.id, new_organisation.id],
+            },
+          }
+
+    assert_template :edit
+    assert_equal ["Editorial remark cannot be blank"], assigns(:edition).errors.full_messages
+    assert_select "input[name='edition[access_limiting]'][value='organisations'][checked=checked]"
+    assert_select "select[name='edition[access_limiting_organisation_ids][]']" do
+      assert_select "option[selected='selected'][value='#{organisation.id}']"
+      assert_select "option[selected='selected'][value='#{new_organisation.id}']"
+    end
+    # Current behaviour
+    assert_equal [organisation.id, new_organisation.id], edition.reload.access_limiting_organisation_ids
+    # Desired behaviour
+    # assert_equal [organisation.id], edition.reload.access_limiting_organisation_ids
   end
 end

--- a/test/functional/admin/fatality_notices_controller_test.rb
+++ b/test/functional/admin/fatality_notices_controller_test.rb
@@ -18,7 +18,7 @@ class Admin::FatalityNoticesControllerTest < ActionController::TestCase
   should_allow_overriding_of_first_published_at_for :fatality_notice
   should_have_summary :fatality_notice
   should_allow_scheduled_publication_of :fatality_notice
-  should_allow_access_limiting_of :fatality_notice
+  access_limiting_organisations_ui_off_should_allow_access_limiting_of :fatality_notice
   access_limiting_organisations_ui_on_should_allow_access_limiting_of :fatality_notice
   should_render_govspeak_history_and_fact_checking_tabs_for :fatality_notice
 

--- a/test/functional/admin/fatality_notices_controller_test.rb
+++ b/test/functional/admin/fatality_notices_controller_test.rb
@@ -19,6 +19,7 @@ class Admin::FatalityNoticesControllerTest < ActionController::TestCase
   should_have_summary :fatality_notice
   should_allow_scheduled_publication_of :fatality_notice
   should_allow_access_limiting_of :fatality_notice
+  access_limiting_organisations_ui_on_should_allow_access_limiting_of :fatality_notice
   should_render_govspeak_history_and_fact_checking_tabs_for :fatality_notice
 
   view_test "show renders the summary" do

--- a/test/functional/admin/publications_controller_test.rb
+++ b/test/functional/admin/publications_controller_test.rb
@@ -22,6 +22,7 @@ class Admin::PublicationsControllerTest < ActionController::TestCase
   should_allow_alternative_format_provider_for :publication
   should_allow_scheduled_publication_of :publication
   should_allow_access_limiting_of :publication
+  access_limiting_organisations_ui_on_should_allow_access_limiting_of :publication
   should_render_govspeak_history_and_fact_checking_tabs_for :publication
   should_allow_overriding_of_first_published_at_for :publication
 

--- a/test/functional/admin/publications_controller_test.rb
+++ b/test/functional/admin/publications_controller_test.rb
@@ -247,6 +247,71 @@ class Admin::PublicationsControllerTest < ActionController::TestCase
     assert_select ".app-view-summary__taxonomy-topics .govuk-link", "Add tags"
   end
 
+  test "POST :create blocks save when access_limiting_organisations_ui feature flag is on and current user's org is not in access limiting orgs" do
+    my_org = create(:organisation)
+    other_org = create(:organisation)
+    login_as create(:writer, organisation: my_org)
+    feature_flags.switch! :access_limiting_organisations_ui, true
+
+    assert_no_difference("Publication.count") do
+      post :create, params: {
+        edition: controller_attributes_for(
+          :publication,
+          first_published_at: Date.parse("2010-10-21"),
+          previously_published: "true",
+          publication_type_id: PublicationType::ResearchAndAnalysis.id,
+          lead_organisation_ids: [my_org.id],
+          access_limiting: "organisations",
+          access_limiting_organisation_ids: [other_org.id.to_s],
+        ),
+      }
+    end
+
+    assert_template "admin/editions/new"
+    assert_equal "Access can only be limited by users belonging to an organisation tagged to the document", flash[:alert]
+  end
+
+  test "PATCH :update blocks update when access_limiting_organisations_ui feature flag is on and current user's org is not in access limiting orgs" do
+    my_org = create(:organisation)
+    other_org = create(:organisation)
+    login_as create(:writer, organisation: my_org)
+    edition = create(:draft_publication, organisations: [my_org])
+    feature_flags.switch! :access_limiting_organisations_ui, true
+
+    patch :update, params: {
+      id: edition,
+      edition: {
+        access_limiting: "organisations",
+        access_limiting_organisation_ids: [other_org.id.to_s],
+      },
+      save: "save",
+    }
+
+    assert_template :edit
+    assert_equal "Access can only be limited by users belonging to an organisation tagged to the document", flash[:alert]
+    assert_equal "none", edition.reload.access_limiting
+    assert_empty edition.reload.access_limiting_organisations
+  end
+
+  test "PATCH :update allows update when access_limiting_organisations_ui feature flag is on and current user's org is included in access limiting orgs" do
+    my_org = create(:organisation)
+    login_as create(:writer, organisation: my_org)
+    edition = create(:draft_publication, organisations: [my_org])
+    feature_flags.switch! :access_limiting_organisations_ui, true
+
+    patch :update, params: {
+      id: edition,
+      edition: {
+        access_limiting: "organisations",
+        access_limiting_organisation_ids: [my_org.id.to_s],
+      },
+      save: "save",
+    }
+
+    assert_equal "organisations", edition.reload.access_limiting
+    assert_includes edition.reload.access_limiting_organisation_ids, my_org.id
+  end
+
 private
 
   def publication_has_no_expanded_links(content_id)

--- a/test/functional/admin/publications_controller_test.rb
+++ b/test/functional/admin/publications_controller_test.rb
@@ -21,7 +21,7 @@ class Admin::PublicationsControllerTest < ActionController::TestCase
   should_allow_association_between_world_locations_and :publication
   should_allow_alternative_format_provider_for :publication
   should_allow_scheduled_publication_of :publication
-  should_allow_access_limiting_of :publication
+  access_limiting_organisations_ui_off_should_allow_access_limiting_of :publication
   access_limiting_organisations_ui_on_should_allow_access_limiting_of :publication
   should_render_govspeak_history_and_fact_checking_tabs_for :publication
   should_allow_overriding_of_first_published_at_for :publication

--- a/test/functional/admin/speeches_controller_test.rb
+++ b/test/functional/admin/speeches_controller_test.rb
@@ -13,6 +13,7 @@ class Admin::SpeechesControllerTest < ActionController::TestCase
   should_allow_association_between_world_locations_and :speech
   should_allow_scheduled_publication_of :speech
   should_allow_access_limiting_of :speech
+  access_limiting_organisations_ui_on_should_allow_access_limiting_of :speech
   should_allow_association_with_topical_events :speech
   should_allow_association_with_topical_event_documents :speech
 

--- a/test/functional/admin/speeches_controller_test.rb
+++ b/test/functional/admin/speeches_controller_test.rb
@@ -12,7 +12,7 @@ class Admin::SpeechesControllerTest < ActionController::TestCase
 
   should_allow_association_between_world_locations_and :speech
   should_allow_scheduled_publication_of :speech
-  should_allow_access_limiting_of :speech
+  access_limiting_organisations_ui_off_should_allow_access_limiting_of :speech
   access_limiting_organisations_ui_on_should_allow_access_limiting_of :speech
   should_allow_association_with_topical_events :speech
   should_allow_association_with_topical_event_documents :speech

--- a/test/functional/admin/standard_editions_controller_test.rb
+++ b/test/functional/admin/standard_editions_controller_test.rb
@@ -1538,6 +1538,77 @@ class Admin::StandardEditionsControllerTest < ActionController::TestCase
     assert_select "a", text: "Extra tab tab is invalid"
   end
 
+  test "POST :create blocks save when access_limiting_organisations_ui feature flag is on and current user's org is not in access limiting orgs" do
+    configurable_document_type = build_configurable_document_type("test_type")
+    ConfigurableDocumentType.setup_test_types(configurable_document_type)
+
+    my_org = create(:organisation)
+    other_org = create(:organisation)
+    login_as create(:writer, organisation: my_org)
+    feature_flags.switch! :access_limiting_organisations_ui, true
+
+    assert_no_difference("StandardEdition.count") do
+      post :create, params: {
+        edition: {
+          configurable_document_type: "test_type",
+          title: "Title",
+          summary: "Summary",
+          access_limiting: "organisations",
+          access_limiting_organisation_ids: [other_org.id.to_s],
+          lead_organisation_ids: [my_org.id],
+        },
+      }
+    end
+
+    assert_template "admin/editions/new"
+    assert_equal "Access can only be limited by users belonging to an organisation tagged to the document", flash[:alert]
+  end
+
+  test "PATCH :update blocks update when access_limiting_organisations_ui feature flag is on and current user's org is not in access limiting orgs" do
+    my_org = create(:organisation)
+    other_org = create(:organisation)
+    login_as create(:writer, organisation: my_org)
+    edition = create(:draft_standard_edition, :with_organisations)
+    feature_flags.switch! :access_limiting_organisations_ui, true
+
+    patch :update, params: {
+      id: edition,
+      edition: {
+        title: edition.title,
+        summary: edition.summary,
+        access_limiting: "organisations",
+        access_limiting_organisation_ids: [other_org.id.to_s],
+      },
+      save: "save",
+    }
+
+    assert_template :edit
+    assert_equal "Access can only be limited by users belonging to an organisation tagged to the document", flash[:alert]
+    assert_equal "none", edition.reload.access_limiting
+    assert_empty edition.reload.access_limiting_organisations
+  end
+
+  test "PATCH :update allows update when access_limiting_organisations_ui feature flag is on and current user's org is included" do
+    my_org = create(:organisation)
+    login_as create(:writer, organisation: my_org)
+    edition = create(:draft_standard_edition, :with_organisations)
+    feature_flags.switch! :access_limiting_organisations_ui, true
+
+    patch :update, params: {
+      id: edition,
+      edition: {
+        title: edition.title,
+        summary: edition.summary,
+        access_limiting: "organisations",
+        access_limiting_organisation_ids: [my_org.id.to_s],
+      },
+      save: "save",
+    }
+
+    assert_equal "organisations", edition.reload.access_limiting
+    assert_includes edition.reload.access_limiting_organisation_ids, my_org.id
+  end
+
   def tabbed_document_type(validations: {})
     config = {
       "forms" => {

--- a/test/functional/admin/statistical_data_sets_controller_test.rb
+++ b/test/functional/admin/statistical_data_sets_controller_test.rb
@@ -15,7 +15,7 @@ class Admin::StatisticalDataSetsControllerTest < ActionController::TestCase
   should_allow_alternative_format_provider_for :statistical_data_set
   should_allow_overriding_of_first_published_at_for :statistical_data_set
   should_allow_scheduled_publication_of :statistical_data_set
-  should_allow_access_limiting_of :statistical_data_set
+  access_limiting_organisations_ui_off_should_allow_access_limiting_of :statistical_data_set
   access_limiting_organisations_ui_on_should_allow_access_limiting_of :statistical_data_set
 
   def controller_attributes_for(edition_type, attributes = {})

--- a/test/functional/admin/statistical_data_sets_controller_test.rb
+++ b/test/functional/admin/statistical_data_sets_controller_test.rb
@@ -16,6 +16,7 @@ class Admin::StatisticalDataSetsControllerTest < ActionController::TestCase
   should_allow_overriding_of_first_published_at_for :statistical_data_set
   should_allow_scheduled_publication_of :statistical_data_set
   should_allow_access_limiting_of :statistical_data_set
+  access_limiting_organisations_ui_on_should_allow_access_limiting_of :statistical_data_set
 
   def controller_attributes_for(edition_type, attributes = {})
     super.except(:alternative_format_provider).reverse_merge(

--- a/test/functional/admin/worldwide_organisations_controller_test.rb
+++ b/test/functional/admin/worldwide_organisations_controller_test.rb
@@ -11,7 +11,7 @@ class Admin::WorldwideOrganisationsControllerTest < ActionController::TestCase
   should_allow_editing_of :worldwide_organisation
   should_allow_only_lead_organisations_for :worldwide_organisation
   should_allow_scheduled_publication_of :worldwide_organisation
-  should_allow_access_limiting_of :worldwide_organisation
+  access_limiting_organisations_ui_off_should_allow_access_limiting_of :worldwide_organisation
   access_limiting_organisations_ui_on_should_allow_access_limiting_of :worldwide_organisation
   should_allow_association_between_roles_and :worldwide_organisation
   should_allow_association_between_world_locations_and :worldwide_organisation

--- a/test/functional/admin/worldwide_organisations_controller_test.rb
+++ b/test/functional/admin/worldwide_organisations_controller_test.rb
@@ -12,6 +12,7 @@ class Admin::WorldwideOrganisationsControllerTest < ActionController::TestCase
   should_allow_only_lead_organisations_for :worldwide_organisation
   should_allow_scheduled_publication_of :worldwide_organisation
   should_allow_access_limiting_of :worldwide_organisation
+  access_limiting_organisations_ui_on_should_allow_access_limiting_of :worldwide_organisation
   should_allow_association_between_roles_and :worldwide_organisation
   should_allow_association_between_world_locations_and :worldwide_organisation
 

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -1129,7 +1129,7 @@ module AdminEditionControllerTestHelpers
       end
     end
 
-    def should_allow_access_limiting_of(edition_type)
+    def access_limiting_organisations_ui_off_should_allow_access_limiting_of(edition_type)
       edition_class = class_for(edition_type)
 
       test "create should record the access_limiting flag" do

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -1016,8 +1016,7 @@ module AdminEditionControllerTestHelpers
         assert created_edition.access_limiting_organisations.exists?(id: organisation.id)
       end
 
-      #  Characterisation test - correct implementation should cause a validation error. Will be done in upcoming work.
-      test "create should save even when user does not belong to one of the access limiting organisations" do
+      test "create should save when user belongs to one of the access limiting organisations" do
         feature_flags.switch! :access_limiting_organisations_ui, true
 
         user_organisation = create(:organisation)
@@ -1030,14 +1029,14 @@ module AdminEditionControllerTestHelpers
                edition: controller_attributes_for(edition_type).merge(
                  lead_organisation_ids: [user_organisation.id],
                  access_limiting: "organisations",
-                 access_limiting_organisation_ids: [access_limiting_organisation.id],
+                 access_limiting_organisation_ids: [access_limiting_organisation.id.to_s, user_organisation.id.to_s],
                ),
              }
 
         created_edition = edition_class.last
         assert_valid created_edition
         assert_equal "organisations", created_edition.access_limiting
-        assert created_edition.access_limiting_organisations.exists?(id: access_limiting_organisation.id)
+        assert_equal [access_limiting_organisation.id, user_organisation.id].sort, edition.access_limiting_organisation_ids.sort
       end
 
       view_test "edit should display persisted access limiting value" do
@@ -1103,8 +1102,7 @@ module AdminEditionControllerTestHelpers
         assert edition.access_limiting_organisations.exists?(id: organisation.id)
       end
 
-      #  Characterisation test - correct implementation should cause a validation error. Will be done in upcoming work.
-      test "update should save even when user does not belong to one of the access limiting organisations" do
+      test "update should save when user belongs to one of the access limiting organisations" do
         feature_flags.switch! :access_limiting_organisations_ui, true
 
         user_organisation = create(:organisation)
@@ -1120,12 +1118,12 @@ module AdminEditionControllerTestHelpers
               edition: {
                 lead_organisation_ids: [user_organisation.id],
                 access_limiting: "organisations",
-                access_limiting_organisation_ids: [access_limiting_organisation.id.to_s],
+                access_limiting_organisation_ids: [access_limiting_organisation.id.to_s, user_organisation.id.to_s],
               },
             }
 
         assert_equal "organisations", edition.reload.access_limiting
-        assert edition.access_limiting_organisations.exists?(id: access_limiting_organisation.id)
+        assert_equal [access_limiting_organisation.id, user_organisation.id].sort, edition.access_limiting_organisation_ids.sort
       end
     end
 

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -962,6 +962,173 @@ module AdminEditionControllerTestHelpers
       end
     end
 
+    def access_limiting_organisations_ui_on_should_allow_access_limiting_of(edition_type)
+      edition_class = class_for(edition_type)
+
+      view_test "new should preselect the 'none' radio button option for access limiting" do
+        feature_flags.switch! :access_limiting_organisations_ui, true
+
+        organisation = create(:organisation)
+        controller.current_user.organisation = organisation
+        controller.current_user.save!
+
+        get :new
+
+        assert_select "form#new_edition" do
+          assert_select "input[name='edition[access_limiting]'][type=radio][value='none'][checked='checked']", count: 1
+          assert_select "input[name='edition[access_limiting]'][type=radio][value='organisations'][checked='checked']", count: 0
+        end
+      end
+
+      test "create should save with access limiting set to 'none'" do
+        feature_flags.switch! :access_limiting_organisations_ui, true
+
+        post :create,
+             params: {
+               edition: controller_attributes_for(edition_type).merge(
+                 access_limiting: "none",
+               ),
+             }
+
+        created_edition = edition_class.last
+        assert_equal "none", created_edition.access_limiting
+        assert_empty created_edition.access_limiting_organisations
+      end
+
+      test "create should save with access limiting set to 'organisations'" do
+        feature_flags.switch! :access_limiting_organisations_ui, true
+
+        organisation = create(:organisation)
+        controller.current_user.organisation = organisation
+        controller.current_user.save!
+
+        post :create,
+             params: {
+               edition: controller_attributes_for(edition_type).merge(
+                 lead_organisation_ids: [organisation.id],
+                 access_limiting: "organisations",
+                 access_limiting_organisation_ids: [organisation.id.to_s],
+               ),
+             }
+
+        created_edition = edition_class.last
+        assert_equal "organisations", created_edition.access_limiting
+        assert created_edition.access_limiting_organisations.exists?(id: organisation.id)
+      end
+
+      #  Characterisation test - correct implementation should cause a validation error. Will be done in upcoming work.
+      test "create should save even when user does not belong to one of the access limiting organisations" do
+        feature_flags.switch! :access_limiting_organisations_ui, true
+
+        user_organisation = create(:organisation)
+        controller.current_user.organisation = user_organisation
+        controller.current_user.save!
+        access_limiting_organisation = create(:organisation)
+
+        post :create,
+             params: {
+               edition: controller_attributes_for(edition_type).merge(
+                 lead_organisation_ids: [user_organisation.id],
+                 access_limiting: "organisations",
+                 access_limiting_organisation_ids: [access_limiting_organisation.id],
+               ),
+             }
+
+        created_edition = edition_class.last
+        assert_valid created_edition
+        assert_equal "organisations", created_edition.access_limiting
+        assert created_edition.access_limiting_organisations.exists?(id: access_limiting_organisation.id)
+      end
+
+      view_test "edit should display persisted access limiting value" do
+        feature_flags.switch! :access_limiting_organisations_ui, true
+
+        organisation = create(:organisation)
+        controller.current_user.organisation = organisation
+        controller.current_user.save!
+
+        edition = create(edition_type, access_limiting: "organisations", access_limiting_organisation_ids: [organisation.id])
+
+        get :edit, params: { id: edition }
+
+        assert_select "form#edit_edition" do
+          assert_select "input[name='edition[access_limiting]'][type=radio][value='organisations'][checked='checked']", count: 1
+          assert_select "input[name='edition[access_limiting]'][type=radio][value='none'][checked='checked']", count: 0
+        end
+      end
+
+      test "update should change access limiting, from 'none' to 'organisations'" do
+        feature_flags.switch! :access_limiting_organisations_ui, true
+
+        organisation = create(:organisation)
+        controller.current_user.organisation = organisation
+        controller.current_user.save!
+
+        edition = create(edition_type, access_limiting: "none")
+
+        put :update,
+            params: {
+              id: edition,
+              edition: {
+                lead_organisation_ids: [organisation.id],
+                access_limiting: "organisations",
+                access_limiting_organisation_ids: [organisation.id.to_s],
+              },
+            }
+
+        assert_equal "organisations", edition.reload.access_limiting
+        assert edition.access_limiting_organisations.exists?(id: organisation.id)
+      end
+
+      test "update should change access limiting, from 'organisations' to 'none', but retains the organisation IDs in the association" do
+        feature_flags.switch! :access_limiting_organisations_ui, true
+
+        organisation = create(:organisation)
+        controller.current_user.organisation = organisation
+        controller.current_user.save!
+
+        edition = create(edition_type, access_limiting: "organisations", access_limiting_organisation_ids: [organisation.id.to_s])
+
+        put :update,
+            params: {
+              id: edition,
+              edition: {
+                lead_organisation_ids: [organisation.id],
+                access_limiting: "none",
+                access_limiting_organisation_ids: [organisation.id.to_s],
+              },
+            }
+
+        assert_equal "none", edition.reload.access_limiting
+        assert edition.access_limiting_organisations.exists?(id: organisation.id)
+      end
+
+      #  Characterisation test - correct implementation should cause a validation error. Will be done in upcoming work.
+      test "update should save even when user does not belong to one of the access limiting organisations" do
+        feature_flags.switch! :access_limiting_organisations_ui, true
+
+        user_organisation = create(:organisation)
+        controller.current_user.organisation = user_organisation
+        controller.current_user.save!
+        access_limiting_organisation = create(:organisation)
+
+        edition = create(edition_type, access_limiting: "none")
+
+        put :update,
+            params: {
+              id: edition,
+              edition: {
+                lead_organisation_ids: [user_organisation.id],
+                access_limiting: "organisations",
+                access_limiting_organisation_ids: [access_limiting_organisation.id.to_s],
+              },
+            }
+
+        assert_equal "organisations", edition.reload.access_limiting
+        assert edition.access_limiting_organisations.exists?(id: access_limiting_organisation.id)
+      end
+    end
+
     def should_allow_access_limiting_of(edition_type)
       edition_class = class_for(edition_type)
 

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -1036,7 +1036,7 @@ module AdminEditionControllerTestHelpers
         created_edition = edition_class.last
         assert_valid created_edition
         assert_equal "organisations", created_edition.access_limiting
-        assert_equal [access_limiting_organisation.id, user_organisation.id].sort, edition.access_limiting_organisation_ids.sort
+        assert_equal [access_limiting_organisation.id, user_organisation.id].sort, created_edition.access_limiting_organisation_ids.sort
       end
 
       view_test "edit should display persisted access limiting value" do

--- a/test/unit/app/models/edition/creating_draft_test.rb
+++ b/test/unit/app/models/edition/creating_draft_test.rb
@@ -156,4 +156,19 @@ class Edition::WorkflowTest < ActiveSupport::TestCase
 
     assert_equal "logos/flag.jpeg", draft_edition.logo_url
   end
+
+  test "should not set access limiting on new drafts of a live document" do
+    organisation = create(:organisation)
+    published_edition = create(
+      :consultation,
+      :published,
+      access_limiting: :none,
+      create_default_organisation: false,
+      lead_organisations: [organisation],
+    )
+    new_draft = published_edition.create_draft(create(:writer))
+
+    assert new_draft.access_limiting_none?
+    assert_empty new_draft.access_limiting_organisations
+  end
 end

--- a/test/unit/app/models/edition/limited_access_test.rb
+++ b/test/unit/app/models/edition/limited_access_test.rb
@@ -62,6 +62,51 @@ class Edition::LimitedAccessTest < ActiveSupport::TestCase
     assert edition.accessible_to?(user)
   end
 
+  test "is invalid when access_limiting is set to 'organisations' and no access limiting organisations are selected" do
+    @feature_flags.switch!(:access_limiting_organisations_ui, true)
+
+    edition = create(:edition)
+    edition.access_limiting = :organisations
+    edition.access_limiting_organisation_ids = []
+
+    assert_not edition.valid?
+    assert_includes edition.errors[:access_limiting_organisation_ids],
+                    "must include at least one organisation when access limiting is enabled"
+  end
+
+  test "is valid when access_limiting is set to 'organisations' and access limiting organisations are present" do
+    @feature_flags.switch!(:access_limiting_organisations_ui, true)
+    org = create(:organisation)
+
+    edition = create(:edition)
+    edition.access_limiting = :organisations
+    edition.access_limiting_organisation_ids = [org.id]
+
+    assert edition.valid?
+  end
+
+  test "is valid when access_limiting is set to 'none' regardless of access limiting organisations" do
+    @feature_flags.switch!(:access_limiting_organisations_ui, true)
+
+    edition = create(:limited_access_edition, access_limiting: :none)
+    edition.access_limiting_organisation_ids = []
+    assert edition.valid?
+  end
+
+  test "is valid when access_limiting is set to 'organisations' and no access limiting organisations are selected when flag is off" do
+    edition = create(:consultation, access_limiting: :organisations)
+    edition.access_limiting_organisation_ids = []
+    assert edition.valid?
+  end
+
+  test "is invalid when access_limiting is set to 'organisations' and no edition organisations are selected when flag is off" do
+    edition = create(:consultation, access_limiting: :organisations)
+    edition.organisation_ids = []
+
+    assert_not edition.valid?
+    assert_includes edition.errors[:lead_organisation_ids], "at least one required"
+  end
+
   test "setting access_limiting writes through to the legacy access_limited column" do
     edition = build(:limited_access_edition)
 

--- a/test/unit/app/services/draft_edition_updater_test.rb
+++ b/test/unit/app/services/draft_edition_updater_test.rb
@@ -37,6 +37,41 @@ class DraftEditionUpdaterTest < ActiveSupport::TestCase
 
     updater.perform!
   end
+  test "cannot perform if user is limiting their own access via access_limiting_organisations when flag is on" do
+    @feature_flags.switch!(:access_limiting_organisations_ui, true)
+
+    other_org = create(:organisation)
+    edition = create(:draft_publication, access_limiting: "organisations", access_limiting_organisation_ids: [other_org.id])
+    updater = DraftEditionUpdater.new(edition, { current_user: create(:user, organisation: create(:organisation)) })
+    updater.expects(:notify!).never
+    updater.expects(:update_publishing_api!).never
+
+    updater.perform!
+  end
+
+  test "cannot perform when access_limiting is organisations but no orgs are set when flag is on" do
+    edition = create(:draft_publication, access_limiting: "organisations")
+
+    @feature_flags.switch!(:access_limiting_organisations_ui, true)
+
+    updater = DraftEditionUpdater.new(edition, { current_user: create(:user, organisation: create(:organisation)) })
+    updater.expects(:notify!).never
+    updater.expects(:update_publishing_api!).never
+
+    updater.perform!
+  end
+
+  test "can perform when the current user's organisation is in access_limiting_organisations when flag is on" do
+    @feature_flags.switch!(:access_limiting_organisations_ui, true)
+
+    organisation = create(:organisation)
+    edition = create(:draft_publication, access_limiting: "organisations", access_limiting_organisation_ids: [organisation.id])
+    updater = DraftEditionUpdater.new(edition, { current_user: create(:user, organisation:) })
+    updater.expects(:update_publishing_api!).once
+    updater.expects(:notify!).once
+
+    updater.perform!
+  end
 
   test "updates editions that cannot be tagged to organisations" do
     organisation = create(:organisation)

--- a/test/unit/app/services/edition_publisher_test.rb
+++ b/test/unit/app/services/edition_publisher_test.rb
@@ -19,6 +19,20 @@ class EditionPublisherTest < ActiveSupport::TestCase
     assert_not edition.access_limited?
   end
 
+  test "#perform! with an access limited edition sets access_limiting to 'none' and clears access_limiting_organisations" do
+    organisation = create(:organisation)
+    edition = create(
+      :submitted_edition,
+      :access_limited,
+      access_limiting_organisation_ids: [organisation.id],
+    )
+
+    assert EditionPublisher.new(edition).perform!
+    assert edition.published?
+    assert_equal "none", edition.access_limiting
+    assert_empty edition.access_limiting_organisations
+  end
+
   %w[published draft rejected superseded].each do |state|
     test "#{state} editions cannot be published" do
       edition = create(:"#{state}_edition")

--- a/test/unit/lib/whitehall/authority/edition_rules_test.rb
+++ b/test/unit/lib/whitehall/authority/edition_rules_test.rb
@@ -1,0 +1,51 @@
+require_relative "authority_test_helper"
+require "ostruct"
+
+class EditionRulesTest < ActiveSupport::TestCase
+  include AuthorityTestHelper
+
+  def user_in(organisation)
+    OpenStruct.new(
+      id: 1,
+      gds_editor?: false,
+      organisation:,
+    )
+  end
+
+  test "access is enforced against access_limiting_organisations when flag is on and organisations are set" do
+    feature_flags.switch! :access_limiting_organisations_ui, true
+
+    org1 = build(:organisation)
+    org2 = build(:organisation)
+    user = user_in(org1)
+
+    edition = build(:edition, access_limiting: "organisations")
+    edition.stubs(:access_limiting_organisations).returns([org2])
+
+    assert_not enforcer_for(user, edition).can?(:see)
+  end
+
+  test "access is granted when user's organisation is in access_limiting_organisations and flag is on" do
+    feature_flags.switch! :access_limiting_organisations_ui, true
+
+    org = build(:organisation)
+    user = user_in(org)
+
+    edition = build(:edition, access_limiting: "organisations")
+    edition.stubs(:access_limiting_organisations).returns([org])
+
+    assert enforcer_for(user, edition).can?(:see)
+  end
+
+  test "ignores access_limiting_organisations and uses lead/supporting organisations when flag is off" do
+    org1 = build(:organisation)
+    org2 = build(:organisation)
+    user = user_in(org1)
+
+    edition = FactoryBot.build(:consultation, access_limiting: "organisations")
+    edition.stubs(:organisations).returns([org1])
+    edition.stubs(:access_limiting_organisations).returns([org2])
+
+    assert enforcer_for(user, edition).can?(:see)
+  end
+end


### PR DESCRIPTION
Prevent editors from accidentally locking themselves out of access-limited documents

When an editor sets access limiting to "organisations" and picks orgs that don't include their own, they'd immediately lose access to the document they just saved. This commit stops that from happening.

Note: Still sits behind a feature flag at this point in time.

How it works:
- A `before_action` -> `prevent_access_limiting_lockout` runs before create and update. If the submitted org list excludes the current user's org, we show an error and don't save the data.
- `access_limiting_organisation_ids` is excluded from assign_attributes and handled separately using mark_for_destruction + in-memory build on the join model. This prevents the has_many `:through` setter from writing to the database before the save is  confirmed; so a blocked or failed save leaves the database unchanged.
- The fix covers all EditionsController subclasses automatically, including the tabbed form path in StandardEditionsController which had its own update flow.


[JIRA](https://gov-uk.atlassian.net/browse/WHIT-3583)


---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
