### PR TITLE
First published at validation 4 [WHIT-3522]

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -71,6 +71,8 @@ class Edition < ApplicationRecord
   validates :political, inclusion: { in: [true, false] }
   validates :image_display_option, inclusion: { in: ["no_image", "organisation_image", "custom_image", nil] }
 
+  validate :first_published_precedes_change_notes, if: :draft?
+
   UNMODIFIABLE_STATES = %w[scheduled published superseded deleted unpublished].freeze
   FROZEN_STATES = %w[superseded deleted].freeze
   PRE_PUBLICATION_STATES = %w[draft submitted rejected scheduled].freeze
@@ -234,6 +236,8 @@ class Edition < ApplicationRecord
   end
 
   def other_editions
+    return Edition.none if document.nil?
+
     if persisted?
       document.editions.where(self.class.arel_table[:id].not_eq(id))
     else
@@ -449,6 +453,19 @@ class Edition < ApplicationRecord
 
   def invalid_tab_messages
     []
+  end
+
+  def first_published_precedes_change_notes
+    return if first_published_at.blank?
+    return if other_editions.empty?
+
+    change_note_dates = other_editions.pluck(:major_change_published_at).compact.sort
+
+    return if change_note_dates.empty?
+
+    if first_published_at >= change_note_dates.first
+      errors.add(:first_published_at, :after_change_notes, latest: change_note_dates.first.strftime("%d/%m/%Y %H:%M"))
+    end
   end
 
 private

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -459,6 +459,7 @@ class Edition < ApplicationRecord
   def first_published_precedes_change_notes
     return if first_published_at.blank?
     return if other_editions.empty?
+    return if political?
 
     change_note_dates = other_editions.pluck(:major_change_published_at).compact.sort
 

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -65,13 +65,13 @@ class Edition < ApplicationRecord
   validates :body, presence: true, if: :body_required?, length: { maximum: 16_777_215 }, unless: ->(record) { record.is_a?(StandardEdition) }
   validates :summary, presence: true, if: :summary_required?, length: { maximum: 65_535 }
   validates :previously_published, inclusion: { in: [true, false], message: "You must specify whether the document has been published before" }
-  validates :first_published_at, presence: true, if: -> { previously_published || published_major_version }
-  validates :first_published_at, inclusion: { in: proc { Date.parse("1900-01-01")..Time.zone.now } }, if: :draft?, allow_blank: true
   validates :scheduled_publication, inclusion: { in: proc { Time.zone.now.. }, message: "must be in the future" }, if: :draft?, allow_blank: true
   validates :political, inclusion: { in: [true, false] }
   validates :image_display_option, inclusion: { in: ["no_image", "organisation_image", "custom_image", nil] }
 
   validate :first_published_precedes_change_notes, if: :draft?
+  validates :first_published_at, presence: true, if: -> { previously_published || published_major_version }
+  validates :first_published_at, inclusion: { in: proc { Date.parse("1900-01-01")..Time.zone.now } }, if: -> { draft? && errors.attribute_names.exclude?(:first_published_at) }, allow_blank: true
 
   UNMODIFIABLE_STATES = %w[scheduled published superseded deleted unpublished].freeze
   FROZEN_STATES = %w[superseded deleted].freeze

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -69,8 +69,8 @@ class Edition < ApplicationRecord
   validates :political, inclusion: { in: [true, false] }
   validates :image_display_option, inclusion: { in: ["no_image", "organisation_image", "custom_image", nil] }
 
-  validate :first_published_precedes_change_notes, if: -> { draft? && first_published_at_changed? }
-  validate :first_published_within_current_govt, if: -> { draft? && first_published_at_changed? }
+  validate :first_published_precedes_change_notes, if: -> { draft? && first_published_at_date_changed? }
+  validate :first_published_within_current_govt, if: -> { draft? && first_published_at_date_changed? }
   validates :first_published_at, presence: true, if: -> { previously_published || published_major_version }
   validates :first_published_at, inclusion: { in: proc { Date.parse("1900-01-01")..Time.zone.now } }, if: -> { draft? && errors.attribute_names.exclude?(:first_published_at) }, allow_blank: true
 
@@ -457,7 +457,6 @@ class Edition < ApplicationRecord
   end
 
   def first_published_precedes_change_notes
-    return if first_published_at.blank?
     return if other_editions.empty?
     return if political?
 
