### PR TITLE
Remove lead and support orgs from access form WHIT-3535

### DIFF
--- a/app/controllers/admin/edition_access_limited_controller.rb
+++ b/app/controllers/admin/edition_access_limited_controller.rb
@@ -49,21 +49,12 @@ private
         :access_limiting_individual_emails,
         :editorial_remark,
         {
-          lead_organisation_ids: [],
-          supporting_organisation_ids: [],
           access_limiting_organisation_ids: [],
         },
       )
   end
 
   def clean_organisation_params
-    if edition_params[:lead_organisation_ids]
-      edition_params[:lead_organisation_ids] = edition_params[:lead_organisation_ids].reject(&:blank?)
-    end
-    if edition_params[:supporting_organisation_ids]
-      edition_params[:supporting_organisation_ids] = edition_params[:supporting_organisation_ids].reject(&:blank?)
-    end
-
     edition_params[:access_limiting_organisation_ids] = [] unless edition_params[:access_limiting] == "organisations"
     edition_params[:access_limiting_individual_emails] = [] unless edition_params[:access_limiting] == "individuals"
   end

--- a/app/views/admin/edition_access_limited/edit.html.erb
+++ b/app/views/admin/edition_access_limited/edit.html.erb
@@ -16,7 +16,6 @@
         text: "This page in only available to GDS Admins. Information in this document could be sensitive and access controls should only be changed at the request of the user.",
       } %>
 
