### PR TITLE
[WHIT-3728] - Toggle access limiting for organisations and backfill orgs

### DIFF
--- a/config/features.rb
+++ b/config/features.rb
@@ -35,7 +35,7 @@ Flipflop.configure do
           default: Rails.env.development?
   feature :access_limiting_organisations_ui,
           description: "Replace the access-limiting checkbox with radio + organisation selector UI",
-          default: Whitehall.integration?
+          default: true
   feature :access_limiting_individuals_ui,
           description: "Extend the access-limiting radio UI with an individuals option",
           default: Whitehall.integration?

--- a/db/migrate/20260714120000_backfill_access_limiting_organisations.rb
+++ b/db/migrate/20260714120000_backfill_access_limiting_organisations.rb
@@ -1,0 +1,38 @@
+class BackfillAccessLimitingOrganisations < ActiveRecord::Migration[8.1]
+  def up
+    safety_assured do
+      execute <<~SQL
+        UPDATE editions
+        SET access_limiting = 'none'
+        WHERE access_limiting = 'organisations'
+          AND (
+            state NOT IN ('draft', 'submitted', 'rejected', 'scheduled')
+            OR type = 'CorporateInformationPage'
+            OR NOT EXISTS (
+              SELECT 1 FROM edition_organisations eo
+              WHERE eo.edition_id = editions.id
+                AND eo.organisation_id IS NOT NULL
+            )
+          )
+      SQL
+
+      execute <<~SQL
+        INSERT INTO access_limiting_organisations (edition_id, organisation_id, created_at, updated_at)
+        SELECT eo.edition_id, eo.organisation_id, NOW(), NOW()
+        FROM edition_organisations eo
+        INNER JOIN editions e ON e.id = eo.edition_id
+        WHERE e.access_limiting = 'organisations'
+          AND e.state IN ('draft', 'submitted', 'rejected', 'scheduled')
+          AND e.type <> 'CorporateInformationPage'
+          AND eo.organisation_id IS NOT NULL
+          AND NOT EXISTS (
+            SELECT 1 FROM access_limiting_organisations alo
+            WHERE alo.edition_id = eo.edition_id
+              AND alo.organisation_id = eo.organisation_id
+          )
+      SQL
+    end
+  end
+
+  def down; end
+end

--- a/features/admin-limit-access-editions.feature
+++ b/features/admin-limit-access-editions.feature
@@ -20,6 +20,7 @@ Feature: Viewing most recent editions in admin
     Given I am an editor
     When I begin drafting a new document
     And I set the Lead organisation to an org I am not in
-    And I check the "Limit access to publishers from organisations associated with this document before you publish" box
+    And I choose organisation access limiting
+    And I select "Some made up org" as an access limiting organisation
     When I click "Save"
-    Then I should see the validation error "Lead or supporting organisations must include your own organisation"
+    Then I should see the validation error "Access limiting organisations must include your own organisation"

--- a/features/step_definitions/admin_limit_access_steps.rb
+++ b/features/step_definitions/admin_limit_access_steps.rb
@@ -30,8 +30,12 @@ When(/^I set the Lead organisation to an org I am not in$/) do
   select @org.name, from: "edition_lead_organisation_ids_1"
 end
 
-When(/^I check the "(.+)" box$/) do |box_name|
-  check box_name
+When(/^I choose organisation access limiting$/) do
+  choose "Limit access to publishers from organisations associated with this document"
+end
+
+When(/^I select "([^"]*)" as an access limiting organisation$/) do |org_name|
+  select org_name, from: "edition_access_limiting_organisation_ids"
 end
 
 When(/^I click "(.+)"$/) do |button_name|

--- a/features/step_definitions/most_recent_editions_steps.rb
+++ b/features/step_definitions/most_recent_editions_steps.rb
@@ -11,6 +11,7 @@ When(/^someone else creates a new edition of the published document "([^"]*)" an
   new_draft = current.create_draft(random_editor)
   new_draft.organisations << org
   new_draft.access_limiting = "organisations"
+  new_draft.access_limiting_organisation_ids = [org.id]
   new_draft.change_note = "Limited to #{org.name}"
   new_draft.save!
 end

--- a/test/factories/editions.rb
+++ b/test/factories/editions.rb
@@ -123,7 +123,15 @@ FactoryBot.define do
       scheduled_publication { 7.days.from_now }
     end
 
-    trait(:access_limited) { access_limiting { "organisations" } }
+    trait(:access_limited_by_organisations) do
+      access_limiting { "organisations" }
+      after(:build) do |edition|
+        next if edition.edition_access_limiting_organisations.any?
+
+        edition.access_limiting_organisations =
+          edition.try(:edition_organisations)&.map(&:organisation).presence || [FactoryBot.build(:organisation)]
+      end
+    end
 
     trait(:with_alternative_format_provider) do
       association :alternative_format_provider, factory: :organisation_with_alternative_format_contact_email
@@ -187,6 +195,6 @@ FactoryBot.define do
   factory :force_published_edition, parent: :edition, traits: [:force_published]
   factory :unpublished_edition, parent: :edition, traits: [:unpublished]
   factory :withdrawn_edition, parent: :edition, traits: [:withdrawn]
