### PR TITLE
Replace Twitter with X in social media options

### DIFF
--- a/app/models/configurable_document_types/topical_event.json
+++ b/app/models/configurable_document_types/topical_event.json
@@ -49,8 +49,8 @@
               "translatable": true,
               "options": [
                 {
-                  "label": "Twitter",
-                  "value": "Twitter"
+                  "label": "X",
+                  "value": "X"
                 },
                 {
                   "label": "Facebook",

--- a/app/models/social_media_account.rb
+++ b/app/models/social_media_account.rb
@@ -23,6 +23,9 @@ class SocialMediaAccount < ApplicationRecord
   end
 
   def display_name
-    title.presence || service_name
+    return title if title.present?
+    return "Follow us on X" if service_name == "X"
+
+    service_name
   end
 end

--- a/app/presenters/publishing_api/payload_builder/block_content.rb
+++ b/app/presenters/publishing_api/payload_builder/block_content.rb
@@ -47,9 +47,17 @@ module PublishingApi
           # `item` looks something like `{"url"=>"foo", "social_media_service_name"=>"Facebook", "title"=> "Optional title"}`
           service_name = item["social_media_service_name"]
           service_url = item["url"]
-          title = item["title"]
+
+          title = if item["title"].present?
+                    item["title"]
+                  elsif service_name.parameterize == "x"
+                    "Follow us on X"
+                  else
+                    service_name
+                  end
+
           {
-            title: title.presence || service_name,
+            title: title,
             service_type: service_name.parameterize, # "Google Plus" => "google-plus"
             href: service_url,
           }

--- a/db/data_migration/20260706153219_replace_twitter_with_x.rb
+++ b/db/data_migration/20260706153219_replace_twitter_with_x.rb
@@ -1,0 +1,1 @@
+SocialMediaService.where(name: "Twitter").update!(name: "X")

--- a/db/migrate/20260708150116_replace_twitter_with_x_on_topical_events.rb
+++ b/db/migrate/20260708150116_replace_twitter_with_x_on_topical_events.rb
@@ -1,0 +1,20 @@
+class ReplaceTwitterWithXOnTopicalEvents < ActiveRecord::Migration[8.1]
+  def change
+    update_social_media_links_sql = <<-SQL
+      UPDATE edition_translations et
+      JOIN editions e
+        ON et.edition_id = e.id
+      SET et.block_content = JSON_REPLACE(
+        et.block_content,
+        JSON_UNQUOTE(JSON_SEARCH(et.block_content, 'one', 'Twitter', NULL, '$.social_media_links[*].social_media_service_name')),
+        'X'
+      )
+      WHERE e.configurable_document_type = 'topical_event'
+        AND JSON_CONTAINS_PATH(et.block_content, 'one', '$.social_media_links')
+        AND JSON_SEARCH(et.block_content, 'one', 'Twitter') IS NOT NULL
+    SQL
+
+    updated_editions = ActiveRecord::Base.connection.update(update_social_media_links_sql)
+    Rails.logger.info "\nMigration completed. Social media link updated to X for #{updated_editions} editions."
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_26_080000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_08_150116) do
   create_table "access_limiting_individuals", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.integer "edition_id", null: false
@@ -1245,9 +1245,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_26_080000) do
     t.datetime "updated_at", precision: nil
   end
 
+  add_foreign_key "access_limiting_individuals", "editions"
   add_foreign_key "documents", "editions", column: "latest_edition_id", on_update: :cascade, on_delete: :nullify
   add_foreign_key "documents", "editions", column: "live_edition_id", on_update: :cascade, on_delete: :nullify
-  add_foreign_key "access_limiting_individuals", "editions"
   add_foreign_key "editions", "governments", on_delete: :nullify
   add_foreign_key "link_checker_api_report_links", "link_checker_api_reports"
   add_foreign_key "link_checker_api_reports", "editions"

