### PR TITLE
Whit 3882 update access limit error messages

### DIFF
--- a/app/models/concerns/edition/limited_access.rb
+++ b/app/models/concerns/edition/limited_access.rb
@@ -142,7 +142,7 @@ private
 
     invalid_format = individuals.select { |individual| ValidatesEmailFormatOf.validate_email_format(individual.email.to_s) }
     if invalid_format.any?
-      errors.add(:access_limiting_individual_emails, "must contain valid email addresses: #{invalid_format.map(&:email).join(', ')}")
+      errors.add(:access_limiting_individual_emails, "must contain valid email addresses separated with commas")
     end
 
     well_formed = individuals - invalid_format

--- a/app/views/admin/editions/_access_limiting_fields.html.erb
+++ b/app/views/admin/editions/_access_limiting_fields.html.erb
@@ -13,18 +13,18 @@
         items: [
           {
             value: "none",
-            text: "No - This document should be available to all publishers",
+            text: "No - make available to all publishers",
             checked: edition.access_limiting_none?,
           },
           Flipflop.access_limiting_organisations_ui? ? {
             value: "organisations",
-            text: "Limit access to the following organisations",
+            text: "Yes – limit access to specific organisations",
             checked: edition.access_limiting_organisations?,
             conditional: render("admin/editions/access_limiting_organisation_select", form: form, edition: edition),
           } : nil,
           Flipflop.access_limiting_individuals_ui? ? {
             value: "individuals",
-            text: "Limit access to named publishers",
+            text: "Yes - limit access to named publishers",
             checked: edition.access_limiting_individuals?,
             conditional: render("govuk_publishing_components/components/textarea", {
               label: { text: "Add the emails of the publishers who will have access (separated by commas)" },

--- a/app/views/admin/editions/_access_limiting_fields.html.erb
+++ b/app/views/admin/editions/_access_limiting_fields.html.erb
@@ -30,7 +30,7 @@
               label: { text: "Add the emails of the publishers who will have access (separated by commas)" },
               name: "edition[access_limiting_individual_emails]",
               textarea_id: "edition_access_limiting_individual_emails",
-              hint: "Include at least 2 names - one should be your managing editor if possible. After publishing, the document will be available to all publishers, until a new draft is created and access is limited on that draft edition.",
+              hint: "If possible, include 2 email addresses. Once published, the document is available to all publishers. Access restrictions apply only to draft editions.",
               value: edition.access_limiting_individual_emails,
             }),
           } : nil,

--- a/features/step_definitions/admin_limit_access_steps.rb
+++ b/features/step_definitions/admin_limit_access_steps.rb
@@ -31,7 +31,7 @@ When(/^I set the Lead organisation to an org I am not in$/) do
 end
 
 When(/^I choose organisation access limiting$/) do
-  choose "Limit access to the following organisations"
+  choose "Yes – limit access to specific organisations"
 end
 
 When(/^I select "([^"]*)" as an access limiting organisation$/) do |org_name|

--- a/test/functional/admin/edition_access_limited_controller_test.rb
+++ b/test/functional/admin/edition_access_limited_controller_test.rb
@@ -385,7 +385,7 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
         }
 
     assert_template :edit
-    assert_select ".govuk-error-summary a", text: "Access limiting individual emails must contain valid email addresses: notanemail", href: "#access_limiting_individuals_emails"
+    assert_select ".govuk-error-summary a", text: "Access limiting individual emails must contain valid email addresses separated with commas", href: "#access_limiting_individuals_emails"
     assert_select "textarea[name='edition[access_limiting_individual_emails]']", text: "user@example.com, another_user@example.com, notanemail"
     assert_select "textarea[name='edition[editorial_remark]']", text: "Test"
 

--- a/test/integration/asset_access_options_integration_test.rb
+++ b/test/integration/asset_access_options_integration_test.rb
@@ -62,7 +62,7 @@ class AssetAccessOptionsIntegrationTest < ActionDispatch::IntegrationTest
           add_file_attachment_with_asset("sample.docx", to: edition)
           edition.save!
           visit edit_admin_edition_path(edition)
-          choose "Limit access to the following organisations"
+          choose "Yes – limit access to specific organisations"
           select organisation.name, from: "edition_access_limiting_organisation_ids"
           click_button "Save"
           assert_text "Your document has been saved"
@@ -84,7 +84,7 @@ class AssetAccessOptionsIntegrationTest < ActionDispatch::IntegrationTest
           add_file_attachment_with_asset("sample.docx", to: edition)
           edition.save!
           visit edit_admin_edition_path(edition)
