### PR TITLE
[WHIT- 3786] Hide sidebar on read-only edition view

### DIFF
--- a/app/components/admin/editions/document_history_tab_component.rb
+++ b/app/components/admin/editions/document_history_tab_component.rb
@@ -12,7 +12,9 @@ class Admin::Editions::DocumentHistoryTabComponent < ViewComponent::Base
 private
 
   def entries_on_newer_editions
-    @entries_on_newer_editions ||= document_history.entries_on_newer_editions(edition)
+    @entries_on_newer_editions ||= document_history.entries_on_newer_editions(edition).reject do |entry|
+      entry.is_a?(EditorialRemark) && !helpers.can?(:see, entry.edition)
+    end
   end
 
   def entries_on_current_edition

--- a/app/views/admin/editions/edit.html.erb
+++ b/app/views/admin/editions/edit.html.erb
@@ -43,38 +43,38 @@
       <%= render "form", edition: @edition, on_document_tab: %>
     </div>
 
-    <% if on_document_tab %>
+    <% if on_document_tab && @edition.editable? %>
       <div class="govuk-grid-column-one-third">
         <%= render "govuk_publishing_components/components/tabs", {
-         disable_ga4: true,
-         tabs: [
-           {
-             id: "govspeak_tab",
-             label: "Help",
-             content: simple_formatting_sidebar(
-               hide_inline_attachments_help: !@edition.allows_inline_attachments?,
-               show_attachments_tab_help: true,
-               link_check_report: LinkCheckerApiService.has_links?(@edition, convert_admin_links: false) ? @edition.link_check_report : nil,
-             ),
-           },
-           {
-             id: "history_tab",
-             label: "History",
-             content: tag.div(
-               render(Admin::Editions::DocumentHistoryTabComponent.new(
-                 edition: @edition,
-                 document_history: @document_history,
-                 editing: true,
-               )),
-               data: { module: "document-history-paginator" },
-             ),
-           },
-           *([{
-             id: "fact_checking_tab",
-             label: "Fact checking",
-             content: render(Admin::Editions::FactCheckingTabComponent.new(edition: @edition)),
-           }] if @edition.can_be_fact_checked?),
-         ],
+          disable_ga4: true,
+          tabs: [
+            {
+              id: "govspeak_tab",
+              label: "Help",
+              content: simple_formatting_sidebar(
+                hide_inline_attachments_help: !@edition.allows_inline_attachments?,
+                show_attachments_tab_help: true,
+                link_check_report: LinkCheckerApiService.has_links?(@edition, convert_admin_links: false) ? @edition.link_check_report : nil,
+                ),
+            },
+            {
+              id: "history_tab",
+              label: "History",
+              content: tag.div(
+                render(Admin::Editions::DocumentHistoryTabComponent.new(
+                  edition: @edition,
+                  document_history: @document_history,
+                  editing: true,
+                  )),
+                data: { module: "document-history-paginator" },
+                ),
+            },
+            *([{
+                 id: "fact_checking_tab",
+                 label: "Fact checking",
+                 content: render(Admin::Editions::FactCheckingTabComponent.new(edition: @edition)),
+               }] if @edition.can_be_fact_checked?),
+          ],
         } %>
       </div>
     <% end %>

--- a/features/admin-history-content-block-updates.feature
+++ b/features/admin-history-content-block-updates.feature
@@ -6,13 +6,13 @@ Feature: Showing content block updates in history
     And the document has been updated by a change to the content block "Some email address"
 
   Scenario: Content block update exists for current edition
-    When I am on the edit page for publication "Stubble to be Outlawed"
+    When I am on the summary page for publication "Stubble to be Outlawed"
     And I click the "History" tab
     Then I should see an entry for the content block "Some email address" on the current edition
 
   Scenario: Content block update exists for a previous edition
     Given some time has passed
     When I force publish a new edition of the publication "Stubble to be Outlawed"
