### PR TITLE
Add access-limiting test coverage for EditionRules and StandardEdition Rules [WHIT-3452]

### DIFF
--- a/test/unit/lib/whitehall/authority/edition_rules_test.rb
+++ b/test/unit/lib/whitehall/authority/edition_rules_test.rb
@@ -4,11 +4,15 @@ require "ostruct"
 class EditionRulesTest < ActiveSupport::TestCase
   include AuthorityTestHelper
 
-  def user_in(organisation)
+  def user_in(organisation, extra_attrs = {})
     OpenStruct.new(
-      id: 1,
-      gds_editor?: false,
-      organisation:,
+      {
+        id: 1,
+        gds_editor?: false,
+        gds_admin?: false,
+        can_unpublish_historic_content?: false,
+        organisation:,
+      }.merge(extra_attrs),
     )
   end
 
@@ -20,32 +24,105 @@ class EditionRulesTest < ActiveSupport::TestCase
     )
   end
 
-  test "grants access when user's organisation is in access_limiting_organisations and flag is on" do
+  def org
+    @org ||= build(:organisation)
+  end
+
+  def other_org
+    @other_org ||= build(:organisation)
+  end
+
+  def historic_access_limited_edition_by_orgs(limiting_orgs)
+    edition = build(:publication)
+    edition.stubs(:historic?).returns(true)
+    edition.stubs(:access_limiting_organisations?).returns(true)
+    edition.stubs(:access_limiting_organisations).returns(limiting_orgs)
+    edition.stubs(:organisations).returns(limiting_orgs)
+    edition
+  end
+
+  def historic_access_limited_edition_by_individuals(allowed_emails)
+    edition = build(:publication, access_limiting: "individuals")
+    edition.stubs(:historic?).returns(true)
+    edition.stubs(:access_limiting_individuals).returns(
+      allowed_emails.map { |email| OpenStruct.new(email:) },
+    )
+    edition
+  end
+
+  def historic_unrestricted_edition
+    edition = build(:edition)
+    edition.stubs(:historic?).returns(true)
+    edition.stubs(:access_limiting_organisations?).returns(false)
+    edition
+  end
+
+  test "grants access based on lead/supporting organisations when flag is OFF" do
+    user = user_in(org)
+    edition = build(:consultation, access_limiting: "organisations")
+    edition.stubs(:historic?).returns(false)
+    edition.stubs(:access_limiting_organisations?).returns(true)
+    edition.stubs(:access_limiting_organisations).returns([other_org])
+    edition.stubs(:organisations).returns([org])
+
+    assert enforcer_for(user, edition).can?(:see)
+  end
+
+  test "revokes access based on lead/supporting organisations when flag is OFF" do
+    user = user_in(org)
+    edition = build(:consultation, access_limiting: "organisations")
+    edition.stubs(:historic?).returns(false)
+    edition.stubs(:access_limiting_organisations?).returns(true)
+    edition.stubs(:access_limiting_organisations).returns([other_org])
+    edition.stubs(:organisations).returns([other_org])
+
+    assert_not enforcer_for(user, edition).can?(:see)
+  end
+
+  test "grants access when access limiting is 'none'" do
+    user = user_in(org)
+    edition = build(:edition, access_limiting: "none")
+    edition.stubs(:historic?).returns(false)
+    edition.stubs(:access_limiting_organisations?).returns(false)
+
+    assert enforcer_for(user, edition).can?(:see)
+  end
+
+  test "revokes access when the user does not have an organisation, and flag is OFF" do
+    user = user_in(nil)
+    edition = build(:consultation, access_limiting: "organisations")
+    edition.stubs(:historic?).returns(false)
+    edition.stubs(:access_limiting_organisations?).returns(true)
+    edition.stubs(:organisations).returns([org])
+
+    assert_not enforcer_for(user, edition).can?(:see)
+  end
+
+  test "grants access when user's organisation is in access_limiting_organisations and flag is ON" do
     feature_flags.switch! :access_limiting_organisations_ui, true
 
-    org = build(:organisation)
     user = user_in(org)
-
     edition = build(:edition, access_limiting: "organisations")
+    edition.stubs(:historic?).returns(false)
+    edition.stubs(:access_limiting_organisations?).returns(true)
     edition.stubs(:access_limiting_organisations).returns([org])
 
     assert enforcer_for(user, edition).can?(:see)
   end
 
-  test "revokes access when the user's organisation is not in access_limiting_organisations and flag is on" do
+  test "revokes access when the user's organisation is not in access_limiting_organisations and flag is ON" do
     feature_flags.switch! :access_limiting_organisations_ui, true
 
-    org1 = build(:organisation)
-    org2 = build(:organisation)
-    user = user_in(org1)
-
+    user = user_in(org)
     edition = build(:edition, access_limiting: "organisations")
