### PR TITLE
[WHIT 3722] FIX for - Entering email addresses that don't exist in Signon does not update draft stack

### DIFF
--- a/app/models/concerns/edition/limited_access.rb
+++ b/app/models/concerns/edition/limited_access.rb
@@ -32,7 +32,7 @@ module Edition::LimitedAccess
     validate :access_limiting_must_include_current_user_organisation
     validate :access_limiting_must_include_current_user_email
     validate :access_limiting_individual_emails_required, if: -> { Flipflop.access_limiting_individuals_ui? && access_limiting_individuals? }
-    validate :access_limiting_individual_emails_format, if: -> { Flipflop.access_limiting_individuals_ui? && access_limiting_individuals? }
+    validate :access_limiting_individual_emails_valid, if: -> { Flipflop.access_limiting_individuals_ui? && access_limiting_individuals? }
   end
 
   def access_limited_object
@@ -137,11 +137,18 @@ private
     errors.add(:access_limiting_individual_emails, "must include at least one email when individual access limiting is enabled") if access_limiting_individuals.reject(&:marked_for_destruction?).empty?
   end
 
-  def access_limiting_individual_emails_format
-    invalid = access_limiting_individuals
-                .reject(&:marked_for_destruction?)
-                .reject { |individual| ValidatesEmailFormatOf.validate_email_format(individual.email.to_s).nil? }
+  def access_limiting_individual_emails_valid
+    individuals = access_limiting_individuals.reject(&:marked_for_destruction?)
 
-    errors.add(:access_limiting_individual_emails, "must contain valid email addresses") if invalid.any?
+    invalid_format = individuals.select { |individual| ValidatesEmailFormatOf.validate_email_format(individual.email.to_s) }
+    if invalid_format.any?
+      errors.add(:access_limiting_individual_emails, "must contain valid email addresses: #{invalid_format.map(&:email).join(', ')}")
+    end
+
+    well_formed = individuals - invalid_format
+    unmatched = well_formed.reject { |individual| User.exists?(["LOWER(email) = ?", individual.email.to_s.downcase]) }
+    if unmatched.any?
+      errors.add(:access_limiting_individual_emails, "must match an existing Signon user: #{unmatched.map(&:email).join(', ')}")
+    end
   end
 end

--- a/test/functional/admin/edition_access_limited_controller_test.rb
+++ b/test/functional/admin/edition_access_limited_controller_test.rb
@@ -279,6 +279,7 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
     feature_flags.switch! :access_limiting_individuals_ui, true
 
     organisation = create(:organisation)
