### PR TITLE
[WHIT-3721] Remove access limiting default logic

### DIFF
--- a/app/models/concerns/edition/limited_access.rb
+++ b/app/models/concerns/edition/limited_access.rb
@@ -8,7 +8,7 @@ module Edition::LimitedAccess
       none: "none",
       organisations: "organisations",
       individuals: "individuals",
-    }, prefix: true, default: nil
+    }, prefix: true
 
     has_many :edition_access_limiting_organisations,
              class_name: "AccessLimitingOrganisation",
@@ -26,7 +26,6 @@ module Edition::LimitedAccess
              validate: false,
              inverse_of: :edition
 
-    after_initialize :set_access_limited
     after_save :clear_pending_access_limiting_organisation_ids
 
     validate :access_limiting_organisations_required, if: -> { Flipflop.access_limiting_organisations_ui? && access_limiting_organisations? }
@@ -34,12 +33,6 @@ module Edition::LimitedAccess
     validate :access_limiting_must_include_current_user_email
     validate :access_limiting_individual_emails_required, if: -> { Flipflop.access_limiting_individuals_ui? && access_limiting_individuals? }
     validate :access_limiting_individual_emails_format, if: -> { Flipflop.access_limiting_individuals_ui? && access_limiting_individuals? }
-  end
-
-  module ClassMethods
-    def access_limited_by_default?
-      false
-    end
   end
 
   def access_limited_object
@@ -54,14 +47,6 @@ module Edition::LimitedAccess
   def access_limiting=(value)
     super
     self.access_limited = !access_limiting_none?
-  end
-
-  delegate :access_limited_by_default?, to: :class
-
-  def set_access_limited
-    return unless new_record? && access_limiting.nil?
-
-    self.access_limiting = access_limited_by_default? ? :organisations : :none
   end
 
   def accessible_to?(user)

--- a/app/models/plan_for_change_landing_page.rb
+++ b/app/models/plan_for_change_landing_page.rb
@@ -25,10 +25,6 @@ class PlanForChangeLandingPage < Edition
     slug
   end
 
