### PR TITLE
Update Department of Health brand colour

### DIFF
--- a/app/models/organisation_brand_colour.rb
+++ b/app/models/organisation_brand_colour.rb
@@ -62,10 +62,10 @@ class OrganisationBrandColour
     title: "Department of Energy & Climate Change",
     class_name: "department-of-energy-climate-change",
   )
-  DepartmentOfHealth = create!(
+  DepartmentOfHealthAndSocialCare = create!(
     id: 12,
-    title: "Department of Health",
-    class_name: "department-of-health",
+    title: "Department of Health & Social Care",
+    class_name: "department-of-health-social-care",
   )
   ForeignCommonwealthOffice = create!(
     id: 13,


### PR DESCRIPTION
## What

Update DepartmentOfHealth in `organisation_brand_colour.rb`

- `title` updated as the Department of Health was [renamed the Department of Health & Social Care in 2018](https://github.com/alphagov/govuk-frontend/pull/3407)
- `class_name` updated to match the correct name in govuk-frontend (design system)

## Why

The deprecated organisation brand colour for "Department of Health" was [removed in v6 of the govuk design system](https://github.com/alphagov/govuk-frontend/pull/3407).

This change will ensure the brand colour for the "Department of Health" does not switch to the default black colour used for Single Identity, when upgrading from v5 to v6 of the govuk design system.

Example page: https://www.gov.uk/government/organisations/department-of-health-and-social-care

Jira card: https://gov-uk.atlassian.net/browse/NAV-18920

### Visual changes

| Before | After |
| --- | --- |
| `department-of-health` - `#00ad93` | `department-of-health-social-care` - `#00a990` |
| <img width="438" height="733" alt="mobile-before" src="https://github.com/user-attachments/assets/26a82e0a-9c50-4d18-b4f6-537b8d13217b" /> | <img width="439" height="739" alt="mobile-after" src="https://github.com/user-attachments/assets/c96bfac8-93b2-4a28-ad7c-448e6f5af1a1" /> |

---
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