+    create(:user, email: "user@example.com")
     edition = create(
       :consultation,
       access_limiting: :organisations,
@@ -308,6 +309,7 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
     feature_flags.switch! :access_limiting_individuals_ui, true
 
     organisation = create(:organisation)
+    create(:user, email: "user@example.com")
     edition = create(
       :consultation,
       access_limiting: :individuals,
@@ -337,6 +339,7 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
     feature_flags.switch! :access_limiting_individuals_ui, true
 
     organisation = create(:organisation)
+    create(:user, email: "user@example.com")
     edition = create(
       :consultation,
       access_limiting: :individuals,
@@ -364,6 +367,7 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
   view_test "PATCH :update re-renders the edit template with error and the submitted values, but does not persist the association, when access limiting individuals invalid" do
     feature_flags.switch! :access_limiting_individuals_ui, true
 
+    create(:user, email: "user@example.com")
     edition = create(
       :consultation,
       access_limiting: :individuals,
@@ -381,7 +385,7 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
         }
 
     assert_template :edit
-    assert_select ".govuk-error-summary a", text: "Access limiting individual emails must contain valid email addresses", href: "#access_limiting_individuals_emails"
+    assert_select ".govuk-error-summary a", text: "Access limiting individual emails must contain valid email addresses: notanemail", href: "#access_limiting_individuals_emails"
     assert_select "textarea[name='edition[access_limiting_individual_emails]']", text: "user@example.com, another_user@example.com, notanemail"
     assert_select "textarea[name='edition[editorial_remark]']", text: "Test"
 

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -1316,7 +1316,7 @@ module AdminEditionControllerTestHelpers
         end
 
         assert_template :new
-        assert_select ".govuk-error-summary a", text: "Access limiting individual emails must contain valid email addresses", href: "#access_limiting_individual_emails"
+        assert_select ".govuk-error-summary a", text: "Access limiting individual emails must contain valid email addresses: gibberish", href: "#access_limiting_individual_emails"
         assert_select "form#new_edition" do
           assert_select "input[name='edition[access_limiting]'][type=radio][value='individuals'][checked='checked']"
           assert_select "textarea[name='edition[access_limiting_individual_emails]']", text: "gibberish"

--- a/test/unit/app/models/edition/limited_access_test.rb
+++ b/test/unit/app/models/edition/limited_access_test.rb
@@ -243,7 +243,7 @@ class Edition::LimitedAccessTest < ActiveSupport::TestCase
     edition.access_limiting_individual_emails = "test@test.com example@example.com some_test@test.com"
 
     assert_not edition.valid?
-    assert_includes edition.errors[:access_limiting_individual_emails], "must contain valid email addresses"
+    assert_includes edition.errors[:access_limiting_individual_emails], "must contain valid email addresses: test@test.com example@example.com some_test@test.com"
   end
 
   test "does not persist access_limiting_individuals on assignment" do
@@ -273,6 +273,7 @@ class Edition::LimitedAccessTest < ActiveSupport::TestCase
   test "is valid when access_limiting is set to 'individuals' and access limiting emails are present" do
     @feature_flags.switch!(:access_limiting_individuals_ui, true)
 
+    create(:user, email: "user@example.com")
     edition = create(:limited_access_edition)
     edition.access_limiting = :individuals
     edition.access_limiting_individual_emails = "user@example.com"
@@ -289,7 +290,7 @@ class Edition::LimitedAccessTest < ActiveSupport::TestCase
 
     assert_not edition.valid?
     assert_includes edition.errors[:access_limiting_individual_emails],
-                    "must contain valid email addresses"
+                    "must contain valid email addresses: not-an-email"
     assert_empty edition.errors[:"access_limiting_individuals.email"]
   end
 
@@ -301,7 +302,7 @@ class Edition::LimitedAccessTest < ActiveSupport::TestCase
     edition.access_limiting_individual_emails = "test@test"
 
     assert_not edition.valid?
-    assert_includes edition.errors[:access_limiting_individual_emails], "must contain valid email addresses"
+    assert_includes edition.errors[:access_limiting_individual_emails], "must contain valid email addresses: test@test"
   end
 
   test "is invalid when valid emails are mixed in with badly formatted emails" do
@@ -312,7 +313,77 @@ class Edition::LimitedAccessTest < ActiveSupport::TestCase
     edition.access_limiting_individual_emails = "user@example.com, gibberish"
 
     assert_not edition.valid?
-    assert_includes edition.errors[:access_limiting_individual_emails], "must contain valid email addresses"
+    assert_includes edition.errors[:access_limiting_individual_emails], "must contain valid email addresses: gibberish"
+  end
+
+  test "shows both the format error and the Signon-match error, when different emails have different problems" do
+    @feature_flags.switch!(:access_limiting_individuals_ui, true)
+
+    edition = create(:limited_access_edition)
+    edition.access_limiting = :individuals
+    edition.access_limiting_individual_emails = "no_such_user@example.com, gibberish"
+
+    assert_not edition.valid?
+    assert_includes edition.errors[:access_limiting_individual_emails], "must contain valid email addresses: gibberish"
+    assert_includes edition.errors[:access_limiting_individual_emails], "must match an existing Signon user: no_such_user@example.com"
+  end
+
+  test "is invalid when access_limiting is set to 'individuals' and the provided email does not match an existing Signon user" do
+    @feature_flags.switch!(:access_limiting_individuals_ui, true)
+
+    edition = create(:limited_access_edition)
+    edition.access_limiting = :individuals
+    edition.access_limiting_individual_emails = "no_such_user@example.com"
+
+    assert_not edition.valid?
+    assert_includes edition.errors[:access_limiting_individual_emails], "must match an existing Signon user: no_such_user@example.com"
+  end
+
+  test "recognizes an existing Signon user regardless of email case" do
+    @feature_flags.switch!(:access_limiting_individuals_ui, true)
+
+    create(:user, email: "User@Example.com")
+    edition = create(:limited_access_edition)
+    edition.access_limiting = :individuals
+    edition.access_limiting_individual_emails = "user@example.com"
+
+    assert edition.valid?
+  end
+
+  test "is invalid when a Signon email is mixed in with an email that does not match any Signon user" do
+    @feature_flags.switch!(:access_limiting_individuals_ui, true)
+
+    create(:user, email: "user@example.com")
+    edition = create(:limited_access_edition)
+    edition.access_limiting = :individuals
+    edition.access_limiting_individual_emails = "user@example.com, no_such_user@example.com"
+
+    assert_not edition.valid?
+    assert_includes edition.errors[:access_limiting_individual_emails], "must match an existing Signon user: no_such_user@example.com"
+  end
+
+  test "does not require a Signon match for an individual email marked for destruction" do
+    @feature_flags.switch!(:access_limiting_individuals_ui, true)
+
+    create(:user, email: "user@example.com")
+    edition = build(:limited_access_edition)
+    edition.access_limiting = :individuals
+    edition.access_limiting_individual_emails = "user@example.com"
+    edition.save!
+
+    # Bypass the edition-level Signon validation to simulate a pre-existing
+    # individual whose email doesn't match any Signon user - e.g. one added
+    # before this validation existed, or whose Signon account was later removed.
+    edition.access_limiting_individuals.create!(email: "no_such_user@example.com")
+    assert edition.access_limiting_individuals.exists?(email: "no_such_user@example.com")
+
+    # Replacing the emails list marks the non-Signon email for destruction,
+    # rather than removing it from the in-memory association immediately.
+    edition.access_limiting_individual_emails = "user@example.com"
+
+    assert edition.access_limiting_individuals.detect { |i| i.email == "no_such_user@example.com" }.marked_for_destruction?
+    assert edition.valid?
+    assert_not_includes edition.errors[:access_limiting_individual_emails], "must match an existing Signon user"
   end
 
   test "is valid when access_limiting is set to 'none' regardless of access limiting individuals" do
@@ -360,7 +431,7 @@ class Edition::LimitedAccessTest < ActiveSupport::TestCase
 
     assert_not edition.valid?
     assert_includes edition.errors[:access_limiting_individual_emails], "must include your own email"
-    assert_includes edition.errors[:access_limiting_individual_emails], "must contain valid email addresses"
+    assert_includes edition.errors[:access_limiting_individual_emails], "must contain valid email addresses: test@test.com example@example.com"
   end
 
   test "is valid when access_limiting is set to 'individuals' and no access limiting individuals are selected when flag is off" do

--- a/test/unit/app/sidekiq/asset_manager_create_asset_job_test.rb
+++ b/test/unit/app/sidekiq/asset_manager_create_asset_job_test.rb
@@ -219,7 +219,8 @@ class AssetManagerCreateAssetJobTest < ActiveSupport::TestCase
     test "sets access limiting to any non nil value returned by the payload builder" do
       @feature_flags.switch!(:access_limiting_individuals_ui, true)
 
-      attachable = FactoryBot.create(:consultation, organisations: [@organisation], access_limiting: "individuals", access_limiting_individual_emails: "some.gibberish@example.com")
+      user = create(:user)
+      attachable = FactoryBot.create(:consultation, organisations: [@organisation], access_limiting: "individuals", access_limiting_individual_emails: user.email)
       file = FactoryBot.create(:file_attachment, attachable:)
       assetable = file.attachment_data
 


### PR DESCRIPTION
[JIRA](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-3722)

**What**

When an individual access-limiting list contained only emails that didn't correspond to a real Signon account (e.g. after removing every valid one but leaving an invalid one behind, or entering only invalid emails), Whitehall Admin would save successfully and block WH permissions for the removed/invalid emails — but this didn't propagate downstream. The draft preview and its assets remained accessible.

Whitehall now raises a validation error at save time if any access-limiting email doesn't match an existing Signon user, so a list containing an unresolvable email can no longer be saved at all. The state described in the recreation steps below is no longer reachable — they describe the pre-fix bug for context, not something you can still reproduce.

**Recreation steps (pre-fix behaviour, no longer reproducible)**

1. Set an edition's access limiting to "individuals" with a list of emails that includes some that exist in Signon and some that don't.
2. Confirm users with real Signon accounts can view the draft in WH and its preview on the draft stack.
3. Remove every email that resolves to a real Signon user, leaving only the non-resolving email(s) in the list.
4. Confirm WH now blocks all users from admin access — but the draft preview remains accessible to a previously-authorised user.

**Root cause**

Nothing validated that an access-limiting email corresponded to a real Signon user. A well-formed but non-existent email would pass the existing format/required checks, then silently fail to resolve to a UID when the downstream payload was built — so the edit appeared to succeed with no indication the named person could never be granted access.

**Changes**

1. app/models/concerns/edition/limited_access.rb: added access_limiting_individual_emails_valid, raising a validation error if any access-limiting email doesn't match an existing User record. Consolidated the existing format check into this same validator, replacing the separate access_limiting_individual_emails_format method, since both checks share the same guard condition. Since every email must now resolve to a real user at save time, the individuals list can no longer resolve to zero UIDs through normal Whitehall use.
2. Error messages include the specific offending email(s), so an editor limiting access to several people can tell which entry is the problem.
3. Updated tests in the LimitedAccess concern spec, the admin controller spec, and AssetManagerCreateAssetJob spec — several existing tests used fabricated emails with no matching Signon user and needed a create(:user, ...) added to remain valid under the new check.

**WITH OUR NEW VALIDATION**


https://github.com/user-attachments/assets/c698d3cf-4107-4f45-9cf9-33971e87ce76


