### PR TITLE
Topical event recipe [WHIT-3270]

### DIFF
--- a/app/models/configurable_document_types/topical_event.json
+++ b/app/models/configurable_document_types/topical_event.json
@@ -211,7 +211,7 @@
     "history_mode_enabled": false,
     "taxon": {
       "enabled": true,
-      "required": true
+      "required": false
     },
     "translations_enabled": false
   }

--- a/app/services/standard_edition_migrator/topical_event_recipe.rb
+++ b/app/services/standard_edition_migrator/topical_event_recipe.rb
@@ -9,6 +9,7 @@ class StandardEditionMigrator::TopicalEventRecipe < StandardEditionMigrator::Bas
     raise WhitehallError, "Topical Events with About pages are not currently supported by the migrator" if record.topical_event_about_page
 
     attributes = {
+      creator: User.find_by(name: "Scheduled Publishing Robot"),
       created_at: record.created_at,
       updated_at: record.updated_at,
       configurable_document_type: "topical_event",

--- a/app/services/standard_edition_migrator/topical_event_recipe.rb
+++ b/app/services/standard_edition_migrator/topical_event_recipe.rb
@@ -43,6 +43,9 @@ class StandardEditionMigrator::TopicalEventRecipe < StandardEditionMigrator::Bas
       # we're not carrying over duration fields to new topical events
       content[:details].delete(:start_date)
       content[:details].delete(:end_date)
+
+      # 'image' (logo) is replaced by 'images'
+      content[:details].delete(:image)
     end
 
     if content[:details] && content[:details][:ordered_featured_documents]

--- a/app/services/standard_edition_migrator/topical_event_recipe.rb
+++ b/app/services/standard_edition_migrator/topical_event_recipe.rb
@@ -22,7 +22,8 @@ class StandardEditionMigrator::TopicalEventRecipe < StandardEditionMigrator::Bas
       summary: record.summary,
       slug_override: record.slug,
       block_content: {
-        "body" => record.description,
+        # A body is now required, and we don't want to loosen the validation on new topical events
+        "body" => record.description || ".",
         "social_media_links" => record.social_media_accounts.map do |account|
           {
             "social_media_service_name" => account.service_name,

--- a/app/services/standard_edition_migrator/topical_event_recipe.rb
+++ b/app/services/standard_edition_migrator/topical_event_recipe.rb
@@ -10,6 +10,7 @@ class StandardEditionMigrator::TopicalEventRecipe < StandardEditionMigrator::Bas
       configurable_document_type: "topical_event",
       title: record.name,
       summary: record.summary,
+      slug_override: record.slug,
       block_content: {
         "body" => record.description,
         "social_media_links" => record.social_media_accounts.map do |account|

--- a/app/services/standard_edition_migrator/topical_event_recipe.rb
+++ b/app/services/standard_edition_migrator/topical_event_recipe.rb
@@ -47,6 +47,7 @@ class StandardEditionMigrator::TopicalEventRecipe < StandardEditionMigrator::Bas
 
   def ignore_new_content_fields(content)
     content.delete(:auth_bypass_ids) # these were not present on legacy topical events and are included by default on StandardEdition
+    content.delete(:links) # legacy Topical Events had no edition links, but StandardEdition ones will
     content
   end
 

--- a/app/services/standard_edition_migrator/topical_event_recipe.rb
+++ b/app/services/standard_edition_migrator/topical_event_recipe.rb
@@ -5,5 +5,11 @@ class StandardEditionMigrator::TopicalEventRecipe < StandardEditionMigrator::Bas
 
   def build_edition(record)
     raise WhitehallError, "Topical Events with About pages are not currently supported by the migrator" if record.topical_event_about_page
+
+    StandardEdition.new(
+      configurable_document_type: "topical_event",
+      title: record.name,
+      summary: record.summary,
+    )
   end
 end

--- a/app/services/standard_edition_migrator/topical_event_recipe.rb
+++ b/app/services/standard_edition_migrator/topical_event_recipe.rb
@@ -23,7 +23,7 @@ class StandardEditionMigrator::TopicalEventRecipe < StandardEditionMigrator::Bas
       slug_override: record.slug,
       block_content: {
         # A body is now required, and we don't want to loosen the validation on new topical events
-        "body" => record.description || ".",
+        "body" => record.description || "&nbsp;",
         "social_media_links" => record.social_media_accounts.map do |account|
           {
             "social_media_service_name" => account.service_name,
@@ -75,6 +75,10 @@ class StandardEditionMigrator::TopicalEventRecipe < StandardEditionMigrator::Bas
 
       # 'image' (logo) is replaced by 'images'
       content[:details].delete(:image)
+    end
+
+    if content[:details] && content[:details][:body] == "<div class=\"govspeak\">\n</div>"
+      content[:details][:body] = "<div class=\"govspeak\"><p>.</p>\n</div>"
     end
 
     if content[:details] && content[:details][:ordered_featured_documents]

--- a/app/services/standard_edition_migrator/topical_event_recipe.rb
+++ b/app/services/standard_edition_migrator/topical_event_recipe.rb
@@ -1,6 +1,11 @@
 class StandardEditionMigrator::TopicalEventRecipe < StandardEditionMigrator::BaseRecipe
   include GovspeakHelper
 
+  def initialize
+    @artefacts_to_save = []
+    super
+  end
+
   def legacy_presenter
     PublishingApi::TopicalEventPresenter
   end
@@ -36,6 +41,24 @@ class StandardEditionMigrator::TopicalEventRecipe < StandardEditionMigrator::Bas
       major_change_published_at: record.created_at,
     }
     StandardEdition.new(attributes)
+  end
+
+  def after_save_edition(edition, legacy_record)
+    # Save the in-memory artefacts that were built during edition creation (e.g. FeatureList, Image, etc.)
+    @artefacts_to_save.each do |artefact|
+      if artefact.respond_to?(:edition_id=)
+        artefact.edition_id = edition.id
+      end
+      artefact.save!
+    end
+    # Create and save the associations that rely on Edition being a persisted record.
+    legacy_record.topical_event_memberships.each do |membership|
+      EditionLink.create!(
+        edition_id: membership.edition_id,
+        document_id: edition.document_id,
+        link_type: "topical_event",
+      )
+    end
   end
 
   def ignore_legacy_content_fields(content)
@@ -127,7 +150,7 @@ private
       Feature.new(attrs)
     end
 
-    queue_for_saving(feature_list)
+    @artefacts_to_save << feature_list
     feature_list
   end
 
@@ -189,7 +212,7 @@ private
     # Assets and ImageData are already persisted above; re-saving ImageData can
     # clobber the mounted uploader identifier and lead to nil URLs in payloads.
     # So deliberately don't save ImageData or its Assets again.
-    queue_for_saving(image)
+    @artefacts_to_save << image
     image
   end
 end

--- a/app/services/standard_edition_migrator/topical_event_recipe.rb
+++ b/app/services/standard_edition_migrator/topical_event_recipe.rb
@@ -85,6 +85,8 @@ class StandardEditionMigrator::TopicalEventRecipe < StandardEditionMigrator::Bas
       end
     end
 
+    # Delete the 'images' array (replacing old 'image' property)
+    content[:details].delete(:images) if content[:details]
     content
   end
 

--- a/app/services/standard_edition_migrator/topical_event_recipe.rb
+++ b/app/services/standard_edition_migrator/topical_event_recipe.rb
@@ -24,13 +24,7 @@ class StandardEditionMigrator::TopicalEventRecipe < StandardEditionMigrator::Bas
       block_content: {
         # A body is now required, and we don't want to loosen the validation on new topical events
         "body" => record.description || "&nbsp;",
-        "social_media_links" => record.social_media_accounts.map do |account|
-          {
-            "social_media_service_name" => account.service_name,
-            "url" => account.url,
-            "title" => account.display_name,
-          }
-        end,
+        "social_media_links" => social_media_links(record),
       },
       lead_organisations: record.topical_event_organisations.where(lead: true).map(&:organisation),
       supporting_organisations: record.topical_event_organisations.where(lead: false).map(&:organisation),
@@ -78,7 +72,7 @@ class StandardEditionMigrator::TopicalEventRecipe < StandardEditionMigrator::Bas
     end
 
     if content[:details] && content[:details][:body] == "<div class=\"govspeak\">\n</div>"
-      content[:details][:body] = "<div class=\"govspeak\"><p>.</p>\n</div>"
+      content[:details][:body] = "<div class=\"govspeak\"><p>&nbsp;</p>\n</div>"
     end
 
     if content[:details] && content[:details][:ordered_featured_documents]
@@ -129,6 +123,21 @@ class StandardEditionMigrator::TopicalEventRecipe < StandardEditionMigrator::Bas
   end
 
 private
+
+  def social_media_links(record)
+    services = {}
+    record.social_media_accounts.map do |account|
+      services[account.service_name] ||= []
+      services[account.service_name] << account.url
+      title = services[account.service_name].count > 1 ? "#{account.display_name} (#{services[account.service_name].count})" : account.display_name
+
+      {
+        "social_media_service_name" => account.service_name,
+        "url" => account.url,
+        "title" => title,
+      }
+    end
+  end
 
   def feature_list(record)
     feature_list = FeatureList.new(locale: "en")

--- a/app/services/standard_edition_migrator/topical_event_recipe.rb
+++ b/app/services/standard_edition_migrator/topical_event_recipe.rb
@@ -45,6 +45,11 @@ class StandardEditionMigrator::TopicalEventRecipe < StandardEditionMigrator::Bas
     content
   end
 
+  def ignore_new_content_fields(content)
+    content.delete(:auth_bypass_ids) # these were not present on legacy topical events and are included by default on StandardEdition
+    content
+  end
+
 private
 
   def feature_list(record)

--- a/app/services/standard_edition_migrator/topical_event_recipe.rb
+++ b/app/services/standard_edition_migrator/topical_event_recipe.rb
@@ -26,7 +26,7 @@ class StandardEditionMigrator::TopicalEventRecipe < StandardEditionMigrator::Bas
         "body" => record.description || "&nbsp;",
         "social_media_links" => social_media_links(record),
       },
-      lead_organisations: record.topical_event_organisations.where(lead: true).map(&:organisation),
+      lead_organisations: record.topical_event_organisations.where(lead: true).order(:lead_ordering).map(&:organisation),
       supporting_organisations: record.topical_event_organisations.where(lead: false).map(&:organisation),
       feature_lists: [feature_list(record)],
       images: [logo(record)].compact,

--- a/app/services/standard_edition_migrator/topical_event_recipe.rb
+++ b/app/services/standard_edition_migrator/topical_event_recipe.rb
@@ -12,6 +12,13 @@ class StandardEditionMigrator::TopicalEventRecipe < StandardEditionMigrator::Bas
       summary: record.summary,
       block_content: {
         "body" => record.description,
+        "social_media_links" => record.social_media_accounts.map do |account|
+          {
+            "social_media_service_name" => account.service_name,
+            "url" => account.url,
+            "title" => account.display_name,
+          }
+        end,
       },
     )
   end

--- a/app/services/standard_edition_migrator/topical_event_recipe.rb
+++ b/app/services/standard_edition_migrator/topical_event_recipe.rb
@@ -42,6 +42,13 @@ class StandardEditionMigrator::TopicalEventRecipe < StandardEditionMigrator::Bas
       content[:details].delete(:end_date)
     end
 
+    if content[:details] && content[:details][:ordered_featured_documents]
+      content[:details][:ordered_featured_documents].each do |featured_document|
+        # Deleting as the value is changed in the StandardEdition equivalent
+        featured_document[:image].delete(:url)
+      end
+    end
+
     content
   end
 

--- a/app/services/standard_edition_migrator/topical_event_recipe.rb
+++ b/app/services/standard_edition_migrator/topical_event_recipe.rb
@@ -112,6 +112,12 @@ class StandardEditionMigrator::TopicalEventRecipe < StandardEditionMigrator::Bas
       end
     end
 
+    if content[:details] && content[:details][:social_media_links]
+      content[:details][:social_media_links].each do |social_media_link|
+        social_media_link[:title] = social_media_link[:title].gsub(/\s+\(\d+\)$/, "") # Remove the "(1)" or "(2)" suffixes that are added in the StandardEdition equivalent
+      end
+    end
+
     # Delete the 'images' array (replacing old 'image' property)
     content[:details].delete(:images) if content[:details]
     content

--- a/app/services/standard_edition_migrator/topical_event_recipe.rb
+++ b/app/services/standard_edition_migrator/topical_event_recipe.rb
@@ -22,7 +22,39 @@ class StandardEditionMigrator::TopicalEventRecipe < StandardEditionMigrator::Bas
       },
       lead_organisations: record.topical_event_organisations.where(lead: true).map(&:organisation),
       supporting_organisations: record.topical_event_organisations.where(lead: false).map(&:organisation),
+      feature_lists: [feature_list(record)],
     }
     StandardEdition.new(attributes)
+  end
+
+private
+
+  def feature_list(record)
+    feature_list = FeatureList.new(locale: "en")
+    feature_list.features = record.topical_event_featurings.map do |featuring|
+      featured_image = FeaturedImageData.new(
+        carrierwave_image: featuring.image.carrierwave_image,
+      )
+      featuring.image.assets.each do |asset|
+        duplicated_asset = asset.dup
+        duplicated_asset.assetable = featured_image
+        featured_image.assets << duplicated_asset
+      end
+
+      attrs = {
+        image: featured_image,
+        alt_text: featuring.alt_text,
+        ordering: featuring.ordering,
+      }
+      if featuring.offsite_link
+        attrs[:offsite_link] = featuring.offsite_link
+      else
+        attrs[:document] = featuring.edition.document
+      end
+      Feature.new(attrs)
+    end
+
+    queue_for_saving(feature_list)
+    feature_list
   end
 end

--- a/app/services/standard_edition_migrator/topical_event_recipe.rb
+++ b/app/services/standard_edition_migrator/topical_event_recipe.rb
@@ -35,6 +35,13 @@ class StandardEditionMigrator::TopicalEventRecipe < StandardEditionMigrator::Bas
     if content[:routes]
       content[:routes] = content[:routes].reject { |route| route[:path].end_with?(".atom") }
     end
+
+    if content[:details]
+      # we're not carrying over duration fields to new topical events
+      content[:details].delete(:start_date)
+      content[:details].delete(:end_date)
+    end
+
     content
   end
 

--- a/app/services/standard_edition_migrator/topical_event_recipe.rb
+++ b/app/services/standard_edition_migrator/topical_event_recipe.rb
@@ -1,0 +1,5 @@
+class StandardEditionMigrator::TopicalEventRecipe < StandardEditionMigrator::BaseRecipe
+  def legacy_presenter
+    PublishingApi::TopicalEventPresenter
+  end
+end

--- a/app/services/standard_edition_migrator/topical_event_recipe.rb
+++ b/app/services/standard_edition_migrator/topical_event_recipe.rb
@@ -55,6 +55,19 @@ class StandardEditionMigrator::TopicalEventRecipe < StandardEditionMigrator::Bas
   def ignore_new_content_fields(content)
     content.delete(:auth_bypass_ids) # these were not present on legacy topical events and are included by default on StandardEdition
     content.delete(:links) # legacy Topical Events had no edition links, but StandardEdition ones will
+
+    if content[:details] && content[:details][:ordered_featured_documents]
+      # Delete medium_resolution_url and high_resolution_url in each feature in ordered_featured_documents - these are new optional extra image variants in the StandardEdition featuring equivalent
+      content[:details][:ordered_featured_documents].each do |featured_document|
+        # Deleting as these are new values in the StandardEdition equivalent
+        featured_document[:image].delete(:medium_resolution_url)
+        featured_document[:image].delete(:high_resolution_url)
+
+        # Deleting as the value is changed in the StandardEdition equivalent
+        featured_document[:image].delete(:url)
+      end
+    end
+
     content
   end
 

--- a/app/services/standard_edition_migrator/topical_event_recipe.rb
+++ b/app/services/standard_edition_migrator/topical_event_recipe.rb
@@ -6,7 +6,7 @@ class StandardEditionMigrator::TopicalEventRecipe < StandardEditionMigrator::Bas
   def build_edition(record)
     raise WhitehallError, "Topical Events with About pages are not currently supported by the migrator" if record.topical_event_about_page
 
-    StandardEdition.new(
+    attributes = {
       configurable_document_type: "topical_event",
       title: record.name,
       summary: record.summary,
@@ -20,6 +20,9 @@ class StandardEditionMigrator::TopicalEventRecipe < StandardEditionMigrator::Bas
           }
         end,
       },
-    )
+      lead_organisations: record.topical_event_organisations.where(lead: true).map(&:organisation),
+      supporting_organisations: record.topical_event_organisations.where(lead: false).map(&:organisation),
+    }
+    StandardEdition.new(attributes)
   end
 end

