### PR TITLE
[WHIT-3757] Enforce access limiting on HTML attachments

### DIFF
--- a/app/presenters/publishing_api/html_attachment_presenter.rb
+++ b/app/presenters/publishing_api/html_attachment_presenter.rb
@@ -26,6 +26,7 @@ module PublishingApi
           links: edition_links,
           auth_bypass_ids: [parent.auth_bypass_id].compact,
         )
+        .merge(PayloadBuilder::AccessLimitation.for(parent))
     end
 
     def links

--- a/test/unit/app/presenters/publishing_api/html_attachment_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/html_attachment_presenter_test.rb
@@ -68,6 +68,77 @@ class PublishingApi::HtmlAttachmentPresenterTest < ActiveSupport::TestCase
     assert_equal %w[auth-bypass-id], present(html_attachment).content[:auth_bypass_ids]
   end
 
+  test "presents the parent edition's organisation access limiting when it is access-limited" do
+    access_limiting_organisation = create(:organisation)
+    edition = create(
+      :publication,
+      :draft,
+      :with_html_attachment,
+      access_limiting: "organisations",
+      access_limiting_organisation_ids: [access_limiting_organisation.id],
+    )
+    html_attachment = edition.html_attachments.first
+
+    assert_equal(
+      { organisations: [access_limiting_organisation.content_id] },
+      present(html_attachment).content[:access_limited],
+    )
+  end
+
+  test "presents the parent edition's named users when individual access limiting is on" do
+    @feature_flags.switch!(:access_limiting_individuals_ui, true)
+    user = create(:user)
+    edition = create(
+      :publication,
+      :draft,
+      :with_html_attachment,
+      access_limiting: "individuals",
+      access_limiting_individual_emails: user.email,
+    )
+    html_attachment = edition.html_attachments.first
+
+    assert_equal(
+      { users: [user.uid] },
+      present(html_attachment).content[:access_limited],
+    )
+  end
+
+  test "presents the parent consultation's access limiting for an HTML attachment on a consultation response" do
+    access_limiting_organisation = create(:organisation)
+    consultation = create(
+      :draft_consultation,
+      access_limiting: "organisations",
+      access_limiting_organisation_ids: [access_limiting_organisation.id],
+    )
+    consultation_response = create(:consultation_outcome, :with_html_attachment, consultation:)
+    html_attachment = consultation_response.html_attachments.first
+
+    assert_equal(
+      { organisations: [access_limiting_organisation.content_id] },
+      present(html_attachment).content[:access_limited],
+    )
+  end
+
+  test "does not present access_limited when the parent is not access-limited" do
+    edition = create(:publication, :draft, :with_html_attachment)
+    html_attachment = edition.html_attachments.first
+
+    assert_not present(html_attachment).content.key?(:access_limited)
+  end
+
+  test "does not present access_limited once the access-limited parent is publicly visible" do
+    edition = create(
+      :publication,
+      :published,
+      :with_html_attachment,
+      access_limiting: "organisations",
+      access_limiting_organisation_ids: [create(:organisation).id],
+    )
+    html_attachment = edition.html_attachments.first
+
+    assert_not present(html_attachment).content.key?(:access_limited)
+  end
+
   test "it includes auto-numbered headers when headers are present in body" do
     html_attachment = create(
       :html_attachment,


### PR DESCRIPTION
[Jira](https://gov-uk.atlassian.net/browse/WHIT-3757)

## Why

An HTML attachment is presented to the Publishing API as its own content item, independent of its parent document. That presenter already carries the parent's preview token across, but never sent the parent's access-limiting data — so an access-limited document's HTML attachment was reachable by users the parent document itself would refuse (403).

## What

Send the parent's access-limiting data on the attachment's content item, via the shared `PayloadBuilder::AccessLimitation` builder that every other edition presenter already uses. Enforcement (403) is then applied downstream off the content item's `access_limited` field, exactly as it is for the parent document.

Consultation outcomes and public feedback present their HTML attachments through the same code path; both delegate their access-limiting methods to the parent consultation via the shared `ConsultationResponse` base, so they are covered by the same one-line change.

The builder no-ops once the parent is publicly visible, so published attachments and existing preview-token / `auth_bypass_ids` behaviour are unchanged.