-    edition.stubs(:access_limiting_organisations).returns([org2])
+    edition.stubs(:historic?).returns(false)
+    edition.stubs(:access_limiting_organisations?).returns(true)
+    edition.stubs(:access_limiting_organisations).returns([other_org])
 
     assert_not enforcer_for(user, edition).can?(:see)
   end
 
-  test "grants access when user's email is in access_limiting_individuals and flag is on" do
+  test "grants access when user's email is in access_limiting_individuals and flag is ON" do
     feature_flags.switch! :access_limiting_individuals_ui, true
 
     user = user_with_email("user@example.com")
@@ -56,7 +133,7 @@ class EditionRulesTest < ActiveSupport::TestCase
     assert enforcer_for(user, edition).can?(:see)
   end
 
-  test "grants access when user's email matches an access_limiting_individual case-insensitively and flag is on" do
+  test "grants access when user's email matches an access_limiting_individual case-insensitively and flag is ON" do
     feature_flags.switch! :access_limiting_individuals_ui, true
 
     user = user_with_email("user@example.com")
@@ -67,7 +144,7 @@ class EditionRulesTest < ActiveSupport::TestCase
     assert enforcer_for(user, edition).can?(:see)
   end
 
-  test "revokes access when user's email is not in access_limiting_individuals and flag is on" do
+  test "revokes access when user's email is not in access_limiting_individuals and flag is ON" do
     feature_flags.switch! :access_limiting_individuals_ui, true
 
     user = user_with_email("user@example.com")
@@ -78,72 +155,31 @@ class EditionRulesTest < ActiveSupport::TestCase
     assert_not enforcer_for(user, edition).can?(:see)
   end
 
-  test "grants access based on lead/supporting organisations when flag is off" do
-    org1 = build(:organisation)
-    org2 = build(:organisation)
-    user = user_in(org1)
-
-    edition = build(:consultation, access_limiting: "organisations")
-    edition.stubs(:organisations).returns([org1])
-    edition.stubs(:access_limiting_organisations).returns([org2])
-
-    assert enforcer_for(user, edition).can?(:see)
-  end
-
-  test "revokes access based on lead/supporting organisations when flag is off" do
-    org1 = build(:organisation)
-    org2 = build(:organisation)
-    user = user_in(org1)
-
-    edition = build(:consultation, access_limiting: "organisations")
-    edition.stubs(:organisations).returns([org2])
-
-    assert_not enforcer_for(user, edition).can?(:see)
-  end
-
-  test "grants access when access limiting is 'none'" do
-    edition = build(:edition, access_limiting: "none")
-    user = create(:user)
-
-    assert enforcer_for(user, edition).can?(:see)
-  end
-
-  test "revokes access when the user does not have an organisation, and flag is on" do
+  test "revokes access when the user does not have an organisation, and flag is ON" do
     feature_flags.switch! :access_limiting_organisations_ui, true
 
-    org = build(:organisation)
-    user = create(:user, organisation: nil)
-
+    user = user_in(nil)
     edition = build(:edition, access_limiting: "organisations")
+    edition.stubs(:historic?).returns(false)
+    edition.stubs(:access_limiting_organisations?).returns(true)
     edition.stubs(:access_limiting_organisations).returns([org])
 
     assert_not enforcer_for(user, edition).can?(:see)
   end
 
-  test "revokes access when the user does not have an organisation, and flag is off" do
-    org = create(:organisation)
-    user = create(:user, organisation: nil)
-
-    edition = build(:consultation, access_limiting: "organisations")
-    edition.stubs(:organisations).returns([org])
-
-    assert_not enforcer_for(user, edition).can?(:see)
-  end
-
-  test "revokes access when access_limiting it set to 'organisations', but there are no access_limiting_organisations on the edition, and flag is on" do
-    #  Special case to cover migration issues. In the latest validation this scenario is not really feasible.
+  test "revokes access when access_limiting is 'organisations' but access_limiting_organisations is empty, and flag is ON" do
     feature_flags.switch! :access_limiting_organisations_ui, true
 
-    org1 = build(:organisation)
-    user = user_in(org1)
-
+    user = user_in(org)
     edition = build(:edition, access_limiting: "organisations")
+    edition.stubs(:historic?).returns(false)
+    edition.stubs(:access_limiting_organisations?).returns(true)
     edition.stubs(:access_limiting_organisations).returns([])
 
     assert_not enforcer_for(user, edition).can?(:see)
   end
 
-  test "revokes access when access_limiting it set to 'individuals', but there are no access_limiting_individuals on the edition, and flag is on" do
+  test "revokes access when access_limiting it set to 'individuals', but there are no access_limiting_individuals on the edition, and flag is ON" do
     #  Special case to cover migration issues. In the latest validation this scenario is not really feasible.
     feature_flags.switch! :access_limiting_individuals_ui, true
 
