### PR TITLE
Access limiting orgs and retagging [WHIT-3735]

### DIFF
--- a/app/views/admin/retagging/preview.html.erb
+++ b/app/views/admin/retagging/preview.html.erb
@@ -3,7 +3,7 @@
 <% content_for :title_margin_bottom, 6 %>
 
 <div class="govuk-grid-row">
-  <section class="govuk-grid-column-full-width">
+  <section class="govuk-grid-column-full">
     <%= render "govuk_publishing_components/components/table", {
       head: [
         {

--- a/app/views/admin/retagging/preview.html.erb
+++ b/app/views/admin/retagging/preview.html.erb
@@ -15,6 +15,9 @@
         {
           text: "Supporting organisations",
         },
+        {
+          text: "Access limiting organisations",
+        },
       ],
       rows: @docs_to_update.map do |hash|
         [
@@ -26,6 +29,9 @@
           },
           {
             text: hash[:supporting_orgs_summary],
+          },
+          {
+            text: hash[:access_limiting_orgs_summary],
           },
         ]
       end,

--- a/lib/data_hygiene/bulk_organisation_updater.rb
+++ b/lib/data_hygiene/bulk_organisation_updater.rb
@@ -171,9 +171,7 @@ module DataHygiene
     end
 
     def update_edition(edition, new_lead_organisations, new_supporting_organisations)
-      return false if
-        edition.lead_organisations == new_lead_organisations &&
-          edition.supporting_organisations == new_supporting_organisations
+      return false if edition_orgs_unchanged?(edition, new_lead_organisations, new_supporting_organisations)
 
       edition.update( # rubocop:disable Rails/SaveBang
         lead_organisations: new_lead_organisations,
@@ -181,6 +179,11 @@ module DataHygiene
       )
 
       true
+    end
+
+    def edition_orgs_unchanged?(edition, new_lead_organisations, new_supporting_organisations)
+      edition.lead_organisations == new_lead_organisations &&
+        edition.supporting_organisations == new_supporting_organisations
     end
 
     def update_statistics_announcement(document, new_organisations)

--- a/lib/data_hygiene/bulk_organisation_updater.rb
+++ b/lib/data_hygiene/bulk_organisation_updater.rb
@@ -35,7 +35,7 @@ module DataHygiene
     def summarise_changes
       @validated_rows.map do |hash|
         {
-          slug: hash[:document].live_edition.slug,
+          slug: hash[:document].latest_edition.slug,
           lead_orgs_summary: diff_orgs(
             hash[:document].latest_edition.lead_organisations.map(&:slug),
             hash[:lead_orgs].map(&:slug),

--- a/lib/data_hygiene/bulk_organisation_updater.rb
+++ b/lib/data_hygiene/bulk_organisation_updater.rb
@@ -44,6 +44,10 @@ module DataHygiene
             hash[:document].latest_edition.supporting_organisations.map(&:slug),
             hash[:supporting_orgs].map(&:slug),
           ),
+          access_limiting_orgs_summary: diff_orgs(
+            hash[:document].latest_edition.access_limiting_organisations.map(&:slug),
+            new_access_limiting_orgs(hash[:document].latest_edition, hash[:lead_orgs], hash[:supporting_orgs]).map(&:slug),
+          ),
         }
       end
     end
@@ -176,6 +180,7 @@ module DataHygiene
       edition.update( # rubocop:disable Rails/SaveBang
         lead_organisations: new_lead_organisations,
         supporting_organisations: new_supporting_organisations,
+        access_limiting_organisations: new_access_limiting_orgs(edition, new_lead_organisations, new_supporting_organisations),
       )
 
       true
@@ -183,7 +188,34 @@ module DataHygiene
 
     def edition_orgs_unchanged?(edition, new_lead_organisations, new_supporting_organisations)
       edition.lead_organisations == new_lead_organisations &&
-        edition.supporting_organisations == new_supporting_organisations
+        edition.supporting_organisations == new_supporting_organisations &&
+        edition_access_limiting_orgs_unchanged?(edition, new_lead_organisations, new_supporting_organisations)
+    end
+
+    def edition_access_limiting_orgs_unchanged?(edition, new_lead_organisations, new_supporting_organisations)
+      return true unless edition.access_limiting_organisations?
+
+      new_organisations = (new_lead_organisations + new_supporting_organisations).uniq
+
+      edition.access_limiting_organisations.none? do |organisation|
+        new_organisations.include?(organisation)
+      end
+    end
+
+    # the new access limiting orgs (ALOs) should be:
+    # - any existing access limiting orgs that are *not* being replaced in the retagging
+    #   (ie remove the current lead and support orgs from the existing list of ALOs)
+    # - the new lead orgs
+    # - the new supporting orgs
+    def new_access_limiting_orgs(edition, new_lead_organisations, new_supporting_organisations)
+      return [] unless edition.access_limiting_organisations?
+
+      new_alos = edition.access_limiting_organisations.reject do |alo|
+        edition.lead_organisations.include?(alo) || edition.supporting_organisations.include?(alo)
+      end
+      new_alos << new_lead_organisations
+      new_alos << new_supporting_organisations
+      new_alos.flatten.uniq
     end
 
     def update_statistics_announcement(document, new_organisations)

--- a/test/unit/lib/data_hygiene/bulk_organisation_updater_test.rb
+++ b/test/unit/lib/data_hygiene/bulk_organisation_updater_test.rb
@@ -132,20 +132,91 @@ class DataHygiene::BulkOrganisationUpdaterTest < ActiveSupport::TestCase
           slug: "some-slug",
           lead_orgs_summary: "Added new-lead-organisation, Removed old-lead-organisation. Result: new-lead-organisation",
           supporting_orgs_summary: "Added new-supporting-organisation, Removed old-supporting-organisation. Result: new-supporting-organisation",
+          access_limiting_orgs_summary: "Unchanged. Result: ",
         },
         {
           slug: "another-slug",
           lead_orgs_summary: "Reordered (from old-lead-organisation, new-lead-organisation). Result: new-lead-organisation, old-lead-organisation",
           supporting_orgs_summary: "Removed old-supporting-organisation. Result: ",
+          access_limiting_orgs_summary: "Unchanged. Result: ",
         },
         {
           slug: "final-slug",
           lead_orgs_summary: "Unchanged. Result: old-lead-organisation",
           supporting_orgs_summary: "Added new-supporting-organisation. Result: new-supporting-organisation",
+          access_limiting_orgs_summary: "Unchanged. Result: ",
         },
       ],
       updater.summarise_changes,
     )
