### PR TITLE
Validate HOC paper number and Parliamentary session on file uploads [WHIT-3744]

### DIFF
--- a/app/views/admin/shared/attachments/_hoc_reference_fields.html.erb
+++ b/app/views/admin/shared/attachments/_hoc_reference_fields.html.erb
@@ -7,8 +7,8 @@
     label: {
       text: "House of Commons paper number",
     },
-    name: "attachment[hoc_paper_number]",
-    id: "attachment_hoc_paper_number",
+    name: "#{name}[hoc_paper_number]",
+    id: "#{name}_hoc_paper_number",
     value: form.object.hoc_paper_number,
     error_items: errors_for(attachment.errors, :unnumbered_hoc_paper),
     heading_size: heading_size,
@@ -17,8 +17,8 @@
   <%= form.hidden_field :unnumbered_hoc_paper, value: "0" %>
 
   <%= render "govuk_publishing_components/components/checkboxes", {
-    name: "attachment[unnumbered_hoc_paper]",
-    id: "attachment_unnumbered_hoc_paper",
+    name: "#{name}[unnumbered_hoc_paper]",
+    id: "#{name}_unnumbered_hoc_paper",
     items: [
       {
         label: "Unnumbered act paper",
@@ -43,8 +43,8 @@
 <div class="govuk-!-margin-bottom-<%= margin_bottom %>">
   <%= render "govuk_publishing_components/components/select", {
     label: "Parliamentary session",
-    name: "attachment[parliamentary_session]",
-    id: "attachment_parliamentary_session",
+    name: "#{name}[parliamentary_session]",
+    id: "#{name}_parliamentary_session",
     heading_level: 3,
     heading_size: heading_size,
     options: options,

--- a/app/views/admin/shared/attachments/_reference_fields.html.erb
+++ b/app/views/admin/shared/attachments/_reference_fields.html.erb
@@ -94,5 +94,5 @@
 </div>
 
 <% if attachable.can_have_attached_house_of_commons_papers? %>
-  <%= render "admin/shared/attachments/hoc_reference_fields", attachable: attachable, form: form, attachment: attachment, heading_size: subheading_size, margin_bottom: %>
+  <%= render "admin/shared/attachments/hoc_reference_fields", attachable: attachable, form: form, attachment: attachment, heading_size: subheading_size, margin_bottom:, name: %>
 <% end %>

--- a/features/step_definitions/upload_steps.rb
+++ b/features/step_definitions/upload_steps.rb
@@ -22,6 +22,32 @@ Then(/^I should see that the publication has attachments$/) do
   expect("greenpaper.pdf").to eq(file_attachments[1].filename)
 end
 
+When("I upload a file and give it a HOC paper number but no Parliamentary session") do
+  @edition = Edition.last
+  visit admin_edition_attachments_path(@edition)
+
+  page.attach_file Rails.root.join("test/fixtures/greenpaper.pdf")
+  click_button "Upload"
+
+  fill_in "Title (required)", with: "Greenpaper title"
+  fill_in "House of Commons paper number", with: "1234"
+
+  click_button "Save"
+end
+
+When("I upload a file and give it a Parliamentary session but no HOC paper number") do
+  @edition = Edition.last
+  visit admin_edition_attachments_path(@edition)
+
+  page.attach_file Rails.root.join("test/fixtures/greenpaper.pdf")
+  click_button "Upload"
+
+  fill_in "Title (required)", with: "Greenpaper title"
+  select "2026-27", from: "Parliamentary session"
+
+  click_button "Save"
+end
+
 When(/^I upload files one with the same filename as an existing file$/) do
   visit admin_edition_attachments_path(@edition)
 

--- a/features/upload.feature
+++ b/features/upload.feature
@@ -9,6 +9,16 @@ Feature: Uploading attachments to editions
     When I upload files and give them titles
     Then I should see that the publication has attachments
 
+  Scenario:
+    Given a draft publication "Example publication" exists
+    When I upload a file and give it a HOC paper number but no Parliamentary session
+    Then I should see an error of "greenpaper.pdf: Parliamentary session is required when house of commons number is set" on the upload page
+
+  Scenario:
+    Given a draft publication "Example publication" exists
+    When I upload a file and give it a Parliamentary session but no HOC paper number
+    Then I should see an error of "greenpaper.pdf: House of commons paper number is required when parliamentary session is set" on the upload page
+
   Scenario: Keep existing attachments
     Given a draft publication "Results of beards survey" with a file attachment exists
     When I upload files one with the same filename as an existing file


### PR DESCRIPTION
## Why 

The field names in `hoc_reference_fields` shared partial are hardcoded (eg to `attachment_hoc_paper_number`), which is fine for every view it is rendered in apart from the initial file upload screen.  On this screen, it is possible edit multiple file attachments at the same time - so this hardcoding results in duplicate id and name attrs in the inputs' HTML.

This means the values in those fields on this screen are not saved to the models, the root cause of a support bug where a user does not receive a validation message when entering a HOC paper number but no parliarmentary session.

## What

This change fixes the root cause by passing the existing `name` variable created in the `set_titles` partial down into the `hoc_reference_fields` partial, extending the existing pattern to deal with fields for multiple uploads.  This replaces the hardcoded field names with dynamic ones for each uploaded file (eg `uploads[attachments][0]_hoc_paper_number`), so that the values are saved and any existing validation is triggered correctly.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
