### PR TITLE
[WHIT-3664] Remove definite article from Skills England CIP type titles

### DIFF
--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -9,6 +9,7 @@ module OrganisationHelper
     /homes england/,
     /british wool/,
     /building law and hygiene/,
+    /skills england/,
   ].freeze
 
   SPONSORED_ORGANISATION_TYPE_KEYS = %i[

--- a/test/unit/app/helpers/organisation_helper_test.rb
+++ b/test/unit/app/helpers/organisation_helper_test.rb
@@ -108,6 +108,7 @@ class OrganisationHelperDisplayNameWithParentalRelationshipTest < ActionView::Te
     assert_definite_article_skipped "HM Treasury"
     assert_definite_article_skipped "Ordnance Survey"
     assert_definite_article_skipped "Homes England"
+    assert_definite_article_skipped "Skills England"
   end
 
   test "definite article added for certain organisations" do


### PR DESCRIPTION
## What

Add Skills England to `PATTERNS_EXEMPT_FROM_DEFINITIVE_ARTICLE` in `OrganisationHelper`, fixing the labels for every CIP type:

- "Research at the Skills England" → "Research at Skills England"
- "Statistics at the Skills England" → "Statistics at Skills England"

[Jira](https://gov-uk.atlassian.net/browse/WHIT-3664)