### PR TITLE
Don't check if page is in the National Archives [WHIT-4007]

### DIFF
--- a/app/models/unpublishing.rb
+++ b/app/models/unpublishing.rb
@@ -9,7 +9,6 @@ class Unpublishing < ApplicationRecord
   validates :alternative_url, uri: true, allow_blank: true
   validates :alternative_url, gov_uk_url_format: true, allow_blank: true
   validate :redirect_not_circular
-  validate :live_archived_url, if: :archived?
 
   after_initialize :ensure_presence_of_content_id
 
@@ -111,19 +110,6 @@ private
     rescue URI::InvalidURIError, Addressable::URI::InvalidURIError
       nil
     end
-  end
-
-  def live_archived_url
-    url = URI.parse(archived_url)
-    req = Net::HTTP.new(url.host, url.port)
-    req.use_ssl = true
-    res = req.request_head(url.path)
-
-    # The National Archives returns a 307 redirect for archived pages, so we check for that instead of a 200 OK.
-    # E.g. https://webarchive.nationalarchives.gov.uk/ukgwa/https://www.gov.uk/government/news/uk-export-finance-appoints-pat-cauthery-to-lead-aerospace-and-defence-business
-    # => 307 redirect =>
-    # https://webarchive.nationalarchives.gov.uk/ukgwa/20260407083257/https://www.gov.uk/government/news/uk-export-finance-appoints-pat-cauthery-to-lead-aerospace-and-defence-business
-    errors.add(:unpublishing_reason, "cannot be \"Archived\" if page has not been archived by the National Archives (\"https://www.webarchive.nationalarchives.gov.uk\")") unless res.code == "307"
   end
 
   def redirect_not_circular

--- a/test/unit/app/helpers/admin/editions_helper_test.rb
+++ b/test/unit/app/helpers/admin/editions_helper_test.rb
@@ -140,9 +140,6 @@ class Admin::EditionsHelperTest < ActionView::TestCase
   test "#status_text has special handling for unpublished (via National Archives)" do
     edition = create(:edition, :unpublished)
 
-    stub_request(:head, edition.unpublishing.archived_url)
-      .to_return(status: 307, body: "", headers: {})
-
     edition.unpublishing.unpublishing_reason_id = UnpublishingReason::ARCHIVED_ID
     edition.unpublishing.save!
 

--- a/test/unit/app/models/unpublishing_test.rb
+++ b/test/unit/app/models/unpublishing_test.rb
@@ -177,21 +177,8 @@ class UnpublishingTest < ActiveSupport::TestCase
     assert_equal ["must be provided to redirect the document"], unpublishing.errors[:alternative_url]
   end
 
-  test "unpublishing_reason is invalid if the reason is Archived and document has not been archived by the National Archives" do
+  test "unpublishing_reason is valid if the reason is Archived" do
     unpublishing = build(:unpublishing, unpublishing_reason: UnpublishingReason::Archived)
-
-    stub_request(:head, unpublishing.archived_url)
-      .to_return(status: 404, body: "", headers: {})
-
-    assert_not unpublishing.valid?
-    assert_equal ["cannot be \"Archived\" if page has not been archived by the National Archives (\"https://www.webarchive.nationalarchives.gov.uk\")"], unpublishing.errors[:unpublishing_reason]
-  end
-
-  test "unpublishing_reason is valid if the reason is Archived and document has been archived by the National Archives" do
-    unpublishing = build(:unpublishing, unpublishing_reason: UnpublishingReason::Archived)
-
-    stub_request(:head, unpublishing.archived_url)
-      .to_return(status: 307, body: "", headers: {})
 
     assert unpublishing.valid?
   end

--- a/test/unit/app/sidekiq/publishing_api_unpublishing_job_test.rb
+++ b/test/unit/app/sidekiq/publishing_api_unpublishing_job_test.rb
@@ -86,8 +86,6 @@ class PublishingApiUnpublishingJobTest < ActiveSupport::TestCase
   end
 
   test "sets I18n.locale for each available locale" do
-    stub_request(:any, %r{\Ahttps://webarchive\.nationalarchives\.gov\.uk/}).to_return(status: 307, body: "", headers: {})
-
     unpublished_edition = create(
       :standard_edition,
       :unpublished_archived,


### PR DESCRIPTION
Publishers are currently unable to unpublish using the "National Archives" option, and are seeing the following error:

> Unpublishing reason cannot be "Archived" if page has not been archived by the National Archives ("https://www.webarchive.nationalarchives.gov.uk")

This is despite the page appearing in the archives.

On closer inspection, the 307 redirect that we normally get when checking the presence of a page in the archives is actually a 405 "HTTPMethodNotAllowed" response on production. Looking at the response body of the request, we can see that our system is being treated (probably quite rightly) as bot traffic and is presented with a CAPTCHA puzzle to prove it's human.

We're therefore removing the validation and trusting publishers to check that their page is in the archives before they unpublish.

Jira: https://gov-uk.atlassian.net/browse/WHIT-4007

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
