### PR TITLE
Add BIST organisation colour

### DIFF
--- a/app/models/organisation_brand_colour.rb
+++ b/app/models/organisation_brand_colour.rb
@@ -187,4 +187,9 @@ class OrganisationBrandColour
     title: "GDS",
     class_name: "government-digital-service",
   )
+  DepartmentForBusinessInnovationScienceAndTrade = create!(
+    id: 37,
+    title: "Department for Business, Innovation, Science and Trade",
+    class_name: "department-for-business-innovation-science-trade",
+  )
 end


### PR DESCRIPTION
## What
Add new brand colour for BIST

## Why
Allow the new brand colour for Department for Business, Innovation, Science and Trade to be selected from the Organisation Colour dropdown in Whitehall

Jira card: https://gov-uk.atlassian.net/browse/NAV-19063