### PR TITLE
Fix access limiting fields display [WHIT - 3768]

### DIFF
--- a/app/models/concerns/edition/limited_access.rb
+++ b/app/models/concerns/edition/limited_access.rb
@@ -39,6 +39,10 @@ module Edition::LimitedAccess
     self
   end
 
+  def access_limiting_enabled?
+    true
+  end
+
   def access_limited?
     access_limiting_organisations? || access_limiting_individuals?
   end

--- a/app/models/corporate_information_page.rb
+++ b/app/models/corporate_information_page.rb
@@ -117,6 +117,10 @@ class CorporateInformationPage < Edition
     false
   end
 
+  def access_limiting_enabled?
+    false
+  end
+
 private
 
   def string_for_slug

--- a/app/presenters/publishing_api/worldwide_organisation_presenter.rb
+++ b/app/presenters/publishing_api/worldwide_organisation_presenter.rb
@@ -35,6 +35,7 @@ module PublishingApi
       )
       content.merge!(PayloadBuilder::PolymorphicPath.for(item))
       content.merge!(PayloadBuilder::AnalyticsIdentifier.for(item))
+      content.merge!(PayloadBuilder::AccessLimitation.for(item))
     end
 
     def edition_links

--- a/app/views/admin/editions/_settings_fields.html.erb
+++ b/app/views/admin/editions/_settings_fields.html.erb
@@ -6,7 +6,7 @@
     } %>
 
     <%= render "accessible_attachment_field", form: form, edition: edition %>
-    <%= render "access_limiting_fields", form: form, edition: edition if edition.organisation_association_enabled? %>
+    <%= render "access_limiting_fields", form: form, edition: edition if edition.access_limiting_enabled? %>
     <%= render "scheduled_publication_fields", form: form, edition: edition %>
     <%= render "review_reminder_fields", form: form, review_reminder: edition.document.review_reminder %>
 </div>

--- a/app/views/admin/standard_editions/_document_form_fields.html.erb
+++ b/app/views/admin/standard_editions/_document_form_fields.html.erb
@@ -67,7 +67,7 @@
 
   <%= render Admin::Editions::LanguageSelectFormControl.new(edition) %>
   <%= render "accessible_attachment_field", form: form, edition: edition if edition.allows_file_attachments? %>
-  <%= render "access_limiting_fields", form: form, edition: edition if edition.organisation_association_enabled? %>
+  <%= render "access_limiting_fields", form: form, edition: edition if edition.access_limiting_enabled? %>
   <%= render "scheduled_publication_fields", form: form, edition: edition %>
   <%= render "review_reminder_fields", form: form, review_reminder: edition.document.review_reminder %>
 </div>

--- a/test/functional/admin/corporate_information_pages_controller_test.rb
+++ b/test/functional/admin/corporate_information_pages_controller_test.rb
@@ -62,6 +62,7 @@ class Admin::CorporateInformationPagesControllerTest < ActionController::TestCas
       assert_select "textarea[name='edition[summary]']", corporate_information_page.summary
       assert_select "select[name='edition[corporate_information_page_type_id]']", count: 0
       assert_select "button[type='submit']"
+      refute_select "legend", text: "Limit access"
     end
   end
 

--- a/test/functional/admin/standard_editions_controller_test.rb
+++ b/test/functional/admin/standard_editions_controller_test.rb
@@ -252,7 +252,7 @@ class Admin::StandardEditionsControllerTest < ActionController::TestCase
     assert_select "label", text: "Summary (required)"
     assert_select "legend", text: "Schedule publication"
     assert_select "legend", text: "Review date"
-    refute_select "legend", text: "Limit access"
+    assert_select "legend", text: "Limit access"
   end
 
   view_test "GET edit renders access limiting fields when organisations are enabled" do

--- a/test/unit/app/presenters/publishing_api/worldwide_organisation_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/worldwide_organisation_presenter_test.rb
@@ -283,4 +283,15 @@ class PublishingApi::WorldwideOrganisationPresenterTest < ActiveSupport::TestCas
 
     assert_equal "", presented_item.content.dig(:details, :body)
   end
+
+  test "includes access limiting" do
+    worldwide_org = create(:worldwide_organisation)
+    PublishingApi::PayloadBuilder::AccessLimitation.expects(:for)
+                                                   .with(worldwide_org)
+                                                   .returns(access_limited: { organisations: %w[abcdef12345] })
+
+    presented_item = present(worldwide_org)
+
+    assert_equal %w[abcdef12345], presented_item.content[:access_limited][:organisations]
+  end
 end


### PR DESCRIPTION
[JIRA](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?assignee=5caf4d888c2c1a75f3e46ef6&selectedIssue=WHIT-3768)

## Summary

Fixes the logic that decides whether the "Limit access" fieldset is shown on an edition's admin edit form, and fixes Worldwide Organisations so that access limiting set in the admin UI actually reaches the content store.

## Context

It was impossible to access-limit a World news story (or History page). The "Limit access" fieldset was gated on `organisation_association_enabled?` — a check on whether a document type has a lead/supporting
organisations field, not about whether access limiting should be offered.

That conflation was harmless while access limiting was based on a document's own organisations, but now that access limiting uses a separate "access limiting organisations" concept, document types with no
organisations field (world news stories, history pages) were incorrectly blocked from ever showing the fieldset.

There was an earlier draft, #11645, which sought to address this, but it only fixed one of the two duplicated guard
clauses and didn't account for Corporate Information Pages or the Worldwide Organisation presenter gap — both addressed here.

## Acceptance criteria

- [x] World news stories have the access limiting options
- [x] There is no option to access-limit Organisations
- [x] The Worldwide Organisation format's access-limiting is fixed

## Testing

Manually verified in the admin: World news story now shows and persists the fieldset; Corporate Information Page still doesn't; Worldwide Organisation's access limiting is passed into the Publishing API payload.