### PR TITLE
Source jasmine-ajax from npm instead of unpkg CDN

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-n": "^17.24.0",
     "eslint-plugin-promise": "^6.6.0",
+    "jasmine-ajax": "^5.0.0",
     "jasmine-browser-runner": "^4.0.0",
     "jasmine-core": "^6.2.0",
     "postcss": "^8.5.15",

--- a/spec/support/jasmine-browser.json
+++ b/spec/support/jasmine-browser.json
@@ -10,7 +10,7 @@
     "spec/javascripts/**/*[sS]pec.js"
   ],
   "helpers": [
-    "https://unpkg.com/jasmine-ajax@4.0.0/lib/mock-ajax.js",
+    "node_modules/jasmine-ajax/lib/mock-ajax.js",
     "spec/javascripts/helpers/helpers.js"
   ],
   "browser": "headlessChrome"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2651,6 +2651,11 @@ jake@^10.8.5:
     filelist "^1.0.1"
     minimatch "^3.0.4"
 
+jasmine-ajax@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/jasmine-ajax/-/jasmine-ajax-5.0.0.tgz#c7ecaeca3d8e076493d314ef088af8bbaf289d9e"
+  integrity sha512-Jj6p3fOEeyKW7NMXz8luvJjneqOUU6WClQAa9SYnulfdUjJSTujGzAKozDOdFq2Oib/EBQd7sBmF0g6WtWMYpA==
+
 jasmine-browser-runner@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/jasmine-browser-runner/-/jasmine-browser-runner-4.0.0.tgz#86724b3a6a63159e4ecc8801b93e1019f8de0583"


### PR DESCRIPTION
## What

The Jasmine suite loaded its `jasmine-ajax` helper at **runtime from a CDN** (`https://unpkg.com/jasmine-ajax@4.0.0/lib/mock-ajax.js`). This change sources it from npm instead:

- Adds `jasmine-ajax` as a devDependency (bumped `4.0.0` → `5.0.0`, same Jasmine-org maintainers)
- Loads the helper from `node_modules` in `spec/support/jasmine-browser.json`

## Why

Fetching the helper over the network during the test run makes the suite fragile. Behind a TLS-intercepting proxy (e.g. Zscaler), the headless browser can't verify the re-signed certificate, so the helper fails to load, `jasmine.Ajax` is `undefined`, and every spec that mocks Ajax errors. It also ties local and CI runs to an external CDN being reachable. Sourcing from `node_modules` means the suite runs with no external network access at test time.