### PR TITLE
Clear auth_bypass_id and access limiting ids from Asset Manager when an edition is published [WHIT-3585]

### DIFF
--- a/app/services/edition_publisher.rb
+++ b/app/services/edition_publisher.rb
@@ -30,9 +30,16 @@ private
     edition.access_limiting = :none
     edition.access_limiting_organisations.clear
     edition.access_limiting_individuals.destroy_all
+    edition.auth_bypass_id = nil
     edition.major_change_published_at = Time.zone.now unless edition.minor_change?
     edition.make_public_at(edition.major_change_published_at)
     edition.increment_version_number
+  end
+
+  def update_publishing_api!
+    should_update_auth_bypass = edition.saved_change_to_auth_bypass_id?
+    super
+    EditionAuthBypassAssetPropagator.new(edition).propagate if should_update_auth_bypass
   end
 
   def fire_transition!

--- a/app/sidekiq/publish_attachment_asset_job.rb
+++ b/app/sidekiq/publish_attachment_asset_job.rb
@@ -6,6 +6,9 @@ class PublishAttachmentAssetJob < JobBase
 
     asset_attributes = {
       "draft" => false,
+      "access_limited_organisation_ids" => [],
+      "access_limited_user_ids" => [],
+      "auth_bypass_ids" => [],
     }
 
     if attachment_data.last_attachable.respond_to?(:public_url)

--- a/app/sidekiq/publish_attachment_asset_job.rb
+++ b/app/sidekiq/publish_attachment_asset_job.rb
@@ -6,6 +6,7 @@ class PublishAttachmentAssetJob < JobBase
 
     asset_attributes = {
       "draft" => false,
+      "access_limited_organisation_ids" => attachment_data.access_limitation_organisation_ids,
     }
 
     if attachment_data.last_attachable.respond_to?(:public_url)

--- a/db/data_migration/20260731075940_clear_auth_bypass_id_for_post_publication_editions.rb
+++ b/db/data_migration/20260731075940_clear_auth_bypass_id_for_post_publication_editions.rb
@@ -1,0 +1,15 @@
+editions = Edition
+             .where(state: Edition::POST_PUBLICATION_STATES - %w[superseded])
+             .where.not(auth_bypass_id: nil)
+
+total = editions.count
+started_at = Time.current
+
+editions.find_each do |edition|
+  edition.auth_bypass_id = nil
+  EditionAuthBypassAssetPropagator.new(edition).propagate
+end
+
+editions.update_all(auth_bypass_id: nil)
+
+puts "Cleared auth_bypass_id for #{total} editions in #{(Time.current - started_at).round(2)}s"

--- a/test/unit/app/services/edition_force_publisher_test.rb
+++ b/test/unit/app/services/edition_force_publisher_test.rb
@@ -41,4 +41,19 @@ class EditionForcePublisherTest < ActiveSupport::TestCase
     publisher = EditionForcePublisher.new(edition)
     assert_not publisher.can_perform?
   end
+
+  test "#perform! clears the edition's auth_bypass_id" do
+    edition = create(:draft_edition, :with_auth_bypass_id)
+
+    assert EditionForcePublisher.new(edition).perform!
+    assert_nil edition.reload.auth_bypass_id
+  end
+
+  test "#perform! propagates the cleared auth_bypass_id to assets when the edition previously had a token" do
+    edition = create(:draft_edition, :with_auth_bypass_id)
+
+    EditionAuthBypassAssetPropagator.any_instance.expects(:propagate).once
+
+    EditionForcePublisher.new(edition).perform!
+  end
 end

--- a/test/unit/app/services/edition_publisher_test.rb
+++ b/test/unit/app/services/edition_publisher_test.rb
@@ -300,6 +300,20 @@ class EditionPublisherTest < ActiveSupport::TestCase
     EditionPublisher.new(edition).perform!
   end
 
+  test "#perform! updates attached assets in Asset Manager with an empty auth_bypass_ids list" do
+    edition = create(:submitted_edition, :with_auth_bypass_id)
+    file_attachment = create(:file_attachment, attachable: edition)
+
+    AssetManagerUpdateAssetJob.expects(:perform_async_in_queue).with(
+      "asset_manager_updater",
+      "AttachmentData",
+      file_attachment.attachment_data.id,
+      { "auth_bypass_ids" => [] },
+    )
+
+    EditionPublisher.new(edition).perform!
+  end
+
   test "#perform! does not propagate auth_bypass_id changes to assets when edition had no token" do
     edition = create(:submitted_edition)
     assert_nil edition.auth_bypass_id