--- a/app/services/standard_edition_migrator/topical_event_recipe.rb
+++ b/app/services/standard_edition_migrator/topical_event_recipe.rb
@@ -60,6 +60,8 @@ class StandardEditionMigrator::TopicalEventRecipe < StandardEditionMigrator::Bas
       end
     end
 
+    # convert public_timestamp to a string in the same format as the StandardEdition equivalent
+    content[:public_updated_at] = content[:public_updated_at].rfc3339 if content[:public_updated_at].respond_to?(:rfc3339)
     content
   end
 

--- a/app/services/standard_edition_migrator/topical_event_recipe.rb
+++ b/app/services/standard_edition_migrator/topical_event_recipe.rb
@@ -30,6 +30,10 @@ class StandardEditionMigrator::TopicalEventRecipe < StandardEditionMigrator::Bas
       supporting_organisations: record.topical_event_organisations.where(lead: false).map(&:organisation),
       feature_lists: [feature_list(record)],
       images: [logo(record)].compact,
+      state: "published",
+      # we can't know that the `updated_at` was a major change; all we can guarantee
+      # is that the initial publication was a major change.
+      major_change_published_at: record.created_at,
     }
     StandardEdition.new(attributes)
   end

--- a/app/services/standard_edition_migrator/topical_event_recipe.rb
+++ b/app/services/standard_edition_migrator/topical_event_recipe.rb
@@ -10,6 +10,9 @@ class StandardEditionMigrator::TopicalEventRecipe < StandardEditionMigrator::Bas
       configurable_document_type: "topical_event",
       title: record.name,
       summary: record.summary,
+      block_content: {
+        "body" => record.description,
+      },
     )
   end
 end

--- a/app/services/standard_edition_migrator/topical_event_recipe.rb
+++ b/app/services/standard_edition_migrator/topical_event_recipe.rb
@@ -30,6 +30,14 @@ class StandardEditionMigrator::TopicalEventRecipe < StandardEditionMigrator::Bas
     StandardEdition.new(attributes)
   end
 
+  def ignore_legacy_content_fields(content)
+    # drop .atom routes - they're not supported anymore
+    if content[:routes]
+      content[:routes] = content[:routes].reject { |route| route[:path].end_with?(".atom") }
+    end
+    content
+  end
+
 private
 
   def feature_list(record)

--- a/app/services/standard_edition_migrator/topical_event_recipe.rb
+++ b/app/services/standard_edition_migrator/topical_event_recipe.rb
@@ -28,6 +28,7 @@ class StandardEditionMigrator::TopicalEventRecipe < StandardEditionMigrator::Bas
       lead_organisations: record.topical_event_organisations.where(lead: true).map(&:organisation),
       supporting_organisations: record.topical_event_organisations.where(lead: false).map(&:organisation),
       feature_lists: [feature_list(record)],
+      images: [logo(record)].compact,
     }
     StandardEdition.new(attributes)
   end
@@ -118,5 +119,67 @@ private
 
     queue_for_saving(feature_list)
     feature_list
+  end
+
+  def logo(record)
+    return unless record.logo
+
+    # We grab the s960 variant because there are some cases where the original
+    # asset is actually smaller than 960, and the s960 variant has then been upscaled.
+    s960_logo_asset = record.logo.assets.find { |asset| asset.variant == "s960" }
+    s960_logo_filename = s960_logo_asset&.filename || record.logo.filename
+
+    unless s960_logo_asset&.asset_manager_id.present? && s960_logo_filename.present?
+      raise WhitehallError, "Topical Event logo cannot be migrated because the legacy s960 logo asset is incomplete"
+    end
+
+    image_data = ImageData.new(
+      image_kind: "topical_event_logo",
+      # We lie below - just to make it 'valid'.
+      # If the publisher ever wants to edit the logo, they'll likely need to upload a new one.
+      crop_data: {
+        x: 0,
+        y: 0,
+        width: 1506,
+        height: 1004,
+      },
+      dimensions: {
+        "width": 1506,
+        "height": 960,
+      },
+    )
+    image_data.save!(validate: false)
+
+    # Set the uploader identifier after create so before_create doesn't try to
+    # probe image dimensions via MiniMagick for a file we are not downloading.
+    image_data.update_column(:carrierwave_image, s960_logo_filename)
+
+    variants = %w[
+      original
+      topical_event_logo_mobile
+      topical_event_logo_mobile_2x
+      topical_event_logo_tablet
+      topical_event_logo_tablet_2x
+      topical_event_logo_desktop
+      topical_event_logo_desktop_2x
+    ]
+    variants.each do |variant|
+      image_data.assets.create!(
+        variant: variant,
+        asset_manager_id: s960_logo_asset.asset_manager_id,
+        filename: s960_logo_filename,
+      )
+    end
+
+    image = Image.create!(
+      usage: "logo",
+      image_data: image_data,
+    )
+
+    # Assets and ImageData are already persisted above; re-saving ImageData can
+    # clobber the mounted uploader identifier and lead to nil URLs in payloads.
+    # So deliberately don't save ImageData or its Assets again.
+    queue_for_saving(image)
+    image
   end
 end