-  factory :protected_edition, parent: :edition, traits: [:access_limited]
+  factory :protected_edition, parent: :edition, traits: [:access_limited_by_organisations]
   factory :edition_with_organisations, parent: :edition, traits: [:with_organisations]
 end

--- a/test/functional/admin/edition_access_limited_controller_test.rb
+++ b/test/functional/admin/edition_access_limited_controller_test.rb
@@ -7,7 +7,6 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
 
   should_be_an_admin_controller
 
-  # flag agnostic
   test "GET :edit should be forbidden unless user is a GDS Admin" do
     edition = create(:consultation)
     login_as :gds_editor
@@ -15,39 +14,6 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
     assert_response :forbidden
   end
 
-  # flag agnostic
-  view_test "GET :edit should display the correct fields" do
-    organisation = create(:organisation)
-
-    edition = create(
-      :consultation,
-      access_limiting: "organisations",
-      create_default_organisation: false,
-      lead_organisations: [organisation],
-    )
-
-    get :edit, params: { id: edition }
-
-    assert_select "form[action='#{update_access_limited_admin_edition_path(edition.id)}']" do
-      assert_select "input[name='edition[access_limiting]'][type=checkbox][value=organisations][checked=checked]"
-      assert_select "textarea[name='edition[editorial_remark]']"
-
-      (1..4).each do |i|
-        select_label = i == 1 && assigns(:edition).lead_organisation_association_required? ? "Lead organisation #{i} (required)" : "Lead organisation #{i}"
-        assert_select "label[for=edition_lead_organisation_ids_#{i}]", text: select_label
-        assert_select("#edition_lead_organisation_ids_#{i}")
-      end
-
-      assert_select("#edition_lead_organisation_ids_1") do
-        assert_select "option[selected='selected']", value: organisation.id
-      end
-
-      refute_select "#edition_lead_organisation_ids_5"
-      assert_select("#edition_supporting_organisation_ids")
-    end
-  end
-
-  # access_limiting_organisations_ui and access_limiting_individuals_ui are on
   view_test "GET :edit should show radio buttons instead of checkbox when access_limiting_organisations_ui flag is on" do
     feature_flags.switch! :access_limiting_organisations_ui, true
     feature_flags.switch! :access_limiting_individuals_ui, true
@@ -68,7 +34,6 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
     assert_select "input[name='edition[access_limited]'][type=checkbox]", count: 0
   end
 
-  # access_limiting_organisations_ui is on
   view_test "GET :edit shows the persisted editions's access limiting value when flag is on" do
     feature_flags.switch! :access_limiting_organisations_ui, true
 
@@ -89,7 +54,6 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
     end
   end
 
-  # Flag reversal scenario, access_limiting_organisations_ui turned on and then off
   view_test "GET :edit shows the persisted editions's access limiting value, and preserves already set access limiting organisations, when flag is turned off" do
     organisation = create(:organisation)
     edition = create(
@@ -100,6 +64,8 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
       access_limiting_organisation_ids: [organisation.id],
     )
 
+    feature_flags.switch! :access_limiting_organisations_ui, false
+
     get :edit, params: { id: edition }
 
     assert edition.access_limited?
@@ -109,7 +75,6 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
     refute_select "select[name='edition[access_limiting_organisation_ids][]']"
   end
 
-  # flag agnostic
   test "PATCH :update should be forbidden unless user is a GDS Admin" do
     edition = create(:consultation)
     login_as :gds_editor
@@ -117,7 +82,6 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
     assert_response :forbidden
   end
 
-  # flag agnostic
   test "PATCH :update should update editions organisations and create an editorial remark" do
     first_organisation = create(:organisation)
     second_organisation = create(:organisation)