+  end
+
+  test "it has a `summarise_changes` method that returns a hash summarising changes to access limiting organisations" do
+    raw_csv = <<~CSV
+      URL,Lead organisations,Supporting organisations
+      https://www.gov.uk/government/publications/no-access-limiting-orgs,new-lead-organisation,new-supporting-organisation
+      https://www.gov.uk/government/publications/additional-access-limiting-orgs,new-lead-organisation,new-supporting-organisation
+      https://www.gov.uk/government/publications/access-limiting-orgs-dont-change,new-lead-organisation,new-supporting-organisation
+    CSV
+
+    old_lead_org = create(:organisation, slug: "old-lead-organisation")
+    new_lead_org = create(:organisation, slug: "new-lead-organisation")
+    extra_access_limiting_org = create(:organisation, slug: "extra-access-limiting-organisation")
+    new_supporting_org = create(:organisation, slug: "new-supporting-organisation")
+    old_supporting_org = create(:organisation, slug: "old-supporting-organisation")
+
+    create(
+      :publication,
+      :draft,
+      title: "No access limiting orgs",
+      lead_organisations: [old_lead_org],
+      supporting_organisations: [old_supporting_org],
+    )
+
+    create(
+      :publication,
+      :draft,
+      title: "Additional access limiting orgs",
+      lead_organisations: [old_lead_org],
+      supporting_organisations: [old_supporting_org],
+      access_limiting: "organisations",
+      access_limiting_organisations: [old_lead_org, old_supporting_org, extra_access_limiting_org],
+    )
+
+    create(
+      :publication,
+      :draft,
+      title: "Access limiting orgs dont change",
+      lead_organisations: [old_lead_org],
+      supporting_organisations: [old_supporting_org],
+      access_limiting: "organisations",
+      access_limiting_organisations: [new_lead_org, new_supporting_org],
+    )
+
+    updater = DataHygiene::BulkOrganisationUpdater.new(raw_csv)
+    updater.validate
+
+    assert_equal([], updater.errors)
+    assert_equal([
+      {
+        slug: "no-access-limiting-orgs",
+        lead_orgs_summary: "Added new-lead-organisation, Removed old-lead-organisation. Result: new-lead-organisation",
+        supporting_orgs_summary: "Added new-supporting-organisation, Removed old-supporting-organisation. Result: new-supporting-organisation",
+        access_limiting_orgs_summary: "Unchanged. Result: ",
+      },
+      {
+        slug: "additional-access-limiting-orgs",
+        lead_orgs_summary: "Added new-lead-organisation, Removed old-lead-organisation. Result: new-lead-organisation",
+        supporting_orgs_summary: "Added new-supporting-organisation, Removed old-supporting-organisation. Result: new-supporting-organisation",
+        access_limiting_orgs_summary: "Added new-lead-organisation, new-supporting-organisation, Removed old-lead-organisation, old-supporting-organisation. Result: extra-access-limiting-organisation, new-lead-organisation, new-supporting-organisation",
+      },
+      {
+        slug: "access-limiting-orgs-dont-change",
+        lead_orgs_summary: "Added new-lead-organisation, Removed old-lead-organisation. Result: new-lead-organisation",
+        supporting_orgs_summary: "Added new-supporting-organisation, Removed old-supporting-organisation. Result: new-supporting-organisation",
+        access_limiting_orgs_summary: "Unchanged. Result: new-lead-organisation, new-supporting-organisation",
+      },
+    ], updater.summarise_changes)
   end
 
   test "it fails with invalid CSV data" do