@@ -154,5 +190,209 @@ class EditionRulesTest < ActiveSupport::TestCase
     edition.stubs(:access_limiting_individuals).returns([])
 
     assert_not enforcer_for(user, edition).can?(:see)
+  end
+
+  test "any user can :see a historic edition that is not access-limited" do
+    user = user_in(org)
+    assert enforcer_for(user, historic_unrestricted_edition).can?(:see)
+  end
+
+  test "a regular user cannot :update a historic edition that is not access-limited" do
+    user = user_in(org)
+    assert_not enforcer_for(user, historic_unrestricted_edition).can?(:update)
+  end
+
+  test "a GDS Editor can :update a historic edition that is not access-limited" do
+    user = user_in(org, gds_editor?: true)
+    assert enforcer_for(user, historic_unrestricted_edition).can?(:update)
+  end
+
+  test "a GDS Admin can :update a historic edition that is not access-limited" do
+    user = user_in(org, gds_admin?: true)
+    assert enforcer_for(user, historic_unrestricted_edition).can?(:update)
+  end
+
+  test "a Historic Content Unpublisher can :unpublish a historic edition that is not access-limited" do
+    user = user_in(org, can_unpublish_historic_content?: true)
+    assert enforcer_for(user, historic_unrestricted_edition).can?(:unpublish)
+  end
+
+  test "a regular user cannot :unpublish a historic edition that is not access-limited" do
+    user = user_in(org)
+    assert_not enforcer_for(user, historic_unrestricted_edition).can?(:unpublish)
+  end
+
+  test "a user in the limiting org can :see an access-limited historic edition" do
+    user = user_in(org)
+    assert enforcer_for(user, historic_access_limited_edition_by_orgs([org])).can?(:see)
+  end
+
+  test "a user NOT in the limiting org cannot :see an access-limited historic edition" do
+    user = user_in(org)
+    assert_not enforcer_for(user, historic_access_limited_edition_by_orgs([other_org])).can?(:see)
+  end
+
+  test "a user NOT in the limiting org cannot perform ANY action on an access-limited historic edition" do
+    user = user_in(org)
+    edition = historic_access_limited_edition_by_orgs([other_org])
+    enforcer = enforcer_for(user, edition)
+
+    Whitehall::Authority::Rules::EditionRules.actions.each do |action|
+      assert_not enforcer.can?(action),
+                 "expected user outside limiting org to be denied :#{action} on access-limited historic edition"
+    end
+  end
+
+  test "a GDS Editor outside the limiting org cannot :see an access-limited historic edition" do
+    user = user_in(org, gds_editor?: true)
+    assert_not enforcer_for(user, historic_access_limited_edition_by_orgs([other_org])).can?(:see)
+  end
+
+  test "a GDS Admin outside the limiting org cannot :see an access-limited historic edition" do
+    user = user_in(org, gds_admin?: true)
+    assert_not enforcer_for(user, historic_access_limited_edition_by_orgs([other_org])).can?(:see)
+  end
+
+  test "a GDS Editor inside the limiting org can :update an access-limited historic edition" do
+    user = user_in(org, gds_editor?: true)
+    assert enforcer_for(user, historic_access_limited_edition_by_orgs([org])).can?(:update)
+  end
+
+  test "a GDS Admin inside the limiting org can :update an access-limited historic edition" do
+    user = user_in(org, gds_admin?: true)
+    assert enforcer_for(user, historic_access_limited_edition_by_orgs([org])).can?(:update)
+  end
+
+  test "a Historic Content Unpublisher inside the limiting org can :unpublish an access-limited historic edition" do
+    user = user_in(org, can_unpublish_historic_content?: true)
+    assert enforcer_for(user, historic_access_limited_edition_by_orgs([org])).can?(:unpublish)
+  end
+
+  test "a Historic Content Unpublisher NOT in the limiting org cannot :unpublish an access-limited historic edition" do
+    user = user_in(org, can_unpublish_historic_content?: true)
+    assert_not enforcer_for(user, historic_access_limited_edition_by_orgs([other_org])).can?(:unpublish)
+  end
+
+  test "a user NOT in access_limiting_organisations cannot :see an access-limited historic edition when flag is ON" do
+    feature_flags.switch! :access_limiting_organisations_ui, true
+
+    user = user_in(org)
+    edition = build(:published_edition, force_published: true)
+    edition.stubs(:historic?).returns(true)
+    edition.stubs(:access_limiting_organisations?).returns(true)
+    edition.stubs(:access_limiting_organisations).returns([other_org])
+
+    assert_not enforcer_for(user, edition).can?(:see)
+  end
+
+  test "a user in access_limiting_organisations can :see an access-limited historic edition when flag is ON" do
+    feature_flags.switch! :access_limiting_organisations_ui, true
+
+    user = user_in(org)
+    edition = build(:published_edition, force_published: true)
+    edition.stubs(:historic?).returns(true)
+    edition.stubs(:access_limiting_organisations?).returns(true)
+    edition.stubs(:access_limiting_organisations).returns([org])
+
+    assert enforcer_for(user, edition).can?(:see)
+  end
+
+  test "a user outside the limiting org cannot perform ANY action on a non-historic access-limited edition when flag is OFF" do
+    user = user_in(other_org)
+    edition = build(:consultation, access_limiting: "organisations")
+    edition.stubs(:historic?).returns(false)
+    edition.stubs(:access_limiting_organisations?).returns(true)
+    edition.stubs(:organisations).returns([org])
+
+    enforcer = enforcer_for(user, edition)
+    Whitehall::Authority::Rules::EditionRules.actions.each do |action|
+      assert_not enforcer.can?(action),
+                 "expected user outside limiting org to be denied :#{action} on access-limited edition when flag is OFF"
+    end
+  end
+
+  test "a user outside the limiting org cannot perform ANY action on a non-historic access-limited edition when flag is ON" do
+    feature_flags.switch! :access_limiting_organisations_ui, true
+
+    user = user_in(other_org)
+    edition = build(:edition, access_limiting: "organisations")
+    edition.stubs(:historic?).returns(false)
+    edition.stubs(:access_limiting_organisations?).returns(true)
+    edition.stubs(:access_limiting_organisations).returns([org])
+
+    enforcer = enforcer_for(user, edition)
+    Whitehall::Authority::Rules::EditionRules.actions.each do |action|
+      assert_not enforcer.can?(action), "expected user outside limiting org to be denied :#{action} on access-limited edition when flag is ON"
+    end
+  end
+
+  test "a user NOT in access_limiting_individuals cannot perform ANY action on a non-historic edition when flag is ON" do
+    feature_flags.switch! :access_limiting_individuals_ui, true
+
+    user = user_with_email("outsider@example.com")
+    edition = build(:edition, access_limiting: "individuals")
+    edition.stubs(:historic?).returns(false)
+    edition.stubs(:access_limiting_individuals).returns([OpenStruct.new(email: "insider@example.com")])
+
+    enforcer = enforcer_for(user, edition)
+    Whitehall::Authority::Rules::EditionRules.actions.each do |action|
+      assert_not enforcer.can?(action), "expected user not in access_limiting_individuals to be denied :#{action}"
+    end
+  end
+
+  test "when the access_limiting_individuals_ui flag is OFF, individuals mode does not enforce access" do
+    user = user_with_email("anyone@example.com")
+    edition = build(:edition, access_limiting: "individuals")
+    edition.stubs(:historic?).returns(false)
+    edition.stubs(:access_limiting_organisations?).returns(false)
+
+    assert enforcer_for(user, edition).can?(:see)
+  end
+
+  test "a user whose email is in access_limiting_individuals can see a historic edition when flag is ON" do
+    feature_flags.switch! :access_limiting_individuals_ui, true
+
+    user = user_with_email("insider@example.com")
+    assert enforcer_for(user, historic_access_limited_edition_by_individuals(["insider@example.com"])).can?(:see)
+  end
+
+  test "a user whose email is NOT in access_limiting_individuals cannot :see a historic edition when flag is ON" do
+    feature_flags.switch! :access_limiting_individuals_ui, true
+
+    user = user_with_email("outsider@example.com")
+    assert_not enforcer_for(user, historic_access_limited_edition_by_individuals(["insider@example.com"])).can?(:see)
+  end
+
+  test "a user NOT in access_limiting_individuals cannot perform ANY action on a historic edition when flag is ON" do
+    feature_flags.switch! :access_limiting_individuals_ui, true
+
+    user = user_with_email("outsider@example.com")
+    edition = historic_access_limited_edition_by_individuals(["insider@example.com"])
+
+    enforcer = enforcer_for(user, edition)
+    Whitehall::Authority::Rules::EditionRules.actions.each do |action|
+      assert_not enforcer.can?(action), "expected user not in access_limiting_individuals to be denied :#{action} on access-limited historic edition"
+    end
+  end
+
+  test "a GDS Editor whose email is NOT in access_limiting_individuals cannot :see a historic edition when flag is ON" do
+    feature_flags.switch! :access_limiting_individuals_ui, true
+
+    user = user_in(org, gds_editor?: true, email: "gds@example.com")
+    assert_not enforcer_for(user, historic_access_limited_edition_by_individuals(["insider@example.com"])).can?(:see)
+  end
+
+  test "a GDS Admin whose email is NOT in access_limiting_individuals cannot :see a historic edition when flag is ON" do
+    feature_flags.switch! :access_limiting_individuals_ui, true
+
+    user = user_in(org, gds_admin?: true, email: "gds@example.com")
+    assert_not enforcer_for(user, historic_access_limited_edition_by_individuals(["insider@example.com"])).can?(:see)
+  end
+
+  test "a GDS Editor whose email is in access_limiting_individuals can :update a historic edition when flag is ON" do
+    feature_flags.switch! :access_limiting_individuals_ui, true
+
+    user = user_in(org, gds_editor?: true, email: "gds@example.com")
+    assert enforcer_for(user, historic_access_limited_edition_by_individuals(["gds@example.com"])).can?(:update)
   end
 end

