### PR TITLE
Update HTML attachment reslug task to cope with document clashes [WHIT-4013]

### DIFF
--- a/lib/tasks/reslugging.rake
+++ b/lib/tasks/reslugging.rake
@@ -47,13 +47,8 @@ namespace :reslug do
   - changes a html attachment slug
   - reindexes the document
   - republishes the document and attachment to Publishing API (automatically handles the redirect)"
-  task :html_attachment, %i[publication_slug old_attachment_slug] => :environment do |_task, args|
-    documents = Edition.where(slug: args.publication_slug).map(&:document)
-    if documents.count > 1
-      raise "There are multiple documents with the slug '#{args.publication_slug}'. Consider writing a migration and fetching the document with a content_id or document_type to uniquely identify it."
-    end
-
-    document = documents.first
+  task :html_attachment, %i[publication_document_id old_attachment_slug] => :environment do |_task, args|
+    document = Document.find(args.publication_document_id)
     edition = document.editions.published.last
     html_attachment = edition.attachments.find_by(slug: args.old_attachment_slug)
 

--- a/test/unit/lib/tasks/reslugging_test.rb
+++ b/test/unit/lib/tasks/reslugging_test.rb
@@ -39,7 +39,7 @@ class ResluggingTest < ActiveSupport::TestCase
 
       existing_html_attachment.update!(title: new_html_attachment_title)
 
-      task.invoke(published_edition.slug, existing_html_attachment.slug)
+      task.invoke(published_edition.document.id, existing_html_attachment.slug)
 
       # attachment slug should have changed
       assert_equal existing_html_attachment.reload.slug, new_html_attachment_slug
@@ -49,7 +49,6 @@ class ResluggingTest < ActiveSupport::TestCase
 
     it "reslugs if deleted attached HTML attachment with same slug" do
       published_edition = create(:published_edition)
-      published_edition.document
 
       deleted_html_attachment = create(:html_attachment, title: html_attachment_title, body: "Some text on a published edition", attachable: published_edition)
 
@@ -57,7 +56,7 @@ class ResluggingTest < ActiveSupport::TestCase
 
       existing_html_attachment = create(:html_attachment, title: html_attachment_title, body: "Some text on a published edition", attachable: published_edition)
 
-      task.invoke(published_edition.slug, existing_html_attachment.slug)
+      task.invoke(published_edition.document.id, existing_html_attachment.slug)
 
       existing_html_attachment = existing_html_attachment.reload
       new_edition = published_edition.document.editions.published.last
@@ -72,14 +71,13 @@ class ResluggingTest < ActiveSupport::TestCase
 
     it "does not reslug if undeleted attached HTML attachment with same slug" do
       published_edition = create(:published_edition)
-      published_edition.document
 
       create(:html_attachment, title: html_attachment_title, body: "Some text on a published edition", attachable: published_edition)
 
       existing_html_attachment = create(:html_attachment, title: html_attachment_title, body: "Some text on a published edition", attachable: published_edition)
 
       assert_raises(StandardError, match: "Attachment with slug '#{html_attachment_slug}' already exists and has been not deleted. Delete this attachment first.") do
-        task.invoke(published_edition.slug, existing_html_attachment.slug)
+        task.invoke(published_edition.document.id, existing_html_attachment.slug)
       end
     end
   end


### PR DESCRIPTION
The previous version of this task only worked if there was one Document with the given 'publication slug'. In the case of my recent support ticket, the rake task failed here and the instructions were to write a data migration, which is a shame when I know exactly which Document I want to pass to the rake task.

Given this is a rake task and we need to establish a kubectl connection anyway, it's fairly quick to find out the Document ID of a given Publication, and pass it to the task. Yes it's marginally less convenient than the Publication slug, but it's unambiguous (and also removes a branch of code logic that had no corresponding unit test).

Solves https://govuk.sentry.io/issues/7726518975/

Tested on integration:

1. Visited https://www.gov.uk/government/publications/cma-structure/cma-structure-chart-as-at-march-2019
2. Used browser extension to switch to integration
3. Used browser extension to open in Whitehall (https://whitehall-admin.integration.publishing.service.gov.uk/government/admin/publications/1826748)
4. Rails console: `Edition.find(1826748).document.id => 211119`
5. Ran the rake task: `reslug:html_attachment[211119,cma-structure-chart-as-at-march-2019]`
6. See the attachment reslugged: https://www.integration.publishing.service.gov.uk/government/publications/cma-structure/cma-structure?cb=214

Jira: https://gov-uk.atlassian.net/browse/WHIT-4013

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the Whitehall Experience team. Please let us know in [#govuk-whitehall-experience-tech](https://gds.slack.com/archives/C02L13S214K) when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
