### PR TITLE
Display limited access errors in conditional fields

### DIFF
--- a/app/views/admin/editions/_access_limiting_fields.html.erb
+++ b/app/views/admin/editions/_access_limiting_fields.html.erb
@@ -7,7 +7,6 @@
       heading: "Limit access",
       heading_level: 3,
       heading_size: "m",
-      error_items: errors_for(edition.errors, :access_limiting_organisation_ids) || errors_for(edition.errors, :access_limiting_individual_emails),
       items: [
         {
           value: "none",
@@ -30,6 +29,7 @@
             textarea_id: "edition_access_limiting_individual_emails",
             hint: "If possible, include 2 email addresses. Once published, the document is available to all publishers. Access restrictions apply only to draft editions.",
             value: edition.access_limiting_individual_emails,
+            error_items: errors_for(edition.errors, :access_limiting_individual_emails),
             data: {
               "ga4-force-report-value-in-form-tracker": true,
             },

--- a/app/views/admin/editions/_access_limiting_organisation_select.html.erb
+++ b/app/views/admin/editions/_access_limiting_organisation_select.html.erb
@@ -5,6 +5,7 @@
   multiple: true,
   heading_size: "s",
   include_blank: true,
+  error_items: errors_for(edition.errors, :access_limiting_organisation_ids),
   options: taggable_organisations_container(edition.access_limiting_organisation_ids),
   data_attributes: {
     "ga4-force-report-value-in-form-tracker": true,


### PR DESCRIPTION
## What

Ensures that access limiting errors are displayed next to the actual fields rather than next to the `Limit access` field header.

## Why

As per the design system guidance, errors for conditionally displayed fields should be rendered on the conditional field, not the enclosing field.  

https://gov-uk.atlassian.net/browse/WHIT-3732


## Visual differences

| Before | After |
| ------- | ---- |
| <img width="815" height="390" alt="image" src="https://github.com/user-attachments/assets/20e01dfb-ff65-44da-853d-7e0a1074be6c" /> |  <img width="819" height="415" alt="image" src="https://github.com/user-attachments/assets/b8079089-0dbc-4274-852f-45dfd5227ade" /> |
| <img width="815" height="563" alt="image" src="https://github.com/user-attachments/assets/c38f3ed9-423e-477b-be4d-50577d9ea53c" /> |  <img width="812" height="528" alt="image" src="https://github.com/user-attachments/assets/d1f7c0d8-4a6b-45f9-addd-b7824d287823" /> |

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