--- a/features/fixtures/test_configurable_document_type.json
+++ b/features/fixtures/test_configurable_document_type.json
@@ -76,8 +76,8 @@
               "translatable": true,
               "options": [
                 {
-                  "label": "Twitter",
-                  "value": "Twitter"
+                  "label": "X",
+                  "value": "X"
                 },
                 {
                   "label": "Facebook",

--- a/test/unit/app/models/social_media_account_test.rb
+++ b/test/unit/app/models/social_media_account_test.rb
@@ -78,6 +78,12 @@ class SocialMediaAccountTest < ActiveSupport::TestCase
     assert_equal "Facebark", account.display_name
   end
 
+  test "display_name is the custom one for X service if the title is blank" do
+    sms = build(:social_media_service, name: "X")
+    account = build(:social_media_account, title: "", social_media_service: sms)
+    assert_equal "Follow us on X", account.display_name
+  end
+
   test "should accept multiple translations" do
     account = create(:social_media_account)
 

--- a/test/unit/app/presenters/publishing_api/payload_builder/block_content_test.rb
+++ b/test/unit/app/presenters/publishing_api/payload_builder/block_content_test.rb
@@ -162,7 +162,7 @@ class PublishingApi::PayloadBuilder::BlockContentTest < ActiveSupport::TestCase
 
     test "social_media_links returns array of social media links" do
       value_of_links = [
-        { "social_media_service_name" => "Twitter", "url" => "https://twitter.com" },
+        { "social_media_service_name" => "Facebook", "url" => "https://facebook.com" },
         { "social_media_service_name" => "Other", "title" => "Other 1", "url" => "https://example.com" },
         { "social_media_service_name" => "Other", "title" => "Other 2", "url" => "https://personal.com" },
       ]
@@ -172,9 +172,9 @@ class PublishingApi::PayloadBuilder::BlockContentTest < ActiveSupport::TestCase
 
       expected_payload = [
         {
-          title: "Twitter",
-          service_type: "twitter",
-          href: "https://twitter.com",
+          title: "Facebook",
+          service_type: "facebook",
+          href: "https://facebook.com",
         },
         {
           title: "Other 1",
@@ -191,15 +191,31 @@ class PublishingApi::PayloadBuilder::BlockContentTest < ActiveSupport::TestCase
     end
 
     test "social_media_links defaults title to service name when no title provided" do
-      value_of_links = [{ "social_media_service_name" => "twitter", "url" => "https://example.com" }]
+      value_of_links = [{ "social_media_service_name" => "Facebook", "url" => "https://example.com" }]
       @block_content.stubs(:some_attribute).returns(value_of_links)
 
       builder = PublishingApi::PayloadBuilder::BlockContent.new(@item)
 
       expected_payload = [
         {
-          title: "twitter",
-          service_type: "twitter",
+          title: "Facebook",
+          service_type: "facebook",
+          href: "https://example.com",
+        },
+      ]
+      assert_equal expected_payload, builder.send(:social_media_links, :some_attribute)
+    end
+
+    test "social_media_links defaults custom title to service name when no title provided for X" do
+      value_of_links = [{ "social_media_service_name" => "X", "url" => "https://example.com" }]
+      @block_content.stubs(:some_attribute).returns(value_of_links)
+
+      builder = PublishingApi::PayloadBuilder::BlockContent.new(@item)
+
+      expected_payload = [
+        {
+          title: "Follow us on X",
+          service_type: "x",
           href: "https://example.com",
         },
       ]


### PR DESCRIPTION
We need to update hardcoded links that still mention ‘Twitter’ on GOV.UK to change them to 'Follow us on X'.
We added X as an option in [publishing-api](https://github.com/alphagov/publishing-api/pull/4111) and in [share_link publishing component](https://github.com/alphagov/govuk_publishing_components/pull/5526). 

Social media links appear in 3 places on GOV.UK: news articles, organisation pages and topical event pages.
For news articles, the change will happen in frontend app, and we already have a PR ready for this.
For organisation pages, we need to create a data migration that replaces Twitter in SocialMediaService table.
For topical events, we need to update the document type config, and also create a db migration for updating the existing editions.

Jira card: https://gov-uk.atlassian.net/browse/NAV-18982


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
