### PR TITLE
Make asset upload temp file cleanup idempotent

### DIFF
--- a/app/sidekiq/asset_manager_create_asset_job.rb
+++ b/app/sidekiq/asset_manager_create_asset_job.rb
@@ -28,8 +28,7 @@ class AssetManagerCreateAssetJob < JobBase
     enqueue_downstream_service_updates(assetable_id, assetable_type, attachable_model_class, attachable_model_id)
 
     file.close
-    FileUtils.rm(file)
-    FileUtils.rmdir(File.dirname(file))
+    FileUtils.rm_rf(File.dirname(temporary_location))
   end
 
 private

--- a/test/unit/app/sidekiq/asset_manager_create_asset_job_test.rb
+++ b/test/unit/app/sidekiq/asset_manager_create_asset_job_test.rb
@@ -98,6 +98,17 @@ class AssetManagerCreateAssetJobTest < ActiveSupport::TestCase
     @job.perform(path, @asset_params)
   end
 
+  test "does not raise if the temp file is removed before cleanup" do
+    Services.asset_manager.stubs(:create_asset).with { |args|
+      FileUtils.rm_rf(File.dirname(args[:file].path))
+      true
+    }.returns(@asset_manager_response)
+
+    assert_nothing_raised do
+      @job.perform(@file.path, @asset_params, false, @attachable.class.to_s, @attachable.id)
+    end
+  end
+
   test "stores corresponding asset_manager_id and filename for current file attachment" do
     Services.asset_manager.stubs(:create_asset).returns(@asset_manager_response)
 


### PR DESCRIPTION
## Why

`AssetManagerCreateAssetJob` cleaned up its temporary upload file with `FileUtils.rm` then `FileUtils.rmdir`. If the temp file was already gone by the time cleanup ran, this raised `Errno::ENOENT` **after** the asset had already been created successfully — failing the job (and, in production, triggering a Sidekiq retry of already-completed work).

The method already guards its start with `return unless File.exist?(temporary_location)`, anticipating a missing temp file. This change extends the same tolerance to cleanup by using `FileUtils.rm_rf` on the per-upload directory, which is idempotent.

## Test this fixes

This was reported as an intermittent failure of:

- **`AssetManagerIntegrationTest::CreatingAnOrganisationLogo`** (`test/integration/asset_manager_test.rb`) — e.g. `test_does_not_mark_the_logo_as_draft_in_Asset_Manager` and `test_sends_the_logo_to_Asset_Manager`, failing with `Errno::ENOENT @ apply2files - .../asset-manager-tmp/<uuid>/960x640_jpeg.jpg` at `asset_manager_create_asset_job.rb:31`.

It only surfaced under the parallel suite (not in isolation) because all parallel test workers share a single upload/temp directory, so cleanup could race against a concurrent run.

A regression test is added that reproduces this exact error:

- **`AssetManagerCreateAssetJobTest#test_does_not_raise_if_the_temp_file_is_removed_before_cleanup`** (`test/unit/app/sidekiq/asset_manager_create_asset_job_test.rb`) — verified red against the old cleanup (`Errno::ENOENT ... :31`) and green with the fix.
