### PR TITLE
[WHIT-3844] - Update content publishing guidance link in design system layout

### DIFF
--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -108,8 +108,8 @@
             text: "Raise a support request",
           },
           {
-            href: "https://www.gov.uk/government/content-publishing",
-            text: "How to write, publish, and improve content",
+            href: "https://guidance.publishing.service.gov.uk",
+            text: "Read the content and publishing guidance",
           },
           {
             href: "https://status.publishing.service.gov.uk/",


### PR DESCRIPTION
## What
Update the guidance link in the footer

From: 
[How to write, publish, and improve content](https://www.gov.uk/government/content-publishing)
 
To:
[Read the content and publishing guidance](https://guidance.publishing.service.gov.uk/)

## Why
Request from content team to make the purpose of the link clearer and point to the updated location for the guidance.

[Zendesk](https://govuk.zendesk.com/agent/tickets/6774757)
[Jira](https://gov-uk.atlassian.net/browse/WHIT-3844)