### PR TITLE
[WHIT-3696] Access limiting assets

### DIFF
--- a/app/controllers/admin/edition_access_limited_controller.rb
+++ b/app/controllers/admin/edition_access_limited_controller.rb
@@ -14,8 +14,9 @@ class Admin::EditionAccessLimitedController < Admin::BaseController
       return render :edit
     end
 
-    if @edition.save
-      PublishingApiDocumentRepublishingJob.perform_async(@edition.document_id, false)
+    if updater.can_perform? && @edition.save
+      updater.perform!
+
       EditorialRemark.create!(
         edition: @edition,
         body: "Access options updated by GDS Admin: #{@editorial_remark}",
@@ -25,6 +26,7 @@ class Admin::EditionAccessLimitedController < Admin::BaseController
       )
       redirect_to admin_editions_path, notice: "Access updated for #{@edition.title}"
     else
+      flash.now[:alert] = updater.failure_reason
       render :edit
     end
   end
@@ -64,5 +66,9 @@ private
 
     edition_params[:access_limiting_organisation_ids] = [] unless edition_params[:access_limiting] == "organisations"
     edition_params[:access_limiting_individual_emails] = [] unless edition_params[:access_limiting] == "individuals"
+  end
+
+  def updater
+    @updater ||= Whitehall.edition_services.draft_updater(@edition)
   end
 end

--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -152,13 +152,13 @@ class AttachmentData < ApplicationRecord
   def access_limitation_organisation_ids
     return [] unless access_limited?
 
-    AssetManagerAccessLimitation.for_organisations(access_limited_object)
+    AssetManagerAccessLimitation.for(access_limited_object, :organisations) || []
   end
 
   def access_limitation_individual_ids
     return [] unless access_limited?
 
-    AssetManagerAccessLimitation.for_individuals(access_limited_object)
+    AssetManagerAccessLimitation.for(access_limited_object, :users) || []
   end
 
   def keep_existing_file?

--- a/app/models/attachment_data.rb
+++ b/app/models/attachment_data.rb
@@ -149,10 +149,16 @@ class AttachmentData < ApplicationRecord
     end
   end
 
-  def access_limitation
+  def access_limitation_organisation_ids
     return [] unless access_limited?
 
-    AssetManagerAccessLimitation.for(access_limited_object)
+    AssetManagerAccessLimitation.for_organisations(access_limited_object)
+  end
+
+  def access_limitation_individual_ids
+    return [] unless access_limited?
+
+    AssetManagerAccessLimitation.for_individuals(access_limited_object)
   end
 
   def keep_existing_file?

--- a/app/models/call_for_evidence_response.rb
+++ b/app/models/call_for_evidence_response.rb
@@ -19,6 +19,10 @@ class CallForEvidenceResponse < ApplicationRecord
 
   delegate :organisations, to: :parent_attachable
 
+  delegate :access_limiting_organisations?, to: :parent_attachable
+
+  delegate :access_limiting_organisations, to: :parent_attachable
+
   delegate :lead_organisations, to: :parent_attachable
 
   delegate :supporting_organisations, to: :parent_attachable

--- a/app/models/call_for_evidence_response.rb
+++ b/app/models/call_for_evidence_response.rb
@@ -23,6 +23,10 @@ class CallForEvidenceResponse < ApplicationRecord
 
   delegate :access_limiting_organisations, to: :parent_attachable
 
+  delegate :access_limiting_individuals?, to: :parent_attachable
+
+  delegate :access_limiting_individuals, to: :parent_attachable
+
   delegate :lead_organisations, to: :parent_attachable
 
   delegate :supporting_organisations, to: :parent_attachable

--- a/app/models/consultation_response.rb
+++ b/app/models/consultation_response.rb
@@ -23,6 +23,10 @@ class ConsultationResponse < ApplicationRecord
 
   delegate :access_limiting_organisations, to: :parent_attachable
 
+  delegate :access_limiting_individuals?, to: :parent_attachable
+
+  delegate :access_limiting_individuals, to: :parent_attachable
+
   delegate :lead_organisations, to: :parent_attachable
 
   delegate :supporting_organisations, to: :parent_attachable

--- a/app/models/consultation_response.rb
+++ b/app/models/consultation_response.rb
@@ -19,6 +19,10 @@ class ConsultationResponse < ApplicationRecord
 
   delegate :organisations, to: :parent_attachable
 
+  delegate :access_limiting_organisations?, to: :parent_attachable
+
+  delegate :access_limiting_organisations, to: :parent_attachable
+
   delegate :lead_organisations, to: :parent_attachable
 
   delegate :supporting_organisations, to: :parent_attachable

--- a/app/services/asset_manager/attachment_updater.rb
+++ b/app/services/asset_manager/attachment_updater.rb
@@ -3,7 +3,8 @@ class AssetManager::AttachmentUpdater
     return if attachment_data.deleted?
 
     asset_attributes = {
-      "access_limited_organisation_ids" => attachment_data.access_limitation,
+      "access_limited_organisation_ids" => attachment_data.access_limitation_organisation_ids,
+      "access_limited_user_ids" => attachment_data.access_limitation_individual_ids,
       "draft" => attachment_data.draft? && !(attachment_data.replaced? || attachment_data.unpublished?),
     }
 

--- a/app/sidekiq/asset_manager_create_asset_job.rb
+++ b/app/sidekiq/asset_manager_create_asset_job.rb
@@ -21,7 +21,9 @@ class AssetManagerCreateAssetJob < JobBase
 
     asset_options = { file:, auth_bypass_ids:, draft: }
     authorised_organisation_uids = get_authorised_organisation_ids(attachable_model_class, attachable_model_id)
-    asset_options[:access_limited_organisation_ids] = authorised_organisation_uids if authorised_organisation_uids
+    asset_options[:access_limited_organisation_ids] = authorised_organisation_uids if authorised_organisation_uids&.any?
+    authorised_individual_uids = get_authorised_individual_ids(attachable_model_class, attachable_model_id)
+    asset_options[:access_limited_user_ids] = authorised_individual_uids if authorised_individual_uids&.any?
 
     create_asset(asset_options, asset_variant, assetable_id, assetable_type)
 
@@ -59,7 +61,16 @@ private
     if attachable_model_class && attachable_model_id
       attachable_model = attachable_model_class.constantize.find(attachable_model_id)
       if attachable_model.respond_to?(:access_limited?) && attachable_model.access_limited?
-        AssetManagerAccessLimitation.for(attachable_model)
+        AssetManagerAccessLimitation.for_organisations(attachable_model)
+      end
+    end
+  end
+
+  def get_authorised_individual_ids(attachable_model_class, attachable_model_id)
+    if attachable_model_class && attachable_model_id
+      attachable_model = attachable_model_class.constantize.find(attachable_model_id)
+      if attachable_model.respond_to?(:access_limited?) && attachable_model.access_limited?
+        AssetManagerAccessLimitation.for_individuals(attachable_model)
       end
     end
   end

--- a/app/sidekiq/asset_manager_create_asset_job.rb
+++ b/app/sidekiq/asset_manager_create_asset_job.rb
@@ -21,9 +21,9 @@ class AssetManagerCreateAssetJob < JobBase
 
     asset_options = { file:, auth_bypass_ids:, draft: }
     authorised_organisation_uids = get_authorised_organisation_ids(attachable_model_class, attachable_model_id)
-    asset_options[:access_limited_organisation_ids] = authorised_organisation_uids if authorised_organisation_uids&.any?
+    asset_options[:access_limited_organisation_ids] = authorised_organisation_uids if authorised_organisation_uids
     authorised_individual_uids = get_authorised_individual_ids(attachable_model_class, attachable_model_id)
-    asset_options[:access_limited_user_ids] = authorised_individual_uids if authorised_individual_uids&.any?
+    asset_options[:access_limited_user_ids] = authorised_individual_uids if authorised_individual_uids
 
     create_asset(asset_options, asset_variant, assetable_id, assetable_type)
 
