### PR TITLE
Backfill auth_bypass_id on existing post-publication editions [WHIT-3896]

### DIFF
--- a/db/data_migration/20260813130045_clear_auth_bypass_id_for_post_publication_editions.rb
+++ b/db/data_migration/20260813130045_clear_auth_bypass_id_for_post_publication_editions.rb
@@ -1,0 +1,15 @@
+editions = Edition
+             .where(state: Edition::POST_PUBLICATION_STATES - %w[superseded])
+             .where.not(auth_bypass_id: nil)
+
+total = editions.count
+started_at = Time.current
+
+editions.find_each do |edition|
+  edition.auth_bypass_id = nil
+  EditionAuthBypassAssetPropagator.new(edition).propagate
+end
+
+editions.update_all(auth_bypass_id: nil)
+
+puts "Cleared auth_bypass_id for #{total} editions in #{(Time.current - started_at).round(2)}s"


### PR DESCRIPTION
Follow-on to [PR #11662](https://github.com/alphagov/whitehall/pull/11662), which stops `auth_bypass_id` (and the access-limiting fields) leaking on publish going forward. This PR clears `auth_bypass_id` on editions that published before that fix shipped, and still hold a stale token in Whitehall/Publishing API/Asset Manager.

It excludes superseded editions from scope - they always have a newer live edition covering the same underlying assets, so there's nothing left to clean up on them, and including them multiplies the migration's scope several times over for no benefit (~1.4M editions touching auth_bypass_id vs ~437k once superseded is excluded).

Run on integration - 436,817 editions cleared in ~35 minutes; downstream Asset Manager propagation peaked the `asset_manager_updater` queue at ~562k jobs and drained cleanly.

## Scope note

This PR previously also included the access-limiting ids backfill (`access_limited_organisation_ids`/`access_limited_user_ids`). That's been split out into its [own PR](https://github.com/alphagov/whitehall/pull/11725), since it surfaced Sentry errors when run (`AssetManager::AssetUpdater::AssetDeleted` - some assets touched by the migration were replaced/deleted at some point in their history, and the update job doesn't currently rescue that exception). Per Chris's suggestion, that fix is separate upcoming work, and this migration - already proven safe and unrelated to that issue - shouldn't be held up waiting for it.

[JIRA](https://gov-uk.atlassian.net/browse/WHIT-3585)