--- a/test/unit/lib/whitehall/authority/gds_admin_test.rb
+++ b/test/unit/lib/whitehall/authority/gds_admin_test.rb
@@ -52,4 +52,36 @@ class GDSAdminTest < ActiveSupport::TestCase
   test "can delete social media accounts" do
     assert enforcer_for(gds_admin, build(:social_media_account)).can?(:delete)
   end
+
+  test "cannot do anything to an access-limited historic edition if not in the limiting org" do
+    org = build(:organisation)
+    other_org = build(:organisation)
+    user = gds_admin
+    user.stubs(:organisation).returns(org)
+
+    edition = build(:publication, :published)
+    edition.stubs(:historic?).returns(true)
+    edition.stubs(:access_limiting_organisations?).returns(true)
+    edition.stubs(:access_limiting_organisations).returns([other_org])
+    edition.stubs(:organisations).returns([other_org])
+
+    Whitehall::Authority::Rules::EditionRules.actions.each do |action|
+      assert_not enforcer_for(user, edition).can?(action),
+                 "expected gds_admin outside limiting org to be denied :#{action} on access-limited historic edition"
+    end
+  end
+
+  test "can :see an access-limited historic edition if in the limiting org" do
+    org = build(:organisation)
+    user = gds_admin
+    user.stubs(:organisation).returns(org)
+
+    edition = build(:publication, :published)
+    edition.stubs(:historic?).returns(true)
+    edition.stubs(:access_limiting_organisations?).returns(true)
+    edition.stubs(:access_limiting_organisations).returns([org])
+    edition.stubs(:organisations).returns([org])
+
+    assert enforcer_for(user, edition).can?(:see)
+  end
 end