-      <%= render "admin/editions/organisation_fields", form: form, edition: @edition %>
       <%= render "admin/editions/access_limiting_fields", form: form, edition: @edition %>
 
       <%= render "govuk_publishing_components/components/textarea", {

--- a/test/functional/admin/edition_access_limited_controller_test.rb
+++ b/test/functional/admin/edition_access_limited_controller_test.rb
@@ -56,40 +56,6 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
     assert_response :forbidden
   end
 
-  test "PATCH :update should update editions organisations and create an editorial remark" do
-    first_organisation = create(:organisation)
-    second_organisation = create(:organisation)
-    third_organisation = create(:organisation)
-
-    edition = create(
-      :consultation,
-      access_limiting: "organisations",
-      access_limiting_organisation_ids: [first_organisation.id],
-      create_default_organisation: false,
-      lead_organisations: [first_organisation],
-      supporting_organisations: [second_organisation],
-    )
-
-    editorial_remark = "Updating the organisations at the users request."
-
-    patch :update,
-          params: {
-            id: edition,
-            edition: {
-              lead_organisation_ids: [second_organisation.id],
-              supporting_organisation_ids: [third_organisation.id],
-              editorial_remark:,
-              access_limiting: "organisations",
-            },
-          }
-
-    assert_equal [second_organisation], edition.reload.lead_organisations
-    assert_equal [third_organisation], edition.supporting_organisations
-    assert_redirected_to admin_editions_path
-    assert_equal "Access updated for #{edition.title}", flash[:notice]
-    assert_equal "Access options updated by GDS Admin: #{editorial_remark}", edition.editorial_remarks.last.body
-  end
-
   test "PATCH :update changes access limiting from 'none' to 'organisations' and creates an editorial remark" do
     organisation = create(:organisation)
     edition = create(
@@ -105,7 +71,6 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
           params: {
             id: edition,
             edition: {
-              lead_organisation_ids: [organisation.id],
               access_limiting: "organisations",
               access_limiting_organisation_ids: [organisation.id.to_s],
               editorial_remark: editorial_remark,
@@ -134,7 +99,6 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
           params: {
             id: edition,
             edition: {
-              lead_organisation_ids: [organisation.id],
               access_limiting: "none",
               access_limiting_organisation_ids: [organisation.id],
               editorial_remark: editorial_remark,
@@ -162,7 +126,6 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
           params: {
             id: edition,
             edition: {
-              lead_organisation_ids: [organisation.id],
               editorial_remark: "",
               access_limiting: "none",
             },
@@ -187,7 +150,6 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
           params: {
             id: edition,
             edition: {
-              lead_organisation_ids: [organisation.id],
               access_limiting: "organisations",
               access_limiting_organisation_ids: [""],
               editorial_remark: "Test",
@@ -204,39 +166,6 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
     end
     assert_equal "organisations", edition.reload.access_limiting
     assert edition.access_limiting_organisations.exists?(id: organisation.id)
-  end
-
-  view_test "PATCH :update re-renders the edit template with the submitted access limiting organisations and editorial remark, when unrelated field fails validation" do
-    organisation = create(:organisation)
-    new_organisation = create(:organisation)
-    edition = create(
-      :consultation,
-      access_limiting: "organisations",
-      create_default_organisation: false,
-      lead_organisations: [organisation],
-      access_limiting_organisation_ids: [organisation.id],
-    )
-
-    patch :update,
-          params: {
-            id: edition,
-            edition: {
-              lead_organisation_ids: [""],
-              access_limiting: "organisations",
-              access_limiting_organisation_ids: [organisation.id, new_organisation.id],
-              editorial_remark: "Test",
-            },
-          }
-
-    assert_template :edit
-    assert_equal ["Lead organisation ids at least one required"], assigns(:edition).errors.full_messages
-    assert_select "input[name='edition[access_limiting]'][value='organisations'][checked=checked]"
-    assert_select "select[name='edition[access_limiting_organisation_ids][]']" do
-      assert_select "option[selected='selected'][value='#{organisation.id}']"
-      assert_select "option[selected='selected'][value='#{new_organisation.id}']"
-    end
-    assert_select "textarea[name='edition[editorial_remark]']", text: "Test"
-    assert_equal [organisation.id], edition.reload.access_limiting_organisation_ids
   end
 
   test "PATCH :update clears access_limiting_organisations when switching to individuals" do
@@ -349,7 +278,6 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
 
   test "PATCH :update should enqueue the edition draft updater" do
     first_organisation = create(:organisation)
-    second_organisation = create(:organisation)
 
     edition = create(
       :consultation,
@@ -369,17 +297,15 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
             edition: {
               access_limiting: "organisations",
               access_limiting_organisation_ids: [first_organisation.id],
-              lead_organisation_ids: [first_organisation.id, second_organisation.id],
               editorial_remark: "Updating lead organisations.",
             },
           }
 
-    assert_equal [first_organisation, second_organisation], edition.reload.lead_organisations
+    assert_equal [first_organisation], edition.access_limiting_organisations
   end
 
   test "PATCH :update should enqueue the attachment updater" do
     first_organisation = create(:organisation)
-    second_organisation = create(:organisation)
 
     edition = create(
       :consultation,
@@ -397,25 +323,26 @@ class Admin::EditionAccessLimitedControllerTest < ActionController::TestCase
             edition: {
               access_limiting: "organisations",
               access_limiting_organisation_ids: [first_organisation.id],
-              lead_organisation_ids: [first_organisation.id, second_organisation.id],
               editorial_remark: "Updating lead organisations.",
             },
           }
 
-    assert_equal [first_organisation, second_organisation], edition.reload.lead_organisations
+    assert_equal [first_organisation], edition.access_limiting_organisations
 
     AssetManagerAttachmentMetadataJob.drain
   end
 
   test "PATCH :update does not change edition if in unmodifiable state" do
+    first_organisation = create(:organisation)
     edition = create(:published_consultation, create_default_organisation: true)
 
     patch :update,
           params: {
             id: edition,
             edition: {
-              lead_organisation_ids: [create(:organisation).id],
-              editorial_remark: "Updating lead organisations.",
+              access_limiting: "organisations",
+              access_limiting_organisation_ids: [first_organisation.id],
+              editorial_remark: "Updating access limiting",
             },
           }
 


### PR DESCRIPTION
## What

Removes the lead and supporting organisation fields from the `edit_access_limited` form that is displayed for GDS Admins to edit access limiting.

## Why

The lead and supporting orgs are no longer involved in determining access rights to an edition, so they can be removed from this form.

https://gov-uk.atlassian.net/browse/WHIT-3535


---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