--- a/app/services/standard_edition_migrator/topical_event_recipe.rb
+++ b/app/services/standard_edition_migrator/topical_event_recipe.rb
@@ -147,7 +147,7 @@ private
 
   def feature_list(record)
     feature_list = FeatureList.new(locale: "en")
-    feature_list.features = record.topical_event_featurings.map do |featuring|
+    feature_list.features = record.topical_event_featurings.order(:ordering).map.with_index do |featuring, index|
       featured_image = FeaturedImageData.new(
         carrierwave_image: featuring.image.carrierwave_image,
       )
@@ -160,7 +160,7 @@ private
       attrs = {
         image: featured_image,
         alt_text: featuring.alt_text,
-        ordering: featuring.ordering,
+        ordering: index + 1,
       }
       if featuring.offsite_link
         attrs[:offsite_link] = featuring.offsite_link

--- a/app/services/standard_edition_migrator/topical_event_recipe.rb
+++ b/app/services/standard_edition_migrator/topical_event_recipe.rb
@@ -1,4 +1,6 @@
 class StandardEditionMigrator::TopicalEventRecipe < StandardEditionMigrator::BaseRecipe
+  include GovspeakHelper
+
   def legacy_presenter
     PublishingApi::TopicalEventPresenter
   end
@@ -44,8 +46,17 @@ class StandardEditionMigrator::TopicalEventRecipe < StandardEditionMigrator::Bas
 
     if content[:details] && content[:details][:ordered_featured_documents]
       content[:details][:ordered_featured_documents].each do |featured_document|
-        # Deleting as the value is changed in the StandardEdition equivalent
-        featured_document[:image].delete(:url)
+        if featured_document[:summary]
+          # Remove stray spaces from end of the summary as that is what the StandardEdition equivalent does
+          featured_document[:summary] = featured_document[:summary].gsub(/\s+$/, "")
+          # Put through govspeak_to_html as that's what the StandardEdition equivalent does
+          featured_document[:summary] = ActionView::Base.full_sanitizer.sanitize(govspeak_to_html(featured_document[:summary])).strip
+        end
+
+        if featured_document[:image]
+          # Deleting as the value is changed in the StandardEdition equivalent
+          featured_document[:image].delete(:url)
+        end
       end
     end
 

--- a/app/services/standard_edition_migrator/topical_event_recipe.rb
+++ b/app/services/standard_edition_migrator/topical_event_recipe.rb
@@ -51,6 +51,11 @@ class StandardEditionMigrator::TopicalEventRecipe < StandardEditionMigrator::Bas
     content
   end
 
+  def ignore_new_links(links)
+    links.delete(:emphasised_organisations) # these are not present on legacy topical events and are included by default on StandardEdition
+    links
+  end
+
 private
 
   def feature_list(record)