@@ -126,6 +90,7 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
     edition = create(
       :consultation,
       access_limiting: "organisations",
+      access_limiting_organisation_ids: [first_organisation.id],
       create_default_organisation: false,
       lead_organisations: [first_organisation],
       supporting_organisations: [second_organisation],
@@ -151,41 +116,6 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
     assert_equal "Access options updated by GDS Admin: #{editorial_remark}", edition.editorial_remarks.last.body
   end
 
-  # access_limiting_organisations_ui flag is off
-  test "PATCH :update should update access_limited and create an editorial remark" do
-    first_organisation = create(:organisation)
-    second_organisation = create(:organisation)
-
-    edition = create(
-      :consultation,
-      access_limiting: "organisations",
-      create_default_organisation: false,
-      lead_organisations: [first_organisation],
-      supporting_organisations: [second_organisation],
-    )
-
-    editorial_remark = "Removing access limited at the users request."
-
-    patch :update,
-          params: {
-            id: edition,
-            edition: {
-              lead_organisation_ids: [first_organisation.id],
-              supporting_organisation_ids: [second_organisation.id],
-              editorial_remark:,
-              access_limiting: "none",
-            },
-          }
-
-    assert_equal [first_organisation], edition.reload.lead_organisations
-    assert_equal [second_organisation], edition.supporting_organisations
-    assert_not edition.access_limited?
-    assert_redirected_to admin_editions_path
-    assert_equal "Access updated for #{edition.title}", flash[:notice]
-    assert_equal "Access options updated by GDS Admin: #{editorial_remark}", edition.editorial_remarks.last.body
-  end
-
-  # access_limiting_organisations_ui is on
   test "PATCH :update changes access limiting from 'none' to 'organisations' and creates an editorial remark" do
     feature_flags.switch! :access_limiting_organisations_ui, true
 
@@ -217,7 +147,6 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
     assert_equal "Access options updated by GDS Admin: #{editorial_remark}", edition.editorial_remarks.last.body
   end
 
-  # access_limiting_organisations_ui is on
   test "PATCH :update changes access limiting from 'organisations' to 'none', clears access limiting organisations, and creates an editorial remark" do
     feature_flags.switch! :access_limiting_organisations_ui, true
 
@@ -249,36 +178,6 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
     assert_equal "Access options updated by GDS Admin: #{editorial_remark}", edition.editorial_remarks.last.body
   end
 
-  # access_limiting_organisations_ui flag is off
-  test "PATCH :update fails and re-renders edit template if editorial remark is not provided" do
-    first_organisation = create(:organisation)
-    second_organisation = create(:organisation)
-
-    edition = create(
-      :consultation,
-      access_limiting: "organisations",
-      create_default_organisation: false,
-      lead_organisations: [first_organisation],
-      supporting_organisations: [second_organisation],
-    )
-
-    patch :update,
-          params: {
-            id: edition,
-            edition: {
-              lead_organisation_ids: [first_organisation.id],
-              supporting_organisation_ids: [second_organisation.id],
-              editorial_remark: "",
-              access_limiting: "none",
-            },
-          }
-
-    assert_template :edit
-    assert_equal ["Editorial remark cannot be blank"], assigns(:edition).errors.full_messages
-    assert edition.reload.access_limited?
-  end
-
-  # access_limiting_organisations_ui is on
   test "PATCH :update fails and re-renders edit template when editorial remark is not provided" do
     feature_flags.switch! :access_limiting_organisations_ui, true
     organisation = create(:organisation)
@@ -305,7 +204,6 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
     assert_equal ["Editorial remark cannot be blank"], assigns(:edition).errors.full_messages
   end
 
-  # access_limiting_organisations_ui is on
   view_test "PATCH :update fails and renders edit template with submitted access limiting organisations, when access limiting organisations empty" do
     feature_flags.switch! :access_limiting_organisations_ui, true
 
@@ -341,7 +239,6 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
     assert edition.access_limiting_organisations.exists?(id: organisation.id)
   end
 
-  # access_limiting_organisations_ui is on
   view_test "PATCH :update re-renders the edit template with the submitted access limiting organisations and editorial remark, when unrelated field fails validation" do
     feature_flags.switch! :access_limiting_organisations_ui, true
 
@@ -377,7 +274,6 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
     assert_equal [organisation.id], edition.reload.access_limiting_organisation_ids
   end
 
-  # both flags on
   test "PATCH :update clears access_limiting_organisations when switching to individuals" do
     feature_flags.switch! :access_limiting_organisations_ui, true
     feature_flags.switch! :access_limiting_individuals_ui, true
@@ -407,7 +303,6 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
     assert edition.access_limiting_individuals.exists?(email: "user@example.com")
   end
 
-  # both flags on
   test "PATCH :update clears access_limiting_individuals when switching to organisations" do
     feature_flags.switch! :access_limiting_organisations_ui, true
     feature_flags.switch! :access_limiting_individuals_ui, true
@@ -437,7 +332,6 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
     assert_empty edition.access_limiting_individuals
   end
 
-  # both flags on
   test "PATCH :update clears both access_limiting_organisations and access_limiting_individuals when switching to none" do
     feature_flags.switch! :access_limiting_organisations_ui, true
     feature_flags.switch! :access_limiting_individuals_ui, true
@@ -467,7 +361,6 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
     assert_empty edition.access_limiting_individuals
   end
 
-  # access_limiting_individuals_ui flag is on
   view_test "PATCH :update re-renders the edit template with error and the submitted values, but does not persist the association, when access limiting individuals invalid" do
     feature_flags.switch! :access_limiting_individuals_ui, true
 
@@ -503,7 +396,7 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
 
     edition = create(
       :consultation,
-      access_limiting: "organisations",
+      :access_limited_by_organisations,
       create_default_organisation: false,
       lead_organisations: [first_organisation],
     )
@@ -517,6 +410,8 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
           params: {
             id: edition,
             edition: {
+              access_limiting: "organisations",
+              access_limiting_organisation_ids: [first_organisation.id],
               lead_organisation_ids: [first_organisation.id, second_organisation.id],
               editorial_remark: "Updating lead organisations.",
             },
@@ -533,7 +428,7 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
     edition = create(
       :consultation,
       :with_file_attachment,
-      access_limiting: "organisations",
+      :access_limited_by_organisations,
       create_default_organisation: false,
       lead_organisations: [first_organisation],
     )
@@ -544,6 +439,8 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
           params: {
             id: edition,
             edition: {
+              access_limiting: "organisations",
+              access_limiting_organisation_ids: [first_organisation.id],
               lead_organisation_ids: [first_organisation.id, second_organisation.id],
               editorial_remark: "Updating lead organisations.",
             },

--- a/test/functional/admin/edition_translations_controller_test.rb
+++ b/test/functional/admin/edition_translations_controller_test.rb
@@ -233,7 +233,7 @@ class Admin::EditionTranslationsControllerTest < ActionController::TestCase
   end
 
   test "should limit access to translations of editions that aren't accessible to the current user" do
-    protected_edition = create(:draft_publication, :access_limited)
+    protected_edition = create(:draft_publication, :access_limited_by_organisations)
 
     post :create, params: { edition_id: protected_edition.id, id: "en" }
     assert_response :forbidden

--- a/test/functional/admin/edition_workflow_controller_test.rb
+++ b/test/functional/admin/edition_workflow_controller_test.rb
@@ -395,7 +395,7 @@ class Admin::EditionWorkflowControllerTest < ActionController::TestCase
   end
 
   test "should prevent access to inaccessible editions" do
-    protected_edition = create(:draft_publication, :access_limited)
+    protected_edition = create(:draft_publication, :access_limited_by_organisations)
 
     post :submit, params: { id: protected_edition.id }
     assert_response :forbidden

--- a/test/functional/admin/editions_controller_test.rb
+++ b/test/functional/admin/editions_controller_test.rb
@@ -286,10 +286,10 @@ class Admin::EditionsControllerTest < ActionController::TestCase
     login_as create(:writer, organisation: my_organisation)
     accessible = [
       create(:draft_publication),
-      create(:draft_publication, publication_type: PublicationType::NationalStatistics, access_limiting: "organisations", organisations: [my_organisation]),
+      create(:draft_publication, :access_limited_by_organisations, publication_type: PublicationType::NationalStatistics, organisations: [my_organisation]),
       create(:draft_publication, publication_type: PublicationType::NationalStatistics, access_limiting: "none", organisations: [other_organisation]),
     ]
-    inaccessible = create(:draft_publication, publication_type: PublicationType::NationalStatistics, access_limiting: "organisations", organisations: [other_organisation])
+    inaccessible = create(:draft_publication, :access_limited_by_organisations, publication_type: PublicationType::NationalStatistics, organisations: [other_organisation])
 
     get :index, params: { state: :active }
 
@@ -302,7 +302,7 @@ class Admin::EditionsControllerTest < ActionController::TestCase
   view_test "index should indicate the protected status of limited access editions which I do have access to" do
     my_organisation = create(:organisation)
     login_as create(:writer, organisation: my_organisation)
-    publication = create(:draft_publication, publication_type: PublicationType::NationalStatistics, access_limiting: "organisations", organisations: [my_organisation])
+    publication = create(:draft_publication, :access_limited_by_organisations, publication_type: PublicationType::NationalStatistics, organisations: [my_organisation])
 
     get :index, params: { state: :active }
 
@@ -314,7 +314,7 @@ class Admin::EditionsControllerTest < ActionController::TestCase
 
   view_test "GET :index admin do not see a view link, but are given a link to edit acccess controls when an access limited edition doesn't belong to their org" do
     login_as create(:gds_admin)
-    publication = create(:draft_publication, access_limiting: "organisations")
+    publication = create(:draft_publication, :access_limited_by_organisations)
 
     get :index, params: { state: :active }
 
@@ -330,7 +330,7 @@ class Admin::EditionsControllerTest < ActionController::TestCase
     my_organisation = create(:organisation)
     other_organisation = create(:organisation)
     login_as create(:writer, organisation: my_organisation)
-    inaccessible = create(:draft_publication, publication_type: PublicationType::NationalStatistics, access_limiting: "organisations", organisations: [other_organisation])
+    inaccessible = create(:draft_publication, :access_limited_by_organisations, publication_type: PublicationType::NationalStatistics, organisations: [other_organisation])
 
     post :revise, params: { id: inaccessible }
     assert_response :forbidden

--- a/test/functional/admin/editorial_remarks_controller_test.rb
+++ b/test/functional/admin/editorial_remarks_controller_test.rb
@@ -51,7 +51,7 @@ class Admin::EditorialRemarksControllerTest < ActionController::TestCase
   end
 
   test "should prevent access to inaccessible editions" do
-    protected_edition = create(:submitted_publication, access_limiting: "organisations")
+    protected_edition = create(:submitted_publication, :access_limited_by_organisations)
 
     get :new, params: { edition_id: protected_edition.id }
     assert_response :forbidden

--- a/test/functional/admin/fact_check_requests_controller_test.rb
+++ b/test/functional/admin/fact_check_requests_controller_test.rb
@@ -189,7 +189,7 @@ class Admin::CreatingFactCheckRequestsControllerTest < ActionController::TestCas
   end
 
   test "should prevent creation of a fact check request if edition is not accessible to the current user" do
-    protected_edition = create(:draft_publication, :access_limited)
+    protected_edition = create(:draft_publication, :access_limited_by_organisations)
     post :create, params: { edition_id: protected_edition.id, fact_check_request: @attributes }
 
     assert_response :forbidden

--- a/test/functional/admin/preview_controller_test.rb
+++ b/test/functional/admin/preview_controller_test.rb
@@ -59,7 +59,7 @@ class Admin::PreviewControllerTest < ActionController::TestCase
   end
 
   test "preview returns a 403 if any of the referenced attachments are inaccessible to the current user" do
-    protected_edition = create(:draft_publication, :access_limited)
+    protected_edition = create(:draft_publication, :access_limited_by_organisations)
     attachment = create(:file_attachment, attachable: protected_edition)
 
     post :preview, params: { body: "blah", attachment_ids: [attachment.id] }

--- a/test/functional/admin/publications_controller_test.rb
+++ b/test/functional/admin/publications_controller_test.rb
@@ -140,7 +140,7 @@ class Admin::PublicationsControllerTest < ActionController::TestCase
     my_organisation = create(:organisation)
     other_organisation = create(:organisation)
     @user = login_as(create(:user, organisation: my_organisation))
-    inaccessible = create(:draft_publication, publication_type: PublicationType::NationalStatistics, access_limiting: "organisations", organisations: [other_organisation])
+    inaccessible = create(:draft_publication, :access_limited_by_organisations, publication_type: PublicationType::NationalStatistics, organisations: [other_organisation])
 
     get :show, params: { id: inaccessible }
     assert_response :forbidden

--- a/test/functional/admin/standard_edition_translations_controller_test.rb
+++ b/test/functional/admin/standard_edition_translations_controller_test.rb
@@ -235,7 +235,7 @@ class Admin::StandardEditionTranslationsControllerTest < ActionController::TestC
         },
       },
     }))
