### PR TITLE
Allow Managing Editors to edit historical documents under a specific govt [WHIT-3703]

### DIFF
--- a/lib/whitehall/authority/rules/edition_rules.rb
+++ b/lib/whitehall/authority/rules/edition_rules.rb
@@ -89,6 +89,7 @@ module Whitehall::Authority::Rules
     def can_with_a_historic_instance?(action)
       return false if access_limit_enforced?
       return true if actor.gds_admin? || actor.gds_editor?
+      return true if actor.managing_editor? && subject.government.slug == "2024-starmer-labour-government" && action != :select_government_for_history_mode
 
       case action
       when :see

--- a/test/functional/admin/generic_editions_controller_tests/political_document_test.rb
+++ b/test/functional/admin/generic_editions_controller_tests/political_document_test.rb
@@ -61,6 +61,19 @@ class Admin::GenericEditionsController::PolticalDocumentsTest < ActionController
     assert_response :redirect
   end
 
+  view_test "lets managing editors edit historic documents only under the Starmer government" do
+    login_as :managing_editor
+    create(:previous_government, name: "2024 Starmer Labour government")
+    create(:current_government, name: "new")
+
+    published_edition = create(:published_publication, first_published_at: 3.years.ago)
+    new_draft = create(:publication, political: true, first_published_at: 3.years.ago, document: published_edition.document)
+
+    get :edit, params: { id: new_draft }
+
+    assert_response :success
+  end
+
   view_test "lets GDS editors edit historic documents" do
     login_as :gds_editor
     edit_historic_document

--- a/test/unit/lib/whitehall/authority/managing_editor_test.rb
+++ b/test/unit/lib/whitehall/authority/managing_editor_test.rb
@@ -158,12 +158,63 @@ class ManagingEditorTest < ActiveSupport::TestCase
     assert enforcer_for(managing_editor, normal_edition).can?(:mark_political)
   end
 
-  test "cannot modify historic editions" do
+  test "can modify historic editions for the Starmer government only" do
+    government = create(:government, name: "2024 Starmer Labour government", start_date: 2.years.ago, end_date: 1.day.ago)
+    historic_edition.stubs(:government).returns(government)
+    assert enforcer_for(managing_editor, historic_edition).can?(:update)
+  end
+
+  test "can publish historic editions for the Starmer government only" do
+    government = create(:government, name: "2024 Starmer Labour government", start_date: 2.years.ago, end_date: 1.day.ago)
+    historic_edition.stubs(:government).returns(government)
+    assert enforcer_for(managing_editor, historic_edition).can?(:publish)
+  end
+
+  test "can mark historic editions as political for the Starmer government only" do
+    government = create(:government, name: "2024 Starmer Labour government", start_date: 2.years.ago, end_date: 1.day.ago)
+    historic_edition.stubs(:government).returns(government)
+    assert enforcer_for(managing_editor, historic_edition).can?(:mark_political)
+  end
+
+  test "cannot select government for historic editions under the Starmer government" do
+    government = create(:government, name: "2024 Starmer Labour government", start_date: 2.years.ago, end_date: 1.day.ago)
+    historic_edition.stubs(:government).returns(government)
+    assert_not enforcer_for(managing_editor, historic_edition).can?(:select_government_for_history_mode)
+  end
+
+  test "cannot modify historic editions for governments other than the Starmer government" do
+    government = create(:government, name: "2023 Other government", start_date: 2.years.ago, end_date: 1.day.ago)
+    historic_edition.stubs(:government).returns(government)
     assert_not enforcer_for(managing_editor, historic_edition).can?(:update)
   end
 
-  test "cannot publish historic editions" do
+  test "cannot publish historic editions for governments other than the Starmer government" do
+    government = create(:government, name: "2023 Other government", start_date: 2.years.ago, end_date: 1.day.ago)
+    historic_edition.stubs(:government).returns(government)
     assert_not enforcer_for(managing_editor, historic_edition).can?(:publish)
+  end
+
+  test "cannot mark historic editions as political for governments other than the Starmer government" do
+    government = create(:government, name: "2023 Other government", start_date: 2.years.ago, end_date: 1.day.ago)
+    historic_edition.stubs(:government).returns(government)
+    assert_not enforcer_for(managing_editor, historic_edition).can?(:mark_political)
+  end
+
+  test "cannot select government for historic editions under any government" do
+    government = create(:government, name: "2023 Other government", start_date: 2.years.ago, end_date: 1.day.ago)
+    historic_edition.stubs(:government).returns(government)
+    assert_not enforcer_for(managing_editor, historic_edition).can?(:select_government_for_history_mode)
+  end
+
+  test "cannot modify a historic edition that is access-limited" do
+    organisation1 = "organisation_1"
+    organisation2 = "organisation_2"
+    user = managing_editor
+    user.stubs(:organisation).returns(organisation1)
+    edition = limited_publication([organisation2])
+    edition.stubs(:historic?).returns(true)
+
+    assert_not enforcer_for(managing_editor, edition).can?(:update)
   end
 
   test "can create social media accounts" do


### PR DESCRIPTION
Allow Managing Editors to edit historical documents under a specific government

Based on request, we're opening this workflow to Managing Editors  (temporarily), in addition to GDS Admins and GDS Editors who already can perform these actions without restriction. 

Note that managing editors will only be able to update documents within the 2024 government. This was specifically requested for the time being. 

Access to select a different government for a document is still restricted to GDS Admins and GDS Editors.

[JIRA](https://gov-uk.atlassian.net/browse/WHIT-3703)

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