--- a/app/services/standard_edition_migrator/topical_event_recipe.rb
+++ b/app/services/standard_edition_migrator/topical_event_recipe.rb
@@ -7,6 +7,8 @@ class StandardEditionMigrator::TopicalEventRecipe < StandardEditionMigrator::Bas
     raise WhitehallError, "Topical Events with About pages are not currently supported by the migrator" if record.topical_event_about_page
 
     attributes = {
+      created_at: record.created_at,
+      updated_at: record.updated_at,
       configurable_document_type: "topical_event",
       title: record.name,
       summary: record.summary,

--- a/app/services/standard_edition_migrator/topical_event_recipe.rb
+++ b/app/services/standard_edition_migrator/topical_event_recipe.rb
@@ -2,4 +2,8 @@ class StandardEditionMigrator::TopicalEventRecipe < StandardEditionMigrator::Bas
   def legacy_presenter
     PublishingApi::TopicalEventPresenter
   end
+
+  def build_edition(record)
+    raise WhitehallError, "Topical Events with About pages are not currently supported by the migrator" if record.topical_event_about_page
+  end
 end

--- a/config/image_kinds.yml
+++ b/config/image_kinds.yml
@@ -161,6 +161,9 @@ topical_event_header:
     # Deliberately no SVG - see WHIT-3206
 topical_event_logo:
   display_name: "Logo"
+  # Temporarily lower the limit for the source image while we migrate topical events.
+  # Older topical events have much smaller logos, e.g. https://assets.publishing.service.gov.uk/media/5a71e47ae5274a7f990285b9/G8_logo.jpg
+  # for https://www.gov.uk/government/topical-events/g8-2013.
   valid_width: 1506
   valid_height: 1004
   version_prefix: true

--- a/test/unit/app/services/standard_edition_migrator/topical_event_recipe_test.rb
+++ b/test/unit/app/services/standard_edition_migrator/topical_event_recipe_test.rb
@@ -286,6 +286,13 @@ class TopicalEventRecipeTest < ActiveSupport::TestCase
       expected_content = { public_updated_at: "2024-01-01T12:00:00+00:00" }
       assert_equal expected_content, recipe.ignore_legacy_content_fields(content)
     end
+
+    it "ignores 'image' property - now replaced by 'images' array" do
+      recipe = StandardEditionMigrator::TopicalEventRecipe.new
+      content = { details: { some: "content", image: { url: "http://example.com/image.jpg" } } }
+      expected_content = { details: { some: "content" } }
+      assert_equal expected_content, recipe.ignore_legacy_content_fields(content)
+    end
   end
 
   describe "#ignore_new_content_fields" do

--- a/test/unit/app/services/standard_edition_migrator/topical_event_recipe_test.rb
+++ b/test/unit/app/services/standard_edition_migrator/topical_event_recipe_test.rb
@@ -96,6 +96,20 @@ class TopicalEventRecipeTest < ActiveSupport::TestCase
       assert_equal("Sample body content", edition.block_content.to_h["body"])
     end
 
+    it "creates a non-empty body for the new edition, even if the legacy record has no body" do
+      legacy_topical_event = create(
+        :topical_event,
+        description: "Sample body content",
+      )
+      legacy_topical_event.description = nil
+      legacy_topical_event.save!(validate: false)
+
+      recipe = StandardEditionMigrator::TopicalEventRecipe.new
+      edition = recipe.build_edition(legacy_topical_event)
+
+      assert_equal ".", edition.block_content.to_h["body"]
+    end
+
     it "carries over social media links to block_content" do
       legacy_topical_event = create(:topical_event)
       legacy_topical_event.social_media_accounts = [

--- a/test/unit/app/services/standard_edition_migrator/topical_event_recipe_test.rb
+++ b/test/unit/app/services/standard_edition_migrator/topical_event_recipe_test.rb
@@ -236,6 +236,13 @@ class TopicalEventRecipeTest < ActiveSupport::TestCase
       }
       assert_equal expected_content, recipe.ignore_legacy_content_fields(content)
     end
+
+    it "converts public_updated_at to a string in the same format as the StandardEdition equivalent" do
+      recipe = StandardEditionMigrator::TopicalEventRecipe.new
+      content = { public_updated_at: Time.zone.local(2024, 1, 1, 12, 0, 0) }
+      expected_content = { public_updated_at: "2024-01-01T12:00:00+00:00" }
+      assert_equal expected_content, recipe.ignore_legacy_content_fields(content)
+    end
   end
 
   describe "#ignore_new_content_fields" do

--- a/test/unit/app/services/standard_edition_migrator/topical_event_recipe_test.rb
+++ b/test/unit/app/services/standard_edition_migrator/topical_event_recipe_test.rb
@@ -43,5 +43,16 @@ class TopicalEventRecipeTest < ActiveSupport::TestCase
       assert_equal "Topical event title", edition.title
       assert_equal "Sample summary", edition.summary
     end
+
+    it "maps the body to block_content" do
+      legacy_topical_event = create(
+        :topical_event,
+        description: "Sample body content",
+      )
+      recipe = StandardEditionMigrator::TopicalEventRecipe.new
+      edition = recipe.build_edition(legacy_topical_event)
+
+      assert_equal("Sample body content", edition.block_content.to_h["body"])
+    end
   end
 end

--- a/test/unit/app/services/standard_edition_migrator/topical_event_recipe_test.rb
+++ b/test/unit/app/services/standard_edition_migrator/topical_event_recipe_test.rb
@@ -155,7 +155,7 @@ class TopicalEventRecipeTest < ActiveSupport::TestCase
       # Needed to persist the Features and create IDs etc
       edition.document = create(:document)
       edition.save!(validate: false)
-      recipe.save_artefacts!(validate: false, edition: edition)
+      recipe.after_save_edition(edition, legacy_topical_event)
       edition.reload # to ensure everything has persisted
       govuk_content_feature = edition.feature_lists.first.features.first
       offsite_link_feature = edition.feature_lists.first.features.second
@@ -175,6 +175,50 @@ class TopicalEventRecipeTest < ActiveSupport::TestCase
       assert_equal 7, offsite_link_feature.image.assets.size
     end
 
+    it "carries over legacy topical_event_memberships as topical_event_links" do
+      # In addition to the new topical_event StandardEdition type, we
+      # need to define a document type that has the Edition::TopicalEvent concern included.
+      test_type_with_topical_event_association = build_configurable_document_type("test_type", { "associations" => [
+        {
+          "key" => "topical_event_documents",
+        },
+      ] })
+
+      topical_event_definition = JSON.parse(File.read(Rails.root.join("app/models/configurable_document_types/topical_event.json")))
+      ConfigurableDocumentType.setup_test_types({
+        "topical_event" => topical_event_definition,
+      }.merge(test_type_with_topical_event_association))
+
+      associated_edition = create(:standard_edition, :with_document)
+      associated_document = associated_edition.document
+      legacy_topical_event = create(:topical_event)
+      create(
+        :topical_event_membership,
+        topical_event_id: legacy_topical_event.id,
+        edition_id: associated_edition.id,
+      )
+      legacy_topical_event.save!
+
+      recipe = StandardEditionMigrator::TopicalEventRecipe.new
+      standard_edition_topical_event = recipe.build_edition(legacy_topical_event)
+
+      # Needed to create and save the document before we can create the EditionLink association
+      standard_edition_topical_event.document = create(:document)
+      standard_edition_topical_event.save!(validate: false)
+      recipe.after_save_edition(standard_edition_topical_event, legacy_topical_event)
+
+      # The `edition` is the linked document. The `document` is the topical event.
+      # #<EditionLink:0x0000ffff624f8fc8
+      #  edition_id: 1708834,
+      #  document_id: 619491,
+      #  link_type: "topical_event">
+
+      assert_equal 1, associated_document.latest_edition.topical_event_links.count
+      assert_equal "topical_event", associated_document.latest_edition.topical_event_links.first.link_type
+      assert_equal standard_edition_topical_event.document.id, associated_document.latest_edition.topical_event_links.first.document.id
+      assert_equal standard_edition_topical_event.document.id, associated_document.latest_edition.topical_event_documents.first.id
+    end
+
     it "carries over the Logo" do
       legacy_topical_event = create(:topical_event)
       legacy_logo = create(:featured_image_data, featured_imageable: legacy_topical_event)
@@ -187,7 +231,7 @@ class TopicalEventRecipeTest < ActiveSupport::TestCase
       # Needed to persist the Logo and create IDs etc
       edition.document = create(:document)
       edition.save!(validate: false)
-      recipe.save_artefacts!(validate: false, edition: edition)
+      recipe.after_save_edition(edition, legacy_topical_event)
       edition.reload # to ensure everything has persisted
 
       assert_equal [

--- a/test/unit/app/services/standard_edition_migrator/topical_event_recipe_test.rb
+++ b/test/unit/app/services/standard_edition_migrator/topical_event_recipe_test.rb
@@ -432,6 +432,35 @@ class TopicalEventRecipeTest < ActiveSupport::TestCase
       expected_content = { details: { some: "content" } }
       assert_equal expected_content, recipe.ignore_new_content_fields(content)
     end
+
+    it "ignores appended suffixes on social media links" do
+      recipe = StandardEditionMigrator::TopicalEventRecipe.new
+      content = {
+        details: {
+          some: "content",
+          social_media_links: [
+            {
+              social_media_service_name: "Facebook",
+              url: "https://www.facebook.com",
+              title: "Facebook link (2)",
+            },
+          ],
+        },
+      }
+      expected_content = {
+        details: {
+          some: "content",
+          social_media_links: [
+            {
+              social_media_service_name: "Facebook",
+              url: "https://www.facebook.com",
+              title: "Facebook link",
+            },
+          ],
+        },
+      }
+      assert_equal expected_content, recipe.ignore_new_content_fields(content)
+    end
   end
 
   describe "#ignore_new_links" do

--- a/test/unit/app/services/standard_edition_migrator/topical_event_recipe_test.rb
+++ b/test/unit/app/services/standard_edition_migrator/topical_event_recipe_test.rb
@@ -213,6 +213,29 @@ class TopicalEventRecipeTest < ActiveSupport::TestCase
       }
       assert_equal expected_content, recipe.ignore_legacy_content_fields(content)
     end
+
+    it "sanitizes the summary field inside ordered_featured_documents, like the StandardEdition equivalent" do
+      recipe = StandardEditionMigrator::TopicalEventRecipe.new
+      content = {
+        details: {
+          ordered_featured_documents: [
+            {
+              summary: "The UK's G8 is committed to support ", # NOTE: the trailing space
+            },
+          ],
+        },
+      }
+      expected_content = {
+        details: {
+          ordered_featured_documents: [
+            {
+              summary: "The UK’s G8 is committed to support", # NOTE: the stripped space and the non-ascii quote
+            },
+          ],
+        },
+      }
+      assert_equal expected_content, recipe.ignore_legacy_content_fields(content)
+    end
   end
 
   describe "#ignore_new_content_fields" do

--- a/test/unit/app/services/standard_edition_migrator/topical_event_recipe_test.rb
+++ b/test/unit/app/services/standard_edition_migrator/topical_event_recipe_test.rb
@@ -44,6 +44,14 @@ class TopicalEventRecipeTest < ActiveSupport::TestCase
       assert_equal "Sample summary", edition.summary
     end
 
+    it "sets the creator as the Scheduled Publishing Robot" do
+      create(:user, name: "Scheduled Publishing Robot")
+      legacy_topical_event = create(:topical_event)
+      recipe = StandardEditionMigrator::TopicalEventRecipe.new
+      edition = recipe.build_edition(legacy_topical_event)
+      assert_equal "Scheduled Publishing Robot", edition.creator.name
+    end
+
     it "carries over the created_at and updated_at timestamps" do
       legacy_topical_event = create(
         :topical_event,

--- a/test/unit/app/services/standard_edition_migrator/topical_event_recipe_test.rb
+++ b/test/unit/app/services/standard_edition_migrator/topical_event_recipe_test.rb
@@ -159,4 +159,13 @@ class TopicalEventRecipeTest < ActiveSupport::TestCase
       assert_equal 7, offsite_link_feature.image.assets.size
     end
   end
+
+  describe "#ignore_legacy_content_fields" do
+    it "removes .atom route as these are not present on StandardEdition documents and we have made a business decision to drop support for them" do
+      recipe = StandardEditionMigrator::TopicalEventRecipe.new
+      content = { details: {}, routes: [{ path: "/government/topical-events/example" }, { path: "/government/topical-events/example.atom" }] }
+      expected_content = { details: {}, routes: [{ path: "/government/topical-events/example" }] }
+      assert_equal expected_content, recipe.ignore_legacy_content_fields(content)
+    end
+  end
 end

--- a/test/unit/app/services/standard_edition_migrator/topical_event_recipe_test.rb
+++ b/test/unit/app/services/standard_edition_migrator/topical_event_recipe_test.rb
@@ -309,6 +309,13 @@ class TopicalEventRecipeTest < ActiveSupport::TestCase
       expected_content = { details: { some: "content" } }
       assert_equal expected_content, recipe.ignore_new_content_fields(content)
     end
+
+    it "ignores 'details.images' array (replacing old 'image' property)" do
+      recipe = StandardEditionMigrator::TopicalEventRecipe.new
+      content = { details: { some: "content", images: [{ url: "http://example.com/image.jpg" }] } }
+      expected_content = { details: { some: "content" } }
+      assert_equal expected_content, recipe.ignore_new_content_fields(content)
+    end
   end
 
   describe "#ignore_new_links" do

--- a/test/unit/app/services/standard_edition_migrator/topical_event_recipe_test.rb
+++ b/test/unit/app/services/standard_edition_migrator/topical_event_recipe_test.rb
@@ -167,5 +167,19 @@ class TopicalEventRecipeTest < ActiveSupport::TestCase
       expected_content = { details: {}, routes: [{ path: "/government/topical-events/example" }] }
       assert_equal expected_content, recipe.ignore_legacy_content_fields(content)
     end
+
+    it "removes 'start_date' as we're not carrying over duration fields to new topical events" do
+      recipe = StandardEditionMigrator::TopicalEventRecipe.new
+      content = { details: { some: "content", start_date: "2024-01-01" } }
+      expected_content = { details: { some: "content" } }
+      assert_equal expected_content, recipe.ignore_legacy_content_fields(content)
+    end
+
+    it "removes 'end_date' as we're not carrying over duration fields to new topical events" do
+      recipe = StandardEditionMigrator::TopicalEventRecipe.new
+      content = { details: { some: "content", end_date: "2024-12-31" } }
+      expected_content = { details: { some: "content" } }
+      assert_equal expected_content, recipe.ignore_legacy_content_fields(content)
+    end
   end
 end

--- a/test/unit/app/services/standard_edition_migrator/topical_event_recipe_test.rb
+++ b/test/unit/app/services/standard_edition_migrator/topical_event_recipe_test.rb
@@ -17,4 +17,17 @@ class TopicalEventRecipeTest < ActiveSupport::TestCase
       assert_equal PublishingApi::TopicalEventPresenter, recipe.legacy_presenter
     end
   end
+
+  describe "#build_edition" do
+    it "raises an exception if passed a Topical Event that has an About page - we're not ready to migrate those yet" do
+      legacy_topical_event = create(:topical_event)
+      recipe = StandardEditionMigrator::TopicalEventRecipe.new
+
+      create(:topical_event_about_page, topical_event: legacy_topical_event, read_more_link_text: "Read more about this event")
+
+      assert_raises(WhitehallError) do
+        recipe.build_edition(legacy_topical_event)
+      end
+    end
+  end
 end

--- a/test/unit/app/services/standard_edition_migrator/topical_event_recipe_test.rb
+++ b/test/unit/app/services/standard_edition_migrator/topical_event_recipe_test.rb
@@ -181,6 +181,38 @@ class TopicalEventRecipeTest < ActiveSupport::TestCase
       expected_content = { details: { some: "content" } }
       assert_equal expected_content, recipe.ignore_legacy_content_fields(content)
     end
+
+    it "ignores 'URL' field inside ordered_featured_documents as the value is changed in the StandardEdition equivalent" do
+      recipe = StandardEditionMigrator::TopicalEventRecipe.new
+      content = {
+        details: {
+          some: "content",
+          ordered_featured_documents: [
+            {
+              title: "Featured document",
+              image: {
+                url: "http://example.com/image.jpg",
+                foo: "bar",
+              },
+            },
+          ],
+        },
+      }
+      expected_content = {
+        details: {
+          some: "content",
+          ordered_featured_documents: [
+            {
+              title: "Featured document",
+              image: {
+                foo: "bar",
+              },
+            },
+          ],
+        },
+      }
+      assert_equal expected_content, recipe.ignore_legacy_content_fields(content)
+    end
   end
 
   describe "#ignore_new_content_fields" do

--- a/test/unit/app/services/standard_edition_migrator/topical_event_recipe_test.rb
+++ b/test/unit/app/services/standard_edition_migrator/topical_event_recipe_test.rb
@@ -1,0 +1,20 @@
+require "test_helper"
+
+class TopicalEventRecipeTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
+  setup do
+    @legacy_topical_event = create(:topical_event)
+    topical_event_definition = JSON.parse(File.read(Rails.root.join("app/models/configurable_document_types/topical_event.json")))
+    ConfigurableDocumentType.setup_test_types({
+      "topical_event" => topical_event_definition,
+    })
+  end
+
+  describe "#legacy_presenter" do
+    it "returns the correct presenter class" do
+      recipe = StandardEditionMigrator::TopicalEventRecipe.new
+      assert_equal PublishingApi::TopicalEventPresenter, recipe.legacy_presenter
+    end
+  end
+end

--- a/test/unit/app/services/standard_edition_migrator/topical_event_recipe_test.rb
+++ b/test/unit/app/services/standard_edition_migrator/topical_event_recipe_test.rb
@@ -77,5 +77,25 @@ class TopicalEventRecipeTest < ActiveSupport::TestCase
         },
       ], edition.block_content.to_h["social_media_links"])
     end
