### PR TITLE
Add cancel link to `edition_access_limited#edit` [WHIT-3787]

### DIFF
--- a/app/views/admin/edition_access_limited/edit.html.erb
+++ b/app/views/admin/edition_access_limited/edit.html.erb
@@ -32,9 +32,12 @@
         rows: 20,
       } %>
 
-      <%= render "govuk_publishing_components/components/button", {
-        text: "Save",
-      } %>
+      <div class="govuk-button-group">
+        <%= render "govuk_publishing_components/components/button", {
+          text: "Save",
+        } %>
+        <%= link_to("Cancel", admin_edition_path(@edition), class: "govuk-link govuk-link--no-visited-state") %>
+      </div>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
## What

Add cancel link to the edit form of the access limiting of an edition.

## Why

Easier user experience.

## Visual Differences

|Before|After|
|-|-|
|<img width="587" height="455" alt="Screenshot 2026-08-24 at 13 28 26" src="https://github.com/user-attachments/assets/f6a3a3c6-c507-41a3-b419-065dff8ba940" />|<img width="606" height="467" alt="Screenshot 2026-08-24 at 13 28 04" src="https://github.com/user-attachments/assets/fe1da20d-1a22-49c3-86f6-88664117cad7" />|

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