@@ -61,7 +61,7 @@ private
     if attachable_model_class && attachable_model_id
       attachable_model = attachable_model_class.constantize.find(attachable_model_id)
       if attachable_model.respond_to?(:access_limited?) && attachable_model.access_limited?
-        AssetManagerAccessLimitation.for_organisations(attachable_model)
+        AssetManagerAccessLimitation.for(attachable_model, :organisations)
       end
     end
   end
@@ -70,7 +70,7 @@ private
     if attachable_model_class && attachable_model_id
       attachable_model = attachable_model_class.constantize.find(attachable_model_id)
       if attachable_model.respond_to?(:access_limited?) && attachable_model.access_limited?
-        AssetManagerAccessLimitation.for_individuals(attachable_model)
+        AssetManagerAccessLimitation.for(attachable_model, :users)
       end
     end
   end

--- a/config/features.rb
+++ b/config/features.rb
@@ -35,8 +35,8 @@ Flipflop.configure do
           default: Rails.env.development?
   feature :access_limiting_organisations_ui,
           description: "Replace the access-limiting checkbox with radio + organisation selector UI",
-          default: false
+          default: Whitehall.integration?
   feature :access_limiting_individuals_ui,
           description: "Extend the access-limiting radio UI with an individuals option",
-          default: false
+          default: Whitehall.integration?
 end

--- a/lib/asset_manager_access_limitation.rb
+++ b/lib/asset_manager_access_limitation.rb
@@ -1,6 +1,11 @@
 class AssetManagerAccessLimitation
-  def self.for(item)
+  def self.for_organisations(item)
     access_limitation = PublishingApi::PayloadBuilder::AccessLimitation.for(item)
-    access_limitation[:access_limited][:organisations]
+    access_limitation.dig(:access_limited, :organisations) || []
+  end
+
+  def self.for_individuals(item)
+    access_limitation = PublishingApi::PayloadBuilder::AccessLimitation.for(item)
+    access_limitation.dig(:access_limited, :users) || []
   end
 end

--- a/lib/asset_manager_access_limitation.rb
+++ b/lib/asset_manager_access_limitation.rb
@@ -1,11 +1,6 @@
 class AssetManagerAccessLimitation
-  def self.for_organisations(item)
+  def self.for(item, type_of_access_limitation)
     access_limitation = PublishingApi::PayloadBuilder::AccessLimitation.for(item)
-    access_limitation.dig(:access_limited, :organisations) || []
-  end
-
-  def self.for_individuals(item)
-    access_limitation = PublishingApi::PayloadBuilder::AccessLimitation.for(item)
-    access_limitation.dig(:access_limited, :users) || []
+    access_limitation.dig(:access_limited, type_of_access_limitation)
   end
 end

--- a/lib/whitehall.rb
+++ b/lib/whitehall.rb
@@ -124,4 +124,9 @@ module Whitehall
     website_root = ENV.fetch("GOVUK_WEBSITE_ROOT", "")
     %w[integration staging].any? { |environment| website_root.include?(environment) }
   end
+
+  def self.integration?
+    website_root = ENV.fetch("GOVUK_WEBSITE_ROOT", "")
+    %w[integration].any? { |environment| website_root.include?(environment) }
+  end
 end

--- a/test/functional/admin/edition_access_limited_controller_test.rb
+++ b/test/functional/admin/edition_access_limited_controller_test.rb
@@ -131,8 +131,6 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
       supporting_organisations: [second_organisation],
     )
 
-    PublishingApiDocumentRepublishingJob.expects(:perform_async).with(edition.document_id, false)
-
     editorial_remark = "Updating the organisations at the users request."
 
     patch :update,
@@ -496,5 +494,80 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
 
     assert edition.reload.access_limiting_individuals.exists?(email: "user@example.com")
     assert_not edition.access_limiting_individuals.exists?(email: "another_user@example.com")
+  end
+
+  # flags agnostic
+  test "PATCH :update should enqueue the edition draft updater" do
+    first_organisation = create(:organisation)
+    second_organisation = create(:organisation)
+
+    edition = create(
+      :consultation,
+      access_limiting: "organisations",
+      create_default_organisation: false,
+      lead_organisations: [first_organisation],
+    )
+
+    draft_updater = mock("draft_updater")
+    Whitehall.edition_services.expects(:draft_updater).with(edition).returns(draft_updater)
+    draft_updater.expects(:can_perform?).returns(true)
+    draft_updater.expects(:perform!).once
+
+    patch :update,
+          params: {
+            id: edition,
+            edition: {
+              lead_organisation_ids: [first_organisation.id, second_organisation.id],
+              editorial_remark: "Updating lead organisations.",
+            },
+          }
+
+    assert_equal [first_organisation, second_organisation], edition.reload.lead_organisations
+  end
+
+  # flags agnostic
+  test "PATCH :update should enqueue the attachment updater" do
+    first_organisation = create(:organisation)
+    second_organisation = create(:organisation)
+
+    edition = create(
+      :consultation,
+      :with_file_attachment,
+      access_limiting: "organisations",
+      create_default_organisation: false,
+      lead_organisations: [first_organisation],
+    )
+
+    AssetManager::AttachmentUpdater.expects(:call).with(edition.attachments.first.attachment_data)
+
+    patch :update,
+          params: {
+            id: edition,
+            edition: {
+              lead_organisation_ids: [first_organisation.id, second_organisation.id],
+              editorial_remark: "Updating lead organisations.",
+            },
+          }
+
+    assert_equal [first_organisation, second_organisation], edition.reload.lead_organisations
+
+    AssetManagerAttachmentMetadataJob.drain
+  end
+
+  # flags agnostic
+  test "PATCH :update does not change edition if in unmodifiable state" do
+    edition = create(:published_consultation, create_default_organisation: true)
+
+    patch :update,
+          params: {
+            id: edition,
+            edition: {
+              lead_organisation_ids: [create(:organisation).id],
+              editorial_remark: "Updating lead organisations.",
+            },
+          }
+
+    assert_template :edit
+    assert_equal "A published edition may not be updated.", flash[:alert]
   end
 end

--- a/test/unit/app/models/attachment_data_test.rb
+++ b/test/unit/app/models/attachment_data_test.rb
@@ -235,8 +235,20 @@ class AttachmentDataTest < ActiveSupport::TestCase
 
   test "#access_limited_object returns nil if there is no last attachable" do
     attachment_data = build(:attachment_data)
-    attachment_data.stubs(:attachments).returns([])
+    assert_nil attachment_data.attachable
     assert_nil attachment_data.access_limited_object
+  end
+
+  test "#access_limitation_organisation_ids returns an empty array if there is no last attachable" do
+    attachment_data = build(:attachment_data)
+    assert_nil attachment_data.attachable
+    assert_empty attachment_data.access_limitation_organisation_ids
+  end
+
+  test "#access_limitation_individual_ids returns an empty array if there is no last attachable" do
+    attachment_data = build(:attachment_data)
+    assert_nil attachment_data.attachable
+    assert_empty attachment_data.access_limitation_individual_ids
   end
 
   test "#access_limited_object delegates to the last attachable" do
@@ -244,6 +256,26 @@ class AttachmentDataTest < ActiveSupport::TestCase
     attachment_data = build(:attachment_data)
     attachment_data.stubs(:last_attachable).returns(attachable)
     assert_equal "access-limited-object", attachment_data.access_limited_object
+  end
+
+  test "#access_limitation_organisation_ids returns the last attachable's access limiting organisations" do
+    attachable = stub("attachable", access_limited?: true, access_limited_object: "access-limited-object")
+    attachment_data = build(:attachment_data)
+    attachment_data.stubs(:last_attachable).returns(attachable)
+
+    AssetManagerAccessLimitation.expects(:for_organisations).with("access-limited-object").returns(%w[content-id-1 content-id-2])
+
+    assert_equal %w[content-id-1 content-id-2], attachment_data.access_limitation_organisation_ids
+  end
+
+  test "#access_limitation_individual_ids returns the last attachable's access limiting individuals" do
+    attachable = stub("attachable", access_limited?: true, access_limited_object: "access-limited-object")
+    attachment_data = build(:attachment_data)
+    attachment_data.stubs(:last_attachable).returns(attachable)
+
+    AssetManagerAccessLimitation.expects(:for_individuals).with("access-limited-object").returns(%w[user-uid-1 user-uid-2])
+
+    assert_equal %w[user-uid-1 user-uid-2], attachment_data.access_limitation_individual_ids
   end
 
   test "#last_publicly_visible_attachment returns publicly visible attachable" do

