### PR TITLE
[WHIT-3551] - Stop using the legacy access_limited column

### DIFF
--- a/app/models/concerns/edition/limited_access.rb
+++ b/app/models/concerns/edition/limited_access.rb
@@ -2,6 +2,8 @@ module Edition::LimitedAccess
   extend ActiveSupport::Concern
 
   included do
+    self.ignored_columns += %w[access_limited]
+
     attr_accessor :current_user_for_validation
 
     enum :access_limiting, {
@@ -41,12 +43,6 @@ module Edition::LimitedAccess
 
   def access_limited?
     access_limiting_organisations? || access_limiting_individuals?
-  end
-
-  # TODO: Remove once nothing reads or writes `access_limited` (drop-column ticket).
-  def access_limiting=(value)
-    super
-    self.access_limited = !access_limiting_none?
   end
 
   def accessible_to?(user)

--- a/app/validators/unmodifiable_validator.rb
+++ b/app/validators/unmodifiable_validator.rb
@@ -12,7 +12,7 @@ class UnmodifiableValidator < ActiveModel::Validator
   def modifiable_attributes(previous_state, current_state)
     modifiable = %w[state updated_at force_published]
     if previous_state == "scheduled"
-      modifiable += %w[major_change_published_at first_published_at access_limited access_limiting]
+      modifiable += %w[major_change_published_at first_published_at access_limiting]
     end
     if Edition::PRE_PUBLICATION_STATES.include?(previous_state) || being_unpublished?(previous_state, current_state)
       modifiable += %w[published_major_version published_minor_version]

--- a/test/unit/app/models/edition/limited_access_test.rb
+++ b/test/unit/app/models/edition/limited_access_test.rb
@@ -365,46 +365,19 @@ class Edition::LimitedAccessTest < ActiveSupport::TestCase
     assert edition.valid?
   end
 
-  test "setting access_limiting writes through to the legacy access_limited column" do
-    edition = build(:limited_access_edition)
-
-    edition.access_limiting = "organisations"
-    assert_equal true, edition[:access_limited]
-
-    edition.access_limiting = "individuals"
-    assert_equal true, edition[:access_limited]
-
-    edition.access_limiting = "none"
-    assert_equal false, edition[:access_limited]
-  end
-
-  test "access_limiting persists across save/reload and keeps both columns in sync" do
+  test "access_limiting persists across save/reload" do
     edition = build(:limited_access_edition)
     edition.access_limiting = "organisations"
     edition.save!
     edition.reload
     assert edition.access_limited?
     assert_equal "organisations", edition.access_limiting
-    assert_equal true, edition[:access_limited]
 
     edition.access_limiting = "individuals"
     edition.save!
     edition.reload
     assert edition.access_limited?
     assert_equal "individuals", edition.access_limiting
-    assert_equal true, edition[:access_limited]
-  end
-
-  test "access_limited? reads from access_limiting, not the legacy boolean" do
-    edition = create(:limited_access_edition, access_limiting: "organisations")
-    # Force the legacy and new columns out of sync via raw SQL (bypasses bridge)
-    Edition.where(id: edition.id).update_all(access_limited: true, access_limiting: "none")
-    edition.reload
-    assert_not edition.access_limited?, "access_limited? should reflect the new column"
-
-    Edition.where(id: edition.id).update_all(access_limited: false, access_limiting: "organisations")
-    edition.reload
-    assert edition.access_limited?, "access_limited? should reflect the new column"
   end
 
   test "access_limited? is true for organisations and individuals modes" do


### PR DESCRIPTION
Tells Active Record to ignore the column so it is no longer read, written, or emitted in generated SQL, and removes the bridge writer that kept it in sync with access_limiting. The column stays in the database for now; a follow-up deploy drops it once this change is live everywhere.

Having this done in a different deployment will prevent errors when we drop the column where old jobs/requests might still be trying to read or write from it