### PR TITLE
[WHIT-3551] - Drop the legacy access_limited column

### DIFF
--- a/app/models/concerns/edition/limited_access.rb
+++ b/app/models/concerns/edition/limited_access.rb
@@ -2,8 +2,6 @@ module Edition::LimitedAccess
   extend ActiveSupport::Concern
 
   included do
-    self.ignored_columns += %w[access_limited]
-
     attr_accessor :current_user_for_validation
 
     enum :access_limiting, {

--- a/db/migrate/20260722120000_remove_access_limited_from_editions.rb
+++ b/db/migrate/20260722120000_remove_access_limited_from_editions.rb
@@ -1,0 +1,5 @@
+class RemoveAccessLimitedFromEditions < ActiveRecord::Migration[8.1]
+  def change
+    safety_assured { remove_column :editions, :access_limited, :boolean, default: false, null: false }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_08_150116) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_22_120000) do
   create_table "access_limiting_individuals", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.integer "edition_id", null: false
@@ -365,7 +365,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_08_150116) do
   end
 
   create_table "editions", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.boolean "access_limited", default: false, null: false
     t.string "access_limiting", default: "none", null: false
     t.string "additional_related_mainstream_content_title"
     t.string "additional_related_mainstream_content_url"


### PR DESCRIPTION
Removes the column from the database now that the previous deploy stopped all code from reading or writing it, and drops the ignored_columns declaration that is no longer needed.