### PR TITLE
Send correct data to GA4 for nested errors [WHIT-3305]

### DIFF
--- a/app/components/admin/error_summary_component.rb
+++ b/app/components/admin/error_summary_component.rb
@@ -73,9 +73,12 @@ private
   end
 
   def ga4_title
-    return object.class.name.humanize if [ActiveModel::Errors, Array].include?(object.class)
+    erroring_object = object
+    erroring_object = object.first.base if object.try(:first).is_a?(ActiveRecord::Associations::NestedError)
 
-    "#{object.try(:new_record?) ? 'New' : 'Editing'} #{object.model_name.human.downcase.titleize}"
+    return erroring_object.class.name.humanize if [ActiveModel::Errors, Array].include?(erroring_object.class)
+
+    "#{erroring_object.try(:new_record?) ? 'New' : 'Editing'} #{erroring_object.model_name.human.downcase.titleize}"
   end
 
   def dotted_array_attribute?(error)

--- a/test/components/admin/error_summary_component_test.rb
+++ b/test/components/admin/error_summary_component_test.rb
@@ -178,6 +178,22 @@ class Admin::ErrorSummaryComponentTest < ViewComponent::TestCase
   ensure
     object.class.model_name.define_singleton_method(:i18n_key) { original_i18n_key }
   end
+
+  test "renders GA4 data correctly for objects with nested errors" do
+    image = build(:image_with_missing_file)
+    image.valid?
+
+    render_inline Admin::ErrorSummaryComponent.new(object: image.errors.objects)
+
+    ga4_data_json = page.find("[data-ga4-auto]").native.to_h["data-ga4-auto"]
+    ga4_data = JSON.parse(ga4_data_json)
+
+    assert_equal ga4_data.keys, %w[event_name type text section action]
+    assert_equal ga4_data["event_name"], "form_error"
+    assert_equal ga4_data["type"], "New Image"
+    assert_equal ga4_data["section"], "Image data.file"
+    assert_equal ga4_data["action"], "error"
+  end
 end
 
 class ErrorSummaryTestObject

--- a/test/factories/image_data.rb
+++ b/test/factories/image_data.rb
@@ -24,6 +24,10 @@ FactoryBot.define do
         image_data.assets << build(:asset, asset_manager_id: "asset_manager_id", variant: Asset.variants[:original], filename: image_data.filename)
       end
     end
+
+    trait(:missing_file) do
+      file { nil }
+    end
   end
 
   factory :hero_image_data, class: ImageData do
@@ -67,4 +71,5 @@ FactoryBot.define do
   factory :image_data, parent: :generic_image_data, traits: [:jpg]
   factory :image_data_for_svg, parent: :generic_image_data, traits: [:svg]
   factory :image_data_with_no_assets, parent: :generic_image_data
+  factory :image_data_with_missing_file, parent: :generic_image_data, traits: [:missing_file]
 end

--- a/test/factories/images.rb
+++ b/test/factories/images.rb
@@ -13,8 +13,13 @@ FactoryBot.define do
     trait(:svg) do
       image_data { build(:image_data_for_svg) }
     end
+
+    trait(:missing_file) do
+      image_data { build(:image_data_with_missing_file) }
+    end
   end
 
   factory :image, parent: :generic_image, traits: [:jpg]
   factory :image_with_no_assets, parent: :generic_image, traits: [:with_no_assets]
+  factory :image_with_missing_file, parent: :generic_image, traits: [:missing_file]
 end


### PR DESCRIPTION
## Why

In certain scenarios, the `Admin::ErrorSummaryComponent` receives an array of `NestedErrors`.   The existing early return meant that `Array` was sent as the `type` to GA4, which is incorrect.  One example is clicking 'Upload' on the image screen without having chosen an image (the error is on the `ImageData` class, nested inside `Image`.)

## What

This change fixes that by inspecting the `object` passed into `Admin::ErrorSummaryComponent` and reporting on the correct object if the passed `object` param is an array of `NestedErrors`.  In these cases the correct object is the object that contains the nested error, ie `object.first.base`.

https://gov-uk.atlassian.net/browse/WHIT-3305

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