@@ -207,6 +278,82 @@ class DataHygiene::BulkOrganisationUpdaterTest < ActiveSupport::TestCase
     assert_equal [organisation1, organisation2], edition.reload.supporting_organisations
     assert_equal 1, PublishingApiDocumentRepublishingJob.jobs.size
     assert_equal edition.document.id, PublishingApiDocumentRepublishingJob.jobs.first["args"].first
+  end
+
+  test "it replaces previous lead and supporting orgs in the edition's access limiting orgs with the new lead and supporting orgs" do
+    csv_file = <<~CSV
+      URL,Lead organisations,Supporting organisations
+      https://www.gov.uk/government/publications/access-limited-edition,"lead-organisation-2","supporting-organisation-2"
+    CSV
+
+    old_lead_org = create(:organisation, slug: "lead-organisation-1")
+    new_lead_org = create(:organisation, slug: "lead-organisation-2")
+    old_supporting_org = create(:organisation, slug: "supporting-organisation-1")
+    new_supporting_org = create(:organisation, slug: "supporting-organisation-2")
+
+    edition = create(
+      :publication,
+      title: "access-limited-edition",
+      lead_organisations: [old_lead_org],
+      supporting_organisations: [old_supporting_org],
+      access_limiting: "organisations",
+      access_limiting_organisations: [old_lead_org, old_supporting_org],
+    )
+
+    process(csv_file)
+
+    assert_same_elements edition.reload.access_limiting_organisations, [new_lead_org, new_supporting_org]
+  end
+
+  test "it retains access limiting orgs that were not previously lead or supporting organisations" do
+    csv_file = <<~CSV
+      URL,Lead organisations,Supporting organisations
+      https://www.gov.uk/government/publications/access-limited-edition,"lead-organisation-2","supporting-organisation-2"
+    CSV
+
+    old_lead_org = create(:organisation, slug: "lead-organisation-1")
+    create(:organisation, slug: "lead-organisation-2")
+    existing_access_limiting_org = create(:organisation, slug: "access-limiting-org")
+    old_supporting_org = create(:organisation, slug: "supporting-organisation-1")
+    create(:organisation, slug: "supporting-organisation-2")
+
+    edition = create(
+      :publication,
+      title: "access-limited-edition",
+      lead_organisations: [old_lead_org],
+      supporting_organisations: [old_supporting_org],
+      access_limiting: "organisations",
+      access_limiting_organisations: [old_lead_org, old_supporting_org, existing_access_limiting_org],
+    )
+
+    process(csv_file)
+
+    assert_includes edition.reload.access_limiting_organisations, existing_access_limiting_org
+  end
+
+  test "it does not change access limiting on editions that were not access limited" do
+    csv_file = <<~CSV
+      URL,Lead organisations,Supporting organisations
+      https://www.gov.uk/government/publications/access-limited-edition,"lead-organisation-2","supporting-organisation-2"
+    CSV
+
+    old_lead_org = create(:organisation, slug: "lead-organisation-1")
+    create(:organisation, slug: "lead-organisation-2")
+    old_supporting_org = create(:organisation, slug: "supporting-organisation-1")
+    create(:organisation, slug: "supporting-organisation-2")
+
+    edition = create(
+      :publication,
+      title: "access-limited-edition",
+      lead_organisations: [old_lead_org],
+      supporting_organisations: [old_supporting_org],
+      access_limiting: "none",
+    )
+
+    process(csv_file)
+
+    assert_equal edition.reload.access_limiting_organisations.empty?, true
+    assert_equal edition.access_limiting, "none"
   end
 
   test "it just updates the draft when there is not a change to the published edition" do


### PR DESCRIPTION
## What

Updates the retagging logic so that:
- the lead and supporting organisations being replaced are also replaced in an edition's access limiting organisations
- any existing access limiting orgs that are not involved in the replacement are retained during retagging

Also corrects the width of the preview table.

### Before
<img width="1624" height="1011" alt="image" src="https://github.com/user-attachments/assets/1ab6aecf-a556-49c5-8a9e-7d11d48e1e77" />


### After

<img width="1624" height="1011" alt="image" src="https://github.com/user-attachments/assets/affa4217-cc5b-4c9b-9b6f-f755941afb5b" />


## Why

So that users do not continue to have access when their orgs are removed during a retagging, and vice versa.

https://gov-uk.atlassian.net/browse/WHIT-3735

---
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
