### PR TITLE
[WHIT - 3819] [WHIT-3809] Preview link not working for scheduled editions

### DIFF
--- a/app/validators/unmodifiable_validator.rb
+++ b/app/validators/unmodifiable_validator.rb
@@ -12,7 +12,7 @@ class UnmodifiableValidator < ActiveModel::Validator
   def modifiable_attributes(previous_state, current_state)
     modifiable = %w[state updated_at force_published]
     if previous_state == "scheduled"
-      modifiable += %w[major_change_published_at first_published_at access_limiting]
+      modifiable += %w[major_change_published_at first_published_at access_limiting auth_bypass_id]
     end
     if Edition::PRE_PUBLICATION_STATES.include?(previous_state) || being_unpublished?(previous_state, current_state)
       modifiable += %w[published_major_version published_minor_version]

--- a/test/unit/app/services/edition_auth_bypass_revoker_test.rb
+++ b/test/unit/app/services/edition_auth_bypass_revoker_test.rb
@@ -34,5 +34,13 @@ class EditionAuthBypassRevokerTest < ActiveSupport::TestCase
 
       EditionAuthBypassRevoker.new(edition:, current_user: user, updater:).call
     end
+
+    test "persists the auth_bypass_id even when the edition is scheduled" do
+      edition = create(:scheduled_edition, :with_auth_bypass_id)
+
+      EditionAuthBypassRevoker.new(edition:, current_user: user, updater:).call
+
+      assert_nil edition.reload.auth_bypass_id
+    end
   end
 end

--- a/test/unit/app/services/editon_auth_bypass_updater_test.rb
+++ b/test/unit/app/services/editon_auth_bypass_updater_test.rb
@@ -38,5 +38,14 @@ class EditionAuthBypassUpdaterTest < ActiveSupport::TestCase
 
       EditionAuthBypassUpdater.new(edition:, current_user: user, updater:).call
     end
+
+    test "persists the new auth_bypass_id even when the edition is scheduled" do
+      edition = create(:scheduled_edition, :with_auth_bypass_id)
+      SecureRandom.stubs(uuid: uid)
+
+      EditionAuthBypassUpdater.new(edition:, current_user: user, updater:).call
+
+      assert_equal uid, edition.reload.auth_bypass_id
+    end
   end
 end

--- a/test/unit/app/validators/unmodifiable_validator_test.rb
+++ b/test/unit/app/validators/unmodifiable_validator_test.rb
@@ -1,0 +1,18 @@
+require "test_helper"
+
+class UnmodifiableValidatorTest < ActiveSupport::TestCase
+  test "allows auth_bypass_id to be changed when the edition was scheduled" do
+    edition = create(:scheduled_edition, :with_auth_bypass_id)
+    edition.auth_bypass_id = SecureRandom.uuid
+
+    assert edition.valid?
+  end
+
+  test "still forbids other attributes being changed when the edition was scheduled" do
+    edition = create(:scheduled_edition)
+    edition.title = "Changed title"
+
+    assert_not edition.valid?
+    assert_includes edition.errors[:title], "cannot be modified when edition is in the scheduled state"
+  end
+end


### PR DESCRIPTION
[Jira](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-3819)

### What
Allow `auth_bypass_id` to be modified on editions in the `scheduled` state, so publishers can generate/regenerate/delete a shareable preview link once an edition has been scheduled for publication.

### Why
`UnmodifiableValidator` blocks changes to any attribute not in its `modifiable_attributes` allowlist once `state_was == "scheduled"`. `auth_bypass_id` wasn't in that list, so `EditionAuthBypassUpdater`/ `EditionAuthBypassRevoker` were silently failing to persist the token on scheduled editions — `save_as` returned `false` , so the UI showed "New document preview link generated" with no link actually created.

This matches the situation reported in this [support ticket ](https://govuk.zendesk.com/agent/tickets/6762542)where a publisher could not generate share-preview links on scheduled editions. 