@@ -480,6 +479,19 @@ class Edition < ApplicationRecord
     if first_published_at.to_date <= current_govt.start_date
       errors.add(:first_published_at, :before_current_govt, earliest: current_govt.start_date.strftime("%d/%m/%Y"))
     end
+  end
+
+  def first_published_at_date_changed?
+    return false if first_published_at_change.nil?
+
+    old_date, new_date = first_published_at_change
+
+    return true if new_date.nil? || old_date.nil?
+
+    # When a first edition is published, seconds and milliseconds are set for `first_published_at`.  The edition form doesn't allow user to specific seconds or milliseconds,
+    # so these are lost when an edition is redrafted.
+    # We need to ignore changes in seconds and milliseconds when considering whether the date has changed for validation purposes.
+    new_date.change(sec: 0) != old_date.change(sec: 0)
   end
 
 private

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -70,6 +70,7 @@ class Edition < ApplicationRecord
   validates :image_display_option, inclusion: { in: ["no_image", "organisation_image", "custom_image", nil] }
 
   validate :first_published_precedes_change_notes, if: :draft?
+  validate :first_published_within_current_govt, if: :draft?
   validates :first_published_at, presence: true, if: -> { previously_published || published_major_version }
   validates :first_published_at, inclusion: { in: proc { Date.parse("1900-01-01")..Time.zone.now } }, if: -> { draft? && errors.attribute_names.exclude?(:first_published_at) }, allow_blank: true
 
@@ -465,6 +466,18 @@ class Edition < ApplicationRecord
 
     if first_published_at >= change_note_dates.first
       errors.add(:first_published_at, :after_change_notes, latest: change_note_dates.first.strftime("%d/%m/%Y %H:%M"))
+    end
+  end
+
+  def first_published_within_current_govt
+    current_govt = Government.current
+
+    return if first_published_at.blank?
+    return if current_govt.blank?
+    return if political?
+
+    if first_published_at.to_date <= current_govt.start_date
+      errors.add(:first_published_at, :before_current_govt, earliest: current_govt.start_date.strftime("%d/%m/%Y"))
     end
   end
 

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -69,8 +69,8 @@ class Edition < ApplicationRecord
   validates :political, inclusion: { in: [true, false] }
   validates :image_display_option, inclusion: { in: ["no_image", "organisation_image", "custom_image", nil] }
 
-  validate :first_published_precedes_change_notes, if: :draft?
-  validate :first_published_within_current_govt, if: :draft?
+  validate :first_published_precedes_change_notes, if: -> { draft? && first_published_at_changed? }
+  validate :first_published_within_current_govt, if: -> { draft? && first_published_at_changed? }
   validates :first_published_at, presence: true, if: -> { previously_published || published_major_version }
   validates :first_published_at, inclusion: { in: proc { Date.parse("1900-01-01")..Time.zone.now } }, if: -> { draft? && errors.attribute_names.exclude?(:first_published_at) }, allow_blank: true
 

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -24,6 +24,7 @@ en:
               blank: Enter a first published date
               inclusion: First published date must be between 1/1/1900 and the present
               after_change_notes: "First published date must be before the first change note (%{latest})"
+              before_current_govt: "First published date must be after the start of the current government (%{earliest})"
             html_attachments:
               missing_contact_reference: "- \"%{html_attachment_title}\" - embedded Contact (ID %{contact_id}) doesn't exist"
             unpublishing:

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -23,6 +23,7 @@ en:
               invalid_date: First published date is not in the correct format
               blank: Enter a first published date
               inclusion: First published date must be between 1/1/1900 and the present
+              after_change_notes: "First published date must be before the first change note (%{latest})"
             html_attachments:
               missing_contact_reference: "- \"%{html_attachment_title}\" - embedded Contact (ID %{contact_id}) doesn't exist"
             unpublishing:

--- a/features/support/document_helper.rb
+++ b/features/support/document_helper.rb
@@ -115,7 +115,7 @@ module DocumentHelper
     fill_in "Logo formatted name", with: "Logo\r\nformatted\r\nname\r\n"
   end
 
-  def fill_in_publication_fields(first_published: "2010-01-01", publication_type: "Research and analysis")
+  def fill_in_publication_fields(first_published: Time.zone.now, publication_type: "Research and analysis")
     checkbox_label = "This document has previously been published on another website"
     check checkbox_label
     within_conditional_reveal checkbox_label do

--- a/features/support/governments_helper.rb
+++ b/features/support/governments_helper.rb
@@ -1,5 +1,5 @@
 module GovernmentsHelper
