### PR TITLE
Add Department for Energy, Security and Net Zero

### DIFF
--- a/app/models/organisation_brand_colour.rb
+++ b/app/models/organisation_brand_colour.rb
@@ -192,4 +192,9 @@ class OrganisationBrandColour
     title: "Department for Business, Innovation, Science and Trade",
     class_name: "department-for-business-innovation-science-trade",
   )
+  DepartmentForEnergySecurityAndNetZero = create!(
+    id: 38,
+    title: "Department for Energy, Security & Net Zero",
+    class_name: "department-for-energy-security-net-zero",
+  )
 end


### PR DESCRIPTION
## What

Add new brand colour for Department for Energy Security & Net Zero

## Why

Allow the new brand colour for Department for Energy Security & Net Zero to be selected from the Organisation Colour dropdown in Whitehall

Jira card: https://gov-uk.atlassian.net/browse/NAV-19110.