### PR TITLE
Fix access controls on history mode documents [WHIT-3956]

### DIFF
--- a/lib/whitehall/authority/rules/edition_rules.rb
+++ b/lib/whitehall/authority/rules/edition_rules.rb
@@ -88,17 +88,24 @@ module Whitehall::Authority::Rules
 
     def can_with_a_historic_instance?(action)
       return false if access_limit_enforced?
+
+      # Allow GDS Editors and above to take any action on historic editions
       return true if actor.gds_admin? || actor.gds_editor?
+
+      # Handle the special case first: publishers who have been given explicit
+      # permission to unpublish historic content, should be able to do so
+      return true if action == :unpublish && actor.can_unpublish_historic_content?
+
+      # Otherwise, if the actor can't take this action on a regular edition,
+      # there's no way they should be allowed to take it on a historic edition
+      return false unless can_with_an_instance?(action)
+
+      # Allow Managing Editors to take any action on historic editions for the 2024 Starmer Labour Government
+      # except for selecting a government for history mode. This temporary measure will be removed in mid Sept.
       return true if actor.managing_editor? && subject.government.slug == "2024-starmer-labour-government" && action != :select_government_for_history_mode
 
-      case action
-      when :see
-        true
-      when :unpublish
-        actor.can_unpublish_historic_content?
-      else
-        false
-      end
+      # Allow viewing of historic editions to all users, but no other actions
+      action == :see
     end
 
     def access_limit_enforced?

--- a/test/unit/lib/whitehall/authority/edition_rules_test.rb
+++ b/test/unit/lib/whitehall/authority/edition_rules_test.rb
@@ -50,10 +50,12 @@ class EditionRulesTest < ActiveSupport::TestCase
     edition
   end
 
-  def historic_unrestricted_edition
+  def historic_unrestricted_edition(author = nil)
     edition = build(:edition)
     edition.stubs(:historic?).returns(true)
     edition.stubs(:access_limiting_organisations?).returns(false)
+    edition.stubs(:government).returns(build(:government, slug: "2024-starmer-labour-government"))
+    edition.stubs(:submitted_by).returns(author)
     edition
   end
 
@@ -166,6 +168,16 @@ class EditionRulesTest < ActiveSupport::TestCase
   test "a Historic Content Unpublisher can :unpublish a historic edition that is not access-limited" do
     user = user_in(org, can_unpublish_historic_content?: true)
     assert enforcer_for(user, historic_unrestricted_edition).can?(:unpublish)
+  end
+
+  test "a Historic Content Publisher Managing Editor can :force_publish a historic edition that is not access-limited" do
+    user = user_in(org, managing_editor?: true)
+    assert enforcer_for(user, historic_unrestricted_edition).can?(:force_publish)
+  end
+
+  test "a Historic Content Publisher Managing Editor cannot :publish a historic edition that is not access-limited, if they are the ones to have submitted it for 2i" do
+    user = user_in(org, managing_editor?: true)
+    assert_not enforcer_for(user, historic_unrestricted_edition(user)).can?(:publish)
   end
 
   test "a regular user cannot :unpublish a historic edition that is not access-limited" do

--- a/test/unit/lib/whitehall/authority/standard_edition_rules_test.rb
+++ b/test/unit/lib/whitehall/authority/standard_edition_rules_test.rb
@@ -98,7 +98,7 @@ class StandardEditionRulesTest < ActiveSupport::TestCase
   end
 
   test "any user can :see a historic standard edition that is not access-limited" do
-    user = User.new(organisation: @other_organisation)
+    user = User.new(organisation: @organisation)
     assert Whitehall::Authority::Enforcer.new(user, historic_standard_edition).can?(:see)
   end
 


### PR DESCRIPTION
Lean on the existing `can_with_an_instance?` checks before going into the history-mode-specific checks. As a general rule, if someone was unable to perform an action against a document that is NOT in history mode, they certainly shouldn't be able to perform that action if the document IS in history mode (where the actions we allow publishers to take is tightened up further). Making a call to `can_with_an_instance?` fixes a bug whereby it is possible for a managing editor to 'submit' a historic document for 2i, and for that same editor to 'publish' (rather than force publish) the document.

Also fixes a 'StandardEdition rules' test that checked that 'any user' could see a document in history mode, but StandardEdition has a [permitted organisations check](https://github.com/alphagov/whitehall/blob/b86bbe006dc3a9ea325252c2d54d06aa64d853ae/lib/whitehall/authority/rules/standard_edition_rules.rb#L6-L7) that was failing because the test content type was configured to be locked down to a specific org. Whether or not the document is historic, we'd expect a user outside that org to be unable to see the document if configured like that.

Jira: https://gov-uk.atlassian.net/browse/WHIT-3956

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
