### PR TITLE
Remove broken link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Whitehall
 
-Whitehall (also known as 'Whitehall Admin' or 'Whitehall Publisher') is used by publishers to create and manage content (e.g. <http://whitehall-admin.dev.gov.uk/government/admin/news/new>).
+Whitehall (also known as 'Whitehall Admin' or 'Whitehall Publisher') is used by publishers to create and manage content.
 
 ## Running the Application
 


### PR DESCRIPTION
This link only worked for devs who had Whitehall checked out and running locally (on govuk-docker).

We've since changed how news articles are created, so even in the above case, the link would 404. Not much value in changing the link - let's just remove it.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