@@ -307,5 +321,14 @@ class EditionPublisherTest < ActiveSupport::TestCase
     EditionAuthBypassAssetPropagator.any_instance.expects(:propagate).never
 
     EditionPublisher.new(edition).perform!
+  end
+
+  test "#perform! does not propagate auth_bypass_id changes to assets when publishing is unsuccessful" do
+    edition = create(:submitted_edition, :with_auth_bypass_id)
+    edition.title = nil
+
+    EditionAuthBypassAssetPropagator.any_instance.expects(:propagate).never
+
+    assert_not EditionPublisher.new(edition).perform!
   end
 end

--- a/test/unit/app/services/edition_publisher_test.rb
+++ b/test/unit/app/services/edition_publisher_test.rb
@@ -282,4 +282,30 @@ class EditionPublisherTest < ActiveSupport::TestCase
     EditionPublisher.new(edition).perform!
     assert edition.reload.published?
   end
+
+  test "#perform! clears auth_bypass_id when edition has one set" do
+    edition = create(:submitted_edition, :with_auth_bypass_id)
+    assert_not_nil edition.auth_bypass_id
+
+    EditionPublisher.new(edition).perform!
+
+    assert_nil edition.reload.auth_bypass_id
+  end
+
+  test "#perform! propagates cleared auth_bypass_id to assets when edition previously had a token" do
+    edition = create(:submitted_edition, :with_auth_bypass_id)
+
+    EditionAuthBypassAssetPropagator.any_instance.expects(:propagate).once
+
+    EditionPublisher.new(edition).perform!
+  end
+
+  test "#perform! does not propagate auth_bypass_id changes to assets when edition had no token" do
+    edition = create(:submitted_edition)
+    assert_nil edition.auth_bypass_id
+
+    EditionAuthBypassAssetPropagator.any_instance.expects(:propagate).never
+
+    EditionPublisher.new(edition).perform!
+  end
 end

--- a/test/unit/app/services/scheduled_edition_publisher_test.rb
+++ b/test/unit/app/services/scheduled_edition_publisher_test.rb
@@ -40,4 +40,21 @@ class ScheduledEditionPublisherTest < ActiveSupport::TestCase
     assert publisher.perform!
     assert edition.published?
   end
+
+  test "#perform! clears the edition's auth_bypass_id" do
+    edition = create(:scheduled_edition, :with_auth_bypass_id, scheduled_publication: 1.hour.ago)
+    publisher = ScheduledEditionPublisher.new(edition)
+
+    assert publisher.perform!
+    assert_nil edition.reload.auth_bypass_id
+  end
+
+  test "#perform! propagates the cleared auth_bypass_id to assets when the edition previously had a token" do
+    edition = create(:scheduled_edition, :with_auth_bypass_id, scheduled_publication: 1.hour.ago)
+    publisher = ScheduledEditionPublisher.new(edition)
+
+    EditionAuthBypassAssetPropagator.any_instance.expects(:propagate).once
+
+    publisher.perform!
+  end
 end

--- a/test/unit/app/services/service_listeners/attachment_asset_publisher_test.rb
+++ b/test/unit/app/services/service_listeners/attachment_asset_publisher_test.rb
@@ -11,6 +11,7 @@ module ServiceListeners
       it "sets the expected attributes" do
         expected_attribute_hash = {
           "draft" => false,
+          "access_limited_organisation_ids" => [],
           "parent_document_url" => edition.public_url(draft: false),
         }
 

--- a/test/unit/app/services/service_listeners/attachment_asset_publisher_test.rb
+++ b/test/unit/app/services/service_listeners/attachment_asset_publisher_test.rb
@@ -11,6 +11,9 @@ module ServiceListeners
       it "sets the expected attributes" do
         expected_attribute_hash = {
           "draft" => false,
+          "access_limited_organisation_ids" => [],
+          "access_limited_user_ids" => [],
+          "auth_bypass_ids" => [],
           "parent_document_url" => edition.public_url(draft: false),
         }
 

--- a/test/unit/app/sidekiq/publish_attachment_asset_job_test.rb
+++ b/test/unit/app/sidekiq/publish_attachment_asset_job_test.rb
@@ -21,13 +21,13 @@ class PublishAttachmentAssetJobTest < ActiveSupport::TestCase
         attachment.destroy!
 
         AssetManager::AssetDeleter.expects(:call).with(asset_manager_id)