+
+    it "carries over lead and supporting organisations" do
+      legacy_topical_event = create(:topical_event)
+      lead_organisation = create(:organisation)
+      supporting_organisation = create(:organisation)
+      legacy_topical_event.topical_event_organisations = [
+        create(:topical_event_organisation, lead: true, organisation: lead_organisation),
+        create(:topical_event_organisation, lead: false, organisation: supporting_organisation),
+      ]
+      legacy_topical_event.save!
+
+      recipe = StandardEditionMigrator::TopicalEventRecipe.new
+      edition = recipe.build_edition(legacy_topical_event)
+      edition.document = create(:document)
+      edition.save!(validate: false)
+      edition.reload
+
+      assert_equal [lead_organisation], edition.lead_organisations
+      assert_equal [supporting_organisation], edition.supporting_organisations
+    end
   end
 end

--- a/test/unit/app/services/standard_edition_migrator/topical_event_recipe_test.rb
+++ b/test/unit/app/services/standard_edition_migrator/topical_event_recipe_test.rb
@@ -190,5 +190,12 @@ class TopicalEventRecipeTest < ActiveSupport::TestCase
       expected_content = { details: { some: "content" } }
       assert_equal expected_content, recipe.ignore_new_content_fields(content)
     end
+
+    it "ignores 'links' as legacy Topical Events had no edition links, but StandardEdition ones will" do
+      recipe = StandardEditionMigrator::TopicalEventRecipe.new
+      content = { details: { some: "content" }, links: { some: "links" } }
+      expected_content = { details: { some: "content" } }
+      assert_equal expected_content, recipe.ignore_new_content_fields(content)
+    end
   end
 end

--- a/test/unit/app/services/standard_edition_migrator/topical_event_recipe_test.rb
+++ b/test/unit/app/services/standard_edition_migrator/topical_event_recipe_test.rb
@@ -44,6 +44,19 @@ class TopicalEventRecipeTest < ActiveSupport::TestCase
       assert_equal "Sample summary", edition.summary
     end
 
