### PR TITLE
Propagate updated 'major_change_published_at' across newer editions [WHIT-3827]

### DIFF
--- a/app/controllers/admin/edition_change_notes_controller.rb
+++ b/app/controllers/admin/edition_change_notes_controller.rb
@@ -52,6 +52,15 @@ class Admin::EditionChangeNotesController < Admin::BaseController
     edition_to_change.major_change_published_at = edition_to_change.document.editions.where(minor_change: false).where("id < ?", edition_to_change.id).last.try(:major_change_published_at)
     edition_to_change.save!(validate: false)
 
+    # We also need to overwrite any 'newer' minor change editions with the revised 'major_change_published_at'
+    # until/unless we encounter the next major change edition (at which point we stop overwriting)
+    edition_to_change.document.editions.where("id > ?", edition_to_change.id).find_each do |newer_edition|
+      break unless newer_edition.minor_change
+
+      newer_edition.major_change_published_at = edition_to_change.major_change_published_at
+      newer_edition.save!(validate: false)
+    end
+
     EditorialRemark.create!(
       edition: edition_to_change,
       body: "Deleted change note: #{old_change_note}",

--- a/app/controllers/admin/edition_change_notes_controller.rb
+++ b/app/controllers/admin/edition_change_notes_controller.rb
@@ -2,6 +2,7 @@ class Admin::EditionChangeNotesController < Admin::BaseController
   before_action :find_edition
   before_action :enforce_permissions!
   before_action :limit_edition_access!
+  before_action :redirect_to_latest_edition_if_not_latest
   def index
     @change_notes = @edition
       .document
@@ -84,5 +85,12 @@ private
   def find_edition
     edition = Edition.find(params[:edition_id])
     @edition = LocalisedModel.new(edition, edition.primary_locale)
+  end
+
+  def redirect_to_latest_edition_if_not_latest
+    latest_edition = @edition.document.latest_edition
+    return if @edition.id == latest_edition.id
+
+    redirect_to admin_edition_change_notes_path(edition_id: latest_edition.id)
   end
 end

--- a/test/functional/admin/edition_change_notes_controller_test.rb
+++ b/test/functional/admin/edition_change_notes_controller_test.rb
@@ -135,6 +135,41 @@ class Admin::EditionChangeNotesControllerTest < ActionController::TestCase
     assert_equal @second_edition.major_change_published_at, @first_edition.major_change_published_at
   end
 
+  test "delete updates major_change_published_at of all subsequent minor editions" do
+    login_as :gds_admin
+
+    @document = create(:document)
+    @first_edition_major = create(:edition, :superseded, change_note: "First change note", major_change_published_at: "2022-12-01 10:00:05", document: @document)
+    @second_edition_major = create(:edition, :superseded, change_note: "Second change note", major_change_published_at: "2022-12-02 15:00:05", document: @document)
+    @third_edition_minor = create(:edition, :superseded, change_note: nil, minor_change: true, major_change_published_at: @second_edition_major.major_change_published_at, document: @document)
+    @current_edition_minor = create(:edition, :published, change_note: nil, minor_change: true, major_change_published_at: @second_edition_major.major_change_published_at, document: @document)
+
+    delete :destroy, params: { edition_id: @current_edition_minor.id, id: @second_edition_major.id }
+
+    assert_equal @first_edition_major.major_change_published_at, @third_edition_minor.reload.major_change_published_at
+    assert_equal @first_edition_major.major_change_published_at, @current_edition_minor.reload.major_change_published_at
+  end
+
+  test "delete does not overwrite major_change_published_at of subsequent major edition (and any subsequent editions from that)" do
+    login_as :gds_admin
+
+    @document = create(:document)
+    @first_edition_major = create(:edition, :superseded, change_note: "First change note", major_change_published_at: "2022-12-01 10:00:05", document: @document)
+    @second_edition_minor = create(:edition, :superseded, change_note: nil, minor_change: true, major_change_published_at: "2022-12-01 10:00:05", document: @document)
+    @third_edition_major = create(:edition, :published, change_note: "Third change note", major_change_published_at: "2022-12-02 15:00:05", document: @document)
+    @fourth_edition_minor = create(:edition, :published, change_note: nil, minor_change: true, major_change_published_at: "2022-12-02 15:00:05", document: @document)
+    @fifth_edition_major = create(:edition, :published, change_note: "Fifth change note", major_change_published_at: "2022-12-03 15:00:05", document: @document)
+    @sixth_edition_minor = create(:edition, :published, change_note: nil, minor_change: true, major_change_published_at: "2022-12-03 15:00:05", document: @document)
+
+    delete :destroy, params: { edition_id: @sixth_edition_minor.id, id: @third_edition_major.id }
+
+    assert_equal @second_edition_minor.reload.major_change_published_at.to_s, "2022-12-01 10:00:05 +0000" #  unchanged
+    assert_equal @third_edition_major.reload.major_change_published_at.to_s, "2022-12-01 10:00:05 +0000" #  updated
+    assert_equal @fourth_edition_minor.reload.major_change_published_at.to_s, "2022-12-01 10:00:05 +0000" #  updated
+    assert_equal @fifth_edition_major.reload.major_change_published_at.to_s, "2022-12-03 15:00:05 +0000" #  unchanged
+    assert_equal @sixth_edition_minor.reload.major_change_published_at.to_s, "2022-12-03 15:00:05 +0000" #  unchanged
+  end
+
   test "delete republishes the document" do
     login_as :gds_admin
 

--- a/test/functional/admin/edition_change_notes_controller_test.rb
+++ b/test/functional/admin/edition_change_notes_controller_test.rb
@@ -20,6 +20,14 @@ class Admin::EditionChangeNotesControllerTest < ActionController::TestCase
     assert_response :forbidden
   end
 
+  test "redirects to the latest edition if the edition is not the latest" do
+    login_as :gds_admin
+
+    get :index, params: { edition_id: @first_edition.id }
+
+    assert_redirected_to admin_edition_change_notes_path(edition_id: @current_edition.id)
+  end
+
   view_test "index lists all the published major changes" do
     login_as :gds_admin
 


### PR DESCRIPTION
## What

Ensure `major_change_published_at` of subsequent minor editions is overwritten to the correct value.

TLDR, a document had edition structure like:

- Edition 1: Superseded (major)
- Edition 2: Superseded (major)
- Edition 3: Published (minor)

Deleting the changenote on Edition 2 only updated the major_change_published_at on that edition - but there was a newer Edition 3 whose major_change_published_at was not updated, so the doc still showed an erroneous ‘last updated’ date. The solution is to find all minor editions after the one we've just deleted a changenote for, and update their major_change_published_at accordingly.

## Why

The change notes edit screen
(https://whitehall-admin.publishing.service.gov.uk/government/admin/publications/1814299) did not account for deleting changenotes when newer minor editions have been published since that major version.

The public timestamp of an edition is determined by its major_change_published_at value
(https://github.com/alphagov/whitehall/blob/dcb4b4c3765166f1b07d39562af9e3b53a8ba287/app/models/edition.rb#L301) which is inherited from its previous edition, because `major_change_published_at` is not in the `ignorable_attribute_keys` (https://github.com/alphagov/whitehall/blob/dcb4b4c3765166f1b07d39562af9e3b53a8ba287/app/models/edition.rb#L182-L195). It's only overwritten on edition publish, if the given edition is considered a 'major change' - it overwrites the timestamp to `Time.zone.now`
(https://github.com/alphagov/whitehall/blob/bd10aa5cbb3aed254afc580dc028b919703241b4/app/services/edition_publisher.rb#L33).

Because `major_change_published_at` is set on every edition in a document's history, we can't just go in and delete a changenote on an old edition and update the `major_change_published_at` of that sole edition - we also need to find any subsequent minor editions and overwrite _their_ `major_change_published_at` values.

The impact of this bug is that our Content colleagues were able to delete a changenote via the UI but the 'public_updated_at' on the content item remained unchanged, because the newer version of the document was a minor change. This caused "Last updated" to show a confusing / incorrect date.

Jira: https://gov-uk.atlassian.net/browse/WHIT-3827

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