--- a/test/unit/lib/whitehall/authority/gds_editor_test.rb
+++ b/test/unit/lib/whitehall/authority/gds_editor_test.rb
@@ -174,4 +174,36 @@ class GDSEditorTest < ActiveSupport::TestCase
   test "can delete social media accounts" do
     assert enforcer_for(gds_editor, build(:social_media_account)).can?(:delete)
   end
+
+  test "cannot do anything to an access-limited historic edition if not in the limiting org" do
+    org = build(:organisation)
+    other_org = build(:organisation)
+    user = gds_editor
+    user.stubs(:organisation).returns(org)
+
+    edition = build(:publication, :published)
+    edition.stubs(:historic?).returns(true)
+    edition.stubs(:access_limiting_organisations?).returns(true)
+    edition.stubs(:access_limiting_organisations).returns([other_org])
+    edition.stubs(:organisations).returns([other_org])
+
+    Whitehall::Authority::Rules::EditionRules.actions.each do |action|
+      assert_not enforcer_for(user, edition).can?(action),
+                 "expected gds_editor outside limiting org to be denied :#{action} on access-limited historic edition"
+    end
+  end
+
+  test "can :see an access-limited historic edition if in the limiting org" do
+    org = build(:organisation)
+    user = gds_editor
+    user.stubs(:organisation).returns(org)
+
+    edition = build(:publication, :published)
+    edition.stubs(:historic?).returns(true)
+    edition.stubs(:access_limiting_organisations?).returns(true)
+    edition.stubs(:access_limiting_organisations).returns([org])
+    edition.stubs(:organisations).returns([org])
+
+    assert enforcer_for(user, edition).can?(:see)
+  end
 end

--- a/test/unit/lib/whitehall/authority/standard_edition_rules_test.rb
+++ b/test/unit/lib/whitehall/authority/standard_edition_rules_test.rb
@@ -3,74 +3,265 @@ require "test_helper"
 class StandardEditionRulesTest < ActiveSupport::TestCase
   setup do
     @organisation = create(:organisation)