+    it "carries over the created_at and updated_at timestamps" do
+      legacy_topical_event = create(
+        :topical_event,
+        created_at: 1.day.ago,
+        updated_at: 1.hour.ago,
+      )
+      recipe = StandardEditionMigrator::TopicalEventRecipe.new
+      edition = recipe.build_edition(legacy_topical_event)
+
+      assert_equal legacy_topical_event.created_at, edition.created_at
+      assert_equal legacy_topical_event.updated_at, edition.updated_at
+    end
+
     it "maps the slug to slug_override" do
       legacy_topical_event = create(
         :topical_event,

--- a/test/unit/app/services/standard_edition_migrator/topical_event_recipe_test.rb
+++ b/test/unit/app/services/standard_edition_migrator/topical_event_recipe_test.rb
@@ -182,4 +182,13 @@ class TopicalEventRecipeTest < ActiveSupport::TestCase
       assert_equal expected_content, recipe.ignore_legacy_content_fields(content)
     end
   end
+
+  describe "#ignore_new_content_fields" do
+    it "ignores 'auth_bypass_ids' as these were not present on legacy topical events and are included by default on StandardEdition" do
+      recipe = StandardEditionMigrator::TopicalEventRecipe.new
+      content = { details: { some: "content" }, auth_bypass_ids: [1, 2, 3] }
+      expected_content = { details: { some: "content" } }
+      assert_equal expected_content, recipe.ignore_new_content_fields(content)
+    end
+  end
 end

--- a/test/unit/app/services/standard_edition_migrator/topical_event_recipe_test.rb
+++ b/test/unit/app/services/standard_edition_migrator/topical_event_recipe_test.rb
@@ -226,6 +226,30 @@ class TopicalEventRecipeTest < ActiveSupport::TestCase
       assert_equal 7, offsite_link_feature.image.assets.size
     end
 
+    it "auto-increments the ordering of Features if the legacy TopicalEventFeaturing uses `order: 1` for each of them" do
+      legacy_topical_event = create(:topical_event)
+      legacy_topical_event.topical_event_featurings = [
+        create(:topical_event_featuring, alt_text: "Should be first", ordering: 1),
+        create(:topical_event_featuring, alt_text: "Should be third", ordering: 2),
+        create(:topical_event_featuring, alt_text: "Should be second", ordering: 1),
+        create(:topical_event_featuring, alt_text: "Should be fourth", ordering: 3),
+      ]
+      legacy_topical_event.save!
+
+      recipe = StandardEditionMigrator::TopicalEventRecipe.new
+      edition = recipe.build_edition(legacy_topical_event)
+      # Needed to persist the Features and create IDs etc
+      edition.document = create(:document)
+      edition.save!(validate: false)
+      recipe.after_save_edition(edition, legacy_topical_event)
+      edition.reload # to ensure everything has persisted
+
+      assert_equal ["Should be first", 1], [edition.feature_lists.first.features.first.alt_text, edition.feature_lists.first.features.first.ordering]
+      assert_equal ["Should be second", 2], [edition.feature_lists.first.features.second.alt_text, edition.feature_lists.first.features.second.ordering]
+      assert_equal ["Should be third", 3], [edition.feature_lists.first.features.third.alt_text, edition.feature_lists.first.features.third.ordering]
+      assert_equal ["Should be fourth", 4], [edition.feature_lists.first.features.fourth.alt_text, edition.feature_lists.first.features.fourth.ordering]
+    end
+
     it "carries over legacy topical_event_memberships as topical_event_links" do
       # In addition to the new topical_event StandardEdition type, we
       # need to define a document type that has the Edition::TopicalEvent concern included.

--- a/test/unit/app/services/standard_edition_migrator/topical_event_recipe_test.rb
+++ b/test/unit/app/services/standard_edition_migrator/topical_event_recipe_test.rb
@@ -97,5 +97,41 @@ class TopicalEventRecipeTest < ActiveSupport::TestCase
       assert_equal [lead_organisation], edition.lead_organisations
       assert_equal [supporting_organisation], edition.supporting_organisations
     end
+
+    it "carries over Features (legacy term: Featurings) and their thumbnails" do
+      legacy_topical_event = create(:topical_event)
+      legacy_govuk_content_featuring = create(:topical_event_featuring, ordering: 1)
+      legacy_offsite_link_featuring = create(:offsite_topical_event_featuring, ordering: 2)
+      legacy_topical_event.topical_event_featurings = [
+        legacy_govuk_content_featuring,
+        legacy_offsite_link_featuring,
+      ]
+      legacy_topical_event.save!
+
+      recipe = StandardEditionMigrator::TopicalEventRecipe.new
+      edition = recipe.build_edition(legacy_topical_event)
+
+      # Needed to persist the Features and create IDs etc
+      edition.document = create(:document)
+      edition.save!(validate: false)
+      recipe.save_artefacts!(validate: false, edition: edition)
+      edition.reload # to ensure everything has persisted
+      govuk_content_feature = edition.feature_lists.first.features.first
+      offsite_link_feature = edition.feature_lists.first.features.second
+
+      # TopicalEventFeaturing -> Featurable
+      assert_equal legacy_govuk_content_featuring.edition.document, govuk_content_feature.document
+      assert_equal legacy_govuk_content_featuring.alt_text, govuk_content_feature.alt_text
+      assert_equal legacy_govuk_content_featuring.ordering, govuk_content_feature.ordering
+      assert_equal legacy_offsite_link_featuring.offsite_link, offsite_link_feature.offsite_link
+      assert_equal legacy_offsite_link_featuring.alt_text, offsite_link_feature.alt_text
+      assert_equal legacy_offsite_link_featuring.ordering, offsite_link_feature.ordering
+
+      # TopicalEventFeaturingImageData -> FeaturedImageData
+      assert_equal legacy_govuk_content_featuring.image.filename, govuk_content_feature.image.filename
+      assert_equal legacy_offsite_link_featuring.image.filename, offsite_link_feature.image.filename
+      assert_equal 7, govuk_content_feature.image.assets.size
+      assert_equal 7, offsite_link_feature.image.assets.size
+    end
   end
 end

--- a/test/unit/app/services/standard_edition_migrator/topical_event_recipe_test.rb
+++ b/test/unit/app/services/standard_edition_migrator/topical_event_recipe_test.rb
@@ -107,7 +107,7 @@ class TopicalEventRecipeTest < ActiveSupport::TestCase
       recipe = StandardEditionMigrator::TopicalEventRecipe.new
       edition = recipe.build_edition(legacy_topical_event)
 
-      assert_equal ".", edition.block_content.to_h["body"]
+      assert_equal "&nbsp;", edition.block_content.to_h["body"]
     end
 
     it "carries over social media links to block_content" do
@@ -365,6 +365,13 @@ class TopicalEventRecipeTest < ActiveSupport::TestCase
       recipe = StandardEditionMigrator::TopicalEventRecipe.new
       content = { details: { some: "content", image: { url: "http://example.com/image.jpg" } } }
       expected_content = { details: { some: "content" } }
+      assert_equal expected_content, recipe.ignore_legacy_content_fields(content)
+    end
+
+    it "ignores where we have defaulted the body to a value of '.'" do
+      recipe = StandardEditionMigrator::TopicalEventRecipe.new
+      content = { details: { body: "<div class=\"govspeak\">\n</div>" } }
+      expected_content = { details: { body: "<div class=\"govspeak\"><p>.</p>\n</div>" } }
       assert_equal expected_content, recipe.ignore_legacy_content_fields(content)
     end
   end

--- a/test/unit/app/services/standard_edition_migrator/topical_event_recipe_test.rb
+++ b/test/unit/app/services/standard_edition_migrator/topical_event_recipe_test.rb
@@ -52,6 +52,14 @@ class TopicalEventRecipeTest < ActiveSupport::TestCase
       assert_equal "Scheduled Publishing Robot", edition.creator.name
     end
 
+    it "sets the state to published and major_change_published_at to the legacy created_at" do
+      legacy_topical_event = create(:topical_event, created_at: 1.day.ago)
+      recipe = StandardEditionMigrator::TopicalEventRecipe.new
+      edition = recipe.build_edition(legacy_topical_event)
+      assert_equal "published", edition.state
+      assert_equal legacy_topical_event.created_at, edition.major_change_published_at
+    end
+
     it "carries over the created_at and updated_at timestamps" do
       legacy_topical_event = create(
         :topical_event,

--- a/test/unit/app/services/standard_edition_migrator/topical_event_recipe_test.rb
+++ b/test/unit/app/services/standard_edition_migrator/topical_event_recipe_test.rb
@@ -44,6 +44,18 @@ class TopicalEventRecipeTest < ActiveSupport::TestCase
       assert_equal "Sample summary", edition.summary
     end
 
+    it "maps the slug to slug_override" do
+      legacy_topical_event = create(
+        :topical_event,
+        name: "Topical event title",
+        slug: "topical-event-slug-that-is-different-from-the-title",
+      )
+      recipe = StandardEditionMigrator::TopicalEventRecipe.new
+      edition = recipe.build_edition(legacy_topical_event)
+
+      assert_equal "topical-event-slug-that-is-different-from-the-title", edition.slug_override
+    end
+
     it "maps the body to block_content" do
       legacy_topical_event = create(
         :topical_event,

--- a/test/unit/app/services/standard_edition_migrator/topical_event_recipe_test.rb
+++ b/test/unit/app/services/standard_edition_migrator/topical_event_recipe_test.rb
@@ -54,5 +54,28 @@ class TopicalEventRecipeTest < ActiveSupport::TestCase
 
       assert_equal("Sample body content", edition.block_content.to_h["body"])
     end
+
+    it "carries over social media links to block_content" do
+      legacy_topical_event = create(:topical_event)
+      legacy_topical_event.social_media_accounts = [
+        create(
+          :social_media_account,
+          social_media_service: SocialMediaService.new(name: "Facebook"),
+          url: "https://www.facebook.com",
+          title: "Facebook link",
+        ),
+      ]
+      legacy_topical_event.save!
+      recipe = StandardEditionMigrator::TopicalEventRecipe.new
+      edition = recipe.build_edition(legacy_topical_event)
+
+      assert_equal([
+        {
+          "social_media_service_name" => "Facebook",
+          "url" => "https://www.facebook.com",
+          "title" => "Facebook link",
+        },
+      ], edition.block_content.to_h["social_media_links"])
+    end
   end
 end

--- a/test/unit/app/services/standard_edition_migrator/topical_event_recipe_test.rb
+++ b/test/unit/app/services/standard_edition_migrator/topical_event_recipe_test.rb
@@ -29,5 +29,19 @@ class TopicalEventRecipeTest < ActiveSupport::TestCase
         recipe.build_edition(legacy_topical_event)
       end
     end
+
+    it "maps the basic legacy fields" do
+      legacy_topical_event = create(
+        :topical_event,
+        name: "Topical event title",
+        summary: "Sample summary",
+      )
+      recipe = StandardEditionMigrator::TopicalEventRecipe.new
+      edition = recipe.build_edition(legacy_topical_event)
+
+      assert_equal "topical_event", edition.configurable_document_type
+      assert_equal "Topical event title", edition.title
+      assert_equal "Sample summary", edition.summary
+    end
   end
 end

--- a/test/unit/app/services/standard_edition_migrator/topical_event_recipe_test.rb
+++ b/test/unit/app/services/standard_edition_migrator/topical_event_recipe_test.rb
@@ -198,4 +198,13 @@ class TopicalEventRecipeTest < ActiveSupport::TestCase
       assert_equal expected_content, recipe.ignore_new_content_fields(content)
     end
   end
+
+  describe "#ignore_new_links" do
+    it "ignores 'emphasised_organisations' as these are not present on legacy topical events and are included by default on StandardEdition" do
+      recipe = StandardEditionMigrator::TopicalEventRecipe.new
+      links = { lead_organisations: [1, 2], emphasised_organisations: [3, 4] }
+      expected_links = { lead_organisations: [1, 2] }
+      assert_equal expected_links, recipe.ignore_new_links(links)
+    end
+  end
 end

--- a/test/unit/app/services/standard_edition_migrator/topical_event_recipe_test.rb
+++ b/test/unit/app/services/standard_edition_migrator/topical_event_recipe_test.rb
@@ -168,12 +168,14 @@ class TopicalEventRecipeTest < ActiveSupport::TestCase
       ], edition.block_content.to_h["social_media_links"])
     end
 
-    it "carries over lead and supporting organisations" do
+    it "carries over lead and supporting organisations in the correct order" do
       legacy_topical_event = create(:topical_event)
-      lead_organisation = create(:organisation)
+      primary_lead_organisation = create(:organisation)
+      secondary_lead_organisation = create(:organisation)
       supporting_organisation = create(:organisation)
       legacy_topical_event.topical_event_organisations = [
-        create(:topical_event_organisation, lead: true, organisation: lead_organisation),
+        create(:topical_event_organisation, lead: true, organisation: secondary_lead_organisation, lead_ordering: 2),
+        create(:topical_event_organisation, lead: true, organisation: primary_lead_organisation, lead_ordering: 1),
         create(:topical_event_organisation, lead: false, organisation: supporting_organisation),
       ]
       legacy_topical_event.save!
@@ -184,7 +186,7 @@ class TopicalEventRecipeTest < ActiveSupport::TestCase
       edition.save!(validate: false)
       edition.reload
 
-      assert_equal [lead_organisation], edition.lead_organisations
+      assert_equal [primary_lead_organisation, secondary_lead_organisation], edition.lead_organisations
       assert_equal [supporting_organisation], edition.supporting_organisations
     end
 

--- a/test/unit/app/services/standard_edition_migrator/topical_event_recipe_test.rb
+++ b/test/unit/app/services/standard_edition_migrator/topical_event_recipe_test.rb
@@ -238,5 +238,37 @@ class TopicalEventRecipeTest < ActiveSupport::TestCase
       expected_links = { lead_organisations: [1, 2] }
       assert_equal expected_links, recipe.ignore_new_links(links)
     end
+
+    it "ignores 'URL' field inside ordered_featured_documents as the value is changed in the StandardEdition equivalent" do
+      recipe = StandardEditionMigrator::TopicalEventRecipe.new
+      content = {
+        details: {
+          some: "content",
+          ordered_featured_documents: [
+            {
+              title: "Featured document",
+              image: {
+                url: "http://example.com/image.jpg",
+                foo: "bar",
+              },
+            },
+          ],
+        },
+      }
+      expected_content = {
+        details: {
+          some: "content",
+          ordered_featured_documents: [
+            {
+              title: "Featured document",
+              image: {
+                foo: "bar",
+              },
+            },
+          ],
+        },
+      }
+      assert_equal expected_content, recipe.ignore_new_content_fields(content)
+    end
   end
 end

--- a/test/unit/app/services/standard_edition_migrator/topical_event_recipe_test.rb
+++ b/test/unit/app/services/standard_edition_migrator/topical_event_recipe_test.rb
@@ -158,6 +158,49 @@ class TopicalEventRecipeTest < ActiveSupport::TestCase
       assert_equal 7, govuk_content_feature.image.assets.size
       assert_equal 7, offsite_link_feature.image.assets.size
     end
+
+    it "carries over the Logo" do
+      legacy_topical_event = create(:topical_event)
+      legacy_logo = create(:featured_image_data, featured_imageable: legacy_topical_event)
+      legacy_topical_event.logo = legacy_logo
+      legacy_topical_event.save!
+
+      recipe = StandardEditionMigrator::TopicalEventRecipe.new
+      edition = recipe.build_edition(legacy_topical_event)
+
+      # Needed to persist the Logo and create IDs etc
+      edition.document = create(:document)
+      edition.save!(validate: false)
+      recipe.save_artefacts!(validate: false, edition: edition)
+      edition.reload # to ensure everything has persisted
+
+      assert_equal [
+        ["asset_manager_id_original", "original", "minister-of-funk.960x640.jpg"],
+        ["asset_manager_id_s960", "s960", "s960_minister-of-funk.960x640.jpg"],
+        ["asset_manager_id_s712", "s712", "s712_minister-of-funk.960x640.jpg"],
+        ["asset_manager_id_s630", "s630", "s630_minister-of-funk.960x640.jpg"],
+        ["asset_manager_id_s465", "s465", "s465_minister-of-funk.960x640.jpg"],
+        ["asset_manager_id_s300", "s300", "s300_minister-of-funk.960x640.jpg"],
+        ["asset_manager_id_s216", "s216", "s216_minister-of-funk.960x640.jpg"],
+      ], legacy_logo.assets.pluck(:asset_manager_id, :variant, :filename)
+
+      assert_equal [
+        ["asset_manager_id_s960", "original", "s960_minister-of-funk.960x640.jpg"],
+        ["asset_manager_id_s960", "topical_event_logo_mobile", "s960_minister-of-funk.960x640.jpg"],
+        ["asset_manager_id_s960", "topical_event_logo_mobile_2x", "s960_minister-of-funk.960x640.jpg"],
+        ["asset_manager_id_s960", "topical_event_logo_tablet", "s960_minister-of-funk.960x640.jpg"],
+        ["asset_manager_id_s960", "topical_event_logo_tablet_2x", "s960_minister-of-funk.960x640.jpg"],
+        ["asset_manager_id_s960", "topical_event_logo_desktop", "s960_minister-of-funk.960x640.jpg"],
+        ["asset_manager_id_s960", "topical_event_logo_desktop_2x", "s960_minister-of-funk.960x640.jpg"],
+      ], edition.images.first.image_data.assets.pluck(:asset_manager_id, :variant, :filename)
+
+      assert_equal "logo", edition.images.first.usage
+      assert_equal "topical_event_logo", edition.images.first.image_data.image_kind
+      dimensions = { "width" => 1506, "height" => 960 }
+      crop_data = { "x" => 0, "y" => 0, "width" => 1506, "height" => 1004 }
+      assert_equal dimensions, edition.images.first.image_data.dimensions
+      assert_equal crop_data, edition.images.first.image_data.crop_data
+    end
   end
 
   describe "#ignore_legacy_content_fields" do

--- a/test/unit/app/services/standard_edition_migrator/topical_event_recipe_test.rb
+++ b/test/unit/app/services/standard_edition_migrator/topical_event_recipe_test.rb
@@ -133,6 +133,41 @@ class TopicalEventRecipeTest < ActiveSupport::TestCase
       ], edition.block_content.to_h["social_media_links"])
     end
 
