### PR TITLE
Revert "Allow Welsh-language mainstream URLs [WHIT-3436]"

### DIFF
--- a/app/models/document_collection_non_whitehall_link/govuk_url.rb
+++ b/app/models/document_collection_non_whitehall_link/govuk_url.rb
@@ -31,24 +31,24 @@ class DocumentCollectionNonWhitehallLink::GovukUrl
   end
 
   def content_item
-    @content_item ||= content_item_from_content_store
+    @content_item ||= Services.publishing_api.get_content(content_id).to_h
   end
 
   def content_id
-    @content_id ||= content_item["content_id"]
-  end
+    @content_id ||= Services.publishing_api.lookup_content_id(base_path: parsed_url.path, with_drafts: true)
 
-  def content_item_from_content_store
-    path = parsed_url.path
-
-    item = Services.content_store.content_item(path).to_h
-
-    if item["base_path"] != path && item["document_type"] != "guide"
-      raise GdsApi::HTTPNotFound, 404
+    if @content_id.blank?
+      toplevel_path_segment = parsed_url.path.split("/").second
+      @content_id = Services.publishing_api.lookup_content_id(base_path: "/#{toplevel_path_segment}", with_drafts: true)
+      if @content_id.blank?
+        raise GdsApi::HTTPNotFound, 404
+      else
+        unless content_item["document_type"] == "guide"
+          raise GdsApi::HTTPNotFound, 404
+        end
+      end
     end
 
-    item
-  rescue GdsApi::ContentStore::ItemNotFound
-    raise GdsApi::HTTPNotFound, 404
+    @content_id
   end
 end