-    And I am on the edit page for publication "Stubble to be Outlawed"
+    And I am on the summary page for publication "Stubble to be Outlawed"
     And I click the "History" tab
     Then I should see an entry for the content block "Some email address" on the previous edition

--- a/features/standard-edition-read-only.feature
+++ b/features/standard-edition-read-only.feature
@@ -11,6 +11,7 @@ Feature: Standard Editions - read-only mode
     And I see the "read-only view" message
     And the form is wrapped inside a disabled fieldset
     And there is no "Save" button
+    And there is no sidebar
 
   Scenario: Viewing a dynamic tab of the published edition
     When I view the "Social media accounts" tab

--- a/features/step_definitions/document_steps.rb
+++ b/features/step_definitions/document_steps.rb
@@ -170,6 +170,12 @@ When(/^I am on the edit page for (.*?) "(.*?)"$/) do |document_type, title|
   visit send("edit_admin_#{document_type}_path", document)
 end
 
+When(/^I am on the summary page for (.*?) "(.*?)"$/) do |document_type, title|
+  document_type = document_type.tr(" ", "_")
+  document = document_type.classify.constantize.where(title:).last
+  visit admin_edition_path(document)
+end
+
 When(/^I check "([^"]*)" adheres to the consultation principles$/) do |title|
   edition = Edition.latest_edition.find_by!(title:)
   edition.read_consultation_principles = true

--- a/features/step_definitions/standard_edition_read_only_steps.rb
+++ b/features/step_definitions/standard_edition_read_only_steps.rb
@@ -71,6 +71,11 @@ And(/^there is no "(.+)" button$/) do |button_text|
   assert_no_selector "button.gem-c-button", text: button_text
 end
 
+And("there is no sidebar") do
+  assert_no_selector "#govspeak_tab"
+  assert_no_selector "#history_tab"
+end
+
 And("there is no file upload form") do
   assert_no_selector "form.new_upload"
 end

--- a/test/components/admin/editions/document_history_tab_component_test.rb
+++ b/test/components/admin/editions/document_history_tab_component_test.rb
@@ -11,10 +11,10 @@ class Admin::Editions::DocumentHistoryTabComponentTest < ViewComponent::TestCase
     seed_document_event_history
     @timeline = Document::PaginatedTimeline.new(document: @document, page: 1)
 
-    pagination = "<nav class='govuk-grid-row govuk-!-margin-bottom-4' role='navigation'>
+    @pagination = "<nav class='govuk-grid-row govuk-!-margin-bottom-4' role='navigation'>
                     <a class='govuk-body govuk-link app-view-document-history-tab__pagination-link' data-remote-pagination='/government/admin/editions/1321865/audit_trail?page=2' rel='next' href='/government/admin/consultations/1321865?page=2'>Older</a>
                    </nav>".html_safe
-    Admin::Editions::DocumentHistoryTabComponent.any_instance.stubs(:helpers).returns(stub(paginate: pagination))
+    Admin::Editions::DocumentHistoryTabComponent.any_instance.stubs(:helpers).returns(stub(paginate: @pagination, can?: true))
   end
 
   test "it renders a link to the add remark page" do
@@ -47,13 +47,27 @@ class Admin::Editions::DocumentHistoryTabComponentTest < ViewComponent::TestCase
     assert_selector ".app-view-document-history-tab__pagination-link", text: "Older", count: 2
   end
 
-  test "it renders the timeline entries in the correct sections for, future, current and previous editions" do
+  test "it renders internal notes on newer editions when the user can see the newer edition" do
     render_inline(Admin::Editions::DocumentHistoryTabComponent.new(edition: @second_edition, document_history: @timeline))
 
     assert_selector ".app-view-editions__newer-edition-entries h3", text: "On newer editions"
     assert_selector ".app-view-editions__newer-edition-entries div.app-view-editions-audit-trail-entry__list-item", count: 2
     assert_selector ".app-view-editions__newer-edition-entries div.app-view-editions-editorial-remark__list-item", count: 1
     assert_selector ".app-view-editions__newer-edition-entries div.app-view-editions-host-content-update-event-entry__list-item", count: 0