+    it "increments the social media title if more than one link is present for the same service" do
+      legacy_topical_event = create(:topical_event)
+      legacy_topical_event.social_media_accounts = [
+        create(
+          :social_media_account,
+          social_media_service: SocialMediaService.new(name: "Facebook"),
+          url: "https://www.facebook.com",
+          title: "Facebook link",
+        ),
+        create(
+          :social_media_account,
+          social_media_service: SocialMediaService.new(name: "Facebook"),
+          url: "https://www.facebook.com/2",
+          title: "Facebook link",
+        ),
+      ]
+      legacy_topical_event.save!
+
+      recipe = StandardEditionMigrator::TopicalEventRecipe.new
+      edition = recipe.build_edition(legacy_topical_event)
+
+      assert_equal([
+        {
+          "social_media_service_name" => "Facebook",
+          "url" => "https://www.facebook.com",
+          "title" => "Facebook link",
+        },
+        {
+          "social_media_service_name" => "Facebook",
+          "url" => "https://www.facebook.com/2",
+          "title" => "Facebook link (2)",
+        },
+      ], edition.block_content.to_h["social_media_links"])
+    end
+
     it "carries over lead and supporting organisations" do
       legacy_topical_event = create(:topical_event)
       lead_organisation = create(:organisation)
@@ -368,10 +403,10 @@ class TopicalEventRecipeTest < ActiveSupport::TestCase
       assert_equal expected_content, recipe.ignore_legacy_content_fields(content)
     end
 
-    it "ignores where we have defaulted the body to a value of '.'" do
+    it "ignores where we have defaulted the body to a value of '&nbsp;'" do
       recipe = StandardEditionMigrator::TopicalEventRecipe.new
       content = { details: { body: "<div class=\"govspeak\">\n</div>" } }
-      expected_content = { details: { body: "<div class=\"govspeak\"><p>.</p>\n</div>" } }
+      expected_content = { details: { body: "<div class=\"govspeak\"><p>&nbsp;</p>\n</div>" } }
       assert_equal expected_content, recipe.ignore_legacy_content_fields(content)
     end
   end


### PR DESCRIPTION
## What

This PR implements the TopicalEventRecipe for migrating legacy Topical Events to StandardEdition.

Dependent on #11562.

### Rollout plan

```
StandardEditionMigrator.bulk_enqueue_migration(
  TopicalEvent.select { |te| !te.topical_event_about_page },
  StandardEditionMigrator::TopicalEventRecipe,
  migration_method: "create_new_document",
)
```

Then `TopicalEvent.select { |te| !te.topical_event_about_page }.map(&:delete!)`.

^ `delete!` rather than `destroy!` to avoid running callbacks that publish a 'Gone' route in Publishing API.

It does mean we'll need to manually destroy any associated [social_media_accounts](https://github.com/alphagov/whitehall/blob/a6c5b68a5d83c61083026721bf8669cf34216627/app/models/topical_event.rb#L19) and [features](https://github.com/alphagov/whitehall/blob/a6c5b68a5d83c61083026721bf8669cf34216627/app/models/topical_event.rb#L16), topical event memberships etc. That can happen in one big cleanup at the end.

Then bulk republish topical events via https://whitehall-admin.integration.publishing.service.gov.uk/government/admin/republishing/bulk/by-type/topical-event/confirm
Though in testing on integration, none of the documents seemed to be represented downstream 🤔 

## Why

Legacy topical events need migrating before they can be deleted.

### Integration testing (screenshots, UI etc)

I ran this on Integration: `StandardEditionMigrator.create_new_document(TopicalEvent.find_by(slug: "g8-2013"), StandardEditionMigrator::TopicalEventRecipe)`

Migrated document:

> <img width="948" height="879" alt="Screenshot 2026-06-20 at 12 03 48" src="https://github.com/user-attachments/assets/66167f18-a2da-4638-ab5b-3931eaf1cb77" />

Migrated document content:

> <img width="982" height="890" alt="Screenshot 2026-06-20 at 12 04 20" src="https://github.com/user-attachments/assets/8c54839e-e7b0-4e71-b672-bdf7191be789" />

Migrated logo:

> <img width="687" height="651" alt="Screenshot 2026-06-20 at 12 04 03" src="https://github.com/user-attachments/assets/b142e2c0-aefd-4773-b194-f228fc02e07d" />

Migrated social media accounts:

> <img width="652" height="902" alt="Screenshot 2026-06-20 at 12 04 08" src="https://github.com/user-attachments/assets/48de19dd-f749-49f2-ac3f-8e167d4898d8" />

Migrated featured section:

> <img width="948" height="887" alt="Screenshot 2026-06-20 at 12 04 13" src="https://github.com/user-attachments/assets/e1240c86-784f-46fd-be20-986d970ec2a4" />

Before and after (I edited the legacy topical event to have "(old)" suffix, and edited the StandardEdition topical event to have "(new)" suffix):

| Before | After |
|--------|------|
| <img width="1365" height="3519" alt="www integration publishing service gov uk_government_topical-events_g8-2013_cachebust=1781953375" src="https://github.com/user-attachments/assets/55f97d68-99af-4b1c-a1f0-d46d7edbe647" /> | <img width="1365" height="3519" alt="www integration publishing service gov uk_government_topical-events_g8-2013_cachebust=1781953375 (1)" src="https://github.com/user-attachments/assets/9c7decff-6c7e-48fd-ae83-468c883b0a8e" /> |

### Local testing (payloads)

I ran this locally:

```
$ puts StandardEditionMigrator.preview_migration(TopicalEvent.find_by(slug: "g8-2013"), StandardEditionMigrator::TopicalEventRecipe)
```

And got this old payload:

```
===CONTENT
{
  "title": "UK Presidency of G8 2013",
  "locale": "en",
  "publishing_app": "whitehall",
  "redirects": [],
  "update_type": "major",
  "description": "Leaders from Canada, France, Germany, Italy, Japan, Russia, USA and UK met at Lough Erne in Northern Ireland for the G8 Summit 17-18 June 2013. ",
  "details": {
    "body": "<div class=\"govspeak\"><p>PM David Cameron is determined to achieve change on three issues: advancing <a href=\"/government/publications/g8-factsheet-trade/g8-factsheet-trade\">trade</a>; ensuring <a href=\"/government/publications/g8-factsheet-tax/g8-factsheet-tax\">tax compliance</a>; and promoting greater <a href=\"/government/publications/g8-factsheet-transparency/g8-factsheet-transparency\">transparency</a>.</p>\n\n<p>Read a <a href=\"/government/publications/uk-g8-presidency-report-2013\">report on progress made on these issues during the UK’s Presidency</a>.</p>\n</div>",
    "image": {
      "url": "http://asset-manager.dev.gov.uk/media/5a71e478e5274a7f990285b7/s300_G8_logo.jpg",
      "medium_resolution_url": "http://asset-manager.dev.gov.uk/media/5a71e47640f0b646ce8d99d2/s630_G8_logo.jpg",
      "high_resolution_url": "http://asset-manager.dev.gov.uk/media/5a71e47540f0b646ce8d99d1/s960_G8_logo.jpg",
      "alt_text": "G8 Logo"
    },
    "start_date": "2013-12-01T00:00:00+00:00",
    "end_date": "2014-12-01T00:00:00+00:00",
    "ordered_featured_documents": [
      {
        "title": "UK G8 Presidency Report 2013",
        "href": "/government/publications/uk-g8-presidency-report-2013",
        "image": {
          "url": "http://asset-manager.dev.gov.uk/media/5a37e28ae5274a7908e35c51/s465_G8-table-960.jpg",
          "alt_text": "G8 table. "
        },
        "summary": "A report on progress made on tax, trade and transparency during the year of the UK’s Presidency of the G8.",
        "public_updated_at": "2013-12-19 13:35:00 +0000",
        "document_type": "Policy paper"
      },
      {
        "title": "Watch the G8 dementia summit live on 11 December",
        "href": "/government/news/watch-the-g8-dementia-summit-live-on-11-december",
        "image": {
          "url": "http://asset-manager.dev.gov.uk/media/5a37dd51e5274a79051c92a7/s465_dementia.jpg",
          "alt_text": "Dementia cafe"
        },
        "summary": "On 11 December 2013, people will be able to watch live coverage of the G8 dementia summit.",
        "public_updated_at": "2013-12-04 14:05:51 +0000",
        "document_type": "News story"
      },
      {
        "title": "G8 Open Data Charter National Action Plan",
        "href": "/government/publications/g8-open-data-charter-national-action-plan",
        "image": {
          "url": "http://asset-manager.dev.gov.uk/media/5a37e164ed915d5a62fdcec5/s465_OGP-agendas-960x640.jpg",
          "alt_text": "Agendas for the Open Government Partnership Summit 2013"
        },
        "summary": "The UK action plan for 2013 on how we will implement the Open Data Charter.",
        "public_updated_at": "2013-11-01 09:50:00 +0000",
        "document_type": "Policy paper"
      },
      {
        "title": "PM speech at Open Government Partnership 2013",
        "href": "/government/speeches/pm-speech-at-open-government-partnership-2013",
        "image": {
          "url": "http://asset-manager.dev.gov.uk/media/5a37e262e5274a7908e35c10/s465_PM-OGP-960.jpg",
          "alt_text": "David Cameron speaks at the Open Government Partnership 2013 "
        },
        "summary": "David Cameron announced plans to create a publicly accessible central registry of information on beneficial ownership.",
        "public_updated_at": "2013-11-06 15:30:55 +0000",
        "document_type": "Transcript"
      },
      {
        "title": "Asset Recovery and the G8 Deauville Partnership with Arab Countries in Transition",
        "href": "/government/news/asset-recovery-and-the-g8-deauville-partnership-with-arab-countries-in-transition",
        "image": {
          "url": "http://asset-manager.dev.gov.uk/media/5a37dfd6ed915d5a62fdcc0f/s465_Deauville_photo.jpg",
          "alt_text": "Asset Recovery"
        },
        "summary": "The UK's G8 is committed to support the recovery of stolen assets for the Arab Countries in Transition",
        "public_updated_at": "2013-10-08 18:00:46 +0100",
        "document_type": "News story"
      },
      {
        "title": "G8 Summit round-up",
        "href": "/government/news/g8-summit-live",
        "image": {
          "url": "http://asset-manager.dev.gov.uk/media/5a37e22ced915d5a62fdd018/s465_familyphoto960.jpg",
          "alt_text": "G8 leaders have family photo taken"
        },
        "summary": "Learn more about the  UK's G8 Summit 2013 in Lough Erne, Northern Ireland.",
        "public_updated_at": "2013-06-19 10:36:28 +0100",
        "document_type": "News story"
      }
    ],
    "social_media_links": [
      {
        "href": "https://twitter.com/G8",
        "service_type": "twitter",
        "title": "Twitter"
      },
      {
        "href": "http://www.flickr.com/photos/g8uk/",
        "service_type": "flickr",
        "title": "Flickr"
      },
      {
        "href": "http://www.youtube.com/playlist?list=PLqHKtAbFyKz6UJ7lOXiyC0noN4KwQ14ya",
        "service_type": "youtube",
        "title": "YouTube"
      }
    ],
    "emphasised_organisations": [
      "96ae61d6-c2a1-48cb-8e67-da9d105ae381"
    ]
  },
  "document_type": "topical_event",
  "public_updated_at": "2018-08-08 14:04:42 +0100",
  "rendering_app": "frontend",
  "schema_name": "topical_event",
  "base_path": "/government/topical-events/g8-2013",
  "routes": [
    {
      "path": "/government/topical-events/g8-2013",
      "type": "exact"
    },
    {
      "path": "/government/topical-events/g8-2013.atom",
      "type": "exact"
    }
  ]
}
===LINKS
{
  "organisations": [
    "96ae61d6-c2a1-48cb-8e67-da9d105ae381",
    "7cd6bf12-bbe9-4118-8523-f927b0442156"
  ],
  "primary_publishing_organisation": [
    "96ae61d6-c2a1-48cb-8e67-da9d105ae381"
  ]
}
```

