### PR TITLE
Change rendering app for Person pages to frontend

### DIFF
--- a/app/presenters/publishing_api/person_presenter.rb
+++ b/app/presenters/publishing_api/person_presenter.rb
@@ -21,7 +21,7 @@ module PublishingApi
         details:,
         document_type: "person",
         public_updated_at: item.updated_at,
-        rendering_app: Whitehall::RenderingApp::COLLECTIONS_FRONTEND,
+        rendering_app: Whitehall::RenderingApp::FRONTEND,
         schema_name: "person",
       )
       content.merge!(PayloadBuilder::PolymorphicPath.for(item))

--- a/test/unit/app/presenters/publishing_api/person_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/person_presenter_test.rb
@@ -29,7 +29,7 @@ class PublishingApi::PersonPresenterTest < ActiveSupport::TestCase
       document_type: "person",
       locale: "en",
       publishing_app: Whitehall::PublishingApp::WHITEHALL,
-      rendering_app: "collections",
+      rendering_app: Whitehall::RenderingApp::FRONTEND,
       public_updated_at: person.updated_at,
       routes: [{ path: public_path, type: "exact" }],
       redirects: [],


### PR DESCRIPTION
We are currently working on migrating People pages to frontend app.
This PR changes the rendering app for person pages from collections to frontend.

It should not be merged until https://github.com/alphagov/frontend/pull/5729 has been merged and deployed.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
