### PR TITLE
Update links to image guidance [WHIT-3995]

### DIFF
--- a/app/components/admin/edition_images/image_upload_component.html.erb
+++ b/app/components/admin/edition_images/image_upload_component.html.erb
@@ -4,7 +4,7 @@
 
   hint_text = ["#{image_usage_title.articleize.upcase_first} must be at least <strong>#{image_kind.valid_width}x#{image_kind.valid_height}</strong>."]
   unless image_usage.multiple
-    hint_text << " If you are uploading more than one #{image_usage_title}, <a class=\"govuk-link\" href=\"https://guidance.publishing.service.gov.uk/formatting-content/images-videos/formatting-images/#image-file-names\">read the image guidance</a> on using unique file names."
+    hint_text << " If you are uploading more than one #{image_usage_title}, <a class=\"govuk-link\" href=\"https://guidance.publishing.service.gov.uk/formatting-content/images/#image-file-names\">read the image guidance</a> on using unique file names."
   end
 %>
 
@@ -50,7 +50,7 @@
       } do %>
         SVGs allow users to magnify images without losing quality.
         Find out <%= link_to "how to create an SVG file (opens in new tab)",
-                            "https://guidance.publishing.service.gov.uk/formatting-content/images-videos/formatting-images/#how-to-create-an-svg-file",
+                            "https://guidance.publishing.service.gov.uk/formatting-content/images/#how-to-create-an-svg-file",
                             class: "govuk-link",
                             target: "_blank",
                             rel: "noopener" %>.

--- a/app/views/admin/edition_images/edit.html.erb
+++ b/app/views/admin/edition_images/edit.html.erb
@@ -51,7 +51,7 @@
             textarea_id: "image_caption",
             value: image.caption,
             rows: 2,
-            hint: raw("Name a person in a photo or add image credit. <a class='govuk-link' href='https://guidance.publishing.service.gov.uk/formatting-content/images-videos/formatting-images/#copyright-standards-and-attributing-images'>Read the image copyright standards</a>. The text appears next to the image."),
+            hint: raw("Name a person in a photo or add image credit. <a class='govuk-link' href='https://guidance.publishing.service.gov.uk/formatting-content/images/#copyright-standards-and-attributing-images'>Read the image copyright standards</a>. The text appears next to the image."),
             margin_bottom: 4,
           } %>
           <p class="govuk-body"><a href="https://www.gov.uk/guidance/content-design/images" class="govuk-link" target="_blank">Using informative and decorative images on GOV.UK (opens in new tab)</a></p>


### PR DESCRIPTION
The URLs for these pages have changed, and it means the anchor links are no longer working.

Support request: https://gov-uk.atlassian.net/browse/WHIT-3995

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