--- a/test/unit/app/models/attachment_data_test.rb
+++ b/test/unit/app/models/attachment_data_test.rb
@@ -258,12 +258,32 @@ class AttachmentDataTest < ActiveSupport::TestCase
     assert_equal "access-limited-object", attachment_data.access_limited_object
   end
 
+  test "#access_limitation_organisation_ids returns an empty array when there are no access limiting organisations" do
+    attachable = stub("attachable", access_limited?: true, access_limited_object: "access-limited-object")
+    attachment_data = build(:attachment_data)
+    attachment_data.stubs(:last_attachable).returns(attachable)
+
+    AssetManagerAccessLimitation.expects(:for).with("access-limited-object", :organisations).returns(nil)
+
+    assert_empty attachment_data.access_limitation_organisation_ids
+  end
+
+  test "#access_limitation_individual_ids returns an empty array when there are no access limiting individuals" do
+    attachable = stub("attachable", access_limited?: true, access_limited_object: "access-limited-object")
+    attachment_data = build(:attachment_data)
+    attachment_data.stubs(:last_attachable).returns(attachable)
+
+    AssetManagerAccessLimitation.expects(:for).with("access-limited-object", :users).returns(nil)
+
+    assert_empty attachment_data.access_limitation_individual_ids
+  end
+
   test "#access_limitation_organisation_ids returns the last attachable's access limiting organisations" do
     attachable = stub("attachable", access_limited?: true, access_limited_object: "access-limited-object")
     attachment_data = build(:attachment_data)
     attachment_data.stubs(:last_attachable).returns(attachable)
 
-    AssetManagerAccessLimitation.expects(:for_organisations).with("access-limited-object").returns(%w[content-id-1 content-id-2])
+    AssetManagerAccessLimitation.expects(:for).with("access-limited-object", :organisations).returns(%w[content-id-1 content-id-2])
 
     assert_equal %w[content-id-1 content-id-2], attachment_data.access_limitation_organisation_ids
   end
@@ -273,7 +293,7 @@ class AttachmentDataTest < ActiveSupport::TestCase
     attachment_data = build(:attachment_data)
     attachment_data.stubs(:last_attachable).returns(attachable)
 
-    AssetManagerAccessLimitation.expects(:for_individuals).with("access-limited-object").returns(%w[user-uid-1 user-uid-2])
+    AssetManagerAccessLimitation.expects(:for).with("access-limited-object", :users).returns(%w[user-uid-1 user-uid-2])
 
     assert_equal %w[user-uid-1 user-uid-2], attachment_data.access_limitation_individual_ids
   end

--- a/test/unit/app/services/asset_manager/attachment_updater_test.rb
+++ b/test/unit/app/services/asset_manager/attachment_updater_test.rb
@@ -64,6 +64,31 @@ class AssetManager::AttachmentUpdaterTest < ActiveSupport::TestCase
 
         AssetManager::AttachmentUpdater.call(attachment.attachment_data)
       end
+
+      it "sets the expected asset attributes when the access_limiting_organisations_ui flag is on" do
+        @feature_flags.switch!(:access_limiting_organisations_ui, true)
+
+        organisation = create(:organisation)
+        edition = create(
+          :publication,
+          access_limiting: "organisations",
+          create_default_organisation: true,
+          access_limiting_organisation_ids: [organisation.id],
+        )
+        attachment = create(:file_attachment, attachable: edition, attachment_data: create(:attachment_data, attachable: edition))
+
+        expected_attribute_hash = {
+          "draft" => true,
+          "parent_document_url" => edition.public_url(draft: true),
+          "access_limited_organisation_ids" => [organisation.content_id],
+        }
+
+        attachment.attachment_data.assets.each do |asset|
+          AssetManager::AssetUpdater.expects(:call).with(asset.asset_manager_id, expected_attribute_hash)
+        end
+
+        AssetManager::AttachmentUpdater.call(attachment.attachment_data)
+      end
     end
 
     context "when attachment belongs to a scheduled edition" do
@@ -244,6 +269,33 @@ class AssetManager::AttachmentUpdaterTest < ActiveSupport::TestCase
           {
             "draft" => true,
             "access_limited_organisation_ids" => [],
+            "parent_document_url" => consultation.public_url(draft: true),
+          },
+        )
+
+        AssetManager::AttachmentUpdater.call(attachment_data)
+      end
+
+      it "sets access limiting to organisations when the access_limiting_organisations_ui flag is on" do
+        @feature_flags.switch!(:access_limiting_organisations_ui, true)
+
+        organisation = create(:organisation)
+        consultation = create(
+          :draft_consultation,
+          access_limiting: "organisations",
+          create_default_organisation: true,
+          access_limiting_organisation_ids: [organisation.id],
+        )
+        outcome = create(:consultation_outcome, consultation:)
+        attachment = create(:file_attachment, attachable: outcome, attachment_data: create(:attachment_data, attachable: outcome))
+        attachment_data = attachment.attachment_data
+        asset_manager_id = attachment_data.assets.first.asset_manager_id
+
+        AssetManager::AssetUpdater.expects(:call).with(
+          asset_manager_id,
+          {
+            "draft" => true,
+            "access_limited_organisation_ids" => [organisation.content_id],
             "parent_document_url" => consultation.public_url(draft: true),
           },
         )

--- a/test/unit/app/services/asset_manager/attachment_updater_test.rb
+++ b/test/unit/app/services/asset_manager/attachment_updater_test.rb
@@ -12,6 +12,7 @@ class AssetManager::AttachmentUpdaterTest < ActiveSupport::TestCase
         expected_attribute_hash = {
           "draft" => true,
           "access_limited_organisation_ids" => [],
+          "access_limited_user_ids" => [],
           "parent_document_url" => edition.public_url(draft: true),
         }
 
@@ -35,6 +36,7 @@ class AssetManager::AttachmentUpdaterTest < ActiveSupport::TestCase
 
           expected_attribute_hash = {
             "access_limited_organisation_ids" => [],
+            "access_limited_user_ids" => [],
             "draft" => false,
           }
 
@@ -47,7 +49,7 @@ class AssetManager::AttachmentUpdaterTest < ActiveSupport::TestCase
       end
     end
 
-    context "when the attachment's attachable is a draft and is access limited" do
+    context "when the attachment's attachable is a draft and is access limited to organisations" do
       it "sets the expected attributes for all assets" do
         edition = create(:draft_publication, :access_limited)
         attachment = create(:file_attachment, attachable: edition, attachment_data: create(:attachment_data, attachable: edition))
@@ -56,6 +58,7 @@ class AssetManager::AttachmentUpdaterTest < ActiveSupport::TestCase
           "draft" => true,
           "parent_document_url" => edition.public_url(draft: true),
           "access_limited_organisation_ids" => edition.organisations.map(&:content_id),
+          "access_limited_user_ids" => [],
         }
 
         attachment.attachment_data.assets.each do |asset|
@@ -81,6 +84,29 @@ class AssetManager::AttachmentUpdaterTest < ActiveSupport::TestCase
           "draft" => true,
           "parent_document_url" => edition.public_url(draft: true),
           "access_limited_organisation_ids" => [organisation.content_id],
