### PR TITLE
Suppress validation on Plan for Change Landing Page pages

### DIFF
--- a/app/models/concerns/plan_for_change_landing_page_image_block.rb
+++ b/app/models/concerns/plan_for_change_landing_page_image_block.rb
@@ -11,14 +11,14 @@ module PlanForChangeLandingPageImageBlock
   included do
     attr_reader :desktop_image, :tablet_image, :mobile_image, :alt
 
-    validates :desktop_image, :tablet_image, :mobile_image, presence: true
-    validates_each :desktop_image, :tablet_image, :mobile_image do |record, attr, value|
-      next if value.blank?
+    # validates :desktop_image, :tablet_image, :mobile_image, presence: true
+    # validates_each :desktop_image, :tablet_image, :mobile_image do |record, attr, value|
+    #   next if value.blank?
 
-      expected_kind = EXPECTED_IMAGE_KINDS.fetch(attr)
-      actual_kind = value.image_data.image_kind
-      record.errors.add(attr, "is of the wrong image kind: #{actual_kind}") if actual_kind != expected_kind
-    end
+    #   expected_kind = EXPECTED_IMAGE_KINDS.fetch(attr)
+    #   actual_kind = value.image_data.image_kind
+    #   record.errors.add(attr, "is of the wrong image kind: #{actual_kind}") if actual_kind != expected_kind
+    # end
 
     def present_image
       {
@@ -31,12 +31,12 @@ module PlanForChangeLandingPageImageBlock
 
     def present_image_sources
       {
-        "desktop" => desktop_image.url(:landing_page_desktop_1x),
-        "desktop_2x" => desktop_image.url(:landing_page_desktop_2x),
-        "tablet" => tablet_image.url(:landing_page_tablet_1x),
-        "tablet_2x" => tablet_image.url(:landing_page_tablet_2x),
-        "mobile" => mobile_image.url(:landing_page_mobile_1x),
-        "mobile_2x" => mobile_image.url(:landing_page_mobile_2x),
+        "desktop" => desktop_image&.url(:landing_page_desktop_1x),
+        "desktop_2x" => desktop_image&.url(:landing_page_desktop_2x),
+        "tablet" => tablet_image&.url(:landing_page_tablet_1x),
+        "tablet_2x" => tablet_image&.url(:landing_page_tablet_2x),
+        "mobile" => mobile_image&.url(:landing_page_mobile_1x),
+        "mobile_2x" => mobile_image&.url(:landing_page_mobile_2x),
       }
     end
 

--- a/app/models/plan_for_change_landing_page/hero_block.rb
+++ b/app/models/plan_for_change_landing_page/hero_block.rb
@@ -10,14 +10,14 @@ class PlanForChangeLandingPage::HeroBlock < PlanForChangeLandingPage::CompoundBl
 
   attr_reader :desktop_image, :tablet_image, :mobile_image
 
-  validates :desktop_image, :tablet_image, :mobile_image, presence: true
-  validates_each :desktop_image, :tablet_image, :mobile_image do |record, attr, value|
-    next if value.blank?
+  # validates :desktop_image, :tablet_image, :mobile_image, presence: true
+  # validates_each :desktop_image, :tablet_image, :mobile_image do |record, attr, value|
+  #   next if value.blank?
 
-    expected_kind = EXPECTED_IMAGE_KINDS.fetch(attr)
-    actual_kind = value.image_data.image_kind
-    record.errors.add(attr, "is of the wrong image kind: #{actual_kind}") if actual_kind != expected_kind
-  end
+  #   expected_kind = EXPECTED_IMAGE_KINDS.fetch(attr)
+  #   actual_kind = value.image_data.image_kind
+  #   record.errors.add(attr, "is of the wrong image kind: #{actual_kind}") if actual_kind != expected_kind
+  # end
 
   def initialize(source, images)
     super(source, images, "hero_content")
@@ -40,12 +40,12 @@ class PlanForChangeLandingPage::HeroBlock < PlanForChangeLandingPage::CompoundBl
 
   def present_image_sources
     {
-      "desktop" => desktop_image.url(:hero_desktop_1x),
-      "desktop_2x" => desktop_image.url(:hero_desktop_2x),
-      "tablet" => tablet_image.url(:hero_tablet_1x),
-      "tablet_2x" => tablet_image.url(:hero_tablet_2x),
-      "mobile" => mobile_image.url(:hero_mobile_1x),
-      "mobile_2x" => mobile_image.url(:hero_mobile_2x),
+      "desktop" => desktop_image&.url(:hero_desktop_1x),
+      "desktop_2x" => desktop_image&.url(:hero_desktop_2x),
+      "tablet" => tablet_image&.url(:hero_tablet_1x),
+      "tablet_2x" => tablet_image&.url(:hero_tablet_2x),
+      "mobile" => mobile_image&.url(:hero_mobile_1x),
+      "mobile_2x" => mobile_image&.url(:hero_mobile_2x),
     }
   end
 

--- a/test/unit/app/models/plan_for_change_landing_page/featured_block_test.rb
+++ b/test/unit/app/models/plan_for_change_landing_page/featured_block_test.rb
@@ -46,26 +46,26 @@ class FeaturedBlockTest < ActiveSupport::TestCase
     assert_equal(expected_result, subject.present_for_publishing_api)
   end
 
-  test "invalid when missing images" do
-    subject = PlanForChangeLandingPage::FeaturedBlock.new(@valid_featured_block_config.except("image"), @valid_featured_images)
-    assert subject.invalid?
-    assert_equal [
-      "Desktop image cannot be blank",
-      "Tablet image cannot be blank",
-      "Mobile image cannot be blank",
-    ], subject.errors.to_a
-  end
+  # test "invalid when missing images" do
+  #   subject = PlanForChangeLandingPage::FeaturedBlock.new(@valid_featured_block_config.except("image"), @valid_featured_images)
+  #   assert subject.invalid?
+  #   assert_equal [
+  #     "Desktop image cannot be blank",
+  #     "Tablet image cannot be blank",
+  #     "Mobile image cannot be blank",
+  #   ], subject.errors.to_a
+  # end
 
-  test "invalid when image expressions are not found" do
-    no_images = []
-    subject = PlanForChangeLandingPage::FeaturedBlock.new(@valid_featured_block_config, no_images)
-    assert subject.invalid?
-    assert_equal [
-      "Desktop image cannot be blank",
-      "Tablet image cannot be blank",
-      "Mobile image cannot be blank",
-    ], subject.errors.to_a
-  end
+  # test "invalid when image expressions are not found" do
+  #   no_images = []
+  #   subject = PlanForChangeLandingPage::FeaturedBlock.new(@valid_featured_block_config, no_images)
+  #   assert subject.invalid?
+  #   assert_equal [
+  #     "Desktop image cannot be blank",
+  #     "Tablet image cannot be blank",
+  #     "Mobile image cannot be blank",
+  #   ], subject.errors.to_a
+  # end
 
   test "valid when missing featured content blocks" do
     subject = PlanForChangeLandingPage::FeaturedBlock.new(

--- a/test/unit/app/models/plan_for_change_landing_page/hero_block_test.rb
+++ b/test/unit/app/models/plan_for_change_landing_page/hero_block_test.rb
@@ -48,26 +48,26 @@ class HeroBlockTest < ActiveSupport::TestCase
     assert_equal(expected_result, subject.present_for_publishing_api)
   end
 
-  test "invalid when missing images" do
-    subject = PlanForChangeLandingPage::HeroBlock.new(@valid_hero_block_config.except("image"), @valid_hero_block_images)
-    assert subject.invalid?
-    assert_equal [
-      "Desktop image cannot be blank",
-      "Tablet image cannot be blank",
-      "Mobile image cannot be blank",
-    ], subject.errors.to_a
-  end
+  # test "invalid when missing images" do
+  #   subject = PlanForChangeLandingPage::HeroBlock.new(@valid_hero_block_config.except("image"), @valid_hero_block_images)
+  #   assert subject.invalid?
+  #   assert_equal [
+  #     "Desktop image cannot be blank",
+  #     "Tablet image cannot be blank",
+  #     "Mobile image cannot be blank",
+  #   ], subject.errors.to_a
+  # end
 
-  test "invalid when image expressions are not found" do
-    no_images = []
-    subject = PlanForChangeLandingPage::HeroBlock.new(@valid_hero_block_config, no_images)
-    assert subject.invalid?
-    assert_equal [
-      "Desktop image cannot be blank",
-      "Tablet image cannot be blank",
-      "Mobile image cannot be blank",
-    ], subject.errors.to_a
-  end
+  # test "invalid when image expressions are not found" do
+  #   no_images = []
+  #   subject = PlanForChangeLandingPage::HeroBlock.new(@valid_hero_block_config, no_images)
+  #   assert subject.invalid?
+  #   assert_equal [
+  #     "Desktop image cannot be blank",
+  #     "Tablet image cannot be blank",
+  #     "Mobile image cannot be blank",
+  #   ], subject.errors.to_a
+  # end
 
   test "valid when missing hero content blocks" do
     subject = PlanForChangeLandingPage::HeroBlock.new(@valid_hero_block_config.except("hero_content"), @valid_hero_block_images)

--- a/test/unit/app/models/plan_for_change_landing_page/image_block_test.rb
+++ b/test/unit/app/models/plan_for_change_landing_page/image_block_test.rb
@@ -41,24 +41,24 @@ class ImageBlockTest < ActiveSupport::TestCase
     assert_equal(expected_result, subject.present_for_publishing_api)
   end
 
-  test "invalid when missing images" do
-    subject = PlanForChangeLandingPage::ImageBlock.new(@valid_image_block_config.except("image"), @valid_landing_page_images)
-    assert subject.invalid?
-    assert_equal [
-      "Desktop image cannot be blank",
-      "Tablet image cannot be blank",
-      "Mobile image cannot be blank",
-    ], subject.errors.to_a
-  end
+  # test "invalid when missing images" do
+  #   subject = PlanForChangeLandingPage::ImageBlock.new(@valid_image_block_config.except("image"), @valid_landing_page_images)
+  #   assert subject.invalid?
+  #   assert_equal [
+  #     "Desktop image cannot be blank",
+  #     "Tablet image cannot be blank",
+  #     "Mobile image cannot be blank",
+  #   ], subject.errors.to_a
+  # end
 
-  test "invalid when image expressions are not found" do
-    no_images = []
-    subject = PlanForChangeLandingPage::ImageBlock.new(@valid_image_block_config, no_images)
-    assert subject.invalid?
-    assert_equal [
-      "Desktop image cannot be blank",
-      "Tablet image cannot be blank",
-      "Mobile image cannot be blank",
-    ], subject.errors.to_a
-  end
+  # test "invalid when image expressions are not found" do
+  #   no_images = []
+  #   subject = PlanForChangeLandingPage::ImageBlock.new(@valid_image_block_config, no_images)
+  #   assert subject.invalid?
+  #   assert_equal [
+  #     "Desktop image cannot be blank",
+  #     "Tablet image cannot be blank",
+  #     "Mobile image cannot be blank",
+  #   ], subject.errors.to_a
+  # end
 end

--- a/test/unit/app/presenters/publishing_api/plan_for_change_landing_page_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/plan_for_change_landing_page_presenter_test.rb
@@ -227,71 +227,71 @@ class PublishingApi::PlanForChangeLandingPagePresenterTest < ActiveSupport::Test
     end
   end
 
-  test "raises errors if files are not found" do
-    body = <<~YAML
-      blocks:
-      - type: hero
-        image:
-          sources:
-            desktop: "[Image: non-existent-file.jpg]"
-            tablet: "[Image: non-existent-file.jpg]"
-            mobile: "[Image: non-existent-file.jpg]"
-        hero_content:
-          blocks:
-          - type: some-block-type
-    YAML
+  # test "raises errors if files are not found" do
+  #   body = <<~YAML
+  #     blocks:
+  #     - type: hero
+  #       image:
+  #         sources:
+  #           desktop: "[Image: non-existent-file.jpg]"
+  #           tablet: "[Image: non-existent-file.jpg]"
+  #           mobile: "[Image: non-existent-file.jpg]"
+  #       hero_content:
+  #         blocks:
+  #         - type: some-block-type
+  #   YAML
 
-    plan_for_change_landing_page = build(
-      :plan_for_change_landing_page,
-      document: create(:document, id: 12_346),
-      body:,
-      title: "Landing Page title",
-      slug_override: "/landing-page/with-images",
-      summary: "Landing Page summary",
-      first_published_at: @first_published_at = Time.zone.now,
-      updated_at: 1.year.ago,
-      images: [],
-    )
+  #   plan_for_change_landing_page = build(
+  #     :plan_for_change_landing_page,
+  #     document: create(:document, id: 12_346),
+  #     body:,
+  #     title: "Landing Page title",
+  #     slug_override: "/landing-page/with-images",
+  #     summary: "Landing Page summary",
+  #     first_published_at: @first_published_at = Time.zone.now,
+  #     updated_at: 1.year.ago,
+  #     images: [],
+  #   )
 
-    presented_landing_page = PublishingApi::PlanForChangeLandingPagePresenter.new(plan_for_change_landing_page)
-    assert_raises(StandardError, match: /cannot present invalid body/) do
-      I18n.with_locale("en") { presented_landing_page.content }
-    end
-  end
+  #   presented_landing_page = PublishingApi::PlanForChangeLandingPagePresenter.new(plan_for_change_landing_page)
+  #   assert_raises(StandardError, match: /cannot present invalid body/) do
+  #     I18n.with_locale("en") { presented_landing_page.content }
+  #   end
+  # end
 
-  test "it presents errors if image kinds don't match up" do
-    body = <<~YAML
-      blocks:
-      - type: hero
-        image:
-          sources:
-            desktop: "[Image: hero_image_mobile_2x.png]" # NOTE - using mobile image for desktop field
-            tablet: "[Image: hero_image_desktop_2x.png]" # NOTE - using desktop image for tablet field
-            mobile: "[Image: hero_image_tablet_2x.png]" # NOTE - using tablet image for desktop field
-        hero_content:
-          blocks:
-          - type: some-block-type
-    YAML
+  # test "it presents errors if image kinds don't match up" do
+  #   body = <<~YAML
+  #     blocks:
+  #     - type: hero
+  #       image:
+  #         sources:
+  #           desktop: "[Image: hero_image_mobile_2x.png]" # NOTE - using mobile image for desktop field
+  #           tablet: "[Image: hero_image_desktop_2x.png]" # NOTE - using desktop image for tablet field
+  #           mobile: "[Image: hero_image_tablet_2x.png]" # NOTE - using tablet image for desktop field
+  #       hero_content:
+  #         blocks:
+  #         - type: some-block-type
+  #   YAML
 
-    plan_for_change_landing_page = build(
-      :plan_for_change_landing_page,
-      document: create(:document, id: 12_346),
-      body:,
-      title: "Landing Page title",
-      slug_override: "/landing-page/with-images",
-      summary: "Landing Page summary",
-      first_published_at: @first_published_at = Time.zone.now,
-      updated_at: 1.year.ago,
-      images: [
-        build(:image, image_data: build(:hero_image_data, image_kind: "hero_desktop", file: upload_fixture("hero_image_desktop_2x.png", "image/png"))),
-        build(:image, image_data: build(:hero_image_data, image_kind: "hero_tablet", file: upload_fixture("hero_image_tablet_2x.png", "image/png"))),
-        build(:image, image_data: build(:hero_image_data, image_kind: "hero_mobile", file: upload_fixture("hero_image_mobile_2x.png", "image/png"))),
-      ],
-    )
+  #   plan_for_change_landing_page = build(
+  #     :plan_for_change_landing_page,
+  #     document: create(:document, id: 12_346),
+  #     body:,
+  #     title: "Landing Page title",
+  #     slug_override: "/landing-page/with-images",
+  #     summary: "Landing Page summary",
+  #     first_published_at: @first_published_at = Time.zone.now,
+  #     updated_at: 1.year.ago,
+  #     images: [
+  #       build(:image, image_data: build(:hero_image_data, image_kind: "hero_desktop", file: upload_fixture("hero_image_desktop_2x.png", "image/png"))),
+  #       build(:image, image_data: build(:hero_image_data, image_kind: "hero_tablet", file: upload_fixture("hero_image_tablet_2x.png", "image/png"))),
+  #       build(:image, image_data: build(:hero_image_data, image_kind: "hero_mobile", file: upload_fixture("hero_image_mobile_2x.png", "image/png"))),
+  #     ],
+  #   )
 
-    presented_landing_page = PublishingApi::PlanForChangeLandingPagePresenter.new(plan_for_change_landing_page)
-    assert_raises(StandardError, match: /cannot present invalid body/) do
-      I18n.with_locale("en") { presented_landing_page.content }
-    end
-  end
+  #   presented_landing_page = PublishingApi::PlanForChangeLandingPagePresenter.new(plan_for_change_landing_page)
+  #   assert_raises(StandardError, match: /cannot present invalid body/) do
+  #     I18n.with_locale("en") { presented_landing_page.content }
+  #   end
+  # end
 end


### PR DESCRIPTION
These are now deprecated and will redirect to the National Archives. In the meantime, if we need to publish anything to these routes, we don't want to be tripped up by validation errors.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