-  def create_government(name:, start_date: Time.zone.today, end_date: nil)
+  def create_government(name:, start_date: 1.day.ago, end_date: nil)
     visit admin_governments_path
 
     click_on "Create new government"

--- a/test/unit/app/models/call_for_evidence_test.rb
+++ b/test/unit/app/models/call_for_evidence_test.rb
@@ -328,7 +328,7 @@ class CallForEvidenceTest < ActiveSupport::TestCase
   test "#government returns the government active on the first_public_at date" do
     create(:current_government)
     previous_government = create(:previous_government)
-    call_for_evidence = create(:call_for_evidence, first_published_at: 4.years.ago)
+    call_for_evidence = build(:call_for_evidence, first_published_at: 4.years.ago)
 
     assert_equal previous_government, call_for_evidence.government
   end

--- a/test/unit/app/models/consultation_test.rb
+++ b/test/unit/app/models/consultation_test.rb
@@ -368,7 +368,7 @@ class ConsultationTest < ActiveSupport::TestCase
   test "#government returns the government active on the first_public_at date" do
     create(:current_government)
     previous_government = create(:previous_government)
-    consultation = create(:consultation, first_published_at: 4.years.ago)
+    consultation = build(:consultation, first_published_at: 4.years.ago)
 
     assert_equal previous_government, consultation.government
   end

--- a/test/unit/app/models/edition_test.rb
+++ b/test/unit/app/models/edition_test.rb
@@ -730,6 +730,22 @@ class EditionTest < ActiveSupport::TestCase
     assert political_edition.valid?
   end
 
+  test "political editions can have their first_published_at date after the earliest change note" do
+    edition_with_change_note = create(:edition_with_document, :published, change_note: "changed", major_change_published_at: 2.days.ago)
+    edition = build(:edition, political: true, document: edition_with_change_note.document, first_published_at: 1.day.ago)
+
+    assert edition.valid?
+  end
+
+  test "historical editions can have their first_published_at date set after the earliest change note" do
+    prev_government = create(:previous_government, start_date: 10.years.ago, end_date: 1.year.ago)
+    create(:current_government, start_date: 1.year.ago)
+    historic_edition_with_change_note = create(:edition_with_document, :published, change_note: "changed", major_change_published_at: 9.years.ago)
+    historic_edition = create(:edition, political: true, first_published_at: 8.years.ago, government_id: prev_government.id, document: historic_edition_with_change_note.document)
+
+    assert historic_edition.valid?
+  end
+
   test "after_change_notes' error message takes priority if multiple validation errors on first_published_at" do
     edition_with_change_note = create(:edition_with_document, :published, change_note: "changed", major_change_published_at: 2.days.ago)
     edition = build(:edition, document: edition_with_change_note.document, first_published_at: 10.years.from_now)
@@ -1092,7 +1108,6 @@ class EditionTest < ActiveSupport::TestCase
 
     assert edition.valid?
   end
-
 
   test "editions can have their first_published_at date changed after the current government" do
     create(:current_government, start_date: 1.month.ago)

--- a/test/unit/app/models/edition_test.rb
+++ b/test/unit/app/models/edition_test.rb
@@ -703,17 +703,21 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal "First published date must be between 1/1/1900 and the present", edition.errors.full_messages.first
   end
 
-  test "first_published_at cannot be after the date of the first change note" do
+  test "a changed first_published_at cannot be after the date of the first change note" do
     edition_with_change_note = create(:edition_with_document, :published, change_note: "changed", major_change_published_at: 2.days.ago)
-    edition = build(:edition, document: edition_with_change_note.document, first_published_at: 1.day.ago)
+    edition = create(:edition, document: edition_with_change_note.document, first_published_at: 3.days.ago)
+
+    edition.first_published_at = 1.day.ago
 
     assert edition.invalid?
     assert_equal "First published date must be before the first change note (09/11/2011 11:11)", edition.errors.full_messages.first
   end
 
-  test "first_published_at cannot be before the start of the current government" do
+  test "a changed first_published_at cannot be before the start of the current government" do
     create(:current_government)
-    edition = build(:edition, first_published_at: 10.years.ago)
+    edition = create(:edition, first_published_at: Time.zone.now)
+
+    edition.first_published_at = 11.years.ago
 
     assert edition.invalid?
     assert_equal "First published date must be after the start of the current government (11/11/2009)", edition.errors.full_messages.first

