### PR TITLE
Update Gujarati native name to be `Gujarati` [WHIT-3690]

### DIFF
--- a/config/languages.yml
+++ b/config/languages.yml
@@ -77,7 +77,7 @@ gd:
 gu:
   direction: ltr
   english_name: Gujarati
-  native_name: જોર્જિયન
+  native_name: ગુજરાતી
 he:
   direction: rtl
   english_name: Hebrew


### PR DESCRIPTION
## What

Use correct native name for Gujarati.

## Why

The previous native name was incorrect (it translated to `Georgian`).


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