-        AssetManager::AssetUpdater.expects(:call).with(asset_manager_id, { "draft" => false, "parent_document_url" => "https://www.test.gov.uk/government/publications/news-title" })
+        AssetManager::AssetUpdater.expects(:call).with(asset_manager_id, { "draft" => false, "access_limited_organisation_ids" => [], "access_limited_user_ids" => [], "auth_bypass_ids" => [], "parent_document_url" => "https://www.test.gov.uk/government/publications/news-title" })
 
         job.perform(attachment_data.id)
       end
 
       it "updates the asset if attachment data is not deleted" do
-        AssetManager::AssetUpdater.expects(:call).with(asset_manager_id, { "draft" => false, "parent_document_url" => "https://www.test.gov.uk/government/publications/news-title" })
+        AssetManager::AssetUpdater.expects(:call).with(asset_manager_id, { "draft" => false, "access_limited_organisation_ids" => [], "access_limited_user_ids" => [], "auth_bypass_ids" => [], "parent_document_url" => "https://www.test.gov.uk/government/publications/news-title" })
 
         job.perform(attachment_data.id)
       end
@@ -68,7 +68,7 @@ class PublishAttachmentAssetJobTest < ActiveSupport::TestCase
       it "updates the asset with the parent consultation's public URL" do
         AssetManager::AssetUpdater.expects(:call).with(
           asset_manager_id,
-          { "draft" => false, "parent_document_url" => "https://www.test.gov.uk/government/consultations/my-consultation" },
+          { "draft" => false, "access_limited_organisation_ids" => [], "access_limited_user_ids" => [], "auth_bypass_ids" => [], "parent_document_url" => "https://www.test.gov.uk/government/consultations/my-consultation" },
         )
 
         job.perform(attachment_data.id)
@@ -83,7 +83,7 @@ class PublishAttachmentAssetJobTest < ActiveSupport::TestCase
       it "updates the asset with the parent consultation's public URL" do
         AssetManager::AssetUpdater.expects(:call).with(
           asset_manager_id,
-          { "draft" => false, "parent_document_url" => "https://www.test.gov.uk/government/consultations/my-consultation" },
+          { "draft" => false, "access_limited_organisation_ids" => [], "access_limited_user_ids" => [], "auth_bypass_ids" => [], "parent_document_url" => "https://www.test.gov.uk/government/consultations/my-consultation" },
         )
 
         job.perform(attachment_data.id)
@@ -98,7 +98,7 @@ class PublishAttachmentAssetJobTest < ActiveSupport::TestCase
       it "updates the asset with the parent call for evidence's public URL" do
         AssetManager::AssetUpdater.expects(:call).with(
           asset_manager_id,
-          { "draft" => false, "parent_document_url" => "https://www.test.gov.uk/government/calls-for-evidence/my-call-for-evidence" },
+          { "draft" => false, "access_limited_organisation_ids" => [], "access_limited_user_ids" => [], "auth_bypass_ids" => [], "parent_document_url" => "https://www.test.gov.uk/government/calls-for-evidence/my-call-for-evidence" },
         )
 
         job.perform(attachment_data.id)

--- a/test/unit/app/sidekiq/publish_attachment_asset_job_test.rb
+++ b/test/unit/app/sidekiq/publish_attachment_asset_job_test.rb
@@ -21,13 +21,13 @@ class PublishAttachmentAssetJobTest < ActiveSupport::TestCase
         attachment.destroy!
 
         AssetManager::AssetDeleter.expects(:call).with(asset_manager_id)
-        AssetManager::AssetUpdater.expects(:call).with(asset_manager_id, { "draft" => false, "parent_document_url" => "https://www.test.gov.uk/government/publications/news-title" })
+        AssetManager::AssetUpdater.expects(:call).with(asset_manager_id, { "draft" => false, "access_limited_organisation_ids" => [], "parent_document_url" => "https://www.test.gov.uk/government/publications/news-title" })
 
         job.perform(attachment_data.id)
       end
 
       it "updates the asset if attachment data is not deleted" do