-    @type_key = "test_type"
-    @no_organisations_type_key = "test_type_without_orgs"
-    test_types = {
+    @other_organisation = create(:organisation)
+
+    ConfigurableDocumentType.setup_test_types(
       "test_type" => {
-        "key" => @type_key,
+        "key" => "test_type",
         "title" => "Test type",
-        "schema" => {
-          "properties" => {
-            "test_attribute" => {
-              "title" => "Test attribute",
-              "type" => "string",
-            },
-          },
-        },
-        "settings" => {
-          "organisations" => [@organisation.content_id],
-        },
+        "schema" => { "properties" => { "test_attribute" => { "title" => "Test attribute", "type" => "string" } } },
+        "settings" => { "organisations" => [@organisation.content_id] },
       },
       "test_type_without_orgs" => {
-        "key" => @no_organisations_type_key,
+        "key" => "test_type_without_orgs",
         "title" => "Test type without orgs",
-        "schema" => {
-          "properties" => {
-            "test_attribute" => {
-              "title" => "Test attribute",
-              "type" => "string",
-            },
-          },
-        },
-        "settings" => {
-          "organisations" => nil,
-        },
+        "schema" => { "properties" => { "test_attribute" => { "title" => "Test attribute", "type" => "string" } } },
+        "settings" => { "organisations" => nil },
       },
-    }
-    ConfigurableDocumentType.setup_test_types(test_types)
+    )
+  end
+
+  def gds_editor_in(organisation)
+    OpenStruct.new(id: 1, gds_editor?: true, gds_admin?: false, organisation:)
+  end
+
+  def user_with_email(email, organisation:)
+    OpenStruct.new(
+      id: 1,
+      gds_editor?: false,
+      gds_admin?: false,
+      can_unpublish_historic_content?: false,
+      organisation:,
+      email:,
+    )
+  end
+
+  def historic_standard_edition
+    page = build(:standard_edition, configurable_document_type: "test_type")
+    page.stubs(:historic?).returns(true)
+    page.stubs(:access_limiting_organisations?).returns(false)
+    page
+  end
+
+  def historic_access_limited_standard_edition_by_orgs(limiting_orgs)
+    page = build(:standard_edition, configurable_document_type: "test_type")
+    page.stubs(:historic?).returns(true)
+    page.stubs(:access_limiting_organisations?).returns(true)
+    page.stubs(:access_limiting_organisations).returns(limiting_orgs)
+    page.stubs(:organisations).returns(limiting_orgs)
+    page
+  end
+
+  def historic_access_limited_standard_edition_by_individuals(allowed_emails)
+    page = build(:standard_edition, configurable_document_type: "test_type", access_limiting: "individuals")
+    page.stubs(:historic?).returns(true)
+    page.stubs(:access_limiting_individuals?).returns(true)
+    page.stubs(:access_limiting_individuals).returns(
+      allowed_emails.map { |email| OpenStruct.new(email:) },
+    )
+    page
   end
 
   test "user can see an edition if the document type is managed by their organisation" do
     user = User.new(organisation: @organisation)
-    page = build(:standard_edition, { configurable_document_type: @type_key })
+    page = build(:standard_edition, configurable_document_type: "test_type")
     assert Whitehall::Authority::Enforcer.new(user, page).can?(:see)
   end
 
-  test "user can not see an edition if the document type is not managed by their organisation" do
-    user = User.new(organisation: create(:organisation))
-    page = build(:standard_edition, { configurable_document_type: @type_key })
+  test "user cannot see an edition if the document type is not managed by their organisation" do
+    user = User.new(organisation: @other_organisation)
+    page = build(:standard_edition, configurable_document_type: "test_type")
     assert_not Whitehall::Authority::Enforcer.new(user, page).can?(:see)
   end
 
   test "normal edition rules are applied for actions requiring higher privileges" do
     user = User.new(organisation: @organisation)
-    page = build(:standard_edition, { configurable_document_type: @type_key })
+    page = build(:standard_edition, configurable_document_type: "test_type")
     assert_not Whitehall::Authority::Enforcer.new(user, page).can?(:force_publish)
   end
 
   test "normal edition rules are applied when the document type is not limited to specific organisations" do
-    user = User.new(organisation: create(:organisation))
-    page = build(:standard_edition, { configurable_document_type: @no_organisations_type_key })
+    user = User.new(organisation: @other_organisation)
+    page = build(:standard_edition, configurable_document_type: "test_type_without_orgs")
     assert Whitehall::Authority::Enforcer.new(user, page).can?(:see)
   end
 
   test "cannot do anything to an edition if they do not belong to a permitted organisation" do
-    user = User.new(organisation: create(:organisation))
-    page = build(:standard_edition, { configurable_document_type: @type_key })
+    user = User.new(organisation: @other_organisation)
+    page = build(:standard_edition, configurable_document_type: "test_type")
     enforcer = Whitehall::Authority::Enforcer.new(user, page)
 
     Whitehall::Authority::Rules::EditionRules.actions.each do |action|
-      assert_not enforcer.can?(action)
+      assert_not enforcer.can?(action),
+                 "expected user outside permitted org to be denied :#{action}"
     end
