### PR TITLE
Fix the archiving URL structure [WHIT-3700]

### DIFF
--- a/app/models/unpublishing.rb
+++ b/app/models/unpublishing.rb
@@ -75,7 +75,8 @@ class Unpublishing < ApplicationRecord
   end
 
   def archived_url
-    full_address = "https://www.gov.uk#{edition.base_path}"
+    locale_suffix = I18n.locale == :en ? "" : ".#{I18n.locale}"
+    full_address = "https://www.gov.uk#{edition.base_path}#{locale_suffix}"
 
     "https://webarchive.nationalarchives.gov.uk/ukgwa/#{full_address}"
   end

--- a/app/models/unpublishing.rb
+++ b/app/models/unpublishing.rb
@@ -77,7 +77,7 @@ class Unpublishing < ApplicationRecord
   def archived_url
     full_address = "https://www.gov.uk#{edition.base_path}"
 
-    "https://webarchive.nationalarchives.gov.uk/ukgwa/3000/#{full_address}"
+    "https://webarchive.nationalarchives.gov.uk/ukgwa/#{full_address}"
   end
 
   # Because the edition may have been deleted, we need to find it unscoped to

--- a/app/models/unpublishing.rb
+++ b/app/models/unpublishing.rb
@@ -119,7 +119,11 @@ private
     req.use_ssl = true
     res = req.request_head(url.path)
 
-    errors.add(:unpublishing_reason, "cannot be \"Archived\" if page has not been archived by the National Archives (\"https://www.webarchive.nationalarchives.gov.uk\")") unless res.code == "200"
+    # The National Archives returns a 307 redirect for archived pages, so we check for that instead of a 200 OK.
+    # E.g. https://webarchive.nationalarchives.gov.uk/ukgwa/https://www.gov.uk/government/news/uk-export-finance-appoints-pat-cauthery-to-lead-aerospace-and-defence-business
+    # => 307 redirect =>
+    # https://webarchive.nationalarchives.gov.uk/ukgwa/20260407083257/https://www.gov.uk/government/news/uk-export-finance-appoints-pat-cauthery-to-lead-aerospace-and-defence-business
+    errors.add(:unpublishing_reason, "cannot be \"Archived\" if page has not been archived by the National Archives (\"https://www.webarchive.nationalarchives.gov.uk\")") unless res.code == "307"
   end
 
   def redirect_not_circular

--- a/app/sidekiq/publishing_api_unpublishing_job.rb
+++ b/app/sidekiq/publishing_api_unpublishing_job.rb
@@ -8,16 +8,41 @@ class PublishingApiUnpublishingJob < JobBase
     content_id = Document.where(id: edition.document_id).pick(:content_id)
 
     edition.available_locales.each do |locale|
-      case unpublishing.unpublishing_reason_id
-      when UnpublishingReason::PUBLISHED_IN_ERROR_ID
-        if unpublishing.redirect?
+      I18n.with_locale(locale) do
+        case unpublishing.unpublishing_reason_id
+        when UnpublishingReason::PUBLISHED_IN_ERROR_ID
+          if unpublishing.redirect?
+            PublishingApiRedirectJob.new.perform(
+              content_id,
+              unpublishing.alternative_path,
+              locale.to_s,
+              allow_draft,
+            )
+          else
+            PublishingApiGoneJob.new.perform(
+              content_id,
+              unpublishing.alternative_path,
+              unpublishing.explanation,
+              locale.to_s,
+              allow_draft,
+            )
+          end
+        when UnpublishingReason::CONSOLIDATED_ID
           PublishingApiRedirectJob.new.perform(
             content_id,
             unpublishing.alternative_path,
             locale.to_s,
             allow_draft,
           )
-        else
+        when UnpublishingReason::WITHDRAWN_ID
+          PublishingApiWithdrawalJob.new.perform(
+            content_id,
+            unpublishing.explanation,
+            locale.to_s,
+            allow_draft,
+            unpublishing.unpublished_at.to_s,
+          )
+        when UnpublishingReason::ARCHIVED_ID
           PublishingApiGoneJob.new.perform(
             content_id,
             unpublishing.alternative_path,
@@ -26,29 +51,6 @@ class PublishingApiUnpublishingJob < JobBase
             allow_draft,
           )
         end
