### PR TITLE
Allow GDS Editors to unpublish content

### DIFF
--- a/lib/whitehall/authority/rules/edition_rules.rb
+++ b/lib/whitehall/authority/rules/edition_rules.rb
@@ -78,7 +78,7 @@ module Whitehall::Authority::Rules
       when :select_government_for_history_mode
         actor.gds_admin? || actor.gds_editor?
       when :unpublish
-        actor.gds_admin? || actor.managing_editor?
+        actor.gds_admin? || actor.gds_editor? || actor.managing_editor?
       when :unwithdraw
         actor.gds_admin? || actor.gds_editor? || actor.managing_editor?
       else

--- a/test/unit/lib/whitehall/authority/gds_editor_fatality_notice_test.rb
+++ b/test/unit/lib/whitehall/authority/gds_editor_fatality_notice_test.rb
@@ -98,7 +98,7 @@ class GDSEditorFatalityNoticeTest < ActiveSupport::TestCase
     assert enforcer_for(gds_editor, normal_fatality_notice).can?(:limit_access)
   end
 
-  test "cannot unpublish a fatality notice" do
-    assert_not enforcer_for(gds_editor, normal_fatality_notice).can?(:unpublish)
+  test "can unpublish a fatality notice" do
+    assert enforcer_for(gds_editor, normal_fatality_notice).can?(:unpublish)
   end
 end

--- a/test/unit/lib/whitehall/authority/gds_editor_test.rb
+++ b/test/unit/lib/whitehall/authority/gds_editor_test.rb
@@ -131,8 +131,8 @@ class GDSEditorTest < ActiveSupport::TestCase
     assert enforcer_for(gds_editor, normal_edition).can?(:limit_access)
   end
 
-  test "cannot unpublish an edition" do
-    assert_not enforcer_for(gds_editor, normal_edition).can?(:unpublish)
+  test "can unpublish an edition" do
+    assert enforcer_for(gds_editor, normal_edition).can?(:unpublish)
   end
 
   test "can reorder cabinet ministers" do


### PR DESCRIPTION
During a recent review of access controls, we noticed that GDS Editors weren't able to unpublish content, despite being able to perform more or less every other action. The decision was made 13 years ago, in https://github.com/alphagov/whitehall/pull/1021/changes/c576251bbe547b52132e2840902d34ca4d60e215, with no reasoning provided.

On reflection, we feel there's no reason not to allow GDS Editors to unpublish content, and that this inconsistency is likely by mistake rather than deliberate.

See https://gds.slack.com/archives/C06HBEH9TM3/p1788356034468729

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
