### PR TITLE
[WHIT-3695] - Use human-readable label for access limiting org error

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -18,6 +18,7 @@ en:
       corporate_information_page/corporate_information_page_attachments/attachment/attachment_data:
         file: The attached file
       edition:
+        access_limiting_organisation_ids: Access limiting organisations
         html_attachments: HTML attachments
         nation_inapplicabilities: Excluded nations
       standard_edition:

--- a/test/functional/admin/edition_access_limited_controller_test.rb
+++ b/test/functional/admin/edition_access_limited_controller_test.rb
@@ -332,7 +332,7 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
           }
 
     assert_template :edit
-    assert_select ".govuk-error-summary a", text: "Access limiting organisation ids must include at least one organisation", href: "#access_limiting_organisation_ids"
+    assert_select ".govuk-error-summary a", text: "Access limiting organisations must include at least one organisation", href: "#access_limiting_organisation_ids"
     assert_select "form#edit_edition" do
       assert_select "input[name='edition[access_limiting]'][value='organisations'][checked=checked]"
       assert_select "select[name='edition[access_limiting_organisation_ids][]']" do

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -1035,7 +1035,7 @@ module AdminEditionControllerTestHelpers
         end
 
         assert_template :new
-        assert_select ".govuk-error-summary a", text: "Access limiting organisation ids must include at least one organisation", href: "#access_limiting_organisation_ids"
+        assert_select ".govuk-error-summary a", text: "Access limiting organisations must include at least one organisation", href: "#access_limiting_organisation_ids"
         assert_select "form#new_edition" do
           assert_select "input[name='edition[access_limiting]'][value='organisations'][checked=checked]"
           assert_select "select[name='edition[access_limiting_organisation_ids][]']" do
@@ -1092,7 +1092,7 @@ module AdminEditionControllerTestHelpers
         end
 
         assert_template :new
-        assert_select ".govuk-error-summary a", text: "Access limiting organisation ids must include your own organisation", href: "#access_limiting_organisation_ids"
+        assert_select ".govuk-error-summary a", text: "Access limiting organisations must include your own organisation", href: "#access_limiting_organisation_ids"
         assert_select "form#new_edition" do
           assert_select "input[name='edition[access_limiting]'][value='organisations'][checked=checked]"
           assert_select "select[name='edition[access_limiting_organisation_ids][]']" do
@@ -1191,7 +1191,7 @@ module AdminEditionControllerTestHelpers
             refute_select "option[selected='selected'][value='#{organisation.id}']"
           end
         end
-        assert_select ".govuk-error-summary a", text: "Access limiting organisation ids must include at least one organisation", href: "#access_limiting_organisation_ids"
+        assert_select ".govuk-error-summary a", text: "Access limiting organisations must include at least one organisation", href: "#access_limiting_organisation_ids"
         assert_equal "organisations", edition.reload.access_limiting
         assert edition.reload.access_limiting_organisations.exists?(id: organisation.id)
       end


### PR DESCRIPTION
The access limiting error summary showed the auto-humanised attribute name ("Access limiting organisation ids ..."). Obviously, the 'ids' part is not going to make sense to publishers, so this update sets a value in the locale ("Access limited organisations") so that it is more obvious what the issue is.