### PR TITLE
Report image usage to GA4

### DIFF
--- a/app/views/admin/edition_images/edit.html.erb
+++ b/app/views/admin/edition_images/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :context, @edition.title %>
-<% content_for :page_title, "Edit image details" %>
+<% content_for :page_title, "Edit #{image.usage.humanize.downcase} image details" %>
 <% content_for :title, "Edit image details" %>
 <% content_for :title_margin_bottom, 6 %>
 


### PR DESCRIPTION
## What

This change adds the image usage (`lead`, `header`, `govspeak embedd` etc) to the `section` property that is sent to GA4 in navigation events and form submissions

## Why

Allows for better image editing reporting / analysis

See https://gov-uk.atlassian.net/browse/WHIT-3331

I couldn't find any existing tests for the data that we send to GA4 (outside of the `ErrorSummaryComponent`), so I haven't added anything for this work. It feels... odd not to include a test but I am assuming it's a conscious decision.  If that's not the case I can add a request spec to test what is rendered in the `data-ga4-auto` attribute.


---
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
