### PR TITLE
Rename `can_be_marked_political` with `_by_publishers` suffix [WHIT-3703]

### DIFF
--- a/app/components/admin/editions/history_mode_form_controls.rb
+++ b/app/components/admin/editions/history_mode_form_controls.rb
@@ -5,7 +5,7 @@ class Admin::Editions::HistoryModeFormControls < ViewComponent::Base
   end
 
   def render?
-    @edition.document&.live? && @edition.can_be_marked_political? && @enforcer.can?(:mark_political)
+    @edition.document&.live? && @edition.can_be_marked_political_by_publishers? && @enforcer.can?(:mark_political)
   end
 
   def renders_government_selector?

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -152,7 +152,7 @@ class Edition < ApplicationRecord
     change_note.present? || minor_change
   end
 
-  def can_be_marked_political?
+  def can_be_marked_political_by_publishers?
     true
   end
 

--- a/app/models/fatality_notice.rb
+++ b/app/models/fatality_notice.rb
@@ -41,7 +41,7 @@ class FatalityNotice < Edition
     PublishingApi::FatalityNoticePresenter
   end
 
-  def can_be_marked_political?
+  def can_be_marked_political_by_publishers?
     false
   end
 end

--- a/app/models/standard_edition.rb
+++ b/app/models/standard_edition.rb
@@ -92,7 +92,7 @@ class StandardEdition < Edition
     ].any? { |path| field_paths.include?(path) }
   end
 
-  def can_be_marked_political?
+  def can_be_marked_political_by_publishers?
     type_instance.settings["history_mode_enabled"]
   end
 

--- a/app/models/worldwide_organisation.rb
+++ b/app/models/worldwide_organisation.rb
@@ -176,7 +176,7 @@ class WorldwideOrganisation < Edition
     false
   end
 
-  def can_be_marked_political?
+  def can_be_marked_political_by_publishers?
     false
   end
 

--- a/lib/political_content_identifier.rb
+++ b/lib/political_content_identifier.rb
@@ -51,7 +51,7 @@ private
   end
 
   def potentially_political_standard_edition?
-    edition.is_a?(StandardEdition) && edition.can_be_marked_political?
+    edition.is_a?(StandardEdition) && edition.can_be_marked_political_by_publishers?
   end
 
   def potentially_political_publication?

--- a/test/unit/app/models/fatality_notice_test.rb
+++ b/test/unit/app/models/fatality_notice_test.rb
@@ -32,7 +32,7 @@ class FatalityNoticeTest < ActiveSupport::TestCase
 
   test "is not able to be marked political" do
     fatality_notice = build(:fatality_notice)
-    assert_not fatality_notice.can_be_marked_political?
+    assert_not fatality_notice.can_be_marked_political_by_publishers?
   end
 
   test "is rendered by frontend" do

--- a/test/unit/app/models/standard_edition_test.rb
+++ b/test/unit/app/models/standard_edition_test.rb
@@ -234,8 +234,8 @@ class StandardEditionTest < ActiveSupport::TestCase
     ConfigurableDocumentType.setup_test_types(test_type_with_history_mode.merge(test_type_without_history_mode))
     page_with_history_mode = StandardEdition.new(configurable_document_type: "test_type_with_history_mode")
     page_without_history_mode = StandardEdition.new(configurable_document_type: "test_type_without_history_mode")
-    assert page_with_history_mode.can_be_marked_political?
-    assert_not page_without_history_mode.can_be_marked_political?
+    assert page_with_history_mode.can_be_marked_political_by_publishers?
+    assert_not page_without_history_mode.can_be_marked_political_by_publishers?
   end
 
   test "it is invalid if the block content does not conform to the configurable document type schema validations" do


### PR DESCRIPTION
Through group code review, we felt this was a more expressive name.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
