### PR TITLE
Stop integration tests leaking auth state into each other

### DIFF
--- a/test/integration/authentication_test.rb
+++ b/test/integration/authentication_test.rb
@@ -6,6 +6,10 @@ class AuthenticationTest < ActionDispatch::IntegrationTest
     ENV["GDS_SSO_MOCK_INVALID"] = "1"
   end
 
+  teardown do
+    ENV.delete("GDS_SSO_MOCK_INVALID")
+  end
+
   test "should use GDS SSO to authenticate" do
     get admin_people_path
     assert_redirected_to "/auth/gds"

--- a/test/integration/component_guide_test.rb
+++ b/test/integration/component_guide_test.rb
@@ -1,6 +1,10 @@
 require "test_helper"
 
 class ComponentGuideTest < ActionDispatch::IntegrationTest
+  teardown do
+    ENV.delete("GDS_SSO_MOCK_INVALID")
+  end
+
   test "redirects unauthenticated users to signon" do
     ENV["GDS_SSO_MOCK_INVALID"] = "1"
     get "/component-guide"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -300,6 +300,9 @@ class ActionDispatch::IntegrationTest
 
   teardown do
     GDS::SSO.test_user = nil
+    # login_as queues a Warden block that fires on the next request. An unused
+    # one outlives the test and signs in the next test that makes a request.
+    Warden.test_reset!
   end
 end
 


### PR DESCRIPTION
Fixes two ways integration tests leak global state into each other. Both cause intermittent CI failures that depend on the order the parallel runner picks.

## Warden test state

`login_as` queues a block via `Warden.on_next_request` rather than signing the user in immediately. A queued login that the test never consumes — a `setup` block that logs in before a test that makes no request, for example — survives into the next test and authenticates its first request.

Tests asserting that an unauthenticated user is redirected to signon therefore fail at random. `ComponentGuideTest#test_redirects_unauthenticated_users_to_signon` and `AuthenticationTest#test_should_use_GDS_SSO_to_authenticate` both fail this way, reporting `Expected response to be a <3XX: redirect>, but was a <200: OK>`.

`Warden.test_reset!` is added to the existing `ActionDispatch::IntegrationTest` teardown, which is what Warden's test helpers expect and what clears the queue.

## GDS_SSO_MOCK_INVALID

`ComponentGuideTest` and `AuthenticationTest` set the environment variable that makes the SSO mock reject the user, and never unset it. It is process-global, so later tests in the same process are redirected to signon. Both now delete it in a teardown, as `ErrorsControllerTest` already does.

## Testing

- [x] `test/integration/` — reproduced the failure locally before the change (seed dependent, roughly 1 run in 8); 8 consecutive runs pass after it.
- [x] `test/functional/` — 2109 runs, 0 failures.
