### PR TITLE
[WHIT - 3752] Add warning callout when featuring on an access-limited document

### DIFF
--- a/app/views/admin/features/new.html.erb
+++ b/app/views/admin/features/new.html.erb
@@ -4,7 +4,13 @@
 
 <% unless @feature_list.featurable_type == "Edition" %>
   <%= render "govuk_publishing_components/components/warning_text", {
-    text: "Warning: changes to features appear instantly on the live site.",
+    text: "Changes to features appear instantly on the live site.",
+  } %>
+<% end %>
+
+<% unless @feature_list.featurable_type == "Organisation" %>
+  <%= render "govuk_publishing_components/components/warning_text", {
+    text: "Any access limiting settings you have set will have no effect on this image.",
   } %>
 <% end %>
 


### PR DESCRIPTION
[JIRA](https://gov-uk.atlassian.net/browse/WHIT-3752?issueKey=WHIT-3752&subProduct=jira-software)

When featuring (e.g. on a topical event or worldwide organisation), we want to add a callout message to warn the user that their uploaded featured image won’t itself be access limited.

We should avoid showing the message on Organisations, however, since they can’t be access limited.

Have also removed 'Warning:' from the existing hint as it could be read out twice by screen readers. 

<img width="970" height="670" alt="Screenshot 2026-07-20 at 16 55 54" src="https://github.com/user-attachments/assets/1da84246-9339-4916-9539-a0cc98c80b56" />