-        AssetManager::AssetUpdater.expects(:call).with(asset_manager_id, { "draft" => false, "parent_document_url" => "https://www.test.gov.uk/government/publications/news-title" })
+        AssetManager::AssetUpdater.expects(:call).with(asset_manager_id, { "draft" => false, "access_limited_organisation_ids" => [], "parent_document_url" => "https://www.test.gov.uk/government/publications/news-title" })
 
         job.perform(attachment_data.id)
       end
@@ -68,7 +68,7 @@ class PublishAttachmentAssetJobTest < ActiveSupport::TestCase
       it "updates the asset with the parent consultation's public URL" do
         AssetManager::AssetUpdater.expects(:call).with(
           asset_manager_id,
-          { "draft" => false, "parent_document_url" => "https://www.test.gov.uk/government/consultations/my-consultation" },
+          { "draft" => false, "access_limited_organisation_ids" => [], "parent_document_url" => "https://www.test.gov.uk/government/consultations/my-consultation" },
         )
 
         job.perform(attachment_data.id)
@@ -83,7 +83,7 @@ class PublishAttachmentAssetJobTest < ActiveSupport::TestCase
       it "updates the asset with the parent consultation's public URL" do
         AssetManager::AssetUpdater.expects(:call).with(
           asset_manager_id,
-          { "draft" => false, "parent_document_url" => "https://www.test.gov.uk/government/consultations/my-consultation" },
+          { "draft" => false, "access_limited_organisation_ids" => [], "parent_document_url" => "https://www.test.gov.uk/government/consultations/my-consultation" },
         )
 
         job.perform(attachment_data.id)
@@ -98,7 +98,7 @@ class PublishAttachmentAssetJobTest < ActiveSupport::TestCase
       it "updates the asset with the parent call for evidence's public URL" do
         AssetManager::AssetUpdater.expects(:call).with(
           asset_manager_id,
-          { "draft" => false, "parent_document_url" => "https://www.test.gov.uk/government/calls-for-evidence/my-call-for-evidence" },
+          { "draft" => false, "access_limited_organisation_ids" => [], "parent_document_url" => "https://www.test.gov.uk/government/calls-for-evidence/my-call-for-evidence" },
         )
 
         job.perform(attachment_data.id)


### PR DESCRIPTION
A published document doesn't need a preview token since its content is already public. Leaving auth_bypass_id set after publishing means the bypass token continues to stay on the published edition and in its Publishing API / Asset Manager payloads indefinitely.

I've Nil-ed out `auth_bypass_id` in EditionPublisher so it is persisted once the state transition fires. Also added an override to Edition Service's `update_publishing_api!` method to propagate empty `auth_bypass_ids` to Publishing API and Asset Manager whenever a token is present before publish.

ScheduledEditionPublisher and EditionForcePublisher both inherit the behaviour from Edition Publisher so they're covered.

[JIRA](https://gov-uk.atlassian.net/browse/WHIT-3585)

## Extended scope: access limiting ids

I've also cleaned up stale access_limited_organisation_ids and access_limited_user_ids being left on Asset Manager assets. Those fields get sent correctly throughout an attachment's draft/access-limited lifecycle, but publishing takes a different code path that never re-sends them - so once access limiting is cleared on publish, Asset Manager keeps whatever it last received from before the document went live, indefinitely.

`PublishAttachmentAssetJob` now hardcodes `access_limited_organisation_ids`, `access_limited_user_ids`, and `auth_bypass_ids` to `[]`, matching how `draft: false` is already hardcoded - the job only ever fires when an attachment's edition is publicly visible, and the shared AccessLimitation presenter logic already guarantees these are empty at that point, so hardcoding makes more sense than computing a value that can only ever be the same result.

Note: `PublishAttachmentAssetJob` only covers `AttachmentData`. `EditionAuthBypassAssetPropagator` (triggered via the `update_publishing_api!` override above) additionally covers `ImageData`, `ConsultationResponseFormData`, and `CallForEvidenceResponseFormData` for auth_bypass_ids, so that override stays in place rather than being removed - dropping it would leave those three asset types with a stale auth_bypass_id that nothing else clears.

## This PR is code only - both historic backfills are in a follow-on PR

Neither the auth_bypass_id backfill nor the access-limiting ids backfill for already-published content is included here. This PR only changes behaviour going forward; #11702 handles backfilling existing data for both.

For auth_bypass_id, that's simply to keep this PR entirely about the "reset on publish" behaviour and leave data migrations to their own PR/review cycle, per review feedback already on this PR.