### PR TITLE
Filter out duplicate topical event content IDs [WHIT-3270]

### DIFF
--- a/app/presenters/publishing_api/payload_builder/topical_events.rb
+++ b/app/presenters/publishing_api/payload_builder/topical_events.rb
@@ -10,7 +10,7 @@ module PublishingApi
         legacy_topical_events = item.topical_events.pluck(:content_id)
         config_driven_topical_events = item.topical_event_documents.pluck(:content_id)
         {
-          topical_events: legacy_topical_events + config_driven_topical_events,
+          topical_events: (legacy_topical_events + config_driven_topical_events).uniq,
         }
       end
     end

--- a/test/unit/app/presenters/publishing_api/payload_builder/topical_events_test.rb
+++ b/test/unit/app/presenters/publishing_api/payload_builder/topical_events_test.rb
@@ -17,6 +17,13 @@ module PublishingApi
         actual_result = PublishingApi::PayloadBuilder::TopicalEvents.for(@publication)
         assert_equal expected_result, actual_result
       end
+
+      test "filters out duplicate content_ids" do
+        @publication.topical_event_documents << @topical_event_document
+        expected_result = { topical_events: [@topical_event.content_id, @topical_event_document.content_id] }
+        actual_result = PublishingApi::PayloadBuilder::TopicalEvents.for(@publication)
+        assert_equal expected_result, actual_result
+      end
     end
   end
 end


### PR DESCRIPTION
During the migration we may have both a TopicalEvent and a Document sharing the same content ID, and both having an association with the same featured document. We need to filter out any duplicates.

https://gov-uk.atlassian.net/browse/WHIT-3270

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