-          choose "No - This document should be available to all publishers"
+          choose "No - make available to all publishers"
           click_button "Save"
           assert_text "Your document has been saved"
         end

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -1316,7 +1316,7 @@ module AdminEditionControllerTestHelpers
         end
 
         assert_template :new
-        assert_select ".govuk-error-summary a", text: "Access limiting individual emails must contain valid email addresses: gibberish", href: "#access_limiting_individual_emails"
+        assert_select ".govuk-error-summary a", text: "Access limiting individual emails must contain valid email addresses separated with commas", href: "#access_limiting_individual_emails"
         assert_select "form#new_edition" do
           assert_select "input[name='edition[access_limiting]'][type=radio][value='individuals'][checked='checked']"
           assert_select "textarea[name='edition[access_limiting_individual_emails]']", text: "gibberish"

--- a/test/unit/app/models/edition/limited_access_test.rb
+++ b/test/unit/app/models/edition/limited_access_test.rb
@@ -243,7 +243,7 @@ class Edition::LimitedAccessTest < ActiveSupport::TestCase
     edition.access_limiting_individual_emails = "test@test.com example@example.com some_test@test.com"
 
     assert_not edition.valid?
-    assert_includes edition.errors[:access_limiting_individual_emails], "must contain valid email addresses: test@test.com example@example.com some_test@test.com"
+    assert_includes edition.errors[:access_limiting_individual_emails], "must contain valid email addresses separated with commas"
   end
 
   test "does not persist access_limiting_individuals on assignment" do
@@ -290,7 +290,7 @@ class Edition::LimitedAccessTest < ActiveSupport::TestCase
 
     assert_not edition.valid?
     assert_includes edition.errors[:access_limiting_individual_emails],
-                    "must contain valid email addresses: not-an-email"
+                    "must contain valid email addresses separated with commas"
     assert_empty edition.errors[:"access_limiting_individuals.email"]
   end
 
@@ -302,7 +302,7 @@ class Edition::LimitedAccessTest < ActiveSupport::TestCase
     edition.access_limiting_individual_emails = "test@test"
 
     assert_not edition.valid?
-    assert_includes edition.errors[:access_limiting_individual_emails], "must contain valid email addresses: test@test"
+    assert_includes edition.errors[:access_limiting_individual_emails], "must contain valid email addresses separated with commas"
   end
 
   test "is invalid when valid emails are mixed in with badly formatted emails" do
@@ -313,7 +313,7 @@ class Edition::LimitedAccessTest < ActiveSupport::TestCase
     edition.access_limiting_individual_emails = "user@example.com, gibberish"
 
     assert_not edition.valid?
-    assert_includes edition.errors[:access_limiting_individual_emails], "must contain valid email addresses: gibberish"
+    assert_includes edition.errors[:access_limiting_individual_emails], "must contain valid email addresses separated with commas"
   end
 
   test "shows both the format error and the Signon-match error, when different emails have different problems" do
@@ -324,7 +324,7 @@ class Edition::LimitedAccessTest < ActiveSupport::TestCase
     edition.access_limiting_individual_emails = "no_such_user@example.com, gibberish"
 
     assert_not edition.valid?
-    assert_includes edition.errors[:access_limiting_individual_emails], "must contain valid email addresses: gibberish"
+    assert_includes edition.errors[:access_limiting_individual_emails], "must contain valid email addresses separated with commas"
     assert_includes edition.errors[:access_limiting_individual_emails], "must match an existing Signon user: no_such_user@example.com"
   end
 
@@ -431,7 +431,7 @@ class Edition::LimitedAccessTest < ActiveSupport::TestCase
 
     assert_not edition.valid?
     assert_includes edition.errors[:access_limiting_individual_emails], "must include your own email"
-    assert_includes edition.errors[:access_limiting_individual_emails], "must contain valid email addresses: test@test.com example@example.com"
+    assert_includes edition.errors[:access_limiting_individual_emails], "must contain valid email addresses separated with commas"
   end
 
   test "is valid when access_limiting is set to 'individuals' and no access limiting individuals are selected when flag is off" do


### PR DESCRIPTION
Following the last bug bash, looks to improve some of the copy used for the access limiting components and error messages:

1. Update the radio button options for access-limiting to:

    > Limit access 
    > - No – make available to all publishers 
    > - [Radio button] Yes – limit access to specific organisations 
    > - [Radio button] Yes – limit access to named publishers 

2. Update the hint text for the individual access-limiting option to:

    > If possible, include 2 email addresses. Once published, the document is available to all publishers. Access restrictions apply only to draft editions. 

3. Update the error messaging (of invalid individual access-limiting inputs) to:

    > must contain valid email addresses separated with commas