+          "access_limited_user_ids" => [],
+        }
+
+        attachment.attachment_data.assets.each do |asset|
+          AssetManager::AssetUpdater.expects(:call).with(asset.asset_manager_id, expected_attribute_hash)
+        end
+
+        AssetManager::AttachmentUpdater.call(attachment.attachment_data)
+      end
+    end
+
+    context "when the attachment's attachable is a draft and is access limited to individuals" do
+      it "sends the individual user uids for all assets when the access_limiting_individuals_ui flag is on" do
+        @feature_flags.switch!(:access_limiting_individuals_ui, true)
+        user = create(:user)
+        edition = create(:draft_publication, access_limiting: "individuals", access_limiting_individual_emails: user.email)
+        attachment = create(:file_attachment, attachable: edition, attachment_data: create(:attachment_data, attachable: edition))
+
+        expected_attribute_hash = {
+          "draft" => true,
+          "parent_document_url" => edition.public_url(draft: true),
+          "access_limited_organisation_ids" => [],
+          "access_limited_user_ids" => [user.uid],
         }
 
         attachment.attachment_data.assets.each do |asset|
@@ -100,6 +126,7 @@ class AssetManager::AttachmentUpdaterTest < ActiveSupport::TestCase
           "draft" => true,
           "parent_document_url" => scheduled_edition.public_url(draft: true),
           "access_limited_organisation_ids" => [],
+          "access_limited_user_ids" => [],
         }
 
         attachment.attachment_data.assets.each do |asset|
@@ -119,6 +146,7 @@ class AssetManager::AttachmentUpdaterTest < ActiveSupport::TestCase
           "draft" => true,
           "parent_document_url" => submitted_edition.public_url(draft: true),
           "access_limited_organisation_ids" => [],
+          "access_limited_user_ids" => [],
         }
 
         attachment.attachment_data.assets.each do |asset|
@@ -138,6 +166,7 @@ class AssetManager::AttachmentUpdaterTest < ActiveSupport::TestCase
           "draft" => true,
           "parent_document_url" => rejected_edition.public_url(draft: true),
           "access_limited_organisation_ids" => [],
+          "access_limited_user_ids" => [],
         }
 
         attachment.attachment_data.assets.each do |asset|
@@ -157,6 +186,7 @@ class AssetManager::AttachmentUpdaterTest < ActiveSupport::TestCase
           "draft" => false,
           "parent_document_url" => edition.public_url,
           "access_limited_organisation_ids" => [],
+          "access_limited_user_ids" => [],
         }
 
         attachment.attachment_data.assets.each do |asset|
@@ -176,6 +206,7 @@ class AssetManager::AttachmentUpdaterTest < ActiveSupport::TestCase
           "draft" => false,
           "parent_document_url" => nil,
           "access_limited_organisation_ids" => [],
+          "access_limited_user_ids" => [],
         }
         attachment.attachment_data.assets.each do |asset|
           AssetManager::AssetUpdater.expects(:call).with(asset.asset_manager_id, expected_attribute_hash)
@@ -198,7 +229,7 @@ class AssetManager::AttachmentUpdaterTest < ActiveSupport::TestCase
 
         before do
           Services.asset_manager.expects(:asset).with(asset_manager_id).returns("id" => asset_manager_id, "parent_document_url" => nil, "draft" => false)
-          Services.asset_manager.expects(:update_asset).with(asset_manager_id, { "parent_document_url" => draft_edition.public_url(draft: true), "draft" => false, "access_limited_organisation_ids" => [] }).raises(GdsApi::HTTPUnprocessableEntity, "Parent document url must be a public GOV.UK URL")
+          Services.asset_manager.expects(:update_asset).with(asset_manager_id, { "parent_document_url" => draft_edition.public_url(draft: true), "draft" => false, "access_limited_organisation_ids" => [], "access_limited_user_ids" => [] }).raises(GdsApi::HTTPUnprocessableEntity, "Parent document url must be a public GOV.UK URL")
         end
 
         it "attempts to update, and does not raise" do
@@ -269,6 +300,7 @@ class AssetManager::AttachmentUpdaterTest < ActiveSupport::TestCase
           {
             "draft" => true,
             "access_limited_organisation_ids" => [],
+            "access_limited_user_ids" => [],
             "parent_document_url" => consultation.public_url(draft: true),
           },
         )
@@ -296,6 +328,35 @@ class AssetManager::AttachmentUpdaterTest < ActiveSupport::TestCase
           {
             "draft" => true,
             "access_limited_organisation_ids" => [organisation.content_id],
+            "access_limited_user_ids" => [],
+            "parent_document_url" => consultation.public_url(draft: true),
+          },
+        )
+
+        AssetManager::AttachmentUpdater.call(attachment_data)
+      end
+
+      it "sets access limiting to individuals when the access_limiting_individuals_ui flag is on" do
+        @feature_flags.switch!(:access_limiting_individuals_ui, true)
+
+        user = create(:user)
+        consultation = create(
+          :draft_consultation,
+          create_default_organisation: true,
+          access_limiting: "individuals",
+          access_limiting_individual_emails: user.email,
+        )
+        outcome = create(:consultation_outcome, consultation:)
+        attachment = create(:file_attachment, attachable: outcome, attachment_data: create(:attachment_data, attachable: outcome))
+        attachment_data = attachment.attachment_data
+        asset_manager_id = attachment_data.assets.first.asset_manager_id
+
+        AssetManager::AssetUpdater.expects(:call).with(
+          asset_manager_id,
+          {
+            "draft" => true,
+            "access_limited_organisation_ids" => [],
+            "access_limited_user_ids" => [user.uid],
             "parent_document_url" => consultation.public_url(draft: true),
           },
         )
@@ -316,6 +377,7 @@ class AssetManager::AttachmentUpdaterTest < ActiveSupport::TestCase
           {
             "draft" => false,
             "access_limited_organisation_ids" => [],
+            "access_limited_user_ids" => [],
             "parent_document_url" => consultation.public_url,
           },
         )
@@ -335,6 +397,7 @@ class AssetManager::AttachmentUpdaterTest < ActiveSupport::TestCase
           {
             "draft" => false,
             "access_limited_organisation_ids" => [],
+            "access_limited_user_ids" => [],
             "parent_document_url" => policy_group.public_url,
           },
         )

--- a/test/unit/app/sidekiq/asset_manager_create_asset_job_test.rb
+++ b/test/unit/app/sidekiq/asset_manager_create_asset_job_test.rb
@@ -203,6 +203,19 @@ class AssetManagerCreateAssetJobTest < ActiveSupport::TestCase
       @job.perform(@file.path, asset_params(assetable), true, attachable.class.to_s, attachable.id)
     end
 
+    test "marks attachments belonging to an edition attachable as access limited to individuals, when flag is on" do
+      @feature_flags.switch!(:access_limiting_individuals_ui, true)
+
+      user = FactoryBot.create(:user)
+      attachable = FactoryBot.create(:consultation, organisations: [@organisation], access_limiting: "individuals", access_limiting_individual_emails: user.email)
+      file = FactoryBot.create(:file_attachment, attachable:)
+      assetable = file.attachment_data
+
+      Services.asset_manager.expects(:create_asset).with(has_entry(access_limited_user_ids: [user.uid])).returns(@asset_manager_response)
+
+      @job.perform(@file.path, asset_params(assetable), true, attachable.class.to_s, attachable.id)
+    end
+
     test "marks attachments belonging to an outcome attachable as access limited to organisations" do
       consultation = FactoryBot.create(:consultation, organisations: [@organisation], access_limiting: "organisations")
       attachable = FactoryBot.create(:consultation_outcome, consultation:)
@@ -224,6 +237,20 @@ class AssetManagerCreateAssetJobTest < ActiveSupport::TestCase
       assetable = file.attachment_data
 
       Services.asset_manager.expects(:create_asset).with(has_entry(access_limited_organisation_ids: [access_limiting_organisation.content_id])).returns(@asset_manager_response)
+
+      @job.perform(@file.path, asset_params(assetable), true, attachable.class.to_s, attachable.id)
+    end
+
+    test "marks attachments belonging to an outcome attachable as access limited to individuals, when flag is on" do
+      @feature_flags.switch!(:access_limiting_individuals_ui, true)
+
+      user = FactoryBot.create(:user)
+      consultation = FactoryBot.create(:consultation, organisations: [@organisation], access_limiting: "individuals", access_limiting_individual_emails: user.email)
+      attachable = FactoryBot.create(:consultation_outcome, consultation:)
+      file = FactoryBot.create(:file_attachment, attachable:)
+      assetable = file.attachment_data
+
+      Services.asset_manager.expects(:create_asset).with(has_entry(access_limited_user_ids: [user.uid])).returns(@asset_manager_response)
 
       @job.perform(@file.path, asset_params(assetable), true, attachable.class.to_s, attachable.id)
     end