+  end
+
+  test "it hides internal notes on newer editions when the user cannot see the newer edition, but still shows other entries" do
+    Admin::Editions::DocumentHistoryTabComponent.any_instance.stubs(:helpers).returns(stub(paginate: @pagination, can?: false))
+
+    render_inline(Admin::Editions::DocumentHistoryTabComponent.new(edition: @second_edition, document_history: @timeline))
+
+    assert_selector ".app-view-editions__newer-edition-entries h3", text: "On newer editions"
+    assert_selector ".app-view-editions__newer-edition-entries div.app-view-editions-audit-trail-entry__list-item", count: 2
+    assert_no_selector ".app-view-editions__newer-edition-entries div.app-view-editions-editorial-remark__list-item"
+  end
+
+  test "it renders the timeline entries in the correct sections for current and previous editions" do
+    render_inline(Admin::Editions::DocumentHistoryTabComponent.new(edition: @second_edition, document_history: @timeline))
 
     assert_selector ".app-view-editions__current-edition-entries h3", text: "On this edition"
     assert_selector ".app-view-editions__current-edition-entries div.app-view-editions-audit-trail-entry__list-item", count: 4


### PR DESCRIPTION
## Summary

Editors could reach internal, potentially sensitive, notes on a document through two paths that weren't gated by access permissions:

1. **The edit page's sidebar.** Viewing a non-editable edition (published/superseded) at `/edit` rendered the same Help, History and Fact checking sidebar as an editable draft — including the full History tab, regardless of whether that edition's document had since been access-limited.

2. **The "On newer editions" history section.** Any edition's History tab (on both the edit page and the document summary page) showed entries from *newer* editions of the same document, including their internal notes — with no check on whether the viewer was actually permitted to see that newer edition. So a user without access to an access-limited draft could still read its internal notes via an older edition's History tab.

### Changes

* **app/views/admin/editions/edit.html.erb** — the sidebar only renders when `@edition.editable?`. Read-only editions now show just the disabled form and read-only notice.

* **app/components/admin/editions/document_history_tab_component.rb** — internal notes (`EditorialRemark`) in the "On newer editions" section are hidden specifically when the current user can't `:see` that newer edition. Other entry types (document updates) are unaffected.

* Feature tests updated to reflect the new conditional sidebar behaviour and access restrictions, including covering both edit and summary page flows where history content is rendered.

### Additional notes

* The document summary page's own sidebar still shows its History tab regardless of edition state — that's unchanged and intentional, since notes belonging to *that* edition are fine to show there; only cross-edition leakage into "On newer editions" was closed.

* This only closes the gap for editions that are access-limited. If a newer edition isn't access-limited (the common case), its internal notes still show on older editions' History tabs, same as before — that's the existing, intended behaviour. 

* The edit page hides its *entire* sidebar when the edition isn't editable, whereas the summary page shows History unconditionally and relies on the access check above to protect it. These are deliberately inconsistent right now: the edit page's blanket hide is largely a UX choice (Govspeak help is meaningless with nothing to edit), not a security requirement, since the access check now protects History wherever it renders. 

## Test plan

* create a draft edition → confirm sidebar still shows on `/edit`
* publish an edition → visiting `/edit` for the now read-only edition shows no sidebar
* with a document that has a superseded edition and a newer draft — add an internal note to the newer draft, access-limit that draft to a different organisation, then view the superseded edition's History tab (via its summary page) as a user outside that organisation → confirm the note is hidden but other history entries (e.g. "Document updated") still show
* repeat the above as a user who *is* in the access-limited organisation → confirm the note is visible


https://github.com/user-attachments/assets/c2f3e383-1557-4be6-94b8-3e1639f11c0e



[JIRA](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-3786)