### PR TITLE
Improve label of "access-limiting organisations" option

### DIFF
--- a/app/views/admin/editions/_access_limiting_fields.html.erb
+++ b/app/views/admin/editions/_access_limiting_fields.html.erb
@@ -18,7 +18,7 @@
           },
           Flipflop.access_limiting_organisations_ui? ? {
             value: "organisations",
-            text: "Limit access to publishers from organisations associated with this document",
+            text: "Limit access to the following organisations",
             checked: edition.access_limiting_organisations?,
             conditional: render("admin/editions/access_limiting_organisation_select", form: form, edition: edition),
           } : nil,
@@ -43,7 +43,7 @@
         error_items: errors_for(edition.errors, :access_limiting),
         items: [
           {
-            label: "Limit access to publishers from organisations associated with this document before you publish",
+            label: "Limit access to the following organisations before you publish",
             value: "organisations",
             checked: edition.access_limited?,
           },

--- a/features/step_definitions/admin_limit_access_steps.rb
+++ b/features/step_definitions/admin_limit_access_steps.rb
@@ -31,7 +31,7 @@ When(/^I set the Lead organisation to an org I am not in$/) do
 end
 
 When(/^I choose organisation access limiting$/) do
-  choose "Limit access to publishers from organisations associated with this document"
+  choose "Limit access to the following organisations"
 end
 
 When(/^I select "([^"]*)" as an access limiting organisation$/) do |org_name|

--- a/test/integration/asset_access_options_integration_test.rb
+++ b/test/integration/asset_access_options_integration_test.rb
@@ -62,7 +62,7 @@ class AssetAccessOptionsIntegrationTest < ActionDispatch::IntegrationTest
           add_file_attachment_with_asset("sample.docx", to: edition)
           edition.save!
           visit edit_admin_edition_path(edition)
-          choose "Limit access to publishers from organisations associated with this document"
+          choose "Limit access to the following organisations"
           select organisation.name, from: "edition_access_limiting_organisation_ids"
           click_button "Save"
           assert_text "Your document has been saved"


### PR DESCRIPTION
As per https://gds.slack.com/archives/C03D4A72HGE/p1784884026659849

The current wording still suggests access-limiting of organisations is determined by selection of Lead/Supporting organisations elsewhere in the form, whereas now publishers have the freedom to set any arbitrary organisations as access-limiting.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