+  end
+
+  test "any user can :see a historic standard edition that is not access-limited" do
+    user = User.new(organisation: @other_organisation)
+    assert Whitehall::Authority::Enforcer.new(user, historic_standard_edition).can?(:see)
+  end
+
+  test "a regular user cannot :update a historic standard edition" do
+    user = create(:user, organisation: @organisation)
+    assert_not Whitehall::Authority::Enforcer.new(user, historic_standard_edition).can?(:update)
+  end
+
+  test "a GDS Editor can :update a historic standard edition" do
+    user = gds_editor_in(@organisation)
+    assert Whitehall::Authority::Enforcer.new(user, historic_standard_edition).can?(:update)
+  end
+
+  test "user inside the limiting org can :see an access-limited historic standard edition" do
+    user = User.new(organisation: @organisation)
+    assert Whitehall::Authority::Enforcer.new(
+      user, historic_access_limited_standard_edition_by_orgs([@organisation])
+    ).can?(:see)
+  end
+
+  test "user outside the limiting org cannot :see an access-limited historic standard edition" do
+    user = User.new(organisation: @other_organisation)
+    assert_not Whitehall::Authority::Enforcer.new(
+      user, historic_access_limited_standard_edition_by_orgs([@organisation])
+    ).can?(:see)
+  end
+
+  test "user outside the limiting org cannot perform any action on an access-limited historic standard edition" do
+    user = User.new(organisation: @other_organisation)
+    edition = historic_access_limited_standard_edition_by_orgs([@organisation])
+    enforcer = Whitehall::Authority::Enforcer.new(user, edition)
+
+    Whitehall::Authority::Rules::EditionRules.actions.each do |action|
+      assert_not enforcer.can?(action),
+                 "expected user outside limiting org to be denied :#{action} on access-limited historic standard edition"
+    end
+  end
+
+  test "a GDS Editor outside the limiting org cannot :see an access-limited historic standard edition" do
+    user = gds_editor_in(@other_organisation)
+    assert_not Whitehall::Authority::Enforcer.new(
+      user, historic_access_limited_standard_edition_by_orgs([@organisation])
+    ).can?(:see)
+  end
+
+  test "a GDS Editor inside the limiting org can :see an access-limited historic standard edition" do
+    user = gds_editor_in(@organisation)
+    assert Whitehall::Authority::Enforcer.new(
+      user, historic_access_limited_standard_edition_by_orgs([@organisation])
+    ).can?(:see)
+  end
+
+  test "user in access_limiting_organisations can :see a non-historic standard edition when flag is ON" do
+    feature_flags.switch! :access_limiting_organisations_ui, true
+
+    user = User.new(organisation: @organisation)
+    page = build(:standard_edition, configurable_document_type: "test_type", access_limiting: "organisations")
+    page.stubs(:historic?).returns(false)
+    page.stubs(:access_limiting_organisations?).returns(true)
+    page.stubs(:access_limiting_organisations).returns([@organisation])
+
+    assert Whitehall::Authority::Enforcer.new(user, page).can?(:see)
+  end
+
+  test "user NOT in access_limiting_organisations cannot :see a non-historic standard edition when flag is ON" do
+    feature_flags.switch! :access_limiting_organisations_ui, true
+
+    user = User.new(organisation: @organisation)
+    page = build(:standard_edition, configurable_document_type: "test_type", access_limiting: "organisations")
+    page.stubs(:historic?).returns(false)
+    page.stubs(:access_limiting_organisations?).returns(true)
+    page.stubs(:access_limiting_organisations).returns([@other_organisation])
+
+    assert_not Whitehall::Authority::Enforcer.new(user, page).can?(:see)
+  end
+
+  test "user whose email IS in access_limiting_individuals can :see a non-historic standard edition when flag is ON" do
+    feature_flags.switch! :access_limiting_individuals_ui, true
+
+    user = User.new(organisation: @organisation, email: "insider@example.com")
+    page = build(:standard_edition, configurable_document_type: "test_type", access_limiting: "individuals")
+    page.stubs(:historic?).returns(false)
+    page.stubs(:access_limiting_individuals).returns([OpenStruct.new(email: "insider@example.com")])
+
+    assert Whitehall::Authority::Enforcer.new(user, page).can?(:see)
+  end
+
+  test "user whose email is NOT in access_limiting_individuals cannot :see a non-historic standard edition when flag is ON" do
+    feature_flags.switch! :access_limiting_individuals_ui, true
+
+    user = User.new(organisation: @organisation, email: "outsider@example.com")
+    page = build(:standard_edition, configurable_document_type: "test_type", access_limiting: "individuals")
+    page.stubs(:historic?).returns(false)
+    page.stubs(:access_limiting_individuals).returns([OpenStruct.new(email: "insider@example.com")])
+
+    assert_not Whitehall::Authority::Enforcer.new(user, page).can?(:see)
+  end
+
+  test "user NOT in access_limiting_individuals cannot perform ANY action on a non-historic standard edition when flag is ON" do
+    feature_flags.switch! :access_limiting_individuals_ui, true
+
+    user = User.new(organisation: @organisation, email: "outsider@example.com")
+    page = build(:standard_edition, configurable_document_type: "test_type", access_limiting: "individuals")
+    page.stubs(:historic?).returns(false)
+    page.stubs(:access_limiting_individuals).returns([OpenStruct.new(email: "insider@example.com")])
+
+    enforcer = Whitehall::Authority::Enforcer.new(user, page)
+    Whitehall::Authority::Rules::EditionRules.actions.each do |action|
+      assert_not enforcer.can?(action),
+                 "expected user not in access_limiting_individuals to be denied :#{action} on standard edition"
+    end
+  end
+
+  test "user whose email is in access_limiting_individuals can :see a historic standard edition when flag is ON" do
+    feature_flags.switch! :access_limiting_individuals_ui, true
+
+    user = user_with_email("insider@example.com", organisation: @organisation)
+    assert Whitehall::Authority::Enforcer.new(
+      user,
+      historic_access_limited_standard_edition_by_individuals(["insider@example.com"]),
+    ).can?(:see)
+  end
+
+  test "user whose email is NOT in access_limiting_individuals cannot :see a historic standard edition when flag is ON" do
+    feature_flags.switch! :access_limiting_individuals_ui, true
+
+    user = user_with_email("outsider@example.com", organisation: @other_organisation)
+    assert_not Whitehall::Authority::Enforcer.new(
+      user,
+      historic_access_limited_standard_edition_by_individuals(["insider@example.com"]),
+    ).can?(:see)
+  end
+
+  test "user NOT in access_limiting_individuals cannot perform ANY action on a historic standard edition when flag is ON" do
+    feature_flags.switch! :access_limiting_individuals_ui, true
+
+    user = user_with_email("outsider@example.com", organisation: @other_organisation)
+    edition = historic_access_limited_standard_edition_by_individuals(["insider@example.com"])
+    enforcer = Whitehall::Authority::Enforcer.new(user, edition)
+
+    Whitehall::Authority::Rules::EditionRules.actions.each do |action|
+      assert_not enforcer.can?(action),
+                 "expected user not in access_limiting_individuals to be denied :#{action} on access-limited historic standard edition"
+    end
+  end
+
+  test "a GDS Editor NOT in access_limiting_individuals cannot :see a historic standard edition when flag is ON" do
+    feature_flags.switch! :access_limiting_individuals_ui, true
+
+    user = OpenStruct.new(id: 1, gds_editor?: true, gds_admin?: false, email: "gds@example.com", organisation: @organisation)
+    assert_not Whitehall::Authority::Enforcer.new(
+      user,
+      historic_access_limited_standard_edition_by_individuals(["insider@example.com"]),
+    ).can?(:see)
+  end
+
+  test "a GDS Editor whose email IS in access_limiting_individuals can :update a historic standard edition when flag is ON" do
+    feature_flags.switch! :access_limiting_individuals_ui, true
+
+    user = OpenStruct.new(id: 1, gds_editor?: true, gds_admin?: false, email: "gds@example.com", organisation: @organisation)
+    assert Whitehall::Authority::Enforcer.new(
+      user,
+      historic_access_limited_standard_edition_by_individuals(["gds@example.com"]),
+    ).can?(:update)
   end
 end


