### PR TITLE
[WHIT-3703] Update political content rake tasks

### DIFF
--- a/lib/tasks/election.rake
+++ b/lib/tasks/election.rake
@@ -62,15 +62,12 @@ namespace :election do
   end
 
   desc "
-  Removes all current ministerial appointments with the exception
-  of the prime minister
-  Usage
-    rake election:end_ministerial_appointments
-
+    Removes all current ministerial appointments with the exception of the prime minister.
+    Usage:
+      rake election:end_ministerial_appointments
     or to specify an end date other than today
-
-    rake election:end_ministerial_appointments[2017-06-09]
-  "
+      rake election:end_ministerial_appointments[2017-06-09]
+    "
   task :end_ministerial_appointments, [:end_date] => :environment do |_t, args|
     appointments = RoleAppointment.current.for_ministerial_roles
     end_date = Time.zone.today
@@ -97,30 +94,149 @@ namespace :election do
   end
 
   desc "
-  Mark all documents of a given organisation as political
+    Mark editions of a given organisation as political.
+    Used to retrospectively mark content as political when an organisation is changed to be political.
     Usage:
-    rake election:identify_political_content_for[organisation_slug, '30-12-2024']
+      rake election:mark_political_content_for[organisation_slug,2024-12-03,true]
     "
-  task :identify_political_content_for, %i[slug date] => :environment do |_t, args|
+  task :mark_political_content_for, %i[slug date dry_run] => :environment do |_t, args|
+    # The organisation should be marked as political before this is run.
+    # The rake task is typically run with the created_at date of the organisation.
+    # This only updates documents in Whitehall. To update documents downstream, use the Whitehall UI bulk republish feature,
+    # with the 'All documents by organisation' option, or the `republish_political_content` rake task.
     date = Date.parse(args[:date])
     org = Organisation.find_by!(slug: args[:slug])
-    puts "Marking all documents as political for #{org.name}..."
+    dry_run = args[:dry_run]&.to_s&.downcase == "true"
+    puts "Adding the political marker to documents tagged to '#{org.name}'..."
 
     editions = org.editions
-    published = editions.published.where("first_published_at >= ?", date)
-    pre_published_editions = Edition.in_pre_publication_state.where(document_id: published.map(&:document_id))
+    post_publication_editions = editions.where(state: Edition::PUBLICLY_VISIBLE_STATES + %w[unpublished]).where("first_published_at >= ?", date)
+    pre_publication_editions_of_published_documents = Edition.in_pre_publication_state.where(document_id: post_publication_editions.map(&:document_id))
 