--- a/test/unit/app/sidekiq/asset_manager_create_asset_job_test.rb
+++ b/test/unit/app/sidekiq/asset_manager_create_asset_job_test.rb
@@ -180,6 +180,57 @@ class AssetManagerCreateAssetJobTest < ActiveSupport::TestCase
   end
 
   context "access limiting" do
+    test "does not set access limited if attachable is not access limited" do
+      attachable = FactoryBot.create(:consultation, organisations: [@organisation], access_limiting: "none")
+      file = FactoryBot.create(:file_attachment, attachable:)
+      assetable = file.attachment_data
+
+      Services.asset_manager.expects(:create_asset).with { |args| !args.key?(:access_limited_organisation_ids) && !args.key?(:access_limited_user_ids) }.returns(@asset_manager_response)
+
+      @job.perform(@file.path, asset_params(assetable), true, attachable.class.to_s, attachable.id)
+    end
+
+    test "does not set organisations access limiting if attachable is not access limited to organisations" do
+      @feature_flags.switch!(:access_limiting_organisations_ui, true)
+      @feature_flags.switch!(:access_limiting_individuals_ui, true)
+
+      attachable = FactoryBot.create(:consultation, organisations: [@organisation], access_limiting: "individuals", access_limiting_individual_emails: create(:user).email)
+      file = FactoryBot.create(:file_attachment, attachable:)
+      assetable = file.attachment_data
+
+      Services.asset_manager.expects(:create_asset).with { |args| !args.key?(:access_limited_organisation_ids) }.returns(@asset_manager_response)
+
+      @job.perform(@file.path, asset_params(assetable), true, attachable.class.to_s, attachable.id)
+    end
+
+    test "does not set individuals access limiting if attachable is not access limited to individuals" do
+      @feature_flags.switch!(:access_limiting_organisations_ui, true)
+      @feature_flags.switch!(:access_limiting_individuals_ui, true)
+
+      attachable = FactoryBot.create(:consultation, organisations: [@organisation], access_limiting: "organisations", access_limiting_organisation_ids: [create(:organisation).id])
+      file = FactoryBot.create(:file_attachment, attachable:)
+      assetable = file.attachment_data
+
+      Services.asset_manager.expects(:create_asset).with { |args| !args.key?(:access_limited_user_ids) }.returns(@asset_manager_response)
+
+      @job.perform(@file.path, asset_params(assetable), true, attachable.class.to_s, attachable.id)
+    end
+
+    test "sets access limiting to any non nil value returned by the payload builder" do
+      @feature_flags.switch!(:access_limiting_individuals_ui, true)
+
+      attachable = FactoryBot.create(:consultation, organisations: [@organisation], access_limiting: "individuals", access_limiting_individual_emails: "some.gibberish@example.com")
+      file = FactoryBot.create(:file_attachment, attachable:)
+      assetable = file.attachment_data
+
+      AssetManagerAccessLimitation.expects(:for).with(attachable, :organisations).returns(nil)
+      AssetManagerAccessLimitation.expects(:for).with(attachable, :users).returns([])
+
+      Services.asset_manager.expects(:create_asset).with(has_entry(access_limited_user_ids: [])).returns(@asset_manager_response)
+
+      @job.perform(@file.path, asset_params(assetable), true, attachable.class.to_s, attachable.id)
+    end
+
     test "marks attachments belonging to an edition attachable as access limited to organisations" do
       attachable = FactoryBot.create(:consultation, organisations: [@organisation], access_limiting: "organisations")
       file = FactoryBot.create(:file_attachment, attachable:)

--- a/test/unit/app/sidekiq/asset_manager_create_asset_job_test.rb
+++ b/test/unit/app/sidekiq/asset_manager_create_asset_job_test.rb
@@ -47,25 +47,48 @@ class AssetManagerCreateAssetJobTest < ActiveSupport::TestCase
     assert_not Dir.exist?(File.dirname(@file))
   end
 
-  test "marks attachments belonging to consultations as access limited" do
+  test "marks attachments belonging to consultations as access limited to organisations" do
     consultation = FactoryBot.create(:consultation, organisations: [@organisation], access_limiting: "organisations")
-    attachment = FactoryBot.create(:file_attachment, attachable: consultation)
-    attachment.attachment_data.attachable = consultation
+    FactoryBot.create(:file_attachment, attachable: consultation)
 
     Services.asset_manager.expects(:create_asset).with(has_entry(access_limited_organisation_ids: [@organisation.content_id])).returns(@asset_manager_response)
 
     @job.perform(@file.path, @asset_params, true, consultation.class.to_s, consultation.id)
   end
 
-  test "marks attachments belonging to consultation responses as access limited" do
+  test "marks attachments belonging to consultations as access limited to organisations, when flag is on" do
+    @feature_flags.switch!(:access_limiting_organisations_ui, true)
+
+    access_limiting_organisation = create(:organisation)
+    consultation = FactoryBot.create(:consultation, organisations: [@organisation], access_limiting: "organisations", access_limiting_organisation_ids: [access_limiting_organisation.id])
+    FactoryBot.create(:file_attachment, attachable: consultation)
+
+    Services.asset_manager.expects(:create_asset).with(has_entry(access_limited_organisation_ids: [access_limiting_organisation.content_id])).returns(@asset_manager_response)
+
+    @job.perform(@file.path, @asset_params, true, consultation.class.to_s, consultation.id)
+  end
+
+  test "marks attachments belonging to consultation responses as access limited to organisations" do
     consultation = FactoryBot.create(:consultation, organisations: [@organisation], access_limiting: "organisations")
     response = FactoryBot.create(:consultation_outcome, consultation:)
-    attachment = FactoryBot.create(:file_attachment, attachable: response)
-    attachment.attachment_data.attachable = consultation
+    FactoryBot.create(:file_attachment, attachable: response)
 
     Services.asset_manager.expects(:create_asset).with(has_entry(access_limited_organisation_ids: [@organisation.content_id])).returns(@asset_manager_response)
 
-    @job.perform(@file.path, @asset_params, true, consultation.class.to_s, consultation.id)
+    @job.perform(@file.path, @asset_params, true, response.class.to_s, response.id)
+  end
+
+  test "marks attachments belonging to consultation responses as access limited to organisations, when flag is on" do
+    @feature_flags.switch!(:access_limiting_organisations_ui, true)
+
+    access_limiting_organisation = create(:organisation)
+    consultation = FactoryBot.create(:consultation, organisations: [@organisation], access_limiting: "organisations", access_limiting_organisation_ids: [access_limiting_organisation.id])
+    response = FactoryBot.create(:consultation_outcome, consultation:)
+    FactoryBot.create(:file_attachment, attachable: response)
+
+    Services.asset_manager.expects(:create_asset).with(has_entry(access_limited_organisation_ids: [access_limiting_organisation.content_id])).returns(@asset_manager_response)
+
+    @job.perform(@file.path, @asset_params, true, response.class.to_s, response.id)
   end
 
   test "does not mark attachments belonging to policy groups as access limited" do

--- a/test/unit/app/sidekiq/asset_manager_create_asset_job_test.rb
+++ b/test/unit/app/sidekiq/asset_manager_create_asset_job_test.rb
@@ -12,11 +12,7 @@ class AssetManagerCreateAssetJobTest < ActiveSupport::TestCase
       "id" => "http://asset-manager/assets/#{@asset_manager_id}",
       "name" => File.basename(@file),
     }
-    @asset_params = {
-      assetable_id: @model_without_assets.id,
-      asset_variant: Asset.variants[:original],
-      assetable_type: @model_without_assets.class.to_s,
-    }.deep_stringify_keys
+    @asset_params = asset_params(@model_without_assets)
   end
 
   test "uploads an asset using a file object at the correct path" do
