### PR TITLE
Add missing back links to document types [WHIT-3758]

### DIFF
--- a/app/views/admin/call_for_evidence_responses/edit.html.erb
+++ b/app/views/admin/call_for_evidence_responses/edit.html.erb
@@ -2,6 +2,11 @@
 <% content_for :title, "Editing #{@response.friendly_name} for call for evidence" %>
 <% content_for :context, "#{@edition.title}" %>
 <% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @response)) %>
+<% content_for :back_link do %>
+  <%= render "govuk_publishing_components/components/back_link", {
+    href: admin_edition_path(@edition),
+  } %>
+<% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/admin/call_for_evidence_responses/show.html.erb
+++ b/app/views/admin/call_for_evidence_responses/show.html.erb
@@ -2,6 +2,11 @@
 <% content_for :title, "#{@response.friendly_name.capitalize} for call for evidence" %>
 <% content_for :context, "#{@edition.title}" %>
 <% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @response)) %>
+<% content_for :back_link do %>
+  <%= render "govuk_publishing_components/components/back_link", {
+    href: admin_edition_path(@edition),
+  } %>
+<% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/admin/consultation_responses/edit.html.erb
+++ b/app/views/admin/consultation_responses/edit.html.erb
@@ -2,6 +2,11 @@
 <% content_for :title, "Editing #{@response.friendly_name} for consultation" %>
 <% content_for :context, "#{@edition.title}" %>
 <% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @response)) %>
+<% content_for :back_link do %>
+  <%= render "govuk_publishing_components/components/back_link", {
+    href: admin_edition_path(@edition),
+  } %>
+<% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">

--- a/app/views/admin/consultation_responses/show.html.erb
+++ b/app/views/admin/consultation_responses/show.html.erb
@@ -2,6 +2,11 @@
 <% content_for :title, "#{@response.friendly_name.capitalize} for consultation" %>
 <% content_for :context, "#{@edition.title}" %>
 <% content_for :error_summary, render(Admin::ErrorSummaryComponent.new(object: @response)) %>
+<% content_for :back_link do %>
+  <%= render "govuk_publishing_components/components/back_link", {
+    href: admin_edition_path(@edition),
+  } %>
+<% end %>
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
## What

Add missing back links to edit screens of:
- Call for Evidence outcome attachments
- Consultation outcome's attachments page
- Consultation public feedback attachments page

NB: I think the ticket was written assuming that the navigation links are generated programmatically? There's no error or regression this could possibly introduce. 

## Why

More consistent UX/UI.

## Visual Differences

|Before|After|
|-|-|
|<img width="730" height="296" alt="Screenshot 2026-08-24 at 14 20 32" src="https://github.com/user-attachments/assets/e213cf6d-e215-457c-a8fc-f90e190069dc" />|<img width="696" height="305" alt="Screenshot 2026-08-24 at 14 20 24" src="https://github.com/user-attachments/assets/f990cf4c-fcf5-404c-8c2e-c0f55127a845" />|
|<img width="605" height="308" alt="Screenshot 2026-08-24 at 14 19 30" src="https://github.com/user-attachments/assets/b1a7dcac-ed24-4a87-a461-d924b45242d0" />|<img width="567" height="318" alt="Screenshot 2026-08-24 at 14 19 22" src="https://github.com/user-attachments/assets/1216d85d-b9a0-4605-b261-e38ed86e3244" />|
|<img width="739" height="258" alt="Screenshot 2026-08-24 at 14 19 15" src="https://github.com/user-attachments/assets/4cb2147a-4160-4202-af27-508e131fa1ea" />|<img width="751" height="330" alt="Screenshot 2026-08-24 at 14 19 02" src="https://github.com/user-attachments/assets/961dc093-2d06-430d-88db-fb93eaafe6f6" />|


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
