### PR TITLE
Remove default 'Translation added' changenote logic [WHIT-3846]

### DIFF
--- a/app/controllers/admin/edition_translations_controller.rb
+++ b/app/controllers/admin/edition_translations_controller.rb
@@ -18,7 +18,6 @@ class Admin::EditionTranslationsController < Admin::BaseController
   end
 
   def update
-    @translated_edition.change_note = "Added translation" if @translated_edition.change_note.blank?
     if translatable_item.update(translation_params)
       save_draft_translation if send_downstream?
       redirect_to update_redirect_path, notice: notice_message("saved")

--- a/app/controllers/admin/standard_edition_translations_controller.rb
+++ b/app/controllers/admin/standard_edition_translations_controller.rb
@@ -10,7 +10,6 @@ class Admin::StandardEditionTranslationsController < Admin::BaseController
   end
 
   def update
-    @translated_edition.change_note = "Added translation" if @translated_edition.change_note.blank?
     if @translated_edition.update(translation_params)
       save_draft_translation
       redirect_to admin_standard_edition_path(@edition), notice: notice_message("saved")

--- a/test/functional/admin/edition_translations_controller_test.rb
+++ b/test/functional/admin/edition_translations_controller_test.rb
@@ -159,6 +159,8 @@ class Admin::EditionTranslationsControllerTest < ActionController::TestCase
   test "update creates a translation for a new draft of a previously published edition" do
     published_edition = create(:published_edition)
     draft_edition = published_edition.create_draft(@writer)
+    draft_edition.change_note = "Added translation"
+    draft_edition.save!
 
     put :update,
         params: { edition_id: draft_edition,

--- a/test/functional/admin/standard_edition_translations_controller_test.rb
+++ b/test/functional/admin/standard_edition_translations_controller_test.rb
@@ -118,6 +118,8 @@ class Admin::StandardEditionTranslationsControllerTest < ActionController::TestC
       block_content: { body: "foo" },
     )
     draft_edition = published_edition.create_draft(@writer)
+    draft_edition.change_note = "Added translation"
+    draft_edition.save!
 
     put :update,
         params: { standard_edition_id: draft_edition,


### PR DESCRIPTION
This logic originates from 2013, but there is no explanation of why it exists in either the commit or the corresponding PR: https://github.com/alphagov/whitehall/commit/8c92ad340f36c1a207af37ce4bce59f90353dac5

It leads to a surprising and unwanted behaviour around:

- Creating a new draft of a new document (e.g. a Publication)
- Adding a translation
- Publishing the document (for the first time)
- The change history for that document showing as "Translation added", as opposed to "First published".

We believe dropping this surprising logic should have no downsides. It's possible the logic only existed because otherwise trying to add a translation when no change note is set causes publishers to face a validation error - but that's not a thing on 'new' documents, it would only come on new drafts, and the answer is for the publisher to fill in the change note when creating a new edition.

Jira: https://gov-uk.atlassian.net/browse/WHIT-3846

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