-  def self.access_limited_by_default?
-    true
-  end
-
   def permitted_image_usages
     super + [
       ImageUsage.new(

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -94,13 +94,11 @@ class Publication < Edition
 
   def publication_type=(publication_type)
     self.publication_type_id = (publication_type && publication_type.id)
-    set_access_limited
     self.publication_type
   end
 
   def publication_type_id=(publication_type_id)
     super
-    set_access_limited
     self.publication_type_id
   end
 
@@ -114,14 +112,6 @@ class Publication < Edition
 
   def statistics?
     PublicationType.statistical.include?(publication_type)
-  end
-
-  def access_limited_by_default?
-    # Without a publication_type we can't correctly work out if we should
-    # be access_limited or not.  When we get a publication_type, we'll
-    # sort this out.  Happily, abesence of a publication_type invalidates
-    # us, so returning nil is ok even though it would break the SQL insert
-    publication_type.presence&.access_limited_by_default?
   end
 
   def translatable?

--- a/app/models/publication_type.rb
+++ b/app/models/publication_type.rb
@@ -30,11 +30,7 @@ class PublicationType
     1000 => "<p>DO NOT USE. This is a holding category for content that has been imported automatically.</p>",
   }.to_json.freeze
 
-  attr_accessor :id, :singular_name, :plural_name, :prevalence, :access_limited_by_default, :key
-
-  def self.access_limitable
-    all.select(&:access_limited_by_default?)
-  end
+  attr_accessor :id, :singular_name, :plural_name, :prevalence, :key
 
   def self.by_prevalence
     all.group_by(&:prevalence)
@@ -76,17 +72,13 @@ class PublicationType
     plural_name.downcase.gsub(/[^a-z]+/, "-")
   end
 
-  def access_limited_by_default?
-    access_limited_by_default == true
-  end
-
   PolicyPaper            = create!(id: 1, key: "policy_paper", singular_name: "Policy paper", plural_name: "Policy papers", prevalence: :primary)
   ImpactAssessment       = create!(id: 2, key: "impact_assessment", singular_name: "Impact assessment", plural_name: "Impact assessments", prevalence: :primary)
   Guidance               = create!(id: 3, key: "guidance", singular_name: "Guidance", plural_name: "Guidance", prevalence: :primary)
   StatutoryGuidance      = create!(id: 19, key: "statutory_guidance", singular_name: "Statutory guidance", plural_name: "Statutory guidance", prevalence: :primary)
   Form                   = create!(id: 4, key: "form", singular_name: "Form", plural_name: "Forms", prevalence: :primary)
-  OfficialStatistics     = create!(id: 5, key: "official_statistics", singular_name: "Official Statistics", plural_name: "Official Statistics", prevalence: :primary, access_limited_by_default: true)
-  NationalStatistics     = create!(id: 15, key: "national_statistics", singular_name: "Accredited Official Statistics", plural_name: "Accredited Official Statistics", prevalence: :primary, access_limited_by_default: true)
+  OfficialStatistics     = create!(id: 5, key: "official_statistics", singular_name: "Official Statistics", plural_name: "Official Statistics", prevalence: :primary)
+  NationalStatistics     = create!(id: 15, key: "national_statistics", singular_name: "Accredited Official Statistics", plural_name: "Accredited Official Statistics", prevalence: :primary)
   ResearchAndAnalysis    = create!(id: 6, key: "research", singular_name: "Research and analysis", plural_name: "Research and analysis", prevalence: :primary)
   CorporateReport        = create!(id: 7, key: "corporate_report", singular_name: "Corporate report", plural_name: "Corporate reports", prevalence: :primary)
   Map                    = create!(id: 17, key: "map", singular_name: "Map", plural_name: "Maps", prevalence: :primary)

--- a/app/models/statistical_data_set.rb
+++ b/app/models/statistical_data_set.rb
@@ -15,10 +15,6 @@ class StatisticalDataSet < Edition
     true
   end
 
-  def self.access_limited_by_default?
-    true
-  end
-
   def rendering_app
     Whitehall::RenderingApp::FRONTEND
   end

--- a/test/functional/admin/editorial_remarks_controller_test.rb
+++ b/test/functional/admin/editorial_remarks_controller_test.rb
@@ -16,7 +16,6 @@ class Admin::EditorialRemarksControllerTest < ActionController::TestCase
   end
 
   view_test "should render the editorial remark form for a statistical data set" do
-    StatisticalDataSet.stubs(access_limited_by_default?: false)
     edition = create(:draft_statistical_data_set, title: "edition-title", body: "edition-body")
     get :new, params: { edition_id: edition }
     assert_select "form#new_editorial_remark"

--- a/test/functional/admin/statistical_data_sets_controller_test.rb
+++ b/test/functional/admin/statistical_data_sets_controller_test.rb
@@ -2,7 +2,6 @@ require "test_helper"
 
 class Admin::StatisticalDataSetsControllerTest < ActionController::TestCase
   setup do
-    StatisticalDataSet.stubs(access_limited_by_default?: false)
     login_as :writer
   end
 

--- a/test/unit/app/models/edition/limited_access_test.rb
+++ b/test/unit/app/models/edition/limited_access_test.rb
@@ -8,32 +8,9 @@ class Edition::LimitedAccessTest < ActiveSupport::TestCase
     include Edition::Organisations
   end
 
-  class LimitedByDefaultEdition < LimitedAccessEdition
-    def self.access_limited_by_default?
-      true
-    end
-  end
-
   FactoryBot.define do
     factory :limited_access_edition, class: LimitedAccessEdition, parent: :edition_with_organisations do
     end
-    factory :limited_by_default_edition, class: LimitedByDefaultEdition, parent: :limited_access_edition do
-    end
-  end
-
-  test "sets access_limit on new instances according to class.access_limited_by_default?" do
-    assert_not build(:limited_access_edition).access_limited?
-    assert build(:limited_by_default_edition).access_limited?
-  end
-
-  test "can persist limited access flag (regardless of <class>.access_limited_by_default?)" do
-    e = build(:limited_by_default_edition)
-    e.access_limiting = "organisations"
-    e.save!
-    assert e.reload.access_limited?
-    e.access_limiting = "none"
-    e.save!
-    assert_not e.reload.access_limited?
   end
 
   test "#access_limited_object returns self" do
@@ -416,10 +393,6 @@ class Edition::LimitedAccessTest < ActiveSupport::TestCase
     assert edition.access_limited?
     assert_equal "individuals", edition.access_limiting
     assert_equal true, edition[:access_limited]
-  end
-
-  test "new instance of default-limited edition has access_limiting = 'organisations'" do
-    assert_equal "organisations", build(:limited_by_default_edition).access_limiting
   end
 
   test "access_limited? reads from access_limiting, not the legacy boolean" do

--- a/test/unit/app/models/publication_test.rb
+++ b/test/unit/app/models/publication_test.rb
@@ -112,32 +112,6 @@ class PublicationTest < ActiveSupport::TestCase
     assert_equal [feb], Publication.published_after("2011-01-29").to_a
   end
 
-  test "new instances are access_limited based on their publication_type" do
-    limit_by_default, dont_limit_by_default =
-      PublicationType.all.partition(&:access_limited_by_default?).map(&:first)
-
-    assert Publication.new(publication_type: limit_by_default).access_limited?
-    assert_not Publication.new(publication_type: dont_limit_by_default).access_limited?
-  end
-
-  test "new instances respect local access_limiting over their publication_type" do
-    limit_by_default, dont_limit_by_default = PublicationType.all.partition(&:access_limited_by_default?).map(&:first)
-    e = build(:draft_publication, publication_type: limit_by_default, access_limiting: "none")
-    assert_not e.access_limited?
-    e = build(:draft_publication, publication_type: dont_limit_by_default, access_limiting: "organisations")
-    assert e.access_limited?
-  end
-
-  test "existing instances don't change access_limiting when their publication_type does" do
-    limit_by_default, dont_limit_by_default = PublicationType.all.partition(&:access_limited_by_default?).map(&:first)
-    e = create(:draft_publication, access_limiting: "none")
-    e.publication_type = limit_by_default
-    assert_not e.access_limited?
-    e = create(:draft_publication, access_limiting: "organisations")
-    e.publication_type = dont_limit_by_default
-    assert e.access_limited?
-  end
-
   test "should be translatable" do
     publication = build(:draft_publication)
     assert publication.translatable?

--- a/test/unit/app/models/publication_type_test.rb
+++ b/test/unit/app/models/publication_type_test.rb
@@ -25,15 +25,4 @@ class PublicationTypeTest < ActiveSupport::TestCase
     assert_equal [primary, less_common, use_discouraged, migration],
                  PublicationType.ordered_by_prevalence
   end
-
-  test "should limit access by default for Official or National Statistics, but not other types" do
-    PublicationType.all.each do |type| # rubocop:disable Rails/FindEach
-      case type
-      when PublicationType::NationalStatistics, PublicationType::OfficialStatistics
-        assert type.access_limited_by_default?
-      else
-        assert_not type.access_limited_by_default?
-      end
-    end
-  end
 end

--- a/test/unit/app/models/statistical_data_set_test.rb
+++ b/test/unit/app/models/statistical_data_set_test.rb
@@ -7,21 +7,6 @@ class StatisticalDataSetTest < ActiveSupport::TestCase
     assert StatisticalDataSet.ancestors.include?(Edition::HasDocumentCollections)
   end
 
-  test "specifically limit access" do
-    data_set = build(:statistical_data_set, access_limiting: "organisations")
-    assert data_set.access_limited?
-  end
-
-  test "specifically do not limit access" do
-    data_set = build(:statistical_data_set, access_limiting: "none")
-    assert_not data_set.access_limited?
-  end
-
-  test "limit access by default" do
-    data_set = build(:statistical_data_set)
-    assert data_set.access_limited?
-  end
-
   test "specifies rendering app to be frontend" do
     statistical_data_set = StatisticalDataSet.new
     assert statistical_data_set.rendering_app.include?(Whitehall::RenderingApp::FRONTEND)


### PR DESCRIPTION
## What and why

The default access limitation applied to a few content types, getting set for new drafts and making them render with the access limitation checkbox already checked. Publishers were able to override the setting if they so wished. The content types that it applied to were: 
- two subtypes of Publication (official and national statistics)
- statistical data sets
- plan for change landing pages

This commit removes that behaviour entirely.

We had to keep the access limitation setter in the concern, as it sets the `none` value on the `access_limiting` field, which cannot be nil in the DB. The setter can only be removed once the field is dropped.

We have checked with content and there is no guidance for default access limitation. The logic has caused issues as we were implementing the new type of limitation (that uses custom organisations, different from lead/supporting organisations, and individual emails). Users previously able to edit content were suddenly locked out when redrafting it. It could be that as we touched the logic, we made it work as it was in the code's original intention. To address the support request, we've already had to remove the default limitation when redrafting a new edition anyway (in commit `86d65ff2`). This commit only cleans up the rest.

## Testing

| Topic | Before - Flag off | After - Flag off | Before - Flag on | After - Flag on | Comment
| --- | --- | --- | --- | --- | --- |
| Publication | <img width="582" height="103" alt="Pub before" src="https://github.com/user-attachments/assets/38817663-208a-490c-9023-0d7c4814c1e9" /> | <img width="582" height="103" alt="Pub after" src="https://github.com/user-attachments/assets/350b48a8-525f-4bbb-b474-e98ba70c2142" /> | <img width="582" height="158" alt="pub before with flag on" src="https://github.com/user-attachments/assets/d6af1f34-e2aa-4f1d-8963-c2a4c0cd3227" /> | <img width="582" height="115" alt="pub after with flag" src="https://github.com/user-attachments/assets/40db8db2-1b42-4502-bba7-60a3e2d5bb39" /> | Pretty much did not work before either |
| Statistical data set | <img width="582" height="109" alt="STDS no flag before" src="https://github.com/user-attachments/assets/5a473aab-72f6-4d44-8164-d853837f4056" /> | <img width="582" height="103" alt="STDS after no flag" src="https://github.com/user-attachments/assets/e9496630-246e-4909-9172-1d1acc1af079" /> | Permission error when trying to access before with org flag on | <img width="582" height="109" alt="STDS after" src="https://github.com/user-attachments/assets/f269725e-22c9-4f57-8d32-2db58ff94f36" /> | As expected, not setting the default flag anymore |
| Plan for change | - | - | - | - | - | Did not test |

## Bugs found

🚨 Permission error when trying to access the app (on main branch) with organisations feature flag on - when creating a statistical data set specifically. Pre-existing bug. It apepars that it is not a problem after these changes anymore, so maybe it was something to do with the default behaviour.

[Jira](https://gov-uk.atlassian.net/browse/WHIT-3721)