--- a/test/unit/app/models/edition_test.rb
+++ b/test/unit/app/models/edition_test.rb
@@ -703,6 +703,14 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal "First published date must be between 1/1/1900 and the present", edition.errors.full_messages.first
   end
 
+  test "first_published_at cannot be after the date of the first change note" do
+    edition_with_change_note = create(:edition_with_document, :published, change_note: "changed", major_change_published_at: 2.days.ago)
+    edition = build(:edition, document: edition_with_change_note.document, first_published_at: 1.day.ago)
+
+    assert edition.invalid?
+    assert_equal "First published date must be before the first change note (09/11/2011 11:11)", edition.errors.full_messages.first
+  end
+
   test "#government returns the associated government when the edition has a specific government_id" do
     create(:current_government)
     previous_government = create(:previous_government)
@@ -1010,6 +1018,51 @@ class EditionTest < ActiveSupport::TestCase
   test "#invalid_tab_reasons returns an empty array" do
     publication = create(:publication)
     assert_equal [], publication.invalid_tab_messages
+  end
+
+  test "#other_editions returns an empty array if there is no associated document" do
+    edition = build(:edition)
+
+    assert_equal edition.other_editions, []
+  end
+
+  test "first_published_at cannot be at the (same) time of the first change note" do
+    change_note_date = 3.days.ago
+    edition_with_change_note = create(:edition_with_document, :published, change_note: "changed", major_change_published_at: change_note_date)
+    edition = build(:edition, document: edition_with_change_note.document, first_published_at: change_note_date)
+    assert edition.invalid?
+  end
+
+  test "first_published_at can be after the date of the first change note" do
+    edition_with_change_note = create(:edition_with_document, :published, change_note: "changed", major_change_published_at: 3.days.ago)
+    edition = create(:edition, document: edition_with_change_note.document, first_published_at: 4.days.ago)
+
+    assert edition.valid?
+  end
+
+  test "a first edition with no related editions can have the first published at date changed" do
+    edition = create(:edition, first_published_at: 1.day.ago)
+    edition.first_published_at = 2.days.ago
+
+    assert edition.valid?
+  end
+
+  test "edition with many related editions with change notes chooses oldest change note for first published at validation" do
+    edition_with_oldest_change_note = create(:edition_with_document, :published, change_note: "changed", major_change_published_at: 10.days.ago) # 01/11/2011
+    create(:edition, :published, document: edition_with_oldest_change_note.document, change_note: "changed", major_change_published_at: 9.days.ago)
+    edition = build(:edition, document: edition_with_oldest_change_note.document, first_published_at: 1.day.ago)
+
+    assert edition.invalid?
+    assert edition.errors.full_messages.first == "First published date must be before the first change note (01/11/2011 11:11)"
+  end
+
+  test "edition with many related editions without change notes can have first published at changed" do
+    first_edition = create(:edition_with_document, :published, minor_change: true)
+    create(:edition, :published, document: first_edition.document, minor_change: true)
+    edition = create(:edition, document: first_edition.document, first_published_at: 2.days.ago)
+    edition.first_published_at = 3.days.ago
+
+    assert edition.valid?
   end
 
   def decoded_token_payload(token)

--- a/test/unit/app/models/edition_test.rb
+++ b/test/unit/app/models/edition_test.rb
@@ -723,11 +723,35 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal "First published date must be after the start of the current government (11/11/2009)", edition.errors.full_messages.first
   end
 
+  test "an edition from a previous government can still be redrafted if it's first published at date hasn't changed" do
+    create(:previous_government, start_date: 10.years.ago, end_date: 5.years.ago)
+
+    first_published_at = 6.years.ago
+
+    first_edition = create(:published_edition, first_published_at: first_published_at)
+    create(:current_government, start_date: 5.years.ago)
+    second_edition = first_edition.create_draft(create(:writer))
+    second_edition.minor_change = true
+
+    # simulate what happens when the draft edition form is saved - ie the seconds part of first_published_at is lost
+    second_edition.first_published_at = first_published_at.change(sec: 0)
+
+    assert second_edition.valid?
+  end
+
   test "political editions can have their first_published_at date set before the current government " do
     create(:current_government)
     political_edition = create(:edition, political: true, first_published_at: 10.years.ago)
 
     assert political_edition.valid?
