### PR TITLE
[WHIT-3551] - Drop the legacy access_limited column

### DIFF
--- a/app/models/concerns/edition/limited_access.rb
+++ b/app/models/concerns/edition/limited_access.rb
@@ -43,12 +43,6 @@ module Edition::LimitedAccess
     access_limiting_organisations? || access_limiting_individuals?
   end
 
-  # TODO: Remove once nothing reads or writes `access_limited` (drop-column ticket).
-  def access_limiting=(value)
-    super
-    self.access_limited = !access_limiting_none?
-  end
-
   def accessible_to?(user)
     user.present? && Whitehall::Authority::Enforcer.new(user, self).can?(:see)
   end

--- a/app/validators/unmodifiable_validator.rb
+++ b/app/validators/unmodifiable_validator.rb
@@ -12,7 +12,7 @@ class UnmodifiableValidator < ActiveModel::Validator
   def modifiable_attributes(previous_state, current_state)
     modifiable = %w[state updated_at force_published]
     if previous_state == "scheduled"
-      modifiable += %w[major_change_published_at first_published_at access_limited access_limiting]
+      modifiable += %w[major_change_published_at first_published_at access_limiting]
     end
     if Edition::PRE_PUBLICATION_STATES.include?(previous_state) || being_unpublished?(previous_state, current_state)
       modifiable += %w[published_major_version published_minor_version]

--- a/db/migrate/20260722120000_remove_access_limited_from_editions.rb
+++ b/db/migrate/20260722120000_remove_access_limited_from_editions.rb
@@ -1,0 +1,5 @@
+class RemoveAccessLimitedFromEditions < ActiveRecord::Migration[8.1]
+  def change
+    safety_assured { remove_column :editions, :access_limited, :boolean, default: false, null: false }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_26_080000) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_22_120000) do
   create_table "access_limiting_individuals", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.integer "edition_id", null: false
@@ -365,7 +365,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_26_080000) do
   end
 
   create_table "editions", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.boolean "access_limited", default: false, null: false
     t.string "access_limiting", default: "none", null: false
     t.string "additional_related_mainstream_content_title"
     t.string "additional_related_mainstream_content_url"
@@ -1245,9 +1244,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_26_080000) do
     t.datetime "updated_at", precision: nil
   end
 
+  add_foreign_key "access_limiting_individuals", "editions"
   add_foreign_key "documents", "editions", column: "latest_edition_id", on_update: :cascade, on_delete: :nullify
   add_foreign_key "documents", "editions", column: "live_edition_id", on_update: :cascade, on_delete: :nullify
-  add_foreign_key "access_limiting_individuals", "editions"
   add_foreign_key "editions", "governments", on_delete: :nullify
   add_foreign_key "link_checker_api_report_links", "link_checker_api_reports"
   add_foreign_key "link_checker_api_reports", "editions"

--- a/test/unit/app/models/edition/limited_access_test.rb
+++ b/test/unit/app/models/edition/limited_access_test.rb
@@ -365,46 +365,19 @@ class Edition::LimitedAccessTest < ActiveSupport::TestCase
     assert edition.valid?
   end
 
-  test "setting access_limiting writes through to the legacy access_limited column" do
-    edition = build(:limited_access_edition)
-
-    edition.access_limiting = "organisations"
-    assert_equal true, edition[:access_limited]
-
-    edition.access_limiting = "individuals"
-    assert_equal true, edition[:access_limited]
-
-    edition.access_limiting = "none"
-    assert_equal false, edition[:access_limited]
-  end
-
-  test "access_limiting persists across save/reload and keeps both columns in sync" do
+  test "access_limiting persists across save/reload" do
     edition = build(:limited_access_edition)
     edition.access_limiting = "organisations"
     edition.save!
     edition.reload
     assert edition.access_limited?
     assert_equal "organisations", edition.access_limiting
-    assert_equal true, edition[:access_limited]
 
     edition.access_limiting = "individuals"
     edition.save!
     edition.reload
     assert edition.access_limited?
     assert_equal "individuals", edition.access_limiting
-    assert_equal true, edition[:access_limited]
-  end
-
-  test "access_limited? reads from access_limiting, not the legacy boolean" do
-    edition = create(:limited_access_edition, access_limiting: "organisations")
-    # Force the legacy and new columns out of sync via raw SQL (bypasses bridge)
-    Edition.where(id: edition.id).update_all(access_limited: true, access_limiting: "none")
-    edition.reload
-    assert_not edition.access_limited?, "access_limited? should reflect the new column"
-
-    Edition.where(id: edition.id).update_all(access_limited: false, access_limiting: "organisations")
-    edition.reload
-    assert edition.access_limited?, "access_limited? should reflect the new column"
   end
 
   test "access_limited? is true for organisations and individuals modes" do


### PR DESCRIPTION
Leaves just the new access_limiting column to determine if and how to restrict access. Also removes the bridge writer that kept the two columns in sync, and the tests that asserted against the dropped column.