### PR TITLE
[WHIT-3881] - Add document access details to document summary

### DIFF
--- a/app/helpers/admin/editions_helper.rb
+++ b/app/helpers/admin/editions_helper.rb
@@ -260,4 +260,11 @@ module Admin::EditionsHelper
   def edition_title_link_or_edition_title(edition)
     edition.public_url ? sanitize(link_to(edition.title, edition.public_url, { class: "govuk-link" })) : edition.title
   end
+
+  def document_access_text(edition)
+    {
+      "individuals" => "Named publishers only",
+      "organisations" => "Organisation only",
+    }[edition.try(:access_limiting)] || "All publishers"
+  end
 end

--- a/app/views/admin/editions/show/_main.html.erb
+++ b/app/views/admin/editions/show/_main.html.erb
@@ -21,6 +21,10 @@
           { field: "Change type", value: @edition.minor_change? ? "Minor" : "Major" },
           *([{ field: "Organisations", value: joined_list(@edition.organisations.map { |o| o.name }) }] if @edition.respond_to?(:organisations)),
           {
+            field: "Document access",
+            value: document_access_text(@edition),
+          },
+          {
             field: "Review date",
             value: @edition.document.review_reminder.present? ? @edition.document.review_reminder.review_at.strftime("%-d %B %Y") : "Not set",
           },

--- a/features/step_definitions/review_reminder_steps.rb
+++ b/features/step_definitions/review_reminder_steps.rb
@@ -15,8 +15,8 @@ And(/^I add a review date of "([^"]*)" and the email address "([^"]*)"$/) do |da
 end
 
 Then(/^I should see the review date of "([^"]*)" on the edition summary page$/) do |date|
-  assert_selector ".app-view-summary__section .govuk-summary-list__row:nth-child(5) .govuk-summary-list__key", text: "Review date"
-  assert_selector ".app-view-summary__section .govuk-summary-list__row:nth-child(5) .govuk-summary-list__value", text: date
+  assert_selector ".app-view-summary__section .govuk-summary-list__row:nth-child(6) .govuk-summary-list__key", text: "Review date"
+  assert_selector ".app-view-summary__section .govuk-summary-list__row:nth-child(6) .govuk-summary-list__value", text: date
 end
 
 Then(/^I should see the review date of "([^"]*)" on the deletion confirmation page$/) do |date|
@@ -24,8 +24,8 @@ Then(/^I should see the review date of "([^"]*)" on the deletion confirmation pa
 end
 
 Then(/^I should not see a review date on the edition summary page$/) do
-  assert_selector ".app-view-summary__section .govuk-summary-list__row:nth-child(5) .govuk-summary-list__key", text: "Review date"
-  assert_selector ".app-view-summary__section .govuk-summary-list__row:nth-child(5) .govuk-summary-list__value", text: "Not set"
+  assert_selector ".app-view-summary__section .govuk-summary-list__row:nth-child(6) .govuk-summary-list__key", text: "Review date"
+  assert_selector ".app-view-summary__section .govuk-summary-list__row:nth-child(6) .govuk-summary-list__value", text: "Not set"
 end
 
 When(/^I click the button "([^"]*)" on the edition summary page for "([^"]*)"$/) do |label, title|

--- a/test/unit/app/helpers/admin/editions_helper_test.rb
+++ b/test/unit/app/helpers/admin/editions_helper_test.rb
@@ -212,4 +212,10 @@ class Admin::EditionsHelperTest < ActionView::TestCase
                     "Alternative URL displayed to user:<br><a href='#{alternative_url}'>#{alternative_url}</a>"
     assert_equal(expected_text, status_text(edition))
   end
+
+  test "#document_access_text returns the correct display string for access limiting types" do
+    assert_equal "All publishers", document_access_text(build(:edition, access_limiting: :none))
+    assert_equal "Named publishers only", document_access_text(build(:edition, access_limiting: :individuals))
+    assert_equal "Organisation only", document_access_text(build(:edition, access_limiting: :organisations))
+  end
 end


### PR DESCRIPTION
Adds a new row to the document summary metadata, so publishers are able to see if and how a document is access restricted.

## No restriction

<img width="1040" height="760" alt="image" src="https://github.com/user-attachments/assets/36ffd9ab-f3c2-4292-90ae-bbcb5bd1cb46" />

## Restricted to orgs

<img width="1552" height="774" alt="image" src="https://github.com/user-attachments/assets/f9dc1bd8-cd62-4155-8115-d9f313ad05c9" />

## Restricted to individuals

<img width="1592" height="1046" alt="image" src="https://github.com/user-attachments/assets/dd498ba3-1512-4c8f-ab6d-71f2bb4d5bda" />

<hr />

[Jira](https://gov-uk.atlassian.net/browse/WHIT-3881)