+  end
+
+  test "non-polictial, published editions with first_published_at date set before the current government can be redrafted" do
+    create(:current_government)
+    first_edition = create(:published_edition, political: false, first_published_at: 10.years.ago)
+    second_edition = first_edition.create_draft(create(:writer))
+    second_edition.minor_change = true
+    assert second_edition.valid?
   end
 
   test "political editions can have their first_published_at date after the earliest change note" do
@@ -1138,6 +1162,41 @@ class EditionTest < ActiveSupport::TestCase
     political_edition = create(:edition, political: true, first_published_at: 9.years.ago, government_id: prev_government.id)
 
     assert political_edition.valid?
+  end
+
+  test "#first_published_at_date_changed? returns true when first_published_at has been added" do
+    edition = create(:edition, first_published_at: nil)
+    edition.first_published_at = Time.zone.now
+    assert edition.first_published_at_date_changed?
+  end
+
+  test "#first_published_at_date_changed? returns true when first_published_at has been removed" do
+    edition = create(:edition, first_published_at: Time.zone.now)
+    edition.first_published_at = nil
+    assert edition.first_published_at_date_changed?
+  end
+
+  test "#first_published_at_date_changed? returns true when the date has changed" do
+    edition = create(:edition, first_published_at: 1.day.ago)
+    edition.first_published_at = Time.zone.today
+    assert edition.first_published_at_date_changed?
+  end
+
+  test "#first_published_at_date_changed? returns false when the date has not changed" do
+    edition = create(:edition, first_published_at: 1.day.ago)
+    assert_not edition.first_published_at_date_changed?
+  end
+
+  test "#first_published_at_date_changed? returns true when the time (excl seconds) has changed" do
+    edition = create(:edition, first_published_at: 1.day.ago)
+    edition.first_published_at = edition.first_published_at.change(hour: 1.hour.ago.hour, min: 1.minute.ago.min)
+    assert edition.first_published_at_date_changed?
+  end
+
+  test "#first_published_at_date_changed? returns false when only the seconds have changed" do
+    edition = create(:edition, first_published_at: 1.day.ago)
+    edition.first_published_at = edition.first_published_at.change(sec: 10.seconds.ago.sec)
+    assert_not edition.first_published_at_date_changed?
   end
 
   def decoded_token_payload(token)

--- a/test/unit/app/models/edition_test.rb
+++ b/test/unit/app/models/edition_test.rb
@@ -711,6 +711,15 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal "First published date must be before the first change note (09/11/2011 11:11)", edition.errors.full_messages.first
   end
 
+  test "after_change_notes' error message takes priority if multiple validation errors on first_published_at" do
+    edition_with_change_note = create(:edition_with_document, :published, change_note: "changed", major_change_published_at: 2.days.ago)
+    edition = build(:edition, document: edition_with_change_note.document, first_published_at: 10.years.from_now)
+    edition.validate
+
+    assert_equal [:first_published_at], edition.errors.attribute_names
+    assert_equal "First published date must be before the first change note (09/11/2011 11:11)", edition.errors.full_messages.first
+  end
+
   test "#government returns the associated government when the edition has a specific government_id" do
     create(:current_government)
     previous_government = create(:previous_government)

--- a/test/unit/app/models/edition_test.rb
+++ b/test/unit/app/models/edition_test.rb
@@ -711,6 +711,21 @@ class EditionTest < ActiveSupport::TestCase
     assert_equal "First published date must be before the first change note (09/11/2011 11:11)", edition.errors.full_messages.first
   end
 
+  test "first_published_at cannot be before the start of the current government" do
+    create(:current_government)
+    edition = build(:edition, first_published_at: 10.years.ago)
+
+    assert edition.invalid?
+    assert_equal "First published date must be after the start of the current government (11/11/2009)", edition.errors.full_messages.first
+  end
+
+  test "political editions can have their first_published_at date set before the current government " do
+    create(:current_government)
+    political_edition = create(:edition, political: true, first_published_at: 10.years.ago)
+
+    assert political_edition.valid?
+  end
+
   test "after_change_notes' error message takes priority if multiple validation errors on first_published_at" do
     edition_with_change_note = create(:edition_with_document, :published, change_note: "changed", major_change_published_at: 2.days.ago)
     edition = build(:edition, document: edition_with_change_note.document, first_published_at: 10.years.from_now)
@@ -748,7 +763,7 @@ class EditionTest < ActiveSupport::TestCase
   test "#government returns the historic government for a previously published edition" do
     previous_government = create(:previous_government)
     create(:current_government)
-    edition = create(:edition, first_published_at: 4.years.ago)
+    edition = build(:edition, first_published_at: 4.years.ago)
     assert_equal previous_government, edition.government
   end
 