-    protected_edition = create(:draft_standard_edition, :access_limited, configurable_document_type: "test_type")
+    protected_edition = create(:draft_standard_edition, :access_limited_by_organisations, configurable_document_type: "test_type")
 
     get :edit, params: { standard_edition_id: protected_edition.id, id: "en" }
     assert_response :forbidden

--- a/test/integration/asset_access_options_integration_test.rb
+++ b/test/integration/asset_access_options_integration_test.rb
@@ -77,7 +77,7 @@ class AssetAccessOptionsIntegrationTest < ActionDispatch::IntegrationTest
       end
 
       context "when a draft is unmarked as access limited" do
-        let(:edition) { create(:detailed_guide, organisations: [organisation], access_limiting: "organisations") }
+        let(:edition) { create(:detailed_guide, :access_limited_by_organisations, organisations: [organisation]) }
 
         before do
           add_file_attachment_with_asset("sample.docx", to: edition)
@@ -98,7 +98,7 @@ class AssetAccessOptionsIntegrationTest < ActionDispatch::IntegrationTest
       end
 
       context "when an attachment is added to an access-limited draft" do
-        let(:edition) { create(:detailed_guide, organisations: [organisation], access_limiting: "organisations") }
+        let(:edition) { create(:detailed_guide, :access_limited_by_organisations, organisations: [organisation]) }
 
         before do
           visit admin_edition_path(edition)
