### PR TITLE
Send correct image type to GA4 on edit

### DIFF
--- a/app/views/admin/edition_images/edit.html.erb
+++ b/app/views/admin/edition_images/edit.html.erb
@@ -1,5 +1,5 @@
 <% content_for :context, @edition.title %>
-<% content_for :page_title, "Edit #{image.usage.humanize.downcase} image details" %>
+<% content_for :page_title, "Edit #{@image_usage.title} details" %>
 <% content_for :title, "Edit image details" %>
 <% content_for :title_margin_bottom, 6 %>
 


### PR DESCRIPTION
## What
Changes the logic used to construct the `section` value that is sent to GA4 when editing an image, so that it is consistent with other actions (eg in `views/admin`edition_images/new.html.erb`).  

Using `@image_usage.title` returns `Edit image details` for an embedded image while retaining the required info for other images, eg `Edit header image details` for header images.


## Why
Previously, the `image.usage` value was used to construct the value sent in `section` when a user was editing an image.  This is fine for most image types, but for embedded images it returns `Edit govspeak embed image details`.  For analytics consistency, this needs to be `Edit image details`.

Ed has checked this on integration

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
