### PR TITLE
[WHIT-3703] Correct logic in HtmlAttachment republish rake task

### DIFF
--- a/lib/tasks/attachments/republish_historically_political_html_attachments.rake
+++ b/lib/tasks/attachments/republish_historically_political_html_attachments.rake
@@ -3,9 +3,11 @@ task republish_historically_political_html_attachments: :environment do
   government_start_date = Government.current.start_date
 
   document_ids = Edition
-    .publicly_visible
-    .where(id: HtmlAttachment.where("attachable_type = 'Edition' AND political = true AND first_published_at < ?", government_start_date).select(:attachable_id))
-    .pluck(:document_id)
+                   .publicly_visible
+                   .where(political: true)
+                   .where("first_published_at < ?", government_start_date)
+                   .where(id: HtmlAttachment.where(attachable_type: "Edition").select(:attachable_id))
+                   .pluck(:document_id)
 
   puts "Enqueueing #{document_ids.count} documents with historically political html attachments"
 

--- a/test/unit/lib/tasks/attachments/republish_historically_political_html_attachments_test.rb
+++ b/test/unit/lib/tasks/attachments/republish_historically_political_html_attachments_test.rb
@@ -5,14 +5,21 @@ class RepublishHistoricallyPoliticalHtmlAttachmentsRake < ActiveSupport::TestCas
     create(:government, start_date: 5.years.ago, end_date: 1.year.ago - 1.day)
     create(:government, start_date: 1.year.ago)
 
-    historically_political_edition = create(
+    published_historically_political_edition = create(
       :edition,
       :with_document,
       :published,
       first_published_at: 2.years.ago,
       political: true,
     )
-    political_edition = create(
+    withdrawn_historically_political_edition = create(
+      :edition,
+      :with_document,
+      :withdrawn,
+      first_published_at: 2.years.ago,
+      political: true,
+    )
+    published_political_edition = create(
       :edition,
       :with_document,
       :published,
@@ -20,7 +27,7 @@ class RepublishHistoricallyPoliticalHtmlAttachmentsRake < ActiveSupport::TestCas
       political: true,
     )
 
-    historical_edition = create(
+    published_historical_edition = create(
       :edition,
       :with_document,
       :published,
@@ -36,26 +43,33 @@ class RepublishHistoricallyPoliticalHtmlAttachmentsRake < ActiveSupport::TestCas
       political: true,
     )
 
-    create(:html_attachment, attachable: historically_political_edition)
-    create(:html_attachment, attachable: political_edition)
-    create(:html_attachment, attachable: historical_edition)
+    create(:html_attachment, attachable: published_historically_political_edition)
+    create(:html_attachment, attachable: withdrawn_historically_political_edition)
+    create(:html_attachment, attachable: published_political_edition)
+    create(:html_attachment, attachable: published_historical_edition)
     create(:html_attachment, attachable: unpublished_historically_political_edition)
 
     PublishingApiDocumentRepublishingJob.expects(:perform_async_in_queue).with(
       "bulk_republishing",
-      historically_political_edition.document_id,
+      published_historically_political_edition.document_id,
       true,
     )
 
     PublishingApiDocumentRepublishingJob.expects(:perform_async_in_queue).with(
       "bulk_republishing",
-      political_edition.document_id,
+      withdrawn_historically_political_edition.document_id,
+      true,
+    )
+
+    PublishingApiDocumentRepublishingJob.expects(:perform_async_in_queue).with(
+      "bulk_republishing",
+      published_political_edition.document_id,
       true,
     ).never
 
     PublishingApiDocumentRepublishingJob.expects(:perform_async_in_queue).with(
       "bulk_republishing",
-      historical_edition.document_id,
+      published_historical_edition.document_id,
       true,
     ).never
 


### PR DESCRIPTION
Changes:
- The query should be looking for editions being political, not attachments. We do not store the political field on the `attachments` table, although we send it downstream for HtmlAttachments, so they too can render the "political" box on the front end.
- I've also included coverage for withdrawn editions in the test.
[Jira](https://gov-uk.atlassian.net/browse/WHIT-3703)
