### PR TITLE
Fix link to "worldwide organisations" in helper sidebar [WHIT-3969]

### DIFF
--- a/app/views/admin/editions/_govspeak_help.html.erb
+++ b/app/views/admin/editions/_govspeak_help.html.erb
@@ -147,7 +147,7 @@
     <p class='govuk-body'>You can also embed contact information:</p>
     <pre class='govspeak-help__pre'>[Contact:<em>n</em>]</pre>
     <p class='govuk-body'>(n is the ID of the contact you want to embed.)</p>
-    <p class='govuk-body'>You can find the ID on the list of contacts for an <%= link_to "organisation", admin_organisations_path, class: "govuk-link" %> or <%= link_to "worldwide organisation", admin_worldwide_organisations_path, class: "govuk-link" %>.</p>
+    <p class='govuk-body'>You can find the ID on the list of contacts for an <%= link_to "organisation", admin_organisations_path, class: "govuk-link" %> or <%= link_to "worldwide organisation", admin_editions_path(type: "worldwide_organisation"), class: "govuk-link" %>.</p>
     <p class='govuk-body'>If it doesn’t exist you will have to add it (see <a class="govuk-link" href='https://www.gov.uk/guidance/how-to-publish-on-gov-uk/organisation-pages'>‘Organisation pages’ guidance</a>). </p>
   <% end %>
 


### PR DESCRIPTION
This has been broken since worldwide orgs were made editionable a few years ago.

Tested locally:

<img width="362" height="565" alt="Screenshot 2026-09-03 at 07 15 02" src="https://github.com/user-attachments/assets/cc86710d-0f5b-41be-9449-311a16caaedd" />

Jira:  https://gov-uk.atlassian.net/browse/WHIT-3969

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