### PR DESCRIPTION
There were gaps in the test coverage for the access-limiting logic in Whitehall::Authority::Rules. This is as a result of a regression in August 2025 (see PR #11446) which caused access-limited editions to be visible to users who should not have had access, and there were no tests in place to catch it early.

What we've done:

- Added tests for every access-limiting mode (none, organisations, individuals) on both normal and historic editions, in EditionRulesTest and StandardEditionRulesTest
- "All actions denied" tests that iterate over every possible action in Edition Rules, so a future regression that skips the access check for any action will be caught early
- Coverage for the `access_limiting_individuals_ui` and `access_limiting_organisations_ui` feature flag being ON or OFF, including the fallback behaviour when the flag is OFF

### Access Limiting Rules 

| Mode | Who can see the content | Who is blocked |
|---|---|---|
| **No limit** | Everyone | Nobody |
| **Organisation limit** | Users whose department is on the access limiting organisations list | Users in any other department |
| **Individual limit** | Users whose email address is on the access limiting organisations list | Everyone else, regardless of their department |
| **Historic edition + Organisation limit** | Only users whose department is on the approved list | Everyone else, including GDS Editors and GDS Admins not on the list |
| **Historic edition + Individual limit** | Only users whose email is on the access limiting individuals list | Everyone else, including GDS Editors and GDS Admins not on the list |

**Note:** Special permission to Unpublish historic content can be granted via signon -> `key: Unpublish historic content` 

And hopefully, a glossary that makes sense to everyone:

| Term | Meaning |
|---|---|
| **Historic edition** | Published content from a previous government (document in history mode) |
| **Access limit** | A restriction placed on a piece of content so fewer people can view or edit |
| **Organisation limit** | Restricted to a team or department |
| **Individual limit** | Restrict to named person(s) (using their email addresses) |
| **GDS Editor / GDS Admin** | GDS team with some elevated access, but access limits override even their privileges |

[JIRA](https://gov-uk.atlassian.net/browse/WHIT-3452)

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
