### PR TITLE
Ensure access limiting options are only wrapped in 1 fieldset [WHIT-3832]

### DIFF
--- a/app/views/admin/editions/_access_limiting_fields.html.erb
+++ b/app/views/admin/editions/_access_limiting_fields.html.erb
@@ -1,54 +1,51 @@
 <div class="govuk-!-margin-bottom-6">
-  <%= render "govuk_publishing_components/components/fieldset", {
-    legend_text: "Limit access",
-    heading_level: 3,
-    heading_size: "m",
-  } do %>
-    <%= form.hidden_field :access_limiting, value: "none" %>
-    <% if Flipflop.access_limiting_organisations_ui? || Flipflop.access_limiting_individuals_ui? %>
-      <%= render "govuk_publishing_components/components/radio", {
-        name: "edition[access_limiting]",
-        id_prefix: "edition_access_limiting",
-        error_items: errors_for(edition.errors, :access_limiting_organisation_ids) || errors_for(edition.errors, :access_limiting_individual_emails),
-        items: [
-          {
-            value: "none",
-            text: "No - make available to all publishers",
-            checked: edition.access_limiting_none?,
-          },
-          Flipflop.access_limiting_organisations_ui? ? {
-            value: "organisations",
-            text: "Yes – limit access to specific organisations",
-            checked: edition.access_limiting_organisations?,
-            conditional: render("admin/editions/access_limiting_organisation_select", form: form, edition: edition),
-          } : nil,
-          Flipflop.access_limiting_individuals_ui? ? {
-            value: "individuals",
-            text: "Yes - limit access to named publishers",
-            checked: edition.access_limiting_individuals?,
-            conditional: render("govuk_publishing_components/components/textarea", {
-              label: { text: "Add the emails of the publishers who will have access (separated by commas)" },
-              name: "edition[access_limiting_individual_emails]",
-              textarea_id: "edition_access_limiting_individual_emails",
-              hint: "If possible, include 2 email addresses. Once published, the document is available to all publishers. Access restrictions apply only to draft editions.",
-              value: edition.access_limiting_individual_emails,
-            }),
-          } : nil,
-        ].compact,
-      } %>
-    <% else %>
-      <%= render "govuk_publishing_components/components/checkboxes", {
-        name: "edition[access_limiting]",
-        id: "edition_access_limiting",
-        error_items: errors_for(edition.errors, :access_limiting),
-        items: [
-          {
-            label: "Limit access to the following organisations before you publish",
-            value: "organisations",
-            checked: edition.access_limited?,
-          },
-        ],
-      } %>
-    <% end %>
+  <%= form.hidden_field :access_limiting, value: "none" %>
+  <% if Flipflop.access_limiting_organisations_ui? || Flipflop.access_limiting_individuals_ui? %>
+    <%= render "govuk_publishing_components/components/radio", {
+      name: "edition[access_limiting]",
+      id_prefix: "edition_access_limiting",
+      heading: "Limit access",
+      heading_level: 3,
+      heading_size: "m",
+      error_items: errors_for(edition.errors, :access_limiting_organisation_ids) || errors_for(edition.errors, :access_limiting_individual_emails),
+      items: [
+        {
+          value: "none",
+          text: "No - make available to all publishers",
+          checked: edition.access_limiting_none?,
+        },
+        Flipflop.access_limiting_organisations_ui? ? {
+          value: "organisations",
+          text: "Yes – limit access to specific organisations",
+          checked: edition.access_limiting_organisations?,
+          conditional: render("admin/editions/access_limiting_organisation_select", form: form, edition: edition),
+        } : nil,
+        Flipflop.access_limiting_individuals_ui? ? {
+          value: "individuals",
+          text: "Yes - limit access to named publishers",
+          checked: edition.access_limiting_individuals?,
+          conditional: render("govuk_publishing_components/components/textarea", {
+            label: { text: "Add the emails of the publishers who will have access (separated by commas)" },
+            name: "edition[access_limiting_individual_emails]",
+            textarea_id: "edition_access_limiting_individual_emails",
+            hint: "If possible, include 2 email addresses. Once published, the document is available to all publishers. Access restrictions apply only to draft editions.",
+            value: edition.access_limiting_individual_emails,
+          }),
+        } : nil,
+      ].compact,
+    } %>
+  <% else %>
+    <%= render "govuk_publishing_components/components/checkboxes", {
+      name: "edition[access_limiting]",
+      id: "edition_access_limiting",
+      error_items: errors_for(edition.errors, :access_limiting),
+      items: [
+        {
+          label: "Limit access to the following organisations before you publish",
+          value: "organisations",
+          checked: edition.access_limited?,
+        },
+      ],
+    } %>
   <% end %>
 </div>


### PR DESCRIPTION
## What

Removes the redundant wrapping `fieldset` in the access limiting field options partial.

The change is more easily seen when you hide whitespace changes in the split diff: https://github.com/alphagov/whitehall/pull/11721/changes?diff=split&w=1

## Why

The access limiting field options were wrapped in a `fieldset` component, which is not necessary because the `radios` component already wraps the radio buttons in a `fieldset`.  This caused the GA4 form tracker to generate inconsistent key/value pairs, as well as being redundant markup.  This PR fixes that issue by removing the wrapping `fieldset`.

After discussion with Ed, we agreed the output of this change is sufficient to meet point (1) in the Jira ticket: https://gov-uk.atlassian.net/browse/WHIT-3832.  

- for no limiting, it creates:  `{ "Limit access":"No - This document should be available to all publishers" }`
- for org limiting, it creates: `{ Limit access":"Limit access to the following organisations","Limit access - Organisations":"2" }`
- for named limiting, it creates: `{"Limit access":"Limit access to named publishers","Limit access - Add the emails of the publishers who will have access (separated by commas)":"44}" }`

It doesn't meet Ed's requirements exactly but it does create a consistent set of key/value pairs without having to change or special case the GA4 form tracking code in the publishing component gem, which is already quite complex.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