@@ -120,7 +120,7 @@ class AssetAccessOptionsIntegrationTest < ActionDispatch::IntegrationTest
       end
 
       context "when multiple files are uploaded to an access-limited draft" do
-        let(:edition) { create(:detailed_guide, organisations: [organisation], access_limiting: "organisations") }
+        let(:edition) { create(:detailed_guide, :access_limited_by_organisations, organisations: [organisation]) }
 
         before do
           visit admin_edition_path(edition)
@@ -147,7 +147,7 @@ class AssetAccessOptionsIntegrationTest < ActionDispatch::IntegrationTest
       end
 
       context "when an attachment is replaced on an access-limited draft" do
-        let(:edition) { create(:detailed_guide, organisations: [organisation], access_limiting: "organisations") }
+        let(:edition) { create(:detailed_guide, :access_limited_by_organisations, organisations: [organisation]) }
 
         before do
           add_file_attachment_with_asset("sample.docx", to: edition)
@@ -170,7 +170,7 @@ class AssetAccessOptionsIntegrationTest < ActionDispatch::IntegrationTest
 
       context "when an attachment is added to an access-limited consultation outcome" do
         # the edition has to have same organisation as logged in user, otherwise it's not visible when access_limited = true
-        let(:edition) { create(:consultation, organisations: [organisation], access_limiting: "organisations") }
+        let(:edition) { create(:consultation, :access_limited_by_organisations, organisations: [organisation]) }
         let(:outcome_attributes) { FactoryBot.attributes_for(:consultation_outcome) }
         let!(:outcome) { edition.create_outcome!(outcome_attributes) }
 

--- a/test/integration/asset_access_options_integration_test.rb
+++ b/test/integration/asset_access_options_integration_test.rb
@@ -62,7 +62,8 @@ class AssetAccessOptionsIntegrationTest < ActionDispatch::IntegrationTest
           add_file_attachment_with_asset("sample.docx", to: edition)
           edition.save!
           visit edit_admin_edition_path(edition)
