### PR TITLE
Revert "Revert "Change rendering app for Person pages to frontend""

### DIFF
--- a/app/presenters/publishing_api/person_presenter.rb
+++ b/app/presenters/publishing_api/person_presenter.rb
@@ -21,7 +21,7 @@ module PublishingApi
         details:,
         document_type: "person",
         public_updated_at: item.updated_at,
-        rendering_app: Whitehall::RenderingApp::COLLECTIONS_FRONTEND,
+        rendering_app: Whitehall::RenderingApp::FRONTEND,
         schema_name: "person",
       )
       content.merge!(PayloadBuilder::PolymorphicPath.for(item))

--- a/test/unit/app/presenters/publishing_api/person_presenter_test.rb
+++ b/test/unit/app/presenters/publishing_api/person_presenter_test.rb
@@ -29,7 +29,7 @@ class PublishingApi::PersonPresenterTest < ActiveSupport::TestCase
       document_type: "person",
       locale: "en",
       publishing_app: Whitehall::PublishingApp::WHITEHALL,
-      rendering_app: "collections",
+      rendering_app: Whitehall::RenderingApp::FRONTEND,
       public_updated_at: person.updated_at,
       routes: [{ path: public_path, type: "exact" }],
       redirects: [],


### PR DESCRIPTION
Reverts alphagov/whitehall#11777

After bulk republishing all the person pages, a few of them that were rendered by frontend were returning 404. We thought this might be an issue with the rendering configuration, so we reverted to people pages being rendered by collections as it was initially.

But it was just a cache problem. All the pages rendered by frontend are working as expected now. So no need to revert these configuration changes.