-      when UnpublishingReason::CONSOLIDATED_ID
-        PublishingApiRedirectJob.new.perform(
-          content_id,
-          unpublishing.alternative_path,
-          locale.to_s,
-          allow_draft,
-        )
-      when UnpublishingReason::WITHDRAWN_ID
-        PublishingApiWithdrawalJob.new.perform(
-          content_id,
-          unpublishing.explanation,
-          locale.to_s,
-          allow_draft,
-          unpublishing.unpublished_at.to_s,
-        )
-      when UnpublishingReason::ARCHIVED_ID
-        PublishingApiGoneJob.new.perform(
-          content_id,
-          unpublishing.alternative_path,
-          unpublishing.explanation,
-          locale.to_s,
-          allow_draft,
-        )
       end
     end
   end

--- a/test/factories/editions.rb
+++ b/test/factories/editions.rb
@@ -176,6 +176,11 @@ FactoryBot.define do
       unpublishing { build(:consolidated_unpublishing) }
     end
 
+    trait(:unpublished_archived) do
+      state { :unpublished }
+      unpublishing { build(:archived_unpublishing) }
+    end
+
     trait(:withdrawn) do
       state { "withdrawn" }
       unpublishing { build(:withdrawn_unpublishing) }

--- a/test/factories/unpublishings.rb
+++ b/test/factories/unpublishings.rb
@@ -30,4 +30,9 @@ FactoryBot.define do
     redirect { false }
     explanation { "content was withdrawn" }
   end
+
+  factory :archived_unpublishing, parent: :unpublishing do
+    unpublishing_reason_id { UnpublishingReason::ARCHIVED_ID }
+    redirect { false }
+  end
 end

--- a/test/unit/app/helpers/admin/editions_helper_test.rb
+++ b/test/unit/app/helpers/admin/editions_helper_test.rb
@@ -141,7 +141,7 @@ class Admin::EditionsHelperTest < ActionView::TestCase
     edition = create(:edition, :unpublished)
 
     stub_request(:head, edition.unpublishing.archived_url)
-      .to_return(status: 200, body: "", headers: {})
+      .to_return(status: 307, body: "", headers: {})
 
     edition.unpublishing.unpublishing_reason_id = UnpublishingReason::ARCHIVED_ID
     edition.unpublishing.save!

--- a/test/unit/app/models/unpublishing_test.rb
+++ b/test/unit/app/models/unpublishing_test.rb
@@ -191,6 +191,20 @@ class UnpublishingTest < ActiveSupport::TestCase
     assert unpublishing.valid?
   end
 
+  test "#archived_url returns the URL for The National Archives" do
+    edition = create(:detailed_guide, :draft)
+    unpublishing = build(
+      :unpublishing,
+      edition:,
+      unpublishing_reason: UnpublishingReason::Archived,
+    )
+
+    stub_request(:head, unpublishing.archived_url)
+      .to_return(status: 200, body: "", headers: {})
+
+    assert_equal "https://webarchive.nationalarchives.gov.uk/ukgwa/3000/https://www.gov.uk#{unpublishing.document_path}", unpublishing.archived_url
+  end
+
   test "always redirects if the reason is Consolidated" do
     unpublishing = Unpublishing.new(unpublishing_reason: UnpublishingReason::Consolidated)
     assert unpublishing.redirect?

--- a/test/unit/app/models/unpublishing_test.rb
+++ b/test/unit/app/models/unpublishing_test.rb
@@ -186,7 +186,7 @@ class UnpublishingTest < ActiveSupport::TestCase
     unpublishing = build(:unpublishing, unpublishing_reason: UnpublishingReason::Archived)
 
     stub_request(:head, unpublishing.archived_url)
-      .to_return(status: 200, body: "", headers: {})
+      .to_return(status: 307, body: "", headers: {})
 
     assert unpublishing.valid?
   end

--- a/test/unit/app/models/unpublishing_test.rb
+++ b/test/unit/app/models/unpublishing_test.rb
@@ -191,7 +191,7 @@ class UnpublishingTest < ActiveSupport::TestCase
     assert unpublishing.valid?
   end
 
