### PR TITLE
Backfill access limiting ids on existing public attachment assets [WHIT-3913]

### DIFF
--- a/app/services/asset_manager/asset_updater.rb
+++ b/app/services/asset_manager/asset_updater.rb
@@ -7,10 +7,8 @@ class AssetManager::AssetUpdater
     end
   end
 
-  class AssetDeleted < StandardError
-    def initialize(asset_manager_id)
-      super("Attempting to update Asset with asset_manager_id: '#{asset_manager_id}' that is live and deleted")
-    end
+  def asset_deleted_message(asset_manager_id)
+    "Attempting to update Asset with asset_manager_id: '#{asset_manager_id}' that is live and deleted"
   end
 
   def self.call(*args)
@@ -35,7 +33,7 @@ private
     # Publishing the deleted state ensured that the original asset redirects to its deleted replacement, and thus 404s as well.
 
     # Asset Manager will raise a 404 when trying to fetch a deleted live asset for update. We raise here to make those cases explicit.
-    raise AssetDeleted, asset_manager_id if attributes["deleted"] && !attributes["draft"]
+    return GovukError.notify(asset_deleted_message(asset_manager_id)) if attributes["deleted"] && !attributes["draft"]
 
     begin
       keys = new_attributes.keys

--- a/db/data_migration/20260812133443_backfill_access_limiting_ids_on_public_attachment_assets.rb
+++ b/db/data_migration/20260812133443_backfill_access_limiting_ids_on_public_attachment_assets.rb
@@ -1,0 +1,13 @@
+attachment_data_scope = AttachmentData
+                          .joins(:attachments)
+                          .where(attachments: { attachable_type: "Edition", attachable_id: Edition.where(state: %w[published withdrawn]).select(:id) })
+                          .distinct
+
+total = attachment_data_scope.count
+started_at = Time.current
+
+attachment_data_scope.find_each do |attachment_data|
+  AssetManagerAttachmentMetadataJob.perform_async_in_queue("asset_manager_updater", attachment_data.id)
+end
+
+puts "Queued Asset Manager metadata refresh for #{total} attachments in #{(Time.current - started_at).round(2)}s"

--- a/test/unit/app/services/asset_manager/asset_updater_test.rb
+++ b/test/unit/app/services/asset_manager/asset_updater_test.rb
@@ -26,13 +26,13 @@ class AssetManager::AssetUpdaterTest < ActiveSupport::TestCase
     end
   end
 
-  test "raises exception if attempting to update a live deleted asset" do
+  test "rescues and logs if attempting to update a live deleted asset" do
     @asset_updater.stubs(:find_asset_by_id).with(@asset_manager_id)
            .returns("id" => @asset_manager_id, "deleted" => true, "draft" => false)
 
-    assert_raises(AssetManager::AssetUpdater::AssetDeleted) do
-      @asset_updater.call(@asset_manager_id, { "redirect_url" => @redirect_url })
-    end
+    GovukError.expects(:notify).with("Attempting to update Asset with asset_manager_id: '#{@asset_manager_id}' that is live and deleted")
+
+    @asset_updater.call(@asset_manager_id, { "redirect_url" => @redirect_url })
   end
 
   test "rescues and logs if attempting to update a live asset with a draft `parent_document_url`" do


### PR DESCRIPTION
Follow-on to [PR #11662](https://github.com/alphagov/whitehall/pull/11662). This PR backfills access_limited_organisation_ids/access_limited_user_ids on existing public attachment assets - re-triggering the existing AssetManagerAttachmentMetadataJob for every attachment currently on a published or withdrawn edition, so stale values left over from before [#11662](https://github.com/alphagov/whitehall/pull/11662) shipped get refreshed to the correct empty ones.

Split out from [#11702](https://github.com/alphagov/whitehall/pull/11702), which originally included this alongside the auth_bypass_id backfill.

**AssetDeleted fix included**

Running this on staging produced a number of Sentry errors: AssetManager::AssetUpdater::AssetDeleted, raised when the migration touches an asset that's been replaced/deleted at some point in its history. This is pre-existing, not something introduced by this migration - it's just the first thing to exercise that code path at enough volume/diversity to hit it.

Rather than holding this PR until image work lands, we've cherry-picked the fix from [#11667](https://github.com/alphagov/whitehall/pull/11667) as a standalone commit here. It changes AssetManager::AssetUpdater to call GovukError.notify instead of raising when it hits a live-and-deleted asset, so the job logs the issue and moves on instead of retrying pointlessly.

**Why this migration can't be scoped as tightly as the auth_bypass_id one**

Unlike auth_bypass_id, there's no column anywhere in Whitehall recording "this attachment was ever access-limited" - once an edition publishes, the access-limiting join records are destroyed, so there's nothing local to filter on. This has to touch every attachment on every currently public edition, which is a much larger and less certain population than the ~437k editions the auth_bypass_id migration handled. It only re-triggers a refresh to the current (correct) state though, so it is safe to re-run if needed.

[JIRA](https://gov-uk.atlassian.net/browse/WHIT-3585)