@@ -47,69 +43,83 @@ class AssetManagerCreateAssetJobTest < ActiveSupport::TestCase
     assert_not Dir.exist?(File.dirname(@file))
   end
 
-  test "marks attachments belonging to consultations as access limited to organisations" do
-    consultation = FactoryBot.create(:consultation, organisations: [@organisation], access_limiting: "organisations")
-    FactoryBot.create(:file_attachment, attachable: consultation)
+  test "marks attachments belonging to an edition attachable as access limited to organisations" do
+    attachable = FactoryBot.create(:consultation, organisations: [@organisation], access_limiting: "organisations")
+    file = FactoryBot.create(:file_attachment, attachable:)
+    assetable = file.attachment_data
 
     Services.asset_manager.expects(:create_asset).with(has_entry(access_limited_organisation_ids: [@organisation.content_id])).returns(@asset_manager_response)
 
-    @job.perform(@file.path, @asset_params, true, consultation.class.to_s, consultation.id)
+    @job.perform(@file.path, asset_params(assetable), true, attachable.class.to_s, attachable.id)
   end
 
-  test "marks attachments belonging to consultations as access limited to organisations, when flag is on" do
+  test "marks attachments belonging to an edition attachable as access limited to organisations, when flag is on" do
+    @feature_flags.switch!(:access_limiting_organisations_ui, true)
+
+    access_limiting_organisation = create(:organisation)
+    attachable = FactoryBot.create(:consultation, organisations: [@organisation], access_limiting: "organisations", access_limiting_organisation_ids: [access_limiting_organisation.id])
+    file = FactoryBot.create(:file_attachment, attachable:)
+    assetable = file.attachment_data
+
+    Services.asset_manager.expects(:create_asset).with(has_entry(access_limited_organisation_ids: [access_limiting_organisation.content_id])).returns(@asset_manager_response)
+
+    @job.perform(@file.path, asset_params(assetable), true, attachable.class.to_s, attachable.id)
+  end
+
+  test "marks attachments belonging to an outcome attachable as access limited to organisations" do
+    consultation = FactoryBot.create(:consultation, organisations: [@organisation], access_limiting: "organisations")
+    attachable = FactoryBot.create(:consultation_outcome, consultation:)
+    file = FactoryBot.create(:file_attachment, attachable:)
+    assetable = file.attachment_data
+
+    Services.asset_manager.expects(:create_asset).with(has_entry(access_limited_organisation_ids: [@organisation.content_id])).returns(@asset_manager_response)
+
+    @job.perform(@file.path, asset_params(assetable), true, attachable.class.to_s, attachable.id)
+  end
+
+  test "marks attachments belonging to an outcome attachable as access limited to organisations, when flag is on" do
     @feature_flags.switch!(:access_limiting_organisations_ui, true)
 
     access_limiting_organisation = create(:organisation)
     consultation = FactoryBot.create(:consultation, organisations: [@organisation], access_limiting: "organisations", access_limiting_organisation_ids: [access_limiting_organisation.id])
-    FactoryBot.create(:file_attachment, attachable: consultation)
+    attachable = FactoryBot.create(:consultation_outcome, consultation:)
+    file = FactoryBot.create(:file_attachment, attachable:)
+    assetable = file.attachment_data
 
     Services.asset_manager.expects(:create_asset).with(has_entry(access_limited_organisation_ids: [access_limiting_organisation.content_id])).returns(@asset_manager_response)
 
-    @job.perform(@file.path, @asset_params, true, consultation.class.to_s, consultation.id)
-  end
-
-  test "marks attachments belonging to consultation responses as access limited to organisations" do
-    consultation = FactoryBot.create(:consultation, organisations: [@organisation], access_limiting: "organisations")
-    response = FactoryBot.create(:consultation_outcome, consultation:)
-    FactoryBot.create(:file_attachment, attachable: response)
-
-    Services.asset_manager.expects(:create_asset).with(has_entry(access_limited_organisation_ids: [@organisation.content_id])).returns(@asset_manager_response)
-
-    @job.perform(@file.path, @asset_params, true, response.class.to_s, response.id)
-  end
-
-  test "marks attachments belonging to consultation responses as access limited to organisations, when flag is on" do
-    @feature_flags.switch!(:access_limiting_organisations_ui, true)
-
-    access_limiting_organisation = create(:organisation)
-    consultation = FactoryBot.create(:consultation, organisations: [@organisation], access_limiting: "organisations", access_limiting_organisation_ids: [access_limiting_organisation.id])
-    response = FactoryBot.create(:consultation_outcome, consultation:)
-    FactoryBot.create(:file_attachment, attachable: response)
-
-    Services.asset_manager.expects(:create_asset).with(has_entry(access_limited_organisation_ids: [access_limiting_organisation.content_id])).returns(@asset_manager_response)
-
-    @job.perform(@file.path, @asset_params, true, response.class.to_s, response.id)
+    @job.perform(@file.path, asset_params(assetable), true, attachable.class.to_s, attachable.id)
   end
 
   test "does not mark attachments belonging to policy groups as access limited" do
-    policy_group = FactoryBot.create(:policy_group)
-    attachment = FactoryBot.create(:file_attachment, attachable: policy_group)
-    attachment.attachment_data.attachable = policy_group
+    attachable = FactoryBot.create(:policy_group)
+    file = FactoryBot.create(:file_attachment, attachable:)
+    assetable = file.attachment_data
 
     Services.asset_manager.expects(:create_asset).with(Not(has_key(:access_limited))).returns(@asset_manager_response)
 
-    @job.perform(@file.path, @asset_params, true, policy_group.class.to_s, policy_group.id)
+    @job.perform(@file.path, asset_params(assetable), true, attachable.class.to_s, attachable.id)
   end
 
-  test "sends auth bypass ids to asset manager when these are passed through in the params" do
+  test "sends an edition attachable's auth bypass ids to asset manager when these are passed through in the params" do
+    attachable = FactoryBot.create(:consultation)
+    file = FactoryBot.create(:file_attachment, attachable:)
+    assetable = file.attachment_data
+
+    Services.asset_manager.expects(:create_asset).with(has_entry(auth_bypass_ids: [attachable.auth_bypass_id])).returns(@asset_manager_response)
+
+    @job.perform(@file.path, asset_params(assetable), true, attachable.class.to_s, attachable.id, assetable.auth_bypass_ids)
+  end
+
+  test "sends an outcome attachable's auth bypass ids to asset manager when these are passed through in the params" do
     consultation = FactoryBot.create(:consultation)
-    response = FactoryBot.create(:consultation_outcome, consultation:)
-    attachment = FactoryBot.create(:file_attachment, attachable: response)
-    attachment.attachment_data.attachable = consultation
+    attachable = FactoryBot.create(:consultation_outcome, consultation:)
+    file = FactoryBot.create(:file_attachment, attachable:)
+    assetable = file.attachment_data
 
     Services.asset_manager.expects(:create_asset).with(has_entry(auth_bypass_ids: [consultation.auth_bypass_id])).returns(@asset_manager_response)
 
-    @job.perform(@file.path, @asset_params, true, consultation.class.to_s, consultation.id, [consultation.auth_bypass_id])
+    @job.perform(@file.path, asset_params(assetable), true, attachable.class.to_s, attachable.id, assetable.auth_bypass_ids)
   end
 
   test "doesn't run if the file is missing (e.g. job ran twice)" do
@@ -244,5 +254,13 @@ class AssetManagerCreateAssetJobTest < ActiveSupport::TestCase
     Services.asset_manager.expects(:create_asset).never
 
     @job.perform(@file.path, @asset_params, true, consultation.class.to_s, consultation.id)
+  end
+
+  def asset_params(assetable)
+    {
+      assetable_id: assetable.id,
+      asset_variant: Asset.variants[:original],
+      assetable_type: assetable.class.to_s,
+    }.deep_stringify_keys
   end
 end

--- a/test/unit/app/sidekiq/asset_manager_create_asset_job_test.rb
+++ b/test/unit/app/sidekiq/asset_manager_create_asset_job_test.rb
@@ -1,6 +1,8 @@
 require "test_helper"
 
 class AssetManagerCreateAssetJobTest < ActiveSupport::TestCase
