### PR TITLE
Data migration to propagate role appointments

### DIFF
--- a/db/data_migration/20260903100458_role_appointment_update.rb
+++ b/db/data_migration/20260903100458_role_appointment_update.rb
@@ -1,0 +1,8 @@
+Person.all.find_each do |person|
+  current_role_appointments = person.current_role_appointments
+  current_role_appointments.each do |role_appointment|
+    role_appointment.publish_to_publishing_api
+    role = role_appointment.role
+    role.publish_to_publishing_api
+  end
+end


### PR DESCRIPTION
## What

Data migration to trigger propagation of role appointments to each person in Whitehall.

## Why

A [change to how publishing API validates formats](https://github.com/alphagov/publishing-api/pull/4128) meant that role appointments were not being correctly saved to the content store. This resulted in several support tickets pointing out that recent changes to roles of people were not visible on GOV.UK (despite being saved in Whitehall).

This [issue has now been fixed](https://github.com/alphagov/publishing-api/pull/4183), subsequent updates to a role will propagate to the content store. However we need to fix up any instances that have not been noticed yet.


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