-          check "Limit access"
+          choose "Limit access to publishers from organisations associated with this document"
+          select organisation.name, from: "edition_access_limiting_organisation_ids"
           click_button "Save"
           assert_text "Your document has been saved"
         end
@@ -83,7 +84,7 @@ class AssetAccessOptionsIntegrationTest < ActionDispatch::IntegrationTest
           add_file_attachment_with_asset("sample.docx", to: edition)
           edition.save!
           visit edit_admin_edition_path(edition)
-          uncheck "Limit access"
+          choose "No - This document should be available to all publishers"
           click_button "Save"
           assert_text "Your document has been saved"
         end

--- a/test/integration/asset_manager_test.rb
+++ b/test/integration/asset_manager_test.rb
@@ -34,7 +34,7 @@ class AssetManagerIntegrationTest
 
     test "sends the user ids of authorised users to Asset Manager" do
       organisation = FactoryBot.create(:organisation)
-      consultation = FactoryBot.create(:consultation, access_limiting: "organisations", organisations: [organisation])
+      consultation = FactoryBot.create(:consultation, access_limiting: "organisations", access_limiting_organisation_ids: [organisation.id], organisations: [organisation])
       @attachment.attachable = consultation
       @attachment.attachment_data.attachable = consultation
       @attachment.save!

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -1492,6 +1492,8 @@ module AdminEditionControllerTestHelpers
       edition_class = class_for(edition_type)
 
       test "create should record the access_limiting flag" do
+        feature_flags.switch! :access_limiting_organisations_ui, false
+
         organisation = create(:organisation)
         controller.current_user.organisation = organisation
         controller.current_user.save!
@@ -1511,6 +1513,8 @@ module AdminEditionControllerTestHelpers
       end
 
       view_test "edit displays persisted access_limiting flag" do
+        feature_flags.switch! :access_limiting_organisations_ui, false
+
         publication = create(edition_type, access_limiting: "none")
 
         get :edit, params: { id: publication }
@@ -1522,6 +1526,8 @@ module AdminEditionControllerTestHelpers
       end
 
       test "update records new value of access_limiting flag" do
+        feature_flags.switch! :access_limiting_organisations_ui, false
+
         controller.current_user.organisation = create(:organisation)
         controller.current_user.save!
         publication = create(edition_type, access_limiting: "none", organisations: [controller.current_user.organisation])
@@ -1538,6 +1544,8 @@ module AdminEditionControllerTestHelpers
       end
 
       view_test "access limiting document fails if user does not belong to one of the tagged organisations" do
+        feature_flags.switch! :access_limiting_organisations_ui, false
+
         controller.current_user.organisation = create(:organisation)
         controller.current_user.save!
         organisation = create(:organisation)

--- a/test/unit/app/models/admin/edition_filter_test.rb
+++ b/test/unit/app/models/admin/edition_filter_test.rb
@@ -7,10 +7,7 @@ class Admin::EditionFilterTest < ActiveSupport::TestCase
 
   test "should return limited access editions when the edition is published by the users organisation" do
     user = create(:user)
-    edition = create(
-      :publication,
-      access_limiting: "organisations",
-    )
+    edition = create(:publication, :access_limited_by_organisations)
     edition.organisations.first.users << user
 
     filter = Admin::EditionFilter.new(Edition, user)
@@ -18,14 +15,14 @@ class Admin::EditionFilterTest < ActiveSupport::TestCase
   end
 
   test "should not return editions which have limited access for other orgs for non-gds admins" do
-    create(:publication, access_limiting: "organisations")
+    create(:publication, :access_limited_by_organisations)
 
     filter = Admin::EditionFilter.new(Edition, build(:user))
     assert_equal 0, filter.editions.count
   end
 
   test "should return limited access editions for GDS admins" do
-    edition = create(:publication, access_limiting: "organisations")
+    edition = create(:publication, :access_limited_by_organisations)
 
     filter = Admin::EditionFilter.new(Edition, build(:gds_admin))
     assert_equal edition, filter.editions.first

--- a/test/unit/app/models/attachment_data_visibility_test.rb
+++ b/test/unit/app/models/attachment_data_visibility_test.rb
@@ -54,6 +54,7 @@ class AttachmentDataVisibilityTest < ActiveSupport::TestCase
         context "edition is access-limited" do
           before do
             edition.access_limiting = "organisations"
+            edition.access_limiting_organisation_ids = edition.edition_organisations.map(&:organisation_id)
             edition.save!
           end
 
@@ -86,6 +87,7 @@ class AttachmentDataVisibilityTest < ActiveSupport::TestCase
                 before do
                   new_edition.change_note = "change-note"
                   new_edition.access_limiting = "organisations"
+                  new_edition.access_limiting_organisation_ids = new_edition.edition_organisations.map(&:organisation_id)
                   new_edition.save!
                 end
 
@@ -222,6 +224,7 @@ class AttachmentDataVisibilityTest < ActiveSupport::TestCase
               before do
                 new_edition.change_note = "change-note"
                 new_edition.access_limiting = "organisations"
+                new_edition.access_limiting_organisation_ids = new_edition.edition_organisations.map(&:organisation_id)
                 new_edition.save!
               end
 
