### PR TITLE
Various fixes for the "Unpublish via the National Archives" option [WHIT-3944]

### DIFF
--- a/app/controllers/admin/edition_unpublishing_controller.rb
+++ b/app/controllers/admin/edition_unpublishing_controller.rb
@@ -5,19 +5,24 @@ class Admin::EditionUnpublishingController < Admin::BaseController
   def edit; end
 
   def update
-    services = Whitehall.edition_services
-    if @unpublishing.update(unpublishing_params)
-      if withdrawing?
-        services.withdrawer(@unpublishing.edition, user: current_user).perform!
+    ActiveRecord::Base.transaction do
+      services = Whitehall.edition_services
+      if @unpublishing.update(unpublishing_params)
+        if withdrawing?
+          services.withdrawer(@unpublishing.edition, user: current_user).perform!
+        else
+          services.unpublisher(@unpublishing.edition).perform!
+        end
+        redirect_to admin_edition_path(@unpublishing.edition), {
+          notice: "The #{helpers.withdrawal_or_unpublishing(@unpublishing.edition)} was updated",
+        }
       else
-        services.unpublisher(@unpublishing.edition).perform!
+        render :edit
       end
-      redirect_to admin_edition_path(@unpublishing.edition), {
-        notice: "The #{helpers.withdrawal_or_unpublishing(@unpublishing.edition)} was updated",
-      }
-    else
-      render :edit
     end
+  rescue GdsApi::HTTPUnprocessableEntity
+    flash.now[:alert] = "Error: Publishing API rejected the redirect"
+    render :edit, status: :unprocessable_entity
   end
 
 private

--- a/app/helpers/admin/editions_helper.rb
+++ b/app/helpers/admin/editions_helper.rb
@@ -180,7 +180,9 @@ module Admin::EditionsHelper
                    "being published in error"
                  end
         details = ""
-        if consolidated || edition.unpublishing.redirect
+        if archived
+          details = " User is redirected from<br><a href='#{Whitehall.public_root}#{edition.base_path}'>#{Whitehall.public_root}#{edition.base_path}</a><br>to<br><a href='#{edition.unpublishing.archived_url}'>#{edition.unpublishing.archived_url}</a>"
+        elsif consolidated || edition.unpublishing.redirect
           details = " User is redirected from<br><a href='#{Whitehall.public_root}#{edition.base_path}'>#{Whitehall.public_root}#{edition.base_path}</a><br>to<br><a href='#{edition.unpublishing.alternative_url}'>#{edition.unpublishing.alternative_url}</a>"
         else
           details << " User-facing reason: '#{edition.unpublishing.explanation}'." if edition.unpublishing.explanation.present?

--- a/app/models/unpublishing.rb
+++ b/app/models/unpublishing.rb
@@ -96,8 +96,8 @@ class Unpublishing < ApplicationRecord
 
     return alternative_uri.to_s unless GovUkUrlFormatValidator.can_be_converted_to_relative_path?(alternative_uri)
 
-    path = alternative_uri.path
-    path << "##{alternative_uri.fragment}" if alternative_uri.fragment.present?
+    path = alternative_uri.path.presence || "/"
+    path += "##{alternative_uri.fragment}" if alternative_uri.fragment.present?
     path
   end
 

--- a/app/views/admin/edition_workflow/confirm_unpublish.html.erb
+++ b/app/views/admin/edition_workflow/confirm_unpublish.html.erb
@@ -215,7 +215,7 @@
         <%= hidden_field_tag "unpublishing[unpublishing_reason_id]", unpublish_reasons[:archived][:id] %>
 
         <p class="govuk-body">
-          This document <a class="govuk-link" href="https://https://www.webarchive.nationalarchives.gov.uk/<%= @unpublishing.archived_url %>">must be live on the National Archives website</a> to select this reason. The URL to the National Archives website will be determined automatically based on the URL of the document.
+          This document <a class="govuk-link" href="https://www.webarchive.nationalarchives.gov.uk/<%= @unpublishing.archived_url %>">must be live on the National Archives website</a> to select this reason. The URL to the National Archives website will be determined automatically based on the URL of the document.
         </p>
 
         <div class="govuk-button-group govuk-!-margin-bottom-6">

--- a/test/functional/admin/edition_unpublishing_controller_test.rb
+++ b/test/functional/admin/edition_unpublishing_controller_test.rb
@@ -94,7 +94,7 @@ class Admin::EditionUnpublishingControllerTest < ActionController::TestCase
     assert_equal false, edition.unpublishing.reload.redirect
   end
 
-  view_test "#updating the withdrawal shows the error message if the update was not possible" do
+  view_test "#update shows an error message if the withdrawal was not possible" do
     edition = create(:edition, :withdrawn)
     original_explanation = edition.unpublishing.explanation
     put :update, params: { edition_id: edition, unpublishing: { explanation: "" } }
@@ -106,7 +106,7 @@ class Admin::EditionUnpublishingControllerTest < ActionController::TestCase
     assert_dom ".govuk-error-message", text: "Error: #{error.full_message}"
   end
 
-  view_test "#updating the unpublishing shows the error message if the update was not possible" do
+  view_test "#update shows the error message if the unpublishing was not possible" do
     edition = create(:edition, :published_in_error_redirect)
     put :update, params: { edition_id: edition.id, unpublishing: { explanation: "", alternative_url: "not a URL" } }
 