@@ -770,13 +785,13 @@ class EditionTest < ActiveSupport::TestCase
 
     previous_government = create(:previous_government)
 
-    edition = create(:edition, political: false, first_published_at: previous_government.start_date)
+    edition = build(:edition, political: false, first_published_at: previous_government.start_date)
     assert_not edition.historic?
 
-    edition = create(:edition, political: false, first_published_at: current_government.start_date)
+    edition = build(:edition, political: false, first_published_at: current_government.start_date)
     assert_not edition.historic?
 
-    edition = create(:edition, political: true, first_published_at: current_government.start_date)
+    edition = build(:edition, political: true, first_published_at: current_government.start_date)
     assert_not edition.historic?
   end
 
@@ -1072,6 +1087,38 @@ class EditionTest < ActiveSupport::TestCase
     edition.first_published_at = 3.days.ago
 
     assert edition.valid?
+  end
+
+
+  test "editions can have their first_published_at date changed after the current government" do
+    create(:current_government, start_date: 1.month.ago)
+    edition = create(:edition, first_published_at: 1.week.ago)
+    edition.first_published_at = 1.day.ago
+
+    assert edition.valid?
+  end
+
+  test "editions can have their first_published_at date changed in the absence of a current government" do
+    edition = create(:edition, first_published_at: 1.week.ago)
+    edition.first_published_at = 1.day.ago
+
+    assert edition.valid?
+  end
+
+  test "editions cannot have their first_published_at date changed to the start of the current govt" do
+    govt = create(:current_government, start_date: 1.month.ago)
+    edition = create(:edition, first_published_at: 1.day.ago)
+    edition.first_published_at = govt.start_date
+
+    assert edition.invalid?
+  end
+
+  test "historical editions can have their first_published_at date set before the current government" do
+    prev_government = create(:previous_government, start_date: 10.years.ago, end_date: 1.year.ago)
+    create(:current_government, start_date: 1.year.ago)
+    political_edition = create(:edition, political: true, first_published_at: 9.years.ago, government_id: prev_government.id)
+
+    assert political_edition.valid?
   end
 
   def decoded_token_payload(token)

--- a/test/unit/app/presenters/publishing_api/document_collection_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/document_collection_presenter_test.rb
@@ -403,7 +403,7 @@ class PublishingApi::DocumentCollectionPresenterPreviousGovernmentTest < ActiveS
       slug: "a-previous-government",
     )
     @presented_document_collection = PublishingApi::DocumentCollectionPresenter.new(
-      create(
+      build(
         :document_collection,
         first_published_at: @previous_government.start_date + 1.day,
       ),

--- a/test/unit/app/presenters/publishing_api/statistical_data_set_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/statistical_data_set_presenter_test.rb
@@ -268,7 +268,7 @@ class PublishingApi::StatisticalDataSetPresenterPreviousGovernmentTest < ActiveS
       slug: "a-previous-government",
     )
     @presented_statistical_data_set = PublishingApi::StatisticalDataSetPresenter.new(
-      create(
+      build(
         :statistical_data_set,
         first_published_at: @previous_government.start_date + 1.day,
       ),


### PR DESCRIPTION
## What

Creates a new `first_published_at_date_changed?` method that ignores changes in seconds and milliseconds when comparing an edition's  existing `first_published_at` with the persisted value.

Replaces the `first_published_at_changed?` in the `validate :first_published_preceeds_change_notes` and `validate :first_published_within_current_govt` conditionals.

These changes are in the last commit ea74b35192ed4abcaf1fa244707a6e55523dc45d - the others are cherry-picked from the reverted PRs.

## Why

When #11473 was deployed, users trying to redraft a non-historic/political first edition were unable to do so because:

- the `first_published_at` timestamp is set by the publishing workflow when an edition is published
- the timestamp is copied to new editions during the redrafting process
- the editing form does not include inputs for seconds and milliseconds
- when this subsequent edition is saved, `#first_published_at_changed?` considers the field changed, since seconds and milliseconds are absent from the form params.

This means that the `first_published_at_changed?` clause in the `validate :first_published_preceeds_change_notes` and `validate :first_published_within_current_govt` conditional allows those validations to fire even if the user hasn't changed `first_published_at` during redrafting.

This incorrectly stops users from redrafting old first editions that were created outside of the current government.  We only want to run those validations if the user has changed `first_published_at`.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