@@ -359,7 +362,7 @@ class AttachmentDataVisibilityTest < ActiveSupport::TestCase
 
         context "consultation is access-limited" do
           before do
-            consultation.update!(access_limiting: "organisations")
+            consultation.update!(access_limiting: "organisations", access_limiting_organisation_ids: consultation.edition_organisations.map(&:organisation_id))
           end
 
           it "is not accessible to anonymous user" do

--- a/test/unit/app/models/edition/limited_access_test.rb
+++ b/test/unit/app/models/edition/limited_access_test.rb
@@ -172,6 +172,10 @@ class Edition::LimitedAccessTest < ActiveSupport::TestCase
   end
 
   context "with access_limiting_organisations_ui flag off" do
+    setup do
+      @feature_flags.switch!(:access_limiting_organisations_ui, false)
+    end
+
     test "is valid when access_limiting is set to 'organisations' and no access limiting organisations are selected" do
       edition = create(:consultation, access_limiting: :organisations)
       edition.access_limiting_organisation_ids = []
@@ -366,8 +370,7 @@ class Edition::LimitedAccessTest < ActiveSupport::TestCase
   end
 
   test "access_limiting persists across save/reload" do
-    edition = build(:limited_access_edition)
-    edition.access_limiting = "organisations"
+    edition = build(:limited_access_edition, :access_limited_by_organisations)
     edition.save!
     edition.reload
     assert edition.access_limited?

--- a/test/unit/app/presenters/publishing_api/fatality_notice_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/fatality_notice_presenter_test.rb
@@ -265,7 +265,7 @@ end
 class PublishingApi::AccessLimitedFatalityNoticeTest < ActiveSupport::TestCase
   setup do
     @presented_fatality_notice = PublishingApi::FatalityNoticePresenter.new(
-      @fatality_notice = create(:fatality_notice, :access_limited),
+      @fatality_notice = create(:fatality_notice, :access_limited_by_organisations),
     )
     @organisation = @fatality_notice.organisations.first
     @presented_content = @presented_fatality_notice.content

--- a/test/unit/app/presenters/publishing_api/payload_builder/access_limitation_test.rb
+++ b/test/unit/app/presenters/publishing_api/payload_builder/access_limitation_test.rb
@@ -16,6 +16,7 @@ module PublishingApi
       end
 
       test "returns organisation content ids for organisation access limiting, when flags are off" do
