### PR TITLE
Send access limiting data to GA4 [WHIT-3832]

### DIFF
--- a/app/views/admin/editions/_access_limiting_fields.html.erb
+++ b/app/views/admin/editions/_access_limiting_fields.html.erb
@@ -30,6 +30,9 @@
             textarea_id: "edition_access_limiting_individual_emails",
             hint: "If possible, include 2 email addresses. Once published, the document is available to all publishers. Access restrictions apply only to draft editions.",
             value: edition.access_limiting_individual_emails,
+            data: {
+              "ga4-force-report-value-in-form-tracker": true,
+            },
           }),
         } : nil,
       ].compact,

--- a/app/views/admin/editions/_access_limiting_organisation_select.html.erb
+++ b/app/views/admin/editions/_access_limiting_organisation_select.html.erb
@@ -6,4 +6,7 @@
   heading_size: "s",
   include_blank: true,
   options: taggable_organisations_container(edition.access_limiting_organisation_ids),
+  data_attributes: {
+    "ga4-force-report-value-in-form-tracker": true,
+  },
 } %>


### PR DESCRIPTION
## What

This change uses the new `data-ga4-force-report-value-in-form-tracker` attribute in the form tracker in publishing components gem to send the number of selected access limiting orgs and the redacted emails for individual access limits.  Each email will appear as [email] due to the PII remover.

## Why

We need to know how the new access limiting fields are being used in GA4.  Previously, all text input and select fields in the form were configured to send character or selected option counts to GA4.  

https://gov-uk.atlassian.net/browse/WHIT-3832


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>