@@ -114,7 +114,7 @@ class Admin::EditionUnpublishingControllerTest < ActionController::TestCase
     assert_dom ".govuk-error-message", text: "Error: #{errors.map(&:full_message).join}"
   end
 
-  view_test "#updating shows the Publishing API error message if a 422 response was received, and doesn't update the Unpublishing" do
+  view_test "#update shows the Publishing API error message if a 422 response was received, and doesn't update the Unpublishing" do
     edition = create(:edition, :published_in_error_redirect)
     original_explanation = edition.unpublishing.explanation
     original_alternative_url = edition.unpublishing.alternative_url

--- a/test/functional/admin/edition_unpublishing_controller_test.rb
+++ b/test/functional/admin/edition_unpublishing_controller_test.rb
@@ -113,4 +113,33 @@ class Admin::EditionUnpublishingControllerTest < ActionController::TestCase
     errors = assigns(:unpublishing).errors.where(:alternative_url)
     assert_dom ".govuk-error-message", text: "Error: #{errors.map(&:full_message).join}"
   end
+
+  view_test "#updating shows the Publishing API error message if a 422 response was received, and doesn't update the Unpublishing" do
+    edition = create(:edition, :published_in_error_redirect)
+    original_explanation = edition.unpublishing.explanation
+    original_alternative_url = edition.unpublishing.alternative_url
+    original_redirect = edition.unpublishing.redirect
+    Whitehall.edition_services
+      .expects(:unpublisher)
+      .with(edition)
+      .returns(unpublisher = stub)
+
+    # Currently happens if you try to redirect to `https://gov.uk`, which Publishing
+    # API rejects because no redirect path was provided, even though the host is
+    # allow-listed.
+    unpublisher.expects(:perform!).raises(GdsApi::HTTPUnprocessableEntity.new(422))
+
+    put :update, params: { edition_id: edition.id,
+                           unpublishing: {
+                             explanation: "this used to say unpublished",
+                             alternative_url: "https://gov.uk/some-page",
+                             redirect: "0",
+                           } }
+
+    assert_template :edit
+    assert_equal "Error: Publishing API rejected the redirect", flash.now[:alert]
+    assert_equal original_explanation, edition.unpublishing.reload.explanation
+    assert_equal original_alternative_url, edition.unpublishing.reload.alternative_url
+    assert_equal original_redirect, edition.unpublishing.reload.redirect
+  end
 end

--- a/test/unit/app/helpers/admin/editions_helper_test.rb
+++ b/test/unit/app/helpers/admin/editions_helper_test.rb
@@ -137,7 +137,7 @@ class Admin::EditionsHelperTest < ActionView::TestCase
     assert_equal "Unpublished (less than a minute ago) due to being consolidated into another page. User is redirected from<br><a href='https://www.test.gov.uk#{edition.base_path}'>https://www.test.gov.uk#{edition.base_path}</a><br>to<br><a href='#{alternative_url}'>#{alternative_url}</a>", status_text(edition)
   end
 
-  test "#status_text has special handling for unpublished (due to being archived)" do
+  test "#status_text has special handling for unpublished (via National Archives)" do
     edition = create(:edition, :unpublished)
 
     stub_request(:head, edition.unpublishing.archived_url)
@@ -145,7 +145,8 @@ class Admin::EditionsHelperTest < ActionView::TestCase
 
     edition.unpublishing.unpublishing_reason_id = UnpublishingReason::ARCHIVED_ID
     edition.unpublishing.save!
-    assert_equal "Unpublished (less than a minute ago) due to being archived via the National Archives.", status_text(edition)
+
+    assert_equal "Unpublished (less than a minute ago) due to being archived via the National Archives. User is redirected from<br><a href='#{edition.public_url}'>#{edition.public_url}</a><br>to<br><a href='#{edition.unpublishing.archived_url}'>#{edition.unpublishing.archived_url}</a>", status_text(edition)
   end
 
   test "#status_text has special handling for unpublished (due to publish in error) - redirect to alternative URL" do

--- a/test/unit/app/models/unpublishing_test.rb
+++ b/test/unit/app/models/unpublishing_test.rb
@@ -129,6 +129,11 @@ class UnpublishingTest < ActiveSupport::TestCase
     assert_equal "https://www.judiciary.uk/about", unpublishing.alternative_path
   end
 
+  test "alternative_path defaults to '/' when given a GOV.UK domain and no path" do
+    unpublishing = build(:unpublishing, redirect: true, alternative_url: "https://www.test.gov.uk")
+    assert_equal "/", unpublishing.alternative_path
+  end
+
   test "alternative_path returns nil if alternative_url is nil" do
     unpublishing = build(:unpublishing, redirect: true, alternative_url: nil)
     assert_nil unpublishing.alternative_path


### PR DESCRIPTION
## What

- Fixes broken preview link to the National Archives link
- Adds clickable link to the "Unpublished via National Archives" document summary
- Handles 422 responses from Publishing API when unpublishing
- Fixes bug where not specifying a path for a GOV.UK redirect URL causes 422 response

## Why

Jira: https://gov-uk.atlassian.net/browse/WHIT-3944

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