+        @feature_flags.switch!(:access_limiting_organisations_ui, false)
         organisation = create(:organisation)
 
         item = build_item(
@@ -31,6 +32,7 @@ module PublishingApi
       end
 
       test "falls back to organisation content ids for a legacy organisation-limited edition when only the individuals flag is on" do
+        @feature_flags.switch!(:access_limiting_organisations_ui, false)
         @feature_flags.switch!(:access_limiting_individuals_ui, true)
         organisation = create(:organisation)
 

--- a/test/unit/app/services/asset_manager/attachment_updater_test.rb
+++ b/test/unit/app/services/asset_manager/attachment_updater_test.rb
@@ -51,7 +51,7 @@ class AssetManager::AttachmentUpdaterTest < ActiveSupport::TestCase
 
     context "when the attachment's attachable is a draft and is access limited to organisations" do
       it "sets the expected attributes for all assets" do
-        edition = create(:draft_publication, :access_limited)
+        edition = create(:draft_publication, :access_limited_by_organisations)
         attachment = create(:file_attachment, attachable: edition, attachment_data: create(:attachment_data, attachable: edition))
 
         expected_attribute_hash = {

--- a/test/unit/app/services/draft_edition_updater_test.rb
+++ b/test/unit/app/services/draft_edition_updater_test.rb
@@ -31,7 +31,7 @@ class DraftEditionUpdaterTest < ActiveSupport::TestCase
 
   test "updates editions that cannot be tagged to organisations" do
     organisation = create(:organisation)
-    edition = create(:draft_corporate_information_page, organisation:, access_limiting: "organisations")
+    edition = create(:draft_corporate_information_page, organisation:, access_limiting: "organisations", access_limiting_organisation_ids: [organisation.id])
     updater = DraftEditionUpdater.new(edition, { current_user: create(:user, organisation:) })
     updater.expects(:update_publishing_api!).once
     updater.expects(:notify!).once

--- a/test/unit/app/services/edition_publisher_test.rb
+++ b/test/unit/app/services/edition_publisher_test.rb
@@ -12,7 +12,7 @@ class EditionPublisherTest < ActiveSupport::TestCase
   end
 
   test "#perform! with an access limited edition clears the flag" do
-    edition = create(:submitted_edition, :access_limited)
+    edition = create(:submitted_edition, :access_limited_by_organisations)
 
     assert EditionPublisher.new(edition).perform!
     assert edition.published?
@@ -23,7 +23,7 @@ class EditionPublisherTest < ActiveSupport::TestCase
     organisation = create(:organisation)
     edition = create(
       :submitted_edition,
-      :access_limited,
+      :access_limited_by_organisations,
       access_limiting_organisation_ids: [organisation.id],
     )
 

--- a/test/unit/app/sidekiq/asset_manager_create_asset_job_test.rb
+++ b/test/unit/app/sidekiq/asset_manager_create_asset_job_test.rb
@@ -169,7 +169,7 @@ class AssetManagerCreateAssetJobTest < ActiveSupport::TestCase
   end
 
   test "should not process the file if the attachable has been deleted" do
-    consultation = FactoryBot.create(:consultation, organisations: [@organisation], access_limiting: "organisations")
+    consultation = FactoryBot.create(:consultation, :access_limited_by_organisations, organisations: [@organisation])
     consultation.delete
     consultation.save!(validate: false)
 

--- a/test/unit/app/sidekiq/asset_manager_create_asset_job_test.rb
+++ b/test/unit/app/sidekiq/asset_manager_create_asset_job_test.rb
@@ -232,6 +232,8 @@ class AssetManagerCreateAssetJobTest < ActiveSupport::TestCase
     end
 
     test "marks attachments belonging to an edition attachable as access limited to organisations" do
+      @feature_flags.switch!(:access_limiting_organisations_ui, false)
+
       attachable = FactoryBot.create(:consultation, organisations: [@organisation], access_limiting: "organisations")
       file = FactoryBot.create(:file_attachment, attachable:)
       assetable = file.attachment_data
@@ -268,6 +270,8 @@ class AssetManagerCreateAssetJobTest < ActiveSupport::TestCase
     end
 
     test "marks attachments belonging to an outcome attachable as access limited to organisations" do
+      @feature_flags.switch!(:access_limiting_organisations_ui, false)
+
       consultation = FactoryBot.create(:consultation, organisations: [@organisation], access_limiting: "organisations")
       attachable = FactoryBot.create(:consultation_outcome, consultation:)
       file = FactoryBot.create(:file_attachment, attachable:)

--- a/test/unit/lib/whitehall/authority/authority_test_helper.rb
+++ b/test/unit/lib/whitehall/authority/authority_test_helper.rb
@@ -32,6 +32,7 @@ module AuthorityTestHelper
     define_method("limited_#{edition_type}") do |orgs|
       le = FactoryBot.build(edition_type, access_limiting: "organisations")
       le.stubs(:organisations).returns(orgs)
+      le.stubs(:access_limiting_organisations).returns(orgs)
       le
     end
     define_method("scheduled_#{edition_type}") do

--- a/test/unit/lib/whitehall/authority/edition_rules_test.rb
+++ b/test/unit/lib/whitehall/authority/edition_rules_test.rb
@@ -58,6 +58,8 @@ class EditionRulesTest < ActiveSupport::TestCase
   end
 
   test "grants access based on lead/supporting organisations when flag is OFF" do
+    feature_flags.switch! :access_limiting_organisations_ui, false
+
     user = user_in(org)
     edition = build(:consultation, access_limiting: "organisations")
     edition.stubs(:historic?).returns(false)
@@ -69,6 +71,8 @@ class EditionRulesTest < ActiveSupport::TestCase
   end
 
   test "revokes access based on lead/supporting organisations when flag is OFF" do
+    feature_flags.switch! :access_limiting_organisations_ui, false
+
     user = user_in(org)
     edition = build(:consultation, access_limiting: "organisations")
     edition.stubs(:historic?).returns(false)
@@ -89,6 +93,8 @@ class EditionRulesTest < ActiveSupport::TestCase
   end
 
   test "revokes access when the user does not have an organisation, and flag is OFF" do
+    feature_flags.switch! :access_limiting_organisations_ui, false
+
     user = user_in(nil)
     edition = build(:consultation, access_limiting: "organisations")
     edition.stubs(:historic?).returns(false)
@@ -180,7 +186,6 @@ class EditionRulesTest < ActiveSupport::TestCase
   end
 
   test "revokes access when access_limiting it set to 'individuals', but there are no access_limiting_individuals on the edition, and flag is ON" do
-    #  Special case to cover migration issues. In the latest validation this scenario is not really feasible.
     feature_flags.switch! :access_limiting_individuals_ui, true
 
     org1 = build(:organisation)
@@ -298,6 +303,8 @@ class EditionRulesTest < ActiveSupport::TestCase
   end
 
   test "a user outside the limiting org cannot perform ANY action on a non-historic access-limited edition when flag is OFF" do
+    feature_flags.switch! :access_limiting_organisations_ui, false
+
     user = user_in(other_org)
     edition = build(:consultation, access_limiting: "organisations")
     edition.stubs(:historic?).returns(false)
@@ -341,6 +348,8 @@ class EditionRulesTest < ActiveSupport::TestCase
   end
 
   test "when the access_limiting_individuals_ui flag is OFF, individuals mode does not enforce access" do
+    feature_flags.switch! :access_limiting_individuals_ui, false
+
     user = user_with_email("anyone@example.com")
     edition = build(:edition, access_limiting: "individuals")
     edition.stubs(:historic?).returns(false)


### PR DESCRIPTION
PR containing the commits to turn on the new access limitation options.

- Handles the organisation backfill
- Turns on the org UI feature flag
- Fixes any tests to handle the new defaults 