### PR TITLE
[WHIT-3765] - Launch individual access limiting

### DIFF
--- a/config/features.rb
+++ b/config/features.rb
@@ -38,5 +38,5 @@ Flipflop.configure do
           default: true
   feature :access_limiting_individuals_ui,
           description: "Extend the access-limiting radio UI with an individuals option",
-          default: Whitehall.integration?
+          default: true
 end

--- a/test/functional/admin/edition_access_limited_controller_test.rb
+++ b/test/functional/admin/edition_access_limited_controller_test.rb
@@ -65,6 +65,7 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
     )
 
     feature_flags.switch! :access_limiting_organisations_ui, false
+    feature_flags.switch! :access_limiting_individuals_ui, false
 
     get :edit, params: { id: edition }
 

--- a/test/support/admin_edition_controller_test_helpers.rb
+++ b/test/support/admin_edition_controller_test_helpers.rb
@@ -1514,6 +1514,7 @@ module AdminEditionControllerTestHelpers
 
       view_test "edit displays persisted access_limiting flag" do
         feature_flags.switch! :access_limiting_organisations_ui, false
+        feature_flags.switch! :access_limiting_individuals_ui, false
 
         publication = create(edition_type, access_limiting: "none")
 

--- a/test/unit/app/models/edition/limited_access_test.rb
+++ b/test/unit/app/models/edition/limited_access_test.rb
@@ -212,6 +212,9 @@ class Edition::LimitedAccessTest < ActiveSupport::TestCase
   end
 
   test "saves access_limiting_individuals with lowercased emails when access_limiting is set to 'individuals'" do
+    create(:user, email: "test@test.com")
+    create(:user, email: "example@example.com")
+
     edition = build(:limited_access_edition)
     edition.access_limiting = "individuals"
     edition.access_limiting_individual_emails = "TEST@test.com, Example@example.com"
@@ -222,6 +225,10 @@ class Edition::LimitedAccessTest < ActiveSupport::TestCase
   end
 
   test "saves and reads access_limiting_individuals when the email separators are comma, semicolon, or newline" do
+    %w[test@test.com example@example.com some_other_test@test.com another_example@example.com].each do |email|
+      create(:user, email:)
+    end
+
     edition = build(:edition)
     edition.access_limiting = "individuals"
     edition.access_limiting_individual_emails =
@@ -247,6 +254,8 @@ class Edition::LimitedAccessTest < ActiveSupport::TestCase
   end
 
   test "does not persist access_limiting_individuals on assignment" do
+    create(:user, email: "test@test.com")
+
     edition = build(:limited_access_edition)
     edition.access_limiting = "individuals"
     edition.access_limiting_individual_emails = "test@test.com"
@@ -435,12 +444,16 @@ class Edition::LimitedAccessTest < ActiveSupport::TestCase
   end
 
   test "is valid when access_limiting is set to 'individuals' and no access limiting individuals are selected when flag is off" do
+    @feature_flags.switch!(:access_limiting_individuals_ui, false)
+
     edition = create(:consultation, access_limiting: :individuals)
     edition.access_limiting_individual_emails = ""
     assert edition.valid?
   end
 
   test "access_limiting persists across save/reload" do
+    create(:user, email: "test@test.com")
+
     edition = build(:limited_access_edition, :access_limited_by_organisations)
     edition.save!
     edition.reload
@@ -448,6 +461,7 @@ class Edition::LimitedAccessTest < ActiveSupport::TestCase
     assert_equal "organisations", edition.access_limiting
 
     edition.access_limiting = "individuals"
+    edition.access_limiting_individual_emails = "test@test.com"
     edition.save!
     edition.reload
     assert edition.access_limited?

--- a/test/unit/app/services/edition_publisher_test.rb
+++ b/test/unit/app/services/edition_publisher_test.rb
@@ -34,6 +34,8 @@ class EditionPublisherTest < ActiveSupport::TestCase
   end
 
   test "#perform! with an access limited edition sets access_limiting to 'none' and clears access_limiting_individuals" do
+    create(:user, email: "user@example.com")
+
     edition = create(
       :submitted_edition,
       access_limiting: "individuals",


### PR DESCRIPTION
Turns `access_limiting_individuals_ui` on by default, launching phase 2 of access limiting: publishers can now limit a draft to named publishers as well as to organisations.

The flag guards are left in place, as they were for the organisations flip in phase 1. Removing them is a separate cleanup.

Fixes the tests that would fail with the flag on as well.