And this new payload:

```
===CONTENT
{
  "title": "UK Presidency of G8 2013",
  "locale": "en",
  "publishing_app": "whitehall",
  "redirects": [],
  "update_type": "major",
  "description": "Leaders from Canada, France, Germany, Italy, Japan, Russia, USA and UK met at Lough Erne in Northern Ireland for the G8 Summit 17-18 June 2013. ",
  "details": {
    "body": "<div class=\"govspeak\"><p>PM David Cameron is determined to achieve change on three issues: advancing <a href=\"/government/publications/g8-factsheet-trade/g8-factsheet-trade\">trade</a>; ensuring <a href=\"/government/publications/g8-factsheet-tax/g8-factsheet-tax\">tax compliance</a>; and promoting greater <a href=\"/government/publications/g8-factsheet-transparency/g8-factsheet-transparency\">transparency</a>.</p>\n\n<p>Read a <a href=\"/government/publications/uk-g8-presidency-report-2013\">report on progress made on these issues during the UK’s Presidency</a>.</p>\n</div>",
    "social_media_links": [
      {
        "title": "Twitter",
        "service_type": "twitter",
        "href": "https://twitter.com/G8"
      },
      {
        "title": "Flickr",
        "service_type": "flickr",
        "href": "http://www.flickr.com/photos/g8uk/"
      },
      {
        "title": "YouTube",
        "service_type": "youtube",
        "href": "http://www.youtube.com/playlist?list=PLqHKtAbFyKz6UJ7lOXiyC0noN4KwQ14ya"
      }
    ],
    "emphasised_organisations": [
      "96ae61d6-c2a1-48cb-8e67-da9d105ae381"
    ],
    "images": [
      {
        "type": "logo",
        "sources": {
          "tablet_2x": "http://asset-manager.dev.gov.uk/media/5a71e47540f0b646ce8d99d1/s960_G8_logo.jpg",
          "tablet": "http://asset-manager.dev.gov.uk/media/5a71e47540f0b646ce8d99d1/s960_G8_logo.jpg",
          "mobile_2x": "http://asset-manager.dev.gov.uk/media/5a71e47540f0b646ce8d99d1/s960_G8_logo.jpg",
          "mobile": "http://asset-manager.dev.gov.uk/media/5a71e47540f0b646ce8d99d1/s960_G8_logo.jpg",
          "desktop_2x": "http://asset-manager.dev.gov.uk/media/5a71e47540f0b646ce8d99d1/s960_G8_logo.jpg",
          "desktop": "http://asset-manager.dev.gov.uk/media/5a71e47540f0b646ce8d99d1/s960_G8_logo.jpg"
        },
        "content_type": "image/jpeg"
      }
    ],
    "ordered_featured_documents": [
      {
        "title": "UK G8 Presidency Report 2013",
        "href": "/government/publications/uk-g8-presidency-report-2013",
        "image": {
          "url": "http://asset-manager.dev.gov.uk/media/5a37e28940f0b649cceb21f5/G8-table-960.jpg",
          "medium_resolution_url": "http://asset-manager.dev.gov.uk/media/5a37e28ae5274a7908e35c51/s465_G8-table-960.jpg",
          "high_resolution_url": "http://asset-manager.dev.gov.uk/media/5a37e28a40f0b649cceb21f6/s712_G8-table-960.jpg",
          "alt_text": "G8 table. "
        },
        "summary": "A report on progress made on tax, trade and transparency during the year of the UK’s Presidency of the G8.",
        "public_updated_at": "2013-12-19 13:35:00 +0000",
        "document_type": "Policy paper"
      },
      {
        "title": "Watch the G8 dementia summit live on 11 December",
        "href": "/government/news/watch-the-g8-dementia-summit-live-on-11-december",
        "image": {
          "url": "http://asset-manager.dev.gov.uk/media/5a37dd51ed915d5a62fdc7b9/dementia.jpg",
          "medium_resolution_url": "http://asset-manager.dev.gov.uk/media/5a37dd51e5274a79051c92a7/s465_dementia.jpg",
          "high_resolution_url": "http://asset-manager.dev.gov.uk/media/5a37dd51ed915d5a5f9660e0/s712_dementia.jpg",
          "alt_text": "Dementia cafe"
        },
        "summary": "On 11 December 2013, people will be able to watch live coverage of the G8 dementia summit.",
        "public_updated_at": "2013-12-04 14:05:51 +0000",
        "document_type": "News story"
      },
      {
        "title": "G8 Open Data Charter National Action Plan",
        "href": "/government/publications/g8-open-data-charter-national-action-plan",
        "image": {
          "url": "http://asset-manager.dev.gov.uk/media/5a37e16440f0b649cfaf8368/OGP-agendas-960x640.jpg",
          "medium_resolution_url": "http://asset-manager.dev.gov.uk/media/5a37e164ed915d5a62fdcec5/s465_OGP-agendas-960x640.jpg",
          "high_resolution_url": "http://asset-manager.dev.gov.uk/media/5a37e163e5274a79051c99fc/s712_OGP-agendas-960x640.jpg",
          "alt_text": "Agendas for the Open Government Partnership Summit 2013"
        },
        "summary": "The UK action plan for 2013 on how we will implement the Open Data Charter.",
        "public_updated_at": "2013-11-01 09:50:00 +0000",
        "document_type": "Policy paper"
      },
      {
        "title": "PM speech at Open Government Partnership 2013",
        "href": "/government/speeches/pm-speech-at-open-government-partnership-2013",
        "image": {
          "url": "http://asset-manager.dev.gov.uk/media/5a37e26240f0b649cfaf8520/PM-OGP-960.jpg",
          "medium_resolution_url": "http://asset-manager.dev.gov.uk/media/5a37e262e5274a7908e35c10/s465_PM-OGP-960.jpg",
          "high_resolution_url": "http://asset-manager.dev.gov.uk/media/5a37e262e5274a79051c9b9d/s712_PM-OGP-960.jpg",
          "alt_text": "David Cameron speaks at the Open Government Partnership 2013 "
        },
        "summary": "David Cameron announced plans to create a publicly accessible central registry of information on beneficial ownership.",
        "public_updated_at": "2013-11-06 15:30:55 +0000",
        "document_type": "Transcript"
      },
      {
        "title": "Asset Recovery and the G8 Deauville Partnership with Arab Countries in Transition",
        "href": "/government/news/asset-recovery-and-the-g8-deauville-partnership-with-arab-countries-in-transition",
        "image": {
          "url": "http://asset-manager.dev.gov.uk/media/5a37dfd6e5274a79051c9723/Deauville_photo.jpg",
          "medium_resolution_url": "http://asset-manager.dev.gov.uk/media/5a37dfd6ed915d5a62fdcc0f/s465_Deauville_photo.jpg",
          "high_resolution_url": "http://asset-manager.dev.gov.uk/media/5a37dfd6ed915d5a5f966548/s712_Deauville_photo.jpg",
          "alt_text": "Asset Recovery"
        },
        "summary": "The UK’s G8 is committed to support the recovery of stolen assets for the Arab Countries in Transition",
        "public_updated_at": "2013-10-08 18:00:46 +0100",
        "document_type": "News story"
      },
      {
        "title": "G8 Summit round-up",
        "href": "/government/news/g8-summit-live",
        "image": {
          "url": "http://asset-manager.dev.gov.uk/media/5a37e22c40f0b649cceb2154/familyphoto960.jpg",
          "medium_resolution_url": "http://asset-manager.dev.gov.uk/media/5a37e22ced915d5a62fdd018/s465_familyphoto960.jpg",
          "high_resolution_url": "http://asset-manager.dev.gov.uk/media/5a37e22ce5274a7908e35bb1/s712_familyphoto960.jpg",
          "alt_text": "G8 leaders have family photo taken"
        },
        "summary": "Learn more about the  UK’s G8 Summit 2013 in Lough Erne, Northern Ireland.",
        "public_updated_at": "2013-06-19 10:36:28 +0100",
        "document_type": "News story"
      }
    ]
  },
  "document_type": "topical_event",
  "public_updated_at": "2018-08-08T14:04:42+01:00",
  "rendering_app": "frontend",
  "schema_name": "topical_event",
  "links": {
    "organisations": [
      "96ae61d6-c2a1-48cb-8e67-da9d105ae381",
      "7cd6bf12-bbe9-4118-8523-f927b0442156"
    ],
    "primary_publishing_organisation": [
      "96ae61d6-c2a1-48cb-8e67-da9d105ae381"
    ],
    "emphasised_organisations": [
      "96ae61d6-c2a1-48cb-8e67-da9d105ae381"
    ]
  },
  "auth_bypass_ids": [
    "a6f5946e-df10-42d2-aa14-42b319eff62e"
  ],
  "base_path": "/government/topical-events/g8-2013",
  "routes": [
    {
      "path": "/government/topical-events/g8-2013",
      "type": "exact"
    }
  ]
}
===LINKS
{
  "organisations": [
    "96ae61d6-c2a1-48cb-8e67-da9d105ae381",
    "7cd6bf12-bbe9-4118-8523-f927b0442156"
  ],
  "primary_publishing_organisation": [
    "96ae61d6-c2a1-48cb-8e67-da9d105ae381"
  ],
  "emphasised_organisations": [
    "96ae61d6-c2a1-48cb-8e67-da9d105ae381"
  ]
}
```

The resulting 'diff' (when these payloads have been run through the normalisation methods) is nil:

```
NORMALISED DIFF
===CONTENT

===LINKS

```

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
