### PR TITLE
Remove conflicting message about taxon requirement [WHIT-3564]

### DIFF
--- a/app/views/admin/editions/show/_main.html.erb
+++ b/app/views/admin/editions/show/_main.html.erb
@@ -80,7 +80,7 @@
           </ol>
         </div>
       <% end %>
-      <% unless @edition_taxons.any? %>
+      <% if @edition.requires_taxon? && @edition_taxons.none? %>
         <%= render "govuk_publishing_components/components/warning_text", {
           text: "You need to add topic tags before you can publish this document.",
         } %>

--- a/test/functional/admin/standard_editions_controller_test.rb
+++ b/test/functional/admin/standard_editions_controller_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class Admin::StandardEditionsControllerTest < ActionController::TestCase
+  include TaxonomyHelper
+
   should_be_an_admin_controller
 
   setup do
@@ -1536,6 +1538,44 @@ class Admin::StandardEditionsControllerTest < ActionController::TestCase
     get :show, params: { id: edition }
 
     assert_select "a", text: "Extra tab tab is invalid"
+  end
+
+  view_test "GET :show renders warning when document is not tagged to the new taxonomy, and when taxons are required" do
+    configurable_document_type = build_configurable_document_type("test_type", {
+      "settings" => {
+        "taxon" => {
+          "enabled" => true,
+          "required" => true,
+        },
+      },
+    })
+    ConfigurableDocumentType.setup_test_types(configurable_document_type)
+
+    edition = create(:draft_standard_edition)
+    stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+
+    get :show, params: { id: edition }
+
+    assert_select ".govuk-warning-text", /You need to add topic tags before you can publish this document./
+  end
+
+  view_test "GET :show does not render warning when document is not tagged to the new taxonomy, and when taxons are optional" do
+    configurable_document_type = build_configurable_document_type("test_type", {
+      "settings" => {
+        "taxon" => {
+          "enabled" => true,
+          "required" => false,
+        },
+      },
+    })
+    ConfigurableDocumentType.setup_test_types(configurable_document_type)
+
+    edition = create(:draft_standard_edition)
+    stub_publishing_api_expanded_links_with_taxons(edition.content_id, [])
+
+    get :show, params: { id: edition }
+
+    refute_select ".govuk-warning-text", text: /You need to add topic tags before you can publish this document./
   end
 
   def tabbed_document_type(validations: {})


### PR DESCRIPTION
This follows on from #11549 and ideally should have been done there.

Now that taxons can be configured to be optional, we need to wrap the "You need to add topic tags before you can publish this document." callout in a conditional such that it only appears if taxons are actually required for publishing.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
