### PR TITLE
[WHIT-3942] - Skip definitive article for Nuclear Waste Services

### DIFF
--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -10,6 +10,7 @@ module OrganisationHelper
     /british wool/,
     /building law and hygiene/,
     /skills england/,
+    /nuclear waste services/,
   ].freeze
 
   SPONSORED_ORGANISATION_TYPE_KEYS = %i[

--- a/test/unit/app/helpers/organisation_helper_test.rb
+++ b/test/unit/app/helpers/organisation_helper_test.rb
@@ -109,6 +109,7 @@ class OrganisationHelperDisplayNameWithParentalRelationshipTest < ActionView::Te
     assert_definite_article_skipped "Ordnance Survey"
     assert_definite_article_skipped "Homes England"
     assert_definite_article_skipped "Skills England"
+    assert_definite_article_skipped "Nuclear Waste Services"
   end
 
   test "definite article added for certain organisations" do


### PR DESCRIPTION
Prevents `the` from being included within the name. I.e.

`Procurement at the Nuclear Waste Services` -> `Procurement at Nuclear Waste Services

<img width="2006" height="1076" alt="image" src="https://github.com/user-attachments/assets/b80a6071-daae-44f6-bf70-0eda68839d08" />