--- a/features/step_definitions/document_collection_steps.rb
+++ b/features/step_definitions/document_collection_steps.rb
@@ -157,8 +157,7 @@ And(/^a GovUK Url exists "([^"]*)" with title "([^"]*)"$/) do |url, title|
   content_id = SecureRandom.uuid
 
   stub_publishing_api_has_lookups(base_path => content_id)
-  stub_content_store_has_item(
-    base_path,
+  stub_publishing_api_has_item(
     content_id:,
     base_path:,
     publishing_app: "content-publisher",

--- a/lib/services.rb
+++ b/lib/services.rb
@@ -1,6 +1,5 @@
 require "gds_api/publishing_api"
 require "gds_api/asset_manager"
-require "gds_api/content_store"
 require "gds_api/search"
 
 module Services
@@ -10,10 +9,6 @@ module Services
 
   def self.publishing_api_with_huge_timeout
     @publishing_api_with_huge_timeout ||= publishing_api_client_with_timeout(60)
-  end
-
-  def self.content_store
-    @content_store ||= GdsApi::ContentStore.new(Plek.find("content-store"))
   end
 
   def self.asset_manager

--- a/test/unit/app/models/document_collection_non_whitehall_link/govuk_url_test.rb
+++ b/test/unit/app/models/document_collection_non_whitehall_link/govuk_url_test.rb
@@ -3,15 +3,16 @@ require "test_helper"
 class DocumentCollectionNonWhitehallLink::GovukUrlTest < ActiveSupport::TestCase
   setup do
     @content_id = SecureRandom.uuid
-    Services.content_store.stubs(:content_item).with("/test").returns(
-      "content_id" => @content_id,
-      "title" => "Test",
-      "base_path" => "/test",
-      "publishing_app" => "content-publisher",
+    stub_publishing_api_has_lookups("/test" => @content_id)
+    stub_publishing_api_has_item(
+      content_id: @content_id,
+      title: "Test",
+      base_path: "/test",
+      publishing_app: "content-publisher",
     )
   end
 
-  test "should be valid when content store has the path" do
+  test "should be valid without a GOV.UK url that Publishing API knows" do
     url = DocumentCollectionNonWhitehallLink::GovukUrl.new(
       url: "https://www.gov.uk/test",
       document_collection_group: build(:document_collection_group),
@@ -31,13 +32,12 @@ class DocumentCollectionNonWhitehallLink::GovukUrlTest < ActiveSupport::TestCase
 
   test "should be valid when a mainstream guide sub-page url is used" do
     content_id = SecureRandom.uuid
-    Services.content_store.stubs(:content_item).with("/foo/subpage").returns(
-      "content_id" => content_id,
-      "title" => "Foo Bar",
-      "base_path" => "/foo",
-      "publishing_app" => "content-publisher",
-      "document_type" => "guide",
-    )
+    stub_publishing_api_has_lookups("/foo" => content_id)
+    stub_publishing_api_has_item(content_id:,
+                                 title: "Foo Bar",
+                                 base_path: "/foo",
+                                 document_type: "guide",
+                                 publishing_app: "content-publisher")
 
     url = DocumentCollectionNonWhitehallLink::GovukUrl.new(
       url: "https://www.gov.uk/foo/subpage",
@@ -85,21 +85,18 @@ class DocumentCollectionNonWhitehallLink::GovukUrlTest < ActiveSupport::TestCase
     assert url.errors.full_messages.include?("Url must be a valid GOV.UK URL")
   end
 
-  test "should be valid for a Welsh-only GOV.UK page (locale: cy)" do
-    welsh_content_id = SecureRandom.uuid
-    content_store_response = { "content_id" => welsh_content_id, "title" => "Talu TWE y cyflogwr", "base_path" => "/talu-treth-twe", "publishing_app" => "publisher", "locale" => "cy" }
-    Services.content_store.stubs(:content_item).with("/talu-treth-twe").returns(content_store_response)
-
+  test "should be invalid when a GOV.UK URL that isn't in the Publishing API" do
     url = DocumentCollectionNonWhitehallLink::GovukUrl.new(
-      url: "https://www.gov.uk/talu-treth-twe",
+      url: "https://www.gov.uk/different-path",
       document_collection_group: build(:document_collection_group),
     )
 
-    assert url.valid?
+    assert_not url.valid?
+    assert url.errors.full_messages.include?("Url must reference a GOV.UK page")
   end
 
-  test "should be invalid when content store returns a 404" do
-    Services.content_store.stubs(:content_item).raises(GdsApi::ContentStore::ItemNotFound.new(404))
+  test "should be invalid when Publishing API returns a 404" do
+    stub_any_publishing_api_call_to_return_not_found
 
     url = DocumentCollectionNonWhitehallLink::GovukUrl.new(
       url: "https://www.gov.uk/test",
@@ -112,13 +109,12 @@ class DocumentCollectionNonWhitehallLink::GovukUrlTest < ActiveSupport::TestCase
 
   test "should be invalid when a non-mainstream guide sub-page url is used" do
     content_id = SecureRandom.uuid
-    Services.content_store.stubs(:content_item).with("/foo/subpage").returns(
-      "content_id" => content_id,
-      "title" => "Foo Bar",
-      "base_path" => "/foo",
-      "publishing_app" => "content-publisher",
-      "document_type" => "other",
-    )
+    stub_publishing_api_has_lookups("/foo" => content_id)
+    stub_publishing_api_has_item(content_id:,
+                                 title: "Foo Bar",
+                                 base_path: "/foo",
+                                 document_type: "other",
+                                 publishing_app: "content-publisher")
 
     url = DocumentCollectionNonWhitehallLink::GovukUrl.new(
       url: "https://www.gov.uk/foo/subpage",
@@ -128,8 +124,8 @@ class DocumentCollectionNonWhitehallLink::GovukUrlTest < ActiveSupport::TestCase
     assert_not url.valid?
   end
 
-  test "should be invalid when Content Store is unavailable" do
-    Services.content_store.stubs(:content_item).raises(GdsApi::HTTPIntermittentServerError.new(503))
+  test "should be invalid when Publishing API is down" do
+    stub_publishing_api_isnt_available
 
     url = DocumentCollectionNonWhitehallLink::GovukUrl.new(
       url: "https://www.gov.uk/test",


### PR DESCRIPTION
Reverts alphagov/whitehall#11442

Whilst the changes fixed the ability to add Welsh language mainstream URLs, it broke the ability to add a draft document URL to a document collection.

There is a [draft PR](https://github.com/alphagov/whitehall/pull/11561) to fix forward, but we'd sooner take a step back and approach the problem more holistically. A follow-on Jira ticket will be created.