### PR TITLE
Only allow image uploads for people in roles [WHIT-3670]

### DIFF
--- a/app/views/admin/people/_form.html.erb
+++ b/app/views/admin/people/_form.html.erb
@@ -57,22 +57,24 @@
     error_items: errors_for(person.errors, :letters),
   } %>
 
-  <%= form.fields_for :image do |_image_fields| %>
-    <%= render "components/single_image_upload", {
-      title: "Image",
-      name: "person[image_attributes]",
-      id: "person_image",
-      image_id: "person_image_file",
-      image_name: "person[image_attributes][file]",
-      remove_alt_text_field: true,
-      filename: person.image.file.identifier,
-      page_errors: person.errors.any?,
-      error_items: errors_for(person.errors, :"image.file"),
-      image_src: person.image.url,
-      image_cache_name: "person[image_attributes][file_cache]",
-      image_cache: person.image.file_cache.presence,
-      image_uploaded: person.image.all_asset_variants_uploaded?,
-    } %>
+  <% if person.current_role_appointments.any? %>
+    <%= form.fields_for :image do |_image_fields| %>
+      <%= render "components/single_image_upload", {
+        title: "Image",
+        name: "person[image_attributes]",
+        id: "person_image",
+        image_id: "person_image_file",
+        image_name: "person[image_attributes][file]",
+        remove_alt_text_field: true,
+        filename: person.image.file.identifier,
+        page_errors: person.errors.any?,
+        error_items: errors_for(person.errors, :"image.file"),
+        image_src: person.image.url,
+        image_cache_name: "person[image_attributes][file_cache]",
+        image_cache: person.image.file_cache.presence,
+        image_uploaded: person.image.all_asset_variants_uploaded?,
+      } %>
+    <% end %>
   <% end %>
 
   <%= render "components/govspeak_editor", {

--- a/features/people.feature
+++ b/features/people.feature
@@ -26,3 +26,11 @@ Feature: Managing a person
     Given a person called "Amanda Appleford" exists with a translation for the locale "French (Français)"
     When I edit the "French (Français)" translation for the person "Amanda Appleford" updating the biography to "Ca va bien"
     Then I should see the translation "French (Français)" and body text "Ca va bien"
+
+  Scenario: Editing a person in a role
+    Given the organisation "Foreign Office" exists
+    And I add a new "Minister" role named "Chief Scientist" to the "Foreign Office"
+    And a person called "Test Scientist" exists with the biography "blah"
+    And I appoint "Test Scientist" as the "Chief Scientist"
+    When I update the person called "Test Scientist"
+    Then I should be be able to add an image

--- a/features/step_definitions/person_steps.rb
+++ b/features/step_definitions/person_steps.rb
@@ -16,7 +16,6 @@ When(/^I add a new person called "([^"]*)"$/) do |name|
   click_link "Create new person"
   fill_in_person_name name
   fill_in "Biography", with: "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
-  attach_file "Upload image", jpg_image
   click_button "Save"
 end
 
@@ -27,6 +26,12 @@ When(/^I update the person called "([^"]*)" to have the name "([^"]*)"$/) do |ol
   fill_in_person_name new_name
   fill_in "Biography", with: "Vivamus fringilla libero et augue fermentum eget molestie felis accumsan."
   click_button "Save"
+end
+
+When(/^I update the person called "([^"]*)"$/) do |name|
+  visit_people_admin
+  click_link name
+  click_on "Edit"
 end
 
 When(/^I remove the person "([^"]*)"$/) do |name|
@@ -67,4 +72,9 @@ Then(/^I should see the translation "([^"]*)" and body text "([^"]*)"$/) do |loc
   end
 
   expect(page).to have_content(text)
+end
+
+Then(/^I should be be able to add an image$/) do
+  attach_file "Upload image", jpg_image
+  click_on "Save"
 end

--- a/test/factories/people.rb
+++ b/test/factories/people.rb
@@ -7,6 +7,13 @@ FactoryBot.define do
     image { build(:featured_image_data) }
   end
 
+  factory :person_in_current_role, parent: :person do
+    after :create do |person|
+      role = create(:role, slug: "test-role")
+      create(:role_appointment, role:, person:)
+    end
+  end
+
   factory :pm, parent: :person do
     after :create do |person, _evaluator|
       role = create(:ministerial_role, slug: "prime-minister")

--- a/test/functional/admin/people_controller_test.rb
+++ b/test/functional/admin/people_controller_test.rb
@@ -16,7 +16,6 @@ class Admin::PeopleControllerTest < ActionController::TestCase
       assert_select "input[name='person[forename]'][type=text]"
       assert_select "input[name='person[surname]'][type=text]"
       assert_select "input[name='person[letters]'][type=text]"
-      assert_select "input[name='person[image_attributes][file]'][type=file]"
       assert_select "textarea[name='person[biography]']"
     end
   end
@@ -45,15 +44,6 @@ class Admin::PeopleControllerTest < ActionController::TestCase
     post :create, params: { person: attributes_for(:person) }
 
     assert_redirected_to admin_person_url(Person.last)
-  end
-
-  test "creating allows attachment of an image" do
-    attributes = attributes_for(:person)
-    attributes[:image_attributes] = { file: upload_fixture("minister-of-funk.960x640.jpg", "image/jpg") }
-
-    post :create, params: { person: attributes }
-
-    assert_equal "minister-of-funk.960x640.jpg", Person.last.image.filename
   end
 
   test "GET on :show assigns the person and renders the show page" do
@@ -115,20 +105,33 @@ class Admin::PeopleControllerTest < ActionController::TestCase
       assert_select "input[name='person[forename]'][type=text]"
       assert_select "input[name='person[surname]'][type=text]"
       assert_select "input[name='person[letters]'][type=text]"
-      assert_select "input[name='person[image_attributes][file]'][type=file]"
       assert_select "textarea[name='person[biography]']"
     end
   end
 
   view_test "editing shows existing image" do
-    person = create(:person, :with_image)
+    person = create(:person_in_current_role, :with_image)
     get :edit, params: { id: person }
 
     assert_select "img[src='#{person.image.url}']"
   end
 
+  view_test "editing form does not allow image upload when the person is not in a role" do
+    person = create(:person)
+    get :edit, params: { id: person }
+
+    assert_not_select "input[name='person[image_attributes][file]'][type=file]"
+  end
+
+  view_test "editing form allows image upload when the person is in a role" do
+    person = create(:person_in_current_role)
+    get :edit, params: { id: person }
+
+    assert_select "input[name='person[image_attributes][file]'][type=file]"
+  end
+
   view_test "editing shows processing label if image assets are not available" do
-    person = build(:person, :with_image)
+    person = create(:person_in_current_role, :with_image)
     person.image.assets = []
     person.save!
 


### PR DESCRIPTION
## What

Changes the image upload fields in the people edit form, so that they are only displayed if that person has been assigned to a role.

Also modifies the behavioural tests to maintain the test coverage for uploading an image that is no longer part of the existing `Editing a person` scenario (by moving the image test into it's own scenario).

## Why

Frontend has logic to only show the image if the person is in a role.  This is not made at all clear to publishers and it has led to support tickets where publishers have complained that the image they have uploaded is not rendering. Disambiguating it in Whitehall UI should lead to a reduction in support tickets.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