+  extend Minitest::Spec::DSL
+
   setup do
     @file = Tempfile.new("asset", Dir.mktmpdir)
     @job = AssetManagerCreateAssetJob.new
@@ -41,85 +43,6 @@ class AssetManagerCreateAssetJobTest < ActiveSupport::TestCase
 
     @job.perform(@file.path, @asset_params, false, @attachable.class.to_s, @attachable.id)
     assert_not Dir.exist?(File.dirname(@file))
-  end
-
-  test "marks attachments belonging to an edition attachable as access limited to organisations" do
-    attachable = FactoryBot.create(:consultation, organisations: [@organisation], access_limiting: "organisations")
-    file = FactoryBot.create(:file_attachment, attachable:)
-    assetable = file.attachment_data
-
-    Services.asset_manager.expects(:create_asset).with(has_entry(access_limited_organisation_ids: [@organisation.content_id])).returns(@asset_manager_response)
-
-    @job.perform(@file.path, asset_params(assetable), true, attachable.class.to_s, attachable.id)
-  end
-
-  test "marks attachments belonging to an edition attachable as access limited to organisations, when flag is on" do
-    @feature_flags.switch!(:access_limiting_organisations_ui, true)
-
-    access_limiting_organisation = create(:organisation)
-    attachable = FactoryBot.create(:consultation, organisations: [@organisation], access_limiting: "organisations", access_limiting_organisation_ids: [access_limiting_organisation.id])
-    file = FactoryBot.create(:file_attachment, attachable:)
-    assetable = file.attachment_data
-
-    Services.asset_manager.expects(:create_asset).with(has_entry(access_limited_organisation_ids: [access_limiting_organisation.content_id])).returns(@asset_manager_response)
-
-    @job.perform(@file.path, asset_params(assetable), true, attachable.class.to_s, attachable.id)
-  end
-
-  test "marks attachments belonging to an outcome attachable as access limited to organisations" do
-    consultation = FactoryBot.create(:consultation, organisations: [@organisation], access_limiting: "organisations")
-    attachable = FactoryBot.create(:consultation_outcome, consultation:)
-    file = FactoryBot.create(:file_attachment, attachable:)
-    assetable = file.attachment_data
-
-    Services.asset_manager.expects(:create_asset).with(has_entry(access_limited_organisation_ids: [@organisation.content_id])).returns(@asset_manager_response)
-
-    @job.perform(@file.path, asset_params(assetable), true, attachable.class.to_s, attachable.id)
-  end
-
-  test "marks attachments belonging to an outcome attachable as access limited to organisations, when flag is on" do
-    @feature_flags.switch!(:access_limiting_organisations_ui, true)
-
-    access_limiting_organisation = create(:organisation)
-    consultation = FactoryBot.create(:consultation, organisations: [@organisation], access_limiting: "organisations", access_limiting_organisation_ids: [access_limiting_organisation.id])
-    attachable = FactoryBot.create(:consultation_outcome, consultation:)
-    file = FactoryBot.create(:file_attachment, attachable:)
-    assetable = file.attachment_data
-
-    Services.asset_manager.expects(:create_asset).with(has_entry(access_limited_organisation_ids: [access_limiting_organisation.content_id])).returns(@asset_manager_response)
-
-    @job.perform(@file.path, asset_params(assetable), true, attachable.class.to_s, attachable.id)
-  end
-
-  test "does not mark attachments belonging to policy groups as access limited" do
-    attachable = FactoryBot.create(:policy_group)
-    file = FactoryBot.create(:file_attachment, attachable:)
-    assetable = file.attachment_data
-
-    Services.asset_manager.expects(:create_asset).with(Not(has_key(:access_limited))).returns(@asset_manager_response)
-
-    @job.perform(@file.path, asset_params(assetable), true, attachable.class.to_s, attachable.id)
-  end
-
-  test "sends an edition attachable's auth bypass ids to asset manager when these are passed through in the params" do
-    attachable = FactoryBot.create(:consultation)
-    file = FactoryBot.create(:file_attachment, attachable:)
-    assetable = file.attachment_data
-
-    Services.asset_manager.expects(:create_asset).with(has_entry(auth_bypass_ids: [attachable.auth_bypass_id])).returns(@asset_manager_response)
-
-    @job.perform(@file.path, asset_params(assetable), true, attachable.class.to_s, attachable.id, assetable.auth_bypass_ids)
-  end
-
-  test "sends an outcome attachable's auth bypass ids to asset manager when these are passed through in the params" do
-    consultation = FactoryBot.create(:consultation)
-    attachable = FactoryBot.create(:consultation_outcome, consultation:)
-    file = FactoryBot.create(:file_attachment, attachable:)
-    assetable = file.attachment_data
-
-    Services.asset_manager.expects(:create_asset).with(has_entry(auth_bypass_ids: [consultation.auth_bypass_id])).returns(@asset_manager_response)
-
-    @job.perform(@file.path, asset_params(assetable), true, attachable.class.to_s, attachable.id, assetable.auth_bypass_ids)
   end
 
   test "doesn't run if the file is missing (e.g. job ran twice)" do
@@ -254,6 +177,87 @@ class AssetManagerCreateAssetJobTest < ActiveSupport::TestCase
     Services.asset_manager.expects(:create_asset).never
 
     @job.perform(@file.path, @asset_params, true, consultation.class.to_s, consultation.id)
+  end
+
+  context "access limiting" do
+    test "marks attachments belonging to an edition attachable as access limited to organisations" do
+      attachable = FactoryBot.create(:consultation, organisations: [@organisation], access_limiting: "organisations")
+      file = FactoryBot.create(:file_attachment, attachable:)
+      assetable = file.attachment_data
+
+      Services.asset_manager.expects(:create_asset).with(has_entry(access_limited_organisation_ids: [@organisation.content_id])).returns(@asset_manager_response)
+
+      @job.perform(@file.path, asset_params(assetable), true, attachable.class.to_s, attachable.id)
+    end
+
+    test "marks attachments belonging to an edition attachable as access limited to organisations, when flag is on" do
+      @feature_flags.switch!(:access_limiting_organisations_ui, true)
+
+      access_limiting_organisation = create(:organisation)
+      attachable = FactoryBot.create(:consultation, organisations: [@organisation], access_limiting: "organisations", access_limiting_organisation_ids: [access_limiting_organisation.id])
+      file = FactoryBot.create(:file_attachment, attachable:)
+      assetable = file.attachment_data
+
+      Services.asset_manager.expects(:create_asset).with(has_entry(access_limited_organisation_ids: [access_limiting_organisation.content_id])).returns(@asset_manager_response)
+
+      @job.perform(@file.path, asset_params(assetable), true, attachable.class.to_s, attachable.id)
+    end
+
+    test "marks attachments belonging to an outcome attachable as access limited to organisations" do
+      consultation = FactoryBot.create(:consultation, organisations: [@organisation], access_limiting: "organisations")
+      attachable = FactoryBot.create(:consultation_outcome, consultation:)
+      file = FactoryBot.create(:file_attachment, attachable:)
+      assetable = file.attachment_data
+
+      Services.asset_manager.expects(:create_asset).with(has_entry(access_limited_organisation_ids: [@organisation.content_id])).returns(@asset_manager_response)
+
+      @job.perform(@file.path, asset_params(assetable), true, attachable.class.to_s, attachable.id)
+    end
+
+    test "marks attachments belonging to an outcome attachable as access limited to organisations, when flag is on" do
+      @feature_flags.switch!(:access_limiting_organisations_ui, true)
+
+      access_limiting_organisation = create(:organisation)
+      consultation = FactoryBot.create(:consultation, organisations: [@organisation], access_limiting: "organisations", access_limiting_organisation_ids: [access_limiting_organisation.id])
+      attachable = FactoryBot.create(:consultation_outcome, consultation:)
+      file = FactoryBot.create(:file_attachment, attachable:)
+      assetable = file.attachment_data
+
+      Services.asset_manager.expects(:create_asset).with(has_entry(access_limited_organisation_ids: [access_limiting_organisation.content_id])).returns(@asset_manager_response)
+
+      @job.perform(@file.path, asset_params(assetable), true, attachable.class.to_s, attachable.id)
+    end
+
+    test "does not mark attachments belonging to policy groups as access limited" do
+      attachable = FactoryBot.create(:policy_group)
+      file = FactoryBot.create(:file_attachment, attachable:)
+      assetable = file.attachment_data
+
+      Services.asset_manager.expects(:create_asset).with(Not(has_key(:access_limited))).returns(@asset_manager_response)
+
+      @job.perform(@file.path, asset_params(assetable), true, attachable.class.to_s, attachable.id)
+    end
+
+    test "sends an edition attachable's auth bypass ids to asset manager when these are passed through in the params" do
+      attachable = FactoryBot.create(:consultation)
+      file = FactoryBot.create(:file_attachment, attachable:)
+      assetable = file.attachment_data
+
+      Services.asset_manager.expects(:create_asset).with(has_entry(auth_bypass_ids: [attachable.auth_bypass_id])).returns(@asset_manager_response)
+
+      @job.perform(@file.path, asset_params(assetable), true, attachable.class.to_s, attachable.id, assetable.auth_bypass_ids)
+    end
+
+    test "sends an outcome attachable's auth bypass ids to asset manager when these are passed through in the params" do
+      consultation = FactoryBot.create(:consultation)
+      attachable = FactoryBot.create(:consultation_outcome, consultation:)
+      file = FactoryBot.create(:file_attachment, attachable:)
+      assetable = file.attachment_data
+
+      Services.asset_manager.expects(:create_asset).with(has_entry(auth_bypass_ids: [consultation.auth_bypass_id])).returns(@asset_manager_response)
+
+      @job.perform(@file.path, asset_params(assetable), true, attachable.class.to_s, attachable.id, assetable.auth_bypass_ids)
+    end
   end
 
   def asset_params(assetable)