-  test "#archived_url returns the URL for The National Archives" do
+  test "#archived_url returns the localised URL for The National Archives" do
     edition = create(:detailed_guide, :draft)
     unpublishing = build(
       :unpublishing,
@@ -203,6 +203,13 @@ class UnpublishingTest < ActiveSupport::TestCase
       .to_return(status: 200, body: "", headers: {})
 
     assert_equal "https://webarchive.nationalarchives.gov.uk/ukgwa/https://www.gov.uk#{unpublishing.document_path}", unpublishing.archived_url
+
+    with_locale(:cy) do
+      stub_request(:head, unpublishing.archived_url)
+        .to_return(status: 200, body: "", headers: {})
+
+      assert_equal "https://webarchive.nationalarchives.gov.uk/ukgwa/https://www.gov.uk#{unpublishing.document_path}.cy", unpublishing.archived_url
+    end
   end
 
   test "always redirects if the reason is Consolidated" do

--- a/test/unit/app/models/unpublishing_test.rb
+++ b/test/unit/app/models/unpublishing_test.rb
@@ -202,7 +202,7 @@ class UnpublishingTest < ActiveSupport::TestCase
     stub_request(:head, unpublishing.archived_url)
       .to_return(status: 200, body: "", headers: {})
 
-    assert_equal "https://webarchive.nationalarchives.gov.uk/ukgwa/3000/https://www.gov.uk#{unpublishing.document_path}", unpublishing.archived_url
+    assert_equal "https://webarchive.nationalarchives.gov.uk/ukgwa/https://www.gov.uk#{unpublishing.document_path}", unpublishing.archived_url
   end
 
   test "always redirects if the reason is Consolidated" do

--- a/test/unit/app/sidekiq/publishing_api_unpublishing_job_test.rb
+++ b/test/unit/app/sidekiq/publishing_api_unpublishing_job_test.rb
@@ -86,7 +86,7 @@ class PublishingApiUnpublishingJobTest < ActiveSupport::TestCase
   end
 
   test "sets I18n.locale for each available locale" do
-    stub_request(:any, %r{\Ahttps://webarchive\.nationalarchives\.gov\.uk/}).to_return(status: 200, body: "", headers: {})
+    stub_request(:any, %r{\Ahttps://webarchive\.nationalarchives\.gov\.uk/}).to_return(status: 307, body: "", headers: {})
 
     unpublished_edition = create(
       :standard_edition,

--- a/test/unit/app/sidekiq/publishing_api_unpublishing_job_test.rb
+++ b/test/unit/app/sidekiq/publishing_api_unpublishing_job_test.rb
@@ -85,6 +85,32 @@ class PublishingApiUnpublishingJobTest < ActiveSupport::TestCase
     PublishingApiUnpublishingJob.new.perform(unpublished_edition.unpublishing.id)
   end
 
+  test "sets I18n.locale for each available locale" do
+    stub_request(:any, %r{\Ahttps://webarchive\.nationalarchives\.gov\.uk/}).to_return(status: 200, body: "", headers: {})
+
+    unpublished_edition = create(
+      :standard_edition,
+      :unpublished_archived,
+    )
+    unpublished_edition.translations.create!(locale: :fr)
+
+    unpublishing = unpublished_edition.unpublishing
+
+    locales_seen = []
+
+    PublishingApiGoneJob.stubs(:new).returns(job = mock)
+
+    job.stubs(:perform).with do |_, _, _, locale, _|
+      locales_seen << [locale, I18n.locale]
+      true
+    end
+
+    PublishingApiUnpublishingJob.new.perform(unpublishing.id)
+
+    assert_includes locales_seen, ["en", :en]
+    assert_includes locales_seen, ["fr", :fr]
+  end
+
   test "passes allow_draft if supplied" do
     unpublished_edition = create(
       :withdrawn_edition,


### PR DESCRIPTION
## What

Fixes:

- ‘3000’ in the URL (and associated validation logic)
- Broken translated archived URLs

More detail on '3000' fix:

- Change the archiving URL construction to be of the form: `https://webarchive.nationalarchives.gov.uk/ukgwa/https://www.gov.uk/government/publications/correction-to-the-designs-register-under-section-21-6472785`
- ...instead of...
- `https://webarchive.nationalarchives.gov.uk/ukgwa/3000/https://www.gov.uk/government/publications/correction-to-the-designs-register-under-section-21-6472785`

More detail on translated URLs:

- Makes the URL construction locale-aware, so that Welsh (and other) translations are redirected to their correct counterparts in the archives.

NB, after merge, I'll run the following in the rails console to have the new URLs take affect:

```ruby
Unpublishing.where(unpublishing_reason_id: 6).each do |unpublishing|
  PublishingApiDocumentRepublishingJob.perform_async(unpublishing.edition.document.id, false)
end
```

## Why

Both of the URLs above are equivalent in behaviour - fetching the latest snapshot of the page - but without the '3000 hack' which is merely a malformed date string, which the national archives rejects. We just omit it in the first place.

And we should always be redirecting to the correct translated page.

Jira: https://gov-uk.atlassian.net/browse/WHIT-3700

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
