### PR TITLE
[WHIT-3835] - Allow GDS editors to edit any organisation

### DIFF
--- a/lib/whitehall/authority/rules/organisation_rules.rb
+++ b/lib/whitehall/authority/rules/organisation_rules.rb
@@ -5,7 +5,7 @@ module Whitehall::Authority::Rules
       when :create
         actor.gds_admin?
       when :edit
-        actor.gds_admin? || actor_is_from_organisation_or_parent?(actor, subject)
+        actor.gds_admin? || actor.gds_editor? || actor_is_from_organisation_or_parent?(actor, subject)
       when :manage_featured_links
         actor.gds_admin? || actor.gds_editor? || managing_editor_for_org?(actor, subject)
       else

--- a/test/functional/admin/organisations_controller_test.rb
+++ b/test/functional/admin/organisations_controller_test.rb
@@ -359,8 +359,8 @@ class Admin::OrganisationsControllerTest < ActionController::TestCase
 
   test "Non-admins can only edit their own organisations or children" do
     organisation1 = create(:organisation)
-    gds_editor = create(:gds_editor, organisation: organisation1)
-    login_as(gds_editor)
+    departmental_editor = create(:departmental_editor, organisation: organisation1)
+    login_as(departmental_editor)
 
     get :edit, params: { id: organisation1 }
     assert_response :success
@@ -370,6 +370,19 @@ class Admin::OrganisationsControllerTest < ActionController::TestCase
     assert_response :forbidden
 
     organisation2.parent_organisations << organisation1
+    get :edit, params: { id: organisation2 }
+    assert_response :success
+  end
+
+  test "GDS editors can edit any organisation" do
+    organisation1 = create(:organisation)
+    gds_editor = create(:gds_editor, organisation: organisation1)
+    login_as(gds_editor)
+
+    get :edit, params: { id: organisation1 }
+    assert_response :success
+
+    organisation2 = create(:organisation)
     get :edit, params: { id: organisation2 }
     assert_response :success
   end

--- a/test/unit/lib/whitehall/authority/gds_editor_test.rb
+++ b/test/unit/lib/whitehall/authority/gds_editor_test.rb
@@ -143,6 +143,16 @@ class GDSEditorTest < ActiveSupport::TestCase
     assert enforcer_for(gds_editor, :sitewide_settings_section).can?(:administer)
   end
 
+  test "can edit any organisation" do
+    user = gds_editor
+
+    editors_org = user.organisation
+    other_org = build(:organisation)
+
+    assert enforcer_for(user, editors_org).can?(:edit)
+    assert enforcer_for(user, other_org).can?(:edit)
+  end
+
   test "can manage featured links for any organisation" do
     user = gds_editor
 


### PR DESCRIPTION
GDS Editor permissions are given to people who need to work across more than one organisation, typically when machinery of government changes mean they are updating pages for both an old and a new organisation. The new organisation is neither their own nor a child of it, so the only route to editing it was GDS Admin, which grants far more access than they need.

Creating an organisation stays GDS Admin only.