### PR TITLE
[WHIT-3662] Fix role job title missing on organisation pages after a role type change

### DIFF
--- a/app/controllers/admin/roles_controller.rb
+++ b/app/controllers/admin/roles_controller.rb
@@ -24,6 +24,7 @@ class Admin::RolesController < Admin::BaseController
   end
 
   def update
+    recast_role_to_selected_type
     if @role.update(role_params)
       redirect_to index_or_edit_path, notice: %("#{@role.name}" updated.)
     else
@@ -74,5 +75,12 @@ private
 
   def sti_type
     RoleTypePresenter.role_attributes_from(params[:role][:role_type])[:type]
+  end
+
+  def recast_role_to_selected_type
+    klass = Role.descendants.find { |descendant| descendant.name == sti_type }
+    return if klass.nil? || @role.instance_of?(klass)
+
+    @role = @role.becomes!(klass)
   end
 end

--- a/test/functional/admin/roles_controller_test.rb
+++ b/test/functional/admin/roles_controller_test.rb
@@ -299,6 +299,49 @@ class Admin::RolesControllerTest < ActionController::TestCase
     assert_equal [org_two], role.organisations
   end
 
+  test "update publishes the role as its new type when the type changes" do
+    stub_any_publishing_api_call
+    role = create(:ministerial_role, name: "role-name")
+
+    Whitehall::PublishingApi.expects(:publish).with(instance_of(BoardMemberRole))
+
+    put :update,
+        params: { id: role,
+                  role: {
+                    name: "role-name",
+                    role_type: "permanent_secretary",
+                  } }
+  end
+
+  test "update publishes the role with its existing type when the type is unchanged" do
+    stub_any_publishing_api_call
+    role = create(:board_member_role, name: "role-name", permanent_secretary: true)
+
+    Whitehall::PublishingApi.expects(:publish).with(instance_of(BoardMemberRole))
+
+    put :update,
+        params: { id: role,
+                  role: {
+                    name: "new-name",
+                    role_type: "permanent_secretary",
+                  } }
+  end
+
+  view_test "update with an unrecognised role type displays an error" do
+    stub_any_publishing_api_call
+    role = create(:ministerial_role, name: "role-name")
+
+    put :update,
+        params: { id: role,
+                  role: {
+                    name: "role-name",
+                    role_type: "not-a-real-role-type",
+                  } }
+
+    assert_select ".govuk-error-summary"
+    assert_equal MinisterialRole, Role.find(role.id).class
+  end
+
   test "update redirects to the index on success" do
     role = create(:role)
 


### PR DESCRIPTION
## What

- `Admin::RolesController#update` now recasts the role to its newly selected type (via `becomes!`) before saving, so the synchronous publish presents it under the correct `document_type`. The target class is resolved from the role's own STI descendants to avoid reflecting on user-supplied input.

[Jira](https://gov-uk.atlassian.net/browse/WHIT-3662)

## Why

When a role's type is changed in the admin, the `type` column is updated but the loaded instance keeps behaving as its original STI class until it is reloaded. The publish that runs from `after_commit` was built from that stale class, so the payload did not match the role's new type.

`collections` only renders a person's job title for roles whose published `document_type` matches the section they appear in (for example `board_member_role` for board members). A stale `document_type` filters the title out on organisation pages, so the person's name shows but their job title does not. Roles have been published with a class-derived `document_type` since June 2018, so any role retyped in the admin since then can be affected.

## Tasks

- [ ] After merge, republish all roles via the [bulk republishing UI](https://whitehall-admin.publishing.service.gov.uk/government/admin/republishing/bulk/by-type/role/confirm)