--- a/test/unit/lib/asset_manager_access_limitation_test.rb
+++ b/test/unit/lib/asset_manager_access_limitation_test.rb
@@ -1,10 +1,17 @@
 require "test_helper"
 
 class AssetManagerAccessLimitationTest < ActiveSupport::TestCase
-  test "delegates to PublishingApi::PayloadBuilder::AccessLimitation to ask for users that can access item" do
+  test "for_organisations delegates to PublishingApi::PayloadBuilder::AccessLimitation" do
     edition = FactoryBot.build(:edition)
     access_limitation = { access_limited: { organisations: %w[org-1] } }
     PublishingApi::PayloadBuilder::AccessLimitation.stubs(:for).with(edition).returns(access_limitation)
-    assert_equal %w[org-1], AssetManagerAccessLimitation.for(edition)
+    assert_equal %w[org-1], AssetManagerAccessLimitation.for_organisations(edition)
+  end
+
+  test "for_individuals delegates to PublishingApi::PayloadBuilder::AccessLimitation" do
+    edition = FactoryBot.build(:edition)
+    access_limitation = { access_limited: { users: %w[user-1] } }
+    PublishingApi::PayloadBuilder::AccessLimitation.stubs(:for).with(edition).returns(access_limitation)
+    assert_equal %w[user-1], AssetManagerAccessLimitation.for_individuals(edition)
   end
 end

--- a/test/unit/lib/asset_manager_access_limitation_test.rb
+++ b/test/unit/lib/asset_manager_access_limitation_test.rb
@@ -1,17 +1,31 @@
 require "test_helper"
 
 class AssetManagerAccessLimitationTest < ActiveSupport::TestCase
-  test "for_organisations delegates to PublishingApi::PayloadBuilder::AccessLimitation" do
+  test ".for delegates to PublishingApi::PayloadBuilder::AccessLimitation for organisations access limiting" do
     edition = FactoryBot.build(:edition)
     access_limitation = { access_limited: { organisations: %w[org-1] } }
     PublishingApi::PayloadBuilder::AccessLimitation.stubs(:for).with(edition).returns(access_limitation)
-    assert_equal %w[org-1], AssetManagerAccessLimitation.for_organisations(edition)
+    assert_equal %w[org-1], AssetManagerAccessLimitation.for(edition, :organisations)
   end
 
-  test "for_individuals delegates to PublishingApi::PayloadBuilder::AccessLimitation" do
+  test ".for delegates to PublishingApi::PayloadBuilder::AccessLimitation for individuals access limiting" do
     edition = FactoryBot.build(:edition)
     access_limitation = { access_limited: { users: %w[user-1] } }
     PublishingApi::PayloadBuilder::AccessLimitation.stubs(:for).with(edition).returns(access_limitation)
-    assert_equal %w[user-1], AssetManagerAccessLimitation.for_individuals(edition)
+    assert_equal %w[user-1], AssetManagerAccessLimitation.for(edition, :users)
+  end
+
+  test ".for returns nil if no access limitation set for the type provided" do
+    edition = FactoryBot.build(:edition)
+    access_limitation = { access_limited: { other_key: "other_value" } }
+    PublishingApi::PayloadBuilder::AccessLimitation.stubs(:for).with(edition).returns(access_limitation)
+    assert_nil AssetManagerAccessLimitation.for(edition, :users)
+  end
+
+  test ".for returns nil if no access limitation found at all" do
+    edition = FactoryBot.build(:edition)
+    access_limitation = {}
+    PublishingApi::PayloadBuilder::AccessLimitation.stubs(:for).with(edition).returns(access_limitation)
+    assert_nil AssetManagerAccessLimitation.for(edition, :organisations)
   end
 end


### PR DESCRIPTION
## What & why

These changes ensure that access limitation is set on assets of `AttachmentData`s (the "assetable"), from organisations- and individuals-based access limitation at the edition (the "attachable") level.

Changes:
- Set the feature flags to true in integration so we can test the changes. Why: we use the flags in models, and the controller flipflop value does not reach there.
- Set asset access limitation to organisations when flag is on -> mainly required test coverage, as we tap into the pre-existing infrastructure for organisations; changes required for response-type attachables.
- Set asset access limitation to individuals when flag is on -> required changes to the creation and update steps in the asset lifecycle, including custom changes for response-type attachables.
- Add update service listeners to the "admin" access limiting controller, so that changes to access limitation also update assets downstream.
- Refactor the create job tests to make them clearer/more explicit. This is in preparation for future changes that might fix the responses "bug" identified.

## Testing

### Feature flags

- Flag default on in integration
- Flag NOT default on in staging

### Assets 

All editions below had assets - the permissions were checked against the assets.
- ✅ Remove and add AL organisations via the edition form - config driven + legacy editions
- ✅ Remove and add individuals via the edition form - config driven + legacy editions
- ✅ Change org access from admin view - config driven + legacy editions [found bug, now fixed in PR]
- ✅ Change individuals access from admin view - config driven + legacy [🐛bug found, see note above]
- ✅ Access limitation is removed on publish - config driven + legacy editions
- ✅ Asset update (e.g. attachment title change) -> maintains AL (tested orgs only)
- ✅ Asset Delete - no-op
- ✅ Asset Replacement -> redirects and new assets has AL (tested orgs only)
- ✅ Check some asset types that instantly download (ods) - AL works as expected for them too
- ✅ Check other types of attachables 
    - ✅ Consultation responses OK [bar the issue 🐞 detailed above]
    - 🔧 Cons response form data - don't work yet, work in progress on a different card
- ✅ Preview link -  still allows sidestepping the restrictions (for edition and assets)
     - 🤔 Once the cookie is set, I can access the pages even if the permissions is removed - which is probably expected, but I wonder when the cookies will expire.

## Bugs found

- 🚨 Removing individual emails and providing valid, but not "real" signon email instead, saves ok, blocks permissions in WH to removed emails, but does not send it downstream -> preview in draft is still accessible, and so are assets. If the replacement input contains at least one valid email, then it works.


[Jira](https://gov-uk.atlassian.net/browse/WHIT-3696)
