### PR TITLE
Force Whitehall to initialise an Asset Manager session [WHIT-3983]

### DIFF
--- a/app/views/layouts/design_system.html.erb
+++ b/app/views/layouts/design_system.html.erb
@@ -13,6 +13,7 @@
     <% end %>
     <%= javascript_include_tag "govuk_publishing_components/load-analytics" %>
     <%= javascript_include_tag "admin/domain-config" %>
+    <%= render partial: "shared/asset_manager_session" %>
   <% end %>
 <% end %>
 

--- a/app/views/shared/_asset_manager_session.html.erb
+++ b/app/views/shared/_asset_manager_session.html.erb
@@ -1,0 +1,30 @@
+<%
+# This is a hack to ensure that the Asset Manager session cookie is set prior
+# to trying to load any images from Asset Manager (e.g. on the Images tab of
+# a draft document), and prior to attempting to preview said document.
+# Otherwise, users without an active Asset Manager session will trigger
+# a number of callbacks (one for every image on the document) which won't
+# necessarily complete in the right order, thus invalidating the session
+# and preventing the images from being loaded.
+#
+# See https://gov-uk.atlassian.net/browse/WHIT-3992
+draft_asset_placeholder_url = lambda do
+  placeholder = StandardEdition::LeadImage::DEFAULT_PLACEHOLDER_IMAGE_URL
+
+  host = {
+    "production" => "draft-assets.publishing.service.gov.uk",
+    "staging" =>  "draft-assets.staging.publishing.service.gov.uk",
+    "integration" =>  "draft-assets.integration.publishing.service.gov.uk",
+  }.fetch(GovukEnvironment.current, nil)
+
+  return placeholder unless host
+
+  placeholder.sub(
+    "assets.publishing.service.gov.uk",
+    host,
+  )
+end
+%>
+<script>
+  new Image().src = "<%= draft_asset_placeholder_url.call %>";
+</script>


### PR DESCRIPTION
We're seeing issues in both Whitehall and Frontend, when attempting to render multiple draft images on the page, without a valid asset manager session cookie in place. Each request triggers a number of redirect requests to authenticate the user in Asset Manager via Signon, and then call back to the original URL. The callback URLs can, and do, arrive out of order, and the user ends up with a CSRF error response and the images fail to load.

The images are eventually fine when the user publishes the content, as no authorisation is needed to view the now-live assets. The images do also sometimes come through with enough refreshes, as if the callbacks arrive in a particular order, there is no mismatch of token and the request is authenticated.

In any case, previewing is currently quite broken, and one sure-fire way of fixing previews is to force an asset manager session. Publishers can, in the short term, manually view a draft asset in order to have their session instantiated, but this PR goes one step further and automatically pulls in a draft asset (invisibly) in order to set up the session. Provided the user visits any page in Whitehall prior to trying to visit the Images tab or the Frontend preview, the session should be live and the user should be able to view images with no problem.

**This is seen as a suboptimal fix**. We will raise a ticket on the Publishing Tech Debt board to reconsider a better engineered solution to the problem, but any alternatives we've considered so far require significantly more work and come with additional risk. Given the draft assets issue is affecting publishers today, we want to prioritise what we think is an acceptable patch here and pay down the technical debt later.

Jira: https://gov-uk.atlassian.net/browse/WHIT-3983

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