-    unless shell.yes?("You're about to update the 'political' value for #{published.size} published editions and #{pre_published_editions.size} pre-publication editions associated with #{org} since #{date}. Proceed? (yes/no)")
-      shell.say_error "Aborted"
+    # Run the evaluation logic to determine which editions are now considered political.
+    post_publication_potentially_political_editions = post_publication_editions.select { |edition| PoliticalContentIdentifier.political?(edition) }
+    pre_publication_potentially_political_editions = pre_publication_editions_of_published_documents.select { |edition| PoliticalContentIdentifier.political?(edition) }
+    total_potentially_political_editions = (post_publication_potentially_political_editions + pre_publication_potentially_political_editions).size
+
+    # Get all the editions that are currently marked as political in the DB to capture where manual overrides have been made and to avoid marking them again.
+    post_publication_already_political_editions = post_publication_potentially_political_editions.select(&:political?)
+    pre_publication_already_political_editions = pre_publication_potentially_political_editions.select(&:political?)
+    total_already_political_editions = (post_publication_already_political_editions + pre_publication_already_political_editions).size
+
+    # Only mark the editions that are not already marked as political.
+    post_publication_editions_about_to_be_marked_political = post_publication_potentially_political_editions - post_publication_already_political_editions
+    pre_publication_editions_about_to_be_marked_political = pre_publication_potentially_political_editions - pre_publication_already_political_editions
+    editions_about_to_be_marked_political = post_publication_editions_about_to_be_marked_political + pre_publication_editions_about_to_be_marked_political
+
+    post_publication_states = (Edition::PUBLICLY_VISIBLE_STATES + %w[unpublished]).join(", ")
+    pre_publication_states = Edition::PRE_PUBLICATION_STATES.join(", ")
+
+    puts <<~INFO
+      Organisation: #{org.name} (created at: #{org.created_at})
+      Date threshold, after which the political marker will be set: #{date}
+      Total editions in organisation: #{editions.size}
+      Total potentially political editions: #{total_potentially_political_editions}, out of which #{total_already_political_editions} are already political.
+        Post-publication editions (#{post_publication_states}): #{post_publication_potentially_political_editions.size}, out of which #{post_publication_already_political_editions.size} are already political.
+        Pre-publication editions (#{pre_publication_states}): #{pre_publication_potentially_political_editions.size}, out of which #{pre_publication_already_political_editions.size} are already political.
+
+      Editions about to be marked political: #{editions_about_to_be_marked_political.size}
+        Post-publication editions (#{post_publication_states}): #{post_publication_editions_about_to_be_marked_political.size}
+        Pre-publication editions (#{pre_publication_states}): #{pre_publication_editions_about_to_be_marked_political.size}
+    INFO
+
+    unless shell.yes?("You're about to add the 'political' marker to #{editions_about_to_be_marked_political.size} editions associated with '#{org.name}' since #{date}. Dry run is #{dry_run ? 'enabled' : 'disabled'}. Proceed? (yes/no)")
+      shell.say_error "Cancelled"
       next
     end
 
-    published.find_each { |edition| edition.update_column(:political, PoliticalContentIdentifier.political?(edition)) }
-    pre_published_editions.find_each { |edition| edition.update_column(:political, PoliticalContentIdentifier.political?(edition)) }
+    editions_about_to_be_marked_political.each do |edition|
+      edition.update_column(:political, true) unless dry_run
+      puts "ID: #{edition.id} (#{edition.type}, #{edition.state}, #{edition.political? ? 'political' : 'not political'}) - #{edition.title} #{dry_run ? 'will be marked as political' : '- DONE'}"
+    end
 
-    puts "Done"
+    puts "\nRake task DONE.\nTo update documents downstream, use the Whitehall UI bulk republish feature, with the 'All documents by organisation' option, or the 'election:republish_political_content' rake task."
   rescue Date::Error => _e
-    puts "The date is not on the right format [\"#{args[:date]}\"]"
+    puts "The date is not in the right format [\"#{args[:date]}\"]"
+  rescue ActiveRecord::RecordNotFound => _e
+    puts "There is no Organisation with slug [\"#{args[:slug]}\"]"
+  end
+
+  desc "
+    Remove political marker from editions of a given organisation.
+    Used to retrospectively unmark political content when an organisation is changed to no longer be political.
+    Usage:
+      rake election:unmark_political_content_for[organisation_slug,2024-12-03,true]
+    "
+
+  task :unmark_political_content_for, %i[slug date dry_run] => :environment do |_t, args|
+    # The organisation should have the political marker removed before this is run.
+    # The rake task is typically run with the created_at date of the organisation.
+    # This only updates documents in Whitehall. To update documents downstream, use the Whitehall UI bulk republish feature,
+    # with the 'All documents by organisation' option.
+    # Note that the current logic removes the political marker from all editions, regardless of how the marker was added.
+    date = Date.parse(args[:date])
+    org = Organisation.find_by!(slug: args[:slug])
+    dry_run = args[:dry_run]&.to_s&.downcase == "true"
+    puts "Removing the political marker for documents tagged to '#{org.name}'..."
+
+    editions = org.editions
+    post_publication_editions = editions.where(state: Edition::PUBLICLY_VISIBLE_STATES + %w[unpublished]).where("first_published_at >= ?", date)
+    pre_publication_editions_of_published_documents = Edition.in_pre_publication_state.where(document_id: post_publication_editions.map(&:document_id))
+
+    # Get all the editions that are currently marked as political in the DB, for comparison with the editions that will be marked as not political.
+    all_post_publication_political_editions = post_publication_editions.select(&:political?)
+    all_pre_publication_political_editions = pre_publication_editions_of_published_documents.select(&:political?)
+    all_political_editions = all_post_publication_political_editions + all_pre_publication_political_editions
+
+    # Run the evaluation logic to determine which editions are now considered not political.
+    # Note that it cannot be deduced which editions were manually marked as political by a publisher, and which by the system, once the organisation has had the political flag removed.
+    # The rake task will unset the marker for all editions, based on the PoliticalContentIdentifier's evaluation logic.
+    # If you want to persist the manually set political marker, run the evaluator logic for all editions before the organisation is marked as not political.
+    # The editions which show the flag as true in the DB but evaluate as false are the ones manually set as political.
+    post_publication_editions_evaluated_as_not_political = post_publication_editions.select { |e| PoliticalContentIdentifier.political?(e) == false }
+    pre_publication_editions_evaluated_as_not_political = pre_publication_editions_of_published_documents.select { |e| PoliticalContentIdentifier.political?(e) == false }
+    all_editions_evaluated_as_not_political = post_publication_editions_evaluated_as_not_political + pre_publication_editions_evaluated_as_not_political
+
+    # Only revert the flag on the editions that actually have the marker true in the DB to avoid unnecessarily updating editions that are already not political.
+    post_publication_editions_about_to_be_marked_not_political = post_publication_editions_evaluated_as_not_political.select(&:political?)
+    pre_publication_editions_about_to_be_marked_not_political = pre_publication_editions_evaluated_as_not_political.select(&:political?)
+    all_editions_about_to_be_marked_not_political = post_publication_editions_about_to_be_marked_not_political + pre_publication_editions_about_to_be_marked_not_political
+
+    # Determine which editions will remain political, likely due to having other editions that are still political.
+    post_publication_editions_that_will_remain_political = all_post_publication_political_editions - post_publication_editions_about_to_be_marked_not_political
+    pre_publication_editions_that_will_remain_political = all_pre_publication_political_editions - pre_publication_editions_about_to_be_marked_not_political
+    all_editions_that_will_remain_political = post_publication_editions_that_will_remain_political + pre_publication_editions_that_will_remain_political
+
+    pre_publication_states = Edition::PRE_PUBLICATION_STATES.join(", ")
+    post_publication_states = (Edition::PUBLICLY_VISIBLE_STATES + %w[unpublished]).join(", ")
+    puts <<~INFO
+      Organisation: #{org.name} (created at: #{org.created_at})
+      Date threshold, after which the political marker will be removed: #{date}
+      Total editions in organisation: #{editions.size}
+      Total political (political marker current true in DB) editions: #{all_political_editions.size}
+        Post-publication political editions (#{post_publication_states}): #{all_post_publication_political_editions.size}
+        Pre-publication political editions (#{pre_publication_states}): #{all_pre_publication_political_editions.size}
+      Total editions that will remain political (likely due to having other editions that are still political): #{all_editions_that_will_remain_political.size}
+        Post-publication editions that will remain political (#{post_publication_states}): #{post_publication_editions_that_will_remain_political.size} - #{post_publication_editions_that_will_remain_political.size.positive? ? post_publication_editions_that_will_remain_political.map(&:id) : '[]'}
+        Pre-publication editions that will remain political (#{pre_publication_states}): #{pre_publication_editions_that_will_remain_political.size} - #{pre_publication_editions_that_will_remain_political.size.positive? ? pre_publication_editions_that_will_remain_political.map(&:id) : '[]'}
+      Editions about to be marked 'not political' (political marker currently true in DB): #{all_editions_about_to_be_marked_not_political.size} out of #{all_editions_evaluated_as_not_political.size} editions evaluated as not political
+        Post-publication editions (#{post_publication_states}): #{post_publication_editions_about_to_be_marked_not_political.size} out of #{post_publication_editions_evaluated_as_not_political.size} editions evaluated as not political
+        Pre-publication editions (#{pre_publication_states}): #{pre_publication_editions_about_to_be_marked_not_political.size} out of #{pre_publication_editions_evaluated_as_not_political.size} editions evaluated as not political
+    INFO
+
+    unless shell.yes?("You're about to remove the political marker for #{all_editions_about_to_be_marked_not_political.size} editions associated with '#{org.name}' since #{date}. Dry run is #{dry_run ? 'enabled' : 'disabled'}. Proceed? (yes/no)")
+      shell.say_error "Cancelled"
+      next
+    end
+
+    all_editions_about_to_be_marked_not_political.each do |edition|
+      edition.update_column(:political, false) unless dry_run
+      puts "ID: #{edition.id} (#{edition.type}, #{edition.state}, #{edition.political? ? 'political' : 'not political'}) - #{edition.title} #{dry_run ? 'will be marked as not political' : '- DONE'}"
+    end
+
+    puts "\nRake task DONE.\nTo update documents downstream, use the Whitehall UI bulk republish feature, with the 'All documents by organisation' option."
+  rescue Date::Error => _e
+    puts "The date is not in the right format [\"#{args[:date]}\"]"
   rescue ActiveRecord::RecordNotFound => _e
     puts "There is no Organisation with slug [\"#{args[:slug]}\"]"
   end

--- a/test/unit/lib/tasks/election_identify_political_content_test.rb
+++ b/test/unit/lib/tasks/election_identify_political_content_test.rb
@@ -26,15 +26,77 @@ class IdentifyPoliticalContentFor < ActiveSupport::TestCase
     end
 
     it "marks eligible published editions of documents first published after the specified date and any associated drafts as political" do
-      document = create(:document)
-      published_edition = create(:publication, :published, document:, first_published_at: "01-01-2023")
-      draft_edition = create(:publication, :draft, document:)
-      organisation.editions = [published_edition, draft_edition]
+      published_document = create(:document)
+      published_edition = create(:publication, :published, document: published_document, first_published_at: "01-01-2023")
+      draft_of_published_edition = create(:publication, :draft, document: published_document)
+      withdrawn_document = create(:document)
+      withdrawn_edition = create(:publication, :withdrawn, document: withdrawn_document, first_published_at: "01-01-2023")
+      draft_of_withdrawn_edition = create(:publication, :draft, document: withdrawn_document)
+      unpublished_document = create(:document)
+      unpublished_edition = create(:publication, :unpublished, document: unpublished_document, first_published_at: "01-01-2023")
+      draft_of_unpublished_edition = create(:publication, :draft, document: unpublished_document)
+      organisation.editions = [published_edition, draft_of_published_edition, withdrawn_edition, draft_of_withdrawn_edition, unpublished_edition, draft_of_unpublished_edition]
       organisation.save!
 
+      # All editions are "potentially" political by virtue of their type
+      assert([published_edition, withdrawn_edition, unpublished_edition].pluck(:publication_type).each { |type| PoliticalContentIdentifier::POLITICAL_PUBLICATION_TYPES.include?(type) })
+
       capture_io { task.invoke(organisation.slug, date) }
+
       assert published_edition.reload.political
-      assert draft_edition.reload.political
+      assert draft_of_published_edition.reload.political
+      # These states are not included
+      assert_not withdrawn_edition.reload.political
+      assert_not draft_of_withdrawn_edition.reload.political
+      assert_not unpublished_edition.reload.political
+      assert_not draft_of_unpublished_edition.reload.political
+    end
+
+    it "unmarks eligible published editions of documents first published after the specified date as not political" do
+      organisation.update!(political: false)
+      published_document = create(:document)
+      published_edition = create(:publication, :published, document: published_document, first_published_at: "01-01-2023", political: true)
+      draft_of_published_edition = create(:publication, :draft, document: published_document, political: true)
+      withdrawn_document = create(:document)
+      withdrawn_edition = create(:publication, :withdrawn, document: withdrawn_document, first_published_at: "01-01-2023", political: true)
+      draft_of_withdrawn_edition = create(:publication, :draft, document: withdrawn_document, political: true)
+      unpublished_document = create(:document)
+      unpublished_edition = create(:publication, :unpublished, document: unpublished_document, first_published_at: "01-01-2023", political: true)
+      draft_of_unpublished_edition = create(:publication, :draft, document: unpublished_document, political: true)
+      organisation.editions = [published_edition, draft_of_published_edition, withdrawn_edition, draft_of_withdrawn_edition, unpublished_edition, draft_of_unpublished_edition]
+      organisation.save!
+
+      # All editions are "potentially" political by virtue of their type
+      assert([published_edition, withdrawn_edition, unpublished_edition].pluck(:publication_type).each { |type| PoliticalContentIdentifier::POLITICAL_PUBLICATION_TYPES.include?(type) })
+
+      capture_io { task.invoke(organisation.slug, date) }
+
+      assert_not published_edition.reload.political
+      assert_not draft_of_published_edition.reload.political
+      # These states are not included
+      assert withdrawn_edition.reload.political
+      assert draft_of_withdrawn_edition.reload.political
+      assert unpublished_edition.reload.political
+      assert draft_of_unpublished_edition.reload.political
+    end
+
+    # This is a characterisation test. Ideally, manually set political markers would not be affected by the task.
+    it "unmarks political flag set by the user for non-political document types" do
+      organisation.update!(political: true)
+      published_document = create(:document)
+      non_political_publication_type = PublicationType.all.detect { |type| PoliticalContentIdentifier::POLITICAL_PUBLICATION_TYPES.exclude?(type) }
+      published_edition = create(:publication, :published, publication_type: non_political_publication_type, document: published_document, first_published_at: "01-01-2023", political: true)
+      organisation.editions = [published_edition]
+      organisation.save!
+
+      # Confirm that the edition was manually set to political
+      assert_not PoliticalContentIdentifier.political?(published_edition)
+      assert published_edition.political
+
+      organisation.update!(political: false)
+      capture_io { task.invoke(organisation.slug, date) }
+
+      assert_not published_edition.reload.political
     end
 
     it "does not mark editions unrelated to documents first published before the specified date as political" do

--- a/test/unit/lib/tasks/election_mark_and_unmark_political_content_test.rb
+++ b/test/unit/lib/tasks/election_mark_and_unmark_political_content_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 require "rake"
 
-class IdentifyPoliticalContentFor < ActiveSupport::TestCase
+class MarkAndUnmarkPoliticalContent < ActiveSupport::TestCase
   extend Minitest::Spec::DSL
 
   setup do
@@ -10,8 +10,8 @@ class IdentifyPoliticalContentFor < ActiveSupport::TestCase
 
   teardown { task.reenable }
 
-  describe "#identify_political_content" do
-    let(:task) { Rake::Task["election:identify_political_content_for"] }
+  describe "#mark_political_content_for" do
+    let(:task) { Rake::Task["election:mark_political_content_for"] }
     let(:organisation) { create(:organisation, political: true) }
     let(:date) { "31-12-2022" }
 
@@ -22,10 +22,10 @@ class IdentifyPoliticalContentFor < ActiveSupport::TestCase
 
     it "raises an error if date is not right format" do
       out, _err = capture_io { task.invoke(organisation.slug, "not a date") }
-      assert_includes out, 'The date is not on the right format ["not a date"]'
+      assert_includes out, 'The date is not in the right format ["not a date"]'
     end
 
-    it "marks eligible published editions of documents first published after the specified date and any associated drafts as political" do
+    it "marks eligible editions of documents first published after the specified date as political" do
       published_document = create(:document)
       published_edition = create(:publication, :published, document: published_document, first_published_at: "01-01-2023")
       draft_of_published_edition = create(:publication, :draft, document: published_document)
@@ -45,15 +45,50 @@ class IdentifyPoliticalContentFor < ActiveSupport::TestCase
 
       assert published_edition.reload.political
       assert draft_of_published_edition.reload.political
-      # These states are not included
-      assert_not withdrawn_edition.reload.political
-      assert_not draft_of_withdrawn_edition.reload.political
-      assert_not unpublished_edition.reload.political
-      assert_not draft_of_unpublished_edition.reload.political
+      assert withdrawn_edition.reload.political
+      assert draft_of_withdrawn_edition.reload.political
+      assert unpublished_edition.reload.political
+      assert draft_of_unpublished_edition.reload.political
     end
 
-    it "unmarks eligible published editions of documents first published after the specified date as not political" do
-      organisation.update!(political: false)
+    it "does not mark editions related to documents first published before the specified date" do
+      non_political_document = create(:document)
+      published_edition = create(:publication, :published, document: non_political_document, political: false, first_published_at: "30-12-2022")
+      draft_edition = create(:publication, :draft, document: non_political_document, political: false)
+      organisation.editions = [published_edition, draft_edition]
+      organisation.save!
+
+      capture_io { task.invoke(organisation.slug, date) }
+      assert_not non_political_document.reload.live_edition.political
+      assert_not non_political_document.reload.latest_edition.political
+    end
+
+    it "does not mark editions that are ineligible as political content" do
+      fatality_notice = create(:fatality_notice, :published)
+      organisation.editions = [fatality_notice]
+      organisation.save!
+
+      capture_io { task.invoke(organisation.slug, date) }
+      assert_not fatality_notice.reload.political
+    end
+  end
+
+  describe "#unmark_political_content_for" do
+    let(:task) { Rake::Task["election:unmark_political_content_for"] }
+    let(:organisation) { create(:organisation, political: false) }
+    let(:date) { "31-12-2022" }
+
+    it "raises an error if organisation does not exist" do
+      out, _err = capture_io { task.invoke("non-existent-slug", date) }
+      assert_includes out, 'There is no Organisation with slug ["non-existent-slug"]'
+    end
+
+    it "raises an error if date is not right format" do
+      out, _err = capture_io { task.invoke(organisation.slug, "not a date") }
+      assert_includes out, 'The date is not in the right format ["not a date"]'
+    end
+
+    it "unmarks eligible editions of documents first published after the specified date as not political" do
       published_document = create(:document)
       published_edition = create(:publication, :published, document: published_document, first_published_at: "01-01-2023", political: true)
       draft_of_published_edition = create(:publication, :draft, document: published_document, political: true)
@@ -73,15 +108,15 @@ class IdentifyPoliticalContentFor < ActiveSupport::TestCase
 
       assert_not published_edition.reload.political
       assert_not draft_of_published_edition.reload.political
-      # These states are not included
-      assert withdrawn_edition.reload.political
-      assert draft_of_withdrawn_edition.reload.political
-      assert unpublished_edition.reload.political
-      assert draft_of_unpublished_edition.reload.political
+      assert_not withdrawn_edition.reload.political
+      assert_not draft_of_withdrawn_edition.reload.political
+      assert_not unpublished_edition.reload.political
+      assert_not draft_of_unpublished_edition.reload.political
     end
 
     # This is a characterisation test. Ideally, manually set political markers would not be affected by the task.
-    it "unmarks political flag set by the user for non-political document types" do
+    # However, it is not straightforward to deduce whether a political marker was set manually or not.
+    it "unmarks editions manually marked as political, for non-potentially-political document types" do
       organisation.update!(political: true)
       published_document = create(:document)
       non_political_publication_type = PublicationType.all.detect { |type| PoliticalContentIdentifier::POLITICAL_PUBLICATION_TYPES.exclude?(type) }
@@ -99,25 +134,16 @@ class IdentifyPoliticalContentFor < ActiveSupport::TestCase
       assert_not published_edition.reload.political
     end
 
-    it "does not mark editions unrelated to documents first published before the specified date as political" do
-      non_political_document = create(:document)
-      published_edition = create(:publication, :published, document: non_political_document, political: false, first_published_at: "30-12-2022")
-      draft_edition = create(:publication, :draft, document: non_political_document, political: false)
+    it "does not unmark editions related to documents first published before the specified date" do
+      political_document = create(:document)
+      published_edition = create(:publication, :published, document: political_document, political: true, first_published_at: "30-12-2022")
+      draft_edition = create(:publication, :draft, document: political_document, political: true)
       organisation.editions = [published_edition, draft_edition]
       organisation.save!
 
       capture_io { task.invoke(organisation.slug, date) }
-      assert_not non_political_document.reload.live_edition.political
-      assert_not non_political_document.reload.latest_edition.political
-    end
-
-    it "does not mark editions that are ineligible as political content as political" do
-      fatality_notice = create(:fatality_notice, :published)
-      organisation.editions = [fatality_notice]
-      organisation.save!
-
-      capture_io { task.invoke(organisation.slug, date) }
-      assert_not fatality_notice.reload.political
+      assert political_document.reload.live_edition.political
+      assert political_document.reload.latest_edition.political
     end
   end
 end


### PR DESCRIPTION
## Changes

- Split the original political marker rake task into two rake tasks to make it explicit when we add and when we remove the political marker.
- Rename the rake tasks - they are not just "identifying" political content but actually setting the marker.
- Introduce withdrawn and unpublish states in the queries. See why below.
- Improve logs to make it easier for developers to validate task execution.
- Add `dry_run` option.


## Testing

- mark political editions - dry run true
<img width="1555" height="378" alt="mark dry run true" src="https://github.com/user-attachments/assets/03f60011-bcf4-4563-8d95-166633552838" />
- mark political editions - dry run false
<img width="1555" height="378" alt="mark dry run false" src="https://github.com/user-attachments/assets/0978ecd7-05b5-42dd-a9e3-33986e24ceb7" />
- unmark political editions - dry run true
<img width="1900" height="450" alt="unmark dry run enabled" src="https://github.com/user-attachments/assets/0d38e598-ff74-4226-8992-ea46047dd9ea" />
- unmark political editions - dry run false
<img width="1900" height="450" alt="unmark dry run disabled" src="https://github.com/user-attachments/assets/08a8a26b-9274-47ae-8ca9-d315fa9983a4" />


[Jira](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-3703)
