### PR TITLE
Fix callback for redirecting statistics announcements [WHIT-3782]

### DIFF
--- a/app/models/statistics_announcement.rb
+++ b/app/models/statistics_announcement.rb
@@ -209,7 +209,9 @@ private
   end
 
   def publication_has_been_published?
-    publication && publication.published?
+    return unless publication
+
+    publication.published? || publication.superseded?
   end
 
   def publication_url

--- a/app/models/statistics_announcement.rb
+++ b/app/models/statistics_announcement.rb
@@ -184,10 +184,6 @@ class StatisticsAnnouncement < ApplicationRecord
     publishing_state == "unpublished"
   end
 
-  def requires_redirect?
-    unpublished? || publication_has_been_published?
-  end
-
   def publishing_api_presenter
     PublishingApi::StatisticsAnnouncementPresenter
   end

--- a/test/unit/app/models/statistics_announcement_test.rb
+++ b/test/unit/app/models/statistics_announcement_test.rb
@@ -14,6 +14,13 @@ class StatisticsAnnouncementTest < ActiveSupport::TestCase
     announcement.touch
   end
 
+  test "publish_redirect_to_publication publishes a redirect to the publication URL (on touch) if the publication is superseded" do
+    announcement = create(:statistics_announcement)
+    publication = create(:superseded_statistics, publication_type_id: PublicationType::OfficialStatistics.id, statistics_announcement: announcement)
+    Whitehall::PublishingApi.expects(:publish_redirect_async).with(announcement.content_id, publication.base_path)
+    announcement.touch
+  end
+
   test "only statistical publication types are valid" do
     assert build(:statistics_announcement, publication_type_id: PublicationType::OfficialStatistics.id).valid?
     assert build(:statistics_announcement, publication_type_id: PublicationType::NationalStatistics.id).valid?

--- a/test/unit/app/models/statistics_announcement_test.rb
+++ b/test/unit/app/models/statistics_announcement_test.rb
@@ -7,6 +7,13 @@ class StatisticsAnnouncementTest < ActiveSupport::TestCase
     assert_equal PublicationType::OfficialStatistics, announcement.publication_type
   end
 
+  test "publish_redirect_to_publication publishes a redirect to the publication URL (on touch) if the publication is published" do
+    announcement = create(:statistics_announcement)
+    publication = create(:published_statistics, publication_type_id: PublicationType::OfficialStatistics.id, statistics_announcement: announcement)
+    Whitehall::PublishingApi.expects(:publish_redirect_async).with(announcement.content_id, publication.base_path)
+    announcement.touch
+  end
+
   test "only statistical publication types are valid" do
     assert build(:statistics_announcement, publication_type_id: PublicationType::OfficialStatistics.id).valid?
     assert build(:statistics_announcement, publication_type_id: PublicationType::NationalStatistics.id).valid?

--- a/test/unit/app/models/statistics_announcement_test.rb
+++ b/test/unit/app/models/statistics_announcement_test.rb
@@ -172,41 +172,6 @@ class StatisticsAnnouncementTest < ActiveSupport::TestCase
     end
   end
 
-  test "requires_redirect? returns true when unpublished?" do
-    statistics_announcement = build(
-      :statistics_announcement,
-      publishing_state: "unpublished",
-    )
-    assert statistics_announcement.requires_redirect?
-  end
-
-  test "requires_redirect? returns false when not unpublished?" do
-    statistics_announcement = build(
-      :statistics_announcement,
-      publishing_state: "published",
-      publication: nil,
-    )
-    assert_not statistics_announcement.requires_redirect?
-  end
-
-  test "requires_redirect? returns true when when publication is published?" do
-    statistics_announcement = build(
-      :statistics_announcement,
-      publishing_state: "published",
-      publication: build(:published_statistics),
-    )
-    assert statistics_announcement.requires_redirect?
-  end
-
-  test "requires_redirect? returns false when when publication is draft" do
-    statistics_announcement = build(
-      :statistics_announcement,
-      publishing_state: "published",
-      publication: build(:draft_statistics),
-    )
-    assert_not statistics_announcement.requires_redirect?
-  end
-
   test "publishes to publishing api with a minor update type" do
     Sidekiq::Testing.inline! do
       edition = create(:statistics_announcement)


### PR DESCRIPTION
## What

Extend the callback such that StatisticsAnnouncements automatically redirect to their linked publication if the publication is in either a published or a superseded state.

## Why

Historically it was possible to link a statistics announcement to a non-draft version of a publication, which has meant that there are a number of statistics announcements which were never redirected as they should have been. This logic should fix things going forward, provided we run this to trigger the logic again:

```
StatisticsAnnouncement
  .joins(:publication)
  .where(editions: { state: "superseded" })
  .find_each(&:touch)
```

This re-presents 11,771 (on integration) statistics announcements, and should fix up cases that we know aren't redirecting when they should be. E.g. https://www.integration.publishing.service.gov.uk/government/statistics/announcements/dementia-profile-update-7th-december-2021?cb=cachebust123 now redirects to https://www.integration.publishing.service.gov.uk/government/statistics/dementia-profile-updates.

Jira: https://gov-uk.atlassian.net/browse/WHIT-3782

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.