### PR TITLE
Revert "Redirect to latest edition when editing changenotes" [WHIT-3846]

### DIFF
--- a/app/controllers/admin/edition_change_notes_controller.rb
+++ b/app/controllers/admin/edition_change_notes_controller.rb
@@ -2,7 +2,6 @@ class Admin::EditionChangeNotesController < Admin::BaseController
   before_action :find_edition
   before_action :enforce_permissions!
   before_action :limit_edition_access!
-  before_action :redirect_to_latest_edition_if_not_latest
   def index
     @change_notes = @edition
       .document
@@ -85,12 +84,5 @@ private
   def find_edition
     edition = Edition.find(params[:edition_id])
     @edition = LocalisedModel.new(edition, edition.primary_locale)
-  end
-
-  def redirect_to_latest_edition_if_not_latest
-    latest_edition = @edition.document.latest_edition
-    return if @edition.id == latest_edition.id
-
-    redirect_to admin_edition_change_notes_path(edition_id: latest_edition.id)
   end
 end

--- a/test/functional/admin/edition_change_notes_controller_test.rb
+++ b/test/functional/admin/edition_change_notes_controller_test.rb
@@ -20,14 +20,6 @@ class Admin::EditionChangeNotesControllerTest < ActionController::TestCase
     assert_response :forbidden
   end
 
-  test "redirects to the latest edition if the edition is not the latest" do
-    login_as :gds_admin
-
-    get :index, params: { edition_id: @first_edition.id }
-
-    assert_redirected_to admin_edition_change_notes_path(edition_id: @current_edition.id)
-  end
-
   view_test "index lists all the published major changes" do
     login_as :gds_admin
 


### PR DESCRIPTION
This stemmed from a misunderstanding of which ID was being used in the change notes controller. Consider this 'Edit' URL on the Change Notes form:

```
href="/government/admin/editions/1800386/change_notes/1800385/edit"
```

In this case, `id` is `1800385` - and it becomes the `edition_to_change` in the action. The edition we navigated to the 'change notes' screen from is `1800386`, but that's largely irrelevant since we're not acting on that edition, we're acting on a (usually older) change note.

93ae1629929e6a25412d3a25423469e9b799c033 meant that we were unable to change any changenote when a newer edition existed - which was not the intention of the commit! Reverting fixes that behaviour.

Jira: https://gov-uk.atlassian.net/browse/WHIT